### PR TITLE
refactoring: warning revamp part 2

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -36,14 +36,13 @@ export function createSubscription<Property, Value>(
 }> {
   const {getCurrentValue, subscribe} = config;
 
-  warningWithoutStack(
-    typeof getCurrentValue === 'function',
-    'Subscription must specify a getCurrentValue function',
-  );
-  warningWithoutStack(
-    typeof subscribe === 'function',
-    'Subscription must specify a subscribe function',
-  );
+  if (!(typeof getCurrentValue === 'function')) {
+    warningWithoutStack('Subscription must specify a getCurrentValue function');
+  }
+
+  if (!(typeof subscribe === 'function')) {
+    warningWithoutStack('Subscription must specify a subscribe function');
+  }
 
   type Props = {
     children: (value: Value) => React$Element<any>,
@@ -129,10 +128,10 @@ export function createSubscription<Property, Value>(
 
         // Store the unsubscribe method for later (in case the subscribable prop changes).
         const unsubscribe = subscribe(source, callback);
-        invariant(
-          typeof unsubscribe === 'function',
-          'A subscription must return an unsubscribe function.',
-        );
+
+        if (!(typeof unsubscribe === 'function')) {
+          invariant('A subscription must return an unsubscribe function.');
+        }
 
         // It's safe to store unsubscribe on the instance because
         // We only read or write that property during the "commit" phase.

--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -30,8 +30,10 @@ function assertYieldsWereCleared(root) {
   const actualYields = Scheduler.unstable_clearYields();
 
   if (!(actualYields.length === 0)) {
-    invariant('Log of yielded values is not empty. ' +
-      'Call expect(ReactTestRenderer).unstable_toHaveYielded(...) first.');
+    invariant(
+      'Log of yielded values is not empty. ' +
+        'Call expect(ReactTestRenderer).unstable_toHaveYielded(...) first.',
+    );
   }
 }
 

--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -28,11 +28,11 @@ function captureAssertion(fn) {
 function assertYieldsWereCleared(root) {
   const Scheduler = root._Scheduler;
   const actualYields = Scheduler.unstable_clearYields();
-  invariant(
-    actualYields.length === 0,
-    'Log of yielded values is not empty. ' +
-      'Call expect(ReactTestRenderer).unstable_toHaveYielded(...) first.',
-  );
+
+  if (!(actualYields.length === 0)) {
+    invariant('Log of yielded values is not empty. ' +
+      'Call expect(ReactTestRenderer).unstable_toHaveYielded(...) first.');
+  }
 }
 
 export function unstable_toMatchRenderedOutput(root, expectedJSX) {

--- a/packages/legacy-events/EventBatching.js
+++ b/packages/legacy-events/EventBatching.js
@@ -56,11 +56,14 @@ export function runEventsInBatch(
   }
 
   forEachAccumulated(processingEventQueue, executeDispatchesAndReleaseTopLevel);
-  invariant(
-    !eventQueue,
-    'processEventQueue(): Additional events were enqueued while processing ' +
-      'an event queue. Support for this has not yet been implemented.',
-  );
+
+  if (eventQueue) {
+    invariant(
+      'processEventQueue(): Additional events were enqueued while processing ' +
+        'an event queue. Support for this has not yet been implemented.',
+    );
+  }
+
   // This would be a good time to rethrow if any of the event handlers threw.
   rethrowCaughtError();
 }

--- a/packages/legacy-events/EventPluginHub.js
+++ b/packages/legacy-events/EventPluginHub.js
@@ -114,12 +114,15 @@ export function getListener(inst: Fiber, registrationName: string) {
   if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
     return null;
   }
-  invariant(
-    !listener || typeof listener === 'function',
-    'Expected `%s` listener to be a function, instead got a value of `%s` type.',
-    registrationName,
-    typeof listener,
-  );
+
+  if (!(!listener || typeof listener === 'function')) {
+    invariant(
+      'Expected `%s` listener to be a function, instead got a value of `%s` type.',
+      registrationName,
+      typeof listener
+    );
+  }
+
   return listener;
 }
 

--- a/packages/legacy-events/EventPluginHub.js
+++ b/packages/legacy-events/EventPluginHub.js
@@ -119,7 +119,7 @@ export function getListener(inst: Fiber, registrationName: string) {
     invariant(
       'Expected `%s` listener to be a function, instead got a value of `%s` type.',
       registrationName,
-      typeof listener
+      typeof listener,
     );
   }
 

--- a/packages/legacy-events/EventPluginRegistry.js
+++ b/packages/legacy-events/EventPluginRegistry.js
@@ -42,34 +42,43 @@ function recomputePluginOrdering(): void {
   for (const pluginName in namesToPlugins) {
     const pluginModule = namesToPlugins[pluginName];
     const pluginIndex = eventPluginOrder.indexOf(pluginName);
-    invariant(
-      pluginIndex > -1,
-      'EventPluginRegistry: Cannot inject event plugins that do not exist in ' +
-        'the plugin ordering, `%s`.',
-      pluginName,
-    );
+
+    if (!(pluginIndex > -1)) {
+      invariant(
+        'EventPluginRegistry: Cannot inject event plugins that do not exist in ' +
+          'the plugin ordering, `%s`.',
+        pluginName,
+      );
+    }
+
     if (plugins[pluginIndex]) {
       continue;
     }
-    invariant(
-      pluginModule.extractEvents,
-      'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
-        'method, but `%s` does not.',
-      pluginName,
-    );
+
+    if (!pluginModule.extractEvents) {
+      invariant(
+        'EventPluginRegistry: Event plugins must implement an `extractEvents` ' +
+          'method, but `%s` does not.',
+        pluginName,
+      );
+    }
+
     plugins[pluginIndex] = pluginModule;
     const publishedEvents = pluginModule.eventTypes;
     for (const eventName in publishedEvents) {
-      invariant(
-        publishEventForPlugin(
+      if (
+        !publishEventForPlugin(
           publishedEvents[eventName],
           pluginModule,
           eventName,
-        ),
-        'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.',
-        eventName,
-        pluginName,
-      );
+        )
+      ) {
+        invariant(
+          'EventPluginRegistry: Failed to publish event `%s` for plugin `%s`.',
+          eventName,
+          pluginName,
+        );
+      }
     }
   }
 }
@@ -87,12 +96,14 @@ function publishEventForPlugin(
   pluginModule: PluginModule<AnyNativeEvent>,
   eventName: string,
 ): boolean {
-  invariant(
-    !eventNameDispatchConfigs.hasOwnProperty(eventName),
-    'EventPluginHub: More than one plugin attempted to publish the same ' +
-      'event name, `%s`.',
-    eventName,
-  );
+  if (eventNameDispatchConfigs.hasOwnProperty(eventName)) {
+    invariant(
+      'EventPluginHub: More than one plugin attempted to publish the same ' +
+        'event name, `%s`.',
+      eventName,
+    );
+  }
+
   eventNameDispatchConfigs[eventName] = dispatchConfig;
 
   const phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
@@ -131,12 +142,14 @@ function publishRegistrationName(
   pluginModule: PluginModule<AnyNativeEvent>,
   eventName: string,
 ): void {
-  invariant(
-    !registrationNameModules[registrationName],
-    'EventPluginHub: More than one plugin attempted to publish the same ' +
-      'registration name, `%s`.',
-    registrationName,
-  );
+  if (registrationNameModules[registrationName]) {
+    invariant(
+      'EventPluginHub: More than one plugin attempted to publish the same ' +
+        'registration name, `%s`.',
+      registrationName,
+    );
+  }
+
   registrationNameModules[registrationName] = pluginModule;
   registrationNameDependencies[registrationName] =
     pluginModule.eventTypes[eventName].dependencies;
@@ -198,11 +211,13 @@ export const possibleRegistrationNames = __DEV__ ? {} : (null: any);
 export function injectEventPluginOrder(
   injectedEventPluginOrder: EventPluginOrder,
 ): void {
-  invariant(
-    !eventPluginOrder,
-    'EventPluginRegistry: Cannot inject event plugin ordering more than ' +
-      'once. You are likely trying to load more than one copy of React.',
-  );
+  if (eventPluginOrder) {
+    invariant(
+      'EventPluginRegistry: Cannot inject event plugin ordering more than ' +
+        'once. You are likely trying to load more than one copy of React.',
+    );
+  }
+
   // Clone the ordering so it cannot be dynamically mutated.
   eventPluginOrder = Array.prototype.slice.call(injectedEventPluginOrder);
   recomputePluginOrdering();
@@ -231,12 +246,14 @@ export function injectEventPluginsByName(
       !namesToPlugins.hasOwnProperty(pluginName) ||
       namesToPlugins[pluginName] !== pluginModule
     ) {
-      invariant(
-        !namesToPlugins[pluginName],
-        'EventPluginRegistry: Cannot inject two different event plugins ' +
-          'using the same name, `%s`.',
-        pluginName,
-      );
+      if (namesToPlugins[pluginName]) {
+        invariant(
+          'EventPluginRegistry: Cannot inject two different event plugins ' +
+            'using the same name, `%s`.',
+          pluginName,
+        );
+      }
+
       namesToPlugins[pluginName] = pluginModule;
       isOrderingDirty = true;
     }

--- a/packages/legacy-events/EventPluginUtils.js
+++ b/packages/legacy-events/EventPluginUtils.js
@@ -22,11 +22,12 @@ export function setComponentTree(
   getInstanceFromNode = getInstanceFromNodeImpl;
   getNodeFromInstance = getNodeFromInstanceImpl;
   if (__DEV__) {
-    warningWithoutStack(
-      getNodeFromInstance && getInstanceFromNode,
-      'EventPluginUtils.setComponentTree(...): Injected ' +
-        'module is missing getNodeFromInstance or getInstanceFromNode.',
-    );
+    if (!(getNodeFromInstance && getInstanceFromNode)) {
+      warningWithoutStack(
+        'EventPluginUtils.setComponentTree(...): Injected ' +
+          'module is missing getNodeFromInstance or getInstanceFromNode.',
+      );
+    }
   }
 }
 
@@ -50,10 +51,9 @@ if (__DEV__) {
         ? 1
         : 0;
 
-    warningWithoutStack(
-      instancesIsArr === listenersIsArr && instancesLen === listenersLen,
-      'EventPluginUtils: Invalid `event`.',
-    );
+    if (!(instancesIsArr === listenersIsArr && instancesLen === listenersLen)) {
+      warningWithoutStack('EventPluginUtils: Invalid `event`.');
+    }
   };
 }
 
@@ -150,10 +150,11 @@ export function executeDirectDispatch(event) {
   }
   const dispatchListener = event._dispatchListeners;
   const dispatchInstance = event._dispatchInstances;
-  invariant(
-    !Array.isArray(dispatchListener),
-    'executeDirectDispatch(...): Invalid `event`.',
-  );
+
+  if (Array.isArray(dispatchListener)) {
+    invariant('executeDirectDispatch(...): Invalid `event`.');
+  }
+
   event.currentTarget = dispatchListener
     ? getNodeFromInstance(dispatchInstance)
     : null;

--- a/packages/legacy-events/EventPropagators.js
+++ b/packages/legacy-events/EventPropagators.js
@@ -46,7 +46,9 @@ function listenerAtPhase(inst, event, propagationPhase: PropagationPhases) {
  */
 function accumulateDirectionalDispatches(inst, phase, event) {
   if (__DEV__) {
-    warningWithoutStack(inst, 'Dispatching inst must not be null');
+    if (!inst) {
+      warningWithoutStack('Dispatching inst must not be null');
+    }
   }
   const listener = listenerAtPhase(inst, event, phase);
   if (listener) {

--- a/packages/legacy-events/ReactControlledComponent.js
+++ b/packages/legacy-events/ReactControlledComponent.js
@@ -32,7 +32,7 @@ function restoreStateOfTarget(target) {
   if (!(typeof restoreImpl === 'function')) {
     invariant(
       'setRestoreImplementation() needs to be called to handle a target for controlled ' +
-        'events. This error is likely caused by a bug in React. Please file an issue.'
+        'events. This error is likely caused by a bug in React. Please file an issue.',
     );
   }
 

--- a/packages/legacy-events/ReactControlledComponent.js
+++ b/packages/legacy-events/ReactControlledComponent.js
@@ -28,11 +28,14 @@ function restoreStateOfTarget(target) {
     // Unmounted
     return;
   }
-  invariant(
-    typeof restoreImpl === 'function',
-    'setRestoreImplementation() needs to be called to handle a target for controlled ' +
-      'events. This error is likely caused by a bug in React. Please file an issue.',
-  );
+
+  if (!(typeof restoreImpl === 'function')) {
+    invariant(
+      'setRestoreImplementation() needs to be called to handle a target for controlled ' +
+        'events. This error is likely caused by a bug in React. Please file an issue.'
+    );
+  }
+
   const props = getFiberCurrentPropsFromNode(internalInstance.stateNode);
   restoreImpl(internalInstance.stateNode, internalInstance.type, props);
 }

--- a/packages/legacy-events/ResponderTouchHistoryStore.js
+++ b/packages/legacy-events/ResponderTouchHistoryStore.js
@@ -99,8 +99,12 @@ function getTouchIdentifier({identifier}: Touch): number {
 
   if (__DEV__) {
     if (!(identifier <= MAX_TOUCH_BANK)) {
-      warningWithoutStack('Touch identifier %s is greater than maximum supported %s which causes ' +
-        'performance issues backfilling array locations for all of the indices.', identifier, MAX_TOUCH_BANK);
+      warningWithoutStack(
+        'Touch identifier %s is greater than maximum supported %s which causes ' +
+          'performance issues backfilling array locations for all of the indices.',
+        identifier,
+        MAX_TOUCH_BANK,
+      );
     }
   }
   return identifier;

--- a/packages/legacy-events/ResponderTouchHistoryStore.js
+++ b/packages/legacy-events/ResponderTouchHistoryStore.js
@@ -93,15 +93,15 @@ function resetTouchRecord(touchRecord: TouchRecord, touch: Touch): void {
 }
 
 function getTouchIdentifier({identifier}: Touch): number {
-  invariant(identifier != null, 'Touch object is missing identifier.');
+  if (!(identifier != null)) {
+    invariant('Touch object is missing identifier.');
+  }
+
   if (__DEV__) {
-    warningWithoutStack(
-      identifier <= MAX_TOUCH_BANK,
-      'Touch identifier %s is greater than maximum supported %s which causes ' +
-        'performance issues backfilling array locations for all of the indices.',
-      identifier,
-      MAX_TOUCH_BANK,
-    );
+    if (!(identifier <= MAX_TOUCH_BANK)) {
+      warningWithoutStack('Touch identifier %s is greater than maximum supported %s which causes ' +
+        'performance issues backfilling array locations for all of the indices.', identifier, MAX_TOUCH_BANK);
+    }
   }
   return identifier;
 }
@@ -200,10 +200,10 @@ const ResponderTouchHistoryStore = {
         }
         if (__DEV__) {
           const activeRecord = touchBank[touchHistory.indexOfSingleActiveTouch];
-          warningWithoutStack(
-            activeRecord != null && activeRecord.touchActive,
-            'Cannot find single active touch.',
-          );
+
+          if (!(activeRecord != null && activeRecord.touchActive)) {
+            warningWithoutStack('Cannot find single active touch.');
+          }
         }
       }
     }

--- a/packages/legacy-events/SyntheticEvent.js
+++ b/packages/legacy-events/SyntheticEvent.js
@@ -293,7 +293,7 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
           'See https://fb.me/react-event-pooling for more information.',
         action,
         propName,
-        result
+        result,
       );
     }
   }
@@ -324,7 +324,9 @@ function releasePooledEvent(event) {
   const EventConstructor = this;
 
   if (!(event instanceof EventConstructor)) {
-    invariant('Trying to release an event instance into a pool of a different type.');
+    invariant(
+      'Trying to release an event instance into a pool of a different type.',
+    );
   }
 
   event.destructor();

--- a/packages/legacy-events/SyntheticEvent.js
+++ b/packages/legacy-events/SyntheticEvent.js
@@ -284,16 +284,18 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
 
   function warn(action, result) {
     const warningCondition = false;
-    warningWithoutStack(
-      warningCondition,
-      "This synthetic event is reused for performance reasons. If you're seeing this, " +
-        "you're %s `%s` on a released/nullified synthetic event. %s. " +
-        'If you must keep the original synthetic event around, use event.persist(). ' +
-        'See https://fb.me/react-event-pooling for more information.',
-      action,
-      propName,
-      result,
-    );
+
+    if (!warningCondition) {
+      warningWithoutStack(
+        "This synthetic event is reused for performance reasons. If you're seeing this, " +
+          "you're %s `%s` on a released/nullified synthetic event. %s. " +
+          'If you must keep the original synthetic event around, use event.persist(). ' +
+          'See https://fb.me/react-event-pooling for more information.',
+        action,
+        propName,
+        result
+      );
+    }
   }
 }
 
@@ -320,10 +322,11 @@ function getPooledEvent(dispatchConfig, targetInst, nativeEvent, nativeInst) {
 
 function releasePooledEvent(event) {
   const EventConstructor = this;
-  invariant(
-    event instanceof EventConstructor,
-    'Trying to release an event instance into a pool of a different type.',
-  );
+
+  if (!(event instanceof EventConstructor)) {
+    invariant('Trying to release an event instance into a pool of a different type.');
+  }
+
   event.destructor();
   if (EventConstructor.eventPool.length < EVENT_POOL_SIZE) {
     EventConstructor.eventPool.push(event);

--- a/packages/legacy-events/accumulate.js
+++ b/packages/legacy-events/accumulate.js
@@ -20,10 +20,9 @@ function accumulate<T>(
   current: ?(T | Array<T>),
   next: T | Array<T>,
 ): T | Array<T> {
-  invariant(
-    next != null,
-    'accumulate(...): Accumulated items must not be null or undefined.',
-  );
+  if (!(next != null)) {
+    invariant('accumulate(...): Accumulated items must not be null or undefined.');
+  }
 
   if (current == null) {
     return next;

--- a/packages/legacy-events/accumulate.js
+++ b/packages/legacy-events/accumulate.js
@@ -21,7 +21,9 @@ function accumulate<T>(
   next: T | Array<T>,
 ): T | Array<T> {
   if (!(next != null)) {
-    invariant('accumulate(...): Accumulated items must not be null or undefined.');
+    invariant(
+      'accumulate(...): Accumulated items must not be null or undefined.',
+    );
   }
 
   if (current == null) {

--- a/packages/legacy-events/accumulateInto.js
+++ b/packages/legacy-events/accumulateInto.js
@@ -26,10 +26,9 @@ function accumulateInto<T>(
   current: ?(Array<T> | T),
   next: T | Array<T>,
 ): T | Array<T> {
-  invariant(
-    next != null,
-    'accumulateInto(...): Accumulated items must not be null or undefined.',
-  );
+  if (!(next != null)) {
+    invariant('accumulateInto(...): Accumulated items must not be null or undefined.');
+  }
 
   if (current == null) {
     return next;

--- a/packages/legacy-events/accumulateInto.js
+++ b/packages/legacy-events/accumulateInto.js
@@ -27,7 +27,9 @@ function accumulateInto<T>(
   next: T | Array<T>,
 ): T | Array<T> {
   if (!(next != null)) {
-    invariant('accumulateInto(...): Accumulated items must not be null or undefined.');
+    invariant(
+      'accumulateInto(...): Accumulated items must not be null or undefined.',
+    );
   }
 
   if (current == null) {

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -247,7 +247,7 @@ export * from 'shared/HostConfigWithNoHydration';
 export function appendInitialChild(parentInstance, child) {
   if (typeof child === 'string') {
     // Noop for string children of Text (eg <Text>{'foo'}{'bar'}</Text>)
-    invariant(false, 'Text children should already be flattened.');
+    invariant('Text children should already be flattened.');
     return;
   }
 
@@ -281,7 +281,9 @@ export function createInstance(type, props, internalInstanceHandle) {
       break;
   }
 
-  invariant(instance, 'ReactART does not support the type "%s"', type);
+  if (!instance) {
+    invariant('ReactART does not support the type "%s"', type);
+  }
 
   instance._applyProps(instance, props);
 
@@ -365,18 +367,18 @@ export function appendChildToContainer(parentInstance, child) {
 }
 
 export function insertBefore(parentInstance, child, beforeChild) {
-  invariant(
-    child !== beforeChild,
-    'ReactART: Can not insert node before itself',
-  );
+  if (!(child !== beforeChild)) {
+    invariant('ReactART: Can not insert node before itself');
+  }
+
   child.injectBefore(beforeChild);
 }
 
 export function insertInContainerBefore(parentInstance, child, beforeChild) {
-  invariant(
-    child !== beforeChild,
-    'ReactART: Can not insert node before itself',
-  );
+  if (!(child !== beforeChild)) {
+    invariant('ReactART: Can not insert node before itself');
+  }
+
   child.injectBefore(beforeChild);
 }
 

--- a/packages/react-cache/src/ReactCache.js
+++ b/packages/react-cache/src/ReactCache.js
@@ -64,14 +64,22 @@ function readContext(Context, observedBits) {
 
 function identityHashFn(input) {
   if (__DEV__) {
-    if (!(typeof input === 'string' ||
-      typeof input === 'number' ||
-      typeof input === 'boolean' ||
-      input === undefined || input === null)) {
-      warningWithoutStack('Invalid key type. Expected a string, number, symbol, or boolean, ' +
-        'but instead received: %s' +
-        '\n\nTo use non-primitive values as keys, you must pass a hash ' +
-        'function as the second argument to createResource().', input);
+    if (
+      !(
+        typeof input === 'string' ||
+        typeof input === 'number' ||
+        typeof input === 'boolean' ||
+        input === undefined ||
+        input === null
+      )
+    ) {
+      warningWithoutStack(
+        'Invalid key type. Expected a string, number, symbol, or boolean, ' +
+          'but instead received: %s' +
+          '\n\nTo use non-primitive values as keys, you must pass a hash ' +
+          'function as the second argument to createResource().',
+        input,
+      );
     }
   }
   return input;

--- a/packages/react-cache/src/ReactCache.js
+++ b/packages/react-cache/src/ReactCache.js
@@ -64,18 +64,15 @@ function readContext(Context, observedBits) {
 
 function identityHashFn(input) {
   if (__DEV__) {
-    warningWithoutStack(
-      typeof input === 'string' ||
-        typeof input === 'number' ||
-        typeof input === 'boolean' ||
-        input === undefined ||
-        input === null,
-      'Invalid key type. Expected a string, number, symbol, or boolean, ' +
+    if (!(typeof input === 'string' ||
+      typeof input === 'number' ||
+      typeof input === 'boolean' ||
+      input === undefined || input === null)) {
+      warningWithoutStack('Invalid key type. Expected a string, number, symbol, or boolean, ' +
         'but instead received: %s' +
         '\n\nTo use non-primitive values as keys, you must pass a hash ' +
-        'function as the second argument to createResource().',
-      input,
-    );
+        'function as the second argument to createResource().', input);
+    }
   }
   return input;
 }

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -112,9 +112,8 @@ if (__DEV__) {
     typeof Set.prototype.forEach !== 'function'
   ) {
     warningWithoutStack(
-      false,
       'React depends on Map and Set built-in types. Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills',
+        'polyfill in older browsers. https://fb.me/react-polyfills'
     );
   }
 
@@ -124,13 +123,12 @@ if (__DEV__) {
         container._reactRootContainer._internalRoot.current,
       );
       if (hostInstance) {
-        warningWithoutStack(
-          hostInstance.parentNode === container,
-          'render(...): It looks like the React-rendered content of this ' +
+        if (!(hostInstance.parentNode === container)) {
+          warningWithoutStack('render(...): It looks like the React-rendered content of this ' +
             'container was removed without using React. This is not ' +
             'supported and will cause errors. Instead, call ' +
-            'ReactDOM.unmountComponentAtNode to empty a container.',
-        );
+            'ReactDOM.unmountComponentAtNode to empty a container.');
+        }
       }
     }
 
@@ -138,34 +136,28 @@ if (__DEV__) {
     const rootEl = getReactRootElementInContainer(container);
     const hasNonRootReactChild = !!(rootEl && getInstanceFromNode(rootEl));
 
-    warningWithoutStack(
-      !hasNonRootReactChild || isRootRenderedBySomeReact,
-      'render(...): Replacing React-rendered children with a new root ' +
+    if (!(!hasNonRootReactChild || isRootRenderedBySomeReact)) {
+      warningWithoutStack('render(...): Replacing React-rendered children with a new root ' +
         'component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state ' +
-        'and render the new components instead of calling ReactDOM.render.',
-    );
+        'and render the new components instead of calling ReactDOM.render.');
+    }
 
-    warningWithoutStack(
-      container.nodeType !== ELEMENT_NODE ||
-        !((container: any): Element).tagName ||
-        ((container: any): Element).tagName.toUpperCase() !== 'BODY',
-      'render(): Rendering components directly into document.body is ' +
+    if (!(container.nodeType !== ELEMENT_NODE ||
+      !((container: any): Element).tagName || ((container: any): Element).tagName.toUpperCase() !== 'BODY')) {
+      warningWithoutStack('render(): Rendering components directly into document.body is ' +
         'discouraged, since its children are often manipulated by third-party ' +
         'scripts and browser extensions. This may lead to subtle ' +
         'reconciliation issues. Try rendering into a container element created ' +
-        'for your app.',
-    );
+        'for your app.');
+    }
   };
 
   warnOnInvalidCallback = function(callback: mixed, callerName: string) {
-    warningWithoutStack(
-      callback === null || typeof callback === 'function',
-      '%s(...): Expected the last optional `callback` argument to be a ' +
-        'function. Instead received: %s.',
-      callerName,
-      callback,
-    );
+    if (!(callback === null || typeof callback === 'function')) {
+      warningWithoutStack('%s(...): Expected the last optional `callback` argument to be a ' +
+        'function. Instead received: %s.', callerName, callback);
+    }
   };
 }
 
@@ -310,12 +302,9 @@ function legacyCreateRootFromDOMContainer(
           (rootSibling: any).hasAttribute(ROOT_ATTRIBUTE_NAME)
         ) {
           warned = true;
-          warningWithoutStack(
-            false,
-            'render(): Target node has markup rendered by React, but there ' +
-              'are unrelated nodes as well. This is most commonly caused by ' +
-              'white-space inserted around server-rendered markup.',
-          );
+          warningWithoutStack('render(): Target node has markup rendered by React, but there ' +
+            'are unrelated nodes as well. This is most commonly caused by ' +
+            'white-space inserted around server-rendered markup.');
         }
       }
       container.removeChild(rootSibling);
@@ -324,12 +313,9 @@ function legacyCreateRootFromDOMContainer(
   if (__DEV__) {
     if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
       warnedAboutHydrateAPI = true;
-      lowPriorityWarningWithoutStack(
-        false,
-        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-          'will stop working in React v17. Replace the ReactDOM.render() call ' +
-          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
-      );
+      lowPriorityWarningWithoutStack('render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+        'will stop working in React v17. Replace the ReactDOM.render() call ' +
+        'with ReactDOM.hydrate() if you want React to attach to the server HTML.');
     }
   }
 
@@ -399,10 +385,10 @@ function createPortal(
   container: DOMContainer,
   key: ?string = null,
 ) {
-  invariant(
-    isValidContainer(container),
-    'Target container is not a DOM element.',
-  );
+  if (!isValidContainer(container)) {
+    invariant('Target container is not a DOM element.');
+  }
+
   // TODO: pass ReactDOM portal implementation as third argument
   return createPortalImpl(children, container, null, key);
 }
@@ -418,15 +404,15 @@ const ReactDOM: Object = {
       if (owner !== null && owner.stateNode !== null) {
         const warnedAboutRefsInRender =
           owner.stateNode._warnedAboutRefsInRender;
-        warningWithoutStack(
-          warnedAboutRefsInRender,
-          '%s is accessing findDOMNode inside its render(). ' +
+
+        if (!warnedAboutRefsInRender) {
+          warningWithoutStack('%s is accessing findDOMNode inside its render(). ' +
             'render() should be a pure function of props and state. It should ' +
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
-            'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
-        );
+            'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+        }
+
         owner.stateNode._warnedAboutRefsInRender = true;
       }
     }
@@ -443,18 +429,16 @@ const ReactDOM: Object = {
   },
 
   hydrate(element: React$Node, container: DOMContainer, callback: ?Function) {
-    invariant(
-      isValidContainer(container),
-      'Target container is not a DOM element.',
-    );
+    if (!isValidContainer(container)) {
+      invariant('Target container is not a DOM element.');
+    }
+
     if (__DEV__) {
-      warningWithoutStack(
-        !container._reactHasBeenPassedToCreateRootDEV,
-        'You are calling ReactDOM.hydrate() on a container that was previously ' +
+      if (container._reactHasBeenPassedToCreateRootDEV) {
+        warningWithoutStack('You are calling ReactDOM.hydrate() on a container that was previously ' +
           'passed to ReactDOM.%s(). This is not supported. ' +
-          'Did you mean to call createRoot(container, {hydrate: true}).render(element)?',
-        enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
-      );
+          'Did you mean to call createRoot(container, {hydrate: true}).render(element)?', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+      }
     }
     // TODO: throw or warn if we couldn't hydrate?
     return legacyRenderSubtreeIntoContainer(
@@ -471,18 +455,16 @@ const ReactDOM: Object = {
     container: DOMContainer,
     callback: ?Function,
   ) {
-    invariant(
-      isValidContainer(container),
-      'Target container is not a DOM element.',
-    );
+    if (!isValidContainer(container)) {
+      invariant('Target container is not a DOM element.');
+    }
+
     if (__DEV__) {
-      warningWithoutStack(
-        !container._reactHasBeenPassedToCreateRootDEV,
-        'You are calling ReactDOM.render() on a container that was previously ' +
+      if (container._reactHasBeenPassedToCreateRootDEV) {
+        warningWithoutStack('You are calling ReactDOM.render() on a container that was previously ' +
           'passed to ReactDOM.%s(). This is not supported. ' +
-          'Did you mean to call root.render(element)?',
-        enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
-      );
+          'Did you mean to call root.render(element)?', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+      }
     }
     return legacyRenderSubtreeIntoContainer(
       null,
@@ -499,14 +481,14 @@ const ReactDOM: Object = {
     containerNode: DOMContainer,
     callback: ?Function,
   ) {
-    invariant(
-      isValidContainer(containerNode),
-      'Target container is not a DOM element.',
-    );
-    invariant(
-      parentComponent != null && hasInstance(parentComponent),
-      'parentComponent must be a valid React Component',
-    );
+    if (!isValidContainer(containerNode)) {
+      invariant('Target container is not a DOM element.');
+    }
+
+    if (!(parentComponent != null && hasInstance(parentComponent))) {
+      invariant('parentComponent must be a valid React Component');
+    }
+
     return legacyRenderSubtreeIntoContainer(
       parentComponent,
       element,
@@ -517,29 +499,29 @@ const ReactDOM: Object = {
   },
 
   unmountComponentAtNode(container: DOMContainer) {
-    invariant(
-      isValidContainer(container),
-      'unmountComponentAtNode(...): Target container is not a DOM element.',
-    );
+    if (!isValidContainer(container)) {
+      invariant('unmountComponentAtNode(...): Target container is not a DOM element.');
+    }
 
     if (__DEV__) {
-      warningWithoutStack(
-        !container._reactHasBeenPassedToCreateRootDEV,
-        'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
-          'passed to ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
-        enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
-      );
+      if (container._reactHasBeenPassedToCreateRootDEV) {
+        warningWithoutStack(
+          'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
+            'passed to ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
+          enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot'
+        );
+      }
     }
 
     if (container._reactRootContainer) {
       if (__DEV__) {
         const rootEl = getReactRootElementInContainer(container);
         const renderedByDifferentReact = rootEl && !getInstanceFromNode(rootEl);
-        warningWithoutStack(
-          !renderedByDifferentReact,
-          "unmountComponentAtNode(): The node you're attempting to unmount " +
-            'was rendered by another copy of React.',
-        );
+
+        if (renderedByDifferentReact) {
+          warningWithoutStack("unmountComponentAtNode(): The node you're attempting to unmount " +
+            'was rendered by another copy of React.');
+        }
       }
 
       // Unmount should not be batched.
@@ -562,16 +544,14 @@ const ReactDOM: Object = {
           isValidContainer(container.parentNode) &&
           !!container.parentNode._reactRootContainer;
 
-        warningWithoutStack(
-          !hasNonRootReactChild,
-          "unmountComponentAtNode(): The node you're attempting to unmount " +
-            'was rendered by React and is not a top-level container. %s',
-          isContainerReactRoot
+        if (hasNonRootReactChild) {
+          warningWithoutStack("unmountComponentAtNode(): The node you're attempting to unmount " +
+            'was rendered by React and is not a top-level container. %s', isContainerReactRoot
             ? 'You may have accidentally passed in a React root node instead ' +
               'of its container.'
             : 'Instead, have the parent component update its state and ' +
-              'rerender in order to remove this component.',
-        );
+              'rerender in order to remove this component.');
+        }
       }
 
       return false;
@@ -583,13 +563,10 @@ const ReactDOM: Object = {
   unstable_createPortal(...args) {
     if (!didWarnAboutUnstableCreatePortal) {
       didWarnAboutUnstableCreatePortal = true;
-      lowPriorityWarningWithoutStack(
-        false,
-        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
-          'and will be removed in React 17+. Update your code to use ' +
-          'ReactDOM.createPortal() instead. It has the exact same API, ' +
-          'but without the "unstable_" prefix.',
-      );
+      lowPriorityWarningWithoutStack('The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+        'and will be removed in React 17+. Update your code to use ' +
+        'ReactDOM.createPortal() instead. It has the exact same API, ' +
+        'but without the "unstable_" prefix.');
     }
     return createPortal(...args);
   },
@@ -653,11 +630,11 @@ function createRoot(
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';
-  invariant(
-    isValidContainer(container),
-    '%s(...): Target container is not a DOM element.',
-    functionName,
-  );
+
+  if (!isValidContainer(container)) {
+    invariant('%s(...): Target container is not a DOM element.', functionName);
+  }
+
   warnIfReactDOMContainerInDEV(container);
   return new ReactRoot(container, options);
 }
@@ -669,23 +646,22 @@ function createSyncRoot(
   const functionName = enableStableConcurrentModeAPIs
     ? 'createRoot'
     : 'unstable_createRoot';
-  invariant(
-    isValidContainer(container),
-    '%s(...): Target container is not a DOM element.',
-    functionName,
-  );
+
+  if (!isValidContainer(container)) {
+    invariant('%s(...): Target container is not a DOM element.', functionName);
+  }
+
   warnIfReactDOMContainerInDEV(container);
   return new ReactSyncRoot(container, BatchedRoot, options);
 }
 
 function warnIfReactDOMContainerInDEV(container) {
   if (__DEV__) {
-    warningWithoutStack(
-      !container._reactRootContainer,
-      'You are calling ReactDOM.%s() on a container that was previously ' +
-        'passed to ReactDOM.render(). This is not supported.',
-      enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
-    );
+    if (container._reactRootContainer) {
+      warningWithoutStack('You are calling ReactDOM.%s() on a container that was previously ' +
+        'passed to ReactDOM.render(). This is not supported.', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+    }
+
     container._reactHasBeenPassedToCreateRootDEV = true;
   }
 }

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -113,7 +113,7 @@ if (__DEV__) {
   ) {
     warningWithoutStack(
       'React depends on Map and Set built-in types. Make sure that you load a ' +
-        'polyfill in older browsers. https://fb.me/react-polyfills'
+        'polyfill in older browsers. https://fb.me/react-polyfills',
     );
   }
 
@@ -124,10 +124,12 @@ if (__DEV__) {
       );
       if (hostInstance) {
         if (!(hostInstance.parentNode === container)) {
-          warningWithoutStack('render(...): It looks like the React-rendered content of this ' +
-            'container was removed without using React. This is not ' +
-            'supported and will cause errors. Instead, call ' +
-            'ReactDOM.unmountComponentAtNode to empty a container.');
+          warningWithoutStack(
+            'render(...): It looks like the React-rendered content of this ' +
+              'container was removed without using React. This is not ' +
+              'supported and will cause errors. Instead, call ' +
+              'ReactDOM.unmountComponentAtNode to empty a container.',
+          );
         }
       }
     }
@@ -137,26 +139,39 @@ if (__DEV__) {
     const hasNonRootReactChild = !!(rootEl && getInstanceFromNode(rootEl));
 
     if (!(!hasNonRootReactChild || isRootRenderedBySomeReact)) {
-      warningWithoutStack('render(...): Replacing React-rendered children with a new root ' +
-        'component. If you intended to update the children of this node, ' +
-        'you should instead have the existing children update their state ' +
-        'and render the new components instead of calling ReactDOM.render.');
+      warningWithoutStack(
+        'render(...): Replacing React-rendered children with a new root ' +
+          'component. If you intended to update the children of this node, ' +
+          'you should instead have the existing children update their state ' +
+          'and render the new components instead of calling ReactDOM.render.',
+      );
     }
 
-    if (!(container.nodeType !== ELEMENT_NODE ||
-      !((container: any): Element).tagName || ((container: any): Element).tagName.toUpperCase() !== 'BODY')) {
-      warningWithoutStack('render(): Rendering components directly into document.body is ' +
-        'discouraged, since its children are often manipulated by third-party ' +
-        'scripts and browser extensions. This may lead to subtle ' +
-        'reconciliation issues. Try rendering into a container element created ' +
-        'for your app.');
+    if (
+      !(
+        container.nodeType !== ELEMENT_NODE ||
+        !((container: any): Element).tagName ||
+        ((container: any): Element).tagName.toUpperCase() !== 'BODY'
+      )
+    ) {
+      warningWithoutStack(
+        'render(): Rendering components directly into document.body is ' +
+          'discouraged, since its children are often manipulated by third-party ' +
+          'scripts and browser extensions. This may lead to subtle ' +
+          'reconciliation issues. Try rendering into a container element created ' +
+          'for your app.',
+      );
     }
   };
 
   warnOnInvalidCallback = function(callback: mixed, callerName: string) {
     if (!(callback === null || typeof callback === 'function')) {
-      warningWithoutStack('%s(...): Expected the last optional `callback` argument to be a ' +
-        'function. Instead received: %s.', callerName, callback);
+      warningWithoutStack(
+        '%s(...): Expected the last optional `callback` argument to be a ' +
+          'function. Instead received: %s.',
+        callerName,
+        callback,
+      );
     }
   };
 }
@@ -302,9 +317,11 @@ function legacyCreateRootFromDOMContainer(
           (rootSibling: any).hasAttribute(ROOT_ATTRIBUTE_NAME)
         ) {
           warned = true;
-          warningWithoutStack('render(): Target node has markup rendered by React, but there ' +
-            'are unrelated nodes as well. This is most commonly caused by ' +
-            'white-space inserted around server-rendered markup.');
+          warningWithoutStack(
+            'render(): Target node has markup rendered by React, but there ' +
+              'are unrelated nodes as well. This is most commonly caused by ' +
+              'white-space inserted around server-rendered markup.',
+          );
         }
       }
       container.removeChild(rootSibling);
@@ -313,9 +330,11 @@ function legacyCreateRootFromDOMContainer(
   if (__DEV__) {
     if (shouldHydrate && !forceHydrate && !warnedAboutHydrateAPI) {
       warnedAboutHydrateAPI = true;
-      lowPriorityWarningWithoutStack('render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
-        'will stop working in React v17. Replace the ReactDOM.render() call ' +
-        'with ReactDOM.hydrate() if you want React to attach to the server HTML.');
+      lowPriorityWarningWithoutStack(
+        'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
+          'will stop working in React v17. Replace the ReactDOM.render() call ' +
+          'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
+      );
     }
   }
 
@@ -406,11 +425,14 @@ const ReactDOM: Object = {
           owner.stateNode._warnedAboutRefsInRender;
 
         if (!warnedAboutRefsInRender) {
-          warningWithoutStack('%s is accessing findDOMNode inside its render(). ' +
-            'render() should be a pure function of props and state. It should ' +
-            'never access something that requires stale data from the previous ' +
-            'render, such as refs. Move this logic to componentDidMount and ' +
-            'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+          warningWithoutStack(
+            '%s is accessing findDOMNode inside its render(). ' +
+              'render() should be a pure function of props and state. It should ' +
+              'never access something that requires stale data from the previous ' +
+              'render, such as refs. Move this logic to componentDidMount and ' +
+              'componentDidUpdate instead.',
+            getComponentName(owner.type) || 'A component',
+          );
         }
 
         owner.stateNode._warnedAboutRefsInRender = true;
@@ -435,9 +457,12 @@ const ReactDOM: Object = {
 
     if (__DEV__) {
       if (container._reactHasBeenPassedToCreateRootDEV) {
-        warningWithoutStack('You are calling ReactDOM.hydrate() on a container that was previously ' +
-          'passed to ReactDOM.%s(). This is not supported. ' +
-          'Did you mean to call createRoot(container, {hydrate: true}).render(element)?', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+        warningWithoutStack(
+          'You are calling ReactDOM.hydrate() on a container that was previously ' +
+            'passed to ReactDOM.%s(). This is not supported. ' +
+            'Did you mean to call createRoot(container, {hydrate: true}).render(element)?',
+          enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+        );
       }
     }
     // TODO: throw or warn if we couldn't hydrate?
@@ -461,9 +486,12 @@ const ReactDOM: Object = {
 
     if (__DEV__) {
       if (container._reactHasBeenPassedToCreateRootDEV) {
-        warningWithoutStack('You are calling ReactDOM.render() on a container that was previously ' +
-          'passed to ReactDOM.%s(). This is not supported. ' +
-          'Did you mean to call root.render(element)?', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+        warningWithoutStack(
+          'You are calling ReactDOM.render() on a container that was previously ' +
+            'passed to ReactDOM.%s(). This is not supported. ' +
+            'Did you mean to call root.render(element)?',
+          enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+        );
       }
     }
     return legacyRenderSubtreeIntoContainer(
@@ -500,7 +528,9 @@ const ReactDOM: Object = {
 
   unmountComponentAtNode(container: DOMContainer) {
     if (!isValidContainer(container)) {
-      invariant('unmountComponentAtNode(...): Target container is not a DOM element.');
+      invariant(
+        'unmountComponentAtNode(...): Target container is not a DOM element.',
+      );
     }
 
     if (__DEV__) {
@@ -508,7 +538,7 @@ const ReactDOM: Object = {
         warningWithoutStack(
           'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
             'passed to ReactDOM.%s(). This is not supported. Did you mean to call root.unmount()?',
-          enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot'
+          enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
         );
       }
     }
@@ -519,8 +549,10 @@ const ReactDOM: Object = {
         const renderedByDifferentReact = rootEl && !getInstanceFromNode(rootEl);
 
         if (renderedByDifferentReact) {
-          warningWithoutStack("unmountComponentAtNode(): The node you're attempting to unmount " +
-            'was rendered by another copy of React.');
+          warningWithoutStack(
+            "unmountComponentAtNode(): The node you're attempting to unmount " +
+              'was rendered by another copy of React.',
+          );
         }
       }
 
@@ -545,12 +577,15 @@ const ReactDOM: Object = {
           !!container.parentNode._reactRootContainer;
 
         if (hasNonRootReactChild) {
-          warningWithoutStack("unmountComponentAtNode(): The node you're attempting to unmount " +
-            'was rendered by React and is not a top-level container. %s', isContainerReactRoot
-            ? 'You may have accidentally passed in a React root node instead ' +
-              'of its container.'
-            : 'Instead, have the parent component update its state and ' +
-              'rerender in order to remove this component.');
+          warningWithoutStack(
+            "unmountComponentAtNode(): The node you're attempting to unmount " +
+              'was rendered by React and is not a top-level container. %s',
+            isContainerReactRoot
+              ? 'You may have accidentally passed in a React root node instead ' +
+                'of its container.'
+              : 'Instead, have the parent component update its state and ' +
+                'rerender in order to remove this component.',
+          );
         }
       }
 
@@ -563,10 +598,12 @@ const ReactDOM: Object = {
   unstable_createPortal(...args) {
     if (!didWarnAboutUnstableCreatePortal) {
       didWarnAboutUnstableCreatePortal = true;
-      lowPriorityWarningWithoutStack('The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
-        'and will be removed in React 17+. Update your code to use ' +
-        'ReactDOM.createPortal() instead. It has the exact same API, ' +
-        'but without the "unstable_" prefix.');
+      lowPriorityWarningWithoutStack(
+        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactDOM.createPortal() instead. It has the exact same API, ' +
+          'but without the "unstable_" prefix.',
+      );
     }
     return createPortal(...args);
   },
@@ -658,8 +695,11 @@ function createSyncRoot(
 function warnIfReactDOMContainerInDEV(container) {
   if (__DEV__) {
     if (container._reactRootContainer) {
-      warningWithoutStack('You are calling ReactDOM.%s() on a container that was previously ' +
-        'passed to ReactDOM.render(). This is not supported.', enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot');
+      warningWithoutStack(
+        'You are calling ReactDOM.%s() on a container that was previously ' +
+          'passed to ReactDOM.render(). This is not supported.',
+        enableStableConcurrentModeAPIs ? 'createRoot' : 'unstable_createRoot',
+      );
     }
 
     container._reactHasBeenPassedToCreateRootDEV = true;

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -183,10 +183,9 @@ if (__DEV__) {
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Text content did not match. Server: "%s" Client: "%s"',
       normalizedServerText,
-      normalizedClientText,
+      normalizedClientText
     );
   };
 
@@ -209,11 +208,10 @@ if (__DEV__) {
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Prop `%s` did not match. Server: %s Client: %s',
       propName,
       JSON.stringify(normalizedServerValue),
-      JSON.stringify(normalizedClientValue),
+      JSON.stringify(normalizedClientValue)
     );
   };
 
@@ -226,26 +224,19 @@ if (__DEV__) {
     attributeNames.forEach(function(name) {
       names.push(name);
     });
-    warningWithoutStack(false, 'Extra attributes from the server: %s', names);
+    warningWithoutStack('Extra attributes from the server: %s', names);
   };
 
   warnForInvalidEventListener = function(registrationName, listener) {
     if (listener === false) {
-      warning(
-        false,
-        'Expected `%s` listener to be a function, instead got `false`.\n\n' +
-          'If you used to conditionally omit it with %s={condition && value}, ' +
-          'pass %s={condition ? value : undefined} instead.',
-        registrationName,
-        registrationName,
-        registrationName,
-      );
+      warning('Expected `%s` listener to be a function, instead got `false`.\n\n' +
+        'If you used to conditionally omit it with %s={condition && value}, ' +
+        'pass %s={condition ? value : undefined} instead.', registrationName, registrationName, registrationName);
     } else {
       warning(
-        false,
         'Expected `%s` listener to be a function, instead got a value of `%s` type.',
         registrationName,
-        typeof listener,
+        typeof listener
       );
     }
   };
@@ -412,15 +403,14 @@ export function createElement(
   if (namespaceURI === HTML_NAMESPACE) {
     if (__DEV__) {
       isCustomComponentTag = isCustomComponent(type, props);
-      // Should this check be gated by parent namespace? Not sure we want to
-      // allow <SVG> or <mATH>.
-      warning(
-        isCustomComponentTag || type === type.toLowerCase(),
-        '<%s /> is using incorrect casing. ' +
+
+      if (!(isCustomComponentTag || type === type.toLowerCase())) {
+        // Should this check be gated by parent namespace? Not sure we want to
+        // allow <SVG> or <mATH>.
+        warning('<%s /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
-          'or lowercase for HTML elements.',
-        type,
-      );
+          'or lowercase for HTML elements.', type);
+      }
     }
 
     if (type === 'script') {
@@ -429,13 +419,10 @@ export function createElement(
       const div = ownerDocument.createElement('div');
       if (__DEV__) {
         if (enableTrustedTypesIntegration && !didWarnScriptTags) {
-          warning(
-            false,
-            'Encountered a script tag while rendering React component. ' +
-              'Scripts inside React components are never executed when rendering ' +
-              'on the client. Consider using template tag instead ' +
-              '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).',
-          );
+          warning('Encountered a script tag while rendering React component. ' +
+            'Scripts inside React components are never executed when rendering ' +
+            'on the client. Consider using template tag instead ' +
+            '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).');
           didWarnScriptTags = true;
         }
       }
@@ -485,13 +472,9 @@ export function createElement(
         !Object.prototype.hasOwnProperty.call(warnedUnknownTags, type)
       ) {
         warnedUnknownTags[type] = true;
-        warning(
-          false,
-          'The tag <%s> is unrecognized in this browser. ' +
-            'If you meant to render a React component, start its name with ' +
-            'an uppercase letter.',
-          type,
-        );
+        warning('The tag <%s> is unrecognized in this browser. ' +
+          'If you meant to render a React component, start its name with ' +
+          'an uppercase letter.', type);
       }
     }
   }
@@ -522,12 +505,8 @@ export function setInitialProperties(
       !didWarnShadyDOM &&
       (domElement: any).shadyRoot
     ) {
-      warning(
-        false,
-        '%s is using shady DOM. Using shady DOM with React can ' +
-          'cause things to break subtly.',
-        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-      );
+      warning('%s is using shady DOM. Using shady DOM with React can ' +
+        'cause things to break subtly.', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
       didWarnShadyDOM = true;
     }
   }
@@ -923,12 +902,8 @@ export function diffHydratedProperties(
       !didWarnShadyDOM &&
       (domElement: any).shadyRoot
     ) {
-      warning(
-        false,
-        '%s is using shady DOM. Using shady DOM with React can ' +
-          'cause things to break subtly.',
-        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-      );
+      warning('%s is using shady DOM. Using shady DOM with React can ' +
+        'cause things to break subtly.', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
       didWarnShadyDOM = true;
     }
   }
@@ -1217,10 +1192,9 @@ export function warnForDeletedHydratableElement(
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Did not expect server HTML to contain a <%s> in <%s>.',
       child.nodeName.toLowerCase(),
-      parentNode.nodeName.toLowerCase(),
+      parentNode.nodeName.toLowerCase()
     );
   }
 }
@@ -1235,10 +1209,9 @@ export function warnForDeletedHydratableText(
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Did not expect server HTML to contain the text node "%s" in <%s>.',
       child.nodeValue,
-      parentNode.nodeName.toLowerCase(),
+      parentNode.nodeName.toLowerCase()
     );
   }
 }
@@ -1254,10 +1227,9 @@ export function warnForInsertedHydratedElement(
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Expected server HTML to contain a matching <%s> in <%s>.',
       tag,
-      parentNode.nodeName.toLowerCase(),
+      parentNode.nodeName.toLowerCase()
     );
   }
 }
@@ -1279,10 +1251,9 @@ export function warnForInsertedHydratedText(
     }
     didWarnInvalidHydration = true;
     warningWithoutStack(
-      false,
       'Expected server HTML to contain a matching text node for "%s" in <%s>.',
       text,
-      parentNode.nodeName.toLowerCase(),
+      parentNode.nodeName.toLowerCase()
     );
   }
 }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -185,7 +185,7 @@ if (__DEV__) {
     warningWithoutStack(
       'Text content did not match. Server: "%s" Client: "%s"',
       normalizedServerText,
-      normalizedClientText
+      normalizedClientText,
     );
   };
 
@@ -211,7 +211,7 @@ if (__DEV__) {
       'Prop `%s` did not match. Server: %s Client: %s',
       propName,
       JSON.stringify(normalizedServerValue),
-      JSON.stringify(normalizedClientValue)
+      JSON.stringify(normalizedClientValue),
     );
   };
 
@@ -229,14 +229,19 @@ if (__DEV__) {
 
   warnForInvalidEventListener = function(registrationName, listener) {
     if (listener === false) {
-      warning('Expected `%s` listener to be a function, instead got `false`.\n\n' +
-        'If you used to conditionally omit it with %s={condition && value}, ' +
-        'pass %s={condition ? value : undefined} instead.', registrationName, registrationName, registrationName);
+      warning(
+        'Expected `%s` listener to be a function, instead got `false`.\n\n' +
+          'If you used to conditionally omit it with %s={condition && value}, ' +
+          'pass %s={condition ? value : undefined} instead.',
+        registrationName,
+        registrationName,
+        registrationName,
+      );
     } else {
       warning(
         'Expected `%s` listener to be a function, instead got a value of `%s` type.',
         registrationName,
-        typeof listener
+        typeof listener,
       );
     }
   };
@@ -407,9 +412,12 @@ export function createElement(
       if (!(isCustomComponentTag || type === type.toLowerCase())) {
         // Should this check be gated by parent namespace? Not sure we want to
         // allow <SVG> or <mATH>.
-        warning('<%s /> is using incorrect casing. ' +
-          'Use PascalCase for React components, ' +
-          'or lowercase for HTML elements.', type);
+        warning(
+          '<%s /> is using incorrect casing. ' +
+            'Use PascalCase for React components, ' +
+            'or lowercase for HTML elements.',
+          type,
+        );
       }
     }
 
@@ -419,10 +427,12 @@ export function createElement(
       const div = ownerDocument.createElement('div');
       if (__DEV__) {
         if (enableTrustedTypesIntegration && !didWarnScriptTags) {
-          warning('Encountered a script tag while rendering React component. ' +
-            'Scripts inside React components are never executed when rendering ' +
-            'on the client. Consider using template tag instead ' +
-            '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).');
+          warning(
+            'Encountered a script tag while rendering React component. ' +
+              'Scripts inside React components are never executed when rendering ' +
+              'on the client. Consider using template tag instead ' +
+              '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).',
+          );
           didWarnScriptTags = true;
         }
       }
@@ -472,9 +482,12 @@ export function createElement(
         !Object.prototype.hasOwnProperty.call(warnedUnknownTags, type)
       ) {
         warnedUnknownTags[type] = true;
-        warning('The tag <%s> is unrecognized in this browser. ' +
-          'If you meant to render a React component, start its name with ' +
-          'an uppercase letter.', type);
+        warning(
+          'The tag <%s> is unrecognized in this browser. ' +
+            'If you meant to render a React component, start its name with ' +
+            'an uppercase letter.',
+          type,
+        );
       }
     }
   }
@@ -505,8 +518,11 @@ export function setInitialProperties(
       !didWarnShadyDOM &&
       (domElement: any).shadyRoot
     ) {
-      warning('%s is using shady DOM. Using shady DOM with React can ' +
-        'cause things to break subtly.', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
+      warning(
+        '%s is using shady DOM. Using shady DOM with React can ' +
+          'cause things to break subtly.',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
+      );
       didWarnShadyDOM = true;
     }
   }
@@ -902,8 +918,11 @@ export function diffHydratedProperties(
       !didWarnShadyDOM &&
       (domElement: any).shadyRoot
     ) {
-      warning('%s is using shady DOM. Using shady DOM with React can ' +
-        'cause things to break subtly.', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
+      warning(
+        '%s is using shady DOM. Using shady DOM with React can ' +
+          'cause things to break subtly.',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
+      );
       didWarnShadyDOM = true;
     }
   }
@@ -1194,7 +1213,7 @@ export function warnForDeletedHydratableElement(
     warningWithoutStack(
       'Did not expect server HTML to contain a <%s> in <%s>.',
       child.nodeName.toLowerCase(),
-      parentNode.nodeName.toLowerCase()
+      parentNode.nodeName.toLowerCase(),
     );
   }
 }
@@ -1211,7 +1230,7 @@ export function warnForDeletedHydratableText(
     warningWithoutStack(
       'Did not expect server HTML to contain the text node "%s" in <%s>.',
       child.nodeValue,
-      parentNode.nodeName.toLowerCase()
+      parentNode.nodeName.toLowerCase(),
     );
   }
 }
@@ -1229,7 +1248,7 @@ export function warnForInsertedHydratedElement(
     warningWithoutStack(
       'Expected server HTML to contain a matching <%s> in <%s>.',
       tag,
-      parentNode.nodeName.toLowerCase()
+      parentNode.nodeName.toLowerCase(),
     );
   }
 }
@@ -1253,7 +1272,7 @@ export function warnForInsertedHydratedText(
     warningWithoutStack(
       'Expected server HTML to contain a matching text node for "%s" in <%s>.',
       text,
-      parentNode.nodeName.toLowerCase()
+      parentNode.nodeName.toLowerCase(),
     );
   }
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -146,7 +146,7 @@ export function getNodeFromInstance(inst) {
 
   // Without this first invariant, passing a non-DOM-component triggers the next
   // invariant for a missing parent, which is super confusing.
-  invariant(false, 'getNodeFromInstance: Invalid argument.');
+  invariant('getNodeFromInstance: Invalid argument.');
 }
 
 export function getFiberCurrentPropsFromNode(node) {

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -80,7 +80,6 @@ export function initWrapperState(element: Element, props: Object) {
       !didWarnCheckedDefaultChecked
     ) {
       warning(
-        false,
         '%s contains an input of type %s with both checked and defaultChecked props. ' +
           'Input elements must be either controlled or uncontrolled ' +
           '(specify either the checked prop, or the defaultChecked prop, but not ' +
@@ -88,7 +87,7 @@ export function initWrapperState(element: Element, props: Object) {
           'element and remove one of these props. More info: ' +
           'https://fb.me/react-controlled-components',
         getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-        props.type,
+        props.type
       );
       didWarnCheckedDefaultChecked = true;
     }
@@ -98,7 +97,6 @@ export function initWrapperState(element: Element, props: Object) {
       !didWarnValueDefaultValue
     ) {
       warning(
-        false,
         '%s contains an input of type %s with both value and defaultValue props. ' +
           'Input elements must be either controlled or uncontrolled ' +
           '(specify either the value prop, or the defaultValue prop, but not ' +
@@ -106,7 +104,7 @@ export function initWrapperState(element: Element, props: Object) {
           'element and remove one of these props. More info: ' +
           'https://fb.me/react-controlled-components',
         getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-        props.type,
+        props.type
       );
       didWarnValueDefaultValue = true;
     }
@@ -144,12 +142,11 @@ export function updateWrapper(element: Element, props: Object) {
       !didWarnUncontrolledToControlled
     ) {
       warning(
-        false,
         'A component is changing an uncontrolled input of type %s to be controlled. ' +
           'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
-        props.type,
+        props.type
       );
       didWarnUncontrolledToControlled = true;
     }
@@ -159,12 +156,11 @@ export function updateWrapper(element: Element, props: Object) {
       !didWarnControlledToUncontrolled
     ) {
       warning(
-        false,
         'A component is changing a controlled input of type %s to be uncontrolled. ' +
           'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
-        props.type,
+        props.type
       );
       didWarnControlledToUncontrolled = true;
     }
@@ -381,11 +377,11 @@ function updateNamedCousins(rootNode, props) {
       // That's probably okay; we don't support it just as we don't support
       // mixing React radio buttons with non-React ones.
       const otherProps = getFiberCurrentPropsFromNode(otherNode);
-      invariant(
-        otherProps,
-        'ReactDOMInput: Mixing React and non-React radio inputs with the ' +
-          'same `name` is not supported.',
-      );
+
+      if (!otherProps) {
+        invariant('ReactDOMInput: Mixing React and non-React radio inputs with the ' +
+          'same `name` is not supported.');
+      }
 
       // We need update the tracked value on the named cousin since the value
       // was changed but the input saw no event or value set

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -87,7 +87,7 @@ export function initWrapperState(element: Element, props: Object) {
           'element and remove one of these props. More info: ' +
           'https://fb.me/react-controlled-components',
         getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-        props.type
+        props.type,
       );
       didWarnCheckedDefaultChecked = true;
     }
@@ -104,7 +104,7 @@ export function initWrapperState(element: Element, props: Object) {
           'element and remove one of these props. More info: ' +
           'https://fb.me/react-controlled-components',
         getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-        props.type
+        props.type,
       );
       didWarnValueDefaultValue = true;
     }
@@ -146,7 +146,7 @@ export function updateWrapper(element: Element, props: Object) {
           'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
-        props.type
+        props.type,
       );
       didWarnUncontrolledToControlled = true;
     }
@@ -160,7 +160,7 @@ export function updateWrapper(element: Element, props: Object) {
           'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
           'Decide between using a controlled or uncontrolled input ' +
           'element for the lifetime of the component. More info: https://fb.me/react-controlled-components',
-        props.type
+        props.type,
       );
       didWarnControlledToUncontrolled = true;
     }
@@ -379,8 +379,10 @@ function updateNamedCousins(rootNode, props) {
       const otherProps = getFiberCurrentPropsFromNode(otherNode);
 
       if (!otherProps) {
-        invariant('ReactDOMInput: Mixing React and non-React radio inputs with the ' +
-          'same `name` is not supported.');
+        invariant(
+          'ReactDOMInput: Mixing React and non-React radio inputs with the ' +
+            'same `name` is not supported.',
+        );
       }
 
       // We need update the tracked value on the named cousin since the value

--- a/packages/react-dom/src/client/ReactDOMOption.js
+++ b/packages/react-dom/src/client/ReactDOMOption.js
@@ -58,21 +58,15 @@ export function validateProps(element: Element, props: Object) {
         }
         if (!didWarnInvalidChild) {
           didWarnInvalidChild = true;
-          warning(
-            false,
-            'Only strings and numbers are supported as <option> children.',
-          );
+          warning('Only strings and numbers are supported as <option> children.');
         }
       });
     }
 
     // TODO: Remove support for `selected` in <option>.
     if (props.selected != null && !didWarnSelectedSetOnOption) {
-      warning(
-        false,
-        'Use the `defaultValue` or `value` props on <select> instead of ' +
-          'setting `selected` on <option>.',
-      );
+      warning('Use the `defaultValue` or `value` props on <select> instead of ' +
+        'setting `selected` on <option>.');
       didWarnSelectedSetOnOption = true;
     }
   }

--- a/packages/react-dom/src/client/ReactDOMOption.js
+++ b/packages/react-dom/src/client/ReactDOMOption.js
@@ -58,15 +58,19 @@ export function validateProps(element: Element, props: Object) {
         }
         if (!didWarnInvalidChild) {
           didWarnInvalidChild = true;
-          warning('Only strings and numbers are supported as <option> children.');
+          warning(
+            'Only strings and numbers are supported as <option> children.',
+          );
         }
       });
     }
 
     // TODO: Remove support for `selected` in <option>.
     if (props.selected != null && !didWarnSelectedSetOnOption) {
-      warning('Use the `defaultValue` or `value` props on <select> instead of ' +
-        'setting `selected` on <option>.');
+      warning(
+        'Use the `defaultValue` or `value` props on <select> instead of ' +
+          'setting `selected` on <option>.',
+      );
       didWarnSelectedSetOnOption = true;
     }
   }

--- a/packages/react-dom/src/client/ReactDOMSelect.js
+++ b/packages/react-dom/src/client/ReactDOMSelect.js
@@ -49,21 +49,11 @@ function checkSelectPropTypes(props) {
     }
     const isArray = Array.isArray(props[propName]);
     if (props.multiple && !isArray) {
-      warning(
-        false,
-        'The `%s` prop supplied to <select> must be an array if ' +
-          '`multiple` is true.%s',
-        propName,
-        getDeclarationErrorAddendum(),
-      );
+      warning('The `%s` prop supplied to <select> must be an array if ' +
+        '`multiple` is true.%s', propName, getDeclarationErrorAddendum());
     } else if (!props.multiple && isArray) {
-      warning(
-        false,
-        'The `%s` prop supplied to <select> must be a scalar ' +
-          'value if `multiple` is false.%s',
-        propName,
-        getDeclarationErrorAddendum(),
-      );
+      warning('The `%s` prop supplied to <select> must be a scalar ' +
+        'value if `multiple` is false.%s', propName, getDeclarationErrorAddendum());
     }
   }
 }
@@ -156,14 +146,11 @@ export function initWrapperState(element: Element, props: Object) {
       props.defaultValue !== undefined &&
       !didWarnValueDefaultValue
     ) {
-      warning(
-        false,
-        'Select elements must be either controlled or uncontrolled ' +
-          '(specify either the value prop, or the defaultValue prop, but not ' +
-          'both). Decide between using a controlled or uncontrolled select ' +
-          'element and remove one of these props. More info: ' +
-          'https://fb.me/react-controlled-components',
-      );
+      warning('Select elements must be either controlled or uncontrolled ' +
+        '(specify either the value prop, or the defaultValue prop, but not ' +
+        'both). Decide between using a controlled or uncontrolled select ' +
+        'element and remove one of these props. More info: ' +
+        'https://fb.me/react-controlled-components');
       didWarnValueDefaultValue = true;
     }
   }

--- a/packages/react-dom/src/client/ReactDOMSelect.js
+++ b/packages/react-dom/src/client/ReactDOMSelect.js
@@ -49,11 +49,19 @@ function checkSelectPropTypes(props) {
     }
     const isArray = Array.isArray(props[propName]);
     if (props.multiple && !isArray) {
-      warning('The `%s` prop supplied to <select> must be an array if ' +
-        '`multiple` is true.%s', propName, getDeclarationErrorAddendum());
+      warning(
+        'The `%s` prop supplied to <select> must be an array if ' +
+          '`multiple` is true.%s',
+        propName,
+        getDeclarationErrorAddendum(),
+      );
     } else if (!props.multiple && isArray) {
-      warning('The `%s` prop supplied to <select> must be a scalar ' +
-        'value if `multiple` is false.%s', propName, getDeclarationErrorAddendum());
+      warning(
+        'The `%s` prop supplied to <select> must be a scalar ' +
+          'value if `multiple` is false.%s',
+        propName,
+        getDeclarationErrorAddendum(),
+      );
     }
   }
 }
@@ -146,11 +154,13 @@ export function initWrapperState(element: Element, props: Object) {
       props.defaultValue !== undefined &&
       !didWarnValueDefaultValue
     ) {
-      warning('Select elements must be either controlled or uncontrolled ' +
-        '(specify either the value prop, or the defaultValue prop, but not ' +
-        'both). Decide between using a controlled or uncontrolled select ' +
-        'element and remove one of these props. More info: ' +
-        'https://fb.me/react-controlled-components');
+      warning(
+        'Select elements must be either controlled or uncontrolled ' +
+          '(specify either the value prop, or the defaultValue prop, but not ' +
+          'both). Decide between using a controlled or uncontrolled select ' +
+          'element and remove one of these props. More info: ' +
+          'https://fb.me/react-controlled-components',
+      );
       didWarnValueDefaultValue = true;
     }
   }

--- a/packages/react-dom/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMTextarea.js
@@ -71,12 +71,15 @@ export function initWrapperState(element: Element, props: Object) {
       props.defaultValue !== undefined &&
       !didWarnValDefaultVal
     ) {
-      warning('%s contains a textarea with both value and defaultValue props. ' +
-        'Textarea elements must be either controlled or uncontrolled ' +
-        '(specify either the value prop, or the defaultValue prop, but not ' +
-        'both). Decide between using a controlled or uncontrolled textarea ' +
-        'and remove one of these props. More info: ' +
-        'https://fb.me/react-controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
+      warning(
+        '%s contains a textarea with both value and defaultValue props. ' +
+          'Textarea elements must be either controlled or uncontrolled ' +
+          '(specify either the value prop, or the defaultValue prop, but not ' +
+          'both). Decide between using a controlled or uncontrolled textarea ' +
+          'and remove one of these props. More info: ' +
+          'https://fb.me/react-controlled-components',
+        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
+      );
       didWarnValDefaultVal = true;
     }
   }
@@ -90,12 +93,16 @@ export function initWrapperState(element: Element, props: Object) {
     let children = props.children;
     if (children != null) {
       if (__DEV__) {
-        warning('Use the `defaultValue` or `value` props instead of setting ' +
-          'children on <textarea>.');
+        warning(
+          'Use the `defaultValue` or `value` props instead of setting ' +
+            'children on <textarea>.',
+        );
       }
 
       if (!(defaultValue == null)) {
-        invariant('If you supply `defaultValue` on a <textarea>, do not pass children.');
+        invariant(
+          'If you supply `defaultValue` on a <textarea>, do not pass children.',
+        );
       }
 
       if (Array.isArray(children)) {

--- a/packages/react-dom/src/client/ReactDOMTextarea.js
+++ b/packages/react-dom/src/client/ReactDOMTextarea.js
@@ -41,10 +41,10 @@ type TextAreaWithWrapperState = HTMLTextAreaElement & {
 
 export function getHostProps(element: Element, props: Object) {
   const node = ((element: any): TextAreaWithWrapperState);
-  invariant(
-    props.dangerouslySetInnerHTML == null,
-    '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
-  );
+
+  if (!(props.dangerouslySetInnerHTML == null)) {
+    invariant('`dangerouslySetInnerHTML` does not make sense on <textarea>.');
+  }
 
   // Always set children to the same thing. In IE9, the selection range will
   // get reset if `textContent` is mutated.  We could add a check in setTextContent
@@ -71,16 +71,12 @@ export function initWrapperState(element: Element, props: Object) {
       props.defaultValue !== undefined &&
       !didWarnValDefaultVal
     ) {
-      warning(
-        false,
-        '%s contains a textarea with both value and defaultValue props. ' +
-          'Textarea elements must be either controlled or uncontrolled ' +
-          '(specify either the value prop, or the defaultValue prop, but not ' +
-          'both). Decide between using a controlled or uncontrolled textarea ' +
-          'and remove one of these props. More info: ' +
-          'https://fb.me/react-controlled-components',
-        getCurrentFiberOwnerNameInDevOrNull() || 'A component',
-      );
+      warning('%s contains a textarea with both value and defaultValue props. ' +
+        'Textarea elements must be either controlled or uncontrolled ' +
+        '(specify either the value prop, or the defaultValue prop, but not ' +
+        'both). Decide between using a controlled or uncontrolled textarea ' +
+        'and remove one of these props. More info: ' +
+        'https://fb.me/react-controlled-components', getCurrentFiberOwnerNameInDevOrNull() || 'A component');
       didWarnValDefaultVal = true;
     }
   }
@@ -94,21 +90,19 @@ export function initWrapperState(element: Element, props: Object) {
     let children = props.children;
     if (children != null) {
       if (__DEV__) {
-        warning(
-          false,
-          'Use the `defaultValue` or `value` props instead of setting ' +
-            'children on <textarea>.',
-        );
+        warning('Use the `defaultValue` or `value` props instead of setting ' +
+          'children on <textarea>.');
       }
-      invariant(
-        defaultValue == null,
-        'If you supply `defaultValue` on a <textarea>, do not pass children.',
-      );
+
+      if (!(defaultValue == null)) {
+        invariant('If you supply `defaultValue` on a <textarea>, do not pass children.');
+      }
+
       if (Array.isArray(children)) {
-        invariant(
-          children.length <= 1,
-          '<textarea> can only have at most one child.',
-        );
+        if (!(children.length <= 1)) {
+          invariant('<textarea> can only have at most one child.');
+        }
+
         children = children[0];
       }
 

--- a/packages/react-dom/src/client/setInnerHTML.js
+++ b/packages/react-dom/src/client/setInnerHTML.js
@@ -33,12 +33,14 @@ const setInnerHTML = createMicrosoftUnsafeLocalFunction(function(
         if (!(typeof trustedTypes === 'undefined')) {
           // TODO: reconsider the text of this warning and when it should show
           // before enabling the feature flag.
-          warning("Using 'dangerouslySetInnerHTML' in an svg element with " +
-            'Trusted Types enabled in an Internet Explorer will cause ' +
-            'the trusted value to be converted to string. Assigning string ' +
-            "to 'innerHTML' will throw an error if Trusted Types are enforced. " +
-            "You can try to wrap your svg element inside a div and use 'dangerouslySetInnerHTML' " +
-            'on the enclosing div instead.');
+          warning(
+            "Using 'dangerouslySetInnerHTML' in an svg element with " +
+              'Trusted Types enabled in an Internet Explorer will cause ' +
+              'the trusted value to be converted to string. Assigning string ' +
+              "to 'innerHTML' will throw an error if Trusted Types are enforced. " +
+              "You can try to wrap your svg element inside a div and use 'dangerouslySetInnerHTML' " +
+              'on the enclosing div instead.',
+          );
         }
       }
     }

--- a/packages/react-dom/src/client/setInnerHTML.js
+++ b/packages/react-dom/src/client/setInnerHTML.js
@@ -30,17 +30,16 @@ const setInnerHTML = createMicrosoftUnsafeLocalFunction(function(
   if (node.namespaceURI === Namespaces.svg) {
     if (__DEV__) {
       if (enableTrustedTypesIntegration) {
-        // TODO: reconsider the text of this warning and when it should show
-        // before enabling the feature flag.
-        warning(
-          typeof trustedTypes === 'undefined',
-          "Using 'dangerouslySetInnerHTML' in an svg element with " +
+        if (!(typeof trustedTypes === 'undefined')) {
+          // TODO: reconsider the text of this warning and when it should show
+          // before enabling the feature flag.
+          warning("Using 'dangerouslySetInnerHTML' in an svg element with " +
             'Trusted Types enabled in an Internet Explorer will cause ' +
             'the trusted value to be converted to string. Assigning string ' +
             "to 'innerHTML' will throw an error if Trusted Types are enforced. " +
             "You can try to wrap your svg element inside a div and use 'dangerouslySetInnerHTML' " +
-            'on the enclosing div instead.',
-        );
+            'on the enclosing div instead.');
+        }
       }
     }
     if (!('innerHTML' in node)) {

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -412,7 +412,9 @@ if (__DEV__) {
 
     if (childText != null) {
       if (!(childTag == null)) {
-        warningWithoutStack('validateDOMNesting: when childText is passed, childTag should be null');
+        warningWithoutStack(
+          'validateDOMNesting: when childText is passed, childTag should be null',
+        );
       }
 
       childTag = '#text';
@@ -467,11 +469,16 @@ if (__DEV__) {
         ancestorTag,
         whitespaceInfo,
         info,
-        addendum
+        addendum,
       );
     } else {
-      warningWithoutStack('validateDOMNesting(...): %s cannot appear as a descendant of ' +
-        '<%s>.%s', tagDisplayName, ancestorTag, addendum);
+      warningWithoutStack(
+        'validateDOMNesting(...): %s cannot appear as a descendant of ' +
+          '<%s>.%s',
+        tagDisplayName,
+        ancestorTag,
+        addendum,
+      );
     }
   };
 }

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -411,10 +411,10 @@ if (__DEV__) {
     const parentTag = parentInfo && parentInfo.tag;
 
     if (childText != null) {
-      warningWithoutStack(
-        childTag == null,
-        'validateDOMNesting: when childText is passed, childTag should be null',
-      );
+      if (!(childTag == null)) {
+        warningWithoutStack('validateDOMNesting: when childText is passed, childTag should be null');
+      }
+
       childTag = '#text';
     }
 
@@ -462,23 +462,16 @@ if (__DEV__) {
           'the browser.';
       }
       warningWithoutStack(
-        false,
         'validateDOMNesting(...): %s cannot appear as a child of <%s>.%s%s%s',
         tagDisplayName,
         ancestorTag,
         whitespaceInfo,
         info,
-        addendum,
+        addendum
       );
     } else {
-      warningWithoutStack(
-        false,
-        'validateDOMNesting(...): %s cannot appear as a descendant of ' +
-          '<%s>.%s',
-        tagDisplayName,
-        ancestorTag,
-        addendum,
-      );
+      warningWithoutStack('validateDOMNesting(...): %s cannot appear as a descendant of ' +
+        '<%s>.%s', tagDisplayName, ancestorTag, addendum);
     }
   };
 }

--- a/packages/react-dom/src/events/DOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DOMEventResponderSystem.js
@@ -235,7 +235,6 @@ function validateEventValue(eventValue: any): void {
     const showWarning = name => {
       if (__DEV__) {
         warning(
-          false,
           '%s is not available on event objects created from event responder modules (React Flare). ' +
             'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.%s }`',
           name,
@@ -473,10 +472,9 @@ export function unmountEventResponder(
 }
 
 function validateResponderContext(): void {
-  invariant(
-    currentInstance !== null,
-    'An event responder context was used outside of an event cycle.',
-  );
+  if (!(currentInstance !== null)) {
+    invariant('An event responder context was used outside of an event cycle.');
+  }
 }
 
 export function dispatchEventForResponderEventSystem(
@@ -546,13 +544,16 @@ function registerRootEventType(
   if (rootEventTypesSet === null) {
     rootEventTypesSet = eventResponderInstance.rootEventTypes = new Set();
   }
-  invariant(
-    !rootEventTypesSet.has(rootEventType),
-    'addRootEventTypes() found a duplicate root event ' +
-      'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
-      'array or because of a previous addRootEventTypes() using this root event type.',
-    rootEventType,
-  );
+
+  if (rootEventTypesSet.has(rootEventType)) {
+    invariant(
+      'addRootEventTypes() found a duplicate root event ' +
+        'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
+        'array or because of a previous addRootEventTypes() using this root event type.',
+      rootEventType,
+    );
+  }
+
   rootEventTypesSet.add(rootEventType);
   rootEventResponderInstances.add(eventResponderInstance);
 }

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -342,12 +342,8 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
       default:
         if (__DEV__) {
           if (knownHTMLTopLevelTypes.indexOf(topLevelType) === -1) {
-            warningWithoutStack(
-              false,
-              'SimpleEventPlugin: Unhandled event type, `%s`. This warning ' +
-                'is likely caused by a bug in React. Please file an issue.',
-              topLevelType,
-            );
+            warningWithoutStack('SimpleEventPlugin: Unhandled event type, `%s`. This warning ' +
+              'is likely caused by a bug in React. Please file an issue.', topLevelType);
           }
         }
         // HTML Events

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -342,8 +342,11 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
       default:
         if (__DEV__) {
           if (knownHTMLTopLevelTypes.indexOf(topLevelType) === -1) {
-            warningWithoutStack('SimpleEventPlugin: Unhandled event type, `%s`. This warning ' +
-              'is likely caused by a bug in React. Please file an issue.', topLevelType);
+            warningWithoutStack(
+              'SimpleEventPlugin: Unhandled event type, `%s`. This warning ' +
+                'is likely caused by a bug in React. Please file an issue.',
+              topLevelType,
+            );
           }
         }
         // HTML Events

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -13,14 +13,14 @@ import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
 function renderToNodeStream() {
   invariant(
     'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToString() instead.'
+      'in the browser. Use ReactDOMServer.renderToString() instead.',
   );
 }
 
 function renderToStaticNodeStream() {
   invariant(
     'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.'
+      'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
   );
 }
 

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -12,17 +12,15 @@ import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
 
 function renderToNodeStream() {
   invariant(
-    false,
     'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToString() instead.',
+      'in the browser. Use ReactDOMServer.renderToString() instead.'
   );
 }
 
 function renderToStaticNodeStream() {
   invariant(
-    false,
     'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
+      'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.'
   );
 }
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -273,9 +273,14 @@ function warnNoop(
       return;
     }
 
-    warningWithoutStack('%s(...): Can only update a mounting component. ' +
-      'This usually means you called %s() outside componentWillMount() on the server. ' +
-      'This is a no-op.\n\nPlease check the code for the %s component.', callerName, callerName, componentName);
+    warningWithoutStack(
+      '%s(...): Can only update a mounting component. ' +
+        'This usually means you called %s() outside componentWillMount() on the server. ' +
+        'This is a no-op.\n\nPlease check the code for the %s component.',
+      callerName,
+      callerName,
+      componentName,
+    );
     didWarnAboutNoopUpdateForComponent[warningKey] = true;
   }
 }
@@ -401,9 +406,12 @@ function createOpenTagMarkup(
 
 function validateRenderResult(child, type) {
   if (child === undefined) {
-    invariant('%s(...): Nothing was returned from render. This usually means a ' +
-      'return statement is missing. Or, to render nothing, ' +
-      'return null.', getComponentName(type) || 'Component');
+    invariant(
+      '%s(...): Nothing was returned from render. This usually means a ' +
+        'return statement is missing. Or, to render nothing, ' +
+        'return null.',
+      getComponentName(type) || 'Component',
+    );
   }
 }
 
@@ -467,10 +475,15 @@ function resolve(
           if (inst.state === null || inst.state === undefined) {
             const componentName = getComponentName(Component) || 'Unknown';
             if (!didWarnAboutUninitializedState[componentName]) {
-              warningWithoutStack('`%s` uses `getDerivedStateFromProps` but its initial state is ' +
-                '%s. This is not recommended. Instead, define the initial state by ' +
-                'assigning an object to `this.state` in the constructor of `%s`. ' +
-                'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, inst.state === null ? 'null' : 'undefined', componentName);
+              warningWithoutStack(
+                '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+                  '%s. This is not recommended. Instead, define the initial state by ' +
+                  'assigning an object to `this.state` in the constructor of `%s`. ' +
+                  'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
+                componentName,
+                inst.state === null ? 'null' : 'undefined',
+                componentName,
+              );
               didWarnAboutUninitializedState[componentName] = true;
             }
           }
@@ -489,7 +502,7 @@ function resolve(
               warningWithoutStack(
                 '%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' +
                   'You have returned undefined.',
-                componentName
+                componentName,
               );
               didWarnAboutUndefinedDerivedState[componentName] = true;
             }
@@ -513,7 +526,7 @@ function resolve(
               "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
                 'This is likely to cause errors. Change %s to extend React.Component instead.',
               componentName,
-              componentName
+              componentName,
             );
             didWarnAboutBadClass[componentName] = true;
           }
@@ -541,7 +554,7 @@ function resolve(
               'cannot be called with `new` by React.',
             componentName,
             componentName,
-            componentName
+            componentName,
           );
           didWarnAboutModulePatternComponent[componentName] = true;
         }
@@ -569,12 +582,15 @@ function resolve(
             const componentName = getComponentName(Component) || 'Unknown';
 
             if (!didWarnAboutDeprecatedWillMount[componentName]) {
-              lowPriorityWarningWithoutStack(// keep this warning in sync with ReactStrictModeWarning.js
-              'componentWillMount has been renamed, and is not recommended for use. ' +
-                'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-                '* Move code from componentWillMount to componentDidMount (preferred in most cases) ' +
-                'or the constructor.\n' +
-                '\nPlease update the following components: %s', componentName);
+              lowPriorityWarningWithoutStack(
+                // keep this warning in sync with ReactStrictModeWarning.js
+                'componentWillMount has been renamed, and is not recommended for use. ' +
+                  'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+                  '* Move code from componentWillMount to componentDidMount (preferred in most cases) ' +
+                  'or the constructor.\n' +
+                  '\nPlease update the following components: %s',
+                componentName,
+              );
               didWarnAboutDeprecatedWillMount[componentName] = true;
             }
           }
@@ -645,7 +661,7 @@ function resolve(
           warningWithoutStack(
             '%s uses the legacy childContextTypes API which is no longer supported. ' +
               'Use React.createContext() instead.',
-            getComponentName(Component) || 'Unknown'
+            getComponentName(Component) || 'Unknown',
           );
         }
       }
@@ -659,13 +675,16 @@ function resolve(
               invariant(
                 '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
                 getComponentName(Component) || 'Unknown',
-                contextKey
+                contextKey,
               );
             }
           }
         } else {
-          warningWithoutStack('%s.getChildContext(): childContextTypes must be defined in order to ' +
-            'use getChildContext().', getComponentName(Component) || 'Unknown');
+          warningWithoutStack(
+            '%s.getChildContext(): childContextTypes must be defined in order to ' +
+              'use getChildContext().',
+            getComponentName(Component) || 'Unknown',
+          );
         }
       }
       if (childContext) {
@@ -778,7 +797,9 @@ class ReactDOMServerRenderer {
   popProvider<T>(provider: ReactProvider<T>): void {
     const index = this.contextIndex;
     if (__DEV__) {
-      if (!(index > -1 && provider === (this.contextProviderStack: any)[index])) {
+      if (
+        !(index > -1 && provider === (this.contextProviderStack: any)[index])
+      ) {
         warningWithoutStack('Unexpected pop.');
       }
     }
@@ -857,8 +878,10 @@ class ReactDOMServerRenderer {
               const fallbackFrame = frame.fallbackFrame;
 
               if (!fallbackFrame) {
-                invariant('ReactDOMServer did not find an internal fallback frame for Suspense. ' +
-                  'This is a bug in React. Please file an issue.');
+                invariant(
+                  'ReactDOMServer did not find an internal fallback frame for Suspense. ' +
+                    'This is a bug in React. Please file an issue.',
+                );
               }
 
               this.stack.push(fallbackFrame);
@@ -893,7 +916,7 @@ class ReactDOMServerRenderer {
                   'A React component suspended while rendering, but no fallback UI was specified.\n' +
                     '\n' +
                     'Add a <Suspense fallback=...> component higher in the tree to ' +
-                    'provide a loading indicator or placeholder to display.'
+                    'provide a loading indicator or placeholder to display.',
                 );
               }
 
@@ -950,13 +973,18 @@ class ReactDOMServerRenderer {
           const $$typeof = nextChild.$$typeof;
 
           if (!($$typeof !== REACT_PORTAL_TYPE)) {
-            invariant('Portals are not currently supported by the server renderer. ' +
-              'Render them conditionally so that they only appear on the client render.');
+            invariant(
+              'Portals are not currently supported by the server renderer. ' +
+                'Render them conditionally so that they only appear on the client render.',
+            );
           }
 
           // Catch-all to prevent an infinite loop if React.Children.toArray() supports some new type.
-          invariant('Unknown element-like object type: %s. This is likely a bug in React. ' +
-            'Please file an issue.', ($$typeof: any).toString());
+          invariant(
+            'Unknown element-like object type: %s. This is likely a bug in React. ' +
+              'Please file an issue.',
+            ($$typeof: any).toString(),
+          );
         }
         const nextChildren = toArray(nextChild);
         const frame: Frame = {
@@ -1151,8 +1179,10 @@ class ReactDOMServerRenderer {
                 if (reactContext !== reactContext.Consumer) {
                   if (!hasWarnedAboutUsingContextAsConsumer) {
                     hasWarnedAboutUsingContextAsConsumer = true;
-                    warning('Rendering <Context> directly is not supported and will be removed in ' +
-                      'a future major release. Did you mean to render <Context.Consumer> instead?');
+                    warning(
+                      'Rendering <Context> directly is not supported and will be removed in ' +
+                        'a future major release. Did you mean to render <Context.Consumer> instead?',
+                    );
                   }
                 }
               } else {
@@ -1211,7 +1241,9 @@ class ReactDOMServerRenderer {
               this.stack.push(frame);
               return open;
             }
-            invariant('ReactDOMServer does not yet support the fundamental API.');
+            invariant(
+              'ReactDOMServer does not yet support the fundamental API.',
+            );
           }
           // eslint-disable-next-line-no-fallthrough
           case REACT_LAZY_TYPE: {
@@ -1247,7 +1279,9 @@ class ReactDOMServerRenderer {
                 throw lazyComponent._result;
               case Pending:
               default:
-                invariant('ReactDOMServer does not yet support lazy-loaded components.');
+                invariant(
+                  'ReactDOMServer does not yet support lazy-loaded components.',
+                );
             }
           }
           // eslint-disable-next-line-no-fallthrough
@@ -1294,9 +1328,13 @@ class ReactDOMServerRenderer {
           info += '\n\nCheck the render method of `' + ownerName + '`.';
         }
       }
-      invariant('Element type is invalid: expected a string (for built-in ' +
-        'components) or a class/function (for composite components) ' +
-        'but got: %s.%s', elementType == null ? elementType : typeof elementType, info);
+      invariant(
+        'Element type is invalid: expected a string (for built-in ' +
+          'components) or a class/function (for composite components) ' +
+          'but got: %s.%s',
+        elementType == null ? elementType : typeof elementType,
+        info,
+      );
     }
   }
 
@@ -1317,9 +1355,12 @@ class ReactDOMServerRenderer {
         if (!(tag === element.type)) {
           // Should this check be gated by parent namespace? Not sure we want to
           // allow <SVG> or <mATH>.
-          warning('<%s /> is using incorrect casing. ' +
-            'Use PascalCase for React components, ' +
-            'or lowercase for HTML elements.', element.type);
+          warning(
+            '<%s /> is using incorrect casing. ' +
+              'Use PascalCase for React components, ' +
+              'or lowercase for HTML elements.',
+            element.type,
+          );
         }
       }
     }
@@ -1344,7 +1385,7 @@ class ReactDOMServerRenderer {
               'element and remove one of these props. More info: ' +
               'https://fb.me/react-controlled-components',
             'A component',
-            props.type
+            props.type,
           );
           didWarnDefaultChecked = true;
         }
@@ -1361,7 +1402,7 @@ class ReactDOMServerRenderer {
               'element and remove one of these props. More info: ' +
               'https://fb.me/react-controlled-components',
             'A component',
-            props.type
+            props.type,
           );
           didWarnDefaultInputValue = true;
         }
@@ -1387,11 +1428,13 @@ class ReactDOMServerRenderer {
           props.defaultValue !== undefined &&
           !didWarnDefaultTextareaValue
         ) {
-          warning('Textarea elements must be either controlled or uncontrolled ' +
-            '(specify either the value prop, or the defaultValue prop, but not ' +
-            'both). Decide between using a controlled or uncontrolled textarea ' +
-            'and remove one of these props. More info: ' +
-            'https://fb.me/react-controlled-components');
+          warning(
+            'Textarea elements must be either controlled or uncontrolled ' +
+              '(specify either the value prop, or the defaultValue prop, but not ' +
+              'both). Decide between using a controlled or uncontrolled textarea ' +
+              'and remove one of these props. More info: ' +
+              'https://fb.me/react-controlled-components',
+          );
           didWarnDefaultTextareaValue = true;
         }
       }
@@ -1403,12 +1446,16 @@ class ReactDOMServerRenderer {
         let textareaChildren = props.children;
         if (textareaChildren != null) {
           if (__DEV__) {
-            warning('Use the `defaultValue` or `value` props instead of setting ' +
-              'children on <textarea>.');
+            warning(
+              'Use the `defaultValue` or `value` props instead of setting ' +
+                'children on <textarea>.',
+            );
           }
 
           if (!(defaultValue == null)) {
-            invariant('If you supply `defaultValue` on a <textarea>, do not pass children.');
+            invariant(
+              'If you supply `defaultValue` on a <textarea>, do not pass children.',
+            );
           }
 
           if (Array.isArray(textareaChildren)) {
@@ -1442,11 +1489,17 @@ class ReactDOMServerRenderer {
           }
           const isArray = Array.isArray(props[propName]);
           if (props.multiple && !isArray) {
-            warning('The `%s` prop supplied to <select> must be an array if ' +
-              '`multiple` is true.', propName);
+            warning(
+              'The `%s` prop supplied to <select> must be an array if ' +
+                '`multiple` is true.',
+              propName,
+            );
           } else if (!props.multiple && isArray) {
-            warning('The `%s` prop supplied to <select> must be a scalar ' +
-              'value if `multiple` is false.', propName);
+            warning(
+              'The `%s` prop supplied to <select> must be a scalar ' +
+                'value if `multiple` is false.',
+              propName,
+            );
           }
         }
 
@@ -1455,11 +1508,13 @@ class ReactDOMServerRenderer {
           props.defaultValue !== undefined &&
           !didWarnDefaultSelectValue
         ) {
-          warning('Select elements must be either controlled or uncontrolled ' +
-            '(specify either the value prop, or the defaultValue prop, but not ' +
-            'both). Decide between using a controlled or uncontrolled select ' +
-            'element and remove one of these props. More info: ' +
-            'https://fb.me/react-controlled-components');
+          warning(
+            'Select elements must be either controlled or uncontrolled ' +
+              '(specify either the value prop, or the defaultValue prop, but not ' +
+              'both). Decide between using a controlled or uncontrolled select ' +
+              'element and remove one of these props. More info: ' +
+              'https://fb.me/react-controlled-components',
+          );
           didWarnDefaultSelectValue = true;
         }
       }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -211,7 +211,10 @@ const VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
 const validatedTagCache = {};
 function validateDangerousTag(tag) {
   if (!validatedTagCache.hasOwnProperty(tag)) {
-    invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
+    if (!VALID_TAG_REGEX.test(tag)) {
+      invariant('Invalid tag: %s', tag);
+    }
+
     validatedTagCache[tag] = true;
   }
 }
@@ -270,15 +273,9 @@ function warnNoop(
       return;
     }
 
-    warningWithoutStack(
-      false,
-      '%s(...): Can only update a mounting component. ' +
-        'This usually means you called %s() outside componentWillMount() on the server. ' +
-        'This is a no-op.\n\nPlease check the code for the %s component.',
-      callerName,
-      callerName,
-      componentName,
-    );
+    warningWithoutStack('%s(...): Can only update a mounting component. ' +
+      'This usually means you called %s() outside componentWillMount() on the server. ' +
+      'This is a no-op.\n\nPlease check the code for the %s component.', callerName, callerName, componentName);
     didWarnAboutNoopUpdateForComponent[warningKey] = true;
   }
 }
@@ -337,10 +334,7 @@ function flattenOptionChildren(children: mixed): ?string {
         typeof child !== 'number'
       ) {
         didWarnInvalidOptionChildren = true;
-        warning(
-          false,
-          'Only strings and numbers are supported as <option> children.',
-        );
+        warning('Only strings and numbers are supported as <option> children.');
       }
     }
   });
@@ -407,13 +401,9 @@ function createOpenTagMarkup(
 
 function validateRenderResult(child, type) {
   if (child === undefined) {
-    invariant(
-      false,
-      '%s(...): Nothing was returned from render. This usually means a ' +
-        'return statement is missing. Or, to render nothing, ' +
-        'return null.',
-      getComponentName(type) || 'Component',
-    );
+    invariant('%s(...): Nothing was returned from render. This usually means a ' +
+      'return statement is missing. Or, to render nothing, ' +
+      'return null.', getComponentName(type) || 'Component');
   }
 }
 
@@ -477,16 +467,10 @@ function resolve(
           if (inst.state === null || inst.state === undefined) {
             const componentName = getComponentName(Component) || 'Unknown';
             if (!didWarnAboutUninitializedState[componentName]) {
-              warningWithoutStack(
-                false,
-                '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
-                  '%s. This is not recommended. Instead, define the initial state by ' +
-                  'assigning an object to `this.state` in the constructor of `%s`. ' +
-                  'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
-                componentName,
-                inst.state === null ? 'null' : 'undefined',
-                componentName,
-              );
+              warningWithoutStack('`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+                '%s. This is not recommended. Instead, define the initial state by ' +
+                'assigning an object to `this.state` in the constructor of `%s`. ' +
+                'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, inst.state === null ? 'null' : 'undefined', componentName);
               didWarnAboutUninitializedState[componentName] = true;
             }
           }
@@ -503,10 +487,9 @@ function resolve(
             const componentName = getComponentName(Component) || 'Unknown';
             if (!didWarnAboutUndefinedDerivedState[componentName]) {
               warningWithoutStack(
-                false,
                 '%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' +
                   'You have returned undefined.',
-                componentName,
+                componentName
               );
               didWarnAboutUndefinedDerivedState[componentName] = true;
             }
@@ -527,11 +510,10 @@ function resolve(
 
           if (!didWarnAboutBadClass[componentName]) {
             warningWithoutStack(
-              false,
               "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
                 'This is likely to cause errors. Change %s to extend React.Component instead.',
               componentName,
-              componentName,
+              componentName
             );
             didWarnAboutBadClass[componentName] = true;
           }
@@ -552,7 +534,6 @@ function resolve(
         const componentName = getComponentName(Component) || 'Unknown';
         if (!didWarnAboutModulePatternComponent[componentName]) {
           warningWithoutStack(
-            false,
             'The <%s /> component appears to be a function component that returns a class instance. ' +
               'Change %s to a class that extends React.Component instead. ' +
               "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -560,7 +541,7 @@ function resolve(
               'cannot be called with `new` by React.',
             componentName,
             componentName,
-            componentName,
+            componentName
           );
           didWarnAboutModulePatternComponent[componentName] = true;
         }
@@ -588,16 +569,12 @@ function resolve(
             const componentName = getComponentName(Component) || 'Unknown';
 
             if (!didWarnAboutDeprecatedWillMount[componentName]) {
-              lowPriorityWarningWithoutStack(
-                false,
-                // keep this warning in sync with ReactStrictModeWarning.js
-                'componentWillMount has been renamed, and is not recommended for use. ' +
-                  'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-                  '* Move code from componentWillMount to componentDidMount (preferred in most cases) ' +
-                  'or the constructor.\n' +
-                  '\nPlease update the following components: %s',
-                componentName,
-              );
+              lowPriorityWarningWithoutStack(// keep this warning in sync with ReactStrictModeWarning.js
+              'componentWillMount has been renamed, and is not recommended for use. ' +
+                'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+                '* Move code from componentWillMount to componentDidMount (preferred in most cases) ' +
+                'or the constructor.\n' +
+                '\nPlease update the following components: %s', componentName);
               didWarnAboutDeprecatedWillMount[componentName] = true;
             }
           }
@@ -666,10 +643,9 @@ function resolve(
         let childContextTypes = Component.childContextTypes;
         if (childContextTypes !== undefined) {
           warningWithoutStack(
-            false,
             '%s uses the legacy childContextTypes API which is no longer supported. ' +
               'Use React.createContext() instead.',
-            getComponentName(Component) || 'Unknown',
+            getComponentName(Component) || 'Unknown'
           );
         }
       }
@@ -679,20 +655,17 @@ function resolve(
         if (typeof childContextTypes === 'object') {
           childContext = inst.getChildContext();
           for (let contextKey in childContext) {
-            invariant(
-              contextKey in childContextTypes,
-              '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-              getComponentName(Component) || 'Unknown',
-              contextKey,
-            );
+            if (!(contextKey in childContextTypes)) {
+              invariant(
+                '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+                getComponentName(Component) || 'Unknown',
+                contextKey
+              );
+            }
           }
         } else {
-          warningWithoutStack(
-            false,
-            '%s.getChildContext(): childContextTypes must be defined in order to ' +
-              'use getChildContext().',
-            getComponentName(Component) || 'Unknown',
-          );
+          warningWithoutStack('%s.getChildContext(): childContextTypes must be defined in order to ' +
+            'use getChildContext().', getComponentName(Component) || 'Unknown');
         }
       }
       if (childContext) {
@@ -805,10 +778,9 @@ class ReactDOMServerRenderer {
   popProvider<T>(provider: ReactProvider<T>): void {
     const index = this.contextIndex;
     if (__DEV__) {
-      warningWithoutStack(
-        index > -1 && provider === (this.contextProviderStack: any)[index],
-        'Unexpected pop.',
-      );
+      if (!(index > -1 && provider === (this.contextProviderStack: any)[index])) {
+        warningWithoutStack('Unexpected pop.');
+      }
     }
 
     const context: ReactContext<any> = this.contextStack[index];
@@ -883,11 +855,12 @@ class ReactDOMServerRenderer {
               suspended = false;
               // If rendering was suspended at this boundary, render the fallbackFrame
               const fallbackFrame = frame.fallbackFrame;
-              invariant(
-                fallbackFrame,
-                'ReactDOMServer did not find an internal fallback frame for Suspense. ' +
-                  'This is a bug in React. Please file an issue.',
-              );
+
+              if (!fallbackFrame) {
+                invariant('ReactDOMServer did not find an internal fallback frame for Suspense. ' +
+                  'This is a bug in React. Please file an issue.');
+              }
+
               this.stack.push(fallbackFrame);
               out[this.suspenseDepth] += '<!--$!-->';
               // Skip flushing output since we're switching to the fallback
@@ -914,17 +887,19 @@ class ReactDOMServerRenderer {
         } catch (err) {
           if (err != null && typeof err.then === 'function') {
             if (enableSuspenseServerRenderer) {
-              invariant(
-                this.suspenseDepth > 0,
-                // TODO: include component name. This is a bit tricky with current factoring.
-                'A React component suspended while rendering, but no fallback UI was specified.\n' +
-                  '\n' +
-                  'Add a <Suspense fallback=...> component higher in the tree to ' +
-                  'provide a loading indicator or placeholder to display.',
-              );
+              if (!(this.suspenseDepth > 0)) {
+                invariant(
+                  // TODO: include component name. This is a bit tricky with current factoring.
+                  'A React component suspended while rendering, but no fallback UI was specified.\n' +
+                    '\n' +
+                    'Add a <Suspense fallback=...> component higher in the tree to ' +
+                    'provide a loading indicator or placeholder to display.'
+                );
+              }
+
               suspended = true;
             } else {
-              invariant(false, 'ReactDOMServer does not yet support Suspense.');
+              invariant('ReactDOMServer does not yet support Suspense.');
             }
           } else {
             throw err;
@@ -973,18 +948,15 @@ class ReactDOMServerRenderer {
         if (nextChild != null && nextChild.$$typeof != null) {
           // Catch unexpected special types early.
           const $$typeof = nextChild.$$typeof;
-          invariant(
-            $$typeof !== REACT_PORTAL_TYPE,
-            'Portals are not currently supported by the server renderer. ' +
-              'Render them conditionally so that they only appear on the client render.',
-          );
+
+          if (!($$typeof !== REACT_PORTAL_TYPE)) {
+            invariant('Portals are not currently supported by the server renderer. ' +
+              'Render them conditionally so that they only appear on the client render.');
+          }
+
           // Catch-all to prevent an infinite loop if React.Children.toArray() supports some new type.
-          invariant(
-            false,
-            'Unknown element-like object type: %s. This is likely a bug in React. ' +
-              'Please file an issue.',
-            ($$typeof: any).toString(),
-          );
+          invariant('Unknown element-like object type: %s. This is likely a bug in React. ' +
+            'Please file an issue.', ($$typeof: any).toString());
         }
         const nextChildren = toArray(nextChild);
         const frame: Frame = {
@@ -1083,7 +1055,7 @@ class ReactDOMServerRenderer {
             this.suspenseDepth++;
             return '<!--$-->';
           } else {
-            invariant(false, 'ReactDOMServer does not yet support Suspense.');
+            invariant('ReactDOMServer does not yet support Suspense.');
           }
         }
         // eslint-disable-next-line-no-fallthrough
@@ -1179,11 +1151,8 @@ class ReactDOMServerRenderer {
                 if (reactContext !== reactContext.Consumer) {
                   if (!hasWarnedAboutUsingContextAsConsumer) {
                     hasWarnedAboutUsingContextAsConsumer = true;
-                    warning(
-                      false,
-                      'Rendering <Context> directly is not supported and will be removed in ' +
-                        'a future major release. Did you mean to render <Context.Consumer> instead?',
-                    );
+                    warning('Rendering <Context> directly is not supported and will be removed in ' +
+                      'a future major release. Did you mean to render <Context.Consumer> instead?');
                   }
                 }
               } else {
@@ -1242,10 +1211,7 @@ class ReactDOMServerRenderer {
               this.stack.push(frame);
               return open;
             }
-            invariant(
-              false,
-              'ReactDOMServer does not yet support the fundamental API.',
-            );
+            invariant('ReactDOMServer does not yet support the fundamental API.');
           }
           // eslint-disable-next-line-no-fallthrough
           case REACT_LAZY_TYPE: {
@@ -1281,10 +1247,7 @@ class ReactDOMServerRenderer {
                 throw lazyComponent._result;
               case Pending:
               default:
-                invariant(
-                  false,
-                  'ReactDOMServer does not yet support lazy-loaded components.',
-                );
+                invariant('ReactDOMServer does not yet support lazy-loaded components.');
             }
           }
           // eslint-disable-next-line-no-fallthrough
@@ -1307,10 +1270,7 @@ class ReactDOMServerRenderer {
               this.stack.push(frame);
               return '';
             }
-            invariant(
-              false,
-              'ReactDOMServer does not yet support scope components.',
-            );
+            invariant('ReactDOMServer does not yet support scope components.');
           }
         }
       }
@@ -1334,14 +1294,9 @@ class ReactDOMServerRenderer {
           info += '\n\nCheck the render method of `' + ownerName + '`.';
         }
       }
-      invariant(
-        false,
-        'Element type is invalid: expected a string (for built-in ' +
-          'components) or a class/function (for composite components) ' +
-          'but got: %s.%s',
-        elementType == null ? elementType : typeof elementType,
-        info,
-      );
+      invariant('Element type is invalid: expected a string (for built-in ' +
+        'components) or a class/function (for composite components) ' +
+        'but got: %s.%s', elementType == null ? elementType : typeof elementType, info);
     }
   }
 
@@ -1359,15 +1314,13 @@ class ReactDOMServerRenderer {
 
     if (__DEV__) {
       if (namespace === Namespaces.html) {
-        // Should this check be gated by parent namespace? Not sure we want to
-        // allow <SVG> or <mATH>.
-        warning(
-          tag === element.type,
-          '<%s /> is using incorrect casing. ' +
+        if (!(tag === element.type)) {
+          // Should this check be gated by parent namespace? Not sure we want to
+          // allow <SVG> or <mATH>.
+          warning('<%s /> is using incorrect casing. ' +
             'Use PascalCase for React components, ' +
-            'or lowercase for HTML elements.',
-          element.type,
-        );
+            'or lowercase for HTML elements.', element.type);
+        }
       }
     }
 
@@ -1384,7 +1337,6 @@ class ReactDOMServerRenderer {
           !didWarnDefaultChecked
         ) {
           warning(
-            false,
             '%s contains an input of type %s with both checked and defaultChecked props. ' +
               'Input elements must be either controlled or uncontrolled ' +
               '(specify either the checked prop, or the defaultChecked prop, but not ' +
@@ -1392,7 +1344,7 @@ class ReactDOMServerRenderer {
               'element and remove one of these props. More info: ' +
               'https://fb.me/react-controlled-components',
             'A component',
-            props.type,
+            props.type
           );
           didWarnDefaultChecked = true;
         }
@@ -1402,7 +1354,6 @@ class ReactDOMServerRenderer {
           !didWarnDefaultInputValue
         ) {
           warning(
-            false,
             '%s contains an input of type %s with both value and defaultValue props. ' +
               'Input elements must be either controlled or uncontrolled ' +
               '(specify either the value prop, or the defaultValue prop, but not ' +
@@ -1410,7 +1361,7 @@ class ReactDOMServerRenderer {
               'element and remove one of these props. More info: ' +
               'https://fb.me/react-controlled-components',
             'A component',
-            props.type,
+            props.type
           );
           didWarnDefaultInputValue = true;
         }
@@ -1436,14 +1387,11 @@ class ReactDOMServerRenderer {
           props.defaultValue !== undefined &&
           !didWarnDefaultTextareaValue
         ) {
-          warning(
-            false,
-            'Textarea elements must be either controlled or uncontrolled ' +
-              '(specify either the value prop, or the defaultValue prop, but not ' +
-              'both). Decide between using a controlled or uncontrolled textarea ' +
-              'and remove one of these props. More info: ' +
-              'https://fb.me/react-controlled-components',
-          );
+          warning('Textarea elements must be either controlled or uncontrolled ' +
+            '(specify either the value prop, or the defaultValue prop, but not ' +
+            'both). Decide between using a controlled or uncontrolled textarea ' +
+            'and remove one of these props. More info: ' +
+            'https://fb.me/react-controlled-components');
           didWarnDefaultTextareaValue = true;
         }
       }
@@ -1455,21 +1403,19 @@ class ReactDOMServerRenderer {
         let textareaChildren = props.children;
         if (textareaChildren != null) {
           if (__DEV__) {
-            warning(
-              false,
-              'Use the `defaultValue` or `value` props instead of setting ' +
-                'children on <textarea>.',
-            );
+            warning('Use the `defaultValue` or `value` props instead of setting ' +
+              'children on <textarea>.');
           }
-          invariant(
-            defaultValue == null,
-            'If you supply `defaultValue` on a <textarea>, do not pass children.',
-          );
+
+          if (!(defaultValue == null)) {
+            invariant('If you supply `defaultValue` on a <textarea>, do not pass children.');
+          }
+
           if (Array.isArray(textareaChildren)) {
-            invariant(
-              textareaChildren.length <= 1,
-              '<textarea> can only have at most one child.',
-            );
+            if (!(textareaChildren.length <= 1)) {
+              invariant('<textarea> can only have at most one child.');
+            }
+
             textareaChildren = textareaChildren[0];
           }
 
@@ -1496,19 +1442,11 @@ class ReactDOMServerRenderer {
           }
           const isArray = Array.isArray(props[propName]);
           if (props.multiple && !isArray) {
-            warning(
-              false,
-              'The `%s` prop supplied to <select> must be an array if ' +
-                '`multiple` is true.',
-              propName,
-            );
+            warning('The `%s` prop supplied to <select> must be an array if ' +
+              '`multiple` is true.', propName);
           } else if (!props.multiple && isArray) {
-            warning(
-              false,
-              'The `%s` prop supplied to <select> must be a scalar ' +
-                'value if `multiple` is false.',
-              propName,
-            );
+            warning('The `%s` prop supplied to <select> must be a scalar ' +
+              'value if `multiple` is false.', propName);
           }
         }
 
@@ -1517,14 +1455,11 @@ class ReactDOMServerRenderer {
           props.defaultValue !== undefined &&
           !didWarnDefaultSelectValue
         ) {
-          warning(
-            false,
-            'Select elements must be either controlled or uncontrolled ' +
-              '(specify either the value prop, or the defaultValue prop, but not ' +
-              'both). Decide between using a controlled or uncontrolled select ' +
-              'element and remove one of these props. More info: ' +
-              'https://fb.me/react-controlled-components',
-          );
+          warning('Select elements must be either controlled or uncontrolled ' +
+            '(specify either the value prop, or the defaultValue prop, but not ' +
+            'both). Decide between using a controlled or uncontrolled select ' +
+            'element and remove one of these props. More info: ' +
+            'https://fb.me/react-controlled-components');
           didWarnDefaultSelectValue = true;
         }
       }

--- a/packages/react-dom/src/server/ReactPartialRendererContext.js
+++ b/packages/react-dom/src/server/ReactPartialRendererContext.js
@@ -112,8 +112,12 @@ export function processContext(
               Object.keys(contextType).join(', ') +
               '}.';
           }
-          warningWithoutStack('%s defines an invalid contextType. ' +
-            'contextType should point to the Context object returned by React.createContext().%s', getComponentName(type) || 'Component', addendum);
+          warningWithoutStack(
+            '%s defines an invalid contextType. ' +
+              'contextType should point to the Context object returned by React.createContext().%s',
+            getComponentName(type) || 'Component',
+            addendum,
+          );
         }
       }
     }
@@ -124,8 +128,11 @@ export function processContext(
     if (disableLegacyContext) {
       if (__DEV__) {
         if (type.contextTypes) {
-          warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with static contextType instead.', getComponentName(type) || 'Unknown');
+          warningWithoutStack(
+            '%s uses the legacy contextTypes API which is no longer supported. ' +
+              'Use React.createContext() with static contextType instead.',
+            getComponentName(type) || 'Unknown',
+          );
         }
       }
       return emptyObject;
@@ -142,8 +149,11 @@ export function processContext(
     if (disableLegacyContext) {
       if (__DEV__) {
         if (type.contextTypes) {
-          warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with React.useContext() instead.', getComponentName(type) || 'Unknown');
+          warningWithoutStack(
+            '%s uses the legacy contextTypes API which is no longer supported. ' +
+              'Use React.createContext() with React.useContext() instead.',
+            getComponentName(type) || 'Unknown',
+          );
         }
       }
       return undefined;

--- a/packages/react-dom/src/server/ReactPartialRendererContext.js
+++ b/packages/react-dom/src/server/ReactPartialRendererContext.js
@@ -112,13 +112,8 @@ export function processContext(
               Object.keys(contextType).join(', ') +
               '}.';
           }
-          warningWithoutStack(
-            false,
-            '%s defines an invalid contextType. ' +
-              'contextType should point to the Context object returned by React.createContext().%s',
-            getComponentName(type) || 'Component',
-            addendum,
-          );
+          warningWithoutStack('%s defines an invalid contextType. ' +
+            'contextType should point to the Context object returned by React.createContext().%s', getComponentName(type) || 'Component', addendum);
         }
       }
     }
@@ -129,12 +124,8 @@ export function processContext(
     if (disableLegacyContext) {
       if (__DEV__) {
         if (type.contextTypes) {
-          warningWithoutStack(
-            false,
-            '%s uses the legacy contextTypes API which is no longer supported. ' +
-              'Use React.createContext() with static contextType instead.',
-            getComponentName(type) || 'Unknown',
-          );
+          warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
+            'Use React.createContext() with static contextType instead.', getComponentName(type) || 'Unknown');
         }
       }
       return emptyObject;
@@ -151,12 +142,8 @@ export function processContext(
     if (disableLegacyContext) {
       if (__DEV__) {
         if (type.contextTypes) {
-          warningWithoutStack(
-            false,
-            '%s uses the legacy contextTypes API which is no longer supported. ' +
-              'Use React.createContext() with React.useContext() instead.',
-            getComponentName(type) || 'Unknown',
-          );
+          warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
+            'Use React.createContext() with React.useContext() instead.', getComponentName(type) || 'Unknown');
         }
       }
       return undefined;

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -58,23 +58,26 @@ let isInHookUserCodeInDev = false;
 let currentHookNameInDev: ?string;
 
 function resolveCurrentlyRenderingComponent(): Object {
-  invariant(
-    currentlyRenderingComponent !== null,
-    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-      ' one of the following reasons:\n' +
-      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-      '2. You might be breaking the Rules of Hooks\n' +
-      '3. You might have more than one copy of React in the same app\n' +
-      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
-  );
-  if (__DEV__) {
-    warning(
-      !isInHookUserCodeInDev,
-      'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. ' +
-        'You can only call Hooks at the top level of your React function. ' +
-        'For more information, see ' +
-        'https://fb.me/rules-of-hooks',
+  if (!(currentlyRenderingComponent !== null)) {
+    invariant(
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
+  }
+
+  if (__DEV__) {
+    if (isInHookUserCodeInDev) {
+      warning(
+        'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. ' +
+          'You can only call Hooks at the top level of your React function. ' +
+          'For more information, see ' +
+          'https://fb.me/rules-of-hooks',
+      );
+    }
   }
   return currentlyRenderingComponent;
 }
@@ -86,7 +89,6 @@ function areHookInputsEqual(
   if (prevDeps === null) {
     if (__DEV__) {
       warning(
-        false,
         '%s received a final argument during this render, but not during ' +
           'the previous render. Even though the final argument is optional, ' +
           'its type cannot change between renders.',
@@ -101,7 +103,6 @@ function areHookInputsEqual(
     // passed inline.
     if (nextDeps.length !== prevDeps.length) {
       warning(
-        false,
         'The final argument passed to %s changed size between renders. The ' +
           'order and size of this array must remain constant.\n\n' +
           'Previous: %s\n' +
@@ -123,7 +124,7 @@ function areHookInputsEqual(
 
 function createHook(): Hook {
   if (numberOfReRenders > 0) {
-    invariant(false, 'Rendered more hooks than during the previous render');
+    invariant('Rendered more hooks than during the previous render');
   }
   return {
     memoizedState: null,
@@ -220,13 +221,14 @@ function readContext<T>(
   let threadID = currentThreadID;
   validateContextBounds(context, threadID);
   if (__DEV__) {
-    warning(
-      !isInHookUserCodeInDev,
-      'Context can only be read while React is rendering. ' +
-        'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
-        'In function components, you can read it directly in the function body, but not ' +
-        'inside Hooks like useReducer() or useMemo().',
-    );
+    if (isInHookUserCodeInDev) {
+      warning(
+        'Context can only be read while React is rendering. ' +
+          'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
+          'In function components, you can read it directly in the function body, but not ' +
+          'inside Hooks like useReducer() or useMemo().',
+      );
+    }
   }
   return context[threadID];
 }
@@ -391,7 +393,6 @@ export function useLayoutEffect(
     currentHookNameInDev = 'useLayoutEffect';
   }
   warning(
-    false,
     'useLayoutEffect does nothing on the server, because its effect cannot ' +
       "be encoded into the server renderer's output format. This will lead " +
       'to a mismatch between the initial, non-hydrated UI and the intended ' +
@@ -406,11 +407,12 @@ function dispatchAction<A>(
   queue: UpdateQueue<A>,
   action: A,
 ) {
-  invariant(
-    numberOfReRenders < RE_RENDER_LIMIT,
-    'Too many re-renders. React limits the number of renders to prevent ' +
-      'an infinite loop.',
-  );
+  if (!(numberOfReRenders < RE_RENDER_LIMIT)) {
+    invariant(
+      'Too many re-renders. React limits the number of renders to prevent ' +
+        'an infinite loop.',
+    );
+  }
 
   if (componentIdentity === currentlyRenderingComponent) {
     // This is a render phase update. Stash it in a lazily-created map of

--- a/packages/react-dom/src/server/ReactThreadIDAllocator.js
+++ b/packages/react-dom/src/server/ReactThreadIDAllocator.js
@@ -25,13 +25,14 @@ function growThreadCountAndReturnNextAvailable() {
   let oldArray = nextAvailableThreadIDs;
   let oldSize = oldArray.length;
   let newSize = oldSize * 2;
-  invariant(
-    newSize <= 0x10000,
-    'Maximum number of concurrent React renderers exceeded. ' +
+
+  if (!(newSize <= 0x10000)) {
+    invariant('Maximum number of concurrent React renderers exceeded. ' +
       'This can happen if you are not properly destroying the Readable provided by React. ' +
       'Ensure that you call .destroy() on it if you no longer want to read from it, ' +
-      'and did not read to the end. If you use .pipe() this should be automatic.',
-  );
+      'and did not read to the end. If you use .pipe() this should be automatic.');
+  }
+
   let newArray = new Uint16Array(newSize);
   newArray.set(oldArray);
   nextAvailableThreadIDs = newArray;

--- a/packages/react-dom/src/server/ReactThreadIDAllocator.js
+++ b/packages/react-dom/src/server/ReactThreadIDAllocator.js
@@ -27,10 +27,12 @@ function growThreadCountAndReturnNextAvailable() {
   let newSize = oldSize * 2;
 
   if (!(newSize <= 0x10000)) {
-    invariant('Maximum number of concurrent React renderers exceeded. ' +
-      'This can happen if you are not properly destroying the Readable provided by React. ' +
-      'Ensure that you call .destroy() on it if you no longer want to read from it, ' +
-      'and did not read to the end. If you use .pipe() this should be automatic.');
+    invariant(
+      'Maximum number of concurrent React renderers exceeded. ' +
+        'This can happen if you are not properly destroying the Readable provided by React. ' +
+        'Ensure that you call .destroy() on it if you no longer want to read from it, ' +
+        'and did not read to the end. If you use .pipe() this should be automatic.',
+    );
   }
 
   let newArray = new Uint16Array(newSize);

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -148,11 +148,16 @@ export function validateShorthandPropertyCollisionInDev(
         continue;
       }
       warnedAbout[warningKey] = true;
-      warning('%s a style property during rerender (%s) when a ' +
-        'conflicting property is set (%s) can lead to styling bugs. To ' +
-        "avoid this, don't mix shorthand and non-shorthand properties " +
-        'for the same value; instead, replace the shorthand with ' +
-        'separate values.', isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating', originalKey, correctOriginalKey);
+      warning(
+        '%s a style property during rerender (%s) when a ' +
+          'conflicting property is set (%s) can lead to styling bugs. To ' +
+          "avoid this, don't mix shorthand and non-shorthand properties " +
+          'for the same value; instead, replace the shorthand with ' +
+          'separate values.',
+        isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating',
+        originalKey,
+        correctOriginalKey,
+      );
     }
   }
 }

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -148,17 +148,11 @@ export function validateShorthandPropertyCollisionInDev(
         continue;
       }
       warnedAbout[warningKey] = true;
-      warning(
-        false,
-        '%s a style property during rerender (%s) when a ' +
-          'conflicting property is set (%s) can lead to styling bugs. To ' +
-          "avoid this, don't mix shorthand and non-shorthand properties " +
-          'for the same value; instead, replace the shorthand with ' +
-          'separate values.',
-        isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating',
-        originalKey,
-        correctOriginalKey,
-      );
+      warning('%s a style property during rerender (%s) when a ' +
+        'conflicting property is set (%s) can lead to styling bugs. To ' +
+        "avoid this, don't mix shorthand and non-shorthand properties " +
+        'for the same value; instead, replace the shorthand with ' +
+        'separate values.', isValueEmpty(styleUpdates[originalKey]) ? 'Removing' : 'Updating', originalKey, correctOriginalKey);
     }
   }
 }

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -84,7 +84,7 @@ export function isAttributeNameSafe(attributeName: string): boolean {
   }
   illegalAttributeNameCache[attributeName] = true;
   if (__DEV__) {
-    warning(false, 'Invalid attribute name: `%s`', attributeName);
+    warning('Invalid attribute name: `%s`', attributeName);
   }
   return false;
 }

--- a/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
@@ -32,21 +32,15 @@ function validateProperty(tagName, name) {
     // DOM properties, then it is an invalid aria-* attribute.
     if (correctName == null) {
       warning(
-        false,
         'Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.',
-        name,
+        name
       );
       warnedProperties[name] = true;
       return true;
     }
     // aria-* attributes should be lowercase; suggest the lowercase version.
     if (name !== correctName) {
-      warning(
-        false,
-        'Invalid ARIA attribute `%s`. Did you mean `%s`?',
-        name,
-        correctName,
-      );
+      warning('Invalid ARIA attribute `%s`. Did you mean `%s`?', name, correctName);
       warnedProperties[name] = true;
       return true;
     }
@@ -66,12 +60,7 @@ function validateProperty(tagName, name) {
     }
     // aria-* attributes should be lowercase; suggest the lowercase version.
     if (name !== standardName) {
-      warning(
-        false,
-        'Unknown ARIA attribute `%s`. Did you mean `%s`?',
-        name,
-        standardName,
-      );
+      warning('Unknown ARIA attribute `%s`. Did you mean `%s`?', name, standardName);
       warnedProperties[name] = true;
       return true;
     }
@@ -95,21 +84,11 @@ function warnInvalidARIAProps(type, props) {
     .join(', ');
 
   if (invalidProps.length === 1) {
-    warning(
-      false,
-      'Invalid aria prop %s on <%s> tag. ' +
-        'For details, see https://fb.me/invalid-aria-prop',
-      unknownPropString,
-      type,
-    );
+    warning('Invalid aria prop %s on <%s> tag. ' +
+      'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
   } else if (invalidProps.length > 1) {
-    warning(
-      false,
-      'Invalid aria props %s on <%s> tag. ' +
-        'For details, see https://fb.me/invalid-aria-prop',
-      unknownPropString,
-      type,
-    );
+    warning('Invalid aria props %s on <%s> tag. ' +
+      'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
   }
 }
 

--- a/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
+++ b/packages/react-dom/src/shared/ReactDOMInvalidARIAHook.js
@@ -33,14 +33,18 @@ function validateProperty(tagName, name) {
     if (correctName == null) {
       warning(
         'Invalid ARIA attribute `%s`. ARIA attributes follow the pattern aria-* and must be lowercase.',
-        name
+        name,
       );
       warnedProperties[name] = true;
       return true;
     }
     // aria-* attributes should be lowercase; suggest the lowercase version.
     if (name !== correctName) {
-      warning('Invalid ARIA attribute `%s`. Did you mean `%s`?', name, correctName);
+      warning(
+        'Invalid ARIA attribute `%s`. Did you mean `%s`?',
+        name,
+        correctName,
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -60,7 +64,11 @@ function validateProperty(tagName, name) {
     }
     // aria-* attributes should be lowercase; suggest the lowercase version.
     if (name !== standardName) {
-      warning('Unknown ARIA attribute `%s`. Did you mean `%s`?', name, standardName);
+      warning(
+        'Unknown ARIA attribute `%s`. Did you mean `%s`?',
+        name,
+        standardName,
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -84,11 +92,19 @@ function warnInvalidARIAProps(type, props) {
     .join(', ');
 
   if (invalidProps.length === 1) {
-    warning('Invalid aria prop %s on <%s> tag. ' +
-      'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
+    warning(
+      'Invalid aria prop %s on <%s> tag. ' +
+        'For details, see https://fb.me/invalid-aria-prop',
+      unknownPropString,
+      type,
+    );
   } else if (invalidProps.length > 1) {
-    warning('Invalid aria props %s on <%s> tag. ' +
-      'For details, see https://fb.me/invalid-aria-prop', unknownPropString, type);
+    warning(
+      'Invalid aria props %s on <%s> tag. ' +
+        'For details, see https://fb.me/invalid-aria-prop',
+      unknownPropString,
+      type,
+    );
   }
 }
 

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -17,13 +17,19 @@ export function validateProperties(type, props) {
   if (props != null && props.value === null && !didWarnValueNull) {
     didWarnValueNull = true;
     if (type === 'select' && props.multiple) {
-      warning('`value` prop on `%s` should not be null. ' +
-        'Consider using an empty array when `multiple` is set to `true` ' +
-        'to clear the component or `undefined` for uncontrolled components.', type);
+      warning(
+        '`value` prop on `%s` should not be null. ' +
+          'Consider using an empty array when `multiple` is set to `true` ' +
+          'to clear the component or `undefined` for uncontrolled components.',
+        type,
+      );
     } else {
-      warning('`value` prop on `%s` should not be null. ' +
-        'Consider using an empty string to clear the component or `undefined` ' +
-        'for uncontrolled components.', type);
+      warning(
+        '`value` prop on `%s` should not be null. ' +
+          'Consider using an empty string to clear the component or `undefined` ' +
+          'for uncontrolled components.',
+        type,
+      );
     }
   }
 }

--- a/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
+++ b/packages/react-dom/src/shared/ReactDOMNullInputValuePropHook.js
@@ -17,21 +17,13 @@ export function validateProperties(type, props) {
   if (props != null && props.value === null && !didWarnValueNull) {
     didWarnValueNull = true;
     if (type === 'select' && props.multiple) {
-      warning(
-        false,
-        '`value` prop on `%s` should not be null. ' +
-          'Consider using an empty array when `multiple` is set to `true` ' +
-          'to clear the component or `undefined` for uncontrolled components.',
-        type,
-      );
+      warning('`value` prop on `%s` should not be null. ' +
+        'Consider using an empty array when `multiple` is set to `true` ' +
+        'to clear the component or `undefined` for uncontrolled components.', type);
     } else {
-      warning(
-        false,
-        '`value` prop on `%s` should not be null. ' +
-          'Consider using an empty string to clear the component or `undefined` ' +
-          'for uncontrolled components.',
-        type,
-      );
+      warning('`value` prop on `%s` should not be null. ' +
+        'Consider using an empty string to clear the component or `undefined` ' +
+        'for uncontrolled components.', type);
     }
   }
 }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -38,12 +38,9 @@ if (__DEV__) {
 
     const lowerCasedName = name.toLowerCase();
     if (lowerCasedName === 'onfocusin' || lowerCasedName === 'onfocusout') {
-      warning(
-        false,
-        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' +
-          'All React events are normalized to bubble, so onFocusIn and onFocusOut ' +
-          'are not needed/supported by React.',
-      );
+      warning('React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' +
+        'All React events are normalized to bubble, so onFocusIn and onFocusOut ' +
+        'are not needed/supported by React.');
       warnedProperties[name] = true;
       return true;
     }
@@ -60,20 +57,15 @@ if (__DEV__) {
         : null;
       if (registrationName != null) {
         warning(
-          false,
           'Invalid event handler property `%s`. Did you mean `%s`?',
           name,
-          registrationName,
+          registrationName
         );
         warnedProperties[name] = true;
         return true;
       }
       if (EVENT_NAME_REGEX.test(name)) {
-        warning(
-          false,
-          'Unknown event handler property `%s`. It will be ignored.',
-          name,
-        );
+        warning('Unknown event handler property `%s`. It will be ignored.', name);
         warnedProperties[name] = true;
         return true;
       }
@@ -82,12 +74,8 @@ if (__DEV__) {
       // So we can't tell if the event name is correct for sure, but we can filter
       // out known bad ones like `onclick`. We can't suggest a specific replacement though.
       if (INVALID_EVENT_NAME_REGEX.test(name)) {
-        warning(
-          false,
-          'Invalid event handler property `%s`. ' +
-            'React events use the camelCase naming convention, for example `onClick`.',
-          name,
-        );
+        warning('Invalid event handler property `%s`. ' +
+          'React events use the camelCase naming convention, for example `onClick`.', name);
       }
       warnedProperties[name] = true;
       return true;
@@ -99,21 +87,15 @@ if (__DEV__) {
     }
 
     if (lowerCasedName === 'innerhtml') {
-      warning(
-        false,
-        'Directly setting property `innerHTML` is not permitted. ' +
-          'For more information, lookup documentation on `dangerouslySetInnerHTML`.',
-      );
+      warning('Directly setting property `innerHTML` is not permitted. ' +
+        'For more information, lookup documentation on `dangerouslySetInnerHTML`.');
       warnedProperties[name] = true;
       return true;
     }
 
     if (lowerCasedName === 'aria') {
-      warning(
-        false,
-        'The `aria` attribute is reserved for future use in React. ' +
-          'Pass individual `aria-` attributes instead.',
-      );
+      warning('The `aria` attribute is reserved for future use in React. ' +
+        'Pass individual `aria-` attributes instead.');
       warnedProperties[name] = true;
       return true;
     }
@@ -125,22 +107,17 @@ if (__DEV__) {
       typeof value !== 'string'
     ) {
       warning(
-        false,
         'Received a `%s` for a string attribute `is`. If this is expected, cast ' +
           'the value to a string.',
-        typeof value,
+        typeof value
       );
       warnedProperties[name] = true;
       return true;
     }
 
     if (typeof value === 'number' && isNaN(value)) {
-      warning(
-        false,
-        'Received NaN for the `%s` attribute. If this is expected, cast ' +
-          'the value to a string.',
-        name,
-      );
+      warning('Received NaN for the `%s` attribute. If this is expected, cast ' +
+        'the value to a string.', name);
       warnedProperties[name] = true;
       return true;
     }
@@ -152,28 +129,18 @@ if (__DEV__) {
     if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
       const standardName = possibleStandardNames[lowerCasedName];
       if (standardName !== name) {
-        warning(
-          false,
-          'Invalid DOM property `%s`. Did you mean `%s`?',
-          name,
-          standardName,
-        );
+        warning('Invalid DOM property `%s`. Did you mean `%s`?', name, standardName);
         warnedProperties[name] = true;
         return true;
       }
     } else if (!isReserved && name !== lowerCasedName) {
       // Unknown attributes should have lowercase casing since that's how they
       // will be cased anyway with server rendering.
-      warning(
-        false,
-        'React does not recognize the `%s` prop on a DOM element. If you ' +
-          'intentionally want it to appear in the DOM as a custom ' +
-          'attribute, spell it as lowercase `%s` instead. ' +
-          'If you accidentally passed it from a parent component, remove ' +
-          'it from the DOM element.',
-        name,
-        lowerCasedName,
-      );
+      warning('React does not recognize the `%s` prop on a DOM element. If you ' +
+        'intentionally want it to appear in the DOM as a custom ' +
+        'attribute, spell it as lowercase `%s` instead. ' +
+        'If you accidentally passed it from a parent component, remove ' +
+        'it from the DOM element.', name, lowerCasedName);
       warnedProperties[name] = true;
       return true;
     }
@@ -183,33 +150,15 @@ if (__DEV__) {
       shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
     ) {
       if (value) {
-        warning(
-          false,
-          'Received `%s` for a non-boolean attribute `%s`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            '%s="%s" or %s={value.toString()}.',
-          value,
-          name,
-          name,
-          value,
-          name,
-        );
+        warning('Received `%s` for a non-boolean attribute `%s`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          '%s="%s" or %s={value.toString()}.', value, name, name, value, name);
       } else {
-        warning(
-          false,
-          'Received `%s` for a non-boolean attribute `%s`.\n\n' +
-            'If you want to write it to the DOM, pass a string instead: ' +
-            '%s="%s" or %s={value.toString()}.\n\n' +
-            'If you used to conditionally omit it with %s={condition && value}, ' +
-            'pass %s={condition ? value : undefined} instead.',
-          value,
-          name,
-          name,
-          value,
-          name,
-          name,
-          name,
-        );
+        warning('Received `%s` for a non-boolean attribute `%s`.\n\n' +
+          'If you want to write it to the DOM, pass a string instead: ' +
+          '%s="%s" or %s={value.toString()}.\n\n' +
+          'If you used to conditionally omit it with %s={condition && value}, ' +
+          'pass %s={condition ? value : undefined} instead.', value, name, name, value, name, name, name);
       }
       warnedProperties[name] = true;
       return true;
@@ -233,19 +182,11 @@ if (__DEV__) {
       propertyInfo !== null &&
       propertyInfo.type === BOOLEAN
     ) {
-      warning(
-        false,
-        'Received the string `%s` for the boolean attribute `%s`. ' +
-          '%s ' +
-          'Did you mean %s={%s}?',
-        value,
-        name,
-        value === 'false'
-          ? 'The browser will interpret it as a truthy value.'
-          : 'Although this works, it will not work as expected if you pass the string "false".',
-        name,
-        value,
-      );
+      warning('Received the string `%s` for the boolean attribute `%s`. ' +
+        '%s ' +
+        'Did you mean %s={%s}?', value, name, value === 'false'
+        ? 'The browser will interpret it as a truthy value.'
+        : 'Although this works, it will not work as expected if you pass the string "false".', name, value);
       warnedProperties[name] = true;
       return true;
     }
@@ -268,21 +209,19 @@ const warnUnknownProperties = function(type, props, canUseEventSystem) {
     .join(', ');
   if (unknownProps.length === 1) {
     warning(
-      false,
       'Invalid value for prop %s on <%s> tag. Either remove it from the element, ' +
         'or pass a string or number value to keep it in the DOM. ' +
         'For details, see https://fb.me/react-attribute-behavior',
       unknownPropString,
-      type,
+      type
     );
   } else if (unknownProps.length > 1) {
     warning(
-      false,
       'Invalid values for props %s on <%s> tag. Either remove them from the element, ' +
         'or pass a string or number value to keep them in the DOM. ' +
         'For details, see https://fb.me/react-attribute-behavior',
       unknownPropString,
-      type,
+      type
     );
   }
 };

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -38,9 +38,11 @@ if (__DEV__) {
 
     const lowerCasedName = name.toLowerCase();
     if (lowerCasedName === 'onfocusin' || lowerCasedName === 'onfocusout') {
-      warning('React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' +
-        'All React events are normalized to bubble, so onFocusIn and onFocusOut ' +
-        'are not needed/supported by React.');
+      warning(
+        'React uses onFocus and onBlur instead of onFocusIn and onFocusOut. ' +
+          'All React events are normalized to bubble, so onFocusIn and onFocusOut ' +
+          'are not needed/supported by React.',
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -59,13 +61,16 @@ if (__DEV__) {
         warning(
           'Invalid event handler property `%s`. Did you mean `%s`?',
           name,
-          registrationName
+          registrationName,
         );
         warnedProperties[name] = true;
         return true;
       }
       if (EVENT_NAME_REGEX.test(name)) {
-        warning('Unknown event handler property `%s`. It will be ignored.', name);
+        warning(
+          'Unknown event handler property `%s`. It will be ignored.',
+          name,
+        );
         warnedProperties[name] = true;
         return true;
       }
@@ -74,8 +79,11 @@ if (__DEV__) {
       // So we can't tell if the event name is correct for sure, but we can filter
       // out known bad ones like `onclick`. We can't suggest a specific replacement though.
       if (INVALID_EVENT_NAME_REGEX.test(name)) {
-        warning('Invalid event handler property `%s`. ' +
-          'React events use the camelCase naming convention, for example `onClick`.', name);
+        warning(
+          'Invalid event handler property `%s`. ' +
+            'React events use the camelCase naming convention, for example `onClick`.',
+          name,
+        );
       }
       warnedProperties[name] = true;
       return true;
@@ -87,15 +95,19 @@ if (__DEV__) {
     }
 
     if (lowerCasedName === 'innerhtml') {
-      warning('Directly setting property `innerHTML` is not permitted. ' +
-        'For more information, lookup documentation on `dangerouslySetInnerHTML`.');
+      warning(
+        'Directly setting property `innerHTML` is not permitted. ' +
+          'For more information, lookup documentation on `dangerouslySetInnerHTML`.',
+      );
       warnedProperties[name] = true;
       return true;
     }
 
     if (lowerCasedName === 'aria') {
-      warning('The `aria` attribute is reserved for future use in React. ' +
-        'Pass individual `aria-` attributes instead.');
+      warning(
+        'The `aria` attribute is reserved for future use in React. ' +
+          'Pass individual `aria-` attributes instead.',
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -109,15 +121,18 @@ if (__DEV__) {
       warning(
         'Received a `%s` for a string attribute `is`. If this is expected, cast ' +
           'the value to a string.',
-        typeof value
+        typeof value,
       );
       warnedProperties[name] = true;
       return true;
     }
 
     if (typeof value === 'number' && isNaN(value)) {
-      warning('Received NaN for the `%s` attribute. If this is expected, cast ' +
-        'the value to a string.', name);
+      warning(
+        'Received NaN for the `%s` attribute. If this is expected, cast ' +
+          'the value to a string.',
+        name,
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -129,18 +144,26 @@ if (__DEV__) {
     if (possibleStandardNames.hasOwnProperty(lowerCasedName)) {
       const standardName = possibleStandardNames[lowerCasedName];
       if (standardName !== name) {
-        warning('Invalid DOM property `%s`. Did you mean `%s`?', name, standardName);
+        warning(
+          'Invalid DOM property `%s`. Did you mean `%s`?',
+          name,
+          standardName,
+        );
         warnedProperties[name] = true;
         return true;
       }
     } else if (!isReserved && name !== lowerCasedName) {
       // Unknown attributes should have lowercase casing since that's how they
       // will be cased anyway with server rendering.
-      warning('React does not recognize the `%s` prop on a DOM element. If you ' +
-        'intentionally want it to appear in the DOM as a custom ' +
-        'attribute, spell it as lowercase `%s` instead. ' +
-        'If you accidentally passed it from a parent component, remove ' +
-        'it from the DOM element.', name, lowerCasedName);
+      warning(
+        'React does not recognize the `%s` prop on a DOM element. If you ' +
+          'intentionally want it to appear in the DOM as a custom ' +
+          'attribute, spell it as lowercase `%s` instead. ' +
+          'If you accidentally passed it from a parent component, remove ' +
+          'it from the DOM element.',
+        name,
+        lowerCasedName,
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -150,15 +173,31 @@ if (__DEV__) {
       shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
     ) {
       if (value) {
-        warning('Received `%s` for a non-boolean attribute `%s`.\n\n' +
-          'If you want to write it to the DOM, pass a string instead: ' +
-          '%s="%s" or %s={value.toString()}.', value, name, name, value, name);
+        warning(
+          'Received `%s` for a non-boolean attribute `%s`.\n\n' +
+            'If you want to write it to the DOM, pass a string instead: ' +
+            '%s="%s" or %s={value.toString()}.',
+          value,
+          name,
+          name,
+          value,
+          name,
+        );
       } else {
-        warning('Received `%s` for a non-boolean attribute `%s`.\n\n' +
-          'If you want to write it to the DOM, pass a string instead: ' +
-          '%s="%s" or %s={value.toString()}.\n\n' +
-          'If you used to conditionally omit it with %s={condition && value}, ' +
-          'pass %s={condition ? value : undefined} instead.', value, name, name, value, name, name, name);
+        warning(
+          'Received `%s` for a non-boolean attribute `%s`.\n\n' +
+            'If you want to write it to the DOM, pass a string instead: ' +
+            '%s="%s" or %s={value.toString()}.\n\n' +
+            'If you used to conditionally omit it with %s={condition && value}, ' +
+            'pass %s={condition ? value : undefined} instead.',
+          value,
+          name,
+          name,
+          value,
+          name,
+          name,
+          name,
+        );
       }
       warnedProperties[name] = true;
       return true;
@@ -182,11 +221,18 @@ if (__DEV__) {
       propertyInfo !== null &&
       propertyInfo.type === BOOLEAN
     ) {
-      warning('Received the string `%s` for the boolean attribute `%s`. ' +
-        '%s ' +
-        'Did you mean %s={%s}?', value, name, value === 'false'
-        ? 'The browser will interpret it as a truthy value.'
-        : 'Although this works, it will not work as expected if you pass the string "false".', name, value);
+      warning(
+        'Received the string `%s` for the boolean attribute `%s`. ' +
+          '%s ' +
+          'Did you mean %s={%s}?',
+        value,
+        name,
+        value === 'false'
+          ? 'The browser will interpret it as a truthy value.'
+          : 'Although this works, it will not work as expected if you pass the string "false".',
+        name,
+        value,
+      );
       warnedProperties[name] = true;
       return true;
     }
@@ -213,7 +259,7 @@ const warnUnknownProperties = function(type, props, canUseEventSystem) {
         'or pass a string or number value to keep it in the DOM. ' +
         'For details, see https://fb.me/react-attribute-behavior',
       unknownPropString,
-      type
+      type,
     );
   } else if (unknownProps.length > 1) {
     warning(
@@ -221,7 +267,7 @@ const warnUnknownProperties = function(type, props, canUseEventSystem) {
         'or pass a string or number value to keep them in the DOM. ' +
         'For details, see https://fb.me/react-attribute-behavior',
       unknownPropString,
-      type
+      type,
     );
   }
 };

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -27,35 +27,58 @@ function assertValidProps(tag: string, props: ?Object) {
   // Note the use of `==` which checks for null or undefined.
   if (voidElementTags[tag]) {
     if (!(props.children == null && props.dangerouslySetInnerHTML == null)) {
-      invariant('%s is a void element tag and must neither have `children` nor ' +
-        'use `dangerouslySetInnerHTML`.%s', tag, __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '');
+      invariant(
+        '%s is a void element tag and must neither have `children` nor ' +
+          'use `dangerouslySetInnerHTML`.%s',
+        tag,
+        __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
+      );
     }
   }
   if (props.dangerouslySetInnerHTML != null) {
     if (!(props.children == null)) {
-      invariant('Can only set one of `children` or `props.dangerouslySetInnerHTML`.');
+      invariant(
+        'Can only set one of `children` or `props.dangerouslySetInnerHTML`.',
+      );
     }
 
-    if (!(typeof props.dangerouslySetInnerHTML === 'object' && HTML in props.dangerouslySetInnerHTML)) {
-      invariant('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
-        'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
-        'for more information.');
+    if (
+      !(
+        typeof props.dangerouslySetInnerHTML === 'object' &&
+        HTML in props.dangerouslySetInnerHTML
+      )
+    ) {
+      invariant(
+        '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+          'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
+          'for more information.',
+      );
     }
   }
   if (__DEV__) {
-    if (!(props.suppressContentEditableWarning ||
-      !props.contentEditable || props.children == null)) {
-      warning('A component is `contentEditable` and contains `children` managed by ' +
-        'React. It is now your responsibility to guarantee that none of ' +
-        'those nodes are unexpectedly modified or duplicated. This is ' +
-        'probably not intentional.');
+    if (
+      !(
+        props.suppressContentEditableWarning ||
+        !props.contentEditable ||
+        props.children == null
+      )
+    ) {
+      warning(
+        'A component is `contentEditable` and contains `children` managed by ' +
+          'React. It is now your responsibility to guarantee that none of ' +
+          'those nodes are unexpectedly modified or duplicated. This is ' +
+          'probably not intentional.',
+      );
     }
   }
 
   if (!(props.style == null || typeof props.style === 'object')) {
-    invariant('The `style` prop expects a mapping from style properties to values, ' +
-      "not a string. For example, style={{marginRight: spacing + 'em'}} when " +
-      'using JSX.%s', __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '');
+    invariant(
+      'The `style` prop expects a mapping from style properties to values, ' +
+        "not a string. For example, style={{marginRight: spacing + 'em'}} when " +
+        'using JSX.%s',
+      __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
+    );
   }
 }
 

--- a/packages/react-dom/src/shared/assertValidProps.js
+++ b/packages/react-dom/src/shared/assertValidProps.js
@@ -26,45 +26,37 @@ function assertValidProps(tag: string, props: ?Object) {
   }
   // Note the use of `==` which checks for null or undefined.
   if (voidElementTags[tag]) {
-    invariant(
-      props.children == null && props.dangerouslySetInnerHTML == null,
-      '%s is a void element tag and must neither have `children` nor ' +
-        'use `dangerouslySetInnerHTML`.%s',
-      tag,
-      __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
-    );
+    if (!(props.children == null && props.dangerouslySetInnerHTML == null)) {
+      invariant('%s is a void element tag and must neither have `children` nor ' +
+        'use `dangerouslySetInnerHTML`.%s', tag, __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '');
+    }
   }
   if (props.dangerouslySetInnerHTML != null) {
-    invariant(
-      props.children == null,
-      'Can only set one of `children` or `props.dangerouslySetInnerHTML`.',
-    );
-    invariant(
-      typeof props.dangerouslySetInnerHTML === 'object' &&
-        HTML in props.dangerouslySetInnerHTML,
-      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+    if (!(props.children == null)) {
+      invariant('Can only set one of `children` or `props.dangerouslySetInnerHTML`.');
+    }
+
+    if (!(typeof props.dangerouslySetInnerHTML === 'object' && HTML in props.dangerouslySetInnerHTML)) {
+      invariant('`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
         'Please visit https://fb.me/react-invariant-dangerously-set-inner-html ' +
-        'for more information.',
-    );
+        'for more information.');
+    }
   }
   if (__DEV__) {
-    warning(
-      props.suppressContentEditableWarning ||
-        !props.contentEditable ||
-        props.children == null,
-      'A component is `contentEditable` and contains `children` managed by ' +
+    if (!(props.suppressContentEditableWarning ||
+      !props.contentEditable || props.children == null)) {
+      warning('A component is `contentEditable` and contains `children` managed by ' +
         'React. It is now your responsibility to guarantee that none of ' +
         'those nodes are unexpectedly modified or duplicated. This is ' +
-        'probably not intentional.',
-    );
+        'probably not intentional.');
+    }
   }
-  invariant(
-    props.style == null || typeof props.style === 'object',
-    'The `style` prop expects a mapping from style properties to values, ' +
+
+  if (!(props.style == null || typeof props.style === 'object')) {
+    invariant('The `style` prop expects a mapping from style properties to values, ' +
       "not a string. For example, style={{marginRight: spacing + 'em'}} when " +
-      'using JSX.%s',
-    __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
-  );
+      'using JSX.%s', __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '');
+  }
 }
 
 export default assertValidProps;

--- a/packages/react-dom/src/shared/checkReact.js
+++ b/packages/react-dom/src/shared/checkReact.js
@@ -11,6 +11,8 @@ import React from 'react';
 import invariant from 'shared/invariant';
 
 if (!React) {
- invariant('ReactDOM was loaded before React. Make sure you load ' +
-   'the React package before loading ReactDOM.');
+  invariant(
+    'ReactDOM was loaded before React. Make sure you load ' +
+      'the React package before loading ReactDOM.',
+  );
 }

--- a/packages/react-dom/src/shared/checkReact.js
+++ b/packages/react-dom/src/shared/checkReact.js
@@ -10,8 +10,7 @@
 import React from 'react';
 import invariant from 'shared/invariant';
 
-invariant(
-  React,
-  'ReactDOM was loaded before React. Make sure you load ' +
-    'the React package before loading ReactDOM.',
-);
+if (!React) {
+ invariant('ReactDOM was loaded before React. Make sure you load ' +
+   'the React package before loading ReactDOM.');
+}

--- a/packages/react-dom/src/shared/sanitizeURL.js
+++ b/packages/react-dom/src/shared/sanitizeURL.js
@@ -33,15 +33,15 @@ let didWarn = false;
 
 function sanitizeURL(url: string) {
   if (disableJavaScriptURLs) {
-    invariant(
-      !isJavaScriptProtocol.test(url),
-      'React has blocked a javascript: URL as a security precaution.%s',
-      __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
-    );
+    if (isJavaScriptProtocol.test(url)) {
+      invariant(
+        'React has blocked a javascript: URL as a security precaution.%s',
+        __DEV__ ? ReactDebugCurrentFrame.getStackAddendum() : '',
+      );
+    }
   } else if (__DEV__ && !didWarn && isJavaScriptProtocol.test(url)) {
     didWarn = true;
     warning(
-      false,
       'A future version of React will block javascript: URLs as a security precaution. ' +
         'Use event handlers instead if you can. If you need to generate unsafe HTML try ' +
         'using dangerouslySetInnerHTML instead. React was passed %s.',

--- a/packages/react-dom/src/shared/warnValidStyle.js
+++ b/packages/react-dom/src/shared/warnValidStyle.js
@@ -41,7 +41,7 @@ if (__DEV__) {
       // As Andi Smith suggests
       // (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
       // is converted to lowercase `ms`.
-      camelize(name.replace(msPattern, 'ms-'))
+      camelize(name.replace(msPattern, 'ms-')),
     );
   };
 
@@ -54,7 +54,7 @@ if (__DEV__) {
     warning(
       'Unsupported vendor-prefixed style property %s. Did you mean %s?',
       name,
-      name.charAt(0).toUpperCase() + name.slice(1)
+      name.charAt(0).toUpperCase() + name.slice(1),
     );
   };
 
@@ -64,8 +64,12 @@ if (__DEV__) {
     }
 
     warnedStyleValues[value] = true;
-    warning("Style property values shouldn't contain a semicolon. " +
-      'Try "%s: %s" instead.', name, value.replace(badStyleValueWithSemicolonPattern, ''));
+    warning(
+      "Style property values shouldn't contain a semicolon. " +
+        'Try "%s: %s" instead.',
+      name,
+      value.replace(badStyleValueWithSemicolonPattern, ''),
+    );
   };
 
   const warnStyleValueIsNaN = function(name, value) {
@@ -83,7 +87,10 @@ if (__DEV__) {
     }
 
     warnedForInfinityValue = true;
-    warning('`Infinity` is an invalid value for the `%s` css style property.', name);
+    warning(
+      '`Infinity` is an invalid value for the `%s` css style property.',
+      name,
+    );
   };
 
   warnValidStyle = function(name, value) {

--- a/packages/react-dom/src/shared/warnValidStyle.js
+++ b/packages/react-dom/src/shared/warnValidStyle.js
@@ -36,13 +36,12 @@ if (__DEV__) {
 
     warnedStyleNames[name] = true;
     warning(
-      false,
       'Unsupported style property %s. Did you mean %s?',
       name,
       // As Andi Smith suggests
       // (http://www.andismith.com/blog/2012/02/modernizr-prefixed/), an `-ms` prefix
       // is converted to lowercase `ms`.
-      camelize(name.replace(msPattern, 'ms-')),
+      camelize(name.replace(msPattern, 'ms-'))
     );
   };
 
@@ -53,10 +52,9 @@ if (__DEV__) {
 
     warnedStyleNames[name] = true;
     warning(
-      false,
       'Unsupported vendor-prefixed style property %s. Did you mean %s?',
       name,
-      name.charAt(0).toUpperCase() + name.slice(1),
+      name.charAt(0).toUpperCase() + name.slice(1)
     );
   };
 
@@ -66,13 +64,8 @@ if (__DEV__) {
     }
 
     warnedStyleValues[value] = true;
-    warning(
-      false,
-      "Style property values shouldn't contain a semicolon. " +
-        'Try "%s: %s" instead.',
-      name,
-      value.replace(badStyleValueWithSemicolonPattern, ''),
-    );
+    warning("Style property values shouldn't contain a semicolon. " +
+      'Try "%s: %s" instead.', name, value.replace(badStyleValueWithSemicolonPattern, ''));
   };
 
   const warnStyleValueIsNaN = function(name, value) {
@@ -81,11 +74,7 @@ if (__DEV__) {
     }
 
     warnedForNaNValue = true;
-    warning(
-      false,
-      '`NaN` is an invalid value for the `%s` css style property.',
-      name,
-    );
+    warning('`NaN` is an invalid value for the `%s` css style property.', name);
   };
 
   const warnStyleValueIsInfinity = function(name, value) {
@@ -94,11 +83,7 @@ if (__DEV__) {
     }
 
     warnedForInfinityValue = true;
-    warning(
-      false,
-      '`Infinity` is an invalid value for the `%s` css style property.',
-      name,
-    );
+    warning('`Infinity` is an invalid value for the `%s` css style property.', name);
   };
 
   warnValidStyle = function(name, value) {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -143,7 +143,6 @@ function validateClassInstance(inst, methodName) {
     received = stringified;
   }
   invariant(
-    false,
     '%s(...): the first argument must be a React class instance. ' +
       'Instead received: %s.',
     methodName,
@@ -235,11 +234,13 @@ const ReactTestUtils = {
         const classList = className.split(/\s+/);
 
         if (!Array.isArray(classNames)) {
-          invariant(
-            classNames !== undefined,
-            'TestUtils.scryRenderedDOMComponentsWithClass expects a ' +
-              'className as a second argument.',
-          );
+          if (!(classNames !== undefined)) {
+            invariant(
+              'TestUtils.scryRenderedDOMComponentsWithClass expects a ' +
+                'className as a second argument.',
+            );
+          }
+
           classNames = classNames.split(/\s+/);
         }
         return classNames.every(function(name) {
@@ -362,7 +363,6 @@ const ReactTestUtils = {
     if (!hasWarnedAboutDeprecatedMockComponent) {
       hasWarnedAboutDeprecatedMockComponent = true;
       lowPriorityWarningWithoutStack(
-        false,
         'ReactTestUtils.mockComponent() is deprecated. ' +
           'Use shallow rendering or jest.mock() instead.\n\n' +
           'See https://fb.me/test-utils-mock-component for more information.',
@@ -400,17 +400,20 @@ const ReactTestUtils = {
  */
 function makeSimulator(eventType) {
   return function(domNode, eventData) {
-    invariant(
-      !React.isValidElement(domNode),
-      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
-        'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
-    );
-    invariant(
-      !ReactTestUtils.isCompositeComponent(domNode),
-      'TestUtils.Simulate expected a DOM node as the first argument but received ' +
-        'a component instance. Pass the DOM node you wish to simulate the event on instead.',
-    );
+    if (React.isValidElement(domNode)) {
+      invariant(
+        'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+          'a React element. Pass the DOM node you wish to simulate the event on instead. ' +
+          'Note that TestUtils.Simulate will not work if you are using shallow rendering.',
+      );
+    }
+
+    if (ReactTestUtils.isCompositeComponent(domNode)) {
+      invariant(
+        'TestUtils.Simulate expected a DOM node as the first argument but received ' +
+          'a component instance. Pass the DOM node you wish to simulate the event on instead.',
+      );
+    }
 
     const dispatchConfig = eventNameDispatchConfigs[eventType];
 

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -102,11 +102,8 @@ function act(callback: () => Thenable) {
     if (__DEV__) {
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-        warningWithoutStack(
-          null,
-          'You seem to have overlapping act() calls, this is not supported. ' +
-            'Be sure to await previous act() calls before making a new one. ',
-        );
+        warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
+          'Be sure to await previous act() calls before making a new one. ');
       }
     }
   }
@@ -135,12 +132,9 @@ function act(callback: () => Thenable) {
           .then(() => {})
           .then(() => {
             if (called === false) {
-              warningWithoutStack(
-                null,
-                'You called act(async () => ...) without await. ' +
-                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                  'calls and mixing their scopes. You should - await act(async () => ...);',
-              );
+              warningWithoutStack('You called act(async () => ...) without await. ' +
+                'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                'calls and mixing their scopes. You should - await act(async () => ...);');
             }
           });
       }
@@ -183,12 +177,10 @@ function act(callback: () => Thenable) {
     };
   } else {
     if (__DEV__) {
-      warningWithoutStack(
-        result === undefined,
-        'The callback passed to act(...) function ' +
-          'must return undefined, or a Promise. You returned %s',
-        result,
-      );
+      if (!(result === undefined)) {
+        warningWithoutStack('The callback passed to act(...) function ' +
+          'must return undefined, or a Promise. You returned %s', result);
+      }
     }
 
     // flush effects until none remain, and cleanup
@@ -212,8 +204,7 @@ function act(callback: () => Thenable) {
       then(resolve: () => void) {
         if (__DEV__) {
           warningWithoutStack(
-            false,
-            'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
+            'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
           );
         }
         resolve();

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -102,8 +102,10 @@ function act(callback: () => Thenable) {
     if (__DEV__) {
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-        warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
-          'Be sure to await previous act() calls before making a new one. ');
+        warningWithoutStack(
+          'You seem to have overlapping act() calls, this is not supported. ' +
+            'Be sure to await previous act() calls before making a new one. ',
+        );
       }
     }
   }
@@ -132,9 +134,11 @@ function act(callback: () => Thenable) {
           .then(() => {})
           .then(() => {
             if (called === false) {
-              warningWithoutStack('You called act(async () => ...) without await. ' +
-                'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                'calls and mixing their scopes. You should - await act(async () => ...);');
+              warningWithoutStack(
+                'You called act(async () => ...) without await. ' +
+                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                  'calls and mixing their scopes. You should - await act(async () => ...);',
+              );
             }
           });
       }
@@ -178,8 +182,11 @@ function act(callback: () => Thenable) {
   } else {
     if (__DEV__) {
       if (!(result === undefined)) {
-        warningWithoutStack('The callback passed to act(...) function ' +
-          'must return undefined, or a Promise. You returned %s', result);
+        warningWithoutStack(
+          'The callback passed to act(...) function ' +
+            'must return undefined, or a Promise. You returned %s',
+          result,
+        );
       }
     }
 
@@ -204,7 +211,7 @@ function act(callback: () => Thenable) {
       then(resolve: () => void) {
         if (__DEV__) {
           warningWithoutStack(
-            'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
+            'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
           );
         }
         resolve();

--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -74,9 +74,8 @@ function createGestureState(e: any, type: PressEventType): PressEvent {
       // NO-OP, we should remove this in the future
       if (__DEV__) {
         warning(
-          false,
           'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`'
         );
       }
     },
@@ -84,9 +83,8 @@ function createGestureState(e: any, type: PressEventType): PressEvent {
       // NO-OP, we should remove this in the future
       if (__DEV__) {
         warning(
-          false,
           'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`'
         );
       }
     },

--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -75,7 +75,7 @@ function createGestureState(e: any, type: PressEventType): PressEvent {
       if (__DEV__) {
         warning(
           'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`'
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
         );
       }
     },
@@ -84,7 +84,7 @@ function createGestureState(e: any, type: PressEventType): PressEvent {
       if (__DEV__) {
         warning(
           'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`'
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
         );
       }
     },

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -192,9 +192,8 @@ function createPressEvent(
       // NO-OP, we should remove this in the future
       if (__DEV__) {
         warning(
-          false,
           'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`'
         );
       }
     },
@@ -202,9 +201,8 @@ function createPressEvent(
       // NO-OP, we should remove this in the future
       if (__DEV__) {
         warning(
-          false,
           'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`'
         );
       }
     },

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -193,7 +193,7 @@ function createPressEvent(
       if (__DEV__) {
         warning(
           'preventDefault is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`'
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.preventDefault() }`',
         );
       }
     },
@@ -202,7 +202,7 @@ function createPressEvent(
       if (__DEV__) {
         warning(
           'stopPropagation is not available on event objects created from event responder modules (React Flare). ' +
-            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`'
+            'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.stopPropagation() }`',
         );
       }
     },

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -88,9 +88,11 @@ export function isAsyncMode(object: any) {
   if (__DEV__) {
     if (!hasWarnedAboutDeprecatedIsAsyncMode) {
       hasWarnedAboutDeprecatedIsAsyncMode = true;
-      lowPriorityWarningWithoutStack('The ReactIs.isAsyncMode() alias has been deprecated, ' +
-        'and will be removed in React 17+. Update your code to use ' +
-        'ReactIs.isConcurrentMode() instead. It has the exact same API.');
+      lowPriorityWarningWithoutStack(
+        'The ReactIs.isAsyncMode() alias has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactIs.isConcurrentMode() instead. It has the exact same API.',
+      );
     }
   }
   return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -88,12 +88,9 @@ export function isAsyncMode(object: any) {
   if (__DEV__) {
     if (!hasWarnedAboutDeprecatedIsAsyncMode) {
       hasWarnedAboutDeprecatedIsAsyncMode = true;
-      lowPriorityWarningWithoutStack(
-        false,
-        'The ReactIs.isAsyncMode() alias has been deprecated, ' +
-          'and will be removed in React 17+. Update your code to use ' +
-          'ReactIs.isConcurrentMode() instead. It has the exact same API.',
-      );
+      lowPriorityWarningWithoutStack('The ReactIs.isAsyncMode() alias has been deprecated, ' +
+        'and will be removed in React 17+. Update your code to use ' +
+        'ReactIs.isConcurrentMode() instead. It has the exact same API.');
     }
   }
   return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -179,12 +179,9 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack(
-          false,
-          'Warning: measureLayout on components using NativeMethodsMixin ' +
-            'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
-            'measureLayout must be called on a native ref. Consider using forwardRef.',
-        );
+        warningWithoutStack('Warning: measureLayout on components using NativeMethodsMixin ' +
+          'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
+          'measureLayout must be called on a native ref. Consider using forwardRef.');
         return;
       } else {
         let relativeNode;
@@ -198,8 +195,7 @@ export default function(
 
         if (relativeNode == null) {
           warningWithoutStack(
-            false,
-            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
+            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
           );
 
           return;
@@ -243,10 +239,7 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack(
-          false,
-          'Warning: setNativeProps is not currently supported in Fabric',
-        );
+        warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
         return;
       }
 
@@ -294,13 +287,13 @@ export default function(
     // __DEV__ without actually implementing them (setting them to undefined
     // isn't allowed by ReactClass)
     const NativeMethodsMixin_DEV = (NativeMethodsMixin: any);
-    invariant(
-      !NativeMethodsMixin_DEV.componentWillMount &&
-        !NativeMethodsMixin_DEV.componentWillReceiveProps &&
-        !NativeMethodsMixin_DEV.UNSAFE_componentWillMount &&
-        !NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps,
-      'Do not override existing functions.',
-    );
+
+    if (!(!NativeMethodsMixin_DEV.componentWillMount &&
+      !NativeMethodsMixin_DEV.componentWillReceiveProps &&
+      !NativeMethodsMixin_DEV.UNSAFE_componentWillMount && !NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps)) {
+      invariant('Do not override existing functions.');
+    }
+
     // TODO (bvaughn) Remove cWM and cWRP in a future version of React Native,
     // Once these lifecycles have been remove from the reconciler.
     NativeMethodsMixin_DEV.componentWillMount = function() {

--- a/packages/react-native-renderer/src/NativeMethodsMixin.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixin.js
@@ -179,9 +179,11 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack('Warning: measureLayout on components using NativeMethodsMixin ' +
-          'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
-          'measureLayout must be called on a native ref. Consider using forwardRef.');
+        warningWithoutStack(
+          'Warning: measureLayout on components using NativeMethodsMixin ' +
+            'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
+            'measureLayout must be called on a native ref. Consider using forwardRef.',
+        );
         return;
       } else {
         let relativeNode;
@@ -195,7 +197,7 @@ export default function(
 
         if (relativeNode == null) {
           warningWithoutStack(
-            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
+            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
           );
 
           return;
@@ -239,7 +241,9 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
+        warningWithoutStack(
+          'Warning: setNativeProps is not currently supported in Fabric',
+        );
         return;
       }
 
@@ -288,9 +292,14 @@ export default function(
     // isn't allowed by ReactClass)
     const NativeMethodsMixin_DEV = (NativeMethodsMixin: any);
 
-    if (!(!NativeMethodsMixin_DEV.componentWillMount &&
-      !NativeMethodsMixin_DEV.componentWillReceiveProps &&
-      !NativeMethodsMixin_DEV.UNSAFE_componentWillMount && !NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps)) {
+    if (
+      !(
+        !NativeMethodsMixin_DEV.componentWillMount &&
+        !NativeMethodsMixin_DEV.componentWillReceiveProps &&
+        !NativeMethodsMixin_DEV.UNSAFE_componentWillMount &&
+        !NativeMethodsMixin_DEV.UNSAFE_componentWillReceiveProps
+      )
+    ) {
       invariant('Do not override existing functions.');
     }
 

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -47,15 +47,16 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
     const owner = ReactCurrentOwner.current;
     if (owner !== null && owner.stateNode !== null) {
-      warningWithoutStack(
-        owner.stateNode._warnedAboutRefsInRender,
-        '%s is accessing findNodeHandle inside its render(). ' +
-          'render() should be a pure function of props and state. It should ' +
-          'never access something that requires stale data from the previous ' +
-          'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.',
-        getComponentName(owner.type) || 'A component',
-      );
+      if (!owner.stateNode._warnedAboutRefsInRender) {
+        warningWithoutStack(
+          '%s is accessing findNodeHandle inside its render(). ' +
+            'render() should be a pure function of props and state. It should ' +
+            'never access something that requires stale data from the previous ' +
+            'render, such as refs. Move this logic to componentDidMount and ' +
+            'componentDidUpdate instead.',
+          getComponentName(owner.type) || 'A component',
+        );
+      }
 
       owner.stateNode._warnedAboutRefsInRender = true;
     }
@@ -115,10 +116,10 @@ const ReactFabric: ReactFabricType = {
 
     if (invalid) {
       warningWithoutStack(
-        !invalid,
         "dispatchCommand was called with a ref that isn't a " +
           'native component. Use React.forwardRef to get access to the underlying native component',
       );
+
       return;
     }
 

--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -13,7 +13,11 @@ function getInstanceFromInstance(instanceHandle) {
 
 function getTagFromInstance(inst) {
   let tag = inst.stateNode.canonical._nativeTag;
-  invariant(tag, 'All native instances should have a tag.');
+
+  if (!tag) {
+    invariant('All native instances should have a tag.');
+  }
+
   return tag;
 }
 

--- a/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
+++ b/packages/react-native-renderer/src/ReactFabricEventResponderSystem.js
@@ -180,7 +180,6 @@ function validateEventValue(eventValue: any): void {
     const showWarning = name => {
       if (__DEV__) {
         warning(
-          false,
           '%s is not available on event objects created from event responder modules (React Flare). ' +
             'Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.%s }`',
           name,
@@ -241,10 +240,9 @@ function createFabricResponderEvent(
 }
 
 function validateResponderContext(): void {
-  invariant(
-    currentInstance,
-    'An event responder context was used outside of an event cycle.',
-  );
+  if (!currentInstance) {
+    invariant('An event responder context was used outside of an event cycle.');
+  }
 }
 
 // TODO this function is almost an exact copy of the DOM version, we should
@@ -438,13 +436,16 @@ function registerRootEventType(
   if (rootEventTypesSet === null) {
     rootEventTypesSet = responderInstance.rootEventTypes = new Set();
   }
-  invariant(
-    !rootEventTypesSet.has(rootEventType),
-    'addRootEventTypes() found a duplicate root event ' +
-      'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
-      'array or because of a previous addRootEventTypes() using this root event type.',
-    rootEventType,
-  );
+
+  if (rootEventTypesSet.has(rootEventType)) {
+    invariant(
+      'addRootEventTypes() found a duplicate root event ' +
+        'type of "%s". This might be because the event type exists in the event responder "rootEventTypes" ' +
+        'array or because of a previous addRootEventTypes() using this root event type.',
+      rootEventType,
+    );
+  }
+
   rootEventTypesSet.add(rootEventType);
   rootEventResponderInstances.add(responderInstance);
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -160,8 +160,7 @@ class ReactFabricHostComponent {
       !(relativeToNativeNode instanceof ReactFabricHostComponent)
     ) {
       warningWithoutStack(
-        false,
-        'Warning: ref.measureLayout must be called with a ref to a native component.',
+        'Warning: ref.measureLayout must be called with a ref to a native component.'
       );
 
       return;
@@ -176,10 +175,7 @@ class ReactFabricHostComponent {
   }
 
   setNativeProps(nativeProps: Object) {
-    warningWithoutStack(
-      false,
-      'Warning: setNativeProps is not currently supported in Fabric',
-    );
+    warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
 
     return;
   }
@@ -247,10 +243,9 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  invariant(
-    hostContext.isInAParentText,
-    'Text strings must be rendered within a <Text> component.',
-  );
+  if (!hostContext.isInAParentText) {
+    invariant('Text strings must be rendered within a <Text> component.');
+  }
 
   const tag = nextReactTag;
   nextReactTag += 2;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -160,7 +160,7 @@ class ReactFabricHostComponent {
       !(relativeToNativeNode instanceof ReactFabricHostComponent)
     ) {
       warningWithoutStack(
-        'Warning: ref.measureLayout must be called with a ref to a native component.'
+        'Warning: ref.measureLayout must be called with a ref to a native component.',
       );
 
       return;
@@ -175,7 +175,9 @@ class ReactFabricHostComponent {
   }
 
   setNativeProps(nativeProps: Object) {
-    warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
+    warningWithoutStack(
+      'Warning: setNativeProps is not currently supported in Fabric',
+    );
 
     return;
   }

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -44,11 +44,11 @@ const ReactNativeBridgeEventPlugin = {
     }
     const bubbleDispatchConfig = customBubblingEventTypes[topLevelType];
     const directDispatchConfig = customDirectEventTypes[topLevelType];
-    invariant(
-      bubbleDispatchConfig || directDispatchConfig,
-      'Unsupported top level event type "%s" dispatched',
-      topLevelType,
-    );
+
+    if (!(bubbleDispatchConfig || directDispatchConfig)) {
+      invariant('Unsupported top level event type "%s" dispatched', topLevelType);
+    }
+
     const event = SyntheticEvent.getPooled(
       bubbleDispatchConfig || directDispatchConfig,
       targetInst,

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -46,7 +46,10 @@ const ReactNativeBridgeEventPlugin = {
     const directDispatchConfig = customDirectEventTypes[topLevelType];
 
     if (!(bubbleDispatchConfig || directDispatchConfig)) {
-      invariant('Unsupported top level event type "%s" dispatched', topLevelType);
+      invariant(
+        'Unsupported top level event type "%s" dispatched',
+        topLevelType,
+      );
     }
 
     const event = SyntheticEvent.getPooled(

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -190,9 +190,11 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack('Warning: measureLayout on components using NativeMethodsMixin ' +
-          'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
-          'measureLayout must be called on a native ref. Consider using forwardRef.');
+        warningWithoutStack(
+          'Warning: measureLayout on components using NativeMethodsMixin ' +
+            'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
+            'measureLayout must be called on a native ref. Consider using forwardRef.',
+        );
         return;
       } else {
         let relativeNode;
@@ -206,7 +208,7 @@ export default function(
 
         if (relativeNode == null) {
           warningWithoutStack(
-            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
+            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
           );
 
           return;
@@ -250,7 +252,9 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
+        warningWithoutStack(
+          'Warning: setNativeProps is not currently supported in Fabric',
+        );
         return;
       }
 

--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -190,12 +190,9 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack(
-          false,
-          'Warning: measureLayout on components using NativeMethodsMixin ' +
-            'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
-            'measureLayout must be called on a native ref. Consider using forwardRef.',
-        );
+        warningWithoutStack('Warning: measureLayout on components using NativeMethodsMixin ' +
+          'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
+          'measureLayout must be called on a native ref. Consider using forwardRef.');
         return;
       } else {
         let relativeNode;
@@ -209,8 +206,7 @@ export default function(
 
         if (relativeNode == null) {
           warningWithoutStack(
-            false,
-            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
+            'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
           );
 
           return;
@@ -254,10 +250,7 @@ export default function(
       }
 
       if (maybeInstance.canonical) {
-        warningWithoutStack(
-          false,
-          'Warning: setNativeProps is not currently supported in Fabric',
-        );
+        warningWithoutStack('Warning: setNativeProps is not currently supported in Fabric');
         return;
       }
 

--- a/packages/react-native-renderer/src/ReactNativeComponentTree.js
+++ b/packages/react-native-renderer/src/ReactNativeComponentTree.js
@@ -28,7 +28,11 @@ function getTagFromInstance(inst) {
   if (tag === undefined) {
     tag = inst.stateNode.canonical._nativeTag;
   }
-  invariant(tag, 'All native instances should have a tag.');
+
+  if (!tag) {
+    invariant('All native instances should have a tag.');
+  }
+
   return tag;
 }
 

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -173,7 +173,9 @@ export function receiveTouches(
     if (target !== null && target !== undefined) {
       if (target < 1) {
         if (__DEV__) {
-          warningWithoutStack('A view is reporting that a touch occurred on tag zero.');
+          warningWithoutStack(
+            'A view is reporting that a touch occurred on tag zero.',
+          );
         }
       } else {
         rootNodeID = target;

--- a/packages/react-native-renderer/src/ReactNativeEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactNativeEventEmitter.js
@@ -173,10 +173,7 @@ export function receiveTouches(
     if (target !== null && target !== undefined) {
       if (target < 1) {
         if (__DEV__) {
-          warningWithoutStack(
-            false,
-            'A view is reporting that a touch occurred on tag zero.',
-          );
+          warningWithoutStack('A view is reporting that a touch occurred on tag zero.');
         }
       } else {
         rootNodeID = target;

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -86,7 +86,7 @@ class ReactNativeFiberHostComponent {
 
     if (relativeNode == null) {
       warningWithoutStack(
-        'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
+        'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
       );
 
       return;

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -86,8 +86,7 @@ class ReactNativeFiberHostComponent {
 
     if (relativeNode == null) {
       warningWithoutStack(
-        false,
-        'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.',
+        'Warning: ref.measureLayout must be called with a node handle or a ref to a native component.'
       );
 
       return;

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -119,10 +119,7 @@ if (__DEV__) {
   };
 } else {
   getInspectorDataForViewTag = () => {
-    invariant(
-      false,
-      'getInspectorDataForViewTag() is not available in production',
-    );
+    invariant('getInspectorDataForViewTag() is not available in production');
   };
 }
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -148,10 +148,9 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  invariant(
-    hostContext.isInAParentText,
-    'Text strings must be rendered within a <Text> component.',
-  );
+  if (!hostContext.isInAParentText) {
+    invariant('Text strings must be rendered within a <Text> component.');
+  }
 
   const tag = allocateTag();
 
@@ -408,14 +407,13 @@ export function insertInContainerBefore(
   child: Instance | TextInstance,
   beforeChild: Instance | TextInstance,
 ): void {
-  // TODO (bvaughn): Remove this check when...
-  // We create a wrapper object for the container in ReactNative render()
-  // Or we refactor to remove wrapper objects entirely.
-  // For more info on pros/cons see PR #8560 description.
-  invariant(
-    typeof parentInstance !== 'number',
-    'Container does not support insertBefore operation',
-  );
+  if (!(typeof parentInstance !== 'number')) {
+    // TODO (bvaughn): Remove this check when...
+    // We create a wrapper object for the container in ReactNative render()
+    // Or we refactor to remove wrapper objects entirely.
+    // For more info on pros/cons see PR #8560 description.
+    invariant('Container does not support insertBefore operation');
+  }
 }
 
 export function removeChild(

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -52,11 +52,14 @@ function findNodeHandle(componentOrHandle: any): ?number {
     const owner = ReactCurrentOwner.current;
     if (owner !== null && owner.stateNode !== null) {
       if (!owner.stateNode._warnedAboutRefsInRender) {
-        warningWithoutStack('%s is accessing findNodeHandle inside its render(). ' +
-          'render() should be a pure function of props and state. It should ' +
-          'never access something that requires stale data from the previous ' +
-          'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+        warningWithoutStack(
+          '%s is accessing findNodeHandle inside its render(). ' +
+            'render() should be a pure function of props and state. It should ' +
+            'never access something that requires stale data from the previous ' +
+            'render, such as refs. Move this logic to componentDidMount and ' +
+            'componentDidUpdate instead.',
+          getComponentName(owner.type) || 'A component',
+        );
       }
 
       owner.stateNode._warnedAboutRefsInRender = true;
@@ -120,8 +123,10 @@ const ReactNativeRenderer: ReactNativeType = {
   dispatchCommand(handle: any, command: string, args: Array<any>) {
     if (handle._nativeTag == null) {
       if (!(handle._nativeTag != null)) {
-        warningWithoutStack("dispatchCommand was called with a ref that isn't a " +
-          'native component. Use React.forwardRef to get access to the underlying native component');
+        warningWithoutStack(
+          "dispatchCommand was called with a ref that isn't a " +
+            'native component. Use React.forwardRef to get access to the underlying native component',
+        );
       }
 
       return;

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -51,15 +51,13 @@ function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
     const owner = ReactCurrentOwner.current;
     if (owner !== null && owner.stateNode !== null) {
-      warningWithoutStack(
-        owner.stateNode._warnedAboutRefsInRender,
-        '%s is accessing findNodeHandle inside its render(). ' +
+      if (!owner.stateNode._warnedAboutRefsInRender) {
+        warningWithoutStack('%s is accessing findNodeHandle inside its render(). ' +
           'render() should be a pure function of props and state. It should ' +
           'never access something that requires stale data from the previous ' +
           'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.',
-        getComponentName(owner.type) || 'A component',
-      );
+          'componentDidUpdate instead.', getComponentName(owner.type) || 'A component');
+      }
 
       owner.stateNode._warnedAboutRefsInRender = true;
     }
@@ -121,11 +119,11 @@ const ReactNativeRenderer: ReactNativeType = {
 
   dispatchCommand(handle: any, command: string, args: Array<any>) {
     if (handle._nativeTag == null) {
-      warningWithoutStack(
-        handle._nativeTag != null,
-        "dispatchCommand was called with a ref that isn't a " +
-          'native component. Use React.forwardRef to get access to the underlying native component',
-      );
+      if (!(handle._nativeTag != null)) {
+        warningWithoutStack("dispatchCommand was called with a ref that isn't a " +
+          'native component. Use React.forwardRef to get access to the underlying native component');
+      }
+
       return;
     }
 

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -54,11 +54,10 @@ const RCTFabricUIManager = {
     props,
     eventTarget,
   ) {
-    invariant(
-      !allocatedTags.has(reactTag),
-      'Created two native views with tag %s',
-      reactTag,
-    );
+    if (allocatedTags.has(reactTag)) {
+      invariant('Created two native views with tag %s', reactTag);
+    }
+
     allocatedTags.add(reactTag);
     return {
       reactTag: reactTag,
@@ -125,27 +124,25 @@ const RCTFabricUIManager = {
   registerEventHandler: jest.fn(function registerEventHandler(callback) {}),
 
   measure: jest.fn(function measure(node, callback) {
-    invariant(
-      typeof node === 'object',
-      'Expected node to be an object, was passed "%s"',
-      typeof node,
-    );
-    invariant(
-      typeof node.viewName === 'string',
-      'Expected node to be a host node.',
-    );
+    if (!(typeof node === 'object')) {
+      invariant('Expected node to be an object, was passed "%s"', typeof node);
+    }
+
+    if (!(typeof node.viewName === 'string')) {
+      invariant('Expected node to be a host node.');
+    }
+
     callback(10, 10, 100, 100, 0, 0);
   }),
   measureInWindow: jest.fn(function measureInWindow(node, callback) {
-    invariant(
-      typeof node === 'object',
-      'Expected node to be an object, was passed "%s"',
-      typeof node,
-    );
-    invariant(
-      typeof node.viewName === 'string',
-      'Expected node to be a host node.',
-    );
+    if (!(typeof node === 'object')) {
+      invariant('Expected node to be an object, was passed "%s"', typeof node);
+    }
+
+    if (!(typeof node.viewName === 'string')) {
+      invariant('Expected node to be a host node.');
+    }
+
     callback(10, 10, 100, 100);
   }),
   measureLayout: jest.fn(function measureLayout(
@@ -154,24 +151,25 @@ const RCTFabricUIManager = {
     fail,
     success,
   ) {
-    invariant(
-      typeof node === 'object',
-      'Expected node to be an object, was passed "%s"',
-      typeof node,
-    );
-    invariant(
-      typeof node.viewName === 'string',
-      'Expected node to be a host node.',
-    );
-    invariant(
-      typeof relativeNode === 'object',
-      'Expected relative node to be an object, was passed "%s"',
-      typeof relativeNode,
-    );
-    invariant(
-      typeof relativeNode.viewName === 'string',
-      'Expected relative node to be a host node.',
-    );
+    if (!(typeof node === 'object')) {
+      invariant('Expected node to be an object, was passed "%s"', typeof node);
+    }
+
+    if (!(typeof node.viewName === 'string')) {
+      invariant('Expected node to be a host node.');
+    }
+
+    if (!(typeof relativeNode === 'object')) {
+      invariant(
+        'Expected relative node to be an object, was passed "%s"',
+        typeof relativeNode,
+      );
+    }
+
+    if (!(typeof relativeNode.viewName === 'string')) {
+      invariant('Expected relative node to be a host node.');
+    }
+
     success(1, 1, 100, 100);
   }),
 };

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/ReactNativeViewConfigRegistry.js
@@ -38,11 +38,12 @@ function processEventTypes(
   if (__DEV__) {
     if (bubblingEventTypes != null && directEventTypes != null) {
       for (const topLevelType in directEventTypes) {
-        invariant(
-          bubblingEventTypes[topLevelType] == null,
-          'Event cannot be both direct and bubbling: %s',
-          topLevelType,
-        );
+        if (!(bubblingEventTypes[topLevelType] == null)) {
+          invariant(
+            'Event cannot be both direct and bubbling: %s',
+            topLevelType,
+          );
+        }
       }
     }
   }
@@ -73,17 +74,18 @@ function processEventTypes(
  * This is done to avoid causing Prepack deopts.
  */
 exports.register = function(name: string, callback: ViewConfigGetter): string {
-  invariant(
-    !viewConfigCallbacks.has(name),
-    'Tried to register two views with the same name %s',
-    name,
-  );
-  invariant(
-    typeof callback === 'function',
-    'View config getter callback for component `%s` must be a function (received `%s`)',
-    name,
-    callback === null ? 'null' : typeof callback,
-  );
+  if (viewConfigCallbacks.has(name)) {
+    invariant('Tried to register two views with the same name %s', name);
+  }
+
+  if (!(typeof callback === 'function')) {
+    invariant(
+      'View config getter callback for component `%s` must be a function (received `%s`)',
+      name,
+      callback === null ? 'null' : typeof callback,
+    );
+  }
+
   viewConfigCallbacks.set(name, callback);
   return name;
 };
@@ -99,7 +101,6 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
     const callback = viewConfigCallbacks.get(name);
     if (typeof callback !== 'function') {
       invariant(
-        false,
         'View config getter callback for component `%s` must be a function (received `%s`).%s',
         name,
         callback === null ? 'null' : typeof callback,
@@ -118,6 +119,10 @@ exports.get = function(name: string): ReactNativeBaseComponentViewConfig<> {
   } else {
     viewConfig = viewConfigs.get(name);
   }
-  invariant(viewConfig, 'View config not found for name %s', name);
+
+  if (!viewConfig) {
+    invariant('View config not found for name %s', name);
+  }
+
   return viewConfig;
 };

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/UIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/UIManager.js
@@ -33,18 +33,19 @@ function autoCreateRoot(tag) {
 function insertSubviewAtIndex(parent, child, index) {
   const parentInfo = views.get(parent);
   const childInfo = views.get(child);
-  invariant(
-    childInfo.parent === null,
-    'Inserting view %s %s which already has parent',
-    child,
-    JSON.stringify(childInfo.props),
-  );
-  invariant(
-    0 <= index && index <= parentInfo.children.length,
-    'Invalid index %s for children %s',
-    index,
-    parentInfo.children,
-  );
+
+  if (!(childInfo.parent === null)) {
+    invariant(
+      'Inserting view %s %s which already has parent',
+      child,
+      JSON.stringify(childInfo.props),
+    );
+  }
+
+  if (!(0 <= index && index <= parentInfo.children.length)) {
+    invariant('Invalid index %s for children %s', index, parentInfo.children);
+  }
+
   parentInfo.children.splice(index, 0, child);
   childInfo.parent = parent;
 }
@@ -53,7 +54,11 @@ function removeChild(parent, child) {
   const parentInfo = views.get(parent);
   const childInfo = views.get(child);
   const index = parentInfo.children.indexOf(child);
-  invariant(index >= 0, 'Missing view %s during removal', child);
+
+  if (!(index >= 0)) {
+    invariant('Missing view %s during removal', child);
+  }
+
   parentInfo.children.splice(index, 1);
   childInfo.parent = null;
 }
@@ -76,11 +81,10 @@ const RCTUIManager = {
   },
   clearJSResponder: jest.fn(),
   createView: jest.fn(function createView(reactTag, viewName, rootTag, props) {
-    invariant(
-      !views.has(reactTag),
-      'Created two native views with tag %s',
-      reactTag,
-    );
+    if (views.has(reactTag)) {
+      invariant('Created two native views with tag %s', reactTag);
+    }
+
     views.set(reactTag, {
       children: [],
       parent: null,
@@ -92,12 +96,12 @@ const RCTUIManager = {
   setJSResponder: jest.fn(),
   setChildren: jest.fn(function setChildren(parentTag, reactTags) {
     autoCreateRoot(parentTag);
-    // Native doesn't actually check this but it seems like a good idea
-    invariant(
-      views.get(parentTag).children.length === 0,
-      'Calling .setChildren on nonempty view %s',
-      parentTag,
-    );
+
+    if (!(views.get(parentTag).children.length === 0)) {
+      // Native doesn't actually check this but it seems like a good idea
+      invariant('Calling .setChildren on nonempty view %s', parentTag);
+    }
+
     // This logic ported from iOS (RCTUIManager.m)
     reactTags.forEach((tag, i) => {
       insertSubviewAtIndex(parentTag, tag, i);
@@ -112,19 +116,24 @@ const RCTUIManager = {
     removeAtIndices = [],
   ) {
     autoCreateRoot(parentTag);
-    // This logic ported from iOS (RCTUIManager.m)
-    invariant(
-      moveFromIndices.length === moveToIndices.length,
-      'Mismatched move indices %s and %s',
-      moveFromIndices,
-      moveToIndices,
-    );
-    invariant(
-      addChildReactTags.length === addAtIndices.length,
-      'Mismatched add indices %s and %s',
-      addChildReactTags,
-      addAtIndices,
-    );
+
+    if (!(moveFromIndices.length === moveToIndices.length)) {
+      // This logic ported from iOS (RCTUIManager.m)
+      invariant(
+        'Mismatched move indices %s and %s',
+        moveFromIndices,
+        moveToIndices,
+      );
+    }
+
+    if (!(addChildReactTags.length === addAtIndices.length)) {
+      invariant(
+        'Mismatched add indices %s and %s',
+        addChildReactTags,
+        addAtIndices,
+      );
+    }
+
     const parentInfo = views.get(parentTag);
     const permanentlyRemovedChildren = removeAtIndices.map(
       index => parentInfo.children[index],
@@ -157,19 +166,17 @@ const RCTUIManager = {
   }),
   replaceExistingNonRootView: jest.fn(),
   measure: jest.fn(function measure(tag, callback) {
-    invariant(
-      typeof tag === 'number',
-      'Expected tag to be a number, was passed %s',
-      tag,
-    );
+    if (!(typeof tag === 'number')) {
+      invariant('Expected tag to be a number, was passed %s', tag);
+    }
+
     callback(10, 10, 100, 100, 0, 0);
   }),
   measureInWindow: jest.fn(function measureInWindow(tag, callback) {
-    invariant(
-      typeof tag === 'number',
-      'Expected tag to be a number, was passed %s',
-      tag,
-    );
+    if (!(typeof tag === 'number')) {
+      invariant('Expected tag to be a number, was passed %s', tag);
+    }
+
     callback(10, 10, 100, 100);
   }),
   measureLayout: jest.fn(function measureLayout(
@@ -178,16 +185,17 @@ const RCTUIManager = {
     fail,
     success,
   ) {
-    invariant(
-      typeof tag === 'number',
-      'Expected tag to be a number, was passed %s',
-      tag,
-    );
-    invariant(
-      typeof relativeTag === 'number',
-      'Expected relativeTag to be a number, was passed %s',
-      relativeTag,
-    );
+    if (!(typeof tag === 'number')) {
+      invariant('Expected tag to be a number, was passed %s', tag);
+    }
+
+    if (!(typeof relativeTag === 'number')) {
+      invariant(
+        'Expected relativeTag to be a number, was passed %s',
+        relativeTag,
+      );
+    }
+
     success(1, 1, 100, 100);
   }),
   __takeSnapshot: jest.fn(),

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -661,8 +661,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (__DEV__) {
         if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
           // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-          warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
-            'Be sure to await previous act() calls before making a new one. ');
+          warningWithoutStack(
+            'You seem to have overlapping act() calls, this is not supported. ' +
+              'Be sure to await previous act() calls before making a new one. ',
+          );
         }
       }
     }
@@ -691,9 +693,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             .then(() => {})
             .then(() => {
               if (called === false) {
-                warningWithoutStack('You called act(async () => ...) without await. ' +
-                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                  'calls and mixing their scopes. You should - await act(async () => ...);');
+                warningWithoutStack(
+                  'You called act(async () => ...) without await. ' +
+                    'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                    'calls and mixing their scopes. You should - await act(async () => ...);',
+                );
               }
             });
         }
@@ -737,8 +741,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     } else {
       if (__DEV__) {
         if (!(result === undefined)) {
-          warningWithoutStack('The callback passed to act(...) function ' +
-            'must return undefined, or a Promise. You returned %s', result);
+          warningWithoutStack(
+            'The callback passed to act(...) function ' +
+              'must return undefined, or a Promise. You returned %s',
+            result,
+          );
         }
       }
 
@@ -764,7 +771,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         then(resolve: () => void) {
           if (__DEV__) {
             warningWithoutStack(
-              'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
+              'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
             );
           }
           resolve();

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -661,11 +661,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (__DEV__) {
         if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
           // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-          warningWithoutStack(
-            null,
-            'You seem to have overlapping act() calls, this is not supported. ' +
-              'Be sure to await previous act() calls before making a new one. ',
-          );
+          warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
+            'Be sure to await previous act() calls before making a new one. ');
         }
       }
     }
@@ -694,12 +691,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
             .then(() => {})
             .then(() => {
               if (called === false) {
-                warningWithoutStack(
-                  null,
-                  'You called act(async () => ...) without await. ' +
-                    'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                    'calls and mixing their scopes. You should - await act(async () => ...);',
-                );
+                warningWithoutStack('You called act(async () => ...) without await. ' +
+                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                  'calls and mixing their scopes. You should - await act(async () => ...);');
               }
             });
         }
@@ -742,12 +736,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       };
     } else {
       if (__DEV__) {
-        warningWithoutStack(
-          result === undefined,
-          'The callback passed to act(...) function ' +
-            'must return undefined, or a Promise. You returned %s',
-          result,
-        );
+        if (!(result === undefined)) {
+          warningWithoutStack('The callback passed to act(...) function ' +
+            'must return undefined, or a Promise. You returned %s', result);
+        }
       }
 
       // flush effects until none remain, and cleanup
@@ -772,8 +764,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         then(resolve: () => void) {
           if (__DEV__) {
             warningWithoutStack(
-              false,
-              'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
+              'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
             );
           }
           resolve();

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -77,8 +77,10 @@ if (__DEV__) {
     }
 
     if (!(typeof child._store === 'object')) {
-      invariant('React Component in warnForMissingKey should have a _store. ' +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'React Component in warnForMissingKey should have a _store. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
     }
 
     child._store.validated = true;
@@ -93,9 +95,11 @@ if (__DEV__) {
     }
     ownerHasKeyUseWarning[currentComponentErrorInfo] = true;
 
-    warning('Each child in a list should have a unique ' +
-      '"key" prop. See https://fb.me/react-warning-keys for ' +
-      'more information.');
+    warning(
+      'Each child in a list should have a unique ' +
+        '"key" prop. See https://fb.me/react-warning-keys for ' +
+        'more information.',
+    );
   };
 }
 
@@ -119,17 +123,26 @@ function coerceRef(
         const componentName = getComponentName(returnFiber.type) || 'Component';
         if (!didWarnAboutStringRefs[componentName]) {
           if (warnAboutStringRefs) {
-            warningWithoutStack('Component "%s" contains the string ref "%s". Support for string refs ' +
-              'will be removed in a future major release. We recommend using ' +
-              'useRef() or createRef() instead. ' +
-              'Learn more about using refs safely here: ' +
-              'https://fb.me/react-strict-mode-string-ref%s', componentName, mixedRef, getStackByFiberInDevAndProd(returnFiber));
+            warningWithoutStack(
+              'Component "%s" contains the string ref "%s". Support for string refs ' +
+                'will be removed in a future major release. We recommend using ' +
+                'useRef() or createRef() instead. ' +
+                'Learn more about using refs safely here: ' +
+                'https://fb.me/react-strict-mode-string-ref%s',
+              componentName,
+              mixedRef,
+              getStackByFiberInDevAndProd(returnFiber),
+            );
           } else {
-            warningWithoutStack('A string ref, "%s", has been found within a strict mode tree. ' +
-              'String refs are a source of potential bugs and should be avoided. ' +
-              'We recommend using useRef() or createRef() instead. ' +
-              'Learn more about using refs safely here: ' +
-              'https://fb.me/react-strict-mode-string-ref%s', mixedRef, getStackByFiberInDevAndProd(returnFiber));
+            warningWithoutStack(
+              'A string ref, "%s", has been found within a strict mode tree. ' +
+                'String refs are a source of potential bugs and should be avoided. ' +
+                'We recommend using useRef() or createRef() instead. ' +
+                'Learn more about using refs safely here: ' +
+                'https://fb.me/react-strict-mode-string-ref%s',
+              mixedRef,
+              getStackByFiberInDevAndProd(returnFiber),
+            );
           }
           didWarnAboutStringRefs[componentName] = true;
         }
@@ -143,16 +156,21 @@ function coerceRef(
         const ownerFiber = ((owner: any): Fiber);
 
         if (!(ownerFiber.tag === ClassComponent)) {
-          invariant('Function components cannot have refs. ' +
-            'Did you mean to use React.forwardRef()?');
+          invariant(
+            'Function components cannot have refs. ' +
+              'Did you mean to use React.forwardRef()?',
+          );
         }
 
         inst = ownerFiber.stateNode;
       }
 
       if (!inst) {
-        invariant('Missing owner for string ref %s. This error is likely caused by a ' +
-          'bug in React. Please file an issue.', mixedRef);
+        invariant(
+          'Missing owner for string ref %s. This error is likely caused by a ' +
+            'bug in React. Please file an issue.',
+          mixedRef,
+        );
       }
 
       const stringRef = '' + mixedRef;
@@ -182,7 +200,7 @@ function coerceRef(
     } else {
       if (!(typeof mixedRef === 'string')) {
         invariant(
-          'Expected ref to be a function, a string, an object returned by React.createRef(), or null.'
+          'Expected ref to be a function, a string, an object returned by React.createRef(), or null.',
         );
       }
 
@@ -194,7 +212,7 @@ function coerceRef(
             "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
             '3. You have multiple copies of React loaded\n' +
             'See https://fb.me/react-refs-must-have-owner for more information.',
-          mixedRef
+          mixedRef,
         );
       }
     }
@@ -216,7 +234,7 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
       Object.prototype.toString.call(newChild) === '[object Object]'
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
         : newChild,
-      addendum
+      addendum,
     );
   }
 }
@@ -233,9 +251,11 @@ function warnOnFunctionType() {
   }
   ownerHasFunctionTypeWarning[currentComponentErrorInfo] = true;
 
-  warning('Functions are not valid as a React child. This may happen if ' +
-    'you return a Component instead of <Component /> from render. ' +
-    'Or maybe you meant to call this function rather than return it.');
+  warning(
+    'Functions are not valid as a React child. This may happen if ' +
+      'you return a Component instead of <Component /> from render. ' +
+      'Or maybe you meant to call this function rather than return it.',
+  );
 }
 
 // This wrapper function exists because I expect to clone the code in each path
@@ -723,11 +743,14 @@ function ChildReconciler(shouldTrackSideEffects) {
             knownKeys.add(key);
             break;
           }
-          warning('Encountered two children with the same key, `%s`. ' +
-            'Keys should be unique so that components maintain their identity ' +
-            'across updates. Non-unique keys may cause children to be ' +
-            'duplicated and/or omitted — the behavior is unsupported and ' +
-            'could change in a future version.', key);
+          warning(
+            'Encountered two children with the same key, `%s`. ' +
+              'Keys should be unique so that components maintain their identity ' +
+              'across updates. Non-unique keys may cause children to be ' +
+              'duplicated and/or omitted — the behavior is unsupported and ' +
+              'could change in a future version.',
+            key,
+          );
           break;
         default:
           break;
@@ -907,8 +930,10 @@ function ChildReconciler(shouldTrackSideEffects) {
     const iteratorFn = getIteratorFn(newChildrenIterable);
 
     if (!(typeof iteratorFn === 'function')) {
-      invariant('An object is not an iterable. This error is likely caused by a bug in ' +
-        'React. Please file an issue.');
+      invariant(
+        'An object is not an iterable. This error is likely caused by a bug in ' +
+          'React. Please file an issue.',
+      );
     }
 
     if (__DEV__) {
@@ -920,11 +945,13 @@ function ChildReconciler(shouldTrackSideEffects) {
         newChildrenIterable[Symbol.toStringTag] === 'Generator'
       ) {
         if (!didWarnAboutGenerators) {
-          warning('Using Generators as children is unsupported and will likely yield ' +
-            'unexpected results because enumerating a generator mutates it. ' +
-            'You may convert it to an array with `Array.from()` or the ' +
-            '`[...spread]` operator before rendering. Keep in mind ' +
-            'you might need to polyfill these features for older browsers.');
+          warning(
+            'Using Generators as children is unsupported and will likely yield ' +
+              'unexpected results because enumerating a generator mutates it. ' +
+              'You may convert it to an array with `Array.from()` or the ' +
+              '`[...spread]` operator before rendering. Keep in mind ' +
+              'you might need to polyfill these features for older browsers.',
+          );
         }
 
         didWarnAboutGenerators = true;
@@ -933,9 +960,11 @@ function ChildReconciler(shouldTrackSideEffects) {
       // Warn about using Maps as children
       if ((newChildrenIterable: any).entries === iteratorFn) {
         if (!didWarnAboutMaps) {
-          warning('Using Maps as children is unsupported and will likely yield ' +
-            'unexpected results. Convert it to a sequence/iterable of keyed ' +
-            'ReactElements instead.');
+          warning(
+            'Using Maps as children is unsupported and will likely yield ' +
+              'unexpected results. Convert it to a sequence/iterable of keyed ' +
+              'ReactElements instead.',
+          );
         }
 
         didWarnAboutMaps = true;
@@ -1335,9 +1364,12 @@ function ChildReconciler(shouldTrackSideEffects) {
         // eslint-disable-next-lined no-fallthrough
         case FunctionComponent: {
           const Component = returnFiber.type;
-          invariant('%s(...): Nothing was returned from render. This usually means a ' +
-            'return statement is missing. Or, to render nothing, ' +
-            'return null.', Component.displayName || Component.name || 'Component');
+          invariant(
+            '%s(...): Nothing was returned from render. This usually means a ' +
+              'return statement is missing. Or, to render nothing, ' +
+              'return null.',
+            Component.displayName || Component.name || 'Component',
+          );
         }
       }
     }

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -75,11 +75,12 @@ if (__DEV__) {
     if (!child._store || child._store.validated || child.key != null) {
       return;
     }
-    invariant(
-      typeof child._store === 'object',
-      'React Component in warnForMissingKey should have a _store. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+
+    if (!(typeof child._store === 'object')) {
+      invariant('React Component in warnForMissingKey should have a _store. ' +
+        'This error is likely caused by a bug in React. Please file an issue.');
+    }
+
     child._store.validated = true;
 
     const currentComponentErrorInfo =
@@ -92,12 +93,9 @@ if (__DEV__) {
     }
     ownerHasKeyUseWarning[currentComponentErrorInfo] = true;
 
-    warning(
-      false,
-      'Each child in a list should have a unique ' +
-        '"key" prop. See https://fb.me/react-warning-keys for ' +
-        'more information.',
-    );
+    warning('Each child in a list should have a unique ' +
+      '"key" prop. See https://fb.me/react-warning-keys for ' +
+      'more information.');
   };
 }
 
@@ -121,28 +119,17 @@ function coerceRef(
         const componentName = getComponentName(returnFiber.type) || 'Component';
         if (!didWarnAboutStringRefs[componentName]) {
           if (warnAboutStringRefs) {
-            warningWithoutStack(
-              false,
-              'Component "%s" contains the string ref "%s". Support for string refs ' +
-                'will be removed in a future major release. We recommend using ' +
-                'useRef() or createRef() instead. ' +
-                'Learn more about using refs safely here: ' +
-                'https://fb.me/react-strict-mode-string-ref%s',
-              componentName,
-              mixedRef,
-              getStackByFiberInDevAndProd(returnFiber),
-            );
+            warningWithoutStack('Component "%s" contains the string ref "%s". Support for string refs ' +
+              'will be removed in a future major release. We recommend using ' +
+              'useRef() or createRef() instead. ' +
+              'Learn more about using refs safely here: ' +
+              'https://fb.me/react-strict-mode-string-ref%s', componentName, mixedRef, getStackByFiberInDevAndProd(returnFiber));
           } else {
-            warningWithoutStack(
-              false,
-              'A string ref, "%s", has been found within a strict mode tree. ' +
-                'String refs are a source of potential bugs and should be avoided. ' +
-                'We recommend using useRef() or createRef() instead. ' +
-                'Learn more about using refs safely here: ' +
-                'https://fb.me/react-strict-mode-string-ref%s',
-              mixedRef,
-              getStackByFiberInDevAndProd(returnFiber),
-            );
+            warningWithoutStack('A string ref, "%s", has been found within a strict mode tree. ' +
+              'String refs are a source of potential bugs and should be avoided. ' +
+              'We recommend using useRef() or createRef() instead. ' +
+              'Learn more about using refs safely here: ' +
+              'https://fb.me/react-strict-mode-string-ref%s', mixedRef, getStackByFiberInDevAndProd(returnFiber));
           }
           didWarnAboutStringRefs[componentName] = true;
         }
@@ -154,19 +141,20 @@ function coerceRef(
       let inst;
       if (owner) {
         const ownerFiber = ((owner: any): Fiber);
-        invariant(
-          ownerFiber.tag === ClassComponent,
-          'Function components cannot have refs. ' +
-            'Did you mean to use React.forwardRef()?',
-        );
+
+        if (!(ownerFiber.tag === ClassComponent)) {
+          invariant('Function components cannot have refs. ' +
+            'Did you mean to use React.forwardRef()?');
+        }
+
         inst = ownerFiber.stateNode;
       }
-      invariant(
-        inst,
-        'Missing owner for string ref %s. This error is likely caused by a ' +
-          'bug in React. Please file an issue.',
-        mixedRef,
-      );
+
+      if (!inst) {
+        invariant('Missing owner for string ref %s. This error is likely caused by a ' +
+          'bug in React. Please file an issue.', mixedRef);
+      }
+
       const stringRef = '' + mixedRef;
       // Check if previous string ref matches new string ref
       if (
@@ -192,20 +180,23 @@ function coerceRef(
       ref._stringRef = stringRef;
       return ref;
     } else {
-      invariant(
-        typeof mixedRef === 'string',
-        'Expected ref to be a function, a string, an object returned by React.createRef(), or null.',
-      );
-      invariant(
-        element._owner,
-        'Element ref was specified as a string (%s) but no owner was set. This could happen for one of' +
-          ' the following reasons:\n' +
-          '1. You may be adding a ref to a function component\n' +
-          "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
-          '3. You have multiple copies of React loaded\n' +
-          'See https://fb.me/react-refs-must-have-owner for more information.',
-        mixedRef,
-      );
+      if (!(typeof mixedRef === 'string')) {
+        invariant(
+          'Expected ref to be a function, a string, an object returned by React.createRef(), or null.'
+        );
+      }
+
+      if (!element._owner) {
+        invariant(
+          'Element ref was specified as a string (%s) but no owner was set. This could happen for one of' +
+            ' the following reasons:\n' +
+            '1. You may be adding a ref to a function component\n' +
+            "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
+            '3. You have multiple copies of React loaded\n' +
+            'See https://fb.me/react-refs-must-have-owner for more information.',
+          mixedRef
+        );
+      }
     }
   }
   return mixedRef;
@@ -221,12 +212,11 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
         getCurrentFiberStackInDev();
     }
     invariant(
-      false,
       'Objects are not valid as a React child (found: %s).%s',
       Object.prototype.toString.call(newChild) === '[object Object]'
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
         : newChild,
-      addendum,
+      addendum
     );
   }
 }
@@ -243,12 +233,9 @@ function warnOnFunctionType() {
   }
   ownerHasFunctionTypeWarning[currentComponentErrorInfo] = true;
 
-  warning(
-    false,
-    'Functions are not valid as a React child. This may happen if ' +
-      'you return a Component instead of <Component /> from render. ' +
-      'Or maybe you meant to call this function rather than return it.',
-  );
+  warning('Functions are not valid as a React child. This may happen if ' +
+    'you return a Component instead of <Component /> from render. ' +
+    'Or maybe you meant to call this function rather than return it.');
 }
 
 // This wrapper function exists because I expect to clone the code in each path
@@ -736,15 +723,11 @@ function ChildReconciler(shouldTrackSideEffects) {
             knownKeys.add(key);
             break;
           }
-          warning(
-            false,
-            'Encountered two children with the same key, `%s`. ' +
-              'Keys should be unique so that components maintain their identity ' +
-              'across updates. Non-unique keys may cause children to be ' +
-              'duplicated and/or omitted — the behavior is unsupported and ' +
-              'could change in a future version.',
-            key,
-          );
+          warning('Encountered two children with the same key, `%s`. ' +
+            'Keys should be unique so that components maintain their identity ' +
+            'across updates. Non-unique keys may cause children to be ' +
+            'duplicated and/or omitted — the behavior is unsupported and ' +
+            'could change in a future version.', key);
           break;
         default:
           break;
@@ -922,11 +905,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     // but using the iterator instead.
 
     const iteratorFn = getIteratorFn(newChildrenIterable);
-    invariant(
-      typeof iteratorFn === 'function',
-      'An object is not an iterable. This error is likely caused by a bug in ' +
-        'React. Please file an issue.',
-    );
+
+    if (!(typeof iteratorFn === 'function')) {
+      invariant('An object is not an iterable. This error is likely caused by a bug in ' +
+        'React. Please file an issue.');
+    }
 
     if (__DEV__) {
       // We don't support rendering Generators because it's a mutation.
@@ -936,25 +919,25 @@ function ChildReconciler(shouldTrackSideEffects) {
         // $FlowFixMe Flow doesn't know about toStringTag
         newChildrenIterable[Symbol.toStringTag] === 'Generator'
       ) {
-        warning(
-          didWarnAboutGenerators,
-          'Using Generators as children is unsupported and will likely yield ' +
+        if (!didWarnAboutGenerators) {
+          warning('Using Generators as children is unsupported and will likely yield ' +
             'unexpected results because enumerating a generator mutates it. ' +
             'You may convert it to an array with `Array.from()` or the ' +
             '`[...spread]` operator before rendering. Keep in mind ' +
-            'you might need to polyfill these features for older browsers.',
-        );
+            'you might need to polyfill these features for older browsers.');
+        }
+
         didWarnAboutGenerators = true;
       }
 
       // Warn about using Maps as children
       if ((newChildrenIterable: any).entries === iteratorFn) {
-        warning(
-          didWarnAboutMaps,
-          'Using Maps as children is unsupported and will likely yield ' +
+        if (!didWarnAboutMaps) {
+          warning('Using Maps as children is unsupported and will likely yield ' +
             'unexpected results. Convert it to a sequence/iterable of keyed ' +
-            'ReactElements instead.',
-        );
+            'ReactElements instead.');
+        }
+
         didWarnAboutMaps = true;
       }
 
@@ -972,7 +955,10 @@ function ChildReconciler(shouldTrackSideEffects) {
     }
 
     const newChildren = iteratorFn.call(newChildrenIterable);
-    invariant(newChildren != null, 'An iterable object provided no iterator.');
+
+    if (!(newChildren != null)) {
+      invariant('An iterable object provided no iterator.');
+    }
 
     let resultingFirstChild: Fiber | null = null;
     let previousNewFiber: Fiber | null = null;
@@ -1349,13 +1335,9 @@ function ChildReconciler(shouldTrackSideEffects) {
         // eslint-disable-next-lined no-fallthrough
         case FunctionComponent: {
           const Component = returnFiber.type;
-          invariant(
-            false,
-            '%s(...): Nothing was returned from render. This usually means a ' +
-              'return statement is missing. Or, to render nothing, ' +
-              'return null.',
-            Component.displayName || Component.name || 'Component',
-          );
+          invariant('%s(...): Nothing was returned from render. This usually means a ' +
+            'return statement is missing. Or, to render nothing, ' +
+            'return null.', Component.displayName || Component.name || 'Component');
         }
       }
     }
@@ -1374,10 +1356,9 @@ export function cloneChildFibers(
   current: Fiber | null,
   workInProgress: Fiber,
 ): void {
-  invariant(
-    current === null || workInProgress.child === current.child,
-    'Resuming work not yet implemented.',
-  );
+  if (!(current === null || workInProgress.child === current.child)) {
+    invariant('Resuming work not yet implemented.');
+  }
 
   if (workInProgress.child === null) {
     return;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -708,9 +708,13 @@ export function createFiberFromTypeAndProps(
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }
         }
-        invariant('Element type is invalid: expected a string (for built-in ' +
-          'components) or a class/function (for composite components) ' +
-          'but got: %s.%s', type == null ? type : typeof type, info);
+        invariant(
+          'Element type is invalid: expected a string (for built-in ' +
+            'components) or a class/function (for composite components) ' +
+            'but got: %s.%s',
+          type == null ? type : typeof type,
+          info,
+        );
       }
     }
   }
@@ -800,7 +804,9 @@ function createFiberFromProfiler(
       typeof pendingProps.id !== 'string' ||
       typeof pendingProps.onRender !== 'function'
     ) {
-      warningWithoutStack('Profiler must specify an "id" string and "onRender" function as props');
+      warningWithoutStack(
+        'Profiler must specify an "id" string and "onRender" function as props',
+      );
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -708,14 +708,9 @@ export function createFiberFromTypeAndProps(
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }
         }
-        invariant(
-          false,
-          'Element type is invalid: expected a string (for built-in ' +
-            'components) or a class/function (for composite components) ' +
-            'but got: %s.%s',
-          type == null ? type : typeof type,
-          info,
-        );
+        invariant('Element type is invalid: expected a string (for built-in ' +
+          'components) or a class/function (for composite components) ' +
+          'but got: %s.%s', type == null ? type : typeof type, info);
       }
     }
   }
@@ -805,10 +800,7 @@ function createFiberFromProfiler(
       typeof pendingProps.id !== 'string' ||
       typeof pendingProps.onRender !== 'function'
     ) {
-      warningWithoutStack(
-        false,
-        'Profiler must specify an "id" string and "onRender" function as props',
-      );
+      warningWithoutStack('Profiler must specify an "id" string and "onRender" function as props');
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -781,12 +781,14 @@ function updateClassComponent(
   if (__DEV__) {
     let inst = workInProgress.stateNode;
     if (inst.props !== nextProps) {
-      warning(
-        didWarnAboutReassigningProps,
-        'It looks like %s is reassigning its own `this.props` while rendering. ' +
-          'This is not supported and can lead to confusing bugs.',
-        getComponentName(workInProgress.type) || 'a component',
-      );
+      if (!didWarnAboutReassigningProps) {
+        warning(
+          'It looks like %s is reassigning its own `this.props` while rendering. ' +
+            'This is not supported and can lead to confusing bugs.',
+          getComponentName(workInProgress.type) || 'a component',
+        );
+      }
+
       didWarnAboutReassigningProps = true;
     }
   }
@@ -907,12 +909,15 @@ function pushHostRootContext(workInProgress) {
 function updateHostRoot(current, workInProgress, renderExpirationTime) {
   pushHostRootContext(workInProgress);
   const updateQueue = workInProgress.updateQueue;
-  invariant(
-    updateQueue !== null,
-    'If the root does not have an updateQueue, we should have already ' +
-      'bailed out. This error is likely caused by a bug in React. Please ' +
-      'file an issue.',
-  );
+
+  if (!(updateQueue !== null)) {
+    invariant(
+      'If the root does not have an updateQueue, we should have already ' +
+        'bailed out. This error is likely caused by a bug in React. Please ' +
+        'file an issue.',
+    );
+  }
+
   const nextProps = workInProgress.pendingProps;
   const prevState = workInProgress.memoizedState;
   const prevChildren = prevState !== null ? prevState.element : null;
@@ -1153,7 +1158,6 @@ function mountLazyComponent(
       // because the fact that it's a separate type of work is an
       // implementation detail.
       invariant(
-        false,
         'Element type is invalid. Received a promise that resolves to: %s. ' +
           'Lazy element type must resolve to a class or function.%s',
         Component,
@@ -1262,7 +1266,6 @@ function mountIndeterminateComponent(
 
       if (!didWarnAboutBadClass[componentName]) {
         warningWithoutStack(
-          false,
           "The <%s /> component appears to have a render method, but doesn't extend React.Component. " +
             'This is likely to cause errors. Change %s to extend React.Component instead.',
           componentName,
@@ -1308,7 +1311,6 @@ function mountIndeterminateComponent(
       const componentName = getComponentName(Component) || 'Unknown';
       if (!didWarnAboutModulePatternComponent[componentName]) {
         warningWithoutStack(
-          false,
           'The <%s /> component appears to be a function component that returns a class instance. ' +
             'Change %s to a class that extends React.Component instead. ' +
             "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -1368,7 +1370,6 @@ function mountIndeterminateComponent(
     if (__DEV__) {
       if (disableLegacyContext && Component.contextTypes) {
         warningWithoutStack(
-          false,
           '%s uses the legacy contextTypes API which is no longer supported. ' +
             'Use React.createContext() with React.useContext() instead.',
           getComponentName(Component) || 'Unknown',
@@ -1402,9 +1403,8 @@ function mountIndeterminateComponent(
 }
 
 function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
-  if (Component) {
+  if (Component && Component.childContextTypes) {
     warningWithoutStack(
-      !Component.childContextTypes,
       '%s(...): childContextTypes cannot be defined on a function component.',
       Component.displayName || Component.name || 'Component',
     );
@@ -1424,7 +1424,6 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
     if (!didWarnAboutFunctionRefs[warningKey]) {
       didWarnAboutFunctionRefs[warningKey] = true;
       warning(
-        false,
         'Function components cannot be given refs. ' +
           'Attempts to access this ref will fail. ' +
           'Did you mean to use React.forwardRef()?%s',
@@ -1441,7 +1440,6 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
 
     if (!didWarnAboutDefaultPropsOnFunctionComponent[componentName]) {
       warningWithoutStack(
-        false,
         '%s: Support for defaultProps will be removed from function components ' +
           'in a future major release. Use JavaScript default parameters instead.',
         componentName,
@@ -1455,7 +1453,6 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
 
     if (!didWarnAboutGetDerivedStateOnFunctionComponent[componentName]) {
       warningWithoutStack(
-        false,
         '%s: Function components do not support getDerivedStateFromProps.',
         componentName,
       );
@@ -1471,7 +1468,6 @@ function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {
 
     if (!didWarnAboutContextTypeOnFunctionComponent[componentName]) {
       warningWithoutStack(
-        false,
         '%s: Function components do not support contextType.',
         componentName,
       );
@@ -1561,7 +1557,6 @@ function updateSuspenseComponent(
       if (!didWarnAboutMaxDuration) {
         didWarnAboutMaxDuration = true;
         warning(
-          false,
           'maxDuration has been removed from React. ' +
             'Remove the maxDuration prop.',
         );
@@ -1969,7 +1964,6 @@ function mountDehydratedSuspenseComponent(
   if ((workInProgress.mode & BatchedMode) === NoMode) {
     if (__DEV__) {
       warning(
-        false,
         'Cannot hydrate Suspense in legacy mode. Switch from ' +
           'ReactDOM.hydrate(element, container) to ' +
           'ReactDOM.unstable_createSyncRoot(container, { hydrate: true })' +
@@ -2204,7 +2198,6 @@ function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
           case 'forwards':
           case 'backwards': {
             warning(
-              false,
               '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
                 'Use lowercase "%s" instead.',
               revealOrder,
@@ -2215,7 +2208,6 @@ function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
           case 'forward':
           case 'backward': {
             warning(
-              false,
               '"%s" is not a valid value for revealOrder on <SuspenseList />. ' +
                 'React uses the -s suffix in the spelling. Use "%ss" instead.',
               revealOrder,
@@ -2225,7 +2217,6 @@ function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
           }
           default:
             warning(
-              false,
               '"%s" is not a supported revealOrder on <SuspenseList />. ' +
                 'Did you mean "together", "forwards" or "backwards"?',
               revealOrder,
@@ -2234,7 +2225,6 @@ function validateRevealOrder(revealOrder: SuspenseListRevealOrder) {
         }
       } else {
         warning(
-          false,
           '%s is not a supported value for revealOrder on <SuspenseList />. ' +
             'Did you mean "together", "forwards" or "backwards"?',
           revealOrder,
@@ -2253,7 +2243,6 @@ function validateTailOptions(
       if (tailMode !== 'collapsed' && tailMode !== 'hidden') {
         didWarnAboutTailOptions[tailMode] = true;
         warning(
-          false,
           '"%s" is not a supported value for tail on <SuspenseList />. ' +
             'Did you mean "collapsed" or "hidden"?',
           tailMode,
@@ -2261,7 +2250,6 @@ function validateTailOptions(
       } else if (revealOrder !== 'forwards' && revealOrder !== 'backwards') {
         didWarnAboutTailOptions[tailMode] = true;
         warning(
-          false,
           '<SuspenseList tail="%s" /> is only valid if revealOrder is ' +
             '"forwards" or "backwards". ' +
             'Did you mean to specify revealOrder="forwards"?',
@@ -2279,7 +2267,6 @@ function validateSuspenseListNestedChild(childSlot: mixed, index: number) {
     if (isArray || isIterable) {
       let type = isArray ? 'array' : 'iterable';
       warning(
-        false,
         'A nested %s was passed to row #%s in <SuspenseList />. Wrap it in ' +
           'an additional SuspenseList to configure its revealOrder: ' +
           '<SuspenseList revealOrder=...> ... ' +
@@ -2326,7 +2313,6 @@ function validateSuspenseListChildren(
           }
         } else {
           warning(
-            false,
             'A single row was passed to a <SuspenseList revealOrder="%s" />. ' +
               'This is not useful since it needs multiple rows. ' +
               'Did you mean to pass multiple children or an array?',
@@ -2614,7 +2600,6 @@ function updateContextConsumer(
         if (!hasWarnedAboutUsingContextAsConsumer) {
           hasWarnedAboutUsingContextAsConsumer = true;
           warning(
-            false,
             'Rendering <Context> directly is not supported and will be removed in ' +
               'a future major release. Did you mean to render <Context.Consumer> instead?',
           );
@@ -2628,13 +2613,14 @@ function updateContextConsumer(
   const render = newProps.children;
 
   if (__DEV__) {
-    warningWithoutStack(
-      typeof render === 'function',
-      'A context consumer was rendered with multiple children, or a child ' +
-        "that isn't a function. A context consumer expects a single child " +
-        'that is a function. If you did pass a function, make sure there ' +
-        'is no trailing or leading whitespace around it.',
-    );
+    if (!(typeof render === 'function')) {
+      warningWithoutStack(
+        'A context consumer was rendered with multiple children, or a child ' +
+          "that isn't a function. A context consumer expects a single child " +
+          'that is a function. If you did pass a function, make sure there ' +
+          'is no trailing or leading whitespace around it.',
+      );
+    }
   }
 
   prepareToReadContext(workInProgress, renderExpirationTime);
@@ -3192,7 +3178,6 @@ function beginWork(
     }
   }
   invariant(
-    false,
     'Unknown unit of work tag (%s). This error is likely caused by a bug in ' +
       'React. Please file an issue.',
     workInProgress.tag,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -93,8 +93,12 @@ if (__DEV__) {
     const key = `${callerName}_${(callback: any)}`;
     if (!didWarnOnInvalidCallback.has(key)) {
       didWarnOnInvalidCallback.add(key);
-      warningWithoutStack('%s(...): Expected the last optional `callback` argument to be a ' +
-        'function. Instead received: %s.', callerName, callback);
+      warningWithoutStack(
+        '%s(...): Expected the last optional `callback` argument to be a ' +
+          'function. Instead received: %s.',
+        callerName,
+        callback,
+      );
     }
   };
 
@@ -106,7 +110,7 @@ if (__DEV__) {
         warningWithoutStack(
           '%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' +
             'You have returned undefined.',
-          componentName
+          componentName,
         );
       }
     }
@@ -120,12 +124,14 @@ if (__DEV__) {
   Object.defineProperty(fakeInternalInstance, '_processChildContext', {
     enumerable: false,
     value: function() {
-      invariant('_processChildContext is not available in React 16+. This likely ' +
-        'means you have multiple copies of React and are attempting to nest ' +
-        'a React 15 tree inside a React 16 tree using ' +
-        "unstable_renderSubtreeIntoContainer, which isn't supported. Try " +
-        'to make sure you have only one copy of React (and ideally, switch ' +
-        'to ReactDOM.createPortal).');
+      invariant(
+        '_processChildContext is not available in React 16+. This likely ' +
+          'means you have multiple copies of React and are attempting to nest ' +
+          'a React 15 tree inside a React 16 tree using ' +
+          "unstable_renderSubtreeIntoContainer, which isn't supported. Try " +
+          'to make sure you have only one copy of React (and ideally, switch ' +
+          'to ReactDOM.createPortal).',
+      );
     },
   });
   Object.freeze(fakeInternalInstance);
@@ -264,8 +270,11 @@ function checkShouldComponentUpdate(
 
     if (__DEV__) {
       if (!(shouldUpdate !== undefined)) {
-        warningWithoutStack('%s.shouldComponentUpdate(): Returned undefined instead of a ' +
-          'boolean value. Make sure to return true or false.', getComponentName(ctor) || 'Component');
+        warningWithoutStack(
+          '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
+            'boolean value. Make sure to return true or false.',
+          getComponentName(ctor) || 'Component',
+        );
       }
     }
 
@@ -289,11 +298,17 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
 
     if (!renderPresent) {
       if (ctor.prototype && typeof ctor.prototype.render === 'function') {
-        warningWithoutStack('%s(...): No `render` method found on the returned component ' +
-          'instance: did you accidentally return an object from the constructor?', name);
+        warningWithoutStack(
+          '%s(...): No `render` method found on the returned component ' +
+            'instance: did you accidentally return an object from the constructor?',
+          name,
+        );
       } else {
-        warningWithoutStack('%s(...): No `render` method found on the returned component ' +
-          'instance: you may have forgotten to define `render`.', name);
+        warningWithoutStack(
+          '%s(...): No `render` method found on the returned component ' +
+            'instance: you may have forgotten to define `render`.',
+          name,
+        );
       }
     }
 
@@ -303,9 +318,12 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       instance.state;
 
     if (!noGetInitialStateOnES6) {
-      warningWithoutStack('getInitialState was defined on %s, a plain JavaScript class. ' +
-        'This is only supported for classes created using React.createClass. ' +
-        'Did you mean to define a state property instead?', name);
+      warningWithoutStack(
+        'getInitialState was defined on %s, a plain JavaScript class. ' +
+          'This is only supported for classes created using React.createClass. ' +
+          'Did you mean to define a state property instead?',
+        name,
+      );
     }
 
     const noGetDefaultPropsOnES6 =
@@ -313,23 +331,32 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       instance.getDefaultProps.isReactClassApproved;
 
     if (!noGetDefaultPropsOnES6) {
-      warningWithoutStack('getDefaultProps was defined on %s, a plain JavaScript class. ' +
-        'This is only supported for classes created using React.createClass. ' +
-        'Use a static property to define defaultProps instead.', name);
+      warningWithoutStack(
+        'getDefaultProps was defined on %s, a plain JavaScript class. ' +
+          'This is only supported for classes created using React.createClass. ' +
+          'Use a static property to define defaultProps instead.',
+        name,
+      );
     }
 
     const noInstancePropTypes = !instance.propTypes;
 
     if (!noInstancePropTypes) {
-      warningWithoutStack('propTypes was defined as an instance property on %s. Use a static ' +
-        'property to define propTypes instead.', name);
+      warningWithoutStack(
+        'propTypes was defined as an instance property on %s. Use a static ' +
+          'property to define propTypes instead.',
+        name,
+      );
     }
 
     const noInstanceContextType = !instance.contextType;
 
     if (!noInstanceContextType) {
-      warningWithoutStack('contextType was defined as an instance property on %s. Use a static ' +
-        'property to define contextType instead.', name);
+      warningWithoutStack(
+        'contextType was defined as an instance property on %s. Use a static ' +
+          'property to define contextType instead.',
+        name,
+      );
     }
 
     if (disableLegacyContext) {
@@ -337,19 +364,25 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         warningWithoutStack(
           '%s uses the legacy childContextTypes API which is no longer supported. ' +
             'Use React.createContext() instead.',
-          name
+          name,
         );
       }
       if (ctor.contextTypes) {
-        warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
-          'Use React.createContext() with static contextType instead.', name);
+        warningWithoutStack(
+          '%s uses the legacy contextTypes API which is no longer supported. ' +
+            'Use React.createContext() with static contextType instead.',
+          name,
+        );
       }
     } else {
       const noInstanceContextTypes = !instance.contextTypes;
 
       if (!noInstanceContextTypes) {
-        warningWithoutStack('contextTypes was defined as an instance property on %s. Use a static ' +
-          'property to define contextTypes instead.', name);
+        warningWithoutStack(
+          'contextTypes was defined as an instance property on %s. Use a static ' +
+            'property to define contextTypes instead.',
+          name,
+        );
       }
 
       if (
@@ -358,8 +391,11 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         !didWarnAboutContextTypeAndContextTypes.has(ctor)
       ) {
         didWarnAboutContextTypeAndContextTypes.add(ctor);
-        warningWithoutStack('%s declares both contextTypes and contextType static properties. ' +
-          'The legacy contextTypes property will be ignored.', name);
+        warningWithoutStack(
+          '%s declares both contextTypes and contextType static properties. ' +
+            'The legacy contextTypes property will be ignored.',
+          name,
+        );
       }
     }
 
@@ -367,10 +403,13 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       typeof instance.componentShouldUpdate !== 'function';
 
     if (!noComponentShouldUpdate) {
-      warningWithoutStack('%s has a method called ' +
-        'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
-        'The name is phrased as a question because the function is ' +
-        'expected to return a value.', name);
+      warningWithoutStack(
+        '%s has a method called ' +
+          'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
+          'The name is phrased as a question because the function is ' +
+          'expected to return a value.',
+        name,
+      );
     }
 
     if (
@@ -378,51 +417,70 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       ctor.prototype.isPureReactComponent &&
       typeof instance.shouldComponentUpdate !== 'undefined'
     ) {
-      warningWithoutStack('%s has a method called shouldComponentUpdate(). ' +
-        'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
-        'Please extend React.Component if shouldComponentUpdate is used.', getComponentName(ctor) || 'A pure component');
+      warningWithoutStack(
+        '%s has a method called shouldComponentUpdate(). ' +
+          'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
+          'Please extend React.Component if shouldComponentUpdate is used.',
+        getComponentName(ctor) || 'A pure component',
+      );
     }
     const noComponentDidUnmount =
       typeof instance.componentDidUnmount !== 'function';
 
     if (!noComponentDidUnmount) {
-      warningWithoutStack('%s has a method called ' +
-        'componentDidUnmount(). But there is no such lifecycle method. ' +
-        'Did you mean componentWillUnmount()?', name);
+      warningWithoutStack(
+        '%s has a method called ' +
+          'componentDidUnmount(). But there is no such lifecycle method. ' +
+          'Did you mean componentWillUnmount()?',
+        name,
+      );
     }
 
     const noComponentDidReceiveProps =
       typeof instance.componentDidReceiveProps !== 'function';
 
     if (!noComponentDidReceiveProps) {
-      warningWithoutStack('%s has a method called ' +
-        'componentDidReceiveProps(). But there is no such lifecycle method. ' +
-        'If you meant to update the state in response to changing props, ' +
-        'use componentWillReceiveProps(). If you meant to fetch data or ' +
-        'run side-effects or mutations after React has updated the UI, use componentDidUpdate().', name);
+      warningWithoutStack(
+        '%s has a method called ' +
+          'componentDidReceiveProps(). But there is no such lifecycle method. ' +
+          'If you meant to update the state in response to changing props, ' +
+          'use componentWillReceiveProps(). If you meant to fetch data or ' +
+          'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
+        name,
+      );
     }
 
     const noComponentWillRecieveProps =
       typeof instance.componentWillRecieveProps !== 'function';
 
     if (!noComponentWillRecieveProps) {
-      warningWithoutStack('%s has a method called ' +
-        'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?', name);
+      warningWithoutStack(
+        '%s has a method called ' +
+          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+        name,
+      );
     }
 
     const noUnsafeComponentWillRecieveProps =
       typeof instance.UNSAFE_componentWillRecieveProps !== 'function';
 
     if (!noUnsafeComponentWillRecieveProps) {
-      warningWithoutStack('%s has a method called ' +
-        'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?', name);
+      warningWithoutStack(
+        '%s has a method called ' +
+          'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
+        name,
+      );
     }
 
     const hasMutatedProps = instance.props !== newProps;
 
     if (!(instance.props === undefined || !hasMutatedProps)) {
-      warningWithoutStack('%s(...): When calling super() in `%s`, make sure to pass ' +
-        "up the same props that your component's constructor was passed.", name, name);
+      warningWithoutStack(
+        '%s(...): When calling super() in `%s`, make sure to pass ' +
+          "up the same props that your component's constructor was passed.",
+        name,
+        name,
+      );
     }
 
     const noInstanceDefaultProps = !instance.defaultProps;
@@ -432,7 +490,7 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         'Setting defaultProps as an instance property on %s is not supported and will be ignored.' +
           ' Instead, define defaultProps as a static property on %s.',
         name,
-        name
+        name,
       );
     }
 
@@ -445,7 +503,7 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       warningWithoutStack(
         '%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
           'This component defines getSnapshotBeforeUpdate() only.',
-        getComponentName(ctor)
+        getComponentName(ctor),
       );
     }
 
@@ -453,24 +511,33 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       typeof instance.getDerivedStateFromProps !== 'function';
 
     if (!noInstanceGetDerivedStateFromProps) {
-      warningWithoutStack('%s: getDerivedStateFromProps() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.', name);
+      warningWithoutStack(
+        '%s: getDerivedStateFromProps() is defined as an instance method ' +
+          'and will be ignored. Instead, declare it as a static method.',
+        name,
+      );
     }
 
     const noInstanceGetDerivedStateFromCatch =
       typeof instance.getDerivedStateFromError !== 'function';
 
     if (!noInstanceGetDerivedStateFromCatch) {
-      warningWithoutStack('%s: getDerivedStateFromError() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.', name);
+      warningWithoutStack(
+        '%s: getDerivedStateFromError() is defined as an instance method ' +
+          'and will be ignored. Instead, declare it as a static method.',
+        name,
+      );
     }
 
     const noStaticGetSnapshotBeforeUpdate =
       typeof ctor.getSnapshotBeforeUpdate !== 'function';
 
     if (!noStaticGetSnapshotBeforeUpdate) {
-      warningWithoutStack('%s: getSnapshotBeforeUpdate() is defined as a static method ' +
-        'and will be ignored. Instead, declare it as an instance method.', name);
+      warningWithoutStack(
+        '%s: getSnapshotBeforeUpdate() is defined as a static method ' +
+          'and will be ignored. Instead, declare it as an instance method.',
+        name,
+      );
     }
 
     const state = instance.state;
@@ -479,8 +546,11 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
     }
     if (typeof instance.getChildContext === 'function') {
       if (!(typeof ctor.childContextTypes === 'object')) {
-        warningWithoutStack('%s.getChildContext(): childContextTypes must be defined in order to ' +
-          'use getChildContext().', name);
+        warningWithoutStack(
+          '%s.getChildContext(): childContextTypes must be defined in order to ' +
+            'use getChildContext().',
+          name,
+        );
       }
     }
   }
@@ -539,8 +609,12 @@ function constructClassInstance(
             Object.keys(contextType).join(', ') +
             '}.';
         }
-        warningWithoutStack('%s defines an invalid contextType. ' +
-          'contextType should point to the Context object returned by React.createContext().%s', getComponentName(ctor) || 'Component', addendum);
+        warningWithoutStack(
+          '%s defines an invalid contextType. ' +
+            'contextType should point to the Context object returned by React.createContext().%s',
+          getComponentName(ctor) || 'Component',
+          addendum,
+        );
       }
     }
   }
@@ -580,10 +654,15 @@ function constructClassInstance(
       const componentName = getComponentName(ctor) || 'Component';
       if (!didWarnAboutUninitializedState.has(componentName)) {
         didWarnAboutUninitializedState.add(componentName);
-        warningWithoutStack('`%s` uses `getDerivedStateFromProps` but its initial state is ' +
-          '%s. This is not recommended. Instead, define the initial state by ' +
-          'assigning an object to `this.state` in the constructor of `%s`. ' +
-          'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, instance.state === null ? 'null' : 'undefined', componentName);
+        warningWithoutStack(
+          '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+            '%s. This is not recommended. Instead, define the initial state by ' +
+            'assigning an object to `this.state` in the constructor of `%s`. ' +
+            'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
+          componentName,
+          instance.state === null ? 'null' : 'undefined',
+          componentName,
+        );
       }
     }
 
@@ -646,7 +725,7 @@ function constructClassInstance(
             foundWillReceivePropsName !== null
               ? `\n  ${foundWillReceivePropsName}`
               : '',
-            foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : ''
+            foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : '',
           );
         }
       }
@@ -677,9 +756,12 @@ function callComponentWillMount(workInProgress, instance) {
 
   if (oldState !== instance.state) {
     if (__DEV__) {
-      warningWithoutStack('%s.componentWillMount(): Assigning directly to this.state is ' +
-        "deprecated (except inside a component's " +
-        'constructor). Use setState instead.', getComponentName(workInProgress.type) || 'Component');
+      warningWithoutStack(
+        '%s.componentWillMount(): Assigning directly to this.state is ' +
+          "deprecated (except inside a component's " +
+          'constructor). Use setState instead.',
+        getComponentName(workInProgress.type) || 'Component',
+      );
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
   }
@@ -707,9 +789,12 @@ function callComponentWillReceiveProps(
         getComponentName(workInProgress.type) || 'Component';
       if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
         didWarnAboutStateAssignmentForComponent.add(componentName);
-        warningWithoutStack('%s.componentWillReceiveProps(): Assigning directly to ' +
-          "this.state is deprecated (except inside a component's " +
-          'constructor). Use setState instead.', componentName);
+        warningWithoutStack(
+          '%s.componentWillReceiveProps(): Assigning directly to ' +
+            "this.state is deprecated (except inside a component's " +
+            'constructor). Use setState instead.',
+          componentName,
+        );
       }
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
@@ -747,9 +832,12 @@ function mountClassInstance(
       const componentName = getComponentName(ctor) || 'Component';
       if (!didWarnAboutDirectlyAssigningPropsToState.has(componentName)) {
         didWarnAboutDirectlyAssigningPropsToState.add(componentName);
-        warningWithoutStack('%s: It is not recommended to assign props directly to state ' +
-          "because updates to props won't be reflected in state. " +
-          'In most cases, it is better to use props directly.', componentName);
+        warningWithoutStack(
+          '%s: It is not recommended to assign props directly to state ' +
+            "because updates to props won't be reflected in state. " +
+            'In most cases, it is better to use props directly.',
+          componentName,
+        );
       }
     }
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -93,13 +93,8 @@ if (__DEV__) {
     const key = `${callerName}_${(callback: any)}`;
     if (!didWarnOnInvalidCallback.has(key)) {
       didWarnOnInvalidCallback.add(key);
-      warningWithoutStack(
-        false,
-        '%s(...): Expected the last optional `callback` argument to be a ' +
-          'function. Instead received: %s.',
-        callerName,
-        callback,
-      );
+      warningWithoutStack('%s(...): Expected the last optional `callback` argument to be a ' +
+        'function. Instead received: %s.', callerName, callback);
     }
   };
 
@@ -109,10 +104,9 @@ if (__DEV__) {
       if (!didWarnAboutUndefinedDerivedState.has(componentName)) {
         didWarnAboutUndefinedDerivedState.add(componentName);
         warningWithoutStack(
-          false,
           '%s.getDerivedStateFromProps(): A valid state object (or null) must be returned. ' +
             'You have returned undefined.',
-          componentName,
+          componentName
         );
       }
     }
@@ -126,15 +120,12 @@ if (__DEV__) {
   Object.defineProperty(fakeInternalInstance, '_processChildContext', {
     enumerable: false,
     value: function() {
-      invariant(
-        false,
-        '_processChildContext is not available in React 16+. This likely ' +
-          'means you have multiple copies of React and are attempting to nest ' +
-          'a React 15 tree inside a React 16 tree using ' +
-          "unstable_renderSubtreeIntoContainer, which isn't supported. Try " +
-          'to make sure you have only one copy of React (and ideally, switch ' +
-          'to ReactDOM.createPortal).',
-      );
+      invariant('_processChildContext is not available in React 16+. This likely ' +
+        'means you have multiple copies of React and are attempting to nest ' +
+        'a React 15 tree inside a React 16 tree using ' +
+        "unstable_renderSubtreeIntoContainer, which isn't supported. Try " +
+        'to make sure you have only one copy of React (and ideally, switch ' +
+        'to ReactDOM.createPortal).');
     },
   });
   Object.freeze(fakeInternalInstance);
@@ -272,12 +263,10 @@ function checkShouldComponentUpdate(
     stopPhaseTimer();
 
     if (__DEV__) {
-      warningWithoutStack(
-        shouldUpdate !== undefined,
-        '%s.shouldComponentUpdate(): Returned undefined instead of a ' +
-          'boolean value. Make sure to return true or false.',
-        getComponentName(ctor) || 'Component',
-      );
+      if (!(shouldUpdate !== undefined)) {
+        warningWithoutStack('%s.shouldComponentUpdate(): Returned undefined instead of a ' +
+          'boolean value. Make sure to return true or false.', getComponentName(ctor) || 'Component');
+      }
     }
 
     return shouldUpdate;
@@ -300,19 +289,11 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
 
     if (!renderPresent) {
       if (ctor.prototype && typeof ctor.prototype.render === 'function') {
-        warningWithoutStack(
-          false,
-          '%s(...): No `render` method found on the returned component ' +
-            'instance: did you accidentally return an object from the constructor?',
-          name,
-        );
+        warningWithoutStack('%s(...): No `render` method found on the returned component ' +
+          'instance: did you accidentally return an object from the constructor?', name);
       } else {
-        warningWithoutStack(
-          false,
-          '%s(...): No `render` method found on the returned component ' +
-            'instance: you may have forgotten to define `render`.',
-          name,
-        );
+        warningWithoutStack('%s(...): No `render` method found on the returned component ' +
+          'instance: you may have forgotten to define `render`.', name);
       }
     }
 
@@ -320,63 +301,56 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
       !instance.getInitialState ||
       instance.getInitialState.isReactClassApproved ||
       instance.state;
-    warningWithoutStack(
-      noGetInitialStateOnES6,
-      'getInitialState was defined on %s, a plain JavaScript class. ' +
+
+    if (!noGetInitialStateOnES6) {
+      warningWithoutStack('getInitialState was defined on %s, a plain JavaScript class. ' +
         'This is only supported for classes created using React.createClass. ' +
-        'Did you mean to define a state property instead?',
-      name,
-    );
+        'Did you mean to define a state property instead?', name);
+    }
+
     const noGetDefaultPropsOnES6 =
       !instance.getDefaultProps ||
       instance.getDefaultProps.isReactClassApproved;
-    warningWithoutStack(
-      noGetDefaultPropsOnES6,
-      'getDefaultProps was defined on %s, a plain JavaScript class. ' +
+
+    if (!noGetDefaultPropsOnES6) {
+      warningWithoutStack('getDefaultProps was defined on %s, a plain JavaScript class. ' +
         'This is only supported for classes created using React.createClass. ' +
-        'Use a static property to define defaultProps instead.',
-      name,
-    );
+        'Use a static property to define defaultProps instead.', name);
+    }
+
     const noInstancePropTypes = !instance.propTypes;
-    warningWithoutStack(
-      noInstancePropTypes,
-      'propTypes was defined as an instance property on %s. Use a static ' +
-        'property to define propTypes instead.',
-      name,
-    );
+
+    if (!noInstancePropTypes) {
+      warningWithoutStack('propTypes was defined as an instance property on %s. Use a static ' +
+        'property to define propTypes instead.', name);
+    }
+
     const noInstanceContextType = !instance.contextType;
-    warningWithoutStack(
-      noInstanceContextType,
-      'contextType was defined as an instance property on %s. Use a static ' +
-        'property to define contextType instead.',
-      name,
-    );
+
+    if (!noInstanceContextType) {
+      warningWithoutStack('contextType was defined as an instance property on %s. Use a static ' +
+        'property to define contextType instead.', name);
+    }
 
     if (disableLegacyContext) {
       if (ctor.childContextTypes) {
         warningWithoutStack(
-          false,
           '%s uses the legacy childContextTypes API which is no longer supported. ' +
             'Use React.createContext() instead.',
-          name,
+          name
         );
       }
       if (ctor.contextTypes) {
-        warningWithoutStack(
-          false,
-          '%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with static contextType instead.',
-          name,
-        );
+        warningWithoutStack('%s uses the legacy contextTypes API which is no longer supported. ' +
+          'Use React.createContext() with static contextType instead.', name);
       }
     } else {
       const noInstanceContextTypes = !instance.contextTypes;
-      warningWithoutStack(
-        noInstanceContextTypes,
-        'contextTypes was defined as an instance property on %s. Use a static ' +
-          'property to define contextTypes instead.',
-        name,
-      );
+
+      if (!noInstanceContextTypes) {
+        warningWithoutStack('contextTypes was defined as an instance property on %s. Use a static ' +
+          'property to define contextTypes instead.', name);
+      }
 
       if (
         ctor.contextType &&
@@ -384,90 +358,83 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         !didWarnAboutContextTypeAndContextTypes.has(ctor)
       ) {
         didWarnAboutContextTypeAndContextTypes.add(ctor);
-        warningWithoutStack(
-          false,
-          '%s declares both contextTypes and contextType static properties. ' +
-            'The legacy contextTypes property will be ignored.',
-          name,
-        );
+        warningWithoutStack('%s declares both contextTypes and contextType static properties. ' +
+          'The legacy contextTypes property will be ignored.', name);
       }
     }
 
     const noComponentShouldUpdate =
       typeof instance.componentShouldUpdate !== 'function';
-    warningWithoutStack(
-      noComponentShouldUpdate,
-      '%s has a method called ' +
+
+    if (!noComponentShouldUpdate) {
+      warningWithoutStack('%s has a method called ' +
         'componentShouldUpdate(). Did you mean shouldComponentUpdate()? ' +
         'The name is phrased as a question because the function is ' +
-        'expected to return a value.',
-      name,
-    );
+        'expected to return a value.', name);
+    }
+
     if (
       ctor.prototype &&
       ctor.prototype.isPureReactComponent &&
       typeof instance.shouldComponentUpdate !== 'undefined'
     ) {
-      warningWithoutStack(
-        false,
-        '%s has a method called shouldComponentUpdate(). ' +
-          'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
-          'Please extend React.Component if shouldComponentUpdate is used.',
-        getComponentName(ctor) || 'A pure component',
-      );
+      warningWithoutStack('%s has a method called shouldComponentUpdate(). ' +
+        'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
+        'Please extend React.Component if shouldComponentUpdate is used.', getComponentName(ctor) || 'A pure component');
     }
     const noComponentDidUnmount =
       typeof instance.componentDidUnmount !== 'function';
-    warningWithoutStack(
-      noComponentDidUnmount,
-      '%s has a method called ' +
+
+    if (!noComponentDidUnmount) {
+      warningWithoutStack('%s has a method called ' +
         'componentDidUnmount(). But there is no such lifecycle method. ' +
-        'Did you mean componentWillUnmount()?',
-      name,
-    );
+        'Did you mean componentWillUnmount()?', name);
+    }
+
     const noComponentDidReceiveProps =
       typeof instance.componentDidReceiveProps !== 'function';
-    warningWithoutStack(
-      noComponentDidReceiveProps,
-      '%s has a method called ' +
+
+    if (!noComponentDidReceiveProps) {
+      warningWithoutStack('%s has a method called ' +
         'componentDidReceiveProps(). But there is no such lifecycle method. ' +
         'If you meant to update the state in response to changing props, ' +
         'use componentWillReceiveProps(). If you meant to fetch data or ' +
-        'run side-effects or mutations after React has updated the UI, use componentDidUpdate().',
-      name,
-    );
+        'run side-effects or mutations after React has updated the UI, use componentDidUpdate().', name);
+    }
+
     const noComponentWillRecieveProps =
       typeof instance.componentWillRecieveProps !== 'function';
-    warningWithoutStack(
-      noComponentWillRecieveProps,
-      '%s has a method called ' +
-        'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
-      name,
-    );
+
+    if (!noComponentWillRecieveProps) {
+      warningWithoutStack('%s has a method called ' +
+        'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?', name);
+    }
+
     const noUnsafeComponentWillRecieveProps =
       typeof instance.UNSAFE_componentWillRecieveProps !== 'function';
-    warningWithoutStack(
-      noUnsafeComponentWillRecieveProps,
-      '%s has a method called ' +
-        'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
-      name,
-    );
+
+    if (!noUnsafeComponentWillRecieveProps) {
+      warningWithoutStack('%s has a method called ' +
+        'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?', name);
+    }
+
     const hasMutatedProps = instance.props !== newProps;
-    warningWithoutStack(
-      instance.props === undefined || !hasMutatedProps,
-      '%s(...): When calling super() in `%s`, make sure to pass ' +
-        "up the same props that your component's constructor was passed.",
-      name,
-      name,
-    );
+
+    if (!(instance.props === undefined || !hasMutatedProps)) {
+      warningWithoutStack('%s(...): When calling super() in `%s`, make sure to pass ' +
+        "up the same props that your component's constructor was passed.", name, name);
+    }
+
     const noInstanceDefaultProps = !instance.defaultProps;
-    warningWithoutStack(
-      noInstanceDefaultProps,
-      'Setting defaultProps as an instance property on %s is not supported and will be ignored.' +
-        ' Instead, define defaultProps as a static property on %s.',
-      name,
-      name,
-    );
+
+    if (!noInstanceDefaultProps) {
+      warningWithoutStack(
+        'Setting defaultProps as an instance property on %s is not supported and will be ignored.' +
+          ' Instead, define defaultProps as a static property on %s.',
+        name,
+        name
+      );
+    }
 
     if (
       typeof instance.getSnapshotBeforeUpdate === 'function' &&
@@ -476,52 +443,45 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
     ) {
       didWarnAboutGetSnapshotBeforeUpdateWithoutDidUpdate.add(ctor);
       warningWithoutStack(
-        false,
         '%s: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
           'This component defines getSnapshotBeforeUpdate() only.',
-        getComponentName(ctor),
+        getComponentName(ctor)
       );
     }
 
     const noInstanceGetDerivedStateFromProps =
       typeof instance.getDerivedStateFromProps !== 'function';
-    warningWithoutStack(
-      noInstanceGetDerivedStateFromProps,
-      '%s: getDerivedStateFromProps() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.',
-      name,
-    );
+
+    if (!noInstanceGetDerivedStateFromProps) {
+      warningWithoutStack('%s: getDerivedStateFromProps() is defined as an instance method ' +
+        'and will be ignored. Instead, declare it as a static method.', name);
+    }
+
     const noInstanceGetDerivedStateFromCatch =
       typeof instance.getDerivedStateFromError !== 'function';
-    warningWithoutStack(
-      noInstanceGetDerivedStateFromCatch,
-      '%s: getDerivedStateFromError() is defined as an instance method ' +
-        'and will be ignored. Instead, declare it as a static method.',
-      name,
-    );
+
+    if (!noInstanceGetDerivedStateFromCatch) {
+      warningWithoutStack('%s: getDerivedStateFromError() is defined as an instance method ' +
+        'and will be ignored. Instead, declare it as a static method.', name);
+    }
+
     const noStaticGetSnapshotBeforeUpdate =
       typeof ctor.getSnapshotBeforeUpdate !== 'function';
-    warningWithoutStack(
-      noStaticGetSnapshotBeforeUpdate,
-      '%s: getSnapshotBeforeUpdate() is defined as a static method ' +
-        'and will be ignored. Instead, declare it as an instance method.',
-      name,
-    );
+
+    if (!noStaticGetSnapshotBeforeUpdate) {
+      warningWithoutStack('%s: getSnapshotBeforeUpdate() is defined as a static method ' +
+        'and will be ignored. Instead, declare it as an instance method.', name);
+    }
+
     const state = instance.state;
     if (state && (typeof state !== 'object' || isArray(state))) {
-      warningWithoutStack(
-        false,
-        '%s.state: must be set to an object or null',
-        name,
-      );
+      warningWithoutStack('%s.state: must be set to an object or null', name);
     }
     if (typeof instance.getChildContext === 'function') {
-      warningWithoutStack(
-        typeof ctor.childContextTypes === 'object',
-        '%s.getChildContext(): childContextTypes must be defined in order to ' +
-          'use getChildContext().',
-        name,
-      );
+      if (!(typeof ctor.childContextTypes === 'object')) {
+        warningWithoutStack('%s.getChildContext(): childContextTypes must be defined in order to ' +
+          'use getChildContext().', name);
+      }
     }
   }
 }
@@ -579,13 +539,8 @@ function constructClassInstance(
             Object.keys(contextType).join(', ') +
             '}.';
         }
-        warningWithoutStack(
-          false,
-          '%s defines an invalid contextType. ' +
-            'contextType should point to the Context object returned by React.createContext().%s',
-          getComponentName(ctor) || 'Component',
-          addendum,
-        );
+        warningWithoutStack('%s defines an invalid contextType. ' +
+          'contextType should point to the Context object returned by React.createContext().%s', getComponentName(ctor) || 'Component', addendum);
       }
     }
   }
@@ -625,16 +580,10 @@ function constructClassInstance(
       const componentName = getComponentName(ctor) || 'Component';
       if (!didWarnAboutUninitializedState.has(componentName)) {
         didWarnAboutUninitializedState.add(componentName);
-        warningWithoutStack(
-          false,
-          '`%s` uses `getDerivedStateFromProps` but its initial state is ' +
-            '%s. This is not recommended. Instead, define the initial state by ' +
-            'assigning an object to `this.state` in the constructor of `%s`. ' +
-            'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.',
-          componentName,
-          instance.state === null ? 'null' : 'undefined',
-          componentName,
-        );
+        warningWithoutStack('`%s` uses `getDerivedStateFromProps` but its initial state is ' +
+          '%s. This is not recommended. Instead, define the initial state by ' +
+          'assigning an object to `this.state` in the constructor of `%s`. ' +
+          'This ensures that `getDerivedStateFromProps` arguments have a consistent shape.', componentName, instance.state === null ? 'null' : 'undefined', componentName);
       }
     }
 
@@ -687,7 +636,6 @@ function constructClassInstance(
         if (!didWarnAboutLegacyLifecyclesAndDerivedState.has(componentName)) {
           didWarnAboutLegacyLifecyclesAndDerivedState.add(componentName);
           warningWithoutStack(
-            false,
             'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
               '%s uses %s but also contains the following legacy lifecycles:%s%s%s\n\n' +
               'The above lifecycles should be removed. Learn more about this warning here:\n' +
@@ -698,7 +646,7 @@ function constructClassInstance(
             foundWillReceivePropsName !== null
               ? `\n  ${foundWillReceivePropsName}`
               : '',
-            foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : '',
+            foundWillUpdateName !== null ? `\n  ${foundWillUpdateName}` : ''
           );
         }
       }
@@ -729,13 +677,9 @@ function callComponentWillMount(workInProgress, instance) {
 
   if (oldState !== instance.state) {
     if (__DEV__) {
-      warningWithoutStack(
-        false,
-        '%s.componentWillMount(): Assigning directly to this.state is ' +
-          "deprecated (except inside a component's " +
-          'constructor). Use setState instead.',
-        getComponentName(workInProgress.type) || 'Component',
-      );
+      warningWithoutStack('%s.componentWillMount(): Assigning directly to this.state is ' +
+        "deprecated (except inside a component's " +
+        'constructor). Use setState instead.', getComponentName(workInProgress.type) || 'Component');
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
   }
@@ -763,13 +707,9 @@ function callComponentWillReceiveProps(
         getComponentName(workInProgress.type) || 'Component';
       if (!didWarnAboutStateAssignmentForComponent.has(componentName)) {
         didWarnAboutStateAssignmentForComponent.add(componentName);
-        warningWithoutStack(
-          false,
-          '%s.componentWillReceiveProps(): Assigning directly to ' +
-            "this.state is deprecated (except inside a component's " +
-            'constructor). Use setState instead.',
-          componentName,
-        );
+        warningWithoutStack('%s.componentWillReceiveProps(): Assigning directly to ' +
+          "this.state is deprecated (except inside a component's " +
+          'constructor). Use setState instead.', componentName);
       }
     }
     classComponentUpdater.enqueueReplaceState(instance, instance.state, null);
@@ -807,13 +747,9 @@ function mountClassInstance(
       const componentName = getComponentName(ctor) || 'Component';
       if (!didWarnAboutDirectlyAssigningPropsToState.has(componentName)) {
         didWarnAboutDirectlyAssigningPropsToState.add(componentName);
-        warningWithoutStack(
-          false,
-          '%s: It is not recommended to assign props directly to state ' +
-            "because updates to props won't be reflected in state. " +
-            'In most cases, it is better to use props directly.',
-          componentName,
-        );
+        warningWithoutStack('%s: It is not recommended to assign props directly to state ' +
+          "because updates to props won't be reflected in state. " +
+          'In most cases, it is better to use props directly.', componentName);
       }
     }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -265,24 +265,21 @@ function commitBeforeMutationLifeCycles(
               finishedWork.type === finishedWork.elementType &&
               !didWarnAboutReassigningProps
             ) {
-              warning(
-                instance.props === finishedWork.memoizedProps,
-                'Expected %s props to match memoized props before ' +
+              if (!(instance.props === finishedWork.memoizedProps)) {
+                warning('Expected %s props to match memoized props before ' +
                   'getSnapshotBeforeUpdate. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
-              warning(
-                instance.state === finishedWork.memoizedState,
-                'Expected %s state to match memoized state before ' +
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
+
+              if (!(instance.state === finishedWork.memoizedState)) {
+                warning('Expected %s state to match memoized state before ' +
                   'getSnapshotBeforeUpdate. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
             }
           }
           const snapshot = instance.getSnapshotBeforeUpdate(
@@ -297,12 +294,8 @@ function commitBeforeMutationLifeCycles(
             >);
             if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
               didWarnSet.add(finishedWork.type);
-              warningWithoutStack(
-                false,
-                '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
-                  'must be returned. You have returned undefined.',
-                getComponentName(finishedWork.type),
-              );
+              warningWithoutStack('%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
+                'must be returned. You have returned undefined.', getComponentName(finishedWork.type));
             }
           }
           instance.__reactInternalSnapshotBeforeUpdate = snapshot;
@@ -319,11 +312,8 @@ function commitBeforeMutationLifeCycles(
       // Nothing to do for these component types
       return;
     default: {
-      invariant(
-        false,
-        'This unit of work tag should not have side-effects. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
+      invariant('This unit of work tag should not have side-effects. This error is ' +
+        'likely caused by a bug in React. Please file an issue.');
     }
   }
 }
@@ -377,13 +367,8 @@ function commitHookEffectList(
             } else {
               addendum = ' You returned: ' + destroy;
             }
-            warningWithoutStack(
-              false,
-              'An effect function must not return anything besides a function, ' +
-                'which is used for clean-up.%s%s',
-              addendum,
-              getStackByFiberInDevAndProd(finishedWork),
-            );
+            warningWithoutStack('An effect function must not return anything besides a function, ' +
+              'which is used for clean-up.%s%s', addendum, getStackByFiberInDevAndProd(finishedWork));
           }
         }
       }
@@ -434,24 +419,21 @@ function commitLifeCycles(
               finishedWork.type === finishedWork.elementType &&
               !didWarnAboutReassigningProps
             ) {
-              warning(
-                instance.props === finishedWork.memoizedProps,
-                'Expected %s props to match memoized props before ' +
+              if (!(instance.props === finishedWork.memoizedProps)) {
+                warning('Expected %s props to match memoized props before ' +
                   'componentDidMount. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
-              warning(
-                instance.state === finishedWork.memoizedState,
-                'Expected %s state to match memoized state before ' +
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
+
+              if (!(instance.state === finishedWork.memoizedState)) {
+                warning('Expected %s state to match memoized state before ' +
                   'componentDidMount. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
             }
           }
           instance.componentDidMount();
@@ -471,24 +453,21 @@ function commitLifeCycles(
               finishedWork.type === finishedWork.elementType &&
               !didWarnAboutReassigningProps
             ) {
-              warning(
-                instance.props === finishedWork.memoizedProps,
-                'Expected %s props to match memoized props before ' +
+              if (!(instance.props === finishedWork.memoizedProps)) {
+                warning('Expected %s props to match memoized props before ' +
                   'componentDidUpdate. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
-              warning(
-                instance.state === finishedWork.memoizedState,
-                'Expected %s state to match memoized state before ' +
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
+
+              if (!(instance.state === finishedWork.memoizedState)) {
+                warning('Expected %s state to match memoized state before ' +
                   'componentDidUpdate. ' +
                   'This might either be because of a bug in React, or because ' +
                   'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.',
-                getComponentName(finishedWork.type) || 'instance',
-              );
+                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              }
             }
           }
           instance.componentDidUpdate(
@@ -506,24 +485,21 @@ function commitLifeCycles(
             finishedWork.type === finishedWork.elementType &&
             !didWarnAboutReassigningProps
           ) {
-            warning(
-              instance.props === finishedWork.memoizedProps,
-              'Expected %s props to match memoized props before ' +
+            if (!(instance.props === finishedWork.memoizedProps)) {
+              warning('Expected %s props to match memoized props before ' +
                 'processing the update queue. ' +
                 'This might either be because of a bug in React, or because ' +
                 'a component reassigns its own `this.props`. ' +
-                'Please file an issue.',
-              getComponentName(finishedWork.type) || 'instance',
-            );
-            warning(
-              instance.state === finishedWork.memoizedState,
-              'Expected %s state to match memoized state before ' +
+                'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+            }
+
+            if (!(instance.state === finishedWork.memoizedState)) {
+              warning('Expected %s state to match memoized state before ' +
                 'processing the update queue. ' +
                 'This might either be because of a bug in React, or because ' +
                 'a component reassigns its own `this.props`. ' +
-                'Please file an issue.',
-              getComponentName(finishedWork.type) || 'instance',
-            );
+                'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+            }
           }
         }
         // We could update instance props and state here,
@@ -623,11 +599,8 @@ function commitLifeCycles(
     case ScopeComponent:
       return;
     default: {
-      invariant(
-        false,
-        'This unit of work tag should not have side-effects. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
+      invariant('This unit of work tag should not have side-effects. This error is ' +
+        'likely caused by a bug in React. Please file an issue.');
     }
   }
 }
@@ -704,13 +677,8 @@ function commitAttachRef(finishedWork: Fiber) {
     } else {
       if (__DEV__) {
         if (!ref.hasOwnProperty('current')) {
-          warningWithoutStack(
-            false,
-            'Unexpected ref object provided for %s. ' +
-              'Use either a ref-setter function or React.createRef().%s',
-            getComponentName(finishedWork.type),
-            getStackByFiberInDevAndProd(finishedWork),
-          );
+          warningWithoutStack('Unexpected ref object provided for %s. ' +
+            'Use either a ref-setter function or React.createRef().%s', getComponentName(finishedWork.type), getStackByFiberInDevAndProd(finishedWork));
         }
       }
 
@@ -950,11 +918,8 @@ function commitContainer(finishedWork: Fiber) {
       return;
     }
     default: {
-      invariant(
-        false,
-        'This unit of work tag should not have side-effects. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
+      invariant('This unit of work tag should not have side-effects. This error is ' +
+        'likely caused by a bug in React. Please file an issue.');
     }
   }
 }
@@ -967,11 +932,8 @@ function getHostParentFiber(fiber: Fiber): Fiber {
     }
     parent = parent.return;
   }
-  invariant(
-    false,
-    'Expected to find a host parent. This error is likely caused by a bug ' +
-      'in React. Please file an issue.',
-  );
+  invariant('Expected to find a host parent. This error is likely caused by a bug ' +
+    'in React. Please file an issue.');
 }
 
 function isHostParent(fiber: Fiber): boolean {
@@ -1060,11 +1022,8 @@ function commitPlacement(finishedWork: Fiber): void {
       }
     // eslint-disable-next-line-no-fallthrough
     default:
-      invariant(
-        false,
-        'Invalid host parent fiber. This error is likely caused by a bug ' +
-          'in React. Please file an issue.',
-      );
+      invariant('Invalid host parent fiber. This error is likely caused by a bug ' +
+        'in React. Please file an issue.');
   }
   if (parentFiber.effectTag & ContentReset) {
     // Reset the text content of the parent before doing any insertions
@@ -1138,11 +1097,11 @@ function unmountHostComponents(
     if (!currentParentIsValid) {
       let parent = node.return;
       findParent: while (true) {
-        invariant(
-          parent !== null,
-          'Expected to find a host parent. This error is likely caused by ' +
-            'a bug in React. Please file an issue.',
-        );
+        if (!(parent !== null)) {
+          invariant('Expected to find a host parent. This error is likely caused by ' +
+            'a bug in React. Please file an issue.');
+        }
+
         const parentStateNode = parent.stateNode;
         switch (parent.tag) {
           case HostComponent:
@@ -1369,11 +1328,11 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       return;
     }
     case HostText: {
-      invariant(
-        finishedWork.stateNode !== null,
-        'This should have a text node initialized. This error is likely ' +
-          'caused by a bug in React. Please file an issue.',
-      );
+      if (!(finishedWork.stateNode !== null)) {
+        invariant('This should have a text node initialized. This error is likely ' +
+          'caused by a bug in React. Please file an issue.');
+      }
+
       const textInstance: TextInstance = finishedWork.stateNode;
       const newText: string = finishedWork.memoizedProps;
       // For hydration we reuse the update path but we treat the oldProps
@@ -1434,11 +1393,8 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       return;
     }
     default: {
-      invariant(
-        false,
-        'This unit of work tag should not have side-effects. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
+      invariant('This unit of work tag should not have side-effects. This error is ' +
+        'likely caused by a bug in React. Please file an issue.');
     }
   }
 }
@@ -1469,7 +1425,7 @@ function commitSuspenseComponent(finishedWork: Fiber) {
       }
     } else if (__DEV__) {
       if (suspenseCallback !== undefined) {
-        warning(false, 'Unexpected type for suspenseCallback.');
+        warning('Unexpected type for suspenseCallback.');
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -266,19 +266,25 @@ function commitBeforeMutationLifeCycles(
               !didWarnAboutReassigningProps
             ) {
               if (!(instance.props === finishedWork.memoizedProps)) {
-                warning('Expected %s props to match memoized props before ' +
-                  'getSnapshotBeforeUpdate. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s props to match memoized props before ' +
+                    'getSnapshotBeforeUpdate. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
 
               if (!(instance.state === finishedWork.memoizedState)) {
-                warning('Expected %s state to match memoized state before ' +
-                  'getSnapshotBeforeUpdate. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s state to match memoized state before ' +
+                    'getSnapshotBeforeUpdate. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
             }
           }
@@ -294,8 +300,11 @@ function commitBeforeMutationLifeCycles(
             >);
             if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
               didWarnSet.add(finishedWork.type);
-              warningWithoutStack('%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
-                'must be returned. You have returned undefined.', getComponentName(finishedWork.type));
+              warningWithoutStack(
+                '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
+                  'must be returned. You have returned undefined.',
+                getComponentName(finishedWork.type),
+              );
             }
           }
           instance.__reactInternalSnapshotBeforeUpdate = snapshot;
@@ -312,8 +321,10 @@ function commitBeforeMutationLifeCycles(
       // Nothing to do for these component types
       return;
     default: {
-      invariant('This unit of work tag should not have side-effects. This error is ' +
-        'likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'This unit of work tag should not have side-effects. This error is ' +
+          'likely caused by a bug in React. Please file an issue.',
+      );
     }
   }
 }
@@ -367,8 +378,12 @@ function commitHookEffectList(
             } else {
               addendum = ' You returned: ' + destroy;
             }
-            warningWithoutStack('An effect function must not return anything besides a function, ' +
-              'which is used for clean-up.%s%s', addendum, getStackByFiberInDevAndProd(finishedWork));
+            warningWithoutStack(
+              'An effect function must not return anything besides a function, ' +
+                'which is used for clean-up.%s%s',
+              addendum,
+              getStackByFiberInDevAndProd(finishedWork),
+            );
           }
         }
       }
@@ -420,19 +435,25 @@ function commitLifeCycles(
               !didWarnAboutReassigningProps
             ) {
               if (!(instance.props === finishedWork.memoizedProps)) {
-                warning('Expected %s props to match memoized props before ' +
-                  'componentDidMount. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s props to match memoized props before ' +
+                    'componentDidMount. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
 
               if (!(instance.state === finishedWork.memoizedState)) {
-                warning('Expected %s state to match memoized state before ' +
-                  'componentDidMount. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s state to match memoized state before ' +
+                    'componentDidMount. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
             }
           }
@@ -454,19 +475,25 @@ function commitLifeCycles(
               !didWarnAboutReassigningProps
             ) {
               if (!(instance.props === finishedWork.memoizedProps)) {
-                warning('Expected %s props to match memoized props before ' +
-                  'componentDidUpdate. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s props to match memoized props before ' +
+                    'componentDidUpdate. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
 
               if (!(instance.state === finishedWork.memoizedState)) {
-                warning('Expected %s state to match memoized state before ' +
-                  'componentDidUpdate. ' +
-                  'This might either be because of a bug in React, or because ' +
-                  'a component reassigns its own `this.props`. ' +
-                  'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+                warning(
+                  'Expected %s state to match memoized state before ' +
+                    'componentDidUpdate. ' +
+                    'This might either be because of a bug in React, or because ' +
+                    'a component reassigns its own `this.props`. ' +
+                    'Please file an issue.',
+                  getComponentName(finishedWork.type) || 'instance',
+                );
               }
             }
           }
@@ -486,19 +513,25 @@ function commitLifeCycles(
             !didWarnAboutReassigningProps
           ) {
             if (!(instance.props === finishedWork.memoizedProps)) {
-              warning('Expected %s props to match memoized props before ' +
-                'processing the update queue. ' +
-                'This might either be because of a bug in React, or because ' +
-                'a component reassigns its own `this.props`. ' +
-                'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              warning(
+                'Expected %s props to match memoized props before ' +
+                  'processing the update queue. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
+                  'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
+              );
             }
 
             if (!(instance.state === finishedWork.memoizedState)) {
-              warning('Expected %s state to match memoized state before ' +
-                'processing the update queue. ' +
-                'This might either be because of a bug in React, or because ' +
-                'a component reassigns its own `this.props`. ' +
-                'Please file an issue.', getComponentName(finishedWork.type) || 'instance');
+              warning(
+                'Expected %s state to match memoized state before ' +
+                  'processing the update queue. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
+                  'Please file an issue.',
+                getComponentName(finishedWork.type) || 'instance',
+              );
             }
           }
         }
@@ -599,8 +632,10 @@ function commitLifeCycles(
     case ScopeComponent:
       return;
     default: {
-      invariant('This unit of work tag should not have side-effects. This error is ' +
-        'likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'This unit of work tag should not have side-effects. This error is ' +
+          'likely caused by a bug in React. Please file an issue.',
+      );
     }
   }
 }
@@ -677,8 +712,12 @@ function commitAttachRef(finishedWork: Fiber) {
     } else {
       if (__DEV__) {
         if (!ref.hasOwnProperty('current')) {
-          warningWithoutStack('Unexpected ref object provided for %s. ' +
-            'Use either a ref-setter function or React.createRef().%s', getComponentName(finishedWork.type), getStackByFiberInDevAndProd(finishedWork));
+          warningWithoutStack(
+            'Unexpected ref object provided for %s. ' +
+              'Use either a ref-setter function or React.createRef().%s',
+            getComponentName(finishedWork.type),
+            getStackByFiberInDevAndProd(finishedWork),
+          );
         }
       }
 
@@ -918,8 +957,10 @@ function commitContainer(finishedWork: Fiber) {
       return;
     }
     default: {
-      invariant('This unit of work tag should not have side-effects. This error is ' +
-        'likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'This unit of work tag should not have side-effects. This error is ' +
+          'likely caused by a bug in React. Please file an issue.',
+      );
     }
   }
 }
@@ -932,8 +973,10 @@ function getHostParentFiber(fiber: Fiber): Fiber {
     }
     parent = parent.return;
   }
-  invariant('Expected to find a host parent. This error is likely caused by a bug ' +
-    'in React. Please file an issue.');
+  invariant(
+    'Expected to find a host parent. This error is likely caused by a bug ' +
+      'in React. Please file an issue.',
+  );
 }
 
 function isHostParent(fiber: Fiber): boolean {
@@ -1022,8 +1065,10 @@ function commitPlacement(finishedWork: Fiber): void {
       }
     // eslint-disable-next-line-no-fallthrough
     default:
-      invariant('Invalid host parent fiber. This error is likely caused by a bug ' +
-        'in React. Please file an issue.');
+      invariant(
+        'Invalid host parent fiber. This error is likely caused by a bug ' +
+          'in React. Please file an issue.',
+      );
   }
   if (parentFiber.effectTag & ContentReset) {
     // Reset the text content of the parent before doing any insertions
@@ -1098,8 +1143,10 @@ function unmountHostComponents(
       let parent = node.return;
       findParent: while (true) {
         if (!(parent !== null)) {
-          invariant('Expected to find a host parent. This error is likely caused by ' +
-            'a bug in React. Please file an issue.');
+          invariant(
+            'Expected to find a host parent. This error is likely caused by ' +
+              'a bug in React. Please file an issue.',
+          );
         }
 
         const parentStateNode = parent.stateNode;
@@ -1329,8 +1376,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
     }
     case HostText: {
       if (!(finishedWork.stateNode !== null)) {
-        invariant('This should have a text node initialized. This error is likely ' +
-          'caused by a bug in React. Please file an issue.');
+        invariant(
+          'This should have a text node initialized. This error is likely ' +
+            'caused by a bug in React. Please file an issue.',
+        );
       }
 
       const textInstance: TextInstance = finishedWork.stateNode;
@@ -1393,8 +1442,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       return;
     }
     default: {
-      invariant('This unit of work tag should not have side-effects. This error is ' +
-        'likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'This unit of work tag should not have side-effects. This error is ' +
+          'likely caused by a bug in React. Please file an issue.',
+      );
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -698,11 +698,11 @@ function completeWork(
         }
       } else {
         if (!newProps) {
-          invariant(
-            workInProgress.stateNode !== null,
-            'We must have new props for new mounts. This error is likely ' +
-              'caused by a bug in React. Please file an issue.',
-          );
+          if (!(workInProgress.stateNode !== null)) {
+            invariant('We must have new props for new mounts. This error is likely ' +
+              'caused by a bug in React. Please file an issue.');
+          }
+
           // This can happen when we abort work.
           break;
         }
@@ -794,12 +794,11 @@ function completeWork(
         updateHostText(current, workInProgress, oldText, newText);
       } else {
         if (typeof newText !== 'string') {
-          invariant(
-            workInProgress.stateNode !== null,
-            'We must have new props for new mounts. This error is likely ' +
-              'caused by a bug in React. Please file an issue.',
-          );
-          // This can happen when we abort work.
+          if (!(workInProgress.stateNode !== null)) {
+            invariant('We must have new props for new mounts. This error is likely ' +
+              'caused by a bug in React. Please file an issue.');
+            // This can happen when we abort work.
+          }
         }
         const rootContainerInstance = getRootHostContainer();
         const currentHostContext = getHostContext();
@@ -829,11 +828,14 @@ function completeWork(
         if (nextState !== null && nextState.dehydrated !== null) {
           if (current === null) {
             let wasHydrated = popHydrationState(workInProgress);
-            invariant(
-              wasHydrated,
-              'A dehydrated suspense component was completed without a hydrated node. ' +
-                'This is probably a bug in React.',
-            );
+
+            if (!wasHydrated) {
+              invariant(
+                'A dehydrated suspense component was completed without a hydrated node. ' +
+                  'This is probably a bug in React.'
+              );
+            }
+
             prepareToHydrateHostSuspenseInstance(workInProgress);
             if (enableSchedulerTracing) {
               markSpawnedWork(Never);
@@ -1284,10 +1286,9 @@ function completeWork(
     }
     default:
       invariant(
-        false,
         'Unknown unit of work tag (%s). This error is likely caused by a bug in ' +
           'React. Please file an issue.',
-        workInProgress.tag,
+        workInProgress.tag
       );
   }
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -699,8 +699,10 @@ function completeWork(
       } else {
         if (!newProps) {
           if (!(workInProgress.stateNode !== null)) {
-            invariant('We must have new props for new mounts. This error is likely ' +
-              'caused by a bug in React. Please file an issue.');
+            invariant(
+              'We must have new props for new mounts. This error is likely ' +
+                'caused by a bug in React. Please file an issue.',
+            );
           }
 
           // This can happen when we abort work.
@@ -795,8 +797,10 @@ function completeWork(
       } else {
         if (typeof newText !== 'string') {
           if (!(workInProgress.stateNode !== null)) {
-            invariant('We must have new props for new mounts. This error is likely ' +
-              'caused by a bug in React. Please file an issue.');
+            invariant(
+              'We must have new props for new mounts. This error is likely ' +
+                'caused by a bug in React. Please file an issue.',
+            );
             // This can happen when we abort work.
           }
         }
@@ -832,7 +836,7 @@ function completeWork(
             if (!wasHydrated) {
               invariant(
                 'A dehydrated suspense component was completed without a hydrated node. ' +
-                  'This is probably a bug in React.'
+                  'This is probably a bug in React.',
               );
             }
 
@@ -1288,7 +1292,7 @@ function completeWork(
       invariant(
         'Unknown unit of work tag (%s). This error is likely caused by a bug in ' +
           'React. Please file an issue.',
-        workInProgress.tag
+        workInProgress.tag,
       );
   }
 

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -169,8 +169,10 @@ function pushTopLevelContextObject(
     return;
   } else {
     if (!(contextStackCursor.current === emptyContextObject)) {
-      invariant('Unexpected context found on stack. ' +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'Unexpected context found on stack. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
     }
 
     push(contextStackCursor, context, fiber);
@@ -202,7 +204,7 @@ function processChildContext(
               'on the instance. You can either define getChildContext() on %s or remove ' +
               'childContextTypes from it.',
             componentName,
-            componentName
+            componentName,
           );
         }
       }
@@ -224,7 +226,7 @@ function processChildContext(
         invariant(
           '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
           getComponentName(type) || 'Unknown',
-          contextKey
+          contextKey,
         );
       }
     }
@@ -285,8 +287,10 @@ function invalidateContextProvider(
     const instance = workInProgress.stateNode;
 
     if (!instance) {
-      invariant('Expected to have an instance by this point. ' +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'Expected to have an instance by this point. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
     }
 
     if (didChange) {
@@ -321,8 +325,10 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
     if (!(isFiberMounted(fiber) && fiber.tag === ClassComponent)) {
       // Currently this is only used with renderSubtreeIntoContainer; not sure if it
       // makes sense elsewhere
-      invariant('Expected subtree parent to be a mounted class component. ' +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      invariant(
+        'Expected subtree parent to be a mounted class component. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
     }
 
     let node = fiber;
@@ -340,8 +346,10 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
       }
       node = node.return;
     } while (node !== null);
-    invariant('Found unexpected detached subtree parent. ' +
-      'This error is likely caused by a bug in React. Please file an issue.');
+    invariant(
+      'Found unexpected detached subtree parent. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -168,11 +168,10 @@ function pushTopLevelContextObject(
   if (disableLegacyContext) {
     return;
   } else {
-    invariant(
-      contextStackCursor.current === emptyContextObject,
-      'Unexpected context found on stack. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+    if (!(contextStackCursor.current === emptyContextObject)) {
+      invariant('Unexpected context found on stack. ' +
+        'This error is likely caused by a bug in React. Please file an issue.');
+    }
 
     push(contextStackCursor, context, fiber);
     push(didPerformWorkStackCursor, didChange, fiber);
@@ -199,12 +198,11 @@ function processChildContext(
         if (!warnedAboutMissingGetChildContext[componentName]) {
           warnedAboutMissingGetChildContext[componentName] = true;
           warningWithoutStack(
-            false,
             '%s.childContextTypes is specified but there is no getChildContext() method ' +
               'on the instance. You can either define getChildContext() on %s or remove ' +
               'childContextTypes from it.',
             componentName,
-            componentName,
+            componentName
           );
         }
       }
@@ -222,12 +220,13 @@ function processChildContext(
       setCurrentPhase(null);
     }
     for (let contextKey in childContext) {
-      invariant(
-        contextKey in childContextTypes,
-        '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
-        getComponentName(type) || 'Unknown',
-        contextKey,
-      );
+      if (!(contextKey in childContextTypes)) {
+        invariant(
+          '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
+          getComponentName(type) || 'Unknown',
+          contextKey
+        );
+      }
     }
     if (__DEV__) {
       const name = getComponentName(type) || 'Unknown';
@@ -284,11 +283,11 @@ function invalidateContextProvider(
     return;
   } else {
     const instance = workInProgress.stateNode;
-    invariant(
-      instance,
-      'Expected to have an instance by this point. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+
+    if (!instance) {
+      invariant('Expected to have an instance by this point. ' +
+        'This error is likely caused by a bug in React. Please file an issue.');
+    }
 
     if (didChange) {
       // Merge parent and own context.
@@ -319,13 +318,12 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
   if (disableLegacyContext) {
     return emptyContextObject;
   } else {
-    // Currently this is only used with renderSubtreeIntoContainer; not sure if it
-    // makes sense elsewhere
-    invariant(
-      isFiberMounted(fiber) && fiber.tag === ClassComponent,
-      'Expected subtree parent to be a mounted class component. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+    if (!(isFiberMounted(fiber) && fiber.tag === ClassComponent)) {
+      // Currently this is only used with renderSubtreeIntoContainer; not sure if it
+      // makes sense elsewhere
+      invariant('Expected subtree parent to be a mounted class component. ' +
+        'This error is likely caused by a bug in React. Please file an issue.');
+    }
 
     let node = fiber;
     do {
@@ -342,11 +340,8 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
       }
       node = node.return;
     } while (node !== null);
-    invariant(
-      false,
-      'Found unexpected detached subtree parent. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+    invariant('Found unexpected detached subtree parent. ' +
+      'This error is likely caused by a bug in React. Please file an issue.');
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -41,12 +41,9 @@ export function injectInternals(internals: Object): boolean {
   }
   if (!hook.supportsFiber) {
     if (__DEV__) {
-      warningWithoutStack(
-        false,
-        'The installed version of React DevTools is too old and will not work ' +
-          'with the current version of React. Please update React DevTools. ' +
-          'https://fb.me/react-devtools',
-      );
+      warningWithoutStack('The installed version of React DevTools is too old and will not work ' +
+        'with the current version of React. Please update React DevTools. ' +
+        'https://fb.me/react-devtools');
     }
     // DevTools exists, even though it doesn't support Fiber.
     return true;
@@ -70,11 +67,7 @@ export function injectInternals(internals: Object): boolean {
       } catch (err) {
         if (__DEV__ && !hasLoggedError) {
           hasLoggedError = true;
-          warningWithoutStack(
-            false,
-            'React DevTools encountered an error: %s',
-            err,
-          );
+          warningWithoutStack('React DevTools encountered an error: %s', err);
         }
       }
     };
@@ -84,22 +77,14 @@ export function injectInternals(internals: Object): boolean {
       } catch (err) {
         if (__DEV__ && !hasLoggedError) {
           hasLoggedError = true;
-          warningWithoutStack(
-            false,
-            'React DevTools encountered an error: %s',
-            err,
-          );
+          warningWithoutStack('React DevTools encountered an error: %s', err);
         }
       }
     };
   } catch (err) {
     // Catch all errors because it is unsafe to throw during initialization.
     if (__DEV__) {
-      warningWithoutStack(
-        false,
-        'React DevTools encountered an error: %s.',
-        err,
-      );
+      warningWithoutStack('React DevTools encountered an error: %s.', err);
     }
   }
   // DevTools exists

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -41,9 +41,11 @@ export function injectInternals(internals: Object): boolean {
   }
   if (!hook.supportsFiber) {
     if (__DEV__) {
-      warningWithoutStack('The installed version of React DevTools is too old and will not work ' +
-        'with the current version of React. Please update React DevTools. ' +
-        'https://fb.me/react-devtools');
+      warningWithoutStack(
+        'The installed version of React DevTools is too old and will not work ' +
+          'with the current version of React. Please update React DevTools. ' +
+          'https://fb.me/react-devtools',
+      );
     }
     // DevTools exists, even though it doesn't support Fiber.
     return true;

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -109,21 +109,20 @@ function updateEventListener(
     responder = listener.responder;
     props = listener.props;
   }
-  invariant(
-    responder && responder.$$typeof === REACT_RESPONDER_TYPE,
-    'An invalid value was used as an event listener. Expect one or many event ' +
-      'listeners created via React.unstable_useResponder().',
-  );
+
+  if (!(responder && responder.$$typeof === REACT_RESPONDER_TYPE)) {
+    invariant(
+      'An invalid value was used as an event listener. Expect one or many event ' +
+        'listeners created via React.unstable_useResponder().'
+    );
+  }
+
   const listenerProps = ((props: any): Object);
   if (visistedResponders.has(responder)) {
     // show warning
     if (__DEV__) {
-      warning(
-        false,
-        'Duplicate event responder "%s" found in event listeners. ' +
-          'Event listeners passed to elements cannot use the same event responder more than once.',
-        responder.displayName,
-      );
+      warning('Duplicate event responder "%s" found in event listeners. ' +
+        'Event listeners passed to elements cannot use the same event responder more than once.', responder.displayName);
     }
     return;
   }

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -113,7 +113,7 @@ function updateEventListener(
   if (!(responder && responder.$$typeof === REACT_RESPONDER_TYPE)) {
     invariant(
       'An invalid value was used as an event listener. Expect one or many event ' +
-        'listeners created via React.unstable_useResponder().'
+        'listeners created via React.unstable_useResponder().',
     );
   }
 
@@ -121,8 +121,11 @@ function updateEventListener(
   if (visistedResponders.has(responder)) {
     // show warning
     if (__DEV__) {
-      warning('Duplicate event responder "%s" found in event listeners. ' +
-        'Event listeners passed to elements cannot use the same event responder more than once.', responder.displayName);
+      warning(
+        'Duplicate event responder "%s" found in event listeners. ' +
+          'Event listeners passed to elements cannot use the same event responder more than once.',
+        responder.displayName,
+      );
     }
     return;
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -240,7 +240,6 @@ function checkDepsAreArrayDev(deps: mixed) {
       // Verify deps, but only on mount to avoid extra checks.
       // It's unlikely their type would change as usually you define them inline.
       warning(
-        false,
         '%s received a final argument that is not an array (instead, received `%s`). When ' +
           'specified, the final argument must be an array.',
         currentHookNameInDev,
@@ -284,7 +283,6 @@ function warnOnHookMismatchInDev(currentHookName: HookType) {
         }
 
         warning(
-          false,
           'React has detected a change in the order of Hooks called by %s. ' +
             'This will lead to bugs and errors if not fixed. ' +
             'For more information, read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -302,7 +300,6 @@ function warnOnHookMismatchInDev(currentHookName: HookType) {
 
 function throwInvalidHookError() {
   invariant(
-    false,
     'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
       ' one of the following reasons:\n' +
       '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
@@ -326,7 +323,6 @@ function areHookInputsEqual(
   if (prevDeps === null) {
     if (__DEV__) {
       warning(
-        false,
         '%s received a final argument during this render, but not during ' +
           'the previous render. Even though the final argument is optional, ' +
           'its type cannot change between renders.',
@@ -341,7 +337,6 @@ function areHookInputsEqual(
     // passed inline.
     if (nextDeps.length !== prevDeps.length) {
       warning(
-        false,
         'The final argument passed to %s changed size between renders. The ' +
           'order and size of this array must remain constant.\n\n' +
           'Previous: %s\n' +
@@ -498,16 +493,17 @@ export function renderWithHooks(
   componentUpdateQueue = null;
   sideEffectTag = 0;
 
-  // These were reset above
-  // didScheduleRenderPhaseUpdate = false;
-  // renderPhaseUpdates = null;
-  // numberOfReRenders = 0;
+  if (didRenderTooFewHooks) {
+    // These were reset above
+    // didScheduleRenderPhaseUpdate = false;
+    // renderPhaseUpdates = null;
+    // numberOfReRenders = 0;
 
-  invariant(
-    !didRenderTooFewHooks,
-    'Rendered fewer hooks than expected. This may be caused by an accidental ' +
-      'early return statement.',
-  );
+    invariant(
+      'Rendered fewer hooks than expected. This may be caused by an accidental ' +
+        'early return statement.',
+    );
+  }
 
   return children;
 }
@@ -593,11 +589,11 @@ function updateWorkInProgressHook(): Hook {
     currentHook = nextCurrentHook;
     nextCurrentHook = currentHook !== null ? currentHook.next : null;
   } else {
-    // Clone from the current hook.
-    invariant(
-      nextCurrentHook !== null,
-      'Rendered more hooks than during the previous render.',
-    );
+    if (!(nextCurrentHook !== null)) {
+      // Clone from the current hook.
+      invariant('Rendered more hooks than during the previous render.');
+    }
+
     currentHook = nextCurrentHook;
 
     const newHook: Hook = {
@@ -667,10 +663,12 @@ function updateReducer<S, I, A>(
 ): [S, Dispatch<A>] {
   const hook = updateWorkInProgressHook();
   const queue = hook.queue;
-  invariant(
-    queue !== null,
-    'Should have a queue. This is likely a bug in React. Please file an issue.',
-  );
+
+  if (!(queue !== null)) {
+    invariant(
+      'Should have a queue. This is likely a bug in React. Please file an issue.',
+    );
+  }
 
   queue.lastRenderedReducer = reducer;
 
@@ -987,12 +985,13 @@ function imperativeHandleEffect<T>(
   } else if (ref !== null && ref !== undefined) {
     const refObject = ref;
     if (__DEV__) {
-      warning(
-        refObject.hasOwnProperty('current'),
-        'Expected useImperativeHandle() first argument to either be a ' +
-          'ref callback or React.createRef() object. Instead received: %s.',
-        'an object with keys {' + Object.keys(refObject).join(', ') + '}',
-      );
+      if (!refObject.hasOwnProperty('current')) {
+        warning(
+          'Expected useImperativeHandle() first argument to either be a ' +
+            'ref callback or React.createRef() object. Instead received: %s.',
+          'an object with keys {' + Object.keys(refObject).join(', ') + '}',
+        );
+      }
     }
     const inst = create();
     refObject.current = inst;
@@ -1008,12 +1007,13 @@ function mountImperativeHandle<T>(
   deps: Array<mixed> | void | null,
 ): void {
   if (__DEV__) {
-    warning(
-      typeof create === 'function',
-      'Expected useImperativeHandle() second argument to be a function ' +
-        'that creates a handle. Instead received: %s.',
-      create !== null ? typeof create : 'null',
-    );
+    if (!(typeof create === 'function')) {
+      warning(
+        'Expected useImperativeHandle() second argument to be a function ' +
+          'that creates a handle. Instead received: %s.',
+        create !== null ? typeof create : 'null',
+      );
+    }
   }
 
   // TODO: If deps are provided, should we skip comparing the ref itself?
@@ -1034,12 +1034,13 @@ function updateImperativeHandle<T>(
   deps: Array<mixed> | void | null,
 ): void {
   if (__DEV__) {
-    warning(
-      typeof create === 'function',
-      'Expected useImperativeHandle() second argument to be a function ' +
-        'that creates a handle. Instead received: %s.',
-      create !== null ? typeof create : 'null',
-    );
+    if (!(typeof create === 'function')) {
+      warning(
+        'Expected useImperativeHandle() second argument to be a function ' +
+          'that creates a handle. Instead received: %s.',
+        create !== null ? typeof create : 'null',
+      );
+    }
   }
 
   // TODO: If deps are provided, should we skip comparing the ref itself?
@@ -1122,19 +1123,21 @@ function dispatchAction<S, A>(
   queue: UpdateQueue<S, A>,
   action: A,
 ) {
-  invariant(
-    numberOfReRenders < RE_RENDER_LIMIT,
-    'Too many re-renders. React limits the number of renders to prevent ' +
-      'an infinite loop.',
-  );
+  if (!(numberOfReRenders < RE_RENDER_LIMIT)) {
+    invariant(
+      'Too many re-renders. React limits the number of renders to prevent ' +
+        'an infinite loop.',
+    );
+  }
 
   if (__DEV__) {
-    warning(
-      typeof arguments[3] !== 'function',
-      "State updates from the useState() and useReducer() Hooks don't support the " +
-        'second callback argument. To execute a side effect after ' +
-        'rendering, declare it in the component body with useEffect().',
-    );
+    if (!(typeof arguments[3] !== 'function')) {
+      warning(
+        "State updates from the useState() and useReducer() Hooks don't support the " +
+          'second callback argument. To execute a side effect after ' +
+          'rendering, declare it in the component body with useEffect().',
+      );
+    }
   }
 
   const alternate = fiber.alternate;
@@ -1315,7 +1318,6 @@ let InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher | null = null;
 if (__DEV__) {
   const warnInvalidContextAccess = () => {
     warning(
-      false,
       'Context can only be read while React is rendering. ' +
         'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
         'In function components, you can read it directly in the function body, but not ' +
@@ -1325,7 +1327,6 @@ if (__DEV__) {
 
   const warnInvalidHookAccess = () => {
     warning(
-      false,
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks. ' +
         'You can only call Hooks at the top level of your React function. ' +
         'For more information, see ' +

--- a/packages/react-reconciler/src/ReactFiberHostConfig.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfig.js
@@ -19,4 +19,4 @@ import invariant from 'shared/invariant';
 // sure that if we *do* accidentally break the configuration,
 // the failure isn't silent.
 
-invariant(false, 'This module must be shimmed by a specific renderer.');
+invariant('This module must be shimmed by a specific renderer.');

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -31,8 +31,10 @@ let rootInstanceStackCursor: StackCursor<Container | NoContextT> = createCursor(
 
 function requiredContext<Value>(c: Value | NoContextT): Value {
   if (!(c !== NO_CONTEXT)) {
-    invariant('Expected host context to exist. This error is likely caused by a bug ' +
-      'in React. Please file an issue.');
+    invariant(
+      'Expected host context to exist. This error is likely caused by a bug ' +
+        'in React. Please file an issue.',
+    );
   }
 
   return (c: any);

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -30,11 +30,11 @@ let rootInstanceStackCursor: StackCursor<Container | NoContextT> = createCursor(
 );
 
 function requiredContext<Value>(c: Value | NoContextT): Value {
-  invariant(
-    c !== NO_CONTEXT,
-    'Expected host context to exist. This error is likely caused by a bug ' +
-      'in React. Please file an issue.',
-  );
+  if (!(c !== NO_CONTEXT)) {
+    invariant('Expected host context to exist. This error is likely caused by a bug ' +
+      'in React. Please file an issue.');
+  }
+
   return (c: any);
 }
 

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -65,9 +65,8 @@ let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
 function warnIfHydrating() {
-  if (__DEV__) {
+  if (__DEV__ && isHydrating) {
     warning(
-      !isHydrating,
       'We should not be hydrating here. This is a bug in React. Please file a bug.',
     );
   }
@@ -298,7 +297,6 @@ function prepareToHydrateHostInstance(
 ): boolean {
   if (!supportsHydration) {
     invariant(
-      false,
       'Expected prepareToHydrateHostInstance() to never be called. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );
@@ -326,7 +324,6 @@ function prepareToHydrateHostInstance(
 function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
   if (!supportsHydration) {
     invariant(
-      false,
       'Expected prepareToHydrateHostTextInstance() to never be called. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );
@@ -374,7 +371,6 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
 function prepareToHydrateHostSuspenseInstance(fiber: Fiber): void {
   if (!supportsHydration) {
     invariant(
-      false,
       'Expected prepareToHydrateHostSuspenseInstance() to never be called. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );
@@ -383,11 +379,14 @@ function prepareToHydrateHostSuspenseInstance(fiber: Fiber): void {
   let suspenseState: null | SuspenseState = fiber.memoizedState;
   let suspenseInstance: null | SuspenseInstance =
     suspenseState !== null ? suspenseState.dehydrated : null;
-  invariant(
-    suspenseInstance,
-    'Expected to have a hydrated suspense instance. ' +
-      'This error is likely caused by a bug in React. Please file an issue.',
-  );
+
+  if (!suspenseInstance) {
+    invariant(
+      'Expected to have a hydrated suspense instance. ' +
+        'This error is likely caused by a bug in React. Please file an issue.',
+    );
+  }
+
   hydrateSuspenseInstance(suspenseInstance, fiber);
 }
 
@@ -396,7 +395,6 @@ function skipPastDehydratedSuspenseInstance(
 ): null | HydratableInstance {
   if (!supportsHydration) {
     invariant(
-      false,
       'Expected skipPastDehydratedSuspenseInstance() to never be called. ' +
         'This error is likely caused by a bug in React. Please file an issue.',
     );

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -85,13 +85,19 @@ export function pushProvider<T>(providerFiber: Fiber, nextValue: T): void {
 
     context._currentValue = nextValue;
     if (__DEV__) {
-      warningWithoutStack(
-        context._currentRenderer === undefined ||
+      if (
+        !(
+          context._currentRenderer === undefined ||
           context._currentRenderer === null ||
-          context._currentRenderer === rendererSigil,
-        'Detected multiple renderers concurrently rendering the ' +
-          'same context provider. This is currently unsupported.',
-      );
+          context._currentRenderer === rendererSigil
+        )
+      ) {
+        warningWithoutStack(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+
       context._currentRenderer = rendererSigil;
     }
   } else {
@@ -99,13 +105,19 @@ export function pushProvider<T>(providerFiber: Fiber, nextValue: T): void {
 
     context._currentValue2 = nextValue;
     if (__DEV__) {
-      warningWithoutStack(
-        context._currentRenderer2 === undefined ||
+      if (
+        !(
+          context._currentRenderer2 === undefined ||
           context._currentRenderer2 === null ||
-          context._currentRenderer2 === rendererSigil,
-        'Detected multiple renderers concurrently rendering the ' +
-          'same context provider. This is currently unsupported.',
-      );
+          context._currentRenderer2 === rendererSigil
+        )
+      ) {
+        warningWithoutStack(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+
       context._currentRenderer2 = rendererSigil;
     }
   }
@@ -139,12 +151,13 @@ export function calculateChangedBits<T>(
         : MAX_SIGNED_31_BIT_INT;
 
     if (__DEV__) {
-      warning(
-        (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
-        'calculateChangedBits: Expected the return value to be a ' +
-          '31-bit integer. Instead received: %s',
-        changedBits,
-      );
+      if (!((changedBits & MAX_SIGNED_31_BIT_INT) === changedBits)) {
+        warning(
+          'calculateChangedBits: Expected the return value to be a ' +
+            '31-bit integer. Instead received: %s',
+          changedBits,
+        );
+      }
     }
     return changedBits | 0;
   }
@@ -255,10 +268,13 @@ export function propagateContextChange(
       // if it will have any context consumers in it. The best we can do is
       // mark it as having updates.
       let parentSuspense = fiber.return;
-      invariant(
-        parentSuspense !== null,
-        'We just came from a parent so we must have had a parent. This is a bug in React.',
-      );
+
+      if (!(parentSuspense !== null)) {
+        invariant(
+          'We just came from a parent so we must have had a parent. This is a bug in React.',
+        );
+      }
+
       if (parentSuspense.expirationTime < renderExpirationTime) {
         parentSuspense.expirationTime = renderExpirationTime;
       }
@@ -333,11 +349,10 @@ export function readContext<T>(
   context: ReactContext<T>,
   observedBits: void | number | boolean,
 ): T {
-  if (__DEV__) {
+  if (__DEV__ && isDisallowedContextReadInDEV) {
     // This warning would fire if you read context inside a Hook like useMemo.
     // Unlike the class check below, it's not enforced in production for perf.
     warning(
-      !isDisallowedContextReadInDEV,
       'Context can only be read while React is rendering. ' +
         'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
         'In function components, you can read it directly in the function body, but not ' +
@@ -369,13 +384,14 @@ export function readContext<T>(
     };
 
     if (lastContextDependency === null) {
-      invariant(
-        currentlyRenderingFiber !== null,
-        'Context can only be read while React is rendering. ' +
-          'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
-          'In function components, you can read it directly in the function body, but not ' +
-          'inside Hooks like useReducer() or useMemo().',
-      );
+      if (!(currentlyRenderingFiber !== null)) {
+        invariant(
+          'Context can only be read while React is rendering. ' +
+            'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
+            'In function components, you can read it directly in the function body, but not ' +
+            'inside Hooks like useReducer() or useMemo().',
+        );
+      }
 
       // This is the first dependency for this component. Create a new list.
       lastContextDependency = contextItem;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -144,7 +144,7 @@ function findHostInstance(component: Object): PublicInstance | null {
     } else {
       invariant(
         'Argument appears to not be a ReactComponent. Keys: %s',
-        Object.keys(component)
+        Object.keys(component),
       );
     }
   }
@@ -167,7 +167,7 @@ function findHostInstanceWithWarning(
       } else {
         invariant(
           'Argument appears to not be a ReactComponent. Keys: %s',
-          Object.keys(component)
+          Object.keys(component),
         );
       }
     }
@@ -180,17 +180,29 @@ function findHostInstanceWithWarning(
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
         if (fiber.mode & StrictMode) {
-          warningWithoutStack('%s is deprecated in StrictMode. ' +
-            '%s was passed an instance of %s which is inside StrictMode. ' +
-            'Instead, add a ref directly to the element you want to reference. ' +
-            'Learn more about using refs safely here: ' +
-            'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
+          warningWithoutStack(
+            '%s is deprecated in StrictMode. ' +
+              '%s was passed an instance of %s which is inside StrictMode. ' +
+              'Instead, add a ref directly to the element you want to reference. ' +
+              'Learn more about using refs safely here: ' +
+              'https://fb.me/react-strict-mode-find-node%s',
+            methodName,
+            methodName,
+            componentName,
+            getStackByFiberInDevAndProd(hostFiber),
+          );
         } else {
-          warningWithoutStack('%s is deprecated in StrictMode. ' +
-            '%s was passed an instance of %s which renders StrictMode children. ' +
-            'Instead, add a ref directly to the element you want to reference. ' +
-            'Learn more about using refs safely here: ' +
-            'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
+          warningWithoutStack(
+            '%s is deprecated in StrictMode. ' +
+              '%s was passed an instance of %s which renders StrictMode children. ' +
+              'Instead, add a ref directly to the element you want to reference. ' +
+              'Learn more about using refs safely here: ' +
+              'https://fb.me/react-strict-mode-find-node%s',
+            methodName,
+            methodName,
+            componentName,
+            getStackByFiberInDevAndProd(hostFiber),
+          );
         }
       }
     }
@@ -256,10 +268,13 @@ export function updateContainer(
       !didWarnAboutNestedUpdates
     ) {
       didWarnAboutNestedUpdates = true;
-      warningWithoutStack('Render methods should be a pure function of props and state; ' +
-        'triggering nested component updates from render is not allowed. ' +
-        'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
-        'Check the render method of %s.', getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown');
+      warningWithoutStack(
+        'Render methods should be a pure function of props and state; ' +
+          'triggering nested component updates from render is not allowed. ' +
+          'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
+          'Check the render method of %s.',
+        getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown',
+      );
     }
   }
 
@@ -271,8 +286,11 @@ export function updateContainer(
   callback = callback === undefined ? null : callback;
   if (callback !== null) {
     if (!(typeof callback === 'function')) {
-      warningWithoutStack('render(...): Expected the last optional `callback` argument to be a ' +
-        'function. Instead received: %s.', callback);
+      warningWithoutStack(
+        'render(...): Expected the last optional `callback` argument to be a ' +
+          'function. Instead received: %s.',
+        callback,
+      );
     }
 
     update.callback = callback;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -140,12 +140,11 @@ function findHostInstance(component: Object): PublicInstance | null {
   const fiber = getInstance(component);
   if (fiber === undefined) {
     if (typeof component.render === 'function') {
-      invariant(false, 'Unable to find node on an unmounted component.');
+      invariant('Unable to find node on an unmounted component.');
     } else {
       invariant(
-        false,
         'Argument appears to not be a ReactComponent. Keys: %s',
-        Object.keys(component),
+        Object.keys(component)
       );
     }
   }
@@ -164,12 +163,11 @@ function findHostInstanceWithWarning(
     const fiber = getInstance(component);
     if (fiber === undefined) {
       if (typeof component.render === 'function') {
-        invariant(false, 'Unable to find node on an unmounted component.');
+        invariant('Unable to find node on an unmounted component.');
       } else {
         invariant(
-          false,
           'Argument appears to not be a ReactComponent. Keys: %s',
-          Object.keys(component),
+          Object.keys(component)
         );
       }
     }
@@ -182,31 +180,17 @@ function findHostInstanceWithWarning(
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
         if (fiber.mode & StrictMode) {
-          warningWithoutStack(
-            false,
-            '%s is deprecated in StrictMode. ' +
-              '%s was passed an instance of %s which is inside StrictMode. ' +
-              'Instead, add a ref directly to the element you want to reference. ' +
-              'Learn more about using refs safely here: ' +
-              'https://fb.me/react-strict-mode-find-node%s',
-            methodName,
-            methodName,
-            componentName,
-            getStackByFiberInDevAndProd(hostFiber),
-          );
+          warningWithoutStack('%s is deprecated in StrictMode. ' +
+            '%s was passed an instance of %s which is inside StrictMode. ' +
+            'Instead, add a ref directly to the element you want to reference. ' +
+            'Learn more about using refs safely here: ' +
+            'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
         } else {
-          warningWithoutStack(
-            false,
-            '%s is deprecated in StrictMode. ' +
-              '%s was passed an instance of %s which renders StrictMode children. ' +
-              'Instead, add a ref directly to the element you want to reference. ' +
-              'Learn more about using refs safely here: ' +
-              'https://fb.me/react-strict-mode-find-node%s',
-            methodName,
-            methodName,
-            componentName,
-            getStackByFiberInDevAndProd(hostFiber),
-          );
+          warningWithoutStack('%s is deprecated in StrictMode. ' +
+            '%s was passed an instance of %s which renders StrictMode children. ' +
+            'Instead, add a ref directly to the element you want to reference. ' +
+            'Learn more about using refs safely here: ' +
+            'https://fb.me/react-strict-mode-find-node%s', methodName, methodName, componentName, getStackByFiberInDevAndProd(hostFiber));
         }
       }
     }
@@ -272,14 +256,10 @@ export function updateContainer(
       !didWarnAboutNestedUpdates
     ) {
       didWarnAboutNestedUpdates = true;
-      warningWithoutStack(
-        false,
-        'Render methods should be a pure function of props and state; ' +
-          'triggering nested component updates from render is not allowed. ' +
-          'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
-          'Check the render method of %s.',
-        getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown',
-      );
+      warningWithoutStack('Render methods should be a pure function of props and state; ' +
+        'triggering nested component updates from render is not allowed. ' +
+        'If necessary, trigger nested updates in componentDidUpdate.\n\n' +
+        'Check the render method of %s.', getComponentName(ReactCurrentFiberCurrent.type) || 'Unknown');
     }
   }
 
@@ -290,12 +270,11 @@ export function updateContainer(
 
   callback = callback === undefined ? null : callback;
   if (callback !== null) {
-    warningWithoutStack(
-      typeof callback === 'function',
-      'render(...): Expected the last optional `callback` argument to be a ' +
-        'function. Instead received: %s.',
-      callback,
-    );
+    if (!(typeof callback === 'function')) {
+      warningWithoutStack('render(...): Expected the last optional `callback` argument to be a ' +
+        'function. Instead received: %s.', callback);
+    }
+
     update.callback = callback;
   }
 

--- a/packages/react-reconciler/src/ReactFiberStack.js
+++ b/packages/react-reconciler/src/ReactFiberStack.js
@@ -75,7 +75,9 @@ function push<T>(cursor: StackCursor<T>, value: T, fiber: Fiber): void {
 function checkThatStackIsEmpty() {
   if (__DEV__) {
     if (index !== -1) {
-      warningWithoutStack('Expected an empty stack. Something was not reset properly.');
+      warningWithoutStack(
+        'Expected an empty stack. Something was not reset properly.',
+      );
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberStack.js
+++ b/packages/react-reconciler/src/ReactFiberStack.js
@@ -38,14 +38,14 @@ function isEmpty(): boolean {
 function pop<T>(cursor: StackCursor<T>, fiber: Fiber): void {
   if (index < 0) {
     if (__DEV__) {
-      warningWithoutStack(false, 'Unexpected pop.');
+      warningWithoutStack('Unexpected pop.');
     }
     return;
   }
 
   if (__DEV__) {
     if (fiber !== fiberStack[index]) {
-      warningWithoutStack(false, 'Unexpected Fiber popped.');
+      warningWithoutStack('Unexpected Fiber popped.');
     }
   }
 
@@ -75,10 +75,7 @@ function push<T>(cursor: StackCursor<T>, value: T, fiber: Fiber): void {
 function checkThatStackIsEmpty() {
   if (__DEV__) {
     if (index !== -1) {
-      warningWithoutStack(
-        false,
-        'Expected an empty stack. Something was not reset properly.',
-      );
+      warningWithoutStack('Expected an empty stack. Something was not reset properly.');
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -125,8 +125,11 @@ function createClassErrorUpdate(
             // If componentDidCatch is the only error boundary method defined,
             // then it needs to call setState to recover from errors.
             // If no state update is scheduled then the boundary will swallow the error.
-            warningWithoutStack('%s: Error boundaries should implement getDerivedStateFromError(). ' +
-              'In that method, return a state update to display an error message or fallback UI.', getComponentName(fiber.type) || 'Unknown');
+            warningWithoutStack(
+              '%s: Error boundaries should implement getDerivedStateFromError(). ' +
+                'In that method, return a state update to display an error message or fallback UI.',
+              getComponentName(fiber.type) || 'Unknown',
+            );
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -121,15 +121,13 @@ function createClassErrorUpdate(
       });
       if (__DEV__) {
         if (typeof getDerivedStateFromError !== 'function') {
-          // If componentDidCatch is the only error boundary method defined,
-          // then it needs to call setState to recover from errors.
-          // If no state update is scheduled then the boundary will swallow the error.
-          warningWithoutStack(
-            fiber.expirationTime === Sync,
-            '%s: Error boundaries should implement getDerivedStateFromError(). ' +
-              'In that method, return a state update to display an error message or fallback UI.',
-            getComponentName(fiber.type) || 'Unknown',
-          );
+          if (!(fiber.expirationTime === Sync)) {
+            // If componentDidCatch is the only error boundary method defined,
+            // then it needs to call setState to recover from errors.
+            // If no state update is scheduled then the boundary will swallow the error.
+            warningWithoutStack('%s: Error boundaries should implement getDerivedStateFromError(). ' +
+              'In that method, return a state update to display an error message or fallback UI.', getComponentName(fiber.type) || 'Unknown');
+          }
         }
       }
     };

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -99,11 +99,14 @@ export function isMounted(component: React$Component<any, any>): boolean {
       const instance = ownerFiber.stateNode;
 
       if (!instance._warnedAboutRefsInRender) {
-        warningWithoutStack('%s is accessing isMounted inside its render() function. ' +
-          'render() should be a pure function of props and state. It should ' +
-          'never access something that requires stale data from the previous ' +
-          'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.', getComponentName(ownerFiber.type) || 'A component');
+        warningWithoutStack(
+          '%s is accessing isMounted inside its render() function. ' +
+            'render() should be a pure function of props and state. It should ' +
+            'never access something that requires stale data from the previous ' +
+            'render, such as refs. Move this logic to componentDidMount and ' +
+            'componentDidUpdate instead.',
+          getComponentName(ownerFiber.type) || 'A component',
+        );
       }
 
       instance._warnedAboutRefsInRender = true;
@@ -237,15 +240,19 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
         }
 
         if (!didFindChild) {
-          invariant('Child was not found in either parent set. This indicates a bug ' +
-            'in React related to the return pointer. Please file an issue.');
+          invariant(
+            'Child was not found in either parent set. This indicates a bug ' +
+              'in React related to the return pointer. Please file an issue.',
+          );
         }
       }
     }
 
     if (!(a.alternate === b)) {
-      invariant("Return fibers should always be each others' alternates. " +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      invariant(
+        "Return fibers should always be each others' alternates. " +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -97,15 +97,15 @@ export function isMounted(component: React$Component<any, any>): boolean {
     if (owner !== null && owner.tag === ClassComponent) {
       const ownerFiber: Fiber = owner;
       const instance = ownerFiber.stateNode;
-      warningWithoutStack(
-        instance._warnedAboutRefsInRender,
-        '%s is accessing isMounted inside its render() function. ' +
+
+      if (!instance._warnedAboutRefsInRender) {
+        warningWithoutStack('%s is accessing isMounted inside its render() function. ' +
           'render() should be a pure function of props and state. It should ' +
           'never access something that requires stale data from the previous ' +
           'render, such as refs. Move this logic to componentDidMount and ' +
-          'componentDidUpdate instead.',
-        getComponentName(ownerFiber.type) || 'A component',
-      );
+          'componentDidUpdate instead.', getComponentName(ownerFiber.type) || 'A component');
+      }
+
       instance._warnedAboutRefsInRender = true;
     }
   }
@@ -118,10 +118,9 @@ export function isMounted(component: React$Component<any, any>): boolean {
 }
 
 function assertIsMounted(fiber) {
-  invariant(
-    getNearestMountedFiber(fiber) === fiber,
-    'Unable to find node on an unmounted component.',
-  );
+  if (!(getNearestMountedFiber(fiber) === fiber)) {
+    invariant('Unable to find node on an unmounted component.');
+  }
 }
 
 export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
@@ -129,10 +128,11 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
   if (!alternate) {
     // If there is no alternate, then we only need to check if it is mounted.
     const nearestMounted = getNearestMountedFiber(fiber);
-    invariant(
-      nearestMounted !== null,
-      'Unable to find node on an unmounted component.',
-    );
+
+    if (!(nearestMounted !== null)) {
+      invariant('Unable to find node on an unmounted component.');
+    }
+
     if (nearestMounted !== fiber) {
       return null;
     }
@@ -184,7 +184,7 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
       }
       // We should never have an alternate for any mounting node. So the only
       // way this could possibly happen is if this was unmounted, if at all.
-      invariant(false, 'Unable to find node on an unmounted component.');
+      invariant('Unable to find node on an unmounted component.');
     }
 
     if (a.return !== b.return) {
@@ -235,26 +235,26 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
           }
           child = child.sibling;
         }
-        invariant(
-          didFindChild,
-          'Child was not found in either parent set. This indicates a bug ' +
-            'in React related to the return pointer. Please file an issue.',
-        );
+
+        if (!didFindChild) {
+          invariant('Child was not found in either parent set. This indicates a bug ' +
+            'in React related to the return pointer. Please file an issue.');
+        }
       }
     }
 
-    invariant(
-      a.alternate === b,
-      "Return fibers should always be each others' alternates. " +
-        'This error is likely caused by a bug in React. Please file an issue.',
-    );
+    if (!(a.alternate === b)) {
+      invariant("Return fibers should always be each others' alternates. " +
+        'This error is likely caused by a bug in React. Please file an issue.');
+    }
   }
-  // If the root is not a host container, we're in a disconnected tree. I.e.
-  // unmounted.
-  invariant(
-    a.tag === HostRoot,
-    'Unable to find node on an unmounted component.',
-  );
+
+  if (!(a.tag === HostRoot)) {
+    // If the root is not a host container, we're in a disconnected tree. I.e.
+    // unmounted.
+    invariant('Unable to find node on an unmounted component.');
+  }
+
   if (a.stateNode.current === a) {
     // We've determined that A is the current branch.
     return fiber;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -56,11 +56,12 @@ function unwindWork(
       popHostContainer(workInProgress);
       popTopLevelLegacyContextObject(workInProgress);
       const effectTag = workInProgress.effectTag;
-      invariant(
-        (effectTag & DidCapture) === NoEffect,
-        'The root failed to unmount after an error. This is likely a bug in ' +
-          'React. Please file an issue.',
-      );
+
+      if (!((effectTag & DidCapture) === NoEffect)) {
+        invariant('The root failed to unmount after an error. This is likely a bug in ' +
+          'React. Please file an issue.');
+      }
+
       workInProgress.effectTag = (effectTag & ~ShouldCapture) | DidCapture;
       return workInProgress;
     }
@@ -75,11 +76,11 @@ function unwindWork(
         const suspenseState: null | SuspenseState =
           workInProgress.memoizedState;
         if (suspenseState !== null && suspenseState.dehydrated !== null) {
-          invariant(
-            workInProgress.alternate !== null,
-            'Threw in newly mounted dehydrated component. This is likely a bug in ' +
-              'React. Please file an issue.',
-          );
+          if (!(workInProgress.alternate !== null)) {
+            invariant('Threw in newly mounted dehydrated component. This is likely a bug in ' +
+              'React. Please file an issue.');
+          }
+
           resetHydrationState();
         }
       }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.js
@@ -58,8 +58,10 @@ function unwindWork(
       const effectTag = workInProgress.effectTag;
 
       if (!((effectTag & DidCapture) === NoEffect)) {
-        invariant('The root failed to unmount after an error. This is likely a bug in ' +
-          'React. Please file an issue.');
+        invariant(
+          'The root failed to unmount after an error. This is likely a bug in ' +
+            'React. Please file an issue.',
+        );
       }
 
       workInProgress.effectTag = (effectTag & ~ShouldCapture) | DidCapture;
@@ -77,8 +79,10 @@ function unwindWork(
           workInProgress.memoizedState;
         if (suspenseState !== null && suspenseState.dehydrated !== null) {
           if (!(workInProgress.alternate !== null)) {
-            invariant('Threw in newly mounted dehydrated component. This is likely a bug in ' +
-              'React. Please file an issue.');
+            invariant(
+              'Threw in newly mounted dehydrated component. This is likely a bug in ' +
+                'React. Please file an issue.',
+            );
           }
 
           resetHydrationState();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1029,8 +1029,10 @@ function performSyncWorkOnRoot(root) {
 
       if (workInProgress !== null) {
         // This is a sync render, so we should have finished the whole tree.
-        invariant('Cannot commit an incomplete root. This error is likely caused by a ' +
-          'bug in React. Please file an issue.');
+        invariant(
+          'Cannot commit an incomplete root. This error is likely caused by a ' +
+            'bug in React. Please file an issue.',
+        );
       } else {
         // We now have a consistent tree. Because this is a sync render, we
         // will commit it even if something suspended.
@@ -1079,8 +1081,10 @@ export function flushDiscreteUpdates() {
     NoContext
   ) {
     if (__DEV__ && (executionContext & RenderContext) !== NoContext) {
-      warning('unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
-        'already rendering.');
+      warning(
+        'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
+          'already rendering.',
+      );
     }
     // We're already rendering, so we can't synchronously flush pending work.
     // This is probably a nested event dispatch triggered by a lifecycle/effect,
@@ -1187,8 +1191,10 @@ export function unbatchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
 
 export function flushSync<A, R>(fn: A => R, a: A): R {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    invariant('flushSync was called from inside a lifecycle method. It cannot be ' +
-      'called when React is already rendering.');
+    invariant(
+      'flushSync was called from inside a lifecycle method. It cannot be ' +
+        'called when React is already rendering.',
+    );
   }
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
@@ -1713,8 +1719,10 @@ function commitRootImpl(root, renderPriorityLevel) {
   root.finishedExpirationTime = NoWork;
 
   if (!(finishedWork !== root.current)) {
-    invariant('Cannot commit the same tree as before. This error is likely caused by ' +
-      'a bug in React. Please file an issue.');
+    invariant(
+      'Cannot commit the same tree as before. This error is likely caused by ' +
+        'a bug in React. Please file an issue.',
+    );
   }
 
   // commitRoot never returns a continuation; it always finishes synchronously.
@@ -2430,8 +2438,10 @@ export function resolveRetryThenable(boundaryFiber: Fiber, thenable: Thenable) {
         retryCache = boundaryFiber.stateNode;
         break;
       default:
-        invariant('Pinged unknown suspense boundary type. ' +
-          'This is probably a bug in React.');
+        invariant(
+          'Pinged unknown suspense boundary type. ' +
+            'This is probably a bug in React.',
+        );
     }
   } else {
     retryCache = boundaryFiber.stateNode;
@@ -2503,19 +2513,23 @@ function checkForNestedUpdates() {
   if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
     nestedUpdateCount = 0;
     rootWithNestedUpdates = null;
-    invariant('Maximum update depth exceeded. This can happen when a component ' +
-      'repeatedly calls setState inside componentWillUpdate or ' +
-      'componentDidUpdate. React limits the number of nested updates to ' +
-      'prevent infinite loops.');
+    invariant(
+      'Maximum update depth exceeded. This can happen when a component ' +
+        'repeatedly calls setState inside componentWillUpdate or ' +
+        'componentDidUpdate. React limits the number of nested updates to ' +
+        'prevent infinite loops.',
+    );
   }
 
   if (__DEV__) {
     if (nestedPassiveUpdateCount > NESTED_PASSIVE_UPDATE_LIMIT) {
       nestedPassiveUpdateCount = 0;
-      warning('Maximum update depth exceeded. This can happen when a component ' +
-        "calls setState inside useEffect, but useEffect either doesn't " +
-        'have a dependency array, or one of the dependencies changes on ' +
-        'every render.');
+      warning(
+        'Maximum update depth exceeded. This can happen when a component ' +
+          "calls setState inside useEffect, but useEffect either doesn't " +
+          'have a dependency array, or one of the dependencies changes on ' +
+          'every render.',
+      );
     }
   }
 }
@@ -2582,11 +2596,15 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     } else {
       didWarnStateUpdateForUnmountedComponent = new Set([componentName]);
     }
-    warningWithoutStack("Can't perform a React state update on an unmounted component. This " +
-      'is a no-op, but it indicates a memory leak in your application. To ' +
-      'fix, cancel all subscriptions and asynchronous tasks in %s.%s', tag === ClassComponent
-      ? 'the componentWillUnmount method'
-      : 'a useEffect cleanup function', getStackByFiberInDevAndProd(fiber));
+    warningWithoutStack(
+      "Can't perform a React state update on an unmounted component. This " +
+        'is a no-op, but it indicates a memory leak in your application. To ' +
+        'fix, cancel all subscriptions and asynchronous tasks in %s.%s',
+      tag === ClassComponent
+        ? 'the componentWillUnmount method'
+        : 'a useEffect cleanup function',
+      getStackByFiberInDevAndProd(fiber),
+    );
   }
 }
 
@@ -2669,16 +2687,20 @@ function warnAboutInvalidUpdatesOnClassComponentsInDEV(fiber) {
           if (didWarnAboutUpdateInGetChildContext) {
             return;
           }
-          warningWithoutStack('setState(...): Cannot call setState() inside getChildContext()');
+          warningWithoutStack(
+            'setState(...): Cannot call setState() inside getChildContext()',
+          );
           didWarnAboutUpdateInGetChildContext = true;
           break;
         case 'render':
           if (didWarnAboutUpdateInRender) {
             return;
           }
-          warningWithoutStack('Cannot update during an existing state transition (such as ' +
-            'within `render`). Render methods should be a pure function of ' +
-            'props and state.');
+          warningWithoutStack(
+            'Cannot update during an existing state transition (such as ' +
+              'within `render`). Render methods should be a pure function of ' +
+              'props and state.',
+          );
           didWarnAboutUpdateInRender = true;
           break;
       }
@@ -2709,7 +2731,7 @@ export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
           '// ...\n' +
           'act(() => ...);' +
           '%s',
-        getStackByFiberInDevAndProd(fiber)
+        getStackByFiberInDevAndProd(fiber),
       );
     }
   }
@@ -2723,17 +2745,21 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {
-      warningWithoutStack('An update to %s ran an effect, but was not wrapped in act(...).\n\n' +
-        'When testing, code that causes React state updates should be ' +
-        'wrapped into act(...):\n\n' +
-        'act(() => {\n' +
-        '  /* fire events that update state */\n' +
-        '});\n' +
-        '/* assert on the output */\n\n' +
-        "This ensures that you're testing the behavior the user would see " +
-        'in the browser.' +
-        ' Learn more at https://fb.me/react-wrap-tests-with-act' +
-        '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
+      warningWithoutStack(
+        'An update to %s ran an effect, but was not wrapped in act(...).\n\n' +
+          'When testing, code that causes React state updates should be ' +
+          'wrapped into act(...):\n\n' +
+          'act(() => {\n' +
+          '  /* fire events that update state */\n' +
+          '});\n' +
+          '/* assert on the output */\n\n' +
+          "This ensures that you're testing the behavior the user would see " +
+          'in the browser.' +
+          ' Learn more at https://fb.me/react-wrap-tests-with-act' +
+          '%s',
+        getComponentName(fiber.type),
+        getStackByFiberInDevAndProd(fiber),
+      );
     }
   }
 }
@@ -2746,17 +2772,21 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {
-      warningWithoutStack('An update to %s inside a test was not wrapped in act(...).\n\n' +
-        'When testing, code that causes React state updates should be ' +
-        'wrapped into act(...):\n\n' +
-        'act(() => {\n' +
-        '  /* fire events that update state */\n' +
-        '});\n' +
-        '/* assert on the output */\n\n' +
-        "This ensures that you're testing the behavior the user would see " +
-        'in the browser.' +
-        ' Learn more at https://fb.me/react-wrap-tests-with-act' +
-        '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
+      warningWithoutStack(
+        'An update to %s inside a test was not wrapped in act(...).\n\n' +
+          'When testing, code that causes React state updates should be ' +
+          'wrapped into act(...):\n\n' +
+          'act(() => {\n' +
+          '  /* fire events that update state */\n' +
+          '});\n' +
+          '/* assert on the output */\n\n' +
+          "This ensures that you're testing the behavior the user would see " +
+          'in the browser.' +
+          ' Learn more at https://fb.me/react-wrap-tests-with-act' +
+          '%s',
+        getComponentName(fiber.type),
+        getStackByFiberInDevAndProd(fiber),
+      );
     }
   }
 }
@@ -2783,7 +2813,7 @@ export function warnIfUnmockedScheduler(fiber: Fiber) {
             'to guarantee consistent behaviour across tests and browsers. ' +
             'For example, with jest: \n' +
             "jest.mock('scheduler', () => require('scheduler/unstable_mock'));\n\n" +
-            'For more info, visit https://fb.me/react-mock-scheduler'
+            'For more info, visit https://fb.me/react-mock-scheduler',
         );
       } else if (warnAboutUnmockedScheduler === true) {
         didWarnAboutUnmockedScheduler = true;
@@ -2792,7 +2822,7 @@ export function warnIfUnmockedScheduler(fiber: Fiber) {
             'to guarantee consistent behaviour across tests and browsers. ' +
             'For example, with jest: \n' +
             "jest.mock('scheduler', () => require('scheduler/unstable_mock'));\n\n" +
-            'For more info, visit https://fb.me/react-mock-scheduler'
+            'For more info, visit https://fb.me/react-mock-scheduler',
         );
       }
     }
@@ -2899,15 +2929,17 @@ function flushSuspensePriorityWarningInDEV() {
       componentsThatTriggeredHighPriSuspend = null;
 
       if (componentNames.length > 0) {
-        warningWithoutStack('%s triggered a user-blocking update that suspended.' +
-          '\n\n' +
-          'The fix is to split the update into multiple parts: a user-blocking ' +
-          'update to provide immediate feedback, and another update that ' +
-          'triggers the bulk of the changes.' +
-          '\n\n' +
-          'Refer to the documentation for useSuspenseTransition to learn how ' +
-          'to implement this pattern.', // TODO: Add link to React docs with more information, once it exists
-        componentNames.sort().join(', '));
+        warningWithoutStack(
+          '%s triggered a user-blocking update that suspended.' +
+            '\n\n' +
+            'The fix is to split the update into multiple parts: a user-blocking ' +
+            'update to provide immediate feedback, and another update that ' +
+            'triggers the bulk of the changes.' +
+            '\n\n' +
+            'Refer to the documentation for useSuspenseTransition to learn how ' +
+            'to implement this pattern.', // TODO: Add link to React docs with more information, once it exists
+          componentNames.sort().join(', '),
+        );
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -350,7 +350,7 @@ export function computeExpirationForFiber(
         expirationTime = Idle;
         break;
       default:
-        invariant(false, 'Expected a valid priority level');
+        invariant('Expected a valid priority level');
     }
   }
 
@@ -644,10 +644,10 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
   const expirationTime = getNextRootExpirationTimeToWorkOn(root);
   if (expirationTime !== NoWork) {
     const originalCallbackNode = root.callbackNode;
-    invariant(
-      (executionContext & (RenderContext | CommitContext)) === NoContext,
-      'Should not already be working.',
-    );
+
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      invariant('Should not already be working.');
+    }
 
     flushPassiveEffects();
 
@@ -735,7 +735,7 @@ function finishConcurrentRender(
   switch (exitStatus) {
     case RootIncomplete:
     case RootFatalErrored: {
-      invariant(false, 'Root did not complete. This is a bug in React.');
+      invariant('Root did not complete. This is a bug in React.');
     }
     // Flow knows about invariant, so it complains if I add a break
     // statement, but eslint doesn't know about invariant, so it complains
@@ -961,7 +961,7 @@ function finishConcurrentRender(
       break;
     }
     default: {
-      invariant(false, 'Unknown root exit status.');
+      invariant('Unknown root exit status.');
     }
   }
 }
@@ -978,10 +978,9 @@ function performSyncWorkOnRoot(root) {
     // batch.commit() API.
     commitRoot(root);
   } else {
-    invariant(
-      (executionContext & (RenderContext | CommitContext)) === NoContext,
-      'Should not already be working.',
-    );
+    if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+      invariant('Should not already be working.');
+    }
 
     flushPassiveEffects();
 
@@ -1030,11 +1029,8 @@ function performSyncWorkOnRoot(root) {
 
       if (workInProgress !== null) {
         // This is a sync render, so we should have finished the whole tree.
-        invariant(
-          false,
-          'Cannot commit an incomplete root. This error is likely caused by a ' +
-            'bug in React. Please file an issue.',
-        );
+        invariant('Cannot commit an incomplete root. This error is likely caused by a ' +
+          'bug in React. Please file an issue.');
       } else {
         // We now have a consistent tree. Because this is a sync render, we
         // will commit it even if something suspended.
@@ -1083,11 +1079,8 @@ export function flushDiscreteUpdates() {
     NoContext
   ) {
     if (__DEV__ && (executionContext & RenderContext) !== NoContext) {
-      warning(
-        false,
-        'unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
-          'already rendering.',
-      );
+      warning('unstable_flushDiscreteUpdates: Cannot flush updates when React is ' +
+        'already rendering.');
     }
     // We're already rendering, so we can't synchronously flush pending work.
     // This is probably a nested event dispatch triggered by a lifecycle/effect,
@@ -1194,11 +1187,8 @@ export function unbatchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
 
 export function flushSync<A, R>(fn: A => R, a: A): R {
   if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
-    invariant(
-      false,
-      'flushSync was called from inside a lifecycle method. It cannot be ' +
-        'called when React is already rendering.',
-    );
+    invariant('flushSync was called from inside a lifecycle method. It cannot be ' +
+      'called when React is already rendering.');
   }
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
@@ -1710,10 +1700,9 @@ function commitRootImpl(root, renderPriorityLevel) {
   flushPassiveEffects();
   flushRenderPhaseStrictModeWarningsInDEV();
 
-  invariant(
-    (executionContext & (RenderContext | CommitContext)) === NoContext,
-    'Should not already be working.',
-  );
+  if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+    invariant('Should not already be working.');
+  }
 
   const finishedWork = root.finishedWork;
   const expirationTime = root.finishedExpirationTime;
@@ -1723,11 +1712,10 @@ function commitRootImpl(root, renderPriorityLevel) {
   root.finishedWork = null;
   root.finishedExpirationTime = NoWork;
 
-  invariant(
-    finishedWork !== root.current,
-    'Cannot commit the same tree as before. This error is likely caused by ' +
-      'a bug in React. Please file an issue.',
-  );
+  if (!(finishedWork !== root.current)) {
+    invariant('Cannot commit the same tree as before. This error is likely caused by ' +
+      'a bug in React. Please file an issue.');
+  }
 
   // commitRoot never returns a continuation; it always finishes synchronously.
   // So we can clear these now to allow a new callback to be scheduled.
@@ -1800,7 +1788,10 @@ function commitRootImpl(root, renderPriorityLevel) {
       if (__DEV__) {
         invokeGuardedCallback(null, commitBeforeMutationEffects, null);
         if (hasCaughtError()) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           const error = clearCaughtError();
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
@@ -1809,7 +1800,10 @@ function commitRootImpl(root, renderPriorityLevel) {
         try {
           commitBeforeMutationEffects();
         } catch (error) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
         }
@@ -1836,7 +1830,10 @@ function commitRootImpl(root, renderPriorityLevel) {
           renderPriorityLevel,
         );
         if (hasCaughtError()) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           const error = clearCaughtError();
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
@@ -1845,7 +1842,10 @@ function commitRootImpl(root, renderPriorityLevel) {
         try {
           commitMutationEffects(root, renderPriorityLevel);
         } catch (error) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
         }
@@ -1875,7 +1875,10 @@ function commitRootImpl(root, renderPriorityLevel) {
           expirationTime,
         );
         if (hasCaughtError()) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           const error = clearCaughtError();
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
@@ -1884,7 +1887,10 @@ function commitRootImpl(root, renderPriorityLevel) {
         try {
           commitLayoutEffects(root, expirationTime);
         } catch (error) {
-          invariant(nextEffect !== null, 'Should be working on an effect.');
+          if (!(nextEffect !== null)) {
+            invariant('Should be working on an effect.');
+          }
+
           captureCommitPhaseError(nextEffect, error);
           nextEffect = nextEffect.nextEffect;
         }
@@ -2169,10 +2175,10 @@ function flushPassiveEffectsImpl() {
   rootWithPendingPassiveEffects = null;
   pendingPassiveEffectsExpirationTime = NoWork;
 
-  invariant(
-    (executionContext & (RenderContext | CommitContext)) === NoContext,
-    'Cannot flush passive effects while already rendering.',
-  );
+  if (!((executionContext & (RenderContext | CommitContext)) === NoContext)) {
+    invariant('Cannot flush passive effects while already rendering.');
+  }
+
   const prevExecutionContext = executionContext;
   executionContext |= CommitContext;
   const prevInteractions = pushInteractions(root);
@@ -2186,7 +2192,10 @@ function flushPassiveEffectsImpl() {
       setCurrentDebugFiberInDEV(effect);
       invokeGuardedCallback(null, commitPassiveHookEffects, null, effect);
       if (hasCaughtError()) {
-        invariant(effect !== null, 'Should be working on an effect.');
+        if (!(effect !== null)) {
+          invariant('Should be working on an effect.');
+        }
+
         const error = clearCaughtError();
         captureCommitPhaseError(effect, error);
       }
@@ -2195,7 +2204,10 @@ function flushPassiveEffectsImpl() {
       try {
         commitPassiveHookEffects(effect);
       } catch (error) {
-        invariant(effect !== null, 'Should be working on an effect.');
+        if (!(effect !== null)) {
+          invariant('Should be working on an effect.');
+        }
+
         captureCommitPhaseError(effect, error);
       }
     }
@@ -2418,11 +2430,8 @@ export function resolveRetryThenable(boundaryFiber: Fiber, thenable: Thenable) {
         retryCache = boundaryFiber.stateNode;
         break;
       default:
-        invariant(
-          false,
-          'Pinged unknown suspense boundary type. ' +
-            'This is probably a bug in React.',
-        );
+        invariant('Pinged unknown suspense boundary type. ' +
+          'This is probably a bug in React.');
     }
   } else {
     retryCache = boundaryFiber.stateNode;
@@ -2494,25 +2503,19 @@ function checkForNestedUpdates() {
   if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
     nestedUpdateCount = 0;
     rootWithNestedUpdates = null;
-    invariant(
-      false,
-      'Maximum update depth exceeded. This can happen when a component ' +
-        'repeatedly calls setState inside componentWillUpdate or ' +
-        'componentDidUpdate. React limits the number of nested updates to ' +
-        'prevent infinite loops.',
-    );
+    invariant('Maximum update depth exceeded. This can happen when a component ' +
+      'repeatedly calls setState inside componentWillUpdate or ' +
+      'componentDidUpdate. React limits the number of nested updates to ' +
+      'prevent infinite loops.');
   }
 
   if (__DEV__) {
     if (nestedPassiveUpdateCount > NESTED_PASSIVE_UPDATE_LIMIT) {
       nestedPassiveUpdateCount = 0;
-      warning(
-        false,
-        'Maximum update depth exceeded. This can happen when a component ' +
-          "calls setState inside useEffect, but useEffect either doesn't " +
-          'have a dependency array, or one of the dependencies changes on ' +
-          'every render.',
-      );
+      warning('Maximum update depth exceeded. This can happen when a component ' +
+        "calls setState inside useEffect, but useEffect either doesn't " +
+        'have a dependency array, or one of the dependencies changes on ' +
+        'every render.');
     }
   }
 }
@@ -2579,16 +2582,11 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     } else {
       didWarnStateUpdateForUnmountedComponent = new Set([componentName]);
     }
-    warningWithoutStack(
-      false,
-      "Can't perform a React state update on an unmounted component. This " +
-        'is a no-op, but it indicates a memory leak in your application. To ' +
-        'fix, cancel all subscriptions and asynchronous tasks in %s.%s',
-      tag === ClassComponent
-        ? 'the componentWillUnmount method'
-        : 'a useEffect cleanup function',
-      getStackByFiberInDevAndProd(fiber),
-    );
+    warningWithoutStack("Can't perform a React state update on an unmounted component. This " +
+      'is a no-op, but it indicates a memory leak in your application. To ' +
+      'fix, cancel all subscriptions and asynchronous tasks in %s.%s', tag === ClassComponent
+      ? 'the componentWillUnmount method'
+      : 'a useEffect cleanup function', getStackByFiberInDevAndProd(fiber));
   }
 }
 
@@ -2671,22 +2669,16 @@ function warnAboutInvalidUpdatesOnClassComponentsInDEV(fiber) {
           if (didWarnAboutUpdateInGetChildContext) {
             return;
           }
-          warningWithoutStack(
-            false,
-            'setState(...): Cannot call setState() inside getChildContext()',
-          );
+          warningWithoutStack('setState(...): Cannot call setState() inside getChildContext()');
           didWarnAboutUpdateInGetChildContext = true;
           break;
         case 'render':
           if (didWarnAboutUpdateInRender) {
             return;
           }
-          warningWithoutStack(
-            false,
-            'Cannot update during an existing state transition (such as ' +
-              'within `render`). Render methods should be a pure function of ' +
-              'props and state.',
-          );
+          warningWithoutStack('Cannot update during an existing state transition (such as ' +
+            'within `render`). Render methods should be a pure function of ' +
+            'props and state.');
           didWarnAboutUpdateInRender = true;
           break;
       }
@@ -2705,7 +2697,6 @@ export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
       IsThisRendererActing.current !== true
     ) {
       warningWithoutStack(
-        false,
         "It looks like you're using the wrong act() around your test interactions.\n" +
           'Be sure to use the matching version of act() corresponding to your renderer:\n\n' +
           '// for react-dom:\n' +
@@ -2718,7 +2709,7 @@ export function warnIfNotScopedWithMatchingAct(fiber: Fiber): void {
           '// ...\n' +
           'act(() => ...);' +
           '%s',
-        getStackByFiberInDevAndProd(fiber),
+        getStackByFiberInDevAndProd(fiber)
       );
     }
   }
@@ -2732,22 +2723,17 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {
-      warningWithoutStack(
-        false,
-        'An update to %s ran an effect, but was not wrapped in act(...).\n\n' +
-          'When testing, code that causes React state updates should be ' +
-          'wrapped into act(...):\n\n' +
-          'act(() => {\n' +
-          '  /* fire events that update state */\n' +
-          '});\n' +
-          '/* assert on the output */\n\n' +
-          "This ensures that you're testing the behavior the user would see " +
-          'in the browser.' +
-          ' Learn more at https://fb.me/react-wrap-tests-with-act' +
-          '%s',
-        getComponentName(fiber.type),
-        getStackByFiberInDevAndProd(fiber),
-      );
+      warningWithoutStack('An update to %s ran an effect, but was not wrapped in act(...).\n\n' +
+        'When testing, code that causes React state updates should be ' +
+        'wrapped into act(...):\n\n' +
+        'act(() => {\n' +
+        '  /* fire events that update state */\n' +
+        '});\n' +
+        '/* assert on the output */\n\n' +
+        "This ensures that you're testing the behavior the user would see " +
+        'in the browser.' +
+        ' Learn more at https://fb.me/react-wrap-tests-with-act' +
+        '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
     }
   }
 }
@@ -2760,22 +2746,17 @@ function warnIfNotCurrentlyActingUpdatesInDEV(fiber: Fiber): void {
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {
-      warningWithoutStack(
-        false,
-        'An update to %s inside a test was not wrapped in act(...).\n\n' +
-          'When testing, code that causes React state updates should be ' +
-          'wrapped into act(...):\n\n' +
-          'act(() => {\n' +
-          '  /* fire events that update state */\n' +
-          '});\n' +
-          '/* assert on the output */\n\n' +
-          "This ensures that you're testing the behavior the user would see " +
-          'in the browser.' +
-          ' Learn more at https://fb.me/react-wrap-tests-with-act' +
-          '%s',
-        getComponentName(fiber.type),
-        getStackByFiberInDevAndProd(fiber),
-      );
+      warningWithoutStack('An update to %s inside a test was not wrapped in act(...).\n\n' +
+        'When testing, code that causes React state updates should be ' +
+        'wrapped into act(...):\n\n' +
+        'act(() => {\n' +
+        '  /* fire events that update state */\n' +
+        '});\n' +
+        '/* assert on the output */\n\n' +
+        "This ensures that you're testing the behavior the user would see " +
+        'in the browser.' +
+        ' Learn more at https://fb.me/react-wrap-tests-with-act' +
+        '%s', getComponentName(fiber.type), getStackByFiberInDevAndProd(fiber));
     }
   }
 }
@@ -2798,22 +2779,20 @@ export function warnIfUnmockedScheduler(fiber: Fiber) {
       if (fiber.mode & BatchedMode || fiber.mode & ConcurrentMode) {
         didWarnAboutUnmockedScheduler = true;
         warningWithoutStack(
-          false,
           'In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' +
             'to guarantee consistent behaviour across tests and browsers. ' +
             'For example, with jest: \n' +
             "jest.mock('scheduler', () => require('scheduler/unstable_mock'));\n\n" +
-            'For more info, visit https://fb.me/react-mock-scheduler',
+            'For more info, visit https://fb.me/react-mock-scheduler'
         );
       } else if (warnAboutUnmockedScheduler === true) {
         didWarnAboutUnmockedScheduler = true;
         warningWithoutStack(
-          false,
           'Starting from React v17, the "scheduler" module will need to be mocked ' +
             'to guarantee consistent behaviour across tests and browsers. ' +
             'For example, with jest: \n' +
             "jest.mock('scheduler', () => require('scheduler/unstable_mock'));\n\n" +
-            'For more info, visit https://fb.me/react-mock-scheduler',
+            'For more info, visit https://fb.me/react-mock-scheduler'
         );
       }
     }
@@ -2920,19 +2899,15 @@ function flushSuspensePriorityWarningInDEV() {
       componentsThatTriggeredHighPriSuspend = null;
 
       if (componentNames.length > 0) {
-        warningWithoutStack(
-          false,
-          '%s triggered a user-blocking update that suspended.' +
-            '\n\n' +
-            'The fix is to split the update into multiple parts: a user-blocking ' +
-            'update to provide immediate feedback, and another update that ' +
-            'triggers the bulk of the changes.' +
-            '\n\n' +
-            'Refer to the documentation for useSuspenseTransition to learn how ' +
-            'to implement this pattern.',
-          // TODO: Add link to React docs with more information, once it exists
-          componentNames.sort().join(', '),
-        );
+        warningWithoutStack('%s triggered a user-blocking update that suspended.' +
+          '\n\n' +
+          'The fix is to split the update into multiple parts: a user-blocking ' +
+          'update to provide immediate feedback, and another update that ' +
+          'triggers the bulk of the changes.' +
+          '\n\n' +
+          'Refer to the documentation for useSuspenseTransition to learn how ' +
+          'to implement this pattern.', // TODO: Add link to React docs with more information, once it exists
+        componentNames.sort().join(', '));
       }
     }
   }

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -192,12 +192,11 @@ if (__DEV__) {
         UNSAFE_componentWillMountUniqueNames,
       );
       warningWithoutStack(
-        false,
         'Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
           '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
           '\nPlease update the following components: %s',
-        sortedNames,
+        sortedNames
       );
     }
 
@@ -206,7 +205,6 @@ if (__DEV__) {
         UNSAFE_componentWillReceivePropsUniqueNames,
       );
       warningWithoutStack(
-        false,
         'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended ' +
           'and may indicate bugs in your code. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
@@ -215,7 +213,7 @@ if (__DEV__) {
           'refactor your code to use memoization techniques or move it to ' +
           'static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state\n' +
           '\nPlease update the following components: %s',
-        sortedNames,
+        sortedNames
       );
     }
 
@@ -223,32 +221,24 @@ if (__DEV__) {
       const sortedNames = setToSortedString(
         UNSAFE_componentWillUpdateUniqueNames,
       );
-      warningWithoutStack(
-        false,
-        'Using UNSAFE_componentWillUpdate in strict mode is not recommended ' +
-          'and may indicate bugs in your code. ' +
-          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-          '* Move data fetching code or side effects to componentDidUpdate.\n' +
-          '\nPlease update the following components: %s',
-        sortedNames,
-      );
+      warningWithoutStack('Using UNSAFE_componentWillUpdate in strict mode is not recommended ' +
+        'and may indicate bugs in your code. ' +
+        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+        '* Move data fetching code or side effects to componentDidUpdate.\n' +
+        '\nPlease update the following components: %s', sortedNames);
     }
 
     if (componentWillMountUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillMountUniqueNames);
 
-      lowPriorityWarningWithoutStack(
-        false,
-        'componentWillMount has been renamed, and is not recommended for use. ' +
-          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-          '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
-          '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' +
-          'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
-          'To rename all deprecated lifecycles to their new names, you can run ' +
-          '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
-          '\nPlease update the following components: %s',
-        sortedNames,
-      );
+      lowPriorityWarningWithoutStack('componentWillMount has been renamed, and is not recommended for use. ' +
+        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+        '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
+        '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' +
+        'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
+        'To rename all deprecated lifecycles to their new names, you can run ' +
+        '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
+        '\nPlease update the following components: %s', sortedNames);
     }
 
     if (componentWillReceivePropsUniqueNames.size > 0) {
@@ -257,7 +247,6 @@ if (__DEV__) {
       );
 
       lowPriorityWarningWithoutStack(
-        false,
         'componentWillReceiveProps has been renamed, and is not recommended for use. ' +
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
           '* Move data fetching code or side effects to componentDidUpdate.\n' +
@@ -269,25 +258,21 @@ if (__DEV__) {
           'To rename all deprecated lifecycles to their new names, you can run ' +
           '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
           '\nPlease update the following components: %s',
-        sortedNames,
+        sortedNames
       );
     }
 
     if (componentWillUpdateUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillUpdateUniqueNames);
 
-      lowPriorityWarningWithoutStack(
-        false,
-        'componentWillUpdate has been renamed, and is not recommended for use. ' +
-          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-          '* Move data fetching code or side effects to componentDidUpdate.\n' +
-          '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' +
-          'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
-          'To rename all deprecated lifecycles to their new names, you can run ' +
-          '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
-          '\nPlease update the following components: %s',
-        sortedNames,
-      );
+      lowPriorityWarningWithoutStack('componentWillUpdate has been renamed, and is not recommended for use. ' +
+        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+        '* Move data fetching code or side effects to componentDidUpdate.\n' +
+        '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' +
+        'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
+        'To rename all deprecated lifecycles to their new names, you can run ' +
+        '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
+        '\nPlease update the following components: %s', sortedNames);
     }
   };
 
@@ -302,11 +287,8 @@ if (__DEV__) {
   ) => {
     const strictRoot = findStrictRoot(fiber);
     if (strictRoot === null) {
-      warningWithoutStack(
-        false,
-        'Expected to find a StrictMode component in a strict mode tree. ' +
-          'This error is likely caused by a bug in React. Please file an issue.',
-      );
+      warningWithoutStack('Expected to find a StrictMode component in a strict mode tree. ' +
+        'This error is likely caused by a bug in React. Please file an issue.');
       return;
     }
 
@@ -344,17 +326,12 @@ if (__DEV__) {
           strictRoot,
         );
 
-        warningWithoutStack(
-          false,
-          'Legacy context API has been detected within a strict-mode tree.' +
-            '\n\nThe old API will be supported in all 16.x releases, but applications ' +
-            'using it should migrate to the new version.' +
-            '\n\nPlease update the following components: %s' +
-            '\n\nLearn more about this warning here: https://fb.me/react-legacy-context' +
-            '%s',
-          sortedNames,
-          strictRootComponentStack,
-        );
+        warningWithoutStack('Legacy context API has been detected within a strict-mode tree.' +
+          '\n\nThe old API will be supported in all 16.x releases, but applications ' +
+          'using it should migrate to the new version.' +
+          '\n\nPlease update the following components: %s' +
+          '\n\nLearn more about this warning here: https://fb.me/react-legacy-context' +
+          '%s', sortedNames, strictRootComponentStack);
       },
     );
   };

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.js
@@ -196,7 +196,7 @@ if (__DEV__) {
           'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
           '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
           '\nPlease update the following components: %s',
-        sortedNames
+        sortedNames,
       );
     }
 
@@ -213,7 +213,7 @@ if (__DEV__) {
           'refactor your code to use memoization techniques or move it to ' +
           'static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state\n' +
           '\nPlease update the following components: %s',
-        sortedNames
+        sortedNames,
       );
     }
 
@@ -221,24 +221,30 @@ if (__DEV__) {
       const sortedNames = setToSortedString(
         UNSAFE_componentWillUpdateUniqueNames,
       );
-      warningWithoutStack('Using UNSAFE_componentWillUpdate in strict mode is not recommended ' +
-        'and may indicate bugs in your code. ' +
-        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-        '* Move data fetching code or side effects to componentDidUpdate.\n' +
-        '\nPlease update the following components: %s', sortedNames);
+      warningWithoutStack(
+        'Using UNSAFE_componentWillUpdate in strict mode is not recommended ' +
+          'and may indicate bugs in your code. ' +
+          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+          '* Move data fetching code or side effects to componentDidUpdate.\n' +
+          '\nPlease update the following components: %s',
+        sortedNames,
+      );
     }
 
     if (componentWillMountUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillMountUniqueNames);
 
-      lowPriorityWarningWithoutStack('componentWillMount has been renamed, and is not recommended for use. ' +
-        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-        '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
-        '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' +
-        'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
-        'To rename all deprecated lifecycles to their new names, you can run ' +
-        '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
-        '\nPlease update the following components: %s', sortedNames);
+      lowPriorityWarningWithoutStack(
+        'componentWillMount has been renamed, and is not recommended for use. ' +
+          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+          '* Move code with side effects to componentDidMount, and set initial state in the constructor.\n' +
+          '* Rename componentWillMount to UNSAFE_componentWillMount to suppress ' +
+          'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
+          'To rename all deprecated lifecycles to their new names, you can run ' +
+          '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
+          '\nPlease update the following components: %s',
+        sortedNames,
+      );
     }
 
     if (componentWillReceivePropsUniqueNames.size > 0) {
@@ -258,21 +264,24 @@ if (__DEV__) {
           'To rename all deprecated lifecycles to their new names, you can run ' +
           '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
           '\nPlease update the following components: %s',
-        sortedNames
+        sortedNames,
       );
     }
 
     if (componentWillUpdateUniqueNames.size > 0) {
       const sortedNames = setToSortedString(componentWillUpdateUniqueNames);
 
-      lowPriorityWarningWithoutStack('componentWillUpdate has been renamed, and is not recommended for use. ' +
-        'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
-        '* Move data fetching code or side effects to componentDidUpdate.\n' +
-        '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' +
-        'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
-        'To rename all deprecated lifecycles to their new names, you can run ' +
-        '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
-        '\nPlease update the following components: %s', sortedNames);
+      lowPriorityWarningWithoutStack(
+        'componentWillUpdate has been renamed, and is not recommended for use. ' +
+          'See https://fb.me/react-unsafe-component-lifecycles for details.\n\n' +
+          '* Move data fetching code or side effects to componentDidUpdate.\n' +
+          '* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress ' +
+          'this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. ' +
+          'To rename all deprecated lifecycles to their new names, you can run ' +
+          '`npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n' +
+          '\nPlease update the following components: %s',
+        sortedNames,
+      );
     }
   };
 
@@ -287,8 +296,10 @@ if (__DEV__) {
   ) => {
     const strictRoot = findStrictRoot(fiber);
     if (strictRoot === null) {
-      warningWithoutStack('Expected to find a StrictMode component in a strict mode tree. ' +
-        'This error is likely caused by a bug in React. Please file an issue.');
+      warningWithoutStack(
+        'Expected to find a StrictMode component in a strict mode tree. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
       return;
     }
 
@@ -326,12 +337,16 @@ if (__DEV__) {
           strictRoot,
         );
 
-        warningWithoutStack('Legacy context API has been detected within a strict-mode tree.' +
-          '\n\nThe old API will be supported in all 16.x releases, but applications ' +
-          'using it should migrate to the new version.' +
-          '\n\nPlease update the following components: %s' +
-          '\n\nLearn more about this warning here: https://fb.me/react-legacy-context' +
-          '%s', sortedNames, strictRootComponentStack);
+        warningWithoutStack(
+          'Legacy context API has been detected within a strict-mode tree.' +
+            '\n\nThe old API will be supported in all 16.x releases, but applications ' +
+            'using it should migrate to the new version.' +
+            '\n\nPlease update the following components: %s' +
+            '\n\nLearn more about this warning here: https://fb.me/react-legacy-context' +
+            '%s',
+          sortedNames,
+          strictRootComponentStack,
+        );
       },
     );
   };

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -299,10 +299,12 @@ export function enqueueUpdate<State>(fiber: Fiber, update: Update<State>) {
         (queue2 !== null && currentlyProcessingQueue === queue2)) &&
       !didWarnUpdateInsideUpdate
     ) {
-      warningWithoutStack('An update (setState, replaceState, or forceUpdate) was scheduled ' +
-        'from inside an update function. Update functions should be pure, ' +
-        'with zero side-effects. Consider using componentDidUpdate or a ' +
-        'callback.');
+      warningWithoutStack(
+        'An update (setState, replaceState, or forceUpdate) was scheduled ' +
+          'from inside an update function. Update functions should be pure, ' +
+          'with zero side-effects. Consider using componentDidUpdate or a ' +
+          'callback.',
+      );
       didWarnUpdateInsideUpdate = true;
     }
   }
@@ -591,8 +593,11 @@ export function processUpdateQueue<State>(
 
 function callCallback(callback, context) {
   if (!(typeof callback === 'function')) {
-    invariant('Invalid argument passed as callback. Expected a function. Instead ' +
-      'received: %s', callback);
+    invariant(
+      'Invalid argument passed as callback. Expected a function. Instead ' +
+        'received: %s',
+      callback,
+    );
   }
 
   callback.call(context);

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -299,13 +299,10 @@ export function enqueueUpdate<State>(fiber: Fiber, update: Update<State>) {
         (queue2 !== null && currentlyProcessingQueue === queue2)) &&
       !didWarnUpdateInsideUpdate
     ) {
-      warningWithoutStack(
-        false,
-        'An update (setState, replaceState, or forceUpdate) was scheduled ' +
-          'from inside an update function. Update functions should be pure, ' +
-          'with zero side-effects. Consider using componentDidUpdate or a ' +
-          'callback.',
-      );
+      warningWithoutStack('An update (setState, replaceState, or forceUpdate) was scheduled ' +
+        'from inside an update function. Update functions should be pure, ' +
+        'with zero side-effects. Consider using componentDidUpdate or a ' +
+        'callback.');
       didWarnUpdateInsideUpdate = true;
     }
   }
@@ -593,12 +590,11 @@ export function processUpdateQueue<State>(
 }
 
 function callCallback(callback, context) {
-  invariant(
-    typeof callback === 'function',
-    'Invalid argument passed as callback. Expected a function. Instead ' +
-      'received: %s',
-    callback,
-  );
+  if (!(typeof callback === 'function')) {
+    invariant('Invalid argument passed as callback. Expected a function. Instead ' +
+      'received: %s', callback);
+  }
+
   callback.call(context);
 }
 

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -30,17 +30,16 @@ const {
 } = Scheduler;
 
 if (enableSchedulerTracing) {
-  // Provide explicit error message when production+profiling bundle of e.g.
-  // react-dom is used with production (non-profiling) bundle of
-  // scheduler/tracing
-  invariant(
-    __interactionsRef != null && __interactionsRef.current != null,
-    'It is not supported to run the profiling version of a renderer (for ' +
+  if (!(__interactionsRef != null && __interactionsRef.current != null)) {
+    // Provide explicit error message when production+profiling bundle of e.g.
+    // react-dom is used with production (non-profiling) bundle of
+    // scheduler/tracing
+    invariant('It is not supported to run the profiling version of a renderer (for ' +
       'example, `react-dom/profiling`) without also replacing the ' +
       '`scheduler/tracing` module with `scheduler/tracing-profiling`. Your ' +
       'bundler might have a setting for aliasing both modules. Learn more at ' +
-      'http://fb.me/react-profiling',
-  );
+      'http://fb.me/react-profiling');
+  }
 }
 
 export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
@@ -96,7 +95,7 @@ export function getCurrentPriorityLevel(): ReactPriorityLevel {
     case Scheduler_IdlePriority:
       return IdlePriority;
     default:
-      invariant(false, 'Unknown priority level.');
+      invariant('Unknown priority level.');
   }
 }
 
@@ -113,7 +112,7 @@ function reactPriorityToSchedulerPriority(reactPriorityLevel) {
     case IdlePriority:
       return Scheduler_IdlePriority;
     default:
-      invariant(false, 'Unknown priority level.');
+      invariant('Unknown priority level.');
   }
 }
 

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -34,11 +34,13 @@ if (enableSchedulerTracing) {
     // Provide explicit error message when production+profiling bundle of e.g.
     // react-dom is used with production (non-profiling) bundle of
     // scheduler/tracing
-    invariant('It is not supported to run the profiling version of a renderer (for ' +
-      'example, `react-dom/profiling`) without also replacing the ' +
-      '`scheduler/tracing` module with `scheduler/tracing-profiling`. Your ' +
-      'bundler might have a setting for aliasing both modules. Learn more at ' +
-      'http://fb.me/react-profiling');
+    invariant(
+      'It is not supported to run the profiling version of a renderer (for ' +
+        'example, `react-dom/profiling`) without also replacing the ' +
+        '`scheduler/tracing` module with `scheduler/tracing-profiling`. Your ' +
+        'bundler might have a setting for aliasing both modules. Learn more at ' +
+        'http://fb.me/react-profiling',
+    );
   }
 }
 

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.native.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.native.js
@@ -13,10 +13,9 @@ import type {CapturedError} from '../ReactCapturedValue';
 import {ReactFiberErrorDialog as RNImpl} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 import invariant from 'shared/invariant';
 
-invariant(
-  typeof RNImpl.showErrorDialog === 'function',
-  'Expected ReactFiberErrorDialog.showErrorDialog to be a function.',
-);
+if (!(typeof RNImpl.showErrorDialog === 'function')) {
+  invariant('Expected ReactFiberErrorDialog.showErrorDialog to be a function.');
+}
 
 export function showErrorDialog(capturedError: CapturedError): boolean {
   return RNImpl.showErrorDialog(capturedError);

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.www.js
@@ -13,10 +13,10 @@ import invariant from 'shared/invariant';
 
 // Provided by www
 const ReactFiberErrorDialogWWW = require('ReactFiberErrorDialog');
-invariant(
-  typeof ReactFiberErrorDialogWWW.showErrorDialog === 'function',
-  'Expected ReactFiberErrorDialog.showErrorDialog to be a function.',
-);
+
+if (!(typeof ReactFiberErrorDialogWWW.showErrorDialog === 'function')) {
+  invariant('Expected ReactFiberErrorDialog.showErrorDialog to be a function.');
+}
 
 export function showErrorDialog(capturedError: CapturedError): boolean {
   return ReactFiberErrorDialogWWW.showErrorDialog(capturedError);

--- a/packages/react-stream/src/ReactFizzFormatConfig.js
+++ b/packages/react-stream/src/ReactFizzFormatConfig.js
@@ -19,4 +19,4 @@ import invariant from 'shared/invariant';
 // sure that if we *do* accidentally break the configuration,
 // the failure isn't silent.
 
-invariant(false, 'This module must be shimmed by a specific renderer.');
+invariant('This module must be shimmed by a specific renderer.');

--- a/packages/react-stream/src/ReactFizzHostConfig.js
+++ b/packages/react-stream/src/ReactFizzHostConfig.js
@@ -19,4 +19,4 @@ import invariant from 'shared/invariant';
 // sure that if we *do* accidentally break the configuration,
 // the failure isn't silent.
 
-invariant(false, 'This module must be shimmed by a specific renderer.');
+invariant('This module must be shimmed by a specific renderer.');

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -61,29 +61,19 @@ function areHookInputsEqual(
   prevDeps: Array<mixed> | null,
 ) {
   if (prevDeps === null) {
-    warning(
-      false,
-      '%s received a final argument during this render, but not during ' +
-        'the previous render. Even though the final argument is optional, ' +
-        'its type cannot change between renders.',
-      currentHookNameInDev,
-    );
+    warning('%s received a final argument during this render, but not during ' +
+      'the previous render. Even though the final argument is optional, ' +
+      'its type cannot change between renders.', currentHookNameInDev);
     return false;
   }
 
   // Don't bother comparing lengths in prod because these arrays should be
   // passed inline.
   if (nextDeps.length !== prevDeps.length) {
-    warning(
-      false,
-      'The final argument passed to %s changed size between renders. The ' +
-        'order and size of this array must remain constant.\n\n' +
-        'Previous: %s\n' +
-        'Incoming: %s',
-      currentHookNameInDev,
-      `[${nextDeps.join(', ')}]`,
-      `[${prevDeps.join(', ')}]`,
-    );
+    warning('The final argument passed to %s changed size between renders. The ' +
+      'order and size of this array must remain constant.\n\n' +
+      'Previous: %s\n' +
+      'Incoming: %s', currentHookNameInDev, `[${nextDeps.join(', ')}]`, `[${prevDeps.join(', ')}]`);
   }
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
     if (is(nextDeps[i], prevDeps[i])) {
@@ -219,15 +209,16 @@ class ReactShallowRenderer {
   _numberOfReRenders: number;
 
   _validateCurrentlyRenderingComponent() {
-    invariant(
-      this._rendering && !this._instance,
-      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-        ' one of the following reasons:\n' +
-        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-        '2. You might be breaking the Rules of Hooks\n' +
-        '3. You might have more than one copy of React in the same app\n' +
-        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
-    );
+    if (!(this._rendering && !this._instance)) {
+      invariant(
+        'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+          ' one of the following reasons:\n' +
+          '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+          '2. You might be breaking the Rules of Hooks\n' +
+          '3. You might have more than one copy of React in the same app\n' +
+          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.'
+      );
+    }
   }
 
   _createDispatcher(): DispatcherType {
@@ -397,11 +388,10 @@ class ReactShallowRenderer {
   }
 
   _dispatchAction<A>(queue: UpdateQueue<A>, action: A) {
-    invariant(
-      this._numberOfReRenders < RE_RENDER_LIMIT,
-      'Too many re-renders. React limits the number of renders to prevent ' +
-        'an infinite loop.',
-    );
+    if (!(this._numberOfReRenders < RE_RENDER_LIMIT)) {
+      invariant('Too many re-renders. React limits the number of renders to prevent ' +
+        'an infinite loop.');
+    }
 
     if (this._rendering) {
       // This is a render phase update. Stash it in a lazily-created map of
@@ -504,34 +494,39 @@ class ReactShallowRenderer {
   }
 
   render(element: ReactElement | null, context: null | Object = emptyObject) {
-    invariant(
-      React.isValidElement(element),
-      'ReactShallowRenderer render(): Invalid component element.%s',
-      typeof element === 'function'
-        ? ' Instead of passing a component class, make sure to instantiate ' +
-          'it by passing it to React.createElement.'
-        : '',
-    );
+    if (!React.isValidElement(element)) {
+      invariant(
+        'ReactShallowRenderer render(): Invalid component element.%s',
+        typeof element === 'function'
+          ? ' Instead of passing a component class, make sure to instantiate ' +
+            'it by passing it to React.createElement.'
+          : ''
+      );
+    }
+
     element = ((element: any): ReactElement);
-    // Show a special message for host elements since it's a common case.
-    invariant(
-      typeof element.type !== 'string',
-      'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
-        'components, not primitives (%s). Instead of calling `.render(el)` and ' +
-        'inspecting the rendered output, look at `el.props` directly instead.',
-      element.type,
-    );
-    invariant(
-      isForwardRef(element) ||
-        (typeof element.type === 'function' || isMemo(element.type)),
-      'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
-        'components, but the provided element type was `%s`.',
-      Array.isArray(element.type)
-        ? 'array'
-        : element.type === null
-          ? 'null'
-          : typeof element.type,
-    );
+
+    if (!(typeof element.type !== 'string')) {
+      // Show a special message for host elements since it's a common case.
+      invariant(
+        'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
+          'components, not primitives (%s). Instead of calling `.render(el)` and ' +
+          'inspecting the rendered output, look at `el.props` directly instead.',
+        element.type
+      );
+    }
+
+    if (!(isForwardRef(element) || (typeof element.type === 'function' || isMemo(element.type)))) {
+      invariant(
+        'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
+          'components, but the provided element type was `%s`.',
+        Array.isArray(element.type)
+          ? 'array'
+          : element.type === null
+            ? 'null'
+            : typeof element.type
+      );
+    }
 
     if (this._rendering) {
       return;
@@ -613,11 +608,13 @@ class ReactShallowRenderer {
             // elementType could still be a ForwardRef if it was
             // nested inside Memo.
             if (elementType.$$typeof === ForwardRef) {
-              invariant(
-                typeof elementType.render === 'function',
-                'forwardRef requires a render function but was given %s.',
-                typeof elementType.render,
-              );
+              if (!(typeof elementType.render === 'function')) {
+                invariant(
+                  'forwardRef requires a render function but was given %s.',
+                  typeof elementType.render
+                );
+              }
+
               this._rendered = elementType.render.call(
                 undefined,
                 element.props,

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -61,19 +61,27 @@ function areHookInputsEqual(
   prevDeps: Array<mixed> | null,
 ) {
   if (prevDeps === null) {
-    warning('%s received a final argument during this render, but not during ' +
-      'the previous render. Even though the final argument is optional, ' +
-      'its type cannot change between renders.', currentHookNameInDev);
+    warning(
+      '%s received a final argument during this render, but not during ' +
+        'the previous render. Even though the final argument is optional, ' +
+        'its type cannot change between renders.',
+      currentHookNameInDev,
+    );
     return false;
   }
 
   // Don't bother comparing lengths in prod because these arrays should be
   // passed inline.
   if (nextDeps.length !== prevDeps.length) {
-    warning('The final argument passed to %s changed size between renders. The ' +
-      'order and size of this array must remain constant.\n\n' +
-      'Previous: %s\n' +
-      'Incoming: %s', currentHookNameInDev, `[${nextDeps.join(', ')}]`, `[${prevDeps.join(', ')}]`);
+    warning(
+      'The final argument passed to %s changed size between renders. The ' +
+        'order and size of this array must remain constant.\n\n' +
+        'Previous: %s\n' +
+        'Incoming: %s',
+      currentHookNameInDev,
+      `[${nextDeps.join(', ')}]`,
+      `[${prevDeps.join(', ')}]`,
+    );
   }
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
     if (is(nextDeps[i], prevDeps[i])) {
@@ -216,7 +224,7 @@ class ReactShallowRenderer {
           '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
           '2. You might be breaking the Rules of Hooks\n' +
           '3. You might have more than one copy of React in the same app\n' +
-          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.'
+          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
       );
     }
   }
@@ -389,8 +397,10 @@ class ReactShallowRenderer {
 
   _dispatchAction<A>(queue: UpdateQueue<A>, action: A) {
     if (!(this._numberOfReRenders < RE_RENDER_LIMIT)) {
-      invariant('Too many re-renders. React limits the number of renders to prevent ' +
-        'an infinite loop.');
+      invariant(
+        'Too many re-renders. React limits the number of renders to prevent ' +
+          'an infinite loop.',
+      );
     }
 
     if (this._rendering) {
@@ -500,7 +510,7 @@ class ReactShallowRenderer {
         typeof element === 'function'
           ? ' Instead of passing a component class, make sure to instantiate ' +
             'it by passing it to React.createElement.'
-          : ''
+          : '',
       );
     }
 
@@ -512,11 +522,16 @@ class ReactShallowRenderer {
         'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
           'components, not primitives (%s). Instead of calling `.render(el)` and ' +
           'inspecting the rendered output, look at `el.props` directly instead.',
-        element.type
+        element.type,
       );
     }
 
-    if (!(isForwardRef(element) || (typeof element.type === 'function' || isMemo(element.type)))) {
+    if (
+      !(
+        isForwardRef(element) ||
+        (typeof element.type === 'function' || isMemo(element.type))
+      )
+    ) {
       invariant(
         'ReactShallowRenderer render(): Shallow rendering works only with custom ' +
           'components, but the provided element type was `%s`.',
@@ -524,7 +539,7 @@ class ReactShallowRenderer {
           ? 'array'
           : element.type === null
             ? 'null'
-            : typeof element.type
+            : typeof element.type,
       );
     }
 
@@ -611,7 +626,7 @@ class ReactShallowRenderer {
               if (!(typeof elementType.render === 'function')) {
                 invariant(
                   'forwardRef requires a render function but was given %s.',
-                  typeof elementType.render
+                  typeof elementType.render,
                 );
               }
 

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -82,13 +82,12 @@ export function appendChild(
   child: Instance | TextInstance,
 ): void {
   if (__DEV__) {
-    warning(
-      Array.isArray(parentInstance.children),
-      'An invalid container has been provided. ' +
+    if (!Array.isArray(parentInstance.children)) {
+      warning('An invalid container has been provided. ' +
         'This may indicate that another renderer is being used in addition to the test renderer. ' +
         '(For example, ReactDOM.createPortal inside of a ReactTestRenderer tree.) ' +
-        'This is not supported.',
-    );
+        'This is not supported.');
+    }
   }
   const index = parentInstance.children.indexOf(child);
   if (index !== -1) {
@@ -215,12 +214,13 @@ export function createTextInstance(
   internalInstanceHandle: Object,
 ): TextInstance {
   if (__DEV__ && enableFlareAPI) {
-    warning(
-      hostContext !== EVENT_COMPONENT_CONTEXT,
-      'validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
-        'Wrap the child text "%s" in an element.',
-      text,
-    );
+    if (!(hostContext !== EVENT_COMPONENT_CONTEXT)) {
+      warning(
+        'validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
+          'Wrap the child text "%s" in an element.',
+        text
+      );
+    }
   }
   return {
     text,

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -83,10 +83,12 @@ export function appendChild(
 ): void {
   if (__DEV__) {
     if (!Array.isArray(parentInstance.children)) {
-      warning('An invalid container has been provided. ' +
-        'This may indicate that another renderer is being used in addition to the test renderer. ' +
-        '(For example, ReactDOM.createPortal inside of a ReactTestRenderer tree.) ' +
-        'This is not supported.');
+      warning(
+        'An invalid container has been provided. ' +
+          'This may indicate that another renderer is being used in addition to the test renderer. ' +
+          '(For example, ReactDOM.createPortal inside of a ReactTestRenderer tree.) ' +
+          'This is not supported.',
+      );
     }
   }
   const index = parentInstance.children.indexOf(child);
@@ -218,7 +220,7 @@ export function createTextInstance(
       warning(
         'validateDOMNesting: React event components cannot have text DOM nodes as children. ' +
           'Wrap the child text "%s" in an element.',
-        text
+        text,
       );
     }
   }

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -207,11 +207,7 @@ function toTree(node: ?Fiber) {
     case ScopeComponent:
       return childrenToTree(node.child);
     default:
-      invariant(
-        false,
-        'toTree() does not yet know how to handle nodes with tag=%s',
-        node.tag,
-      );
+      invariant('toTree() does not yet know how to handle nodes with tag=%s', node.tag);
   }
 }
 
@@ -267,21 +263,21 @@ class ReactTestInstance {
   _currentFiber(): Fiber {
     // Throws if this component has been unmounted.
     const fiber = findCurrentFiberUsingSlowPath(this._fiber);
-    invariant(
-      fiber !== null,
-      "Can't read from currently-mounting component. This error is likely " +
-        'caused by a bug in React. Please file an issue.',
-    );
+
+    if (!(fiber !== null)) {
+      invariant("Can't read from currently-mounting component. This error is likely " +
+        'caused by a bug in React. Please file an issue.');
+    }
+
     return fiber;
   }
 
   constructor(fiber: Fiber) {
-    invariant(
-      validWrapperTypes.has(fiber.tag),
-      'Unexpected object passed to ReactTestInstance constructor (tag: %s). ' +
-        'This is probably a bug in React.',
-      fiber.tag,
-    );
+    if (!validWrapperTypes.has(fiber.tag)) {
+      invariant('Unexpected object passed to ReactTestInstance constructor (tag: %s). ' +
+        'This is probably a bug in React.', fiber.tag);
+    }
+
     this._fiber = fiber;
   }
 
@@ -446,7 +442,11 @@ const ReactTestRendererFiber = {
       false,
       null,
     );
-    invariant(root != null, 'something went wrong');
+
+    if (!(root != null)) {
+      invariant('something went wrong');
+    }
+
     updateContainer(element, root, null, null);
 
     const entry = {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -207,7 +207,10 @@ function toTree(node: ?Fiber) {
     case ScopeComponent:
       return childrenToTree(node.child);
     default:
-      invariant('toTree() does not yet know how to handle nodes with tag=%s', node.tag);
+      invariant(
+        'toTree() does not yet know how to handle nodes with tag=%s',
+        node.tag,
+      );
   }
 }
 
@@ -265,8 +268,10 @@ class ReactTestInstance {
     const fiber = findCurrentFiberUsingSlowPath(this._fiber);
 
     if (!(fiber !== null)) {
-      invariant("Can't read from currently-mounting component. This error is likely " +
-        'caused by a bug in React. Please file an issue.');
+      invariant(
+        "Can't read from currently-mounting component. This error is likely " +
+          'caused by a bug in React. Please file an issue.',
+      );
     }
 
     return fiber;
@@ -274,8 +279,11 @@ class ReactTestInstance {
 
   constructor(fiber: Fiber) {
     if (!validWrapperTypes.has(fiber.tag)) {
-      invariant('Unexpected object passed to ReactTestInstance constructor (tag: %s). ' +
-        'This is probably a bug in React.', fiber.tag);
+      invariant(
+        'Unexpected object passed to ReactTestInstance constructor (tag: %s). ' +
+          'This is probably a bug in React.',
+        fiber.tag,
+      );
     }
 
     this._fiber = fiber;

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -83,11 +83,8 @@ function act(callback: () => Thenable) {
     if (__DEV__) {
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-        warningWithoutStack(
-          null,
-          'You seem to have overlapping act() calls, this is not supported. ' +
-            'Be sure to await previous act() calls before making a new one. ',
-        );
+        warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
+          'Be sure to await previous act() calls before making a new one. ');
       }
     }
   }
@@ -116,12 +113,9 @@ function act(callback: () => Thenable) {
           .then(() => {})
           .then(() => {
             if (called === false) {
-              warningWithoutStack(
-                null,
-                'You called act(async () => ...) without await. ' +
-                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                  'calls and mixing their scopes. You should - await act(async () => ...);',
-              );
+              warningWithoutStack('You called act(async () => ...) without await. ' +
+                'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                'calls and mixing their scopes. You should - await act(async () => ...);');
             }
           });
       }
@@ -164,12 +158,10 @@ function act(callback: () => Thenable) {
     };
   } else {
     if (__DEV__) {
-      warningWithoutStack(
-        result === undefined,
-        'The callback passed to act(...) function ' +
-          'must return undefined, or a Promise. You returned %s',
-        result,
-      );
+      if (!(result === undefined)) {
+        warningWithoutStack('The callback passed to act(...) function ' +
+          'must return undefined, or a Promise. You returned %s', result);
+      }
     }
 
     // flush effects until none remain, and cleanup
@@ -193,8 +185,7 @@ function act(callback: () => Thenable) {
       then(resolve: () => void) {
         if (__DEV__) {
           warningWithoutStack(
-            false,
-            'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
+            'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
           );
         }
         resolve();

--- a/packages/react-test-renderer/src/ReactTestRendererAct.js
+++ b/packages/react-test-renderer/src/ReactTestRendererAct.js
@@ -83,8 +83,10 @@ function act(callback: () => Thenable) {
     if (__DEV__) {
       if (actingUpdatesScopeDepth > previousActingUpdatesScopeDepth) {
         // if it's _less than_ previousActingUpdatesScopeDepth, then we can assume the 'other' one has warned
-        warningWithoutStack('You seem to have overlapping act() calls, this is not supported. ' +
-          'Be sure to await previous act() calls before making a new one. ');
+        warningWithoutStack(
+          'You seem to have overlapping act() calls, this is not supported. ' +
+            'Be sure to await previous act() calls before making a new one. ',
+        );
       }
     }
   }
@@ -113,9 +115,11 @@ function act(callback: () => Thenable) {
           .then(() => {})
           .then(() => {
             if (called === false) {
-              warningWithoutStack('You called act(async () => ...) without await. ' +
-                'This could lead to unexpected testing behaviour, interleaving multiple act ' +
-                'calls and mixing their scopes. You should - await act(async () => ...);');
+              warningWithoutStack(
+                'You called act(async () => ...) without await. ' +
+                  'This could lead to unexpected testing behaviour, interleaving multiple act ' +
+                  'calls and mixing their scopes. You should - await act(async () => ...);',
+              );
             }
           });
       }
@@ -159,8 +163,11 @@ function act(callback: () => Thenable) {
   } else {
     if (__DEV__) {
       if (!(result === undefined)) {
-        warningWithoutStack('The callback passed to act(...) function ' +
-          'must return undefined, or a Promise. You returned %s', result);
+        warningWithoutStack(
+          'The callback passed to act(...) function ' +
+            'must return undefined, or a Promise. You returned %s',
+          result,
+        );
       }
     }
 
@@ -185,7 +192,7 @@ function act(callback: () => Thenable) {
       then(resolve: () => void) {
         if (__DEV__) {
           warningWithoutStack(
-            'Do not await the result of calling act(...) with sync logic, it is not a Promise.'
+            'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
           );
         }
         resolve();

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -56,13 +56,12 @@ Component.prototype.isReactComponent = {};
  * @protected
  */
 Component.prototype.setState = function(partialState, callback) {
-  invariant(
-    typeof partialState === 'object' ||
-      typeof partialState === 'function' ||
-      partialState == null,
-    'setState(...): takes an object of state variables to update or a ' +
-      'function which returns an object of state variables.',
-  );
+  if (!(typeof partialState === 'object' ||
+    typeof partialState === 'function' || partialState == null)) {
+    invariant('setState(...): takes an object of state variables to update or a ' +
+      'function which returns an object of state variables.');
+  }
+
   this.updater.enqueueSetState(this, partialState, callback, 'setState');
 };
 
@@ -106,10 +105,9 @@ if (__DEV__) {
     Object.defineProperty(Component.prototype, methodName, {
       get: function() {
         lowPriorityWarningWithoutStack(
-          false,
           '%s(...) is deprecated in plain JavaScript React classes. %s',
           info[0],
-          info[1],
+          info[1]
         );
         return undefined;
       },

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -56,10 +56,17 @@ Component.prototype.isReactComponent = {};
  * @protected
  */
 Component.prototype.setState = function(partialState, callback) {
-  if (!(typeof partialState === 'object' ||
-    typeof partialState === 'function' || partialState == null)) {
-    invariant('setState(...): takes an object of state variables to update or a ' +
-      'function which returns an object of state variables.');
+  if (
+    !(
+      typeof partialState === 'object' ||
+      typeof partialState === 'function' ||
+      partialState == null
+    )
+  ) {
+    invariant(
+      'setState(...): takes an object of state variables to update or a ' +
+        'function which returns an object of state variables.',
+    );
   }
 
   this.updater.enqueueSetState(this, partialState, callback, 'setState');
@@ -107,7 +114,7 @@ if (__DEV__) {
         lowPriorityWarningWithoutStack(
           '%s(...) is deprecated in plain JavaScript React classes. %s',
           info[0],
-          info[1]
+          info[1],
         );
         return undefined;
       },

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -162,12 +162,12 @@ function traverseAllChildrenImpl(
       if (__DEV__) {
         // Warn about using Maps as children
         if (iteratorFn === children.entries) {
-          warning(
-            didWarnAboutMaps,
-            'Using Maps as children is unsupported and will likely yield ' +
+          if (!didWarnAboutMaps) {
+            warning('Using Maps as children is unsupported and will likely yield ' +
               'unexpected results. Convert it to a sequence/iterable of keyed ' +
-              'ReactElements instead.',
-          );
+              'ReactElements instead.');
+          }
+
           didWarnAboutMaps = true;
         }
       }
@@ -195,12 +195,11 @@ function traverseAllChildrenImpl(
       }
       const childrenString = '' + children;
       invariant(
-        false,
         'Objects are not valid as a React child (found: %s).%s',
         childrenString === '[object Object]'
           ? 'object with keys {' + Object.keys(children).join(', ') + '}'
           : childrenString,
-        addendum,
+        addendum
       );
     }
   }
@@ -385,10 +384,10 @@ function toArray(children) {
  * structure.
  */
 function onlyChild(children) {
-  invariant(
-    isValidElement(children),
-    'React.Children.only expected to receive a single React element child.',
-  );
+  if (!isValidElement(children)) {
+    invariant('React.Children.only expected to receive a single React element child.');
+  }
+
   return children;
 }
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -163,9 +163,11 @@ function traverseAllChildrenImpl(
         // Warn about using Maps as children
         if (iteratorFn === children.entries) {
           if (!didWarnAboutMaps) {
-            warning('Using Maps as children is unsupported and will likely yield ' +
-              'unexpected results. Convert it to a sequence/iterable of keyed ' +
-              'ReactElements instead.');
+            warning(
+              'Using Maps as children is unsupported and will likely yield ' +
+                'unexpected results. Convert it to a sequence/iterable of keyed ' +
+                'ReactElements instead.',
+            );
           }
 
           didWarnAboutMaps = true;
@@ -199,7 +201,7 @@ function traverseAllChildrenImpl(
         childrenString === '[object Object]'
           ? 'object with keys {' + Object.keys(children).join(', ') + '}'
           : childrenString,
-        addendum
+        addendum,
       );
     }
   }
@@ -385,7 +387,9 @@ function toArray(children) {
  */
 function onlyChild(children) {
   if (!isValidElement(children)) {
-    invariant('React.Children.only expected to receive a single React element child.');
+    invariant(
+      'React.Children.only expected to receive a single React element child.',
+    );
   }
 
   return children;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -22,9 +22,17 @@ export function createContext<T>(
     calculateChangedBits = null;
   } else {
     if (__DEV__) {
-      if (!(calculateChangedBits === null || typeof calculateChangedBits === 'function')) {
-        warningWithoutStack('createContext: Expected the optional second argument to be a ' +
-          'function. Instead received: %s', calculateChangedBits);
+      if (
+        !(
+          calculateChangedBits === null ||
+          typeof calculateChangedBits === 'function'
+        )
+      ) {
+        warningWithoutStack(
+          'createContext: Expected the optional second argument to be a ' +
+            'function. Instead received: %s',
+          calculateChangedBits,
+        );
       }
     }
   }
@@ -72,7 +80,7 @@ export function createContext<T>(
             hasWarnedAboutUsingConsumerProvider = true;
             warning(
               'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
-                'a future major release. Did you mean to render <Context.Provider> instead?'
+                'a future major release. Did you mean to render <Context.Provider> instead?',
             );
           }
           return context.Provider;
@@ -111,7 +119,7 @@ export function createContext<T>(
             hasWarnedAboutUsingNestedContextConsumers = true;
             warning(
               'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
-                'a future major release. Did you mean to render <Context.Consumer> instead?'
+                'a future major release. Did you mean to render <Context.Consumer> instead?',
             );
           }
           return context.Consumer;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -22,13 +22,10 @@ export function createContext<T>(
     calculateChangedBits = null;
   } else {
     if (__DEV__) {
-      warningWithoutStack(
-        calculateChangedBits === null ||
-          typeof calculateChangedBits === 'function',
-        'createContext: Expected the optional second argument to be a ' +
-          'function. Instead received: %s',
-        calculateChangedBits,
-      );
+      if (!(calculateChangedBits === null || typeof calculateChangedBits === 'function')) {
+        warningWithoutStack('createContext: Expected the optional second argument to be a ' +
+          'function. Instead received: %s', calculateChangedBits);
+      }
     }
   }
 
@@ -74,9 +71,8 @@ export function createContext<T>(
           if (!hasWarnedAboutUsingConsumerProvider) {
             hasWarnedAboutUsingConsumerProvider = true;
             warning(
-              false,
               'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
-                'a future major release. Did you mean to render <Context.Provider> instead?',
+                'a future major release. Did you mean to render <Context.Provider> instead?'
             );
           }
           return context.Provider;
@@ -114,9 +110,8 @@ export function createContext<T>(
           if (!hasWarnedAboutUsingNestedContextConsumers) {
             hasWarnedAboutUsingNestedContextConsumers = true;
             warning(
-              false,
               'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
-                'a future major release. Did you mean to render <Context.Consumer> instead?',
+                'a future major release. Did you mean to render <Context.Consumer> instead?'
             );
           }
           return context.Consumer;

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -51,7 +51,6 @@ function defineKeyPropWarningGetter(props, displayName) {
     if (!specialPropKeyWarningShown) {
       specialPropKeyWarningShown = true;
       warningWithoutStack(
-        false,
         '%s: `key` is not a prop. Trying to access it will result ' +
           'in `undefined` being returned. If you need to access the same ' +
           'value within the child component, you should pass it as a different ' +
@@ -72,7 +71,6 @@ function defineRefPropWarningGetter(props, displayName) {
     if (!specialPropRefWarningShown) {
       specialPropRefWarningShown = true;
       warningWithoutStack(
-        false,
         '%s: `ref` is not a prop. Trying to access it will result ' +
           'in `undefined` being returned. If you need to access the same ' +
           'value within the child component, you should pass it as a different ' +
@@ -427,11 +425,12 @@ export function cloneAndReplaceKey(oldElement, newKey) {
  * See https://reactjs.org/docs/react-api.html#cloneelement
  */
 export function cloneElement(element, config, children) {
-  invariant(
-    !(element === null || element === undefined),
-    'React.cloneElement(...): The argument must be a React element, but you passed %s.',
-    element,
-  );
+  if (element === null || element === undefined) {
+    invariant(
+      'React.cloneElement(...): The argument must be a React element, but you passed %s.',
+      element,
+    );
+  }
 
   let propName;
 

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -133,8 +133,12 @@ function validateExplicitKey(element, parentType) {
 
   setCurrentlyValidatingElement(element);
   if (__DEV__) {
-    warning('Each child in a list should have a unique "key" prop.' +
-      '%s%s See https://fb.me/react-warning-keys for more information.', currentComponentErrorInfo, childOwner);
+    warning(
+      'Each child in a list should have a unique "key" prop.' +
+        '%s%s See https://fb.me/react-warning-keys for more information.',
+      currentComponentErrorInfo,
+      childOwner,
+    );
   }
   setCurrentlyValidatingElement(null);
 }
@@ -222,13 +226,15 @@ function validatePropTypes(element) {
     propTypesMisspellWarningShown = true;
     warningWithoutStack(
       'Component %s declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?',
-      name || 'Unknown'
+      name || 'Unknown',
     );
   }
   if (typeof type.getDefaultProps === 'function') {
     if (!type.getDefaultProps.isReactClassApproved) {
-      warningWithoutStack('getDefaultProps is only used on classic React.createClass ' +
-        'definitions. Use a static property named `defaultProps` instead.');
+      warningWithoutStack(
+        'getDefaultProps is only used on classic React.createClass ' +
+          'definitions. Use a static property named `defaultProps` instead.',
+      );
     }
   }
 }
@@ -244,8 +250,11 @@ function validateFragmentProps(fragment) {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     if (key !== 'children' && key !== 'key') {
-      warning('Invalid prop `%s` supplied to `React.Fragment`. ' +
-        'React.Fragment can only have `key` and `children` props.', key);
+      warning(
+        'Invalid prop `%s` supplied to `React.Fragment`. ' +
+          'React.Fragment can only have `key` and `children` props.',
+        key,
+      );
       break;
     }
   }
@@ -302,9 +311,13 @@ export function jsxWithValidation(
       typeString = typeof type;
     }
 
-    warning('React.jsx: type is invalid -- expected a string (for ' +
-      'built-in components) or a class/function (for composite ' +
-      'components) but got: %s.%s', typeString, info);
+    warning(
+      'React.jsx: type is invalid -- expected a string (for ' +
+        'built-in components) or a class/function (for composite ' +
+        'components) but got: %s.%s',
+      typeString,
+      info,
+    );
   }
 
   const element = jsxDEV(type, props, key, source, self);
@@ -334,9 +347,11 @@ export function jsxWithValidation(
             Object.freeze(children);
           }
         } else {
-          warning('React.jsx: Static children should always be an array. ' +
-            'You are likely explicitly calling React.jsxs or React.jsxDEV. ' +
-            'Use the Babel transform instead.');
+          warning(
+            'React.jsx: Static children should always be an array. ' +
+              'You are likely explicitly calling React.jsxs or React.jsxDEV. ' +
+              'Use the Babel transform instead.',
+          );
         }
       } else {
         validateChildKeys(children, type);
@@ -345,9 +360,11 @@ export function jsxWithValidation(
   }
 
   if (hasOwnProperty.call(props, 'key')) {
-    warning('React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
-      'Explicitly pass a key after spreading props in your JSX call. ' +
-      'E.g. <ComponentName {...props} key={key} />');
+    warning(
+      'React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
+        'Explicitly pass a key after spreading props in your JSX call. ' +
+        'E.g. <ComponentName {...props} key={key} />',
+    );
   }
 
   if (type === REACT_FRAGMENT_TYPE) {
@@ -409,9 +426,13 @@ export function createElementWithValidation(type, props, children) {
       typeString = typeof type;
     }
 
-    warning('React.createElement: type is invalid -- expected a string (for ' +
-      'built-in components) or a class/function (for composite ' +
-      'components) but got: %s.%s', typeString, info);
+    warning(
+      'React.createElement: type is invalid -- expected a string (for ' +
+        'built-in components) or a class/function (for composite ' +
+        'components) but got: %s.%s',
+      typeString,
+      info,
+    );
   }
 
   const element = createElement.apply(this, arguments);
@@ -450,8 +471,10 @@ export function createFactoryWithValidation(type) {
     Object.defineProperty(validatedFactory, 'type', {
       enumerable: false,
       get: function() {
-        lowPriorityWarningWithoutStack('Factory.type is deprecated. Access the class directly ' +
-          'before passing it to createFactory.');
+        lowPriorityWarningWithoutStack(
+          'Factory.type is deprecated. Access the class directly ' +
+            'before passing it to createFactory.',
+        );
         Object.defineProperty(this, 'type', {
           value: type,
         });

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -133,13 +133,8 @@ function validateExplicitKey(element, parentType) {
 
   setCurrentlyValidatingElement(element);
   if (__DEV__) {
-    warning(
-      false,
-      'Each child in a list should have a unique "key" prop.' +
-        '%s%s See https://fb.me/react-warning-keys for more information.',
-      currentComponentErrorInfo,
-      childOwner,
-    );
+    warning('Each child in a list should have a unique "key" prop.' +
+      '%s%s See https://fb.me/react-warning-keys for more information.', currentComponentErrorInfo, childOwner);
   }
   setCurrentlyValidatingElement(null);
 }
@@ -226,17 +221,15 @@ function validatePropTypes(element) {
   } else if (type.PropTypes !== undefined && !propTypesMisspellWarningShown) {
     propTypesMisspellWarningShown = true;
     warningWithoutStack(
-      false,
       'Component %s declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?',
-      name || 'Unknown',
+      name || 'Unknown'
     );
   }
   if (typeof type.getDefaultProps === 'function') {
-    warningWithoutStack(
-      type.getDefaultProps.isReactClassApproved,
-      'getDefaultProps is only used on classic React.createClass ' +
-        'definitions. Use a static property named `defaultProps` instead.',
-    );
+    if (!type.getDefaultProps.isReactClassApproved) {
+      warningWithoutStack('getDefaultProps is only used on classic React.createClass ' +
+        'definitions. Use a static property named `defaultProps` instead.');
+    }
   }
 }
 
@@ -251,18 +244,14 @@ function validateFragmentProps(fragment) {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     if (key !== 'children' && key !== 'key') {
-      warning(
-        false,
-        'Invalid prop `%s` supplied to `React.Fragment`. ' +
-          'React.Fragment can only have `key` and `children` props.',
-        key,
-      );
+      warning('Invalid prop `%s` supplied to `React.Fragment`. ' +
+        'React.Fragment can only have `key` and `children` props.', key);
       break;
     }
   }
 
   if (fragment.ref !== null) {
-    warning(false, 'Invalid attribute `ref` supplied to `React.Fragment`.');
+    warning('Invalid attribute `ref` supplied to `React.Fragment`.');
   }
 
   setCurrentlyValidatingElement(null);
@@ -313,14 +302,9 @@ export function jsxWithValidation(
       typeString = typeof type;
     }
 
-    warning(
-      false,
-      'React.jsx: type is invalid -- expected a string (for ' +
-        'built-in components) or a class/function (for composite ' +
-        'components) but got: %s.%s',
-      typeString,
-      info,
-    );
+    warning('React.jsx: type is invalid -- expected a string (for ' +
+      'built-in components) or a class/function (for composite ' +
+      'components) but got: %s.%s', typeString, info);
   }
 
   const element = jsxDEV(type, props, key, source, self);
@@ -350,12 +334,9 @@ export function jsxWithValidation(
             Object.freeze(children);
           }
         } else {
-          warning(
-            false,
-            'React.jsx: Static children should always be an array. ' +
-              'You are likely explicitly calling React.jsxs or React.jsxDEV. ' +
-              'Use the Babel transform instead.',
-          );
+          warning('React.jsx: Static children should always be an array. ' +
+            'You are likely explicitly calling React.jsxs or React.jsxDEV. ' +
+            'Use the Babel transform instead.');
         }
       } else {
         validateChildKeys(children, type);
@@ -364,12 +345,9 @@ export function jsxWithValidation(
   }
 
   if (hasOwnProperty.call(props, 'key')) {
-    warning(
-      false,
-      'React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
-        'Explicitly pass a key after spreading props in your JSX call. ' +
-        'E.g. <ComponentName {...props} key={key} />',
-    );
+    warning('React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
+      'Explicitly pass a key after spreading props in your JSX call. ' +
+      'E.g. <ComponentName {...props} key={key} />');
   }
 
   if (type === REACT_FRAGMENT_TYPE) {
@@ -431,14 +409,9 @@ export function createElementWithValidation(type, props, children) {
       typeString = typeof type;
     }
 
-    warning(
-      false,
-      'React.createElement: type is invalid -- expected a string (for ' +
-        'built-in components) or a class/function (for composite ' +
-        'components) but got: %s.%s',
-      typeString,
-      info,
-    );
+    warning('React.createElement: type is invalid -- expected a string (for ' +
+      'built-in components) or a class/function (for composite ' +
+      'components) but got: %s.%s', typeString, info);
   }
 
   const element = createElement.apply(this, arguments);
@@ -477,11 +450,8 @@ export function createFactoryWithValidation(type) {
     Object.defineProperty(validatedFactory, 'type', {
       enumerable: false,
       get: function() {
-        lowPriorityWarningWithoutStack(
-          false,
-          'Factory.type is deprecated. Access the class directly ' +
-            'before passing it to createFactory.',
-        );
+        lowPriorityWarningWithoutStack('Factory.type is deprecated. Access the class directly ' +
+          'before passing it to createFactory.');
         Object.defineProperty(this, 'type', {
           value: type,
         });

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -28,7 +28,7 @@ function resolveDispatcher() {
         '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
         '2. You might be breaking the Rules of Hooks\n' +
         '3. You might have more than one copy of React in the same app\n' +
-        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.'
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
     );
   }
 
@@ -42,13 +42,17 @@ export function useContext<T>(
   const dispatcher = resolveDispatcher();
   if (__DEV__) {
     if (!(unstable_observedBits === undefined)) {
-      warning('useContext() second argument is reserved for future ' +
-        'use in React. Passing it is not supported. ' +
-        'You passed: %s.%s', unstable_observedBits, typeof unstable_observedBits === 'number' && Array.isArray(arguments[2])
-        ? '\n\nDid you call array.map(useContext)? ' +
-          'Calling Hooks inside a loop is not supported. ' +
-          'Learn more at https://fb.me/rules-of-hooks'
-        : '');
+      warning(
+        'useContext() second argument is reserved for future ' +
+          'use in React. Passing it is not supported. ' +
+          'You passed: %s.%s',
+        unstable_observedBits,
+        typeof unstable_observedBits === 'number' && Array.isArray(arguments[2])
+          ? '\n\nDid you call array.map(useContext)? ' +
+            'Calling Hooks inside a loop is not supported. ' +
+            'Learn more at https://fb.me/rules-of-hooks'
+          : '',
+      );
     }
 
     // TODO: add a more generic warning for invalid values.
@@ -59,11 +63,13 @@ export function useContext<T>(
       if (realContext.Consumer === Context) {
         warning(
           'Calling useContext(Context.Consumer) is not supported, may cause bugs, and will be ' +
-            'removed in a future major release. Did you mean to call useContext(Context) instead?'
+            'removed in a future major release. Did you mean to call useContext(Context) instead?',
         );
       } else if (realContext.Provider === Context) {
-        warning('Calling useContext(Context.Provider) is not supported. ' +
-          'Did you mean to call useContext(Context) instead?');
+        warning(
+          'Calling useContext(Context.Provider) is not supported. ' +
+            'Did you mean to call useContext(Context) instead?',
+        );
       }
     }
   }
@@ -148,7 +154,7 @@ export function useResponder(
     if (responder == null || responder.$$typeof !== REACT_RESPONDER_TYPE) {
       warning(
         'useResponder: invalid first argument. Expected an event responder, but instead got %s',
-        responder
+        responder,
       );
       return;
     }

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -20,15 +20,18 @@ import ReactCurrentDispatcher from './ReactCurrentDispatcher';
 
 function resolveDispatcher() {
   const dispatcher = ReactCurrentDispatcher.current;
-  invariant(
-    dispatcher !== null,
-    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-      ' one of the following reasons:\n' +
-      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-      '2. You might be breaking the Rules of Hooks\n' +
-      '3. You might have more than one copy of React in the same app\n' +
-      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
-  );
+
+  if (!(dispatcher !== null)) {
+    invariant(
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.'
+    );
+  }
+
   return dispatcher;
 }
 
@@ -38,18 +41,15 @@ export function useContext<T>(
 ) {
   const dispatcher = resolveDispatcher();
   if (__DEV__) {
-    warning(
-      unstable_observedBits === undefined,
-      'useContext() second argument is reserved for future ' +
+    if (!(unstable_observedBits === undefined)) {
+      warning('useContext() second argument is reserved for future ' +
         'use in React. Passing it is not supported. ' +
-        'You passed: %s.%s',
-      unstable_observedBits,
-      typeof unstable_observedBits === 'number' && Array.isArray(arguments[2])
+        'You passed: %s.%s', unstable_observedBits, typeof unstable_observedBits === 'number' && Array.isArray(arguments[2])
         ? '\n\nDid you call array.map(useContext)? ' +
           'Calling Hooks inside a loop is not supported. ' +
           'Learn more at https://fb.me/rules-of-hooks'
-        : '',
-    );
+        : '');
+    }
 
     // TODO: add a more generic warning for invalid values.
     if ((Context: any)._context !== undefined) {
@@ -58,16 +58,12 @@ export function useContext<T>(
       // and nobody should be using this in existing code.
       if (realContext.Consumer === Context) {
         warning(
-          false,
           'Calling useContext(Context.Consumer) is not supported, may cause bugs, and will be ' +
-            'removed in a future major release. Did you mean to call useContext(Context) instead?',
+            'removed in a future major release. Did you mean to call useContext(Context) instead?'
         );
       } else if (realContext.Provider === Context) {
-        warning(
-          false,
-          'Calling useContext(Context.Provider) is not supported. ' +
-            'Did you mean to call useContext(Context) instead?',
-        );
+        warning('Calling useContext(Context.Provider) is not supported. ' +
+          'Did you mean to call useContext(Context) instead?');
       }
     }
   }
@@ -151,9 +147,8 @@ export function useResponder(
   if (__DEV__) {
     if (responder == null || responder.$$typeof !== REACT_RESPONDER_TYPE) {
       warning(
-        false,
         'useResponder: invalid first argument. Expected an event responder, but instead got %s',
-        responder,
+        responder
       );
       return;
     }

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -30,9 +30,11 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           return defaultProps;
         },
         set(newDefaultProps) {
-          warning('React.lazy(...): It is not supported to assign `defaultProps` to ' +
-            'a lazy component import. Either specify them where the component ' +
-            'is defined, or create a wrapping component around it.');
+          warning(
+            'React.lazy(...): It is not supported to assign `defaultProps` to ' +
+              'a lazy component import. Either specify them where the component ' +
+              'is defined, or create a wrapping component around it.',
+          );
           defaultProps = newDefaultProps;
           // Match production behavior more closely:
           Object.defineProperty(lazyType, 'defaultProps', {
@@ -46,9 +48,11 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           return propTypes;
         },
         set(newPropTypes) {
-          warning('React.lazy(...): It is not supported to assign `propTypes` to ' +
-            'a lazy component import. Either specify them where the component ' +
-            'is defined, or create a wrapping component around it.');
+          warning(
+            'React.lazy(...): It is not supported to assign `propTypes` to ' +
+              'a lazy component import. Either specify them where the component ' +
+              'is defined, or create a wrapping component around it.',
+          );
           propTypes = newPropTypes;
           // Match production behavior more closely:
           Object.defineProperty(lazyType, 'propTypes', {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -30,12 +30,9 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           return defaultProps;
         },
         set(newDefaultProps) {
-          warning(
-            false,
-            'React.lazy(...): It is not supported to assign `defaultProps` to ' +
-              'a lazy component import. Either specify them where the component ' +
-              'is defined, or create a wrapping component around it.',
-          );
+          warning('React.lazy(...): It is not supported to assign `defaultProps` to ' +
+            'a lazy component import. Either specify them where the component ' +
+            'is defined, or create a wrapping component around it.');
           defaultProps = newDefaultProps;
           // Match production behavior more closely:
           Object.defineProperty(lazyType, 'defaultProps', {
@@ -49,12 +46,9 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           return propTypes;
         },
         set(newPropTypes) {
-          warning(
-            false,
-            'React.lazy(...): It is not supported to assign `propTypes` to ' +
-              'a lazy component import. Either specify them where the component ' +
-              'is defined, or create a wrapping component around it.',
-          );
+          warning('React.lazy(...): It is not supported to assign `propTypes` to ' +
+            'a lazy component import. Either specify them where the component ' +
+            'is defined, or create a wrapping component around it.');
           propTypes = newPropTypes;
           // Match production behavior more closely:
           Object.defineProperty(lazyType, 'propTypes', {

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -19,10 +19,14 @@ function warnNoop(publicInstance, callerName) {
     if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
       return;
     }
-    warningWithoutStack("Can't call %s on a component that is not yet mounted. " +
-      'This is a no-op, but it might indicate a bug in your application. ' +
-      'Instead, assign to `this.state` directly or define a `state = {};` ' +
-      'class property with the desired state in the %s component.', callerName, componentName);
+    warningWithoutStack(
+      "Can't call %s on a component that is not yet mounted. " +
+        'This is a no-op, but it might indicate a bug in your application. ' +
+        'Instead, assign to `this.state` directly or define a `state = {};` ' +
+        'class property with the desired state in the %s component.',
+      callerName,
+      componentName,
+    );
     didWarnStateUpdateForUnmountedComponent[warningKey] = true;
   }
 }

--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -19,15 +19,10 @@ function warnNoop(publicInstance, callerName) {
     if (didWarnStateUpdateForUnmountedComponent[warningKey]) {
       return;
     }
-    warningWithoutStack(
-      false,
-      "Can't call %s on a component that is not yet mounted. " +
-        'This is a no-op, but it might indicate a bug in your application. ' +
-        'Instead, assign to `this.state` directly or define a `state = {};` ' +
-        'class property with the desired state in the %s component.',
-      callerName,
-      componentName,
-    );
+    warningWithoutStack("Can't call %s on a component that is not yet mounted. " +
+      'This is a no-op, but it might indicate a bug in your application. ' +
+      'Instead, assign to `this.state` directly or define a `state = {};` ' +
+      'class property with the desired state in the %s component.', callerName, componentName);
     didWarnStateUpdateForUnmountedComponent[warningKey] = true;
   }
 }

--- a/packages/react/src/forwardRef.js
+++ b/packages/react/src/forwardRef.js
@@ -15,34 +15,37 @@ export default function forwardRef<Props, ElementType: React$ElementType>(
   if (__DEV__) {
     if (render != null && render.$$typeof === REACT_MEMO_TYPE) {
       warningWithoutStack(
-        false,
         'forwardRef requires a render function but received a `memo` ' +
           'component. Instead of forwardRef(memo(...)), use ' +
           'memo(forwardRef(...)).',
       );
     } else if (typeof render !== 'function') {
       warningWithoutStack(
-        false,
         'forwardRef requires a render function but was given %s.',
         render === null ? 'null' : typeof render,
       );
     } else {
-      warningWithoutStack(
+      if (
         // Do not warn for 0 arguments because it could be due to usage of the 'arguments' object
-        render.length === 0 || render.length === 2,
-        'forwardRef render functions accept exactly two parameters: props and ref. %s',
-        render.length === 1
-          ? 'Did you forget to use the ref parameter?'
-          : 'Any additional parameter will be undefined.',
-      );
+        render.length !== 0 &&
+        render.length !== 2
+      ) {
+        warningWithoutStack(
+          'forwardRef render functions accept exactly two parameters: props and ref. %s',
+          render.length === 1
+            ? 'Did you forget to use the ref parameter?'
+            : 'Any additional parameter will be undefined.',
+        );
+      }
     }
 
     if (render != null) {
-      warningWithoutStack(
-        render.defaultProps == null && render.propTypes == null,
-        'forwardRef render functions do not support propTypes or defaultProps. ' +
-          'Did you accidentally pass a React component?',
-      );
+      if (!(render.defaultProps == null && render.propTypes == null)) {
+        warningWithoutStack(
+          'forwardRef render functions do not support propTypes or defaultProps. ' +
+            'Did you accidentally pass a React component?',
+        );
+      }
     }
   }
 

--- a/packages/react/src/memo.js
+++ b/packages/react/src/memo.js
@@ -16,8 +16,11 @@ export default function memo<Props>(
 ) {
   if (__DEV__) {
     if (!isValidElementType(type)) {
-      warningWithoutStack('memo: The first argument must be a component. Instead ' +
-        'received: %s', type === null ? 'null' : typeof type);
+      warningWithoutStack(
+        'memo: The first argument must be a component. Instead ' +
+          'received: %s',
+        type === null ? 'null' : typeof type,
+      );
     }
   }
   return {

--- a/packages/react/src/memo.js
+++ b/packages/react/src/memo.js
@@ -16,12 +16,8 @@ export default function memo<Props>(
 ) {
   if (__DEV__) {
     if (!isValidElementType(type)) {
-      warningWithoutStack(
-        false,
-        'memo: The first argument must be a component. Instead ' +
-          'received: %s',
-        type === null ? 'null' : typeof type,
-      );
+      warningWithoutStack('memo: The first argument must be a component. Instead ' +
+        'received: %s', type === null ? 'null' : typeof type);
     }
   }
   return {

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -13,9 +13,11 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant('The current renderer does not support hydration. ' +
-    'This error is likely caused by a bug in React. ' +
-    'Please file an issue.');
+  invariant(
+    'The current renderer does not support hydration. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Hydration (when unsupported)

--- a/packages/shared/HostConfigWithNoHydration.js
+++ b/packages/shared/HostConfigWithNoHydration.js
@@ -13,12 +13,9 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant(
-    false,
-    'The current renderer does not support hydration. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+  invariant('The current renderer does not support hydration. ' +
+    'This error is likely caused by a bug in React. ' +
+    'Please file an issue.');
 }
 
 // Hydration (when unsupported)

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -13,9 +13,11 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant('The current renderer does not support mutation. ' +
-    'This error is likely caused by a bug in React. ' +
-    'Please file an issue.');
+  invariant(
+    'The current renderer does not support mutation. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Mutation (when unsupported)

--- a/packages/shared/HostConfigWithNoMutation.js
+++ b/packages/shared/HostConfigWithNoMutation.js
@@ -13,12 +13,9 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant(
-    false,
-    'The current renderer does not support mutation. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+  invariant('The current renderer does not support mutation. ' +
+    'This error is likely caused by a bug in React. ' +
+    'Please file an issue.');
 }
 
 // Mutation (when unsupported)

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -13,9 +13,11 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant('The current renderer does not support persistence. ' +
-    'This error is likely caused by a bug in React. ' +
-    'Please file an issue.');
+  invariant(
+    'The current renderer does not support persistence. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
 }
 
 // Persistence (when unsupported)

--- a/packages/shared/HostConfigWithNoPersistence.js
+++ b/packages/shared/HostConfigWithNoPersistence.js
@@ -13,12 +13,9 @@ import invariant from 'shared/invariant';
 // can re-export everything from this module.
 
 function shim(...args: any) {
-  invariant(
-    false,
-    'The current renderer does not support persistence. ' +
-      'This error is likely caused by a bug in React. ' +
-      'Please file an issue.',
-  );
+  invariant('The current renderer does not support persistence. ' +
+    'This error is likely caused by a bug in React. ' +
+    'Please file an issue.');
 }
 
 // Persistence (when unsupported)

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -117,7 +117,9 @@ export function clearCaughtError() {
     caughtError = null;
     return error;
   } else {
-    invariant('clearCaughtError was called but no error was captured. This error ' +
-      'is likely caused by a bug in React. Please file an issue.');
+    invariant(
+      'clearCaughtError was called but no error was captured. This error ' +
+        'is likely caused by a bug in React. Please file an issue.',
+    );
   }
 }

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -117,10 +117,7 @@ export function clearCaughtError() {
     caughtError = null;
     return error;
   } else {
-    invariant(
-      false,
-      'clearCaughtError was called but no error was captured. This error ' +
-        'is likely caused by a bug in React. Please file an issue.',
-    );
+    invariant('clearCaughtError was called but no error was captured. This error ' +
+      'is likely caused by a bug in React. Please file an issue.');
   }
 }

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -52,9 +52,12 @@ export function initializeLazyComponentType(
           const defaultExport = moduleObject.default;
           if (__DEV__) {
             if (defaultExport === undefined) {
-              warning('lazy: Expected the result of a dynamic import() call. ' +
-                'Instead received: %s\n\nYour code should look like: \n  ' +
-                "const MyComponent = lazy(() => import('./MyComponent'))", moduleObject);
+              warning(
+                'lazy: Expected the result of a dynamic import() call. ' +
+                  'Instead received: %s\n\nYour code should look like: \n  ' +
+                  "const MyComponent = lazy(() => import('./MyComponent'))",
+                moduleObject,
+              );
             }
           }
           lazyComponent._status = Resolved;

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -52,13 +52,9 @@ export function initializeLazyComponentType(
           const defaultExport = moduleObject.default;
           if (__DEV__) {
             if (defaultExport === undefined) {
-              warning(
-                false,
-                'lazy: Expected the result of a dynamic import() call. ' +
-                  'Instead received: %s\n\nYour code should look like: \n  ' +
-                  "const MyComponent = lazy(() => import('./MyComponent'))",
-                moduleObject,
-              );
+              warning('lazy: Expected the result of a dynamic import() call. ' +
+                'Instead received: %s\n\nYour code should look like: \n  ' +
+                "const MyComponent = lazy(() => import('./MyComponent'))", moduleObject);
             }
           }
           lazyComponent._status = Resolved;

--- a/packages/shared/enqueueTask.js
+++ b/packages/shared/enqueueTask.js
@@ -29,10 +29,12 @@ try {
         didWarnAboutMessageChannel = true;
 
         if (!(typeof MessageChannel !== 'undefined')) {
-          warningWithoutStack('This browser does not have a MessageChannel implementation, ' +
-            'so enqueuing tasks via await act(async () => ...) will fail. ' +
-            'Please file an issue at https://github.com/facebook/react/issues ' +
-            'if you encounter this warning.');
+          warningWithoutStack(
+            'This browser does not have a MessageChannel implementation, ' +
+              'so enqueuing tasks via await act(async () => ...) will fail. ' +
+              'Please file an issue at https://github.com/facebook/react/issues ' +
+              'if you encounter this warning.',
+          );
         }
       }
     }

--- a/packages/shared/enqueueTask.js
+++ b/packages/shared/enqueueTask.js
@@ -27,13 +27,13 @@ try {
     if (__DEV__) {
       if (didWarnAboutMessageChannel === false) {
         didWarnAboutMessageChannel = true;
-        warningWithoutStack(
-          typeof MessageChannel !== 'undefined',
-          'This browser does not have a MessageChannel implementation, ' +
+
+        if (!(typeof MessageChannel !== 'undefined')) {
+          warningWithoutStack('This browser does not have a MessageChannel implementation, ' +
             'so enqueuing tasks via await act(async () => ...) will fail. ' +
             'Please file an issue at https://github.com/facebook/react/issues ' +
-            'if you encounter this warning.',
-        );
+            'if you encounter this warning.');
+        }
       }
     }
     const channel = new MessageChannel();

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -46,7 +46,7 @@ export const enableTrustedTypesIntegration = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  invariant('Not implemented.');
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -41,7 +41,7 @@ export const enableTrustedTypesIntegration = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  invariant('Not implemented.');
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -41,7 +41,7 @@ export const enableTrustedTypesIntegration = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  invariant('Not implemented.');
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -41,7 +41,7 @@ export const enableTrustedTypesIntegration = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  invariant('Not implemented.');
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -39,7 +39,7 @@ export const enableTrustedTypesIntegration = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  invariant('Not implemented.');
 }
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/invokeGuardedCallbackImpl.www.js
+++ b/packages/shared/forks/invokeGuardedCallbackImpl.www.js
@@ -9,10 +9,10 @@ import invariant from 'shared/invariant';
 
 // Provided by www
 const ReactFbErrorUtils = require('ReactFbErrorUtils');
-invariant(
-  typeof ReactFbErrorUtils.invokeGuardedCallback === 'function',
-  'Expected ReactFbErrorUtils.invokeGuardedCallback to be a function.',
-);
+
+if (!(typeof ReactFbErrorUtils.invokeGuardedCallback === 'function')) {
+  invariant('Expected ReactFbErrorUtils.invokeGuardedCallback to be a function.');
+}
 
 let invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(
   name: string | null,

--- a/packages/shared/forks/invokeGuardedCallbackImpl.www.js
+++ b/packages/shared/forks/invokeGuardedCallbackImpl.www.js
@@ -11,7 +11,9 @@ import invariant from 'shared/invariant';
 const ReactFbErrorUtils = require('ReactFbErrorUtils');
 
 if (!(typeof ReactFbErrorUtils.invokeGuardedCallback === 'function')) {
-  invariant('Expected ReactFbErrorUtils.invokeGuardedCallback to be a function.');
+  invariant(
+    'Expected ReactFbErrorUtils.invokeGuardedCallback to be a function.',
+  );
 }
 
 let invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(

--- a/packages/shared/forks/lowPriorityWarningWithoutStack.www.js
+++ b/packages/shared/forks/lowPriorityWarningWithoutStack.www.js
@@ -6,4 +6,8 @@
  */
 
 // This "lowPriorityWarning" is an external module
-export default require('lowPriorityWarning');
+const _lowPriorityWarning = require('lowPriorityWarning');
+
+export default function lowPriorityWarningWithoutStack(format, ...args) {
+  return _lowPriorityWarning(false, format, ...args);
+}

--- a/packages/shared/forks/warningWithoutStack.www.js
+++ b/packages/shared/forks/warningWithoutStack.www.js
@@ -5,4 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export default require('warning');
+const _warning = require('warning');
+
+export default function warningWithoutStack(format, ...args) {
+  return _warning(false, format, ...args);
+}

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -44,11 +44,8 @@ function getComponentName(type: mixed): string | null {
   }
   if (__DEV__) {
     if (typeof (type: any).tag === 'number') {
-      warningWithoutStack(
-        false,
-        'Received an unexpected object in getComponentName(). ' +
-          'This is likely a bug in React. Please file an issue.',
-      );
+      warningWithoutStack('Received an unexpected object in getComponentName(). ' +
+        'This is likely a bug in React. Please file an issue.');
     }
   }
   if (typeof type === 'function') {

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -44,8 +44,10 @@ function getComponentName(type: mixed): string | null {
   }
   if (__DEV__) {
     if (typeof (type: any).tag === 'number') {
-      warningWithoutStack('Received an unexpected object in getComponentName(). ' +
-        'This is likely a bug in React. Please file an issue.');
+      warningWithoutStack(
+        'Received an unexpected object in getComponentName(). ' +
+          'This is likely a bug in React. Please file an issue.',
+      );
     }
   }
   if (typeof type === 'function') {

--- a/packages/shared/invariant.js
+++ b/packages/shared/invariant.js
@@ -17,7 +17,7 @@
  * will remain to ensure logic does not differ in production.
  */
 
-export default function invariant(condition, format, a, b, c, d, e, f) {
+export default function invariant(format, a, b, c, d, e, f) {
   throw new Error(
     'Internal React error: invariant() is meant to be replaced at compile ' +
       'time. There is no runtime version.',

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -69,20 +69,22 @@ if (__DEV__) {
       e: E,
       f: F,
     ) {
-      // If document doesn't exist we know for sure we will crash in this method
-      // when we call document.createEvent(). However this can cause confusing
-      // errors: https://github.com/facebookincubator/create-react-app/issues/3482
-      // So we preemptively throw with a better message instead.
-      invariant(
-        typeof document !== 'undefined',
-        'The `document` global was defined when React was initialized, but is not ' +
-          'defined anymore. This can happen in a test environment if a component ' +
-          'schedules an update from an asynchronous callback, but the test has already ' +
-          'finished running. To solve this, you can either unmount the component at ' +
-          'the end of your test (and ensure that any asynchronous operations get ' +
-          'canceled in `componentWillUnmount`), or you can change the test itself ' +
-          'to be asynchronous.',
-      );
+      if (!(typeof document !== 'undefined')) {
+        // If document doesn't exist we know for sure we will crash in this method
+        // when we call document.createEvent(). However this can cause confusing
+        // errors: https://github.com/facebookincubator/create-react-app/issues/3482
+        // So we preemptively throw with a better message instead.
+        invariant(
+          'The `document` global was defined when React was initialized, but is not ' +
+            'defined anymore. This can happen in a test environment if a component ' +
+            'schedules an update from an asynchronous callback, but the test has already ' +
+            'finished running. To solve this, you can either unmount the component at ' +
+            'the end of your test (and ensure that any asynchronous operations get ' +
+            'canceled in `componentWillUnmount`), or you can change the test itself ' +
+            'to be asynchronous.'
+        );
+      }
+
       const evt = document.createEvent('Event');
 
       // Keeps track of whether the user-provided callback threw an error. We

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -81,7 +81,7 @@ if (__DEV__) {
             'finished running. To solve this, you can either unmount the component at ' +
             'the end of your test (and ensure that any asynchronous operations get ' +
             'canceled in `componentWillUnmount`), or you can change the test itself ' +
-            'to be asynchronous.'
+            'to be asynchronous.',
         );
       }
 

--- a/packages/shared/lowPriorityWarning.js
+++ b/packages/shared/lowPriorityWarning.js
@@ -18,14 +18,11 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 let lowPriorityWarning = lowPriorityWarningWithoutStack;
 
 if (__DEV__) {
-  lowPriorityWarning = function(condition, format, ...args) {
-    if (condition) {
-      return;
-    }
+  lowPriorityWarning = function(format, ...args) {
     const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
     const stack = ReactDebugCurrentFrame.getStackAddendum();
     // eslint-disable-next-line react-internal/warning-and-invariant-args
-    lowPriorityWarningWithoutStack(false, format + '%s', ...args, stack);
+    lowPriorityWarningWithoutStack(format + '%s', ...args, stack);
   };
 }
 

--- a/packages/shared/lowPriorityWarningWithoutStack.js
+++ b/packages/shared/lowPriorityWarningWithoutStack.js
@@ -36,16 +36,14 @@ if (__DEV__) {
     } catch (x) {}
   };
 
-  lowPriorityWarningWithoutStack = function(condition, format, ...args) {
+  lowPriorityWarningWithoutStack = function(format, ...args) {
     if (format === undefined) {
       throw new Error(
-        '`lowPriorityWarningWithoutStack(condition, format, ...args)` requires a warning ' +
+        '`lowPriorityWarningWithoutStack(format, ...args)` requires a warning ' +
           'message argument',
       );
     }
-    if (!condition) {
-      printWarning(format, ...args);
-    }
+    printWarning(format, ...args);
   };
 }
 

--- a/packages/shared/warning.js
+++ b/packages/shared/warning.js
@@ -18,14 +18,11 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 let warning = warningWithoutStack;
 
 if (__DEV__) {
-  warning = function(condition, format, ...args) {
-    if (condition) {
-      return;
-    }
+  warning = function(format, ...args) {
     const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
     const stack = ReactDebugCurrentFrame.getStackAddendum();
     // eslint-disable-next-line react-internal/warning-and-invariant-args
-    warningWithoutStack(false, format + '%s', ...args, stack);
+    warningWithoutStack(format + '%s', ...args, stack);
   };
 }
 

--- a/packages/shared/warningWithoutStack.js
+++ b/packages/shared/warningWithoutStack.js
@@ -15,21 +15,17 @@
 let warningWithoutStack = () => {};
 
 if (__DEV__) {
-  warningWithoutStack = function(condition, format, ...args) {
+  warningWithoutStack = function(format, ...args) {
     if (format === undefined) {
       throw new Error(
-        '`warningWithoutStack(condition, format, ...args)` requires a warning ' +
+        '`warningWithoutStack(format, ...args)` requires a warning ' +
           'message argument',
       );
     }
     if (args.length > 8) {
-      // Check before the condition to catch violations early.
       throw new Error(
         'warningWithoutStack() currently supports at most 8 arguments.',
       );
-    }
-    if (condition) {
-      return;
     }
     if (typeof console !== 'undefined') {
       const argsWithFormat = args.map(item => '' + item);

--- a/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
+++ b/scripts/babel/__tests__/wrap-warning-with-env-check-test.js
@@ -35,22 +35,72 @@ describe('wrap-warning-with-env-check', () => {
 
   it('should wrap warning calls', () => {
     compare(
-      "warning(condition, 'a %s b', 'c');",
-      "__DEV__ ? !condition ? warning(false, 'a %s b', 'c') : void 0 : void 0;"
+      `if (condition) {
+  warning('a %s b', 'c');
+}`,
+      `if (__DEV__ && condition) {
+  warning('a %s b', 'c');
+}`
+    );
+    compare(
+      "warning('a %s b', 'c');",
+      "__DEV__ ? warning('a %s b', 'c') : void 0;"
     );
   });
 
   it('should wrap warningWithoutStack calls', () => {
     compare(
-      "warningWithoutStack(condition, 'a %s b', 'c');",
-      "__DEV__ ? !condition ? warningWithoutStack(false, 'a %s b', 'c') : void 0 : void 0;"
+      `if (condition) {
+  warningWithoutStack('a %s b', 'c');
+}`,
+      `if (__DEV__ && condition) {
+  warningWithoutStack('a %s b', 'c');
+}`
+    );
+    compare(
+      "warningWithoutStack('a %s b', 'c');",
+      "__DEV__ ? warningWithoutStack('a %s b', 'c') : void 0;"
+    );
+  });
+
+  it('should wrap lowPriorityWarning calls', () => {
+    compare(
+      `if (condition) {
+  lowPriorityWarning('a %s b', 'c');
+}`,
+      `if (__DEV__ && condition) {
+  lowPriorityWarning('a %s b', 'c');
+}`
+    );
+    compare(
+      "lowPriorityWarning('a %s b', 'c');",
+      "__DEV__ ? lowPriorityWarning('a %s b', 'c') : void 0;"
+    );
+  });
+
+  it('should wrap lowPriorityWarningWithoutStack calls', () => {
+    compare(
+      `if (condition) {
+  lowPriorityWarningWithoutStack('a %s b', 'c');
+}`,
+      `if (__DEV__ && condition) {
+  lowPriorityWarningWithoutStack('a %s b', 'c');
+}`
+    );
+    compare(
+      "lowPriorityWarningWithoutStack('a %s b', 'c');",
+      "__DEV__ ? lowPriorityWarningWithoutStack('a %s b', 'c') : void 0;"
     );
   });
 
   it('should not wrap invariant calls', () => {
     compare(
-      "invariant(condition, 'a %s b', 'c');",
-      "invariant(condition, 'a %s b', 'c');"
+      `if (condition) {
+  invariant('a %s b', 'c');
+}`,
+      `if (condition) {
+  invariant('a %s b', 'c');
+}`
     );
   });
 });

--- a/scripts/error-codes/__tests__/__snapshots__/transform-error-messages.js.snap
+++ b/scripts/error-codes/__tests__/__snapshots__/transform-error-messages.js.snap
@@ -3,8 +3,8 @@
 exports[`error transform should correctly transform invariants that are not in the error codes map 1`] = `
 "import invariant from 'shared/invariant';
 
-/*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
 if (!condition) {
+  /*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
   throw Error(\\"This is not a real error message.\\");
 }"
 `;
@@ -12,8 +12,8 @@ if (!condition) {
 exports[`error transform should handle escaped characters 1`] = `
 "import invariant from 'shared/invariant';
 
-/*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
 if (!condition) {
+  /*FIXME (minify-errors-in-prod): Unminified error message in production build!*/
   throw Error(\\"What's up?\\");
 }"
 `;
@@ -23,9 +23,7 @@ exports[`error transform should replace simple invariant calls 1`] = `
 import invariant from 'shared/invariant';
 
 if (!condition) {
-  {
-    throw Error(__DEV__ ? \\"Do not override existing functions.\\" : _formatProdErrorMessage(16));
-  }
+  throw Error(__DEV__ ? \\"Do not override existing functions.\\" : _formatProdErrorMessage(16));
 }"
 `;
 
@@ -34,9 +32,7 @@ exports[`error transform should support invariant calls with a concatenated temp
 import invariant from 'shared/invariant';
 
 if (!condition) {
-  {
-    throw Error(__DEV__ ? \\"Expected a component class, got \\" + Foo + \\".\\" + Bar : _formatProdErrorMessage(18, Foo, Bar));
-  }
+  throw Error(__DEV__ ? \\"Expected a component class, got \\" + Foo + \\".\\" + Bar : _formatProdErrorMessage(18, Foo, Bar));
 }"
 `;
 
@@ -45,9 +41,7 @@ exports[`error transform should support invariant calls with args 1`] = `
 import invariant from 'shared/invariant';
 
 if (!condition) {
-  {
-    throw Error(__DEV__ ? \\"Expected \\" + foo + \\" target to be an array; got \\" + bar : _formatProdErrorMessage(7, foo, bar));
-  }
+  throw Error(__DEV__ ? \\"Expected \\" + foo + \\" target to be an array; got \\" + bar : _formatProdErrorMessage(7, foo, bar));
 }"
 `;
 

--- a/scripts/error-codes/__tests__/transform-error-messages.js
+++ b/scripts/error-codes/__tests__/transform-error-messages.js
@@ -32,7 +32,9 @@ describe('error transform', () => {
     expect(
       transform(`
 import invariant from 'shared/invariant';
-invariant(condition, 'Do not override existing functions.');
+if (!condition) {
+  invariant('Do not override existing functions.');
+}
 `)
     ).toMatchSnapshot();
   });
@@ -41,7 +43,7 @@ invariant(condition, 'Do not override existing functions.');
     expect(() => {
       transform(`
 import invariant from 'shared/invariant';
-cond && invariant(condition, 'Do not override existing functions.');
+cond && !condition && invariant('Do not override existing functions.');
 `);
     }).toThrow('invariant() cannot be called from expression context');
   });
@@ -50,7 +52,9 @@ cond && invariant(condition, 'Do not override existing functions.');
     expect(
       transform(`
 import invariant from 'shared/invariant';
-invariant(condition, 'Expected %s target to be an array; got %s', foo, bar);
+if (!condition) {
+  invariant('Expected %s target to be an array; got %s', foo, bar);
+}
 `)
     ).toMatchSnapshot();
   });
@@ -59,7 +63,9 @@ invariant(condition, 'Expected %s target to be an array; got %s', foo, bar);
     expect(
       transform(`
 import invariant from 'shared/invariant';
-invariant(condition, 'Expected a component class, ' + 'got %s.' + '%s', Foo, Bar);
+if (!condition) {
+  invariant('Expected a component class, ' + 'got %s.' + '%s', Foo, Bar);
+}
 `)
     ).toMatchSnapshot();
   });
@@ -68,7 +74,9 @@ invariant(condition, 'Expected a component class, ' + 'got %s.' + '%s', Foo, Bar
     expect(
       transform(`
 import invariant from 'shared/invariant';
-invariant(condition, 'This is not a real error message.');
+if (!condition) {
+  invariant('This is not a real error message.');
+}
 `)
     ).toMatchSnapshot();
   });
@@ -77,7 +85,9 @@ invariant(condition, 'This is not a real error message.');
     expect(
       transform(`
 import invariant from 'shared/invariant';
-invariant(condition, 'What\\'s up?');
+if (!condition) {
+  invariant('What\\'s up?');
+}
 `)
     ).toMatchSnapshot();
   });
@@ -87,7 +97,9 @@ invariant(condition, 'What\\'s up?');
       transform(
         `
 import invariant from 'shared/invariant';
-invariant(condition, 'Do not override existing functions.');
+if (!condition) {
+  invariant('Do not override existing functions.');
+}
 `,
         {noMinify: true}
       )

--- a/scripts/error-codes/extract-errors.js
+++ b/scripts/error-codes/extract-errors.js
@@ -75,7 +75,7 @@ module.exports = function(opts) {
 
             // error messages can be concatenated (`+`) at runtime, so here's a
             // trivial partial evaluator that interprets the literal value
-            const errorMsgLiteral = evalToString(node.arguments[1]);
+            const errorMsgLiteral = evalToString(node.arguments[0]);
             addToErrorMap(errorMsgLiteral);
           }
         },

--- a/scripts/eslint-rules/__tests__/warning-and-invariant-args-test.internal.js
+++ b/scripts/eslint-rules/__tests__/warning-and-invariant-args-test.internal.js
@@ -15,60 +15,60 @@ const ruleTester = new RuleTester();
 
 ruleTester.run('eslint-rules/warning-and-invariant-args', rule, {
   valid: [
-    "warning(true, 'hello, world');",
-    "warning(true, 'expected %s, got %s', 42, 24);",
+    "warning('hello, world');",
+    "warning('expected %s, got %s', 42, 24);",
     'arbitraryFunction(a, b)',
     // These messages are in the error code map
-    "invariant(false, 'Do not override existing functions.')",
-    "invariant(false, '%s(...): Target container is not a DOM element.', str)",
+    "invariant('Do not override existing functions.')",
+    "invariant('%s(...): Target container is not a DOM element.', str)",
   ],
   invalid: [
     {
-      code: "warning('hello, world');",
+      code: 'warning();',
       errors: [
         {
-          message: 'warning takes at least two arguments',
+          message: 'warning takes at least one argument',
         },
       ],
     },
     {
-      code: 'warning(true, null);',
+      code: 'warning(null);',
       errors: [
         {
-          message: 'The second argument to warning must be a string literal',
+          message: 'The first argument to warning must be a string literal',
         },
       ],
     },
     {
-      code: 'var g = 5; invariant(true, g);',
+      code: 'var g = 5; invariant(g);',
       errors: [
         {
-          message: 'The second argument to invariant must be a string literal',
+          message: 'The first argument to invariant must be a string literal',
         },
       ],
     },
     {
-      code: "warning(true, 'expected %s, got %s');",
+      code: "warning('expected %s, got %s');",
       errors: [
         {
           message:
-            'Expected 4 arguments in call to warning based on the number of ' +
+            'Expected 3 arguments in call to warning based on the number of ' +
+            '"%s" substitutions, but got 1',
+        },
+      ],
+    },
+    {
+      code: "warning('foo is a bar under foobar', 'junk argument');",
+      errors: [
+        {
+          message:
+            'Expected 1 argument in call to warning based on the number of ' +
             '"%s" substitutions, but got 2',
         },
       ],
     },
     {
-      code: "warning(true, 'foo is a bar under foobar', 'junk argument');",
-      errors: [
-        {
-          message:
-            'Expected 2 arguments in call to warning based on the number of ' +
-            '"%s" substitutions, but got 3',
-        },
-      ],
-    },
-    {
-      code: "invariant(true, 'error!');",
+      code: "invariant('error!');",
       errors: [
         {
           message:
@@ -78,7 +78,7 @@ ruleTester.run('eslint-rules/warning-and-invariant-args', rule, {
       ],
     },
     {
-      code: "warning(true, 'error!');",
+      code: "warning('error!');",
       errors: [
         {
           message:
@@ -88,7 +88,7 @@ ruleTester.run('eslint-rules/warning-and-invariant-args', rule, {
       ],
     },
     {
-      code: "warning(true, '%s %s, %s %s: %s (%s)', 1, 2, 3, 4, 5, 6);",
+      code: "warning('%s %s, %s %s: %s (%s)', 1, 2, 3, 4, 5, 6);",
       errors: [
         {
           message:
@@ -99,7 +99,7 @@ ruleTester.run('eslint-rules/warning-and-invariant-args', rule, {
       ],
     },
     {
-      code: "invariant(false, 'Not in error map')",
+      code: "invariant('Not in error map')",
       errors: [
         {
           message:

--- a/scripts/eslint-rules/warning-and-invariant-args.js
+++ b/scripts/eslint-rules/warning-and-invariant-args.js
@@ -47,21 +47,23 @@ module.exports = function(context) {
         node.callee.type === 'Identifier' &&
         (node.callee.name === 'warning' ||
           node.callee.name === 'warningWithoutStack' ||
+          node.callee.name === 'lowPriorityWarning' ||
+          node.callee.name === 'lowPriorityWarningWithoutStack' ||
           node.callee.name === 'invariant');
       if (!isWarningOrInvariant) {
         return;
       }
-      if (node.arguments.length < 2) {
-        context.report(node, '{{name}} takes at least two arguments', {
+      if (node.arguments.length < 1) {
+        context.report(node, '{{name}} takes at least one argument', {
           name: node.callee.name,
         });
         return;
       }
-      const format = getLiteralString(node.arguments[1]);
+      const format = getLiteralString(node.arguments[0]);
       if (format === null) {
         context.report(
           node,
-          'The second argument to {{name}} must be a string literal',
+          'The first argument to {{name}} must be a string literal',
           {name: node.callee.name}
         );
         return;
@@ -75,15 +77,16 @@ module.exports = function(context) {
         );
         return;
       }
-      // count the number of formatting substitutions, plus the first two args
-      const expectedNArgs = (format.match(/%s/g) || []).length + 2;
+      // count the number of formatting substitutions, plus the first arg
+      const expectedNArgs = (format.match(/%s/g) || []).length + 1;
       if (node.arguments.length !== expectedNArgs) {
         context.report(
           node,
-          'Expected {{expectedNArgs}} arguments in call to {{name}} based on ' +
+          'Expected {{expectedNArgs}} argument{{s}} in call to {{name}} based on ' +
             'the number of "%s" substitutions, but got {{length}}',
           {
             expectedNArgs: expectedNArgs,
+            s: expectedNArgs > 1 ? 's' : '',
             name: node.callee.name,
             length: node.arguments.length,
           }


### PR DESCRIPTION
Part 2 of https://github.com/facebook/react/issues/16753

Updating the babel plugin to handle the new syntax was a bit tricky.

`invariant` was also originally not part of the scope, but because the plugin that validated arguments to `warning` also expected `invariant` to have the same interface, I had to choose between forking the plugin or also transforming `invariant`.

Some of the expressions may look funny; they were generated by this codemod:

<details>

```js
'use strict';

module.exports = function transformer(file, api) {
  const j = api.jscodeshift;

  return j(file.source)
    .find(j.CallExpression)
    .filter(path => {
      const callee = path.value.callee;
      if (callee.type !== 'Identifier') {
        return false;
      }
      const name = callee.name;
      const scope = path.scope.lookup(name);

      return (
        // "isGlobal" just means file scope, even in Modules
        (scope === null || scope.isGlobal) &&
        (name === 'warning' ||
          name === 'warningWithoutStack' ||
          name === 'lowPriorityWarning' ||
          name === 'lowPriorityWarningWithoutStack' ||
          name === 'invariant')
      );
    })
    .forEach(path => {
      const firstArgument = path.value.arguments[0];
      if (firstArgument.type === 'StringLiteral') {
        // already transformed?
        return;
      }
      if (firstArgument.type === 'Literal') {
        if (firstArgument.value) {
          if (path.parentPath.value.type === 'ExpressionStatement') {
            path.prune();
          } else {
            path.replace(j.identifier('undefined'));
          }
          return;
        }
        path.value.arguments.shift();
        return;
      }

      path.value.arguments.shift();
      if (path.parentPath.value.type === 'ExpressionStatement') {
        return path.parentPath.replace(
          j.ifStatement(
            j.unaryExpression('!', firstArgument),
            j.blockStatement([path.parentPath.node])
          )
        );
      } else {
        return path.replace(
          j.sequenceExpression([
            j.logicalExpression('||', firstArgument, path.node),
            j.identifier('undefined'),
          ])
        );
      }
    })
    .toSource();
};
```
</details>