### PR TITLE
Fixed a bug with illegal invocation for Trusted Types

### DIFF
--- a/packages/react-dom/src/client/ToStringValue.js
+++ b/packages/react-dom/src/client/ToStringValue.js
@@ -53,15 +53,14 @@ export opaque type TrustedValue: {toString(): string, valueOf(): string} = {
  */
 export let toStringOrTrustedType: any => string | TrustedValue = toString;
 if (enableTrustedTypesIntegration && typeof trustedTypes !== 'undefined') {
-  const isHTML = trustedTypes.isHTML;
-  const isScript = trustedTypes.isScript;
-  const isScriptURL = trustedTypes.isScriptURL;
-  // TrustedURLs are deprecated and will be removed soon: https://github.com/WICG/trusted-types/pull/204
-  const isURL = trustedTypes.isURL ? trustedTypes.isURL : value => false;
   toStringOrTrustedType = value => {
     if (
       typeof value === 'object' &&
-      (isHTML(value) || isScript(value) || isScriptURL(value) || isURL(value))
+      (trustedTypes.isHTML(value) ||
+        trustedTypes.isScript(value) ||
+        trustedTypes.isScriptURL(value) ||
+        /* TrustedURLs are deprecated and will be removed soon: https://github.com/WICG/trusted-types/pull/204 */
+        (trustedTypes.isURL && trustedTypes.isURL(value)))
     ) {
       // Pass Trusted Types through.
       return value;

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -22,9 +22,9 @@ describe('when Trusted Types are available in global object', () => {
     container = document.createElement('div');
     const fakeTTObjects = new Set();
     window.trustedTypes = {
-      isHTML: value => {
+      isHTML: function(value) {
         if (this !== window.trustedTypes) {
-          throw new Error('Illegal invocation');
+          throw new Error(this);
         }
         return fakeTTObjects.has(value);
       },

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -22,7 +22,12 @@ describe('when Trusted Types are available in global object', () => {
     container = document.createElement('div');
     const fakeTTObjects = new Set();
     window.trustedTypes = {
-      isHTML: value => fakeTTObjects.has(value),
+      isHTML: value => {
+        if (this !== window.trustedTypes) {
+          throw new Error('Illegal invocation');
+        }
+        return fakeTTObjects.has(value);
+      },
       isScript: () => false,
       isScriptURL: () => false,
     };


### PR DESCRIPTION
`trustedTypes.is*` functions need to be bound to the `trustedTypes` object when called. This PR fixes the bug.