### PR TITLE
Update release scripts to support experimental releases

### DIFF
--- a/scripts/release/prepare-stable.js
+++ b/scripts/release/prepare-stable.js
@@ -14,6 +14,7 @@ const printPrereleaseSummary = require('./shared-commands/print-prerelease-summa
 const testPackagingFixture = require('./shared-commands/test-packaging-fixture');
 const testTracingFixture = require('./shared-commands/test-tracing-fixture');
 const updateStableVersionNumbers = require('./prepare-stable-commands/update-stable-version-numbers');
+const theme = require('./theme');
 
 const run = async () => {
   try {
@@ -28,6 +29,13 @@ const run = async () => {
 
     if (!params.version) {
       params.version = await getLatestCanaryVersion();
+    }
+
+    if (params.version.includes('experimental')) {
+      console.error(
+        theme.error`Cannot promote an experimental build to stable.`
+      );
+      process.exit(1);
     }
 
     await checkOutPackages(params);

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -51,18 +51,22 @@ const getArtifactsList = async buildID => {
     );
     process.exit(1);
   }
-
+  const artifactsJobName = buildMetadata.workflows.job_name.endsWith(
+    '_experimental'
+  )
+    ? 'process_artifacts_experimental'
+    : 'process_artifacts';
   const workflowID = buildMetadata.workflows.workflow_id;
   const workflowMetadataURL = `https://circleci.com/api/v2/workflow/${workflowID}/jobs?circle-token=${
     process.env.CIRCLE_CI_API_TOKEN
   }`;
   const workflowMetadata = await http.get(workflowMetadataURL, true);
   const job = workflowMetadata.items.find(
-    ({name}) => name === 'process_artifacts'
+    ({name}) => name === artifactsJobName
   );
   if (!job || !job.job_number) {
     console.log(
-      theme`{error Could not find "process_artifacts" job for workflow ${workflowID}.}`
+      theme`{error Could not find "${artifactsJobName}" job for workflow ${workflowID}.}`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Adds a check to the `prepare-stable` script to prevent experimental builds from being published using stable semver versions.

Also updates the function that downloads the artifacts to pull from the correct CI job. I think instead of two separate CI workflows, a better approach might be to build stable artifacts to the `build` directory and the experimental artifacts to a `build_experimental` directory, and generate both within the same workflow. This would take some work since lots of things assume the output directory is `build`, but something to consider in the future.

### Test plan

Run 

```sh
./scripts/release/prepare-stable.js --skipTests --version=0.0.0-experimental-d364d8555
```

and confirm that it exits with an error message.