### PR TITLE
[eslint] Allow assignment of hook and componentWithHook to object property

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -479,7 +479,7 @@ const tests = {
       `,
       errors: [functionError('useState', 'invalidComponentOrHookName')],
     },
-    
+
     {
       code: `
         // Invalid because it's dangerous and might not warn otherwise.

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -109,6 +109,16 @@ const tests = {
     `,
     `
       // Valid because hooks can call hooks.
+      Foo.useHook = () => { useState(); }
+      Foo.Bar.useHook = () => { useState(); }
+    `,
+    `
+      // Valid because components can call hooks.
+      Components.Foo = () => { useState(); }
+      Components.Bar = () => { useState(); }
+    `,
+    `
+      // Valid because hooks can call hooks.
       function useHook() {
         useHook1();
         useHook2();

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -475,6 +475,13 @@ const tests = {
     },
     {
       code: `
+        A.invalidComponentOrHookName = () => { useState() }
+      `,
+      errors: [functionError('useState', 'invalidComponentOrHookName')],
+    },
+    
+    {
+      code: `
         // Invalid because it's dangerous and might not warn otherwise.
         // This *must* be invalid.
         function ComponentWithHookInsideLoop() {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -116,6 +116,11 @@ const tests = {
       // Valid because components can call hooks.
       Components.Foo = () => { useState(); }
       Components.Bar = () => { useState(); }
+
+      // Valid because components can call hooks.
+      Components.Foo = function () { useState(); }
+      Components.whatever = function Foo() { useState(); }
+      Components.Bar = () => { useState(); } 
     `,
     `
       // Valid because hooks can call hooks.
@@ -479,7 +484,18 @@ const tests = {
       `,
       errors: [functionError('useState', 'invalidComponentOrHookName')],
     },
-
+    {
+      code: `
+        Components.whatever = function () { useState(); }
+      `,
+      errors: [functionError('useState', 'whatever')],
+    },
+    {
+      code: `
+        Components.Foo = function whatever() { useState(); }
+      `,
+      errors: [functionError('useState', 'whatever')],
+    },
     {
       code: `
         // Invalid because it's dangerous and might not warn otherwise.

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -514,7 +514,10 @@ function getFunctionName(node) {
     ) {
       // const Hooks = {}
       // Hooks.useHook = () => {};
-      if (node.parent.left.type === 'MemberExpression') {
+      if (
+        node.parent.left.type === 'MemberExpression' &&
+        !node.parent.left.computed
+      ) {
         return node.parent.left.property;
       }
       // useHook = () => {};

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -512,6 +512,11 @@ function getFunctionName(node) {
       node.parent.right === node &&
       node.parent.operator === '='
     ) {
+      // const Hooks = {}
+      // Hooks.useHook = () => {};
+      if (node.parent.left.type === 'MemberExpression') {
+        return node.parent.left.property;
+      }
       // useHook = () => {};
       return node.parent.left;
     } else if (


### PR DESCRIPTION
Allow assignment of function component with hook or hook function to object property.

```js
// Components
const Components = {}
Components.ComponentThatUseHook = () => { useState() };

// Hooks
const Hooks = {}
Hooks.useHook = () => { useState(); }
```

Probably resolve #17078 

---


**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
