### PR TITLE
[babel-plugin-react-jsx] Avoid duplicate "children" key in props object

### DIFF
--- a/packages/babel-plugin-react-jsx/__tests__/TransformJSXToReactJSX-test.js
+++ b/packages/babel-plugin-react-jsx/__tests__/TransformJSXToReactJSX-test.js
@@ -480,4 +480,10 @@ describe('transform react to jsx', () => {
       transform(`<Component y={2} {...x} />`, {useBuiltIns: false})
     ).toMatchSnapshot();
   });
+
+  it('should not contain duplicate children key in props object', () => {
+    expect(
+      transform(`<Component children={1}>2</Component>`)
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/babel-plugin-react-jsx/__tests__/__snapshots__/TransformJSXToReactJSX-test.js.snap
+++ b/packages/babel-plugin-react-jsx/__tests__/__snapshots__/TransformJSXToReactJSX-test.js.snap
@@ -251,9 +251,11 @@ var e = React.jsx(F, {
 `;
 
 exports[`transform react to jsx should not contain duplicate children key in props object 1`] = `
-React.jsx(Component, {
+React.jsx(Component, Object.assign({
+  children: 1
+}, {
   children: "2"
-});
+}));
 `;
 
 exports[`transform react to jsx should not strip nbsp even couple with other whitespace 1`] = `

--- a/packages/babel-plugin-react-jsx/__tests__/__snapshots__/TransformJSXToReactJSX-test.js.snap
+++ b/packages/babel-plugin-react-jsx/__tests__/__snapshots__/TransformJSXToReactJSX-test.js.snap
@@ -250,6 +250,12 @@ var e = React.jsx(F, {
 });
 `;
 
+exports[`transform react to jsx should not contain duplicate children key in props object 1`] = `
+React.jsx(Component, {
+  children: "2"
+});
+`;
+
 exports[`transform react to jsx should not strip nbsp even couple with other whitespace 1`] = `
 React.jsx("div", {
   children: "\\xA0 "

--- a/packages/babel-plugin-react-jsx/src/TransformJSXToReactBabelPlugin.js
+++ b/packages/babel-plugin-react-jsx/src/TransformJSXToReactBabelPlugin.js
@@ -296,9 +296,15 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
       if (t.isJSXSpreadAttribute(prop)) {
         _props = pushProps(_props, objs);
         objs.push(prop.argument);
-      } else if (!hasChildren || !isChildrenProp(prop)) {
+      } else if (hasChildren && isChildrenProp(prop)) {
         // In order to avoid having duplicate "children" keys, we avoid
-        // pushing the "children" prop if we have actual children.
+        // pushing the "children" prop if we have actual children. Instead
+        // we put the children into a separate object and then rely on
+        // the Object.assign logic below to ensure the correct object is
+        // formed.
+        _props = pushProps(_props, objs);
+        objs.push(t.objectExpression([convertAttribute(prop)]));
+      } else {
         _props.push(convertAttribute(prop));
       }
     }


### PR DESCRIPTION
This PR fixes a duplicate "children" key bug in the `TransformJSXToReactJSX` Babel transform. Specifically, when we have JSX that looks like this:

```jsx
<Component children={1}>2</Component>
```

Before this PR, the output would have been:

```jsx
React.jsx(Component, {\n  children: 1,\n  children: "2"\n})
```

In the above output, the `children` property is duplicated in the object literal expression. In JS strict mode, this can cause errors in certain browsers (notably IE) where an object cannot contain duplicate property keys.

This PR changed the logic, so when this pattern is encountered (explicitly with `children` only) we create a new object and put the `children` property in it and then use `Object.assign` (or whatever the native helper is) to ensure the correct object is formed as an end-result. So the above would output:

```jsx
React.jsx(Component, Object.assign({
  children: 1
}, {
  children: "2"
}));
```