### PR TITLE
DevTools does not eagerly patch console for RN

### DIFF
--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -7,11 +7,6 @@
  * @flow
  */
 
-import {
-  patch as patchConsole,
-  registerRenderer as registerRendererWithConsole,
-} from './backend/console';
-
 import type {DevToolsHook} from 'react-devtools-shared/src/backend/types';
 
 declare var window: any;
@@ -161,32 +156,6 @@ export function installHook(target: any): DevToolsHook | null {
     const reactBuildType = hasDetectedBadDCE
       ? 'deadcode'
       : detectReactBuildType(renderer);
-
-    // Patching the console enables DevTools to do a few useful things:
-    // * Append component stacks to warnings and error messages
-    // * Disable logging during re-renders to inspect hooks (see inspectHooksOfFiber)
-    //
-    // For React Native, we intentionally patch early (during injection).
-    // This provides React Native developers with components stacks even if they don't run DevTools.
-    // This won't work for DOM though, since this entire file is eval'ed and inserted as a script tag.
-    // In that case, we'll patch later (when the frontend attaches).
-    //
-    // Don't patch in test environments because we don't want to interfere with Jest's own console overrides.
-    if (process.env.NODE_ENV !== 'test') {
-      try {
-        // The installHook() function is injected by being stringified in the browser,
-        // so imports outside of this function do not get included.
-        //
-        // Normally we could check "typeof patchConsole === 'function'",
-        // but Webpack wraps imports with an object (e.g. _backend_console__WEBPACK_IMPORTED_MODULE_0__)
-        // and the object itself will be undefined as well for the reasons mentioned above,
-        // so we use try/catch instead.
-        if (window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ !== false) {
-          registerRendererWithConsole(renderer);
-          patchConsole();
-        }
-      } catch (error) {}
-    }
 
     // If we have just reloaded to profile, we need to inject the renderer interface before the app loads.
     // Otherwise the renderer won't yet exist and we can skip this step.


### PR DESCRIPTION
Previously, the DevTools backend eagerly patched the console (to append ["component stacks"](https://github.com/facebook/react/blob/master/packages/react-devtools/CHANGELOG.md#component-stacks) to warnings and errors) even if no DevTools frontend was running. I did this because I thought the components stacks would be very helpful, and a lot of RN developers don't even run the DevTools UI to otherwise get them. (Also there would be no other way to get them for errors logged during mount.)

Unfortunately this had the observable effect of changing the source code line shown for the errors/warnings in debugger tooling (where the actual call to the native `console.error` is made) from `YellowBox.js` (the RN override) to the DevTools `backend.js` script. Some people complained, so this PR removes that default behavior<sup>1</sup>.

This should not affect the browser/DOM extension. I have tested to confirm this in the browser. I tested the change in RN by building the `react-native-core` backend and patching my local version of React Native.

Resolves https://github.com/facebook/react-native/issues/26788

<sup>1</sup> I'm not sure I understand why the previous behavior (of showing the `YellowBox.js` override location) was preferable to showing the DevTools backend. Neither is the location of the original caller. I've asked for clarification on the RN issue. If we decide to remove the DevTools override though, this is the way to do it.