### PR TITLE
Temporary patch www fork with prefixed APIs

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFB.js
+++ b/packages/react-dom/src/client/ReactDOMFB.js
@@ -39,4 +39,12 @@ Object.assign(
   },
 );
 
+// TODO: These are temporary until we update the callers downstream.
+ReactDOM.unstable_createRoot = ReactDOM.createRoot;
+ReactDOM.unstable_createSyncRoot = ReactDOM.createSyncRoot;
+ReactDOM.unstable_interactiveUpdates = (fn, a, b, c) => {
+  ReactDOM.unstable_flushDiscreteUpdates();
+  return ReactDOM.unstable_discreteUpdates(fn, a, b, c);
+};
+
 export default ReactDOM;


### PR DESCRIPTION
I'm doing this here instead of in the downstream repo so that if the sync diff gets reverted, it doesn't revert this, too.

Once the sync has landed, and the callers are updated in www, I will remove this.