### PR TITLE
unstable_createRoot -> createRoot in test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -2526,7 +2526,7 @@ describe('ReactDOMServerPartialHydration', () => {
     container.innerHTML = finalHTML;
 
     suspend = true;
-    let root = ReactDOM.unstable_createRoot(container, {hydrate: true});
+    let root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App showSibling={false} />);
     expect(Scheduler).toFlushAndYield([]);
 


### PR DESCRIPTION
Fixes test added in #17105, which was based on an earlier commit than the one that removed the `unstable_` prefix from `createRoot`.