### PR TITLE
Remove prefixed concurrent APIs from www build

### DIFF
--- a/packages/react-dom/src/client/ReactDOMFB.js
+++ b/packages/react-dom/src/client/ReactDOMFB.js
@@ -39,12 +39,4 @@ Object.assign(
   },
 );
 
-// TODO: These are temporary until we update the callers downstream.
-ReactDOM.unstable_createRoot = ReactDOM.createRoot;
-ReactDOM.unstable_createSyncRoot = ReactDOM.createSyncRoot;
-ReactDOM.unstable_interactiveUpdates = (fn, a, b, c) => {
-  ReactDOM.unstable_flushDiscreteUpdates();
-  return ReactDOM.unstable_discreteUpdates(fn, a, b, c);
-};
-
 export default ReactDOM;


### PR DESCRIPTION
The downstream callers have been updated, so we can remove these.

~~I'll wait a few days before merging this, in case the www diffs get reverted for some reason.~~ I think a day is fine. The sync didn't include any changes other than adding the unprefixed APIs.