### PR TITLE
[react-interactions] Add onFocusWithin event to FocusWithin responder

### DIFF
--- a/packages/react-interactions/events/src/dom/Focus.js
+++ b/packages/react-interactions/events/src/dom/Focus.js
@@ -49,6 +49,7 @@ type FocusEventType = 'focus' | 'blur' | 'focuschange' | 'focusvisiblechange';
 
 type FocusWithinProps = {
   disabled?: boolean,
+  onFocusWithin?: (e: FocusEvent) => void,
   onBlurWithin?: (e: FocusEvent) => void,
   onFocusWithinChange?: boolean => void,
   onFocusWithinVisibleChange?: boolean => void,
@@ -57,7 +58,8 @@ type FocusWithinProps = {
 type FocusWithinEventType =
   | 'focuswithinvisiblechange'
   | 'focuswithinchange'
-  | 'blurwithin';
+  | 'blurwithin'
+  | 'focuswithin';
 
 /**
  * Shared between Focus and FocusWithin
@@ -236,6 +238,26 @@ function dispatchBlurEvents(
   dispatchFocusChange(context, props, false);
   if (state.isFocusVisible) {
     dispatchFocusVisibleChangeEvent(context, props, false);
+  }
+}
+
+function dispatchFocusWithinEvents(
+  context: ReactDOMResponderContext,
+  event: ReactDOMResponderEvent,
+  props: FocusWithinProps,
+  state: FocusState,
+) {
+  const pointerType = state.pointerType;
+  const target = ((state.focusTarget: any): Element | Document) || event.target;
+  const onFocusWithin = (props.onFocusWithin: any);
+  if (isFunction(onFocusWithin)) {
+    const syntheticEvent = createFocusEvent(
+      context,
+      'focuswithin',
+      target,
+      pointerType,
+    );
+    context.dispatchEvent(syntheticEvent, onFocusWithin, DiscreteEvent);
   }
 }
 
@@ -474,6 +496,7 @@ const focusWithinResponderImpl = {
           state.isFocusVisible = isGlobalFocusVisible;
           dispatchFocusWithinVisibleChangeEvent(context, props, state, true);
         }
+        dispatchFocusWithinEvents(context, event, props, state);
         break;
       }
       case 'blur': {


### PR DESCRIPTION
This adds the `onFocusWithin` event callback to the `FocusWithin` event responder. We already have `onBlurWithin` which is required for our rich internal focus management and accessibility component experiments and now we also need `onFocusWithin` so we can properly handle cases where we need to remember the last focused node in the cases where we have to restore focus.