### PR TITLE
[react-interactions] Make events non-passive to allow preventDefault

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -114,11 +114,18 @@ const DEFAULT_PRESS_RETENTION_OFFSET = {
 };
 
 const targetEventTypes = hasPointerEvents
-  ? ['keydown_active', 'pointerdown', 'click_active']
-  : ['keydown_active', 'touchstart', 'mousedown', 'click_active'];
+  ? ['keydown_active', 'pointerdown_active', 'click_active']
+  : ['keydown_active', 'touchstart', 'mousedown_active', 'click_active'];
 
 const rootEventTypes = hasPointerEvents
-  ? ['pointerup', 'pointermove', 'pointercancel', 'click', 'keyup', 'scroll']
+  ? [
+      'pointerup_active',
+      'pointermove',
+      'pointercancel',
+      'click',
+      'keyup',
+      'scroll',
+    ]
   : [
       'click',
       'keyup',
@@ -128,7 +135,7 @@ const rootEventTypes = hasPointerEvents
       'touchcancel',
       // Used as a 'cancel' signal for mouse interactions
       'dragstart',
-      'mouseup',
+      'mouseup_active',
       'touchend',
     ];
 

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -1134,11 +1134,13 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
   it('event.preventDefault works as expected', () => {
     const onPress = jest.fn(e => e.preventDefault());
+    const onPressStart = jest.fn(e => e.preventDefault());
+    const onPressEnd = jest.fn(e => e.preventDefault());
     const preventDefault = jest.fn();
     const buttonRef = React.createRef();
 
     const Component = () => {
-      const listener = usePress({onPress});
+      const listener = usePress({onPress, onPressStart, onPressEnd});
       return <button ref={buttonRef} listeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
@@ -1147,5 +1149,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     target.pointerdown();
     target.pointerup({preventDefault});
     expect(preventDefault).toBeCalled();
+    expect(onPressStart).toBeCalled();
+    expect(onPressEnd).toBeCalled();
   });
 });


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/17113, where I forgot to change the events to be non-passive. Doh. This is a temporary stop-gap still, as we don't plan on keeping this Legacy Press responder around for too much longer.