### PR TITLE
Build script should default to experimental

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,13 @@ jobs:
       - checkout
       - *restore_yarn_cache
       - *run_yarn
-      - run: ./scripts/circleci/add_build_info_json.sh
-      - run: ./scripts/circleci/update_package_versions.sh
-      - run: yarn build
+      - run:
+          environment:
+            RELEASE_CHANNEL: stable
+          command: |
+            ./scripts/circleci/add_build_info_json.sh
+            ./scripts/circleci/update_package_versions.sh
+            yarn build
       - run: echo "stable" >> build/RELEASE_CHANNEL
       - persist_to_workspace:
           root: build

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -25,7 +25,14 @@ const {asyncCopyTo, asyncRimRaf} = require('./utils');
 const codeFrame = require('babel-code-frame');
 const Wrappers = require('./wrappers');
 
-const __EXPERIMENTAL__ = process.env.RELEASE_CHANNEL === 'experimental';
+const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL;
+
+// Default to building in experimental mode. If the release channel is set via
+// an environment variable, then check if it's "experimental".
+const __EXPERIMENTAL__ =
+  typeof RELEASE_CHANNEL === 'string'
+    ? RELEASE_CHANNEL === 'experimental'
+    : true;
 
 // Errors in promises should be fatal.
 let loggedErrors = new Set();


### PR DESCRIPTION
`yarn build` defaults to building in experimental mode. To opt-out, set the `RELEASE_CHANNEL` environment variable to `stable`. This is the same as what we do when running tests via `yarn test`, to make local development easier.