### PR TITLE
Experimental test helper: `it.experimental`

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1292,8 +1292,9 @@ describe('ReactUpdates', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz']);
   });
 
-  if (__EXPERIMENTAL__) {
-    it('delays sync updates inside hidden subtrees in Concurrent Mode', () => {
+  it.experimental(
+    'delays sync updates inside hidden subtrees in Concurrent Mode',
+    () => {
       const container = document.createElement('div');
 
       function Baz() {
@@ -1368,8 +1369,8 @@ describe('ReactUpdates', () => {
         expect(Scheduler).toFlushAndYield(['Bar']);
       }
       expect(hiddenDiv.innerHTML).toBe('<p>bar 1</p>');
-    });
-  }
+    },
+  );
 
   it('can render ridiculously large number of roots without triggering infinite update loop error', () => {
     class Foo extends React.Component {


### PR DESCRIPTION
Special version of Jest's `it` for experimental tests. Tests marked as experimental will run **both** stable and experimental modes. In experimental mode, they work the same as the normal Jest methods. In stable mode, they are **expected to fail**. This means we can detect when a test previously marked as experimental can be un-marked when the feature becomes stable. It also reduces the chances that we accidentally add experimental APIs to the stable builds before we intend.

I added corresponding methods for the focus and skip APIs:

- `fit` -> `fit.experimental`
- `it.only` -> `it.only.experimental` or `it.experimental.only`
- `xit` -> `xit.experimental`
- `it.skip` -> `it.skip.experimental` or `it.experimental.skip`

Since `it` is an alias of `test`, `test.experimental` works, too.

Here's what it will look like when a test marked as experimental passes in stable:

<img width="757" alt="Screen Shot 2019-10-19 at 2 05 25 PM" src="https://user-images.githubusercontent.com/3624098/67151337-ab468180-f279-11e9-9d11-c257a3357a22.png">

I only marked a single test as experimental in this PR, to show that it works. I will convert the others in follow ups.