### PR TITLE
Use a microtask to detect end of event

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -294,12 +294,14 @@ export function requestCurrentTime() {
     return msToExpirationTime(now());
   }
   // We're not inside React, so we may be in the middle of a browser event.
-  if (currentEventTime !== NoWork) {
+  if (currentEventTime === NoWork) {
     // Use the same start time for all updates until we enter React again.
-    return currentEventTime;
+    currentEventTime = msToExpirationTime(now());
+    scheduleCallback(ImmediatePriority, () => {
+      currentEventTime = NoWork;
+      return null;
+    });
   }
-  // This is the first update since React yielded. Compute a new start time.
-  currentEventTime = msToExpirationTime(now());
   return currentEventTime;
 }
 

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -72,7 +72,7 @@ describe('ReactExpiration', () => {
     // Schedule an update.
     ReactNoop.render(<Text text="A" />);
     // Advance the timer.
-    Scheduler.unstable_advanceTime(2000);
+    Scheduler.unstable_advanceCPUBoundTime(2000);
     // Partially flush the the first update, then interrupt it.
     expect(Scheduler).toFlushAndYieldThrough(['A [render]']);
     interrupt();
@@ -100,7 +100,7 @@ describe('ReactExpiration', () => {
     // Now do the same thing again, except this time don't flush any work in
     // between the two updates.
     ReactNoop.render(<Text text="A" />);
-    Scheduler.unstable_advanceTime(2000);
+    Scheduler.unstable_advanceCPUBoundTime(2000);
     expect(Scheduler).toHaveYielded([]);
     expect(ReactNoop.getChildren()).toEqual([span('B')]);
     // Schedule another update.
@@ -137,7 +137,7 @@ describe('ReactExpiration', () => {
       // Schedule an update.
       ReactNoop.render(<Text text="A" />);
       // Advance the timer.
-      Scheduler.unstable_advanceTime(2000);
+      Scheduler.unstable_advanceCPUBoundTime(2000);
       // Partially flush the the first update, then interrupt it.
       expect(Scheduler).toFlushAndYieldThrough(['A [render]']);
       interrupt();
@@ -165,7 +165,7 @@ describe('ReactExpiration', () => {
       // Now do the same thing again, except this time don't flush any work in
       // between the two updates.
       ReactNoop.render(<Text text="A" />);
-      Scheduler.unstable_advanceTime(2000);
+      Scheduler.unstable_advanceCPUBoundTime(2000);
       expect(Scheduler).toHaveYielded([]);
       expect(ReactNoop.getChildren()).toEqual([span('B')]);
 

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -177,4 +177,26 @@ describe('ReactProfiler DevTools integration', () => {
       {name: 'some event', timestamp: eventTime},
     ]);
   });
+
+  it('regression test: #<TODO: add issue number>', () => {
+    function Text({text}) {
+      Scheduler.unstable_yieldValue(text);
+      return text;
+    }
+
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
+
+    root.update(<Text text="A" />);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(root).toMatchRenderedOutput('A');
+
+    Scheduler.unstable_advanceTime(10000);
+    root.update(<Text text="B" />);
+
+    // Update B should not have expired
+    expect(Scheduler).toFlushExpired([]);
+
+    expect(Scheduler).toFlushAndYield(['B']);
+    expect(root).toMatchRenderedOutput('B');
+  });
 });

--- a/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
@@ -211,6 +211,12 @@ export function unstable_advanceTime(ms: number) {
   }
 }
 
+export function unstable_advanceCPUBoundTime(ms: number) {
+  // Advances the time but does not fire events, as if the main thread
+  // is blocked.
+  currentTime += ms;
+}
+
 export function requestPaint() {
   needsPaint = true;
 }

--- a/packages/scheduler/unstable_mock.js
+++ b/packages/scheduler/unstable_mock.js
@@ -18,4 +18,5 @@ export {
   unstable_flushAll,
   unstable_yieldValue,
   unstable_advanceTime,
+  unstable_advanceCPUBoundTime,
 } from './src/SchedulerHostConfig.js';


### PR DESCRIPTION
Updates of like priority that occur within the same browser event are guaranteed to be batched. This is an important guarantee for event emitter or subscription-like patterns where a single browser event can spawn updates on many different components, all of which need to commit consistently.

To do this, we have a heuristic of marking the first "event time" of an update inside an event. Subsequent updates in the same event will reuse the same event time.

At the end of the event, the event time should be cleared. Failing to clear the event time has the effect of "freezing" the timeline, causing weird expiration quirks.

The event time used to be cleared right before entering the render phase. This mostly works, since every update will eventually be followed by a render task. However, it has some flaws: if there's lots of other non-React main thread work in the mean time, subsequent events could get overbatched. The heuristic is also a bit fragile; it happens to be the case that every call to `requestCurrentTime` is accompanied by a render task, but that may not necessarily always be the case, creating a subtle refactor hazard.

Instead of relying on the next render task to reset the current event time, this change schedules a microtask.

I didn't use an actual microtask because React does not currently require a Promise polyfill. Instead, I'm using a Scheduler task at immediate priority, which has almost the same semantics. (There's even an open question of whether we should get rid of Scheduler's "immediate" priority in favor of microtasks, but since it currently exists in the browser proposal, too, we can figure that out later.)

See https://github.com/facebook/react/pull/17159 for context on what prompted this PR