### PR TITLE
Failing test: DevTools hook freezes timeline

### DIFF
--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -177,4 +177,26 @@ describe('ReactProfiler DevTools integration', () => {
       {name: 'some event', timestamp: eventTime},
     ]);
   });
+
+  it('regression test: #<TODO: add issue number>', () => {
+    function Text({text}) {
+      Scheduler.unstable_yieldValue(text);
+      return text;
+    }
+
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
+
+    root.update(<Text text="A" />);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(root).toMatchRenderedOutput('A');
+
+    Scheduler.unstable_advanceTime(10000);
+    root.update(<Text text="B" />);
+
+    // Update B should not have expired
+    expect(Scheduler).toFlushExpired([]);
+
+    expect(Scheduler).toFlushAndYield(['B']);
+    expect(root).toMatchRenderedOutput('B');
+  });
 });


### PR DESCRIPTION
The DevTools hook calls `requestCurrentTime` after the commit phase has ended, which has the accidental consequence of freezing the start time for subsequent updates. If enough time goes by, the next update will instantly expire.

I'll open potential fixes in separate PRs:

1. Use microtask to reset current event time: #17158
2. Don't call `requestCurrentTime` after commit phase has ended: #17160