### PR TITLE
Rename createSyncRoot to createBlockingRoot

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -180,7 +180,7 @@ describe('React hooks DevTools integration', () => {
     }
   });
 
-  it('should support overriding suspense in sync mode', () => {
+  it('should support overriding suspense in legacy mode', () => {
     if (__DEV__) {
       // Lock the first render
       setSuspenseHandler(() => true);

--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/storeStressSync-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/storeStressSync-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 1`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 1`] = `
 [root]
   ▾ <Root>
       <X>
@@ -9,7 +9,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 2`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 2`] = `
 [root]
   ▾ <Root>
       <X>
@@ -18,69 +18,69 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 3`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <A key="a">
-        <B key="b">
-        <C key="c">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 4`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <B key="b">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 5`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 6`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 7`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 8`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 3`] = `
 [root]
   ▾ <Root>
       <X>
     ▾ <Suspense>
         <A key="a">
         <B key="b">
+        <C key="c">
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 9`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 4`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <B key="b">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 5`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 6`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 7`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 8`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+        <B key="b">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 9`] = `
 [root]
   ▾ <Root>
       <X>
@@ -89,7 +89,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 10`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 10`] = `
 [root]
   ▾ <Root>
       <X>
@@ -97,7 +97,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 11`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 11`] = `
 [root]
   ▾ <Root>
       <X>
@@ -106,7 +106,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync Mode) 12`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense (Legacy Mode) 12`] = `
 [root]
   ▾ <Root>
       <X>
@@ -115,7 +115,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense (Sync 
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 1`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 1`] = `
 [root]
   ▾ <Root>
       <X>
@@ -126,7 +126,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 2`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 2`] = `
 [root]
   ▾ <Root>
       <X>
@@ -137,7 +137,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 3`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 3`] = `
 [root]
   ▾ <Root>
       <X>
@@ -150,7 +150,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 4`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 4`] = `
 [root]
   ▾ <Root>
       <X>
@@ -163,7 +163,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 5`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 5`] = `
 [root]
   ▾ <Root>
       <X>
@@ -175,7 +175,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 6`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 6`] = `
 [root]
   ▾ <Root>
       <X>
@@ -187,7 +187,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 7`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 7`] = `
 [root]
   ▾ <Root>
       <X>
@@ -199,7 +199,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 8`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 8`] = `
 [root]
   ▾ <Root>
       <X>
@@ -211,7 +211,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 9`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 9`] = `
 [root]
   ▾ <Root>
       <X>
@@ -222,7 +222,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 10`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 10`] = `
 [root]
   ▾ <Root>
       <X>
@@ -232,7 +232,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 11`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 11`] = `
 [root]
   ▾ <Root>
       <X>
@@ -243,7 +243,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 12`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 12`] = `
 [root]
   ▾ <Root>
       <X>
@@ -254,7 +254,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 13`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 13`] = `
 [root]
   ▾ <Root>
       <X>
@@ -263,7 +263,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 14`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 14`] = `
 [root]
   ▾ <Root>
       <X>
@@ -272,69 +272,69 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 15`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <A key="a">
-        <B key="b">
-        <C key="c">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 16`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <B key="b">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 17`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 18`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 19`] = `
-[root]
-  ▾ <Root>
-      <X>
-    ▾ <Suspense>
-        <C key="c">
-        <A key="a">
-      <Y>
-`;
-
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 20`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 15`] = `
 [root]
   ▾ <Root>
       <X>
     ▾ <Suspense>
         <A key="a">
         <B key="b">
+        <C key="c">
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 21`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 16`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <B key="b">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 17`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 18`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 19`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <C key="c">
+        <A key="a">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 20`] = `
+[root]
+  ▾ <Root>
+      <X>
+    ▾ <Suspense>
+        <A key="a">
+        <B key="b">
+      <Y>
+`;
+
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 21`] = `
 [root]
   ▾ <Root>
       <X>
@@ -343,7 +343,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 22`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 22`] = `
 [root]
   ▾ <Root>
       <X>
@@ -351,7 +351,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 23`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 23`] = `
 [root]
   ▾ <Root>
       <X>
@@ -360,7 +360,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test for Suspense without type change (Sync Mode) 24`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test for Suspense without type change (Legacy Mode) 24`] = `
 [root]
   ▾ <Root>
       <X>
@@ -369,7 +369,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test for Suspense withou
       <Y>
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test with different tree operations (Sync Mode): 1: abcde 1`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test with different tree operations (Legacy Mode): 1: abcde 1`] = `
 [root]
   ▾ <Parent>
       <A key="a">
@@ -379,7 +379,7 @@ exports[`StoreStress (Sync Mode) should handle a stress test with different tree
       <E key="e">
 `;
 
-exports[`StoreStress (Sync Mode) should handle a stress test with different tree operations (Sync Mode): 2: abxde 1`] = `
+exports[`StoreStress (Legacy Mode) should handle a stress test with different tree operations (Legacy Mode): 2: abxde 1`] = `
 [root]
   ▾ <Parent>
       <A key="a">
@@ -390,102 +390,102 @@ exports[`StoreStress (Sync Mode) should handle a stress test with different tree
       <E key="e">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 1`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 1`] = `
 [root]
   ▾ <Root>
       <A key="a">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 2`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 2`] = `
 [root]
   ▾ <Root>
       <B key="b">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 3`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 3`] = `
 [root]
   ▾ <Root>
       <C key="c">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 4`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 4`] = `
 [root]
   ▾ <Root>
       <D key="d">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 5`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 5`] = `
 [root]
   ▾ <Root>
       <E key="e">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 6`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 6`] = `
 [root]
   ▾ <Root>
       <A key="a">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 7`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 7`] = `
 [root]
   ▾ <Root>
       <B key="b">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 8`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 8`] = `
 [root]
   ▾ <Root>
       <C key="c">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 9`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 9`] = `
 [root]
   ▾ <Root>
       <D key="d">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 10`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 10`] = `
 [root]
   ▾ <Root>
       <E key="e">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 11`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 11`] = `
 [root]
   ▾ <Root>
       <A key="a">
       <B key="b">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 12`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 12`] = `
 [root]
   ▾ <Root>
       <B key="b">
       <A key="a">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 13`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 13`] = `
 [root]
   ▾ <Root>
       <B key="b">
       <C key="c">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 14`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 14`] = `
 [root]
   ▾ <Root>
       <C key="c">
       <B key="b">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 15`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 15`] = `
 [root]
   ▾ <Root>
       <A key="a">
       <C key="c">
 `;
 
-exports[`StoreStress (Sync Mode) should handle stress test with reordering (Sync Mode) 16`] = `
+exports[`StoreStress (Legacy Mode) should handle stress test with reordering (Legacy Mode) 16`] = `
 [root]
   ▾ <Root>
       <C key="c">

--- a/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-describe('StoreStress (Sync Mode)', () => {
+describe('StoreStress (Legacy Mode)', () => {
   let React;
   let ReactDOM;
   let act;
@@ -29,7 +29,7 @@ describe('StoreStress (Sync Mode)', () => {
 
   // This is a stress test for the tree mount/update/unmount traversal.
   // It renders different trees that should produce the same output.
-  it('should handle a stress test with different tree operations (Sync Mode)', () => {
+  it('should handle a stress test with different tree operations (Legacy Mode)', () => {
     let setShowX;
     const A = () => 'a';
     const B = () => 'b';
@@ -170,7 +170,7 @@ describe('StoreStress (Sync Mode)', () => {
     expect(print(store)).toBe('');
   });
 
-  it('should handle stress test with reordering (Sync Mode)', () => {
+  it('should handle stress test with reordering (Legacy Mode)', () => {
     const A = () => 'a';
     const B = () => 'b';
     const C = () => 'c';
@@ -270,7 +270,7 @@ describe('StoreStress (Sync Mode)', () => {
     }
   });
 
-  it('should handle a stress test for Suspense (Sync Mode)', async () => {
+  it('should handle a stress test for Suspense (Legacy Mode)', async () => {
     const A = () => 'a';
     const B = () => 'b';
     const C = () => 'c';
@@ -663,7 +663,7 @@ describe('StoreStress (Sync Mode)', () => {
     }
   });
 
-  it('should handle a stress test for Suspense without type change (Sync Mode)', () => {
+  it('should handle a stress test for Suspense without type change (Legacy Mode)', () => {
     const A = () => 'a';
     const B = () => 'b';
     const C = () => 'c';

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -575,9 +575,9 @@ describe('ReactDOMFiberAsync', () => {
       });
     });
 
-    describe('createSyncRoot', () => {
+    describe('createBlockingRoot', () => {
       it('updates flush without yielding in the next event', () => {
-        const root = ReactDOM.createSyncRoot(container);
+        const root = ReactDOM.createBlockingRoot(container);
 
         function Text(props) {
           Scheduler.unstable_yieldValue(props.text);

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -344,7 +344,7 @@ describe('ReactDOMServerPartialHydration', () => {
     }).toWarnDev(
       'Warning: Cannot hydrate Suspense in legacy mode. Switch from ' +
         'ReactDOM.hydrate(element, container) to ' +
-        'ReactDOM.createSyncRoot(container, { hydrate: true })' +
+        'ReactDOM.createBlockingRoot(container, { hydrate: true })' +
         '.render(element) or remove the Suspense components from the server ' +
         'rendered components.' +
         '\n    in Suspense (at **)' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -126,7 +126,7 @@ describe('ReactDOMServerSuspense', () => {
     expect(divB.textContent).toBe('B');
 
     ReactTestUtils.act(() => {
-      const root = ReactDOM.createSyncRoot(parent, {hydrate: true});
+      const root = ReactDOM.createBlockingRoot(parent, {hydrate: true});
       root.render(example);
     });
 

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -53,45 +53,50 @@ describe('ReactTestUtils.act()', () => {
     );
   }
 
-  // and then in sync mode
+  // and then in legacy mode
 
-  let syncDom = null;
-  function renderSync(el, dom) {
-    syncDom = dom;
+  let legacyDom = null;
+  function renderLegacy(el, dom) {
+    legacyDom = dom;
     ReactDOM.render(el, dom);
   }
 
-  function unmountSync(dom) {
-    syncDom = null;
+  function unmountLegacy(dom) {
+    legacyDom = null;
     ReactDOM.unmountComponentAtNode(dom);
   }
 
-  function rerenderSync(el) {
-    ReactDOM.render(el, syncDom);
+  function rerenderLegacy(el) {
+    ReactDOM.render(el, legacyDom);
   }
 
-  runActTests('legacy sync mode', renderSync, unmountSync, rerenderSync);
+  runActTests('legacy mode', renderLegacy, unmountLegacy, rerenderLegacy);
 
-  // and then in batched mode
+  // and then in blocking mode
   if (__EXPERIMENTAL__) {
-    let batchedRoot = null;
+    let blockingRoot = null;
     const renderBatched = (el, dom) => {
-      batchedRoot = ReactDOM.createSyncRoot(dom);
-      batchedRoot.render(el);
+      blockingRoot = ReactDOM.createBlockingRoot(dom);
+      blockingRoot.render(el);
     };
 
     const unmountBatched = dom => {
-      if (batchedRoot !== null) {
-        batchedRoot.unmount();
-        batchedRoot = null;
+      if (blockingRoot !== null) {
+        blockingRoot.unmount();
+        blockingRoot = null;
       }
     };
 
     const rerenderBatched = el => {
-      batchedRoot.render(el);
+      blockingRoot.render(el);
     };
 
-    runActTests('batched mode', renderBatched, unmountBatched, rerenderBatched);
+    runActTests(
+      'blocking mode',
+      renderBatched,
+      unmountBatched,
+      rerenderBatched,
+    );
   }
 
   describe('unacted effects', () => {
@@ -100,7 +105,7 @@ describe('ReactTestUtils.act()', () => {
       return null;
     }
 
-    it('does not warn in legacy sync mode', () => {
+    it('does not warn in legacy mode', () => {
       expect(() => {
         ReactDOM.render(<App />, document.createElement('div'));
       }).toWarnDev([]);
@@ -121,9 +126,11 @@ describe('ReactTestUtils.act()', () => {
     });
 
     if (__EXPERIMENTAL__) {
-      it('warns in batched mode', () => {
+      it('warns in blocking mode', () => {
         expect(() => {
-          const root = ReactDOM.createSyncRoot(document.createElement('div'));
+          const root = ReactDOM.createBlockingRoot(
+            document.createElement('div'),
+          );
           root.render(<App />);
           Scheduler.unstable_flushAll();
         }).toWarnDev([

--- a/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.internal.js
@@ -28,7 +28,7 @@ afterEach(() => {
   ReactFeatureFlags.warnAboutUnmockedScheduler = false;
 });
 
-it('should warn in sync mode', () => {
+it('should warn in legacy mode', () => {
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
   }).toWarnDev(

--- a/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
   ReactDOM = require('react-dom');
 });
 
-it('does not warn when rendering in sync mode', () => {
+it('does not warn when rendering in legacy mode', () => {
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
   }).toWarnDev([]);
@@ -42,9 +42,11 @@ if (__EXPERIMENTAL__) {
     }).toWarnDev([]);
   });
 
-  it('should warn when rendering in batched mode', () => {
+  it('should warn when rendering in blocking mode', () => {
     expect(() => {
-      ReactDOM.createSyncRoot(document.createElement('div')).render(<App />);
+      ReactDOM.createBlockingRoot(document.createElement('div')).render(
+        <App />,
+      );
     }).toWarnDev(
       'In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' +
         'to guarantee consistent behaviour across tests and browsers.',
@@ -52,7 +54,9 @@ if (__EXPERIMENTAL__) {
     );
     // does not warn twice
     expect(() => {
-      ReactDOM.createSyncRoot(document.createElement('div')).render(<App />);
+      ReactDOM.createBlockingRoot(document.createElement('div')).render(
+        <App />,
+      );
     }).toWarnDev([]);
   });
 }

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1099,7 +1099,7 @@ describe('ReactUpdates', () => {
   });
 
   it(
-    'in sync mode, updates in componentWillUpdate and componentDidUpdate ' +
+    'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       'should both flush in the immediately subsequent commit',
     () => {
       let ops = [];
@@ -1142,7 +1142,7 @@ describe('ReactUpdates', () => {
   );
 
   it(
-    'in sync mode, updates in componentWillUpdate and componentDidUpdate ' +
+    'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       '(on a sibling) should both flush in the immediately subsequent commit',
     () => {
       let ops = [];

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -209,7 +209,7 @@ function createRootImpl(
   return root;
 }
 
-function ReactSyncRoot(
+function ReactBlockingRoot(
   container: DOMContainer,
   tag: RootTag,
   options: void | RootOptions,
@@ -221,7 +221,7 @@ function ReactRoot(container: DOMContainer, options: void | RootOptions) {
   this._internalRoot = createRootImpl(container, ConcurrentRoot, options);
 }
 
-ReactRoot.prototype.render = ReactSyncRoot.prototype.render = function(
+ReactRoot.prototype.render = ReactBlockingRoot.prototype.render = function(
   children: ReactNodeList,
   callback: ?() => mixed,
 ): void {
@@ -233,7 +233,7 @@ ReactRoot.prototype.render = ReactSyncRoot.prototype.render = function(
   updateContainer(children, root, null, callback);
 };
 
-ReactRoot.prototype.unmount = ReactSyncRoot.prototype.unmount = function(
+ReactRoot.prototype.unmount = ReactBlockingRoot.prototype.unmount = function(
   callback: ?() => mixed,
 ): void {
   const root = this._internalRoot;
@@ -334,7 +334,7 @@ function legacyCreateRootFromDOMContainer(
   }
 
   // Legacy roots are not batched.
-  return new ReactSyncRoot(
+  return new ReactBlockingRoot(
     container,
     LegacyRoot,
     shouldHydrate
@@ -636,7 +636,7 @@ function createRoot(
   return new ReactRoot(container, options);
 }
 
-function createSyncRoot(
+function createBlockingRoot(
   container: DOMContainer,
   options?: RootOptions,
 ): _ReactRoot {
@@ -645,7 +645,7 @@ function createSyncRoot(
     'createRoot(...): Target container is not a DOM element.',
   );
   warnIfReactDOMContainerInDEV(container);
-  return new ReactSyncRoot(container, BatchedRoot, options);
+  return new ReactBlockingRoot(container, BatchedRoot, options);
 }
 
 function warnIfReactDOMContainerInDEV(container) {
@@ -661,7 +661,7 @@ function warnIfReactDOMContainerInDEV(container) {
 
 if (exposeConcurrentModeAPIs) {
   ReactDOM.createRoot = createRoot;
-  ReactDOM.createSyncRoot = createSyncRoot;
+  ReactDOM.createBlockingRoot = createBlockingRoot;
 
   ReactDOM.unstable_discreteUpdates = discreteUpdates;
   ReactDOM.unstable_flushDiscreteUpdates = flushDiscreteUpdates;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -944,7 +944,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       };
     },
 
-    createSyncRoot() {
+    createBlockingRoot() {
       const container = {
         rootID: '' + idCounter++,
         pendingChildren: [],

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -74,7 +74,7 @@ import {
   ConcurrentMode,
   ProfileMode,
   StrictMode,
-  BatchedMode,
+  BlockingMode,
 } from './ReactTypeOfMode';
 import {
   REACT_FORWARD_REF_TYPE,
@@ -573,9 +573,9 @@ export function resetWorkInProgress(
 export function createHostRootFiber(tag: RootTag): Fiber {
   let mode;
   if (tag === ConcurrentRoot) {
-    mode = ConcurrentMode | BatchedMode | StrictMode;
+    mode = ConcurrentMode | BlockingMode | StrictMode;
   } else if (tag === BatchedRoot) {
-    mode = BatchedMode | StrictMode;
+    mode = BlockingMode | StrictMode;
   } else {
     mode = NoMode;
   }
@@ -627,7 +627,7 @@ export function createFiberFromTypeAndProps(
         );
       case REACT_CONCURRENT_MODE_TYPE:
         fiberTag = Mode;
-        mode |= ConcurrentMode | BatchedMode | StrictMode;
+        mode |= ConcurrentMode | BlockingMode | StrictMode;
         break;
       case REACT_STRICT_MODE_TYPE:
         fiberTag = Mode;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -103,7 +103,7 @@ import {
   NoMode,
   ProfileMode,
   StrictMode,
-  BatchedMode,
+  BlockingMode,
 } from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
@@ -1626,8 +1626,8 @@ function updateSuspenseComponent(
       );
       primaryChildFragment.return = workInProgress;
 
-      if ((workInProgress.mode & BatchedMode) === NoMode) {
-        // Outside of batched mode, we commit the effects from the
+      if ((workInProgress.mode & BlockingMode) === NoMode) {
+        // Outside of blocking mode, we commit the effects from the
         // partially completed, timed-out tree, too.
         const progressedState: SuspenseState = workInProgress.memoizedState;
         const progressedPrimaryChild: Fiber | null =
@@ -1712,8 +1712,8 @@ function updateSuspenseComponent(
             // that we're not going to hydrate.
             primaryChildFragment.child = null;
 
-            if ((workInProgress.mode & BatchedMode) === NoMode) {
-              // Outside of batched mode, we commit the effects from the
+            if ((workInProgress.mode & BlockingMode) === NoMode) {
+              // Outside of blocking mode, we commit the effects from the
               // partially completed, timed-out tree, too.
               let progressedChild = (primaryChildFragment.child =
                 workInProgress.child);
@@ -1781,8 +1781,8 @@ function updateSuspenseComponent(
         );
         primaryChildFragment.return = workInProgress;
 
-        if ((workInProgress.mode & BatchedMode) === NoMode) {
-          // Outside of batched mode, we commit the effects from the
+        if ((workInProgress.mode & BlockingMode) === NoMode) {
+          // Outside of blocking mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;
           const progressedPrimaryChild: Fiber | null =
@@ -1876,8 +1876,8 @@ function updateSuspenseComponent(
         // schedule a placement.
         // primaryChildFragment.effectTag |= Placement;
 
-        if ((workInProgress.mode & BatchedMode) === NoMode) {
-          // Outside of batched mode, we commit the effects from the
+        if ((workInProgress.mode & BlockingMode) === NoMode) {
+          // Outside of blocking mode, we commit the effects from the
           // partially completed, timed-out tree, too.
           const progressedState: SuspenseState = workInProgress.memoizedState;
           const progressedPrimaryChild: Fiber | null =
@@ -1966,13 +1966,13 @@ function mountDehydratedSuspenseComponent(
 ): null | Fiber {
   // During the first pass, we'll bail out and not drill into the children.
   // Instead, we'll leave the content in place and try to hydrate it later.
-  if ((workInProgress.mode & BatchedMode) === NoMode) {
+  if ((workInProgress.mode & BlockingMode) === NoMode) {
     if (__DEV__) {
       warning(
         false,
         'Cannot hydrate Suspense in legacy mode. Switch from ' +
           'ReactDOM.hydrate(element, container) to ' +
-          'ReactDOM.createSyncRoot(container, { hydrate: true })' +
+          'ReactDOM.createBlockingRoot(container, { hydrate: true })' +
           '.render(element) or remove the Suspense components from ' +
           'the server rendered components.',
       );
@@ -2019,7 +2019,7 @@ function updateDehydratedSuspenseComponent(
   // but after we've already committed once.
   warnIfHydrating();
 
-  if ((workInProgress.mode & BatchedMode) === NoMode) {
+  if ((workInProgress.mode & BlockingMode) === NoMode) {
     return retrySuspenseComponentWithoutHydrating(
       current,
       workInProgress,
@@ -2433,8 +2433,8 @@ function updateSuspenseListComponent(
   }
   pushSuspenseContext(workInProgress, suspenseContext);
 
-  if ((workInProgress.mode & BatchedMode) === NoMode) {
-    // Outside of batched mode, SuspenseList doesn't work so we just
+  if ((workInProgress.mode & BlockingMode) === NoMode) {
+    // Outside of blocking mode, SuspenseList doesn't work so we just
     // use make it a noop by treating it as the default revealOrder.
     workInProgress.memoizedState = null;
   } else {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -52,7 +52,7 @@ import {
   FundamentalComponent,
   ScopeComponent,
 } from 'shared/ReactWorkTags';
-import {NoMode, BatchedMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {
   Ref,
   Update,
@@ -899,12 +899,12 @@ function completeWork(
       }
 
       if (nextDidTimeout && !prevDidTimeout) {
-        // If this subtreee is running in batched mode we can suspend,
+        // If this subtreee is running in blocking mode we can suspend,
         // otherwise we won't suspend.
         // TODO: This will still suspend a synchronous tree if anything
         // in the concurrent tree already suspended during this render.
         // This is a known bug.
-        if ((workInProgress.mode & BatchedMode) !== NoMode) {
+        if ((workInProgress.mode & BlockingMode) !== NoMode) {
           // TODO: Move this back to throwException because this is too late
           // if this is a large tree which is common for initial loads. We
           // don't know if we should restart a render or not until we get

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -30,7 +30,7 @@ import {
   ShouldCapture,
   LifecycleEffectMask,
 } from 'shared/ReactSideEffectTags';
-import {NoMode, BatchedMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent';
 
 import {createCapturedValue} from './ReactCapturedValue';
@@ -222,15 +222,15 @@ function throwException(
           thenables.add(thenable);
         }
 
-        // If the boundary is outside of batched mode, we should *not*
+        // If the boundary is outside of blocking mode, we should *not*
         // suspend the commit. Pretend as if the suspended component rendered
         // null and keep rendering. In the commit phase, we'll schedule a
         // subsequent synchronous update to re-render the Suspense.
         //
         // Note: It doesn't matter whether the component that suspended was
-        // inside a batched mode tree. If the Suspense is outside of it, we
+        // inside a blocking mode tree. If the Suspense is outside of it, we
         // should *not* suspend the commit.
-        if ((workInProgress.mode & BatchedMode) === NoMode) {
+        if ((workInProgress.mode & BlockingMode) === NoMode) {
           workInProgress.effectTag |= DidCapture;
 
           // We're going to commit this fiber even though it didn't complete.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -74,7 +74,7 @@ import {
   NoMode,
   StrictMode,
   ProfileMode,
-  BatchedMode,
+  BlockingMode,
   ConcurrentMode,
 } from './ReactTypeOfMode';
 import {
@@ -313,7 +313,7 @@ export function computeExpirationForFiber(
   suspenseConfig: null | SuspenseConfig,
 ): ExpirationTime {
   const mode = fiber.mode;
-  if ((mode & BatchedMode) === NoMode) {
+  if ((mode & BlockingMode) === NoMode) {
     return Sync;
   }
 
@@ -413,7 +413,7 @@ export function scheduleUpdateOnFiber(
         // a batch. This is intentionally inside scheduleUpdateOnFiber instead of
         // scheduleCallbackForFiber to preserve the ability to schedule a callback
         // without immediately flushing it. We only do this for user-initiated
-        // updates, to preserve historical behavior of sync mode.
+        // updates, to preserve historical behavior of legacy mode.
         flushSyncCallbackQueue();
       }
     }
@@ -2801,7 +2801,7 @@ export function warnIfUnmockedScheduler(fiber: Fiber) {
       didWarnAboutUnmockedScheduler === false &&
       Scheduler.unstable_flushAllWithoutAsserting === undefined
     ) {
-      if (fiber.mode & BatchedMode || fiber.mode & ConcurrentMode) {
+      if (fiber.mode & BlockingMode || fiber.mode & ConcurrentMode) {
         didWarnAboutUnmockedScheduler = true;
         warningWithoutStack(
           false,

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -11,8 +11,8 @@ export type TypeOfMode = number;
 
 export const NoMode = 0b0000;
 export const StrictMode = 0b0001;
-// TODO: Remove BatchedMode and ConcurrentMode by reading from the root
+// TODO: Remove BlockingMode and ConcurrentMode by reading from the root
 // tag instead
-export const BatchedMode = 0b0010;
+export const BlockingMode = 0b0010;
 export const ConcurrentMode = 0b0100;
 export const ProfileMode = 0b1000;

--- a/packages/react-reconciler/src/__tests__/ReactBatchedMode-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactBatchedMode-test.internal.js
@@ -6,7 +6,7 @@ let ReactCache;
 let Suspense;
 let TextResource;
 
-describe('ReactBatchedMode', () => {
+describe('ReactBlockingMode', () => {
   beforeEach(() => {
     jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
@@ -50,7 +50,7 @@ describe('ReactBatchedMode', () => {
   }
 
   it('updates flush without yielding in the next event', () => {
-    const root = ReactNoop.createSyncRoot();
+    const root = ReactNoop.createBlockingRoot();
 
     root.render(
       <>
@@ -78,7 +78,7 @@ describe('ReactBatchedMode', () => {
       return <Text text="Hi" />;
     }
 
-    const root = ReactNoop.createSyncRoot();
+    const root = ReactNoop.createBlockingRoot();
     root.render(<App />);
     expect(root).toMatchRenderedOutput(null);
 
@@ -87,7 +87,7 @@ describe('ReactBatchedMode', () => {
   });
 
   it('uses proper Suspense semantics, not legacy ones', async () => {
-    const root = ReactNoop.createSyncRoot();
+    const root = ReactNoop.createBlockingRoot();
     root.render(
       <Suspense fallback={<Text text="Loading..." />}>
         <span>
@@ -122,7 +122,7 @@ describe('ReactBatchedMode', () => {
 
   it('flushSync does not flush batched work', () => {
     const {useState, forwardRef, useImperativeHandle} = React;
-    const root = ReactNoop.createSyncRoot();
+    const root = ReactNoop.createBlockingRoot();
 
     const Foo = forwardRef(({label}, ref) => {
       const [step, setStep] = useState(0);

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1056,7 +1056,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         }
         act(() => {
           ReactNoop.renderLegacySyncRoot(<Counter count={0} />);
-          // Even in sync mode, effects are deferred until after paint
+          // Even in legacy mode, effects are deferred until after paint
           expect(Scheduler).toFlushAndYieldThrough(['Count: (empty)']);
           expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
         });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -197,7 +197,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(Scheduler).toFlushAndYieldThrough([
       'Indirection',
       // Now that the tree is complete, and there's no remaining work, React
-      // reverts to sync mode to retry one more time before handling the error.
+      // reverts to legacy mode to retry one more time before handling the error.
 
       'ErrorBoundary (try)',
       'Indirection',

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -970,7 +970,7 @@ describe('ReactSuspense', () => {
       expect(root).toMatchRenderedOutput('Step: 3');
     });
 
-    it('does not remount the fallback while suspended children resolve in sync mode', () => {
+    it('does not remount the fallback while suspended children resolve in legacy mode', () => {
       let mounts = 0;
       class ShouldMountOnce extends React.Component {
         componentDidMount() {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -177,7 +177,7 @@ describe('ReactSuspenseFuzz', () => {
       ReactNoop.renderLegacySyncRoot(null);
 
       resetCache();
-      const batchedBlockingRoot = ReactNoop.createSyncRoot();
+      const batchedBlockingRoot = ReactNoop.createBlockingRoot();
       batchedBlockingRoot.render(children);
       resolveAllTasks();
       const batchedSyncOutput = batchedBlockingRoot.getChildrenAsJSX();

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -177,10 +177,10 @@ describe('ReactSuspenseFuzz', () => {
       ReactNoop.renderLegacySyncRoot(null);
 
       resetCache();
-      const batchedSyncRoot = ReactNoop.createSyncRoot();
-      batchedSyncRoot.render(children);
+      const batchedBlockingRoot = ReactNoop.createSyncRoot();
+      batchedBlockingRoot.render(children);
       resolveAllTasks();
-      const batchedSyncOutput = batchedSyncRoot.getChildrenAsJSX();
+      const batchedSyncOutput = batchedBlockingRoot.getChildrenAsJSX();
       expect(batchedSyncOutput).toEqual(expectedOutput);
 
       resetCache();

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -69,7 +69,7 @@ export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;
 
 // We will enforce mocking scheduler with scheduler/unstable_mock at some point. (v17?)
-// Till then, we warn about the missing mock, but still fallback to a sync mode compatible version
+// Till then, we warn about the missing mock, but still fallback to a legacy mode compatible version
 export const warnAboutUnmockedScheduler = false;
 
 // For tests, we flush suspense fallbacks in an act scope;


### PR DESCRIPTION
"Sync" is easy to confuse with the Legacy mode. It also might sound too positive.

While I'm renaming `createSyncRoot` to `createBlockingRoot`, I also did some find-and-replace in comments and internal naming. Let's standardize on:

* Legacy Mode: The old one.
* Blocking Mode: createBlockingRoot
* Concurrent Mode: createRoot