### PR TITLE
Add CodeSandbox CI Config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,scheduler/index",
+  "buildCommand": "build --type=NODE react/index,react-dom/index,scheduler/index,scheduler/tracing",
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["packages/react", "packages/react-dom"],
+  "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
   "buildCommand": "build --type=NODE react/index,react-dom/index,scheduler/index",
   "publishDirectory": {
     "react": "build/node_modules/react",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,8 @@
+{
+  "packages": ["packages/react", "packages/react-dom"],
+  "buildCommand": "build react/index,react-dom/index",
+  "publishDirectory": {
+    "react": "build/node_modules/react",
+    "react-dom": "build/node_modules/react-dom"
+  }
+}

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,9 +1,10 @@
 {
   "packages": ["packages/react", "packages/react-dom"],
-  "buildCommand": "build react/index,react-dom/index",
+  "buildCommand": "build --type=NODE react/index,react-dom/index,scheduler/index",
   "publishDirectory": {
     "react": "build/node_modules/react",
-    "react-dom": "build/node_modules/react-dom"
+    "react-dom": "build/node_modules/react-dom",
+    "scheduler": "build/node_modules/scheduler"
   },
   "sandboxes": ["new"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -4,5 +4,6 @@
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom"
-  }
+  },
+  "sandboxes": ["new"]
 }


### PR DESCRIPTION
This will enable [CodeSandbox CI](https://ci.codesandbox.io) on the React repo. To have a better idea of what CodeSandbox CI does you can read more about it here: https://u2edh.csb.app/. I recommend merging this PR first before installing the GitHub App, to ensure that all future PRs will work from the get-go.

The gist of it is:

The goal of this app is to make it easier for you to test your library without publishing to npm yet. Since CodeSandbox is already used for bug reports we wanted to make it possible to also test the PR version of your library with the existing bug reports.

In an ideal flow, it would work like this:

1. Someone opens an issue for a bug with a sandbox reproducible
2. Someone opens a fix PR mentioning the issue
3. We build the library from the PR, fork the sandbox repro and install the new library in that sandbox
This way you will only have to open the generated sandbox to confirm that the fix works. No need to clone, install or test locally.