### PR TITLE
fix: do not invoke function-like values in useDeferredValue

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1132,14 +1132,14 @@ function mountDeferredValue<T>(
   value: T,
   config: TimeoutConfig | void | null,
 ): T {
-  const [prevValue, setValue] = mountState(value);
+  const [prevValue, setValue] = mountState(() => value);
   mountEffect(
     () => {
       Scheduler.unstable_next(() => {
         const previousConfig = ReactCurrentBatchConfig.suspense;
         ReactCurrentBatchConfig.suspense = config === undefined ? null : config;
         try {
-          setValue(value);
+          setValue(() => value);
         } finally {
           ReactCurrentBatchConfig.suspense = previousConfig;
         }
@@ -1154,14 +1154,14 @@ function updateDeferredValue<T>(
   value: T,
   config: TimeoutConfig | void | null,
 ): T {
-  const [prevValue, setValue] = updateState(value);
+  const [prevValue, setValue] = updateState(() => value);
   updateEffect(
     () => {
       Scheduler.unstable_next(() => {
         const previousConfig = ReactCurrentBatchConfig.suspense;
         ReactCurrentBatchConfig.suspense = config === undefined ? null : config;
         try {
-          setValue(value);
+          setValue(() => value);
         } finally {
           ReactCurrentBatchConfig.suspense = previousConfig;
         }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -2179,6 +2179,49 @@ describe('ReactHooksWithNoopRenderer', () => {
         expect(ReactNoop.getChildren()).toEqual([span('B'), span('B')]);
       });
     });
+
+    it('preserves function values', async () => {
+      let _setFunc;
+      function App() {
+        const [func, setFunc] = useState(() => () => 'A');
+        const deferredFunc = useDeferredValue(func, {
+          timeoutMs: 500,
+        });
+        _setFunc = setFunc;
+        return deferredFunc();
+      }
+
+      act(() => {
+        ReactNoop.render(<App />);
+      });
+
+      expect(ReactNoop.getChildren()).toEqual([{hidden: false, text: 'A'}]);
+
+      act(() => {
+        _setFunc(() => () => 'B');
+      });
+
+      expect(ReactNoop.getChildren()).toEqual([{hidden: false, text: 'B'}]);
+    });
+
+    it('does not invoke constructors', async () => {
+      let _setClass;
+      function App() {
+        const [klass, setClass] = useState(() => class {});
+        useDeferredValue(klass, {
+          timeoutMs: 500,
+        });
+        _setClass = setClass;
+        return null;
+      }
+
+      act(() => {
+        ReactNoop.render(<App />);
+      });
+      act(() => {
+        _setClass(() => class {});
+      });
+    });
   }
   describe('progressive enhancement (not supported)', () => {
     it('mount additional state', () => {


### PR DESCRIPTION
When reading the code I noticed that, because the `State` hook is used internally in the implementation, trying to hold a function or class value as a `DeferredValue` would cause it to be invoked as a lazy initializer, or updater function.

This fixes it by using a closure. I considered using a `typeof` check, but I'm not sure if adding the extra branches is useful. The branch could potentially avoid creating a closure on the common case, though. Not sure which is the best trade-off.