### PR TITLE
[react-interactions] Disable event listener guarding for Flare

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -328,7 +328,10 @@ export function dispatchEvent(
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
 ): void {
-  if (!_enabled) {
+  // For Flare, need "blur" and "focus" events to fire in React
+  // for mutations to DOM nodes. Without this, it's not possible
+  // to appropiately address a11y related focus management problems.
+  if (!_enabled && eventSystemFlags & PLUGIN_EVENT_SYSTEM) {
     return;
   }
   if (hasQueuedDiscreteEvents() && isReplayableDiscreteEvent(topLevelType)) {


### PR DESCRIPTION
I stumbled across a big internal issue relating to handling accessibility related focus management controls.

Specifically, we want to be able to track events that fire `focus` or `blur` events from mutations that ReactDOM makes to the DOM. So for example, if an `<input>` is focused and React unmounts this component (thus detatching it from the DOM tree and triggering respective `focus` and `blur` events) we want to be properly notified of such events (the `body` should gain `focus` in the above case). The reason why React today does not notify us on these events, is that we set an `enabled` flag during the commit phase of mutating the DOM. [The code for this can be found here](https://github.com/facebook/react/blob/master/packages/react-dom/src/events/ReactDOMEventListener.js#L331-L333).

Without such functionality, it's not possible to properly use React to track such changes appropriately – resulting into having manual DOM event listeners bypass React.