### PR TITLE
Support package.json generation at build time

### DIFF
--- a/packages/react-dom/package.js
+++ b/packages/react-dom/package.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const packageInfo = require('./package.json');
+
+if (__EXPERIMENTAL__) {
+  // Add experimental files
+  packageInfo.files.push(
+    'unstable-fizz.js',
+    'unstable-fizz.browser.js',
+    'unstable-fizz.node.js',
+    'unstable-flight-server.js',
+    'unstable-flight-server.browser.js',
+    'unstable-flight-server.node.js',
+  );
+
+  packageInfo.browser['./unstable-fizz.js'] = './unstable-fizz.browser.js';
+  packageInfo.browser['./unstable-flight-server.js'] =
+    './unstable-flight-server.browser.js';
+}
+
+module.exports = packageInfo;

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -35,21 +35,12 @@
     "server.browser.js",
     "server.node.js",
     "test-utils.js",
-    "unstable-fire.js",
-    "unstable-fizz.js",
-    "unstable-fizz.browser.js",
-    "unstable-fizz.node.js",
-    "unstable-flight-server.js",
-    "unstable-flight-server.browser.js",
-    "unstable-flight-server.node.js",
     "unstable-native-dependencies.js",
     "cjs/",
     "umd/"
   ],
   "browser": {
-    "./server.js": "./server.browser.js",
-    "./unstable-fizz.js": "./unstable-fizz.browser.js",
-    "./unstable-flight-server.js": "./unstable-flight-server.browser.js"
+    "./server.js": "./server.browser.js"
   },
   "browserify": {
     "transform": [

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -14,13 +14,11 @@ global.ReadableStream = require('@mattiasbuelens/web-streams-polyfill/ponyfill/e
 global.TextEncoder = require('util').TextEncoder;
 
 let React;
-let ReactDOMFizzServer;
 
 describe('ReactDOMFizzServer', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactDOMFizzServer = require('react-dom/unstable-fizz.browser');
   });
 
   async function readResult(stream) {
@@ -35,7 +33,8 @@ describe('ReactDOMFizzServer', () => {
     }
   }
 
-  it('should call renderToReadableStream', async () => {
+  it.experimental('should call renderToReadableStream', async () => {
+    const ReactDOMFizzServer = require('react-dom/unstable-fizz.browser');
     let stream = ReactDOMFizzServer.renderToReadableStream(
       <div>hello world</div>,
     );

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -12,13 +12,11 @@
 
 let Stream;
 let React;
-let ReactDOMFizzServer;
 
 describe('ReactDOMFizzServer', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactDOMFizzServer = require('react-dom/unstable-fizz');
     Stream = require('stream');
   });
 
@@ -30,7 +28,8 @@ describe('ReactDOMFizzServer', () => {
     return writable;
   }
 
-  it('should call pipeToNodeWritable', () => {
+  it.experimental('should call pipeToNodeWritable', () => {
+    const ReactDOMFizzServer = require('react-dom/unstable-fizz');
     let writable = getTestWritable();
     ReactDOMFizzServer.pipeToNodeWritable(<div>hello world</div>, writable);
     jest.runAllTimers();

--- a/packages/react-dom/src/client/flight/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-dom/src/client/flight/__tests__/ReactFlightDOMBrowser-test.js
@@ -14,13 +14,11 @@ global.ReadableStream = require('@mattiasbuelens/web-streams-polyfill/ponyfill/e
 global.TextEncoder = require('util').TextEncoder;
 
 let React;
-let ReactFlightDOMServer;
 
 describe('ReactFlightDOM', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactFlightDOMServer = require('react-dom/unstable-flight-server.browser');
   });
 
   async function readResult(stream) {
@@ -35,7 +33,9 @@ describe('ReactFlightDOM', () => {
     }
   }
 
-  it('should resolve HTML', async () => {
+  it.experimental('should resolve HTML', async () => {
+    const ReactFlightDOMServer = require('react-dom/unstable-flight-server.browser');
+
     function Text({children}) {
       return <span>{children}</span>;
     }

--- a/packages/react-dom/src/client/flight/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-dom/src/client/flight/__tests__/ReactFlightDOMNode-test.js
@@ -12,13 +12,11 @@
 
 let Stream;
 let React;
-let ReactFlightDOMServer;
 
 describe('ReactFlightDOM', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactFlightDOMServer = require('react-dom/unstable-flight-server');
     Stream = require('stream');
   });
 
@@ -30,7 +28,9 @@ describe('ReactFlightDOM', () => {
     return writable;
   }
 
-  it('should resolve HTML', () => {
+  it.experimental('should resolve HTML', () => {
+    const ReactFlightDOMServer = require('react-dom/unstable-flight-server');
+
     function Text({children}) {
       return <span>{children}</span>;
     }

--- a/packages/react-dom/src/server/flight/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-dom/src/server/flight/__tests__/ReactFlightDOMBrowser-test.js
@@ -14,13 +14,11 @@ global.ReadableStream = require('@mattiasbuelens/web-streams-polyfill/ponyfill/e
 global.TextEncoder = require('util').TextEncoder;
 
 let React;
-let ReactFlightDOMServer;
 
 describe('ReactFlightDOM', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactFlightDOMServer = require('react-dom/unstable-flight-server.browser');
   });
 
   async function readResult(stream) {
@@ -35,7 +33,9 @@ describe('ReactFlightDOM', () => {
     }
   }
 
-  it('should resolve HTML', async () => {
+  it.experimental('should resolve HTML', async () => {
+    const ReactFlightDOMServer = require('react-dom/unstable-flight-server.browser');
+
     function Text({children}) {
       return <span>{children}</span>;
     }

--- a/packages/react-dom/src/server/flight/__tests__/ReactFlightDOMNode-test.js
+++ b/packages/react-dom/src/server/flight/__tests__/ReactFlightDOMNode-test.js
@@ -12,13 +12,11 @@
 
 let Stream;
 let React;
-let ReactFlightDOMServer;
 
 describe('ReactFlightDOM', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactFlightDOMServer = require('react-dom/unstable-flight-server');
     Stream = require('stream');
   });
 
@@ -30,7 +28,9 @@ describe('ReactFlightDOM', () => {
     return writable;
   }
 
-  it('should resolve HTML', () => {
+  it.experimental('should resolve HTML', () => {
+    const ReactFlightDOMServer = require('react-dom/unstable-flight-server');
+
     function Text({children}) {
       return <span>{children}</span>;
     }

--- a/scripts/jest/getIgnoredNpmFiles.js
+++ b/scripts/jest/getIgnoredNpmFiles.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+'use strict';
+
+const path = require('path');
+const {existsSync, readdirSync, statSync} = require('fs');
+const glob = require('glob');
+
+require('./setupEnvironment');
+
+function getIgnoredNpmFiles() {
+  const packagesPath = path.resolve('packages');
+  const packageNames = readdirSync('packages');
+
+  const result = [];
+  for (const packageName of packageNames) {
+    const packagePath = path.join(packagesPath, packageName);
+
+    if (statSync(packagePath).isFile()) {
+      continue;
+    }
+
+    let packageInfo;
+    const packageJSONModulePath = path.join(packagePath, 'package.js');
+    const packageJSONPath = path.join(packagePath, 'package.json');
+    if (existsSync(packageJSONModulePath)) {
+      packageInfo = require(packageJSONModulePath);
+    } else if (existsSync(packageJSONPath)) {
+      packageInfo = require(packageJSONPath);
+    } else {
+      continue;
+    }
+
+    if (packageInfo.private) {
+      continue;
+    }
+
+    if (packageInfo.files) {
+      const ignoredFilesGlobs = [];
+      for (let filePattern of packageInfo.files) {
+        if (filePattern.endsWith('/')) {
+          filePattern = filePattern.slice(0, -1);
+        }
+        ignoredFilesGlobs.push(filePattern);
+      }
+      const ignoredFilesGlob = '!(' + ignoredFilesGlobs.join('|') + ')';
+      const ignoredFiles = glob
+        .sync(ignoredFilesGlob, {cwd: packagePath})
+        .map(f => path.join(packageName, f));
+      result.push(...ignoredFiles);
+    }
+  }
+  return result;
+}
+
+module.exports = getIgnoredNpmFiles;

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -33,6 +33,7 @@ const __EXPERIMENTAL__ =
   typeof RELEASE_CHANNEL === 'string'
     ? RELEASE_CHANNEL === 'experimental'
     : true;
+global.__EXPERIMENTAL__ = __EXPERIMENTAL__;
 
 // Errors in promises should be fatal.
 let loggedErrors = new Set();


### PR DESCRIPTION
This commit adds the ability to limit the inclusion of certain files to the experimental releases, such as `react-dom/unstable-flight-server.js`. More generally, it supports generating different package.jsons depending on the build environment (release channel).

The package.json files that live at `packages/<package_name>/package.json` serve multiple purposes. The release scripts use them for guessing the next stable version numbers; they serve as templates for the actual package.jsons that get published to npm (the release script rewrites the version numbers first); during local development, the package source is symlinked into node_modules, which means the package.json is used for module resolution by Jest, Flow, Rollup, node scripts, and so on.

So I would rather not fork the packages entirely like we do with other files (host config, feature flags, www-specific modules), because it could get confusing trying to keep the copies in sync.

There are a few different approaches we could use. One option is to generate the package.jsons in a post-install step, like we do with the Flow configs.

But since the immediate requirement is only to conditionally generate the package.jsons that are published to npm, another option is to generate those files during the build step. Everything else can use the existing package.json files that live in the source.

So it works like this:

- If a package includes a `package.js`, the build script will use that instead of `package.json`.
- `package.js` is a module that returns a JavaScript object of keys and values. The build script will serialize this to JSON and write it to the artifacts directory.
- By convention, `package.js` files will import the `package.json` file from source and modify it before re-exporting.
- If `package.js` does not exist for a module, the build script will use `package.json` directly.