### PR TITLE
Move resetAfterCommit until after we updated the root's current tree

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1858,13 +1858,14 @@ function commitRootImpl(root, renderPriorityLevel) {
       }
     } while (nextEffect !== null);
     stopCommitHostEffectsTimer();
-    resetAfterCommit(root.containerInfo);
 
     // The work-in-progress tree is now the current tree. This must come after
     // the mutation phase, so that the previous tree is still current during
     // componentWillUnmount, but before the layout phase, so that the finished
     // work is current during componentDidMount/Update.
     root.current = finishedWork;
+
+    resetAfterCommit(root.containerInfo);
 
     // The next phase is the layout phase, where we call effects that read
     // the host tree after it's been mutated. The idiomatic use case for this is


### PR DESCRIPTION
Currently we disable all user space events in resetAfterCommit so, if you just use React events, it doesn't really matter where we call this.

However, setting focus and selection can be observable e.g. using native browser events. If you setState or something in those events, they should probably behave as if you're already on the new tree.

Similarly if we do end up triggering blur/focus events simulated, then those should see the updated tree.

Interestingly, this would fire before life-cycles which is confusing. Although that also happens if you set focus manually on the DOM in a life-cycle too. Triggering a blur after life-cycles could work but needs to take into account that focus can change possibly several times in the life-cycles too.

Related to https://github.com/facebook/react/pull/17214