### PR TITLE
[react-interactions] Add handleSimulateChildBlur upon DOM node removal

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -447,10 +447,28 @@ export function insertInContainerBefore(
   }
 }
 
+function handleSimulateChildBlur(
+  child: Instance | TextInstance | SuspenseInstance,
+): void {
+  if (
+    enableFlareAPI &&
+    selectionInformation &&
+    child === selectionInformation.focusedElem
+  ) {
+    const simulatedEvent: any = document.createEvent('CustomEvent');
+    simulatedEvent.initCustomEvent('blur', false, true);
+    simulatedEvent.relatedTarget = null;
+    ReactBrowserEventEmitterSetEnabled(true);
+    child.dispatchEvent(simulatedEvent);
+    ReactBrowserEventEmitterSetEnabled(false);
+  }
+}
+
 export function removeChild(
   parentInstance: Instance,
   child: Instance | TextInstance | SuspenseInstance,
 ): void {
+  handleSimulateChildBlur(child);
   parentInstance.removeChild(child);
 }
 
@@ -461,6 +479,7 @@ export function removeChildFromContainer(
   if (container.nodeType === COMMENT_NODE) {
     (container.parentNode: any).removeChild(child);
   } else {
+    handleSimulateChildBlur(child);
     container.removeChild(child);
   }
 }

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -77,23 +77,24 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
   describe('onFocusWithinChange', () => {
     let onFocusWithinChange, ref, innerRef, innerRef2;
 
+    const Component = ({show}) => {
+      const listener = useFocusWithin({
+        onFocusWithinChange,
+      });
+      return (
+        <div ref={ref} listeners={listener}>
+          {show && <input ref={innerRef} />}
+          <div ref={innerRef2} />
+        </div>
+      );
+    };
+
     beforeEach(() => {
       onFocusWithinChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
-      const Component = () => {
-        const listener = useFocusWithin({
-          onFocusWithinChange,
-        });
-        return (
-          <div ref={ref} listeners={listener}>
-            <div ref={innerRef} />
-            <div ref={innerRef2} />
-          </div>
-        );
-      };
-      ReactDOM.render(<Component />, container);
+      ReactDOM.render(<Component show={true} />, container);
     });
 
     it('is called after "blur" and "focus" events on focus target', () => {
@@ -140,28 +141,38 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onFocusWithinChange).toHaveBeenCalledTimes(2);
       expect(onFocusWithinChange).toHaveBeenCalledWith(false);
     });
+
+    it('is called after a focused element is unmounted', () => {
+      innerRef.current.focus();
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(true);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(false);
+    });
   });
 
   describe('onFocusWithinVisibleChange', () => {
     let onFocusWithinVisibleChange, ref, innerRef, innerRef2;
+
+    const Component = ({show}) => {
+      const listener = useFocusWithin({
+        onFocusWithinVisibleChange,
+      });
+      return (
+        <div ref={ref} listeners={listener}>
+          {show && <input ref={innerRef} />}
+          <div ref={innerRef2} />
+        </div>
+      );
+    };
 
     beforeEach(() => {
       onFocusWithinVisibleChange = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
-      const Component = () => {
-        const listener = useFocusWithin({
-          onFocusWithinVisibleChange,
-        });
-        return (
-          <div ref={ref} listeners={listener}>
-            <div ref={innerRef} />
-            <div ref={innerRef2} />
-          </div>
-        );
-      };
-      ReactDOM.render(<Component />, container);
+      ReactDOM.render(<Component show={true} />, container);
     });
 
     it('is called after "focus" and "blur" on focus target if keyboard was used', () => {
@@ -255,6 +266,18 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
       // focus shifts outside subtree
       innerTarget1.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+    });
+
+    it('is called after a focused element is unmounted', () => {
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      inner.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      ReactDOM.render(<Component show={false} />, container);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
     });

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -143,7 +143,8 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
     });
 
     it('is called after a focused element is unmounted', () => {
-      innerRef.current.focus();
+      const target = createEventTarget(innerRef.current);
+      target.focus();
       expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
       expect(onFocusWithinChange).toHaveBeenCalledWith(true);
       ReactDOM.render(<Component show={false} />, container);
@@ -274,7 +275,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       const inner = innerRef.current;
       const target = createEventTarget(inner);
       target.keydown({key: 'Tab'});
-      inner.focus();
+      target.focus();
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
       ReactDOM.render(<Component show={false} />, container);

--- a/packages/react-interactions/events/src/dom/testing-library/index.js
+++ b/packages/react-interactions/events/src/dom/testing-library/index.js
@@ -34,6 +34,7 @@ const createEventTarget = node => ({
   },
   focus(payload) {
     node.dispatchEvent(domEvents.focus(payload));
+    node.focus();
   },
   scroll(payload) {
     node.dispatchEvent(domEvents.scroll(payload));


### PR DESCRIPTION
Follow up to https://github.com/facebook/react/pull/17214.

This PR adds functionality to React Flare, in that a simulated `blur` event is fired when a DOM node being removed when it was actively focused (via the internal event system for Flare). The reason for doing it this way, opposed to within `restoreSelection` where it's far too late to trigger a `blur` event (as the DOM node has already been detached from the tree, so it's impossible to propagate such events).