### PR TITLE
Rename findHostInstance_deprecated to findHostInstance_DEPRECATED

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -44,7 +44,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
-function findHostInstance_deprecated(
+function findHostInstance_DEPRECATED(
   componentOrHandle: any,
 ): ?HostComponent<mixed> {
   if (__DEV__) {
@@ -76,7 +76,7 @@ function findHostInstance_deprecated(
   if (__DEV__) {
     hostInstance = findHostInstanceWithWarning(
       componentOrHandle,
-      'findHostInstance_deprecated',
+      'findHostInstance_DEPRECATED',
     );
   } else {
     hostInstance = findHostInstance(componentOrHandle);
@@ -158,7 +158,7 @@ const ReactFabric: ReactFabricType = {
 
   // This is needed for implementation details of TouchableNativeFeedback
   // Remove this once TouchableNativeFeedback doesn't use cloneElement
-  findHostInstance_deprecated,
+  findHostInstance_DEPRECATED,
   findNodeHandle,
 
   dispatchCommand(handle: any, command: string, args: Array<any>) {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -47,7 +47,7 @@ import warningWithoutStack from 'shared/warningWithoutStack';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
-function findHostInstance_deprecated(
+function findHostInstance_DEPRECATED(
   componentOrHandle: any,
 ): ?HostComponent<mixed> {
   if (__DEV__) {
@@ -79,7 +79,7 @@ function findHostInstance_deprecated(
   if (__DEV__) {
     hostInstance = findHostInstanceWithWarning(
       componentOrHandle,
-      'findHostInstance_deprecated',
+      'findHostInstance_DEPRECATED',
     );
   } else {
     hostInstance = findHostInstance(componentOrHandle);
@@ -167,7 +167,7 @@ const ReactNativeRenderer: ReactNativeType = {
 
   // This is needed for implementation details of TouchableNativeFeedback
   // Remove this once TouchableNativeFeedback doesn't use cloneElement
-  findHostInstance_deprecated,
+  findHostInstance_DEPRECATED,
   findNodeHandle,
 
   dispatchCommand(handle: any, command: string, args: Array<any>) {

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -141,6 +141,7 @@ type SecretInternalsFabricType = {
  */
 export type ReactNativeType = {
   NativeComponent: typeof ReactNativeComponent,
+  findHostInstance_DEPRECATED(componentOrHandle: any): ?HostComponent<mixed>,
   findNodeHandle(componentOrHandle: any): ?number,
   dispatchCommand(handle: any, command: string, args: Array<any>): void,
   render(
@@ -157,6 +158,7 @@ export type ReactNativeType = {
 
 export type ReactFabricType = {
   NativeComponent: typeof ReactNativeComponent,
+  findHostInstance_DEPRECATED(componentOrHandle: any): ?HostComponent<mixed>,
   findNodeHandle(componentOrHandle: any): ?number,
   dispatchCommand(handle: any, command: string, args: Array<any>): void,
   render(

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -779,7 +779,7 @@ describe('ReactFabric', () => {
     expect(touchStart2).toBeCalled();
   });
 
-  it('findHostInstance_deprecated should warn if used to find a host component inside StrictMode', () => {
+  it('findHostInstance_DEPRECATED should warn if used to find a host component inside StrictMode', () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -802,10 +802,10 @@ describe('ReactFabric', () => {
 
     let match;
     expect(
-      () => (match = ReactFabric.findHostInstance_deprecated(parent)),
+      () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
     ).toWarnDev([
-      'Warning: findHostInstance_deprecated is deprecated in StrictMode. ' +
-        'findHostInstance_deprecated was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
+      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+        'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
         'https://fb.me/react-strict-mode-find-node' +
@@ -816,7 +816,7 @@ describe('ReactFabric', () => {
     expect(match).toBe(child);
   });
 
-  it('findHostInstance_deprecated should warn if passed a component that is inside StrictMode', () => {
+  it('findHostInstance_DEPRECATED should warn if passed a component that is inside StrictMode', () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -840,10 +840,10 @@ describe('ReactFabric', () => {
 
     let match;
     expect(
-      () => (match = ReactFabric.findHostInstance_deprecated(parent)),
+      () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
     ).toWarnDev([
-      'Warning: findHostInstance_deprecated is deprecated in StrictMode. ' +
-        'findHostInstance_deprecated was passed an instance of IsInStrictMode which is inside StrictMode. ' +
+      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+        'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
         'https://fb.me/react-strict-mode-find-node' +

--- a/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
@@ -50,7 +50,7 @@ describe('created with ReactFabric called with ReactNative', () => {
 
     ReactFabric.render(<Component ref={ref} />, 11);
 
-    let instance = ReactNative.findHostInstance_deprecated(ref.current);
+    let instance = ReactNative.findHostInstance_DEPRECATED(ref.current);
     expect(instance._nativeTag).toBe(2);
   });
 
@@ -130,7 +130,7 @@ describe('created with ReactNative called with ReactFabric', () => {
 
     ReactNative.render(<Component ref={ref} />, 11);
 
-    let instance = ReactFabric.findHostInstance_deprecated(ref.current);
+    let instance = ReactFabric.findHostInstance_DEPRECATED(ref.current);
     expect(instance._nativeTag).toBe(3);
   });
 

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -541,7 +541,7 @@ describe('ReactNative', () => {
     );
   });
 
-  it('findHostInstance_deprecated should warn if used to find a host component inside StrictMode', () => {
+  it('findHostInstance_DEPRECATED should warn if used to find a host component inside StrictMode', () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -564,10 +564,10 @@ describe('ReactNative', () => {
 
     let match;
     expect(
-      () => (match = ReactNative.findHostInstance_deprecated(parent)),
+      () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
     ).toWarnDev([
-      'Warning: findHostInstance_deprecated is deprecated in StrictMode. ' +
-        'findHostInstance_deprecated was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
+      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+        'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
         'https://fb.me/react-strict-mode-find-node' +
@@ -578,7 +578,7 @@ describe('ReactNative', () => {
     expect(match).toBe(child);
   });
 
-  it('findHostInstance_deprecated should warn if passed a component that is inside StrictMode', () => {
+  it('findHostInstance_DEPRECATED should warn if passed a component that is inside StrictMode', () => {
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {foo: true},
       uiViewClassName: 'RCTView',
@@ -602,10 +602,10 @@ describe('ReactNative', () => {
 
     let match;
     expect(
-      () => (match = ReactNative.findHostInstance_deprecated(parent)),
+      () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
     ).toWarnDev([
-      'Warning: findHostInstance_deprecated is deprecated in StrictMode. ' +
-        'findHostInstance_deprecated was passed an instance of IsInStrictMode which is inside StrictMode. ' +
+      'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
+        'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
         'Learn more about using refs safely here: ' +
         'https://fb.me/react-strict-mode-find-node' +


### PR DESCRIPTION
@yungsters wants this to be `_DEPRECATED` to be more obnoxious than the lower case version. It's also more consistent with our internal files that we deprecate. React also has methods prefixed with `UNSAFE_` so the all caps seem reasonable.