### PR TITLE
Revert "Dispatch commands to both UIManagers from both renderers (#17…

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -180,15 +180,7 @@ const ReactNativeRenderer: ReactNativeType = {
       return;
     }
 
-    if (handle._internalInstanceHandle) {
-      nativeFabricUIManager.dispatchCommand(
-        handle._internalInstanceHandle.stateNode.node,
-        command,
-        args,
-      );
-    } else {
-      UIManager.dispatchViewManagerCommand(handle._nativeTag, command, args);
-    }
+    UIManager.dispatchViewManagerCommand(handle._nativeTag, command, args);
   },
 
   render(element: React$Element<any>, containerTag: any, callback: ?Function) {

--- a/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
@@ -16,7 +16,7 @@ let ReactNative;
 let UIManager;
 let createReactNativeComponentClass;
 
-describe('created with ReactFabric called with ReactNative', () => {
+describe('ReactFabric', () => {
   beforeEach(() => {
     jest.resetModules();
     require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
@@ -75,86 +75,6 @@ describe('created with ReactFabric called with ReactNative', () => {
   });
 
   it('dispatches commands on Fabric nodes with the RN renderer', () => {
-    nativeFabricUIManager.dispatchCommand.mockClear();
-    const View = createReactNativeComponentClass('RCTView', () => ({
-      validAttributes: {title: true},
-      uiViewClassName: 'RCTView',
-    }));
-
-    let ref = React.createRef();
-
-    ReactFabric.render(<View title="bar" ref={ref} />, 11);
-    expect(nativeFabricUIManager.dispatchCommand).not.toBeCalled();
-    ReactNative.dispatchCommand(ref.current, 'myCommand', [10, 20]);
-    expect(nativeFabricUIManager.dispatchCommand).toHaveBeenCalledTimes(1);
-    expect(nativeFabricUIManager.dispatchCommand).toHaveBeenCalledWith(
-      expect.any(Object),
-      'myCommand',
-      [10, 20],
-    );
-    expect(UIManager.dispatchViewManagerCommand).not.toBeCalled();
-  });
-});
-
-describe('created with ReactNative called with ReactFabric', () => {
-  beforeEach(() => {
-    jest.resetModules();
-    require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
-    ReactFabric = require('react-native-renderer/fabric');
-    jest.resetModules();
-    UIManager = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
-      .UIManager;
-    jest.mock('shared/ReactFeatureFlags', () =>
-      require('shared/forks/ReactFeatureFlags.native-oss'),
-    );
-    ReactNative = require('react-native-renderer');
-
-    React = require('react');
-    createReactNativeComponentClass = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
-      .ReactNativeViewConfigRegistry.register;
-  });
-
-  it('find Paper instances with the Fabric renderer', () => {
-    const View = createReactNativeComponentClass('RCTView', () => ({
-      validAttributes: {title: true},
-      uiViewClassName: 'RCTView',
-    }));
-
-    let ref = React.createRef();
-
-    class Component extends React.Component {
-      render() {
-        return <View title="foo" />;
-      }
-    }
-
-    ReactNative.render(<Component ref={ref} />, 11);
-
-    let instance = ReactFabric.findHostInstance_DEPRECATED(ref.current);
-    expect(instance._nativeTag).toBe(3);
-  });
-
-  it('find Paper nodes with the Fabric renderer', () => {
-    const View = createReactNativeComponentClass('RCTView', () => ({
-      validAttributes: {title: true},
-      uiViewClassName: 'RCTView',
-    }));
-
-    let ref = React.createRef();
-
-    class Component extends React.Component {
-      render() {
-        return <View title="foo" />;
-      }
-    }
-
-    ReactNative.render(<Component ref={ref} />, 11);
-
-    let handle = ReactFabric.findNodeHandle(ref.current);
-    expect(handle).toBe(3);
-  });
-
-  it('dispatches commands on Paper nodes with the Fabric renderer', () => {
     UIManager.dispatchViewManagerCommand.mockReset();
     const View = createReactNativeComponentClass('RCTView', () => ({
       validAttributes: {title: true},
@@ -163,16 +83,14 @@ describe('created with ReactNative called with ReactFabric', () => {
 
     let ref = React.createRef();
 
-    ReactNative.render(<View title="bar" ref={ref} />, 11);
+    ReactFabric.render(<View title="bar" ref={ref} />, 11);
     expect(UIManager.dispatchViewManagerCommand).not.toBeCalled();
-    ReactFabric.dispatchCommand(ref.current, 'myCommand', [10, 20]);
+    ReactNative.dispatchCommand(ref.current, 'myCommand', [10, 20]);
     expect(UIManager.dispatchViewManagerCommand).toHaveBeenCalledTimes(1);
     expect(UIManager.dispatchViewManagerCommand).toHaveBeenCalledWith(
       expect.any(Number),
       'myCommand',
       [10, 20],
     );
-
-    expect(nativeFabricUIManager.dispatchCommand).not.toBeCalled();
   });
 });


### PR DESCRIPTION
#17211 needs to be reverted because the Fabric components on iOS aren't implementing commands yet through the Fabric pipeline. Those commands will need to be implemented and then we can revert this revert.