### PR TITLE
Add preload() to React.lazy

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -7,6 +7,7 @@
 
 import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
 
+import {initializeLazyComponentType} from 'shared/ReactLazyComponent';
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 import warning from 'shared/warning';
 
@@ -17,6 +18,10 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
     // React uses these fields to store the result.
     _status: -1,
     _result: null,
+    // Public API for initializing a lazy component ahead of render time.
+    preload() {
+      initializeLazyComponentType(lazyType);
+    },
   };
 
   if (__DEV__) {


### PR DESCRIPTION
This allows lazy components to be initialized ahead of render time. My use case is for preloading lazy components in React Router ahead of when they are needed. We could do this in a number of scenarios including when we first determine a component is going to be part of the render tree or when anticipating it will be.

Just submitting this draft to get feedback from the core team. If it's something you'd like, I can go ahead and write a test.
