### PR TITLE
Don't show empty (no work) commits in Profiler

### DIFF
--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -284,6 +284,9 @@ export type DevToolsHook = {
   onCommitFiberRoot: (
     rendererID: RendererID,
     fiber: Object,
+    // Added in v16.9 to support Profiler priority labels
     commitPriority?: number,
+    // Added in v16.9 to support Fast Refresh
+    didError?: boolean,
   ) => void,
 };


### PR DESCRIPTION
Improves DevTools experience for #16980

This PR works around broken behavior (arguably) with the synthetic event system. It updates the DevTools backend to ignore commits for which React bailed out at the root without doing any work.

My logic for detecting this bailout case is as follows:
```js
const didBailoutAtRoot =
  root.current === root.current.alternate ||
  (alternate !== null &&
    alternate.expirationTime === 0 &&
    alternate.childExpirationTime === 0);
```

I initially tried checking for bailout in the same way as `bailoutOnAlreadyFinishedWork`:
https://github.com/facebook/react/blob/a2e05b6c148b25590884e8911d4d4acfcb76a487/packages/react-reconciler/src/ReactFiberBeginWork.js#L2735-L2741

But this had false positives (e.g. mounting, certain types of root updates). Based on my own testing, the approach above seems like a more reliable check. (It doesn't break any of the automated tests, and it "fixes" both of the failing cases reported in #16980.)

We should probably follow up to this issue by fixing the event system to not schedule these unnecessary updates, and/or updating React to not commit empty changes, but at least this change improves the current confusing profiling experience.