### PR TITLE
[eslint] Check forwardRef callbacks

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -142,21 +142,27 @@ const tests = {
       }
     `,
     `
-      // Valid because hooks can be used in forwardRef.
-      const FancyButton = React.forwardRef(() => {
-        return useHook();
+      // Valid because hooks can be used in anonymous arrow-function arguments
+      // to forwardRef.
+      const FancyButton = React.forwardRef((props, ref) => {
+        useHook();
+        return <button {...props} ref={ref} />
       });
     `,
     `
-      // Valid because hooks can be used in forwardRef.
-      const FancyButton = React.forwardRef(function () {
-        return useHook();
+      // Valid because hooks can be used in anonymous function arguments to
+      // forwardRef.
+      const FancyButton = React.forwardRef(function (props, ref) {
+        useHook();
+        return <button {...props} ref={ref} />
       });
     `,
     `
-      // Valid because hooks can be used in forwardRef.
-      const FancyButton = forwardRef(function () {
-        return useHook();
+      // Valid because hooks can be used in anonymous function arguments to
+      // forwardRef.
+      const FancyButton = forwardRef(function (props, ref) {
+        useHook();
+        return <button {...props} ref={ref} />
       });
     `,
     `
@@ -459,10 +465,11 @@ const tests = {
       code: `
         // Invalid because it's a common misunderstanding.
         // We *could* make it valid but the runtime error could be confusing.
-        const ComponentWithHookInsideCallback = React.forwardRef(() => {
+        const ComponentWithHookInsideCallback = React.forwardRef((props, ref) => {
           useEffect(() => {
             useHookInsideCallback();
           });
+          return <button {...props} ref={ref} />
         });
       `,
       errors: [genericError('useHookInsideCallback')],

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -303,8 +303,8 @@ const tests = {
       }
     `,
     `
-      // Similarly, this is valid because "use"-prefixed functions called in
-      // the callbacks of unrecognised functions are not assumed to be hooks.
+      // This is valid because "use"-prefixed functions called in
+      // unnamed function arguments are not assumed to be hooks.
       React.unknownFunction((foo, bar) => {
         if (foo) {
           useNotAHook(bar)
@@ -312,8 +312,8 @@ const tests = {
       });
     `,
     `
-      // Similarly, this is valid because "use"-prefixed functions called in
-      // the callbacks of unrecognised functions are not assumed to be hooks.
+      // This is valid because "use"-prefixed functions called in
+      // unnamed function arguments are not assumed to be hooks.
       unknownFunction(function(foo, bar) {
         if (foo) {
           useNotAHook(bar)
@@ -817,6 +817,16 @@ const tests = {
         });
       `,
       errors: [conditionalError('useCustomHook')],
+    },
+    {
+      code: `
+        // This is invalid because "use"-prefixed functions used in named
+        // functions are assumed to be hooks.
+        React.unknownFunction(function notAComponent(foo, bar) {
+          useProbablyAHook(bar)
+        });
+      `,
+      errors: [functionError('useProbablyAHook', 'notAComponent')],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -166,6 +166,22 @@ const tests = {
       });
     `,
     `
+      // Valid because hooks can be used in anonymous function arguments to
+      // React.memo.
+      const MemoizedFunction = React.memo(props => {
+        useHook();
+        return <button {...props} />
+      });
+    `,
+    `
+      // Valid because hooks can be used in anonymous function arguments to
+      // memo.
+      const MemoizedFunction = memo(function (props) {
+        useHook();
+        return <button {...props} />
+      });
+    `,
+    `
       // Valid because classes can call functions.
       // We don't consider these to be hooks.
       class C {
@@ -478,6 +494,19 @@ const tests = {
       code: `
         // Invalid because it's a common misunderstanding.
         // We *could* make it valid but the runtime error could be confusing.
+        const ComponentWithHookInsideCallback = React.memo(props => {
+          useEffect(() => {
+            useHookInsideCallback();
+          });
+          return <button {...props} />
+        });
+      `,
+      errors: [genericError('useHookInsideCallback')],
+    },
+    {
+      code: `
+        // Invalid because it's a common misunderstanding.
+        // We *could* make it valid but the runtime error could be confusing.
         function ComponentWithHookInsideCallback() {
           function handleClick() {
             useState();
@@ -754,6 +783,19 @@ const tests = {
             useCustomHook();
           }
           return <button ref={ref}>{props.children}</button>;
+        });
+      `,
+      errors: [conditionalError('useCustomHook')],
+    },
+    {
+      code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        const MemoizedButton = memo(function(props) {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button>{props.children}</button>;
         });
       `,
       errors: [conditionalError('useCustomHook')],

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -303,6 +303,24 @@ const tests = {
       }
     `,
     `
+      // Similarly, this is valid because "use"-prefixed functions called in
+      // the callbacks of unrecognised functions are not assumed to be hooks.
+      React.unknownFunction((foo, bar) => {
+        if (foo) {
+          useNotAHook(bar)
+        }
+      });
+    `,
+    `
+      // Similarly, this is valid because "use"-prefixed functions called in
+      // the callbacks of unrecognised functions are not assumed to be hooks.
+      unknownFunction(function(foo, bar) {
+        if (foo) {
+          useNotAHook(bar)
+        }
+      });
+    `,
+    `
       // Regression test for incorrectly flagged valid code.
       function RegressionTest() {
         const foo = cond ? a : b;

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -142,6 +142,24 @@ const tests = {
       }
     `,
     `
+      // Valid because hooks can be used in forwardRef.
+      const FancyButton = React.forwardRef(() => {
+        return useHook();
+      });
+    `,
+    `
+      // Valid because hooks can be used in forwardRef.
+      const FancyButton = React.forwardRef(function () {
+        return useHook();
+      });
+    `,
+    `
+      // Valid because hooks can be used in forwardRef.
+      const FancyButton = forwardRef(function () {
+        return useHook();
+      });
+    `,
+    `
       // Valid because classes can call functions.
       // We don't consider these to be hooks.
       class C {
@@ -441,6 +459,18 @@ const tests = {
       code: `
         // Invalid because it's a common misunderstanding.
         // We *could* make it valid but the runtime error could be confusing.
+        const ComponentWithHookInsideCallback = React.forwardRef(() => {
+          useEffect(() => {
+            useHookInsideCallback();
+          });
+        });
+      `,
+      errors: [genericError('useHookInsideCallback')],
+    },
+    {
+      code: `
+        // Invalid because it's a common misunderstanding.
+        // We *could* make it valid but the runtime error could be confusing.
         function ComponentWithHookInsideCallback() {
           function handleClick() {
             useState();
@@ -694,6 +724,32 @@ const tests = {
         // doesn't plan full support for ?? until it advances.
         // conditionalError('useState'),
       ],
+    },
+    {
+      code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        const FancyButton = React.forwardRef((props, ref) => {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button ref={ref}>{props.children}</button>;
+        });
+      `,
+      errors: [conditionalError('useCustomHook')],
+    },
+    {
+      code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        const FancyButton = forwardRef(function(props, ref) {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button ref={ref}>{props.children}</button>;
+        });
+      `,
+      errors: [conditionalError('useCustomHook')],
     },
     {
       code: `


### PR DESCRIPTION
Closes #17220 

This checks that the rules of hooks apply to callback arguments of `forwardRef`. 

I'm unsure whether this counts as a backwards-incompatible change or not. It's making the linter stricter, but I'd only expect new errors to be reported in code that's already breaking the rules of hooks. There is a potential edge-case of code with a forwardRef-wrapped component using a non-hook function with a name starting with "use"; this change would now return a false positive.

<!--
**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
10. If you haven't already, complete the CLA.

**Learn more about contributing:** https://reactjs.org/docs/how-to-contribute.html
-->