### PR TITLE
Avoid bundling in ponyfill for Object.assign in use-subscription package

### DIFF
--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -14,6 +14,9 @@
     "index.js",
     "cjs/"
   ],
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  },
   "peerDependencies": {
     "react": "^16.8.0"
   },


### PR DESCRIPTION
I've noticed that distributed `use-subscription` contained code `object-assign`'s code. As you keep it external in case of other packages it makes sense to do the same here.

Just adding it as a dependency in package.json fixes the problem because your Rollup scripts read that and put those into externals option.