### PR TITLE
[react-dom] window.getComputedStyle for robust way to extract vendor prefixed event names. Closes: #17290

### DIFF
--- a/packages/react-dom/src/events/getVendorPrefixedEventName.js
+++ b/packages/react-dom/src/events/getVendorPrefixedEventName.js
@@ -48,7 +48,7 @@ let style = {};
  * Bootstrap if a DOM exists.
  */
 if (canUseDOM) {
-  style = document.createElement('div').style;
+  style = window.getComputedStyle(document.createElement('div'));
 
   // On some platforms, in particular some releases of Android 4.x,
   // the un-prefixed "animation" and "transition" properties are defined on the


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/17290

This type of behavior has been reported [before](https://github.com/facebook/react/issues/13170). The issue was closed due to being caused by a browser plugin apparently. That's not the case here (will also make that closed case work).

In getVendorPrefixedEventName, the use case is to find the correct vendor prefixed event name. According to the MDN doc above these should not be available on a freshly created element with no style attribute set. Somehow it seems to work, except in my use case.

According to the [getComputedStyle](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#Description) documentation, "The element.style object should be used to set styles on that element, or inspect styles directly added to it from JavaScript manipulation or the global style attribute"

Using getComputedStyle on the newly created element,  react-dom vendor prefixed event name sniffing runs, which makes sense given MDN docs as this is a readonly use case. After all react-dom is trying to go through all styles of the element, no just those set in it's style attribute.

