### PR TITLE
Types: findHostInstance_DEPRECATED returns React.ElementRef<HostComponent<mixed>>

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -45,7 +45,7 @@ const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 function findHostInstance_DEPRECATED(
   componentOrHandle: any,
-): ?HostComponent<mixed> {
+): ?React$ElementRef<HostComponent<mixed>> {
   if (__DEV__) {
     const owner = ReactCurrentOwner.current;
     if (owner !== null && owner.stateNode !== null) {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -49,7 +49,7 @@ const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 function findHostInstance_DEPRECATED(
   componentOrHandle: any,
-): ?HostComponent<mixed> {
+): ?React$ElementRef<HostComponent<mixed>> {
   if (__DEV__) {
     const owner = ReactCurrentOwner.current;
     if (owner !== null && owner.stateNode !== null) {

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -141,7 +141,9 @@ type SecretInternalsFabricType = {
  */
 export type ReactNativeType = {
   NativeComponent: typeof ReactNativeComponent,
-  findHostInstance_DEPRECATED(componentOrHandle: any): ?ElementRef<HostComponent<mixed>>,
+  findHostInstance_DEPRECATED(
+    componentOrHandle: any,
+  ): ?ElementRef<HostComponent<mixed>>,
   findNodeHandle(componentOrHandle: any): ?number,
   dispatchCommand(handle: any, command: string, args: Array<any>): void,
   render(

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -141,7 +141,7 @@ type SecretInternalsFabricType = {
  */
 export type ReactNativeType = {
   NativeComponent: typeof ReactNativeComponent,
-  findHostInstance_DEPRECATED(componentOrHandle: any): ?HostComponent<mixed>,
+  findHostInstance_DEPRECATED(componentOrHandle: any): ?ElementRef<HostComponent<mixed>>,
   findNodeHandle(componentOrHandle: any): ?number,
   dispatchCommand(handle: any, command: string, args: Array<any>): void,
   render(


### PR DESCRIPTION
This was returning the wrong type and couldn't be used correctly. @lunaleaps found this issue when trying to use it in TouchableNativeFeedback for the first time.