### PR TITLE
[react-interactions] Prevent duplicate onPress firing for keyboard Enter

### DIFF
--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -97,7 +97,7 @@ function isValidKey(e): boolean {
   const {key, target} = e;
   const {tagName, isContentEditable} = (target: any);
   return (
-    (key === 'Enter' || key === ' ') &&
+    (key === 'Enter' || key === ' ' || key === 'Spacebar') &&
     (tagName !== 'INPUT' &&
       tagName !== 'TEXTAREA' &&
       isContentEditable !== true)

--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -106,7 +106,10 @@ function isValidKey(e): boolean {
 
 function handlePreventDefault(preventDefault: ?boolean, e: any): void {
   const key = e.key;
-  if (preventDefault !== false && (key === ' ' || key === 'Enter')) {
+  if (
+    preventDefault !== false &&
+    (key === ' ' || key === 'Enter' || key === 'Spacebar')
+  ) {
     e.preventDefault();
   }
 }

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -570,15 +570,14 @@ const pressResponderImpl = {
                 metaKey,
                 shiftKey,
               } = (nativeEvent: MouseEvent);
-              if (isValidKeyboardEvent(nativeEvent)) {
-                nativeEvent.preventDefault();
-              } else if (
+              if (
                 props.preventDefault !== false &&
                 !shiftKey &&
                 !metaKey &&
                 !ctrlKey &&
                 !altKey
               ) {
+                nativeEvent.preventDefault();
                 state.shouldPreventClick = true;
               }
             } else {

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -570,7 +570,7 @@ const pressResponderImpl = {
                 metaKey,
                 shiftKey,
               } = (nativeEvent: MouseEvent);
-              if (nativeEvent.key === ' ') {
+              if (isValidKeyboardEvent(nativeEvent)) {
                 nativeEvent.preventDefault();
               } else if (
                 props.preventDefault !== false &&

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -914,8 +914,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       ReactDOM.render(<Component />, container);
 
       const target = createEventTarget(ref.current);
-      target.keydown({key: 'Enter'});
-      target.click({preventDefault});
+      target.keydown({key: 'Enter', preventDefault});
       target.keyup({key: 'Enter'});
       expect(preventDefault).toBeCalled();
       expect(onPress).toHaveBeenCalledWith(


### PR DESCRIPTION
Internally, we encountered an issue where the `LegacyPress` responder would double fire `onPress` when the `Enter` keyboard key was pressed. Looking into this deeply, the reason for this was because the browser triggers a `click` event which passes the logic in `isScreenReaderVirtualClick`.

I tried to find different discrepancies between screen reader clicks and the click that is fired from the browser when you press `Enter` but I couldn't see anything that stood out – so I took another approach and realized, by accident, the reason this doesn't happen when you press `Space` or ` ` key – we trigger `nativeEvent.preventDefault`. This means that the corresponding native `click` never gets triggered by the browser, but the responder still correctly fires the `onPress` callback – this time only once though!

I also noticed that is behavior didn't occur in the newer Press responder. I added support for the `Spacebar` key type there, but I also noticed a difference in `input` and `textarea` logic between the two responders that might be worth while tracking in a separate task – but maybe this is something @necolas has already considered.