### PR TITLE
Bailout without entering work loop for roots without work WIP

### DIFF
--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -140,18 +140,18 @@ describe('reactiverefs', () => {
     expectClickLogsLengthToBe(testRefsComponent, 1);
 
     // After clicking the reset, there should still only be one click log ref.
-    testRefsComponent.refs.resetDiv.click();
+    ReactTestUtils.act(() => testRefsComponent.refs.resetDiv.click());
     expectClickLogsLengthToBe(testRefsComponent, 1);
 
     // Begin incrementing clicks (and therefore refs).
-    clickIncrementer.click();
+    ReactTestUtils.act(() => clickIncrementer.click());
     expectClickLogsLengthToBe(testRefsComponent, 2);
 
-    clickIncrementer.click();
+    ReactTestUtils.act(() => clickIncrementer.click());
     expectClickLogsLengthToBe(testRefsComponent, 3);
 
     // Now reset again
-    testRefsComponent.refs.resetDiv.click();
+    ReactTestUtils.act(() => testRefsComponent.refs.resetDiv.click());
     expectClickLogsLengthToBe(testRefsComponent, 1);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -661,6 +661,24 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
       root !== workInProgressRoot ||
       expirationTime !== renderExpirationTime
     ) {
+      // Before starting a fresh render, check if we can bailout on the entire tree.
+      // For non-root fibers, this bailout usually happens in the begin phase
+      // of the parent component, but roots are special because they don't
+      // have parents.
+      const remainingExpirationTimeOnRoot =
+        root.current.expirationTime > root.current.childExpirationTime
+          ? root.current.expirationTime
+          : root.current.childExpirationTime;
+      if (remainingExpirationTimeOnRoot < renderExpirationTime) {
+        // We can bailout without entering the work loop.
+        markRootFinishedAtTime(
+          root,
+          expirationTime,
+          remainingExpirationTimeOnRoot,
+        );
+        return null;
+      }
+
       prepareFreshStack(root, expirationTime);
       startWorkOnPendingInteractions(root, expirationTime);
     }
@@ -997,6 +1015,24 @@ function performSyncWorkOnRoot(root) {
       root !== workInProgressRoot ||
       expirationTime !== renderExpirationTime
     ) {
+      // Before starting a fresh render, check if we can bailout on the entire tree.
+      // For non-root fibers, this bailout usually happens in the begin phase
+      // of the parent component, but roots are special because they don't
+      // have parents.
+      const remainingExpirationTimeOnRoot =
+        root.current.expirationTime > root.current.childExpirationTime
+          ? root.current.expirationTime
+          : root.current.childExpirationTime;
+      if (remainingExpirationTimeOnRoot < renderExpirationTime) {
+        // We can bailout without entering the work loop.
+        markRootFinishedAtTime(
+          root,
+          expirationTime,
+          remainingExpirationTimeOnRoot,
+        );
+        return null;
+      }
+
       prepareFreshStack(root, expirationTime);
       startWorkOnPendingInteractions(root, expirationTime);
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -669,7 +669,7 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
         root.current.expirationTime > root.current.childExpirationTime
           ? root.current.expirationTime
           : root.current.childExpirationTime;
-      if (remainingExpirationTimeOnRoot < renderExpirationTime) {
+      if (remainingExpirationTimeOnRoot < expirationTime) {
         // We can bailout without entering the work loop.
         markRootFinishedAtTime(
           root,
@@ -1023,7 +1023,7 @@ function performSyncWorkOnRoot(root) {
         root.current.expirationTime > root.current.childExpirationTime
           ? root.current.expirationTime
           : root.current.childExpirationTime;
-      if (remainingExpirationTimeOnRoot < renderExpirationTime) {
+      if (remainingExpirationTimeOnRoot < expirationTime) {
         // We can bailout without entering the work loop.
         markRootFinishedAtTime(
           root,


### PR DESCRIPTION
Wraps up #16980

This addresses some edge cases where React currently does a no-op render and an empty/unnecessary commit.

- [x] Bailout without entering work loop for roots without work (see #16980).
- [x] Fix failing refs-test by wrapping updates with `act()`.
- [x] See if any other tests trigger this early bailout behavior to better understand the causes.

The tests listed below trigger this new early bailout code. Everyone is in `performSyncWorkOnRoot` (none trigger the new code in `performConcurrentWorkOnRoot`). I spot checked a couple of them to see why the new code is being hit, to see if it looked problematic. Below is my findings:

* `ReactES6Class-test` "_renders only once when setting state in componentWillMount_"
This one calls `performSyncWorkOnRoot()` twice. The first time is the callback passed from `legacyRenderSubtreeIntoContainer` to `unbatchedUpdates`. The second one (the one that bails out) is when `unbatchedUpdates` calls `flushSyncCallbackQueue`. This flush can be bailed out on.

* `RaectDOMInput-test` "_should control a value in reentrant events_"
This one hits the new codepath when it dispatch a discrete "input" event. It looks like when our test calls `node.dispatchEvent()` for the "input" event, something is actually dispatching a series of events (input, input, blur, focus) which causes more updates to be scheduled with React than necessary. Now we bail out after the first.

* `ReactCompositeComponent` "_should warn about `setState` in render_"
This one calls `setState` in render. Without this call, the bailout codepath doesn't get hit. Looks like the `setState` call leaves two things in the queue, so when the subsequent call to `flushSyncCallbackQueue` flushes them both, the second one is a no-op. The first thing gets added to the queue when the `setState` call is made. The second one by `commitRootImpl()` when it calls `ensureRootIsScheduled()` because `getNextRootExpirationTimeToWorkOn` returns a value that indicates there's more work.

---

* `ReactTestUtils.act()` > legacy mode › sync › flushes effects on every call
* `ReactTestUtils.act()` > blocking mode › sync › flushes effects on every call
* `ReactDOMInput` > should control a value in reentrant events
* `ReactDOMInput` > should control values in reentrant events with different targets
* `ReactDOMInput` > switching text inputs between numeric and string numbers › changes the number 2 to "2.0" using a change handler
* `ReactDOMInput` > should control radio buttons if the tree updates during render
* `ReactDOMInput` > assigning the value attribute on controlled inputs › always sets the attribute when values change on text inputs
* `ReactDOMInput` > assigning the value attribute on controlled inputs › does not set the value attribute on number inputs if focused
* `ReactDOMInput` > assigning the value attribute on controlled inputs › sets the value attribute on number inputs on blur
* `ReactDOMInput` > setting a controlled input to undefined › reverts the value attribute to the initial value
* `ReactDOMInput` > setting a controlled input to undefined › preserves the value property
* `ReactDOMInput` > setting a controlled input to null › reverts the value attribute to the initial value
* `ReactDOMInput` > setting a controlled input to null › preserves the value property
* `ReactUpdates` > should queue updates from during mount
* `ReactUpdates` > uses correct base state for setState inside render phase
* `ReactFresh` > can preserve state for forwardRef
* `ReactFresh` > should not consider two forwardRefs around the same type to be equivalent
* `ReactFresh` > can update forwardRef render function with its wrapper
* `ReactFresh` > can update forwardRef render function in isolation
* `ReactFresh` > can preserve state for simple memo
* `ReactFresh` > can preserve state for memo with custom comparison
* `ReactFresh` > can update simple memo function in isolation
* `ReactFresh` > can preserve state for memo(forwardRef)
* `ReactFresh` > can preserve state for lazy after resolution
* `ReactFresh` > can patch lazy before resolution
* `ReactFresh` > can patch lazy(forwardRef) before resolution
* `ReactFresh` > can patch lazy(memo) before resolution
* `ReactFresh` > can patch lazy(memo(forwardRef)) before resolution
* `ReactFresh` > can patch both trees while suspense is displaying the fallback
* `ReactFresh` > does not re-render ancestor components unnecessarily during a hot update
* `ReactFresh` > does not leak state between components
* `ReactFresh` > can force remount by changing signature
* `ReactFresh` > can remount on signature change within a <root> wrapper
* `ReactFresh` > can remount on signature change within a simple memo wrapper
* `ReactFresh` > can remount on signature change within a lazy simple memo wrapper
* `ReactFresh` > can remount on signature change within forwardRef
* `ReactFresh` > can remount on signature change within forwardRef render function
* `ReactFresh` > can remount on signature change within nested memo
* `ReactFresh` > can remount on signature change within a memo wrapper and custom comparison
* `ReactFresh` > can remount on signature change within a class
* `ReactFresh` > can remount on signature change within a context provider
* `ReactFresh` > can remount on signature change within a context consumer
* `ReactFresh` > can remount on signature change within a suspense node
* `ReactFresh` > can remount on signature change within a mode node
* `ReactFresh` > can remount on signature change within a fragment node
* `ReactFresh` > can remount on signature change within multiple siblings
* `ReactFresh` > can remount on signature change within a profiler node
* `ReactFresh` > resets hooks with dependencies on hot reload
* `ReactFresh` > can hot reload offscreen components
* `ReactFresh` > remounts classes on every edit
* `ReactFresh` > remounts on conversion from class to function and back
* `ReactFresh` > can update multiple roots independently
* `ReactCompositeComponent` > should warn about `setState` in render
* `ReactCompositeComponent` > should warn about `setState` in getChildContext
* `ReactCompositeComponent` > this.state should be updated on setState callback inside componentWillMount
* `ReactDOMServerIntegration` > legacy context › renders with a call to componentWillMount before getChildContext with clean client render
* `ReactDOMServerIntegration` > legacy context › renders with a call to componentWillMount before getChildContext with client render on top of good server markup
* `ReactDOMServerIntegration` > legacy context › renders with a call to componentWillMount before getChildContext with client render on top of bad server markup
* `SimpleEventPlugin` > interactive events, in concurrent mode › flushes pending interactive work before extracting event handler
* `SimpleEventPlugin` > interactive events, in concurrent mode › flushes discrete updates in order
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled text input with clean client render
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled text input with client render on top of good server markup
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled textarea with clean client render
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled textarea with client render on top of good server markup
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled checkbox with clean client render
* `ReactDOMServerIntegrationUserInteraction` > user interaction with controlled inputs › renders a controlled checkbox with client render on top of good server markup
* `ReactBrowserEventEmitter` > should not invoke newly inserted handlers while bubbling
* `ReactDOMServerSelectiveHydration` > hydrates at higher pri if sync did not work first time
* `ReactDOMServerSelectiveHydration` > hydrates at higher pri for secondary discrete events
* `ReactES6Class` > renders only once when setting state in componentWillMount
* `mixing responders with the heritage event system` > should properly flush sync when the event systems are mixed with unstable_flushDiscreteUpdates
* `mixing responders with the heritage event system` > mixing the Input and Press repsonders › is async for non-input events
* `ReactTypeScriptClass` > renders only once when setting state in componentWillMount
* `ReactCoffeeScriptClass` > renders only once when setting state in componentWillMount
* `ReactDOMHooks` > should not bail out when an update is scheduled from within an event handler in Concurrent Mode
* `ReactIncrementalScheduling` > can opt-out of batching using unbatchedUpdates
* `ReactCompositeComponent-state` > should support setting state
* `ReactCompositeComponent-state` > should treat assigning to this.state inside cWM as a replaceState, with a warning
* `ReactDOMComponentTree` > finds a controlled instance from node and gets its current fiber props