### PR TITLE
[react-interactions] Add optional searchNodes to Scope.queryAllNodes

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -72,6 +72,50 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
+    it('queryAllNodes() works as intended with included nodes array', () => {
+      const testScopeQuery = (type, props) => type === 'div';
+      const TestScope = React.unstable_createScope();
+      const scopeRef = React.createRef();
+      const divRef = React.createRef();
+      const spanRef = React.createRef();
+      const aRef = React.createRef();
+
+      function Test({toggle}) {
+        return toggle ? (
+          <TestScope ref={scopeRef}>
+            <div ref={divRef}>DIV</div>
+            <span ref={spanRef}>SPAN</span>
+            <a ref={aRef}>A</a>
+          </TestScope>
+        ) : (
+          <TestScope ref={scopeRef}>
+            <a ref={aRef}>A</a>
+            <div ref={divRef}>DIV</div>
+            <span ref={spanRef}>SPAN</span>
+          </TestScope>
+        );
+      }
+
+      ReactDOM.render(<Test toggle={true} />, container);
+      let nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      expect(nodes).toEqual([divRef.current]);
+      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [spanRef.current]);
+      expect(nodes).toEqual([divRef.current, spanRef.current]);
+      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [
+        spanRef.current,
+        aRef.current,
+      ]);
+      expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
+      ReactDOM.render(<Test toggle={false} />, container);
+      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [
+        spanRef.current,
+        aRef.current,
+      ]);
+      expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
+      ReactDOM.render(null, container);
+      expect(scopeRef.current).toBe(null);
+    });
+
     it('queryFirstNode() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -171,6 +171,7 @@ export type ReactScopeMethods = {|
   getProps(): Object,
   queryAllNodes(
     (type: string | Object, props: Object) => boolean,
+    searchNodes?: Array<Object>,
   ): null | Array<Object>,
   queryFirstNode(
     (type: string | Object, props: Object) => boolean,


### PR DESCRIPTION
The experimental React Scopes API has a method available when using a ref called `queryAllNodes`. Previously, this expected only a scope query function, but now with this PR, can additionally take an optional array of DOM nodes that will also be included in the host component search in a scope. This was an internal request, so that we can easily merge different scope queries together, and the existing focused elements without causing bugs in the UI.