### PR TITLE
[RN] Hoist static deepDiffer options object

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -32,13 +32,17 @@ type NestedNode = Array<NestedNode> | Object;
 let removedKeys = null;
 let removedKeyCount = 0;
 
+const deepDifferOptions = {
+  unsafelyIgnoreFunctions: true,
+};
+
 function defaultDiffer(prevProp: mixed, nextProp: mixed): boolean {
   if (typeof nextProp !== 'object' || nextProp === null) {
     // Scalars have already been checked for equality
     return true;
   } else {
     // For objects and arrays, the default diffing algorithm is a deep compare
-    return deepDiffer(prevProp, nextProp, {unsafelyIgnoreFunctions: true});
+    return deepDiffer(prevProp, nextProp, deepDifferOptions);
   }
 }
 


### PR DESCRIPTION
Hoists the options object literal from `defaultDiffer` to the module scope so it's not recreated on every prop update. Addresses https://github.com/facebook/react/pull/17282#discussion_r343677204.