### PR TITLE
Pass suspense config to `startTransition` instead of `useTransition`

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -161,11 +161,9 @@ export function useResponder(
   return dispatcher.useResponder(responder, listenerProps || emptyObject);
 }
 
-export function useTransition(
-  config: ?Object,
-): [(() => void) => void, boolean] {
+export function useTransition(): [(() => void) => void, boolean] {
   const dispatcher = resolveDispatcher();
-  return dispatcher.useTransition(config);
+  return dispatcher.useTransition();
 }
 
 export function useDeferredValue<T>(value: T, config: ?Object): T {


### PR DESCRIPTION
This avoids the problem of having to bind the config object to `startTransition`, invalidating downstream memoizations.

See #17284 for more details.

I'll need to codemod the existing callers in www, but that's not a blocker because www uses a userspace fork.