### PR TITLE
Fix missing file check

### DIFF
--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -14,7 +14,11 @@ const packages = readdirSync(packagesRoot).filter(dir => {
     return false;
   }
   const packagePath = join(packagesRoot, dir, 'package.json');
-  return statSync(packagePath).isFile();
+  try {
+    return statSync(packagePath).isFile();
+  } catch (err) {
+    return false;
+  }
 });
 
 // Create a module map to point React packages to the build output

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -11,7 +11,11 @@ const packages = readdirSync(packagesRoot).filter(dir => {
     return false;
   }
   const packagePath = join(packagesRoot, dir, 'package.json');
-  return statSync(packagePath).isFile();
+  try {
+    return statSync(packagePath).isFile();
+  } catch (err) {
+    return false;
+  }
 });
 
 // Create a module map to point React packages to the build output


### PR DESCRIPTION
This fixes the case where you `yarn test-build` and have leftover empty dirs without `package.json`. I think the original check was meant to catch that case but it wasn't right.