### PR TITLE
Add yarn build --unsafe-partial

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -646,7 +646,9 @@ function handleRollupError(error) {
 }
 
 async function buildEverything() {
-  await asyncRimRaf('build');
+  if (!argv.partial) {
+    await asyncRimRaf('build');
+  }
 
   // Run them serially for better console output
   // and to avoid any potential race conditions.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -646,7 +646,7 @@ function handleRollupError(error) {
 }
 
 async function buildEverything() {
-  if (!argv.partial) {
+  if (!argv['unsafe-partial']) {
     await asyncRimRaf('build');
   }
 


### PR DESCRIPTION
We normally delete the `build` folder when rebuilding for consistency. This can be annoying if I make a tiny scoped edit to a particular package. This is an escape hatch so I can iterate faster when I know what I'm doing.