### PR TITLE
Fix '__DEV__ is not defined' error in react-art fixture and change message to use 'yarn' over 'npm'

### DIFF
--- a/fixtures/art/index.html
+++ b/fixtures/art/index.html
@@ -9,8 +9,8 @@
     <p>If you're seeing this message, it means you haven't generated the bundle file for this example. Try running:</p>
 
     <pre><code>
-    npm install
-    npm run build
+    yarn install
+    yarn build
     </code></pre>
 
     <p>then reload the page.</p>

--- a/fixtures/art/webpack.config.js
+++ b/fixtures/art/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      '__DEV__': true,
+      __DEV__: true,
     }),
   ],
   resolve: {

--- a/fixtures/art/webpack.config.js
+++ b/fixtures/art/webpack.config.js
@@ -22,9 +22,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development'),
-      },
+      '__DEV__': true,
     }),
   ],
   resolve: {


### PR DESCRIPTION
I am using yarn 1.19.1, node v10.16.3, and npm 6.13.0.

* After running `yarn install` and `yarn build` and opening index.html, I received the error `__DEV__ is not defined` from the produced bundle.js file.  My change in the webpack config simply sets `__DEV__` to `true` to get rid of this error, allowing the successful rendering of the React logo animation after running the build.

*  I changed the message in index.html to suggest running `yarn install` and `yarn build` over `npm install` and `npm run build`, for two reasons:
    * The lockfile in the fixture is `yarn.lock`
    * The `"link:"` protocol in package.json is supported by yarn, not npm, so `npm install` fails with `EUNSUPPORTEDPROTOCOL`.
