### PR TITLE
Warn when createRoot() is called on existing root

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -212,4 +212,22 @@ describe('ReactDOMRoot', () => {
       {withoutStack: true},
     );
   });
+
+  it('warns when creating two roots managing the same container', () => {
+    ReactDOM.createRoot(container);
+    expect(() => {
+      ReactDOM.createRoot(container);
+    }).toWarnDev(
+      'You are calling ReactDOM.createRoot() on a container that ' +
+        'has already been passed to createRoot() before. Instead, call ' +
+        'root.render() on the existing root instead if you want to update it.',
+      {withoutStack: true},
+    );
+  });
+
+  it('does not warn when creating second root after first one is unmounted', () => {
+    const root = ReactDOM.createRoot(container);
+    root.unmount();
+    ReactDOM.createRoot(container); // No warning
+  });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -242,6 +242,10 @@ ReactRoot.prototype.unmount = ReactBlockingRoot.prototype.unmount = function(
     warnOnInvalidCallback(callback, 'render');
   }
   updateContainer(null, root, null, callback);
+  if (__DEV__) {
+    const container = root.containerInfo;
+    container._reactHasBeenPassedToCreateRootDEV = false;
+  }
 };
 
 /**
@@ -654,6 +658,12 @@ function warnIfReactDOMContainerInDEV(container) {
       !container._reactRootContainer,
       'You are calling ReactDOM.createRoot() on a container that was previously ' +
         'passed to ReactDOM.render(). This is not supported.',
+    );
+    warningWithoutStack(
+      !container._reactHasBeenPassedToCreateRootDEV,
+      'You are calling ReactDOM.createRoot() on a container that ' +
+        'has already been passed to createRoot() before. Instead, call ' +
+        'root.render() on the existing root instead if you want to update it.',
     );
     container._reactHasBeenPassedToCreateRootDEV = true;
   }


### PR DESCRIPTION
The behavior is pretty confusing: https://codesandbox.io/s/frosty-satoshi-z87yi

So this adds a warning. Will be useful to people who replace `.render()` with `.createRoot().render()` without considering that they may be running it multiple times.

I don't warn if you `.unmount()` first. That seems okay-ish. Maybe you really don't have access to the root instance but at least you can free the previous one.