### PR TITLE
Warn when doing createRoot twice on the same node (another approach)

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -228,6 +228,7 @@ describe('ReactDOMRoot', () => {
   it('does not warn when creating second root after first one is unmounted', () => {
     const root = ReactDOM.createRoot(container);
     root.unmount();
+    Scheduler.unstable_flushAll();
     ReactDOM.createRoot(container); // No warning
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -212,4 +212,22 @@ describe('ReactDOMRoot', () => {
       {withoutStack: true},
     );
   });
+
+  it('warns when creating two roots managing the same container', () => {
+    ReactDOM.createRoot(container);
+    expect(() => {
+      ReactDOM.createRoot(container);
+    }).toWarnDev(
+      'You are calling ReactDOM.createRoot() on a container that ' +
+        'has already been passed to createRoot() before. Instead, call ' +
+        'root.render() on the existing root instead if you want to update it.',
+      {withoutStack: true},
+    );
+  });
+
+  it('does not warn when creating second root after first one is unmounted', () => {
+    const root = ReactDOM.createRoot(container);
+    root.unmount();
+    ReactDOM.createRoot(container); // No warning
+  });
 });

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -241,8 +241,13 @@ ReactRoot.prototype.unmount = ReactBlockingRoot.prototype.unmount = function(
   if (__DEV__) {
     warnOnInvalidCallback(callback, 'render');
   }
-  updateContainer(null, root, null, callback);
-  unmarkContainerAsRoot(root.containerInfo);
+  const container = root.containerInfo;
+  updateContainer(null, root, null, () => {
+    unmarkContainerAsRoot(container);
+    if (callback !== null) {
+      callback();
+    }
+  });
 };
 
 /**

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -664,11 +664,22 @@ function createBlockingRoot(
 
 function warnIfReactDOMContainerInDEV(container) {
   if (__DEV__) {
-    warningWithoutStack(
-      !container._reactRootContainer,
-      'You are calling ReactDOM.createRoot() on a container that was previously ' +
-        'passed to ReactDOM.render(). This is not supported.',
-    );
+    if (isContainerMarkedAsRoot(container)) {
+      if (container._reactRootContainer) {
+        warningWithoutStack(
+          false,
+          'You are calling ReactDOM.createRoot() on a container that was previously ' +
+            'passed to ReactDOM.render(). This is not supported.',
+        );
+      } else {
+        warningWithoutStack(
+          false,
+          'You are calling ReactDOM.createRoot() on a container that ' +
+            'has already been passed to createRoot() before. Instead, call ' +
+            'root.render() on the existing root instead if you want to update it.',
+        );
+      }
+    }
   }
 }
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -450,7 +450,8 @@ const ReactDOM: Object = {
     );
     if (__DEV__) {
       const isModernRoot =
-        isContainerMarkedAsRoot(container) && !container._reactRootContainer;
+        isContainerMarkedAsRoot(container) &&
+        container._reactRootContainer === undefined;
       if (isModernRoot) {
         warningWithoutStack(
           false,
@@ -481,7 +482,8 @@ const ReactDOM: Object = {
     );
     if (__DEV__) {
       const isModernRoot =
-        isContainerMarkedAsRoot(container) && !container._reactRootContainer;
+        isContainerMarkedAsRoot(container) &&
+        container._reactRootContainer === undefined;
       if (isModernRoot) {
         warningWithoutStack(
           false,
@@ -531,7 +533,8 @@ const ReactDOM: Object = {
 
     if (__DEV__) {
       const isModernRoot =
-        isContainerMarkedAsRoot(container) && !container._reactRootContainer;
+        isContainerMarkedAsRoot(container) &&
+        container._reactRootContainer === undefined;
       if (isModernRoot) {
         warningWithoutStack(
           false,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -226,26 +226,26 @@ ReactRoot.prototype.render = ReactBlockingRoot.prototype.render = function(
   callback: ?() => mixed,
 ): void {
   const root = this._internalRoot;
-  callback = callback === undefined ? null : callback;
+  const cb = callback === undefined ? null : callback;
   if (__DEV__) {
-    warnOnInvalidCallback(callback, 'render');
+    warnOnInvalidCallback(cb, 'render');
   }
-  updateContainer(children, root, null, callback);
+  updateContainer(children, root, null, cb);
 };
 
 ReactRoot.prototype.unmount = ReactBlockingRoot.prototype.unmount = function(
   callback: ?() => mixed,
 ): void {
   const root = this._internalRoot;
-  callback = callback === undefined ? null : callback;
+  const cb = callback === undefined ? null : callback;
   if (__DEV__) {
-    warnOnInvalidCallback(callback, 'render');
+    warnOnInvalidCallback(cb, 'render');
   }
   const container = root.containerInfo;
   updateContainer(null, root, null, () => {
     unmarkContainerAsRoot(container);
-    if (callback !== null) {
-      callback();
+    if (cb !== null) {
+      cb();
     }
   });
 };

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -30,6 +30,14 @@ export function markContainerAsRoot(hostRoot, node) {
   node[internalContainerInstanceKey] = hostRoot;
 }
 
+export function unmarkContainerAsRoot(node) {
+  node[internalContainerInstanceKey] = null;
+}
+
+export function isContainerMarkedAsRoot(node) {
+  return !!node[internalContainerInstanceKey];
+}
+
 // Given a DOM node, return the closest HostComponent or HostText fiber ancestor.
 // If the target node is part of a hydrated or not yet rendered subtree, then
 // this may also return a SuspenseComponent or HostRoot to indicate that.


### PR DESCRIPTION
Alternative to #17328. Uses an existing flag. First commit is a refactoring, second adds a new warning.