### PR TITLE
Align root container onclick behavior with legacy mode

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -231,4 +231,39 @@ describe('ReactDOMRoot', () => {
     Scheduler.unstable_flushAll();
     ReactDOM.createRoot(container); // No warning
   });
+
+  it('sets noop onclick for Mobile Safari on portal containers', () => {
+    // We set noop onclick for portals (so clicks don't get lost in iOS Safari)
+    // but there's no reason to do this for top-level containers.
+
+    // Legacy Root
+    const portalContainer1 = document.createElement('div');
+    const rootContainer1 = document.createElement('div');
+    ReactDOM.render(
+      <div>{ReactDOM.createPortal(<div />, portalContainer1)}</div>,
+      rootContainer1,
+    );
+    expect(rootContainer1.onclick).toBe(null);
+    expect(portalContainer1.onclick).not.toBe(null);
+
+    // Blocking Root
+    const portalContainer2 = document.createElement('div');
+    const rootContainer2 = document.createElement('div');
+    ReactDOM.createBlockingRoot(rootContainer2).render(
+      <div>{ReactDOM.createPortal(<div />, portalContainer2)}</div>,
+    );
+    Scheduler.unstable_flushAll();
+    expect(rootContainer2.onclick).toBe(null);
+    expect(portalContainer2.onclick).not.toBe(null);
+
+    // Concurrent Root
+    const portalContainer3 = document.createElement('div');
+    const rootContainer3 = document.createElement('div');
+    ReactDOM.createRoot(rootContainer3).render(
+      <div>{ReactDOM.createPortal(<div />, portalContainer3)}</div>,
+    );
+    Scheduler.unstable_flushAll();
+    expect(rootContainer3.onclick).toBe(null);
+    expect(portalContainer3.onclick).not.toBe(null);
+  });
 });

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -11,6 +11,7 @@ import {
   precacheFiberNode,
   updateFiberProps,
   getClosestInstanceFromNode,
+  isContainerMarkedAsRoot,
 } from './ReactDOMComponentTree';
 import {
   createElement,
@@ -422,11 +423,7 @@ export function appendChildToContainer(
   // This is why we ensure that non React root containers have inline onclick
   // defined.
   // https://github.com/facebook/react/issues/11918
-  const reactRootContainer = container._reactRootContainer;
-  if (
-    (reactRootContainer === null || reactRootContainer === undefined) &&
-    parentNode.onclick === null
-  ) {
+  if (!isContainerMarkedAsRoot(container) && parentNode.onclick === null) {
     // TODO: This cast may not be sound for SVG, MathML or custom elements.
     trapClickOnNonInteractiveElement(((parentNode: any): HTMLElement));
   }


### PR DESCRIPTION
So... this isn't really important but we're inconsistent with how we set `onclick` on container nodes.

In Legacy Mode, we only set them on Portal Containers (but not Root Containers).
In modern Modes, we set them both on Portal Containers and Root Containers.

There's no particular good reason to set them on Root Containers (Portal Containers need it for `onclick` event to bubble on Safari). So I'm changing them to behave the same way as in Legacy Mode.

I guess it would also be ok to always set it. Another way to think of it is this is removing some usage of `_reactRootContainer` where the code implies "root" because it's really only "legacy root" and this isn't obvious. For example someone may change this logic later and assume all roots have `_reactRootContainer`.