### PR TITLE
Add failing test for #17213

### DIFF
--- a/packages/use-subscription/src/__tests__/useSubscription-test.internal.js
+++ b/packages/use-subscription/src/__tests__/useSubscription-test.internal.js
@@ -55,7 +55,7 @@ describe('useSubscription', () => {
   it('handles memo components', () => {
     const observable = createBehaviorSubject('start');
 
-    function Child({value = 'default', id }) {
+    function Child({value = 'default', id}) {
       React.useEffect(
         () => {
           Scheduler.unstable_yieldValue(`Commit(${id}): ${value}`);
@@ -79,7 +79,7 @@ describe('useSubscription', () => {
           [observable],
         ),
       );
-      return <Child value={value} id={id}/>;
+      return <Child value={value} id={id} />;
     }
     // Change this to see the test pass
     const isMemo = true;
@@ -91,7 +91,7 @@ describe('useSubscription', () => {
       setCount = _setCount;
       return (
         <>
-          <Subbed id="Not Memod"/>
+          <Subbed id="Not Memod" />
           <MemodSubbed id="Memo" />
           <Child value={count} id="Child" />
         </>
@@ -126,7 +126,7 @@ describe('useSubscription', () => {
       expect(Scheduler).toFlushAndYieldThrough([
         // Subbed Memo Renders with original value
         'Render(Not Memod): start',
-        ...(!isMemo ? [ 'Render(Memo): start'] : []),
+        ...(!isMemo ? ['Render(Memo): start'] : []),
         'Render(Child): 123',
         'Commit(Child): 123',
       ]);


### PR DESCRIPTION
I've tried to add a failing test for the issue described here. 
https://github.com/facebook/react/issues/17314


If you run it locally, and change `isMemo` to be false, the test will pass. The test will also pass if you change the line to 
`    const MemodSubbed = isMemo ? React.memo(Subbed, () => true) : Subbed;`


----

Below are my half-hearted attempts to look into this bug. 

It looks like when the `compare` function is defined it makes React call `createFiberFromTypeAndProps`. However, if the `compare` function is not defined, it means React goes down the codepath below; 

https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberBeginWork.js#L380-L403

In other words, the bug is likely caused somewhere in `updateSimpleMemoComponent` 

