### PR TITLE
Devtools: Hide scrollbar on flame graph React Profiler

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.css
@@ -8,3 +8,14 @@
   stroke: var(--color-commit-did-not-render-pattern);
   stroke-width: 1;
 }
+
+.FixedSizeList {
+  overflow-y: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* Internet Explorer 10+ */
+}
+
+.FixedSizeList::-webkit-scrollbar { /* WebKit */
+  width: 0;
+  height: 0;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
@@ -142,6 +142,7 @@ function CommitFlamegraph({chartData, commitTree, height, width}: Props) {
 
   return (
     <FixedSizeList
+      className={styles.FixedSizeList}
       height={height}
       innerElementType={InnerElementType}
       itemCount={chartData.depth}


### PR DESCRIPTION
Hide scrollbar to appear on flame graph React Profiler.

The reason is that the scrollbar seems to block some of the flame graph and does not provide any purpose.

This is the issue https://github.com/facebook/react/issues/16550

This is the end result

Chrome
![chrome](https://user-images.githubusercontent.com/25560419/68567872-08a6aa80-0495-11ea-85fa-c67128511610.gif)

Firefox
![firefox](https://user-images.githubusercontent.com/25560419/68567878-0ba19b00-0495-11ea-9a7f-66f01b454133.gif)

