### PR TITLE
[react-interactions] Expose host instance to Scope Query function

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -72,7 +72,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
-    it('queryAllNodes() works as intended with included nodes array', () => {
+    it('queryAllNodes() provides the correct host instance', () => {
       const testScopeQuery = (type, props) => type === 'div';
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -99,18 +99,20 @@ describe('ReactScope', () => {
       ReactDOM.render(<Test toggle={true} />, container);
       let nodes = scopeRef.current.queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([divRef.current]);
-      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [spanRef.current]);
+      let filterQuery = (type, props, instance) =>
+        instance === spanRef.current || testScopeQuery(type, props);
+      nodes = scopeRef.current.queryAllNodes(filterQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current]);
-      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [
-        spanRef.current,
-        aRef.current,
-      ]);
+      filterQuery = (type, props, instance) =>
+        [spanRef.current, aRef.current].includes(instance) ||
+        testScopeQuery(type, props);
+      nodes = scopeRef.current.queryAllNodes(filterQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
       ReactDOM.render(<Test toggle={false} />, container);
-      nodes = scopeRef.current.queryAllNodes(testScopeQuery, [
-        spanRef.current,
-        aRef.current,
-      ]);
+      filterQuery = (type, props, instance) =>
+        [spanRef.current, aRef.current].includes(instance) ||
+        testScopeQuery(type, props);
+      nodes = scopeRef.current.queryAllNodes(filterQuery);
       expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
       ReactDOM.render(null, container);
       expect(scopeRef.current).toBe(null);

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -170,11 +170,10 @@ export type ReactScopeMethods = {|
   getParent(): null | ReactScopeMethods,
   getProps(): Object,
   queryAllNodes(
-    (type: string | Object, props: Object) => boolean,
-    searchNodes?: Array<Object>,
+    (type: string | Object, props: Object, instance: Object) => boolean,
   ): null | Array<Object>,
   queryFirstNode(
-    (type: string | Object, props: Object) => boolean,
+    (type: string | Object, props: Object, instance: Object) => boolean,
   ): null | Object,
   containsNode(Object): boolean,
 |};


### PR DESCRIPTION
This PR is a follow up from #17293. Specifically, we added a 2nd argument to the `queryAllNodes ` Scope API. After some internal profiling, I noticed that this pushed engineers towards doing extra work after the query scope, which was a waste of CPU cycles.

To avoid doing extra work, this PR changes the API so that we now pass through the host instance to the query function. That means not only does the query function get the previously existing `type` and `props`, but it also gets a third argument `instance`. In the case of ReactDOM, this will be the DOM element instance.

This then allows for more precise querying of the scope without having to do wasted work after – it can be done as part of the query.