### PR TITLE
Change legacy-events plugin nativeEventTarget to allow null

### DIFF
--- a/packages/legacy-events/EventPluginHub.js
+++ b/packages/legacy-events/EventPluginHub.js
@@ -134,7 +134,7 @@ function extractPluginEvents(
   topLevelType: TopLevelType,
   targetInst: null | Fiber,
   nativeEvent: AnyNativeEvent,
-  nativeEventTarget: EventTarget,
+  nativeEventTarget: null | EventTarget,
   eventSystemFlags: EventSystemFlags,
 ): Array<ReactSyntheticEvent> | ReactSyntheticEvent | null {
   let events = null;
@@ -161,7 +161,7 @@ export function runExtractedPluginEventsInBatch(
   topLevelType: TopLevelType,
   targetInst: null | Fiber,
   nativeEvent: AnyNativeEvent,
-  nativeEventTarget: EventTarget,
+  nativeEventTarget: null | EventTarget,
   eventSystemFlags: EventSystemFlags,
 ) {
   const events = extractPluginEvents(

--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -27,7 +27,7 @@ export type PluginModule<NativeEvent> = {
     topLevelType: TopLevelType,
     targetInst: null | Fiber,
     nativeTarget: NativeEvent,
-    nativeEventTarget: EventTarget,
+    nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -250,7 +250,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
     topLevelType: TopLevelType,
     targetInst: null | Fiber,
     nativeEvent: MouseEvent,
-    nativeEventTarget: EventTarget,
+    nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
   ): null | ReactSyntheticEvent {
     const dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];

--- a/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
+++ b/packages/react-native-renderer/src/ReactNativeBridgeEventPlugin.js
@@ -35,7 +35,7 @@ const ReactNativeBridgeEventPlugin = {
     topLevelType: TopLevelType,
     targetInst: null | Object,
     nativeEvent: AnyNativeEvent,
-    nativeEventTarget: Object,
+    nativeEventTarget: null | Object,
     eventSystemFlags: EventSystemFlags,
   ): ?Object {
     if (targetInst == null) {


### PR DESCRIPTION
React Native is changing the event target to be a react element instance instead of a reactTag. We pull this element instance off of the fiber, which might be null, thus the target might now be null.

It looks like the only thing that uses the target is SyntheticEvent which just sets it on the event:

https://github.com/facebook/react/blob/6cff70a740d1e6ad10070ebf88514bd3a49d0f0d/packages/legacy-events/SyntheticEvent.js#L93-L95