### PR TITLE
[Native] Add FeatureFlag to dispatch events with instance currentTarget

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -7,14 +7,25 @@
 
 import invariant from 'shared/invariant';
 
+import {enableNativeTargetAsInstance} from 'shared/ReactFeatureFlags';
+
 function getInstanceFromInstance(instanceHandle) {
   return instanceHandle;
 }
 
 function getTagFromInstance(inst) {
-  let tag = inst.stateNode.canonical._nativeTag;
-  invariant(tag, 'All native instances should have a tag.');
-  return tag;
+  if (enableNativeTargetAsInstance) {
+    let nativeInstance = inst.stateNode.canonical;
+    invariant(
+      nativeInstance._nativeTag,
+      'All native instances should have a tag.',
+    );
+    return nativeInstance;
+  } else {
+    let tag = inst.stateNode.canonical._nativeTag;
+    invariant(tag, 'All native instances should have a tag.');
+    return tag;
+  }
 }
 
 export {

--- a/packages/react-native-renderer/src/ReactNativeComponentTree.js
+++ b/packages/react-native-renderer/src/ReactNativeComponentTree.js
@@ -7,6 +7,8 @@
 
 import invariant from 'shared/invariant';
 
+import {enableNativeTargetAsInstance} from 'shared/ReactFeatureFlags';
+
 const instanceCache = new Map();
 const instanceProps = new Map();
 
@@ -24,12 +26,23 @@ function getInstanceFromTag(tag) {
 }
 
 function getTagFromInstance(inst) {
-  let tag = inst.stateNode._nativeTag;
-  if (tag === undefined) {
-    tag = inst.stateNode.canonical._nativeTag;
+  if (enableNativeTargetAsInstance) {
+    let nativeInstance = inst.stateNode;
+    let tag = nativeInstance._nativeTag;
+    if (tag === undefined) {
+      nativeInstance = nativeInstance.canonical;
+      tag = nativeInstance._nativeTag;
+    }
+    invariant(tag, 'All native instances should have a tag.');
+    return nativeInstance;
+  } else {
+    let tag = inst.stateNode._nativeTag;
+    if (tag === undefined) {
+      tag = inst.stateNode.canonical._nativeTag;
+    }
+    invariant(tag, 'All native instances should have a tag.');
+    return tag;
   }
-  invariant(tag, 'All native instances should have a tag.');
-  return tag;
 }
 
 export {

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -826,6 +826,9 @@ describe('ReactFabric', () => {
             expect(ReactFabric.findNodeHandle(ref1.current)).toEqual(
               event.target,
             );
+            expect(ReactFabric.findNodeHandle(ref1.current)).toEqual(
+              event.currentTarget,
+            );
           }}
           onStartShouldSetResponder={() => true}
         />
@@ -836,6 +839,9 @@ describe('ReactFabric', () => {
             expect(ref2.current).not.toBeNull();
             expect(ReactFabric.findNodeHandle(ref2.current)).toEqual(
               event.target,
+            );
+            expect(ReactFabric.findNodeHandle(ref2.current)).toEqual(
+              event.currentTarget,
             );
           }}
           onStartShouldSetResponder={() => true}
@@ -875,7 +881,7 @@ describe('ReactFabric', () => {
       changedTouches: [],
     });
 
-    expect.assertions(4);
+    expect.assertions(6);
   });
 
   it('dispatches event with target as instance', () => {
@@ -922,6 +928,7 @@ describe('ReactFabric', () => {
             expect(ref1.current).not.toBeNull();
             // Check for referential equality
             expect(ref1.current).toBe(event.target);
+            expect(ref1.current).toBe(event.currentTarget);
           }}
           onStartShouldSetResponder={() => true}
         />
@@ -932,6 +939,7 @@ describe('ReactFabric', () => {
             expect(ref2.current).not.toBeNull();
             // Check for referential equality
             expect(ref2.current).toBe(event.target);
+            expect(ref2.current).toBe(event.currentTarget);
           }}
           onStartShouldSetResponder={() => true}
         />
@@ -970,7 +978,7 @@ describe('ReactFabric', () => {
       changedTouches: [],
     });
 
-    expect.assertions(4);
+    expect.assertions(6);
   });
 
   it('findHostInstance_DEPRECATED should warn if used to find a host component inside StrictMode', () => {

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -484,6 +484,9 @@ it('dispatches event with target as reactTag', () => {
           expect(ReactNative.findNodeHandle(ref1.current)).toEqual(
             event.target,
           );
+          expect(ReactNative.findNodeHandle(ref1.current)).toEqual(
+            event.currentTarget,
+          );
         }}
         onStartShouldSetResponder={() => true}
       />
@@ -494,6 +497,9 @@ it('dispatches event with target as reactTag', () => {
           expect(ref2.current).not.toBeNull();
           expect(ReactNative.findNodeHandle(ref2.current)).toEqual(
             event.target,
+          );
+          expect(ReactNative.findNodeHandle(ref2.current)).toEqual(
+            event.currentTarget,
           );
         }}
         onStartShouldSetResponder={() => true}
@@ -526,7 +532,7 @@ it('dispatches event with target as reactTag', () => {
     [0],
   );
 
-  expect.assertions(4);
+  expect.assertions(6);
 });
 
 it('dispatches event with target as instance', () => {
@@ -553,6 +559,7 @@ it('dispatches event with target as instance', () => {
           expect(ref1.current).not.toBeNull();
           // Check for referential equality
           expect(ref1.current).toBe(event.target);
+          expect(ref1.current).toBe(event.currentTarget);
         }}
         onStartShouldSetResponder={() => true}
       />
@@ -563,6 +570,7 @@ it('dispatches event with target as instance', () => {
           expect(ref2.current).not.toBeNull();
           // Check for referential equality
           expect(ref2.current).toBe(event.target);
+          expect(ref2.current).toBe(event.currentTarget);
         }}
         onStartShouldSetResponder={() => true}
       />
@@ -594,5 +602,5 @@ it('dispatches event with target as instance', () => {
     [0],
   );
 
-  expect.assertions(4);
+  expect.assertions(6);
 });

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -13,6 +13,7 @@
 let PropTypes;
 let RCTEventEmitter;
 let React;
+let ReactFabric;
 let ReactNative;
 let ReactFeatureFlags;
 let ResponderEventPlugin;

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -13,7 +13,6 @@
 let PropTypes;
 let RCTEventEmitter;
 let React;
-let ReactFabric;
 let ReactNative;
 let ReactFeatureFlags;
 let ResponderEventPlugin;


### PR DESCRIPTION
Dependent on facebook#17323 to make event.currentTarget an instance instead of a reactTag.

I tested this in RNTester in React Native ensuring that Touchable and Pressable correctly handle the updated currentTarget. I have found no other internal callsite referencing this value.