### PR TITLE
[react-interactions] Refine custom active element blur logic

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -465,3 +465,7 @@ export function unmountFundamentalComponent(fundamentalInstance) {
 export function getInstanceFromNode(node) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeRemoveInstance(instance) {
+  // noop
+}

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -465,16 +465,17 @@ export function insertInContainerBefore(
   }
 }
 
-function dispatchCustomFlareEvent(
-  type: string,
+function dispatchFlareDetachedBlurEvent(
+  elementDetached: boolean,
   targetInstance: null | Object,
   target: Element | Document,
 ): void {
   // Simlulate the custom event to the React Flare responder system.
   dispatchEventForResponderEventSystem(
-    type,
+    'blur',
     targetInstance,
     ({
+      elementDetached,
       target,
       timeStamp: Date.now(),
     }: any),
@@ -486,17 +487,13 @@ function dispatchCustomFlareEvent(
 function dispatchBeforeActiveElementBlur(element: HTMLElement): void {
   const targtInstance = getClosestInstanceFromNode(element);
   ((selectionInformation: any): SelectionInformation).blurredActiveElement = element;
-  dispatchCustomFlareEvent('beforeactiveelementblur', targtInstance, element);
+  dispatchFlareDetachedBlurEvent(false, targtInstance, element);
 }
 
 function dispatchActiveElementBlur(
   node: Instance | TextInstance | SuspenseInstance,
 ): void {
-  dispatchCustomFlareEvent(
-    'activeelementblur',
-    null,
-    ((node: any): HTMLElement),
-  );
+  dispatchFlareDetachedBlurEvent(true, null, ((node: any): HTMLElement));
 }
 
 // This is a specific event for the React Flare

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -100,6 +100,8 @@ export function hasSelectionCapabilities(elem) {
 export function getSelectionInformation() {
   const focusedElem = getActiveElementDeep();
   return {
+    // Used by Flare
+    blurredActiveElement: null,
     focusedElem: focusedElem,
     selectionRange: hasSelectionCapabilities(focusedElem)
       ? getSelection(focusedElem)

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -262,16 +262,16 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
     });
   });
 
-  describe('onBeforeActiveElementBlur/onActiveElementBlur', () => {
-    let onBeforeActiveElementBlur,
-      onActiveElementBlur,
+  describe('onBeforeFocusedElementDetached/onFocusedElementDetached', () => {
+    let onBeforeFocusedElementDetached,
+      onFocusedElementDetached,
       ref,
       innerRef,
       innerRef2;
 
     beforeEach(() => {
-      onBeforeActiveElementBlur = jest.fn();
-      onActiveElementBlur = jest.fn();
+      onBeforeFocusedElementDetached = jest.fn();
+      onFocusedElementDetached = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
@@ -280,8 +280,8 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
     it('is called after a focused element is unmounted', () => {
       const Component = ({show}) => {
         const listener = useFocusWithin({
-          onBeforeActiveElementBlur,
-          onActiveElementBlur,
+          onBeforeFocusedElementDetached,
+          onFocusedElementDetached,
         });
         return (
           <div ref={ref} listeners={listener}>
@@ -297,18 +297,18 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       const target = createEventTarget(inner);
       target.keydown({key: 'Tab'});
       target.focus();
-      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(0);
-      expect(onActiveElementBlur).toHaveBeenCalledTimes(0);
+      expect(onBeforeFocusedElementDetached).toHaveBeenCalledTimes(0);
+      expect(onFocusedElementDetached).toHaveBeenCalledTimes(0);
       ReactDOM.render(<Component show={false} />, container);
-      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(1);
-      expect(onActiveElementBlur).toHaveBeenCalledTimes(1);
+      expect(onBeforeFocusedElementDetached).toHaveBeenCalledTimes(1);
+      expect(onFocusedElementDetached).toHaveBeenCalledTimes(1);
     });
 
     it('is called after a nested focused element is unmounted', () => {
       const Component = ({show}) => {
         const listener = useFocusWithin({
-          onBeforeActiveElementBlur,
-          onActiveElementBlur,
+          onBeforeFocusedElementDetached,
+          onFocusedElementDetached,
         });
         return (
           <div ref={ref} listeners={listener}>
@@ -328,11 +328,11 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       const target = createEventTarget(inner);
       target.keydown({key: 'Tab'});
       target.focus();
-      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(0);
-      expect(onActiveElementBlur).toHaveBeenCalledTimes(0);
+      expect(onBeforeFocusedElementDetached).toHaveBeenCalledTimes(0);
+      expect(onFocusedElementDetached).toHaveBeenCalledTimes(0);
       ReactDOM.render(<Component show={false} />, container);
-      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(1);
-      expect(onActiveElementBlur).toHaveBeenCalledTimes(1);
+      expect(onBeforeFocusedElementDetached).toHaveBeenCalledTimes(1);
+      expect(onFocusedElementDetached).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -262,37 +262,77 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
     });
   });
 
-  describe('onDetachedVisibleNode', () => {
-    let onDetachedVisibleNode, ref, innerRef, innerRef2;
-
-    const Component = ({show}) => {
-      const listener = useFocusWithin({
-        onDetachedVisibleNode,
-      });
-      return (
-        <div ref={ref} listeners={listener}>
-          {show && <input ref={innerRef} />}
-          <div ref={innerRef2} />
-        </div>
-      );
-    };
+  describe('onBeforeActiveElementBlur/onActiveElementBlur', () => {
+    let onBeforeActiveElementBlur,
+      onActiveElementBlur,
+      ref,
+      innerRef,
+      innerRef2;
 
     beforeEach(() => {
-      onDetachedVisibleNode = jest.fn();
+      onBeforeActiveElementBlur = jest.fn();
+      onActiveElementBlur = jest.fn();
       ref = React.createRef();
       innerRef = React.createRef();
       innerRef2 = React.createRef();
-      ReactDOM.render(<Component show={true} />, container);
     });
 
     it('is called after a focused element is unmounted', () => {
+      const Component = ({show}) => {
+        const listener = useFocusWithin({
+          onBeforeActiveElementBlur,
+          onActiveElementBlur,
+        });
+        return (
+          <div ref={ref} listeners={listener}>
+            {show && <input ref={innerRef} />}
+            <div ref={innerRef2} />
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+
       const inner = innerRef.current;
       const target = createEventTarget(inner);
       target.keydown({key: 'Tab'});
       target.focus();
-      expect(onDetachedVisibleNode).toHaveBeenCalledTimes(0);
+      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(0);
+      expect(onActiveElementBlur).toHaveBeenCalledTimes(0);
       ReactDOM.render(<Component show={false} />, container);
-      expect(onDetachedVisibleNode).toHaveBeenCalledTimes(1);
+      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(1);
+      expect(onActiveElementBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called after a nested focused element is unmounted', () => {
+      const Component = ({show}) => {
+        const listener = useFocusWithin({
+          onBeforeActiveElementBlur,
+          onActiveElementBlur,
+        });
+        return (
+          <div ref={ref} listeners={listener}>
+            {show && (
+              <div>
+                <input ref={innerRef} />
+              </div>
+            )}
+            <div ref={innerRef2} />
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(0);
+      expect(onActiveElementBlur).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeActiveElementBlur).toHaveBeenCalledTimes(1);
+      expect(onActiveElementBlur).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -495,3 +495,7 @@ export function cloneFundamentalInstance(fundamentalInstance) {
 export function getInstanceFromNode(node) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeRemoveInstance(instance) {
+  // noop
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -534,3 +534,7 @@ export function unmountFundamentalComponent(fundamentalInstance) {
 export function getInstanceFromNode(node) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeRemoveInstance(instance) {
+  // noop
+}

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -105,6 +105,7 @@ import {
   updateFundamentalComponent,
   commitHydratedContainer,
   commitHydratedSuspenseInstance,
+  beforeRemoveInstance,
 } from './ReactFiberHostConfig';
 import {
   captureCommitPhaseError,
@@ -808,6 +809,7 @@ function commitUnmount(
             dependencies.responders = null;
           }
         }
+        beforeRemoveInstance(current.stateNode);
       }
       safelyDetachRef(current);
       return;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -70,6 +70,7 @@ export const mountFundamentalComponent =
 export const shouldUpdateFundamentalComponent =
   $$$hostConfig.shouldUpdateFundamentalComponent;
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
+export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
 
 // -------------------
 //      Mutation

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -367,3 +367,7 @@ export function getInstanceFromNode(mockNode: Object) {
   }
   return null;
 }
+
+export function beforeRemoveInstance(instance) {
+  // noop
+}


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/17291. Specifically, these PR tackles three things:

- Has a much better event name for what the actions occurring. Specifically: `onDetachedVisibleNode` -> `onBeforeFocusedElementDetached `
- Provides another callback that lets the user know the active blur has occurred on the removed node, this event is `onFocusedElementDetached `.
- Fixes a bug where where a focused active element is removed as part of a larger sub-tree, where the active element isn't removed directly, but an ancestor above it is. We now use the `beforeRemoveInstance` to correctly unify this logic (removing it from the `removeChild` and `removeChildFromContainer` methods)

## Why do we need two events? What is the for?

These callbacks are to help with our experimental internal accessibility work at Facebook. There are various ways to tackle this problem. I've been working closely with @tatermelon (Tatiana from the accessibility team) to guide this implementation internally and apply it.

The problem these tackle are when active elements (elements that are focused on the document) are unmounted. This is a big problem with accessibility and it's been a big problem that folks have tried to tackle for a while with hacks. The realism is that there's no real good way to do this in user-land today, which is evident by how many websites simply don't handle this use-case.

This problem is made more evident with the introduction of Suspense fallbacks, where content if focused for a spinner, but is then removed to show the actual real content after X time. We need some way to know that this has occurred, so we can re-align with the document and imperatively move focus to the right node.

Two events are essential here:
- `onBeforeFocusedElementDetached` fires before the active focused element is removed from the DOM. This is the perfect place to work out the "before" state, find what nodes are in view and do some calculations needed for the actual active blur event.
- `onFocusedElementDetached ` fires after all the changes have been committed and it's time to use the logic we stored in the before event, to work out what node we should imperatively focus next.