### PR TITLE
Update Prettier parser name

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -8,7 +8,7 @@ module.exports = {
   jsxBracketSameLine: true,
   trailingComma: 'es5',
   printWidth: 80,
-  parser: 'babylon',
+  parser: 'babel',
 
   overrides: [
     {


### PR DESCRIPTION
According to [Prettier's parser options](https://prettier.io/docs/en/options.html#parser), "babylon" was changed to "babel":

> "babel" (via @babel/parser) Named "babylon" until v1.16.0

So I just updated the name.