### PR TITLE
[react-interactions] Enable event system before dispatching blur

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -211,6 +211,8 @@ export function prepareForCommit(containerInfo: Container): void {
 
 export function resetAfterCommit(containerInfo: Container): void {
   restoreSelection(selectionInformation);
+  ReactBrowserEventEmitterSetEnabled(eventsEnabled);
+  eventsEnabled = null;
   if (enableFlareAPI) {
     const activeElementDetached = (selectionInformation: any)
       .activeElementDetached;
@@ -219,8 +221,6 @@ export function resetAfterCommit(containerInfo: Container): void {
     }
   }
   selectionInformation = null;
-  ReactBrowserEventEmitterSetEnabled(eventsEnabled);
-  eventsEnabled = null;
 }
 
 export function createInstance(


### PR DESCRIPTION
We should really call `dispatchDetachedBlur` after we re-enable the event system again, otherwise we might have downstream problems when logic is handled in this phase.