### PR TITLE
[react-interactions] additional check to avoid middle clicks triggering press

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -600,10 +600,12 @@ const pressResponderImpl = {
             state.activePointerId = touchEvent.identifier;
           }
 
-          // Ignore any device buttons except primary/middle and touch/pen contact.
+          // Ignore any device buttons except primary and touch/pen contact.
           // Additionally we ignore primary-button + ctrl-key with Macs as that
           // acts like right-click and opens the contextmenu.
           if (
+            // Ignore middle clicks
+            nativeEvent.button === 1 ||
             nativeEvent.buttons === 2 ||
             nativeEvent.buttons > 4 ||
             (isMac && isMouseEvent && nativeEvent.ctrlKey)

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -600,12 +600,10 @@ const pressResponderImpl = {
             state.activePointerId = touchEvent.identifier;
           }
 
-          // Ignore any device buttons except primary and touch/pen contact.
+          // Ignore any device buttons except primary/middle and touch/pen contact.
           // Additionally we ignore primary-button + ctrl-key with Macs as that
           // acts like right-click and opens the contextmenu.
           if (
-            // Ignore middle clicks
-            nativeEvent.button === 1 ||
             nativeEvent.buttons === 2 ||
             nativeEvent.buttons > 4 ||
             (isMac && isMouseEvent && nativeEvent.ctrlKey)
@@ -761,7 +759,7 @@ const pressResponderImpl = {
             }
             isKeyboardEvent = true;
             removeRootEventTypes(context, state);
-          } else if (buttons === 4) {
+          } else if (buttons === 4 || nativeEvent.button === 1) {
             // Remove the root events here as no 'click' event is dispatched when this 'button' is pressed.
             removeRootEventTypes(context, state);
           }
@@ -819,7 +817,11 @@ const pressResponderImpl = {
               }
             }
 
-            if (state.isPressWithinResponderRegion && buttons !== 4) {
+            if (
+              state.isPressWithinResponderRegion &&
+              buttons !== 4 &&
+              nativeEvent.button !== 1
+            ) {
               dispatchEvent(
                 event,
                 onPress,


### PR DESCRIPTION
Middle clicks in Chrome/Firefox on Mac using a touchpad + BetterTouchTool tap gesture trigger a press, causing navigation when this happens on links (in addition to opening links in new tabs).

T57092269 contains more information and videos of fix.

I'm not 100% sure if my edits to the comment make sense.

Looking at the native event for pointer up and down, buttons === 0 and button === 1 when this happens. We covered for buttons === 4 in pointer up, but it looks like these types of middle clicks look slightly different. According to the [pointer events spec, button === 1 means it's a middle click](https://www.w3.org/TR/pointerevents/#the-button-property), so we added this quick check to avoid triggering press on middle clicks.

I'd be happy to make more changes. Before this the intention was to keep middle clicks around and check for buttons === 4 in pointer up to discard presses there. An alternative to this change could be checking button there instead (as button is still 1  during pointer up). Or, we ignore button === 1 and buttons >= 4 in pointer down and can then remove the 4 check in pointer up completely.