### PR TITLE
[react-interactions] Fix unattached fiber bug

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -482,10 +482,9 @@ function dispatchBeforeDetachedBlur(target: HTMLElement): void {
 }
 
 function dispatchDetachedBlur(target: HTMLElement): void {
-  const targetInstance = getClosestInstanceFromNode(target);
   dispatchEventForResponderEventSystem(
     'blur',
-    targetInstance,
+    null,
     ({
       isTargetAttached: false,
       target,


### PR DESCRIPTION
When we fire `dispatchDetachedBlur` the target node has already been removed from the fiber tree so trying to attach its fiber will result in a detached fiber being passed around. Instead we should pass `null` so this becomes a root event instead – which resolves the error.