### PR TITLE
[react-test-renderer] Silence error boundary console logs

### DIFF
--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CapturedError} from '../ReactCapturedValue';
+
+export type Features = {
+  errorBoundary: boolean;
+}
+
+const silenced: $Exact<Features> = {
+  errorBoundary: true,
+};
+
+export function silenceFeatures(features: Features) {
+  Object.assign(silenced, features);
+}
+
+export function showErrorDialog(capturedError: CapturedError): boolean {
+  if (capturedError.errorBoundaryFound && silenced.errorBoundary) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
@@ -9,26 +9,8 @@
 
 import type {CapturedError} from '../ReactCapturedValue';
 
-export type Features = {
-  errorBoundary: boolean;
-}
-
-const silenced: $Exact<Features> = {
-  errorBoundary: true,
-};
-
-export function silenceErrors(features: boolean | Features) {
-  if (typeof features === 'boolean') {
-    Object.assign(silenced, {
-      errorBoundary: features,
-    });
-  } else {
-    Object.assign(silenced, features);
-  }
-}
-
 export function showErrorDialog(capturedError: CapturedError): boolean {
-  if (capturedError.errorBoundaryFound && silenced.errorBoundary) {
+  if (capturedError.errorBoundary) {
     return false;
   }
 

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
@@ -7,12 +7,19 @@
  * @flow
  */
 
-import type {CapturedError} from '../ReactCapturedValue';
+import type {Fiber} from '../ReactFiber.old';
+import type {CapturedValue} from '../ReactCapturedValue';
 
-export function showErrorDialog(capturedError: CapturedError): boolean {
-  if (capturedError.errorBoundary) {
-    return false;
-  }
+import {ClassComponent} from '../ReactWorkTags';
 
-  return true;
+export function showErrorDialog(
+  boundary: Fiber,
+  errorInfo: CapturedValue<mixed>,
+): boolean {
+  const errorBoundary =
+    boundary !== null && boundary.tag === ClassComponent
+      ? boundary.stateNode
+      : null;
+
+  return !errorBoundary;
 }

--- a/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
+++ b/packages/react-reconciler/src/forks/ReactFiberErrorDialog.test.js
@@ -17,8 +17,14 @@ const silenced: $Exact<Features> = {
   errorBoundary: true,
 };
 
-export function silenceFeatures(features: Features) {
-  Object.assign(silenced, features);
+export function silenceErrors(features: boolean | Features) {
+  if (typeof features === 'boolean') {
+    Object.assign(silenced, {
+      errorBoundary: features,
+    });
+  } else {
+    Object.assign(silenced, features);
+  }
 }
 
 export function showErrorDialog(capturedError: CapturedError): boolean {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -50,9 +50,6 @@ import {ConcurrentRoot, LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
-  silenceErrors: boolean | {
-    errorBoundary: boolean
-  },
   unstable_isConcurrent: boolean,
   ...
 };

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -50,6 +50,9 @@ import {ConcurrentRoot, LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
+  silenceErrors: boolean | {
+    errorBoundary: boolean
+  },
   unstable_isConcurrent: boolean,
   ...
 };

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -468,6 +468,33 @@ describe('ReactTestRenderer', () => {
     ]);
   });
 
+  it('silences error boundary logs', () => {
+    const spy = spyOnDevAndProd(console, 'error');
+
+    function Angry() {
+      throw new Error('Please, do not render me.');
+    }
+
+    class TestBoundary extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = { didError: false };
+      }
+      componentDidCatch(err) {
+        this.setState({ didError: true });
+      }
+      render() {
+        return this.state.didError ? null : this.props.children;
+      }
+    }
+
+    ReactTestRenderer.create(<TestBoundary><Angry /></TestBoundary>);
+
+    expect(spy).not.toHaveBeenCalledWith(
+      expect.stringContaining('The above error occurred in the <Angry> component')
+    );
+  });
+
   it('can update text nodes', () => {
     class Component extends React.Component {
       render() {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -478,20 +478,26 @@ describe('ReactTestRenderer', () => {
     class TestBoundary extends React.Component {
       constructor(props) {
         super(props);
-        this.state = { didError: false };
+        this.state = {didError: false};
       }
       componentDidCatch(err) {
-        this.setState({ didError: true });
+        this.setState({didError: true});
       }
       render() {
         return this.state.didError ? null : this.props.children;
       }
     }
 
-    ReactTestRenderer.create(<TestBoundary><Angry /></TestBoundary>);
+    ReactTestRenderer.create(
+      <TestBoundary>
+        <Angry />
+      </TestBoundary>,
+    );
 
     expect(spy).not.toHaveBeenCalledWith(
-      expect.stringContaining('The above error occurred in the <Angry> component')
+      expect.stringContaining(
+        'The above error occurred in the <Angry> component',
+      ),
     );
   });
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -494,6 +494,7 @@ describe('ReactTestRenderer', () => {
       </TestBoundary>,
     );
 
+    expect(spy).toHaveBeenCalledTimes(0);
     expect(spy).not.toHaveBeenCalledWith(
       expect.stringContaining(
         'The above error occurred in the <Angry> component',

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -86,17 +86,6 @@ inlinedHostConfigs.forEach(rendererInfo => {
       return require.requireActual(entryPoint);
     });
   });
-
-  if (rendererInfo.shortName === 'test') {
-    jest.mock('react-reconciler/src/ReactFiberErrorDialog', () => {
-      hasImportedShimmedConfig = true;
-      return require.requireActual(
-        `react-reconciler/src/forks/ReactFiberErrorDialog.${
-          rendererInfo.shortName
-        }.js`
-      );
-    });
-  }
 });
 
 // Make it possible to import this module inside

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -86,6 +86,17 @@ inlinedHostConfigs.forEach(rendererInfo => {
       return require.requireActual(entryPoint);
     });
   });
+
+  if (rendererInfo.shortName === 'test') {
+    jest.mock('react-reconciler/src/ReactFiberErrorDialog', () => {
+      hasImportedShimmedConfig = true;
+      return require.requireActual(
+        `react-reconciler/src/forks/ReactFiberErrorDialog.${
+          rendererInfo.shortName
+        }.js`
+      );
+    });
+  }
 });
 
 // Make it possible to import this module inside

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -86,6 +86,14 @@ inlinedHostConfigs.forEach(rendererInfo => {
       return require.requireActual(entryPoint);
     });
   });
+
+  if (rendererInfo.shortName === 'test') {
+    jest.mock('react-reconciler/src/ReactFiberErrorDialog', () => {
+      return require.requireActual(
+        'react-reconciler/src/forks/ReactFiberErrorDialog.test.js'
+      );
+    });
+  }
 });
 
 // Make it possible to import this module inside

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -306,8 +306,13 @@ const forks = Object.freeze({
       case FB_WWW_DEV:
       case FB_WWW_PROD:
       case FB_WWW_PROFILING:
-        // Use the www fork which shows an error dialog.
-        return 'react-reconciler/src/forks/ReactFiberErrorDialog.www.js';
+        switch (entry) {
+          case 'react-test-renderer':
+            return 'react-reconciler/src/forks/ReactFiberErrorDialog.test.js';
+          default:
+            // Use the www fork which shows an error dialog.
+            return 'react-reconciler/src/forks/ReactFiberErrorDialog.www.js';
+        }
       case RN_OSS_DEV:
       case RN_OSS_PROD:
       case RN_OSS_PROFILING:
@@ -319,8 +324,6 @@ const forks = Object.freeze({
           case 'react-native-renderer/fabric':
             // Use the RN fork which plays well with redbox.
             return 'react-reconciler/src/forks/ReactFiberErrorDialog.native.js';
-          case 'react-test-renderer':
-            return 'react-reconciler/src/forks/ReactFiberErrorDialog.test.js';
           default:
             return null;
         }

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -319,6 +319,8 @@ const forks = Object.freeze({
           case 'react-native-renderer/fabric':
             // Use the RN fork which plays well with redbox.
             return 'react-reconciler/src/forks/ReactFiberErrorDialog.native.js';
+          case 'react-test-renderer':
+            return 'react-reconciler/src/forks/ReactFiberErrorDialog.test.js';
           default:
             return null;
         }


### PR DESCRIPTION
to: @trueadm @acdlite @bvaughn 
cc: @mpeyper

Solves https://github.com/facebook/react/issues/15520

Basically, when an error is thrown and an error boundary exists, `react-test-renderer` will *always* log the "The above error occurred in the component" message with `console.error`. There's currently no way to disable or hide it.

This PR makes a change (using forks) that entirely silences that log if an error boundary catches it. I'm unable to think of any situation where this log is desirable.

Would love to avoid this current hack: https://github.com/milesj/rut/blob/master/packages/rut/src/internals/patch.ts