### PR TITLE
[react-interactions] Rename Flare listeners prop to DEPRECATED_flareListeners

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
@@ -29,7 +29,7 @@ describe('ReactHooksInspection', () => {
       const listener = React.unstable_useResponder(TestResponder, {
         preventDefault: false,
       });
-      return <div listeners={listener}>Hello world</div>;
+      return <div DEPRECATED_flareListeners={listener}>Hello world</div>;
     }
     let tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -1892,7 +1892,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     function Button() {
       let listener = React.unstable_useResponder(TestResponder, {});
-      return <a listeners={listener}>Click me</a>;
+      return <a DEPRECATED_flareListeners={listener}>Click me</a>;
     }
 
     function App() {
@@ -2041,7 +2041,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     function Button() {
       let listener = React.unstable_useResponder(TestResponder, {});
-      return <a listeners={listener}>Click me</a>;
+      return <a DEPRECATED_flareListeners={listener}>Click me</a>;
     }
 
     function Child() {
@@ -2408,13 +2408,13 @@ describe('ReactDOMServerPartialHydration', () => {
       return (
         <div>
           <Suspense fallback="Loading First...">
-            <span listeners={listener1} />
+            <span DEPRECATED_flareListeners={listener1} />
             {/* We suspend after to test what happens when we eager
                 attach the listener. */}
             <First />
           </Suspense>
           <Suspense fallback="Loading Second...">
-            <span listeners={listener2}>
+            <span DEPRECATED_flareListeners={listener2}>
               <Second />
             </span>
           </Suspense>

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -103,7 +103,7 @@ const AUTOFOCUS = 'autoFocus';
 const CHILDREN = 'children';
 const STYLE = 'style';
 const HTML = '__html';
-const LISTENERS = 'listeners';
+const DEPRECATED_flareListeners = 'DEPRECATED_flareListeners';
 
 const {html: HTML_NAMESPACE} = Namespaces;
 
@@ -346,7 +346,7 @@ function setInitialDOMProperties(
         setTextContent(domElement, '' + nextProp);
       }
     } else if (
-      (enableFlareAPI && propKey === LISTENERS) ||
+      (enableFlareAPI && propKey === DEPRECATED_flareListeners) ||
       propKey === SUPPRESS_CONTENT_EDITABLE_WARNING ||
       propKey === SUPPRESS_HYDRATION_WARNING
     ) {
@@ -715,7 +715,7 @@ export function diffProperties(
     } else if (propKey === DANGEROUSLY_SET_INNER_HTML || propKey === CHILDREN) {
       // Noop. This is handled by the clear text mechanism.
     } else if (
-      (enableFlareAPI && propKey === LISTENERS) ||
+      (enableFlareAPI && propKey === DEPRECATED_flareListeners) ||
       propKey === SUPPRESS_CONTENT_EDITABLE_WARNING ||
       propKey === SUPPRESS_HYDRATION_WARNING
     ) {
@@ -810,7 +810,7 @@ export function diffProperties(
         (updatePayload = updatePayload || []).push(propKey, '' + nextProp);
       }
     } else if (
-      (enableFlareAPI && propKey === LISTENERS) ||
+      (enableFlareAPI && propKey === DEPRECATED_flareListeners) ||
       propKey === SUPPRESS_CONTENT_EDITABLE_WARNING ||
       propKey === SUPPRESS_HYDRATION_WARNING
     ) {
@@ -1065,7 +1065,7 @@ export function diffHydratedProperties(
       if (suppressHydrationWarning) {
         // Don't bother comparing. We're ignoring all these warnings.
       } else if (
-        (enableFlareAPI && propKey === LISTENERS) ||
+        (enableFlareAPI && propKey === DEPRECATED_flareListeners) ||
         propKey === SUPPRESS_CONTENT_EDITABLE_WARNING ||
         propKey === SUPPRESS_HYDRATION_WARNING ||
         // Controlled attributes are not validated

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -96,7 +96,7 @@ describe('DOMEventResponderSystem', () => {
     function Test() {
       const listener = React.unstable_useResponder(TestResponder, {});
 
-      return <div listeners={listener}>Hello world</div>;
+      return <div DEPRECATED_flareListeners={listener}>Hello world</div>;
     }
     const renderer = ReactTestRenderer.create(<Test />);
     expect(renderer).toMatchRenderedOutput(<div>Hello world</div>);
@@ -108,7 +108,7 @@ describe('DOMEventResponderSystem', () => {
     function Test() {
       const listener = React.unstable_useResponder(TestResponder, {});
 
-      return <div listeners={listener}>Hello world</div>;
+      return <div DEPRECATED_flareListeners={listener}>Hello world</div>;
     }
     const output = ReactDOMServer.renderToString(<Test />);
     expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
@@ -127,7 +127,7 @@ describe('DOMEventResponderSystem', () => {
 
       return (
         <div>
-          <span listeners={listener} ref={ref}>
+          <span DEPRECATED_flareListeners={listener} ref={ref}>
             Hello world
           </span>
         </div>
@@ -165,7 +165,7 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {});
 
       return (
-        <button ref={buttonRef} listeners={listener}>
+        <button ref={buttonRef} DEPRECATED_flareListeners={listener}>
           Click me!
         </button>
       );
@@ -225,7 +225,7 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {});
 
       return (
-        <button ref={buttonRef} listeners={listener}>
+        <button ref={buttonRef} DEPRECATED_flareListeners={listener}>
           Click me!
         </button>
       );
@@ -270,7 +270,9 @@ describe('DOMEventResponderSystem', () => {
       const listener2 = React.unstable_useResponder(TestResponder, {});
 
       return (
-        <button ref={buttonRef} listeners={[listener, listener2]}>
+        <button
+          ref={buttonRef}
+          DEPRECATED_flareListeners={[listener, listener2]}>
           Click me!
         </button>
       );
@@ -304,8 +306,8 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {});
 
       return (
-        <div listeners={listener}>
-          <button ref={buttonRef} listeners={listener}>
+        <div DEPRECATED_flareListeners={listener}>
+          <button ref={buttonRef} DEPRECATED_flareListeners={listener}>
             Click me!
           </button>
         </div>
@@ -353,7 +355,9 @@ describe('DOMEventResponderSystem', () => {
       const listener2 = React.unstable_useResponder(TestResponderB, {});
 
       return (
-        <button ref={buttonRef} listeners={[listener, listener2]}>
+        <button
+          ref={buttonRef}
+          DEPRECATED_flareListeners={[listener, listener2]}>
           Click me!
         </button>
       );
@@ -374,8 +378,8 @@ describe('DOMEventResponderSystem', () => {
       const listener2 = React.unstable_useResponder(TestResponderB, {});
 
       return (
-        <div listeners={listener}>
-          <button ref={buttonRef} listeners={listener2}>
+        <div DEPRECATED_flareListeners={listener}>
+          <button ref={buttonRef} DEPRECATED_flareListeners={listener2}>
             Click me!
           </button>
         </div>
@@ -406,8 +410,8 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {name: 'A'});
       const listener2 = React.unstable_useResponder(TestResponder, {name: 'B'});
       return (
-        <div listeners={listener}>
-          <button ref={buttonRef} listeners={listener2}>
+        <div DEPRECATED_flareListeners={listener}>
+          <button ref={buttonRef} DEPRECATED_flareListeners={listener2}>
             Click me!
           </button>
         </div>
@@ -454,7 +458,7 @@ describe('DOMEventResponderSystem', () => {
       });
 
       return (
-        <button ref={buttonRef} listeners={listener}>
+        <button ref={buttonRef} DEPRECATED_flareListeners={listener}>
           Click me!
         </button>
       );
@@ -490,9 +494,9 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {});
       const listener2 = React.unstable_useResponder(TestResponder2, {});
       if (toggle) {
-        return <button listeners={[listener2, listener]} />;
+        return <button DEPRECATED_flareListeners={[listener2, listener]} />;
       }
-      return <button listeners={[listener, listener2]} />;
+      return <button DEPRECATED_flareListeners={[listener, listener2]} />;
     }
 
     ReactDOM.render(<Test />, container);
@@ -515,15 +519,15 @@ describe('DOMEventResponderSystem', () => {
     function Test({test}) {
       const listener = React.unstable_useResponder(TestResponder, {});
       if (test === 0) {
-        return <button listeners={[listener]} />;
+        return <button DEPRECATED_flareListeners={[listener]} />;
       } else if (test === 1) {
-        return <button listeners={null} />;
+        return <button DEPRECATED_flareListeners={null} />;
       } else if (test === 2) {
-        return <button listeners={[]} />;
+        return <button DEPRECATED_flareListeners={[]} />;
       } else if (test === 3) {
         return <button />;
       } else if (test === 4) {
-        return <button listeners={listener} />;
+        return <button DEPRECATED_flareListeners={listener} />;
       }
     }
 
@@ -563,7 +567,7 @@ describe('DOMEventResponderSystem', () => {
 
     const Test = () => {
       const listener = React.unstable_useResponder(TestResponder, {});
-      return <button listeners={listener} />;
+      return <button DEPRECATED_flareListeners={listener} />;
     };
 
     ReactDOM.render(<Test />, container);
@@ -590,7 +594,7 @@ describe('DOMEventResponderSystem', () => {
 
     const Test = () => {
       const listener = React.unstable_useResponder(TestResponder, {});
-      return <button listeners={listener}>Click me!</button>;
+      return <button DEPRECATED_flareListeners={listener}>Click me!</button>;
     };
 
     ReactDOM.render(<Test />, container);
@@ -645,8 +649,8 @@ describe('DOMEventResponderSystem', () => {
       const listener2 = React.unstable_useResponder(TestResponderB, {});
 
       return (
-        <div listeners={listener}>
-          <button ref={buttonRef} listeners={listener2}>
+        <div DEPRECATED_flareListeners={listener}>
+          <button ref={buttonRef} DEPRECATED_flareListeners={listener2}>
             Click me!
           </button>
         </div>
@@ -709,8 +713,8 @@ describe('DOMEventResponderSystem', () => {
       const listener2 = React.unstable_useResponder(TestResponderB, {});
 
       return (
-        <div listeners={listener}>
-          <button listeners={listener2}>Click me!</button>
+        <div DEPRECATED_flareListeners={listener}>
+          <button DEPRECATED_flareListeners={listener2}>Click me!</button>
         </div>
       );
     };
@@ -759,7 +763,7 @@ describe('DOMEventResponderSystem', () => {
       });
 
       return (
-        <button listeners={listener} ref={buttonRef}>
+        <button DEPRECATED_flareListeners={listener} ref={buttonRef}>
           Click me!
         </button>
       );
@@ -823,7 +827,7 @@ describe('DOMEventResponderSystem', () => {
         onFoo: e => eventLogs.push('hook'),
       });
 
-      return <button ref={buttonRef} listeners={listener} />;
+      return <button ref={buttonRef} DEPRECATED_flareListeners={listener} />;
     };
 
     ReactDOM.render(<Test />, container);
@@ -838,7 +842,7 @@ describe('DOMEventResponderSystem', () => {
         onFoo: e => eventLogs.push('hook'),
       });
 
-      return <button ref={buttonRef} listeners={listener} />;
+      return <button ref={buttonRef} DEPRECATED_flareListeners={listener} />;
     };
 
     ReactDOM.render(<Test2 />, container);
@@ -859,7 +863,7 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {counter});
       Scheduler.unstable_yieldValue('Test');
       return (
-        <button listeners={listener} ref={ref}>
+        <button DEPRECATED_flareListeners={listener} ref={ref}>
           Press me
         </button>
       );
@@ -927,7 +931,7 @@ describe('DOMEventResponderSystem', () => {
       const listener = React.unstable_useResponder(TestResponder, {
         onClick: logEvent,
       });
-      return <button ref={ref} listeners={listener} />;
+      return <button ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
     dispatchClickEvent(ref.current);
@@ -970,7 +974,7 @@ describe('DOMEventResponderSystem', () => {
     const Component = () => {
       const listener = React.unstable_useResponder(TestResponder, {});
       return (
-        <div listeners={listener}>
+        <div DEPRECATED_flareListeners={listener}>
           {ReactDOM.createPortal(<button ref={buttonRef} />, domNode)}
         </div>
       );
@@ -994,7 +998,7 @@ describe('DOMEventResponderSystem', () => {
     const Component = () => {
       const listener = React.unstable_useResponder(TestResponder, {});
       return (
-        <div listeners={listener}>
+        <div DEPRECATED_flareListeners={listener}>
           {ReactDOM.createPortal(<button ref={buttonRef} />, domNode)}
         </div>
       );

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -370,7 +370,7 @@ function createOpenTagMarkup(
     if (!hasOwnProperty.call(props, propKey)) {
       continue;
     }
-    if (enableFlareAPI && propKey === 'listeners') {
+    if (enableFlareAPI && propKey === 'DEPRECATED_flareListeners') {
       continue;
     }
     let propValue = props[propKey];

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -8,6 +8,7 @@
  */
 
 import warning from 'shared/warning';
+import {enableFlareAPI} from 'shared/ReactFeatureFlags';
 
 type PropertyType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -207,7 +208,7 @@ function PropertyInfoRecord(
 const properties = {};
 
 // These props are reserved by React. They shouldn't be written to the DOM.
-[
+const reservedProps = [
   'children',
   'dangerouslySetInnerHTML',
   // TODO: This prevents the assignment of defaultValue to regular
@@ -219,7 +220,12 @@ const properties = {};
   'suppressContentEditableWarning',
   'suppressHydrationWarning',
   'style',
-].forEach(name => {
+];
+if (enableFlareAPI) {
+  reservedProps.push('DEPRECATED_flareListeners');
+}
+
+reservedProps.forEach(name => {
   properties[name] = new PropertyInfoRecord(
     name,
     RESERVED,

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -36,7 +36,7 @@ if (__DEV__) {
         props.readOnly ||
         props.disabled ||
         props[propName] == null ||
-        (enableFlareAPI && props.listeners)
+        (enableFlareAPI && props.DEPRECATED_flareListeners)
       ) {
         return null;
       }
@@ -53,7 +53,7 @@ if (__DEV__) {
         props.readOnly ||
         props.disabled ||
         props[propName] == null ||
-        (enableFlareAPI && props.listeners)
+        (enableFlareAPI && props.DEPRECATED_flareListeners)
       ) {
         return null;
       }

--- a/packages/react-interactions/accessibility/src/FocusContain.js
+++ b/packages/react-interactions/accessibility/src/FocusContain.js
@@ -82,7 +82,9 @@ export default function FocusContain({
   );
 
   return (
-    <FocusContainScope ref={scopeRef} listeners={[keyboard, focusWithin]}>
+    <FocusContainScope
+      ref={scopeRef}
+      DEPRECATED_flareListeners={[keyboard, focusWithin]}>
       {children}
     </FocusContainScope>
   );

--- a/packages/react-interactions/accessibility/src/FocusGroup.js
+++ b/packages/react-interactions/accessibility/src/FocusGroup.js
@@ -217,7 +217,10 @@ export function createFocusGroup(
       },
     });
     return (
-      <TableScope listeners={keyboard} ref={scopeRef} type="item">
+      <TableScope
+        DEPRECATED_flareListeners={keyboard}
+        ref={scopeRef}
+        type="item">
         {children}
       </TableScope>
     );

--- a/packages/react-interactions/accessibility/src/FocusTable.js
+++ b/packages/react-interactions/accessibility/src/FocusTable.js
@@ -346,7 +346,7 @@ export function createFocusTable(
     });
     return (
       <TableScope
-        listeners={keyboard}
+        DEPRECATED_flareListeners={keyboard}
         ref={scopeRef}
         type="cell"
         colSpan={colSpan}>

--- a/packages/react-interactions/events/docs/ContextMenu.md
+++ b/packages/react-interactions/events/docs/ContextMenu.md
@@ -12,7 +12,7 @@ const Button = (props) => {
   });
 
   return (
-    <div listeners={contextmenu}>
+    <div DEPRECATED_flareListeners={contextmenu}>
       {props.children}
     </div>
   );

--- a/packages/react-interactions/events/docs/Focus.md
+++ b/packages/react-interactions/events/docs/Focus.md
@@ -19,7 +19,7 @@ const Button = (props) => {
   return (
     <button
       children={props.children}
-      listeners={focus}
+      DEPRECATED_flareListeners={focus}
       style={{
         ...(isFocusVisible && focusVisibleStyles)
       }}

--- a/packages/react-interactions/events/docs/FocusWithin.md
+++ b/packages/react-interactions/events/docs/FocusWithin.md
@@ -19,7 +19,7 @@ const Button = (props) => {
   return (
     <button
       children={props.children}
-      listeners={focusWithin}
+      DEPRECATED_flareListeners={focusWithin}
       style={{
         ...(isFocusWithin && focusWithinStyles),
         ...(isFocusWithinVisible && focusWithinVisibleStyles)

--- a/packages/react-interactions/events/docs/Hover.md
+++ b/packages/react-interactions/events/docs/Hover.md
@@ -18,7 +18,7 @@ const Link = (props) => (
     <a
       {...props}
       href={props.href}
-      listeners={hover}
+      DEPRECATED_flareListeners={hover}
       style={{
         ...props.style,
         textDecoration: isHovered ? 'underline': 'none'

--- a/packages/react-interactions/events/docs/Press.md
+++ b/packages/react-interactions/events/docs/Press.md
@@ -21,7 +21,7 @@ const Button = (props) => (
   return (
     <div
       {...props}
-      listeners={press}
+      DEPRECATED_flareListeners={press}
       role="button"
       tabIndex={0}
       style={

--- a/packages/react-interactions/events/src/dom/__tests__/ContextMenu-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/ContextMenu-test.internal.js
@@ -57,7 +57,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useContextMenu({onContextMenu});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -80,7 +80,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useContextMenu({onContextMenu});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -105,7 +105,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
           onContextMenu,
           disabled: true,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -123,7 +123,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
           onContextMenu,
           preventDefault: false,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -149,7 +149,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useContextMenu({onContextMenu});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -181,7 +181,7 @@ describe.each(table)('ContextMenu responder', hasPointerEvents => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useContextMenu({onContextMenu});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 

--- a/packages/react-interactions/events/src/dom/__tests__/Drag-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Drag-test.internal.js
@@ -48,7 +48,7 @@ describe('Drag event responder', () => {
         onDragChange: handleOnDrag,
       });
       return (
-        <div ref={divRef} listeners={listener}>
+        <div ref={divRef} DEPRECATED_flareListeners={listener}>
           Drag me!
         </div>
       );
@@ -105,7 +105,7 @@ describe('Drag event responder', () => {
         onDragEnd: handleDragEnd,
       });
       return (
-        <div ref={divRef} listeners={listener}>
+        <div ref={divRef} DEPRECATED_flareListeners={listener}>
           Drag me!
         </div>
       );
@@ -157,7 +157,7 @@ describe('Drag event responder', () => {
         onDragMove: handleDragMove,
       });
       return (
-        <div ref={divRef} listeners={listener}>
+        <div ref={divRef} DEPRECATED_flareListeners={listener}>
           Drag me!
         </div>
       );

--- a/packages/react-interactions/events/src/dom/__tests__/Focus-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Focus-test.internal.js
@@ -59,7 +59,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onBlur,
           onFocus,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -83,7 +83,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
         const listener = useFocus({
           onBlur,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -108,7 +108,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onFocus,
         });
         return (
-          <div ref={ref} listeners={listener}>
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
             <a ref={innerRef} />
           </div>
         );
@@ -207,7 +207,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onFocusChange,
         });
         return (
-          <div ref={ref} listeners={listener}>
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
             <div ref={innerRef} />
           </div>
         );
@@ -246,7 +246,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onFocusVisibleChange,
         });
         return (
-          <div ref={ref} listeners={listener}>
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
             <div ref={innerRef} />
           </div>
         );
@@ -320,7 +320,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onFocus: createEventHandler('inner: onFocus'),
           onFocusChange: createEventHandler('inner: onFocusChange'),
         });
-        return <div ref={innerRef} listeners={listener} />;
+        return <div ref={innerRef} DEPRECATED_flareListeners={listener} />;
       };
 
       const Outer = () => {
@@ -330,7 +330,7 @@ describe.each(table)('Focus responder', hasPointerEvents => {
           onFocusChange: createEventHandler('outer: onFocusChange'),
         });
         return (
-          <div ref={outerRef} listeners={listener}>
+          <div ref={outerRef} DEPRECATED_flareListeners={listener}>
             <Inner />
           </div>
         );

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -60,7 +60,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
           onFocusWithinChange,
           onFocusWithinVisibleChange,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -82,7 +82,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
         onFocusWithinChange,
       });
       return (
-        <div ref={ref} listeners={listener}>
+        <div ref={ref} DEPRECATED_flareListeners={listener}>
           {show && <input ref={innerRef} />}
           <div ref={innerRef2} />
         </div>
@@ -151,7 +151,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
         onFocusWithinVisibleChange,
       });
       return (
-        <div ref={ref} listeners={listener}>
+        <div ref={ref} DEPRECATED_flareListeners={listener}>
           {show && <input ref={innerRef} />}
           <div ref={innerRef2} />
         </div>
@@ -280,7 +280,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
           onBlurWithin,
         });
         return (
-          <div ref={ref} listeners={listener}>
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
             {show && <input ref={innerRef} />}
             <div ref={innerRef2} />
           </div>
@@ -310,7 +310,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
           onBlurWithin,
         });
         return (
-          <div ref={ref} listeners={listener}>
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
             {show && (
               <div>
                 <input ref={innerRef} />

--- a/packages/react-interactions/events/src/dom/__tests__/Hover-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Hover-test.internal.js
@@ -63,7 +63,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
           onHoverMove,
           onHoverEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -89,7 +89,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         const listener = useHover({
           onHoverStart: onHoverStart,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -126,7 +126,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         const listener = useHover({
           onHoverChange,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -159,7 +159,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         const listener = useHover({
           onHoverEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -203,7 +203,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         const listener = useHover({
           onHoverMove,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -233,7 +233,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
           onHoverEnd: createEventHandler('inner: onHoverEnd'),
           onHoverChange: createEventHandler('inner: onHoverChange'),
         });
-        return <div ref={innerRef} listeners={listener} />;
+        return <div ref={innerRef} DEPRECATED_flareListeners={listener} />;
       };
 
       const Outer = () => {
@@ -243,7 +243,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
           onHoverChange: createEventHandler('outer: onHoverChange'),
         });
         return (
-          <div ref={outerRef} listeners={listener}>
+          <div ref={outerRef} DEPRECATED_flareListeners={listener}>
             <Inner />
           </div>
         );
@@ -309,7 +309,7 @@ describe.each(table)('Hover responder', hasPointerEvents => {
         onHoverEnd: logEvent,
         onHoverMove: logEvent,
       });
-      return <div ref={ref} listeners={listener} />;
+      return <div ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 

--- a/packages/react-interactions/events/src/dom/__tests__/Input-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Input-test.internal.js
@@ -72,7 +72,7 @@ describe('Input event responder', () => {
           onChange,
           onValueChange,
         });
-        return <input ref={ref} listeners={listener} />;
+        return <input ref={ref} DEPRECATED_flareListeners={listener} />;
       }
       ReactDOM.render(<Component />, container);
     });
@@ -123,7 +123,7 @@ describe('Input event responder', () => {
             type="text"
             ref={ref}
             defaultValue="foo"
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
           />
         );
       }
@@ -163,7 +163,7 @@ describe('Input event responder', () => {
             type="checkbox"
             ref={ref}
             defaultChecked={true}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
           />
         );
       }
@@ -206,7 +206,7 @@ describe('Input event responder', () => {
             type="checkbox"
             ref={ref}
             defaultChecked={false}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
           />
         );
       }
@@ -243,7 +243,13 @@ describe('Input event responder', () => {
           onChange,
           onValueChange,
         });
-        return <input type="checkbox" ref={ref} listeners={listener} />;
+        return (
+          <input
+            type="checkbox"
+            ref={ref}
+            DEPRECATED_flareListeners={listener}
+          />
+        );
       }
       ReactDOM.render(<Component />, container);
 
@@ -289,7 +295,7 @@ describe('Input event responder', () => {
             type="text"
             defaultValue="foo"
             ref={ref}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
           />
         );
       }
@@ -347,7 +353,12 @@ describe('Input event responder', () => {
           onValueChange,
         });
         return (
-          <input type="text" defaultValue="42" ref={ref} listeners={listener} />
+          <input
+            type="text"
+            defaultValue="42"
+            ref={ref}
+            DEPRECATED_flareListeners={listener}
+          />
         );
       }
       ReactDOM.render(<Component />, container);
@@ -391,7 +402,7 @@ describe('Input event responder', () => {
             type="checkbox"
             defaultChecked={false}
             ref={ref}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
           />
         );
       }
@@ -439,7 +450,9 @@ describe('Input event responder', () => {
           onChange,
           onValueChange,
         });
-        return <input type="radio" ref={ref} listeners={listener} />;
+        return (
+          <input type="radio" ref={ref} DEPRECATED_flareListeners={listener} />
+        );
       }
       ReactDOM.render(<Component />, container);
 
@@ -484,7 +497,13 @@ describe('Input event responder', () => {
           onChange: onChange1,
           onValueChange: onValueChange1,
         });
-        return <input type="radio" name="group" listeners={listener} />;
+        return (
+          <input
+            type="radio"
+            name="group"
+            DEPRECATED_flareListeners={listener}
+          />
+        );
       }
 
       function Radio2() {
@@ -492,7 +511,13 @@ describe('Input event responder', () => {
           onChange: onChange2,
           onValueChange: onValueChange2,
         });
-        return <input type="radio" name="group" listeners={listener} />;
+        return (
+          <input
+            type="radio"
+            name="group"
+            DEPRECATED_flareListeners={listener}
+          />
+        );
       }
 
       function Component() {
@@ -560,7 +585,12 @@ describe('Input event responder', () => {
             onValueChange,
           });
           return (
-            <input type={type} name="group" ref={ref} listeners={listener} />
+            <input
+              type={type}
+              name="group"
+              ref={ref}
+              DEPRECATED_flareListeners={listener}
+            />
           );
         }
         ReactDOM.render(<Component />, container);
@@ -587,7 +617,9 @@ describe('Input event responder', () => {
             onChange,
             onValueChange,
           });
-          return <input type={type} ref={ref} listeners={listener} />;
+          return (
+            <input type={type} ref={ref} DEPRECATED_flareListeners={listener} />
+          );
         }
         ReactDOM.render(<Component2 />, container);
         // Should be ignored (no change):
@@ -613,7 +645,9 @@ describe('Input event responder', () => {
             onChange,
             onValueChange,
           });
-          return <input type={type} ref={ref} listeners={listener} />;
+          return (
+            <input type={type} ref={ref} DEPRECATED_flareListeners={listener} />
+          );
         }
         ReactDOM.render(<Component3 />, container);
         // Should be ignored (no change):
@@ -653,7 +687,9 @@ describe('Input event responder', () => {
           onChange,
           onValueChange,
         });
-        return <input type="range" ref={ref} listeners={listener} />;
+        return (
+          <input type="range" ref={ref} DEPRECATED_flareListeners={listener} />
+        );
       }
       ReactDOM.render(<Component />, container);
 
@@ -690,7 +726,9 @@ describe('Input event responder', () => {
           onChange,
           onValueChange,
         });
-        return <input type="range" ref={ref} listeners={listener} />;
+        return (
+          <input type="range" ref={ref} DEPRECATED_flareListeners={listener} />
+        );
       }
       ReactDOM.render(<Component />, container);
 
@@ -766,7 +804,7 @@ describe('Input event responder', () => {
               type="text"
               ref={innerRef}
               value={controlledValue}
-              listeners={listener}
+              DEPRECATED_flareListeners={listener}
             />
           );
         }
@@ -826,7 +864,7 @@ describe('Input event responder', () => {
               type="checkbox"
               ref={innerRef}
               checked={controlledValue}
-              listeners={listener}
+              DEPRECATED_flareListeners={listener}
             />
           );
         }
@@ -901,7 +939,7 @@ describe('Input event responder', () => {
               type="text"
               ref={innerRef}
               value={controlledValue}
-              listeners={listener}
+              DEPRECATED_flareListeners={listener}
             />
           );
         }

--- a/packages/react-interactions/events/src/dom/__tests__/Keyboard-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Keyboard-test.internal.js
@@ -60,8 +60,8 @@ describe('Keyboard responder', () => {
         onKeyUp: onKeyUpOuter,
       });
       return (
-        <div listeners={listenerOuter}>
-          <div ref={ref} listeners={listenerInner} />
+        <div DEPRECATED_flareListeners={listenerOuter}>
+          <div ref={ref} DEPRECATED_flareListeners={listenerInner} />
         </div>
       );
     };
@@ -130,7 +130,7 @@ describe('Keyboard responder', () => {
       ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard({disabled: true, onKeyDown, onKeyUp});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -154,7 +154,7 @@ describe('Keyboard responder', () => {
       ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard({onClick});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -232,7 +232,7 @@ describe('Keyboard responder', () => {
       ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard({onKeyDown});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -293,7 +293,7 @@ describe('Keyboard responder', () => {
       ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard({onKeyUp});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -353,7 +353,7 @@ describe('Keyboard responder', () => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard(props);
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       return ref;
@@ -398,7 +398,7 @@ describe('Keyboard responder', () => {
       const ref = React.createRef();
       const Component = () => {
         const listener = useKeyboard(props);
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       return ref;

--- a/packages/react-interactions/events/src/dom/__tests__/MixedResponders-test-internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/MixedResponders-test-internal.js
@@ -60,7 +60,7 @@ describe('mixing responders with the heritage event system', () => {
         <div>
           <button
             ref={ref}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
             onClick={() => {
               updateCounter(count => count + 1);
             }}>
@@ -129,7 +129,7 @@ describe('mixing responders with the heritage event system', () => {
         <div>
           <button
             ref={ref}
-            listeners={listener}
+            DEPRECATED_flareListeners={listener}
             onClick={() => {
               // This should flush synchronously
               ReactDOM.unstable_flushDiscreteUpdates();
@@ -210,7 +210,7 @@ describe('mixing responders with the heritage event system', () => {
         return (
           <div>
             <button
-              listeners={tap}
+              DEPRECATED_flareListeners={tap}
               ref={button}
               onClick={() => updateClicksCount(clicksCount + 1)}>
               Presses: {pressesCount}, Clicks: {clicksCount}
@@ -255,7 +255,7 @@ describe('mixing responders with the heritage event system', () => {
             type="text"
             ref={innerRef}
             value={controlledValue}
-            listeners={[inputListener, listeners]}
+            DEPRECATED_flareListeners={[inputListener, listeners]}
           />
         );
       }

--- a/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
@@ -67,7 +67,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
           onPressEnd,
           onPress,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -105,7 +105,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressStart,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -190,7 +190,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -288,7 +288,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressChange,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -328,7 +328,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPress,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       ref.current.getBoundingClientRect = () => ({
@@ -377,7 +377,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
       const inputRef = React.createRef();
       const Component = () => {
         const listener = usePress({onPress});
-        return <input ref={inputRef} listeners={listener} />;
+        return <input ref={inputRef} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       const target = createEventTarget(inputRef.current);
@@ -426,7 +426,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressMove,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       ref.current.getBoundingClientRect = () => ({
@@ -476,7 +476,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -497,7 +497,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -522,7 +522,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
         const listener = usePress({onPress});
         return (
           <a href="#">
-            <button ref={buttonRef} listeners={listener} />
+            <button ref={buttonRef} DEPRECATED_flareListeners={listener} />
           </a>
         );
       };
@@ -542,7 +542,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
       const Component = () => {
         const listener = usePress({onPress});
         return (
-          <a href="#" listeners={listener}>
+          <a href="#" DEPRECATED_flareListeners={listener}>
             <div ref={ref} />
           </a>
         );
@@ -565,7 +565,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -587,7 +587,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress, preventDefault: false});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -607,7 +607,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress, preventDefault: false});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -628,7 +628,7 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
 
     const Component = () => {
       const listener = usePress();
-      return <button ref={ref} listeners={listener} />;
+      return <button ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -75,7 +75,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
           onPress,
           onPressEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -101,7 +101,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressStart,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -201,7 +201,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -299,7 +299,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressChange,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -339,7 +339,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPress,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       ref.current.getBoundingClientRect = () => ({
@@ -388,7 +388,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const inputRef = React.createRef();
       const Component = () => {
         const listener = usePress({onPress});
-        return <input ref={inputRef} listeners={listener} />;
+        return <input ref={inputRef} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       const target = createEventTarget(inputRef.current);
@@ -419,7 +419,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const Component = () => {
         const listener = usePress({onPress});
         return (
-          <div ref={divRef} listeners={listener}>
+          <div ref={divRef} DEPRECATED_flareListeners={listener}>
             <button ref={buttonRef} />
           </div>
         );
@@ -459,7 +459,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({
           onPressMove,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       ref.current.getBoundingClientRect = () => ({
@@ -521,7 +521,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         });
         return (
           <div ref={outerRef}>
-            <div ref={ref} listeners={listener} />
+            <div ref={ref} DEPRECATED_flareListeners={listener} />
           </div>
         );
       };
@@ -610,7 +610,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
             onPressEnd: createEventHandler('onPressEnd'),
             pressRetentionOffset,
           });
-          return <div ref={localRef} listeners={listener} />;
+          return <div ref={localRef} DEPRECATED_flareListeners={listener} />;
         };
         ReactDOM.render(<Component />, container);
 
@@ -756,7 +756,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
           return (
             <div
               ref={ref}
-              listeners={listener}
+              DEPRECATED_flareListeners={listener}
               onPointerDown={createEventHandler('pointerdown')}
               onPointerUp={createEventHandler('pointerup')}
               onKeyDown={createEventHandler('keydown')}
@@ -774,7 +774,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
             onPressEnd: createEventHandler('outer: onPressEnd'),
           });
           return (
-            <div listeners={listener}>
+            <div DEPRECATED_flareListeners={listener}>
               <Inner />
             </div>
           );
@@ -804,13 +804,13 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
         const Inner = () => {
           const listener = usePress({onPress});
-          return <div ref={ref} listeners={listener} />;
+          return <div ref={ref} DEPRECATED_flareListeners={listener} />;
         };
 
         const Outer = () => {
           const listener = usePress({onPress});
           return (
-            <div listeners={listener}>
+            <div DEPRECATED_flareListeners={listener}>
               <Inner />
             </div>
           );
@@ -831,13 +831,13 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
         const Inner = () => {
           const listener = usePress({onPressStart, onPressEnd});
-          return <div ref={ref} listeners={listener} />;
+          return <div ref={ref} DEPRECATED_flareListeners={listener} />;
         };
 
         const Outer = () => {
           const listener = usePress({onPressStart, onPressEnd});
           return (
-            <div listeners={listener}>
+            <div DEPRECATED_flareListeners={listener}>
               <Inner />
             </div>
           );
@@ -859,13 +859,13 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
         const Inner = () => {
           const listener = usePress({onPressChange});
-          return <div ref={ref} listeners={listener} />;
+          return <div ref={ref} DEPRECATED_flareListeners={listener} />;
         };
 
         const Outer = () => {
           const listener = usePress({onPressChange});
           return (
-            <div listeners={listener}>
+            <div DEPRECATED_flareListeners={listener}>
               <Inner />
             </div>
           );
@@ -889,7 +889,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -909,7 +909,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -931,7 +931,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
         const listener = usePress({onPress});
         return (
           <a href="#">
-            <button ref={buttonRef} listeners={listener} />
+            <button ref={buttonRef} DEPRECATED_flareListeners={listener} />
           </a>
         );
       };
@@ -951,7 +951,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const Component = () => {
         const listener = usePress({onPress});
         return (
-          <a href="#" listeners={listener}>
+          <a href="#" DEPRECATED_flareListeners={listener}>
             <div ref={ref} />
           </a>
         );
@@ -974,7 +974,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -996,7 +996,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress, preventDefault: false});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -1016,7 +1016,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPress, preventDefault: false});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -1038,7 +1038,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
       const Component = () => {
         const listener = usePress({onPressEnd});
-        return <a href="#" ref={ref} listeners={listener} />;
+        return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
 
@@ -1055,7 +1055,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     const Component = () => {
       const listener = usePress({onPressEnd});
-      return <a href="#" ref={ref} listeners={listener} />;
+      return <a href="#" ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 
@@ -1075,7 +1075,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const listener = usePress({onPressEnd});
       return (
         <div ref={containerRef}>
-          <a ref={ref} listeners={listener} />
+          <a ref={ref} DEPRECATED_flareListeners={listener} />
         </div>
       );
     };
@@ -1097,7 +1097,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const listener = usePress({onPressEnd});
       return (
         <div>
-          <a ref={ref} listeners={listener} />
+          <a ref={ref} DEPRECATED_flareListeners={listener} />
           <span ref={outsideRef} />
         </div>
       );
@@ -1120,7 +1120,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     const Component = () => {
       const listener = usePress();
-      return <button ref={ref} listeners={listener} />;
+      return <button ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 
@@ -1140,7 +1140,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     const Component = () => {
       const listener = usePress({onPress, onPressStart, onPressEnd});
-      return <button ref={buttonRef} listeners={listener} />;
+      return <button ref={buttonRef} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 

--- a/packages/react-interactions/events/src/dom/__tests__/Scroll-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Scroll-test.internal.js
@@ -55,7 +55,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
           disabled: true,
           onScroll,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -77,7 +77,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
         const listener = useScroll({
           onScroll,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -148,7 +148,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
         const listener = useScroll({
           onScrollDragStart,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -178,7 +178,7 @@ describe.each(table)('Scroll responder', hasPointerEvents => {
         const listener = useScroll({
           onScrollDragEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });

--- a/packages/react-interactions/events/src/dom/__tests__/Tap-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Tap-test.internal.js
@@ -87,7 +87,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
     const ref = React.createRef();
     const Component = () => {
       const listener = useTap();
-      return <button ref={ref} listeners={listener} />;
+      return <button ref={ref} DEPRECATED_flareListeners={listener} />;
     };
     ReactDOM.render(<Component />, container);
 
@@ -122,7 +122,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
           onTapCancel,
           onTapEnd,
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
     });
@@ -145,7 +145,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
     function render(props) {
       const Component = () => {
         const listener = useTap(props);
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -201,7 +201,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
       ref = React.createRef();
       const Component = () => {
         const listener = useTap({onAuxiliaryTap});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -234,7 +234,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
       ref = React.createRef();
       const Component = () => {
         const listener = useTap({onTapStart});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -338,7 +338,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
       ref = React.createRef();
       const Component = () => {
         const listener = useTap({onTapEnd});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -391,7 +391,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
       const Component = () => {
         const listener = useTap({onTapEnd});
         return (
-          <div ref={targetRef} listeners={listener}>
+          <div ref={targetRef} DEPRECATED_flareListeners={listener}>
             <button ref={innerRef} />
           </div>
         );
@@ -480,7 +480,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
       ref = React.createRef();
       const Component = () => {
         const listener = useTap({onTapUpdate});
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -592,7 +592,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
           onTapEnd: logger('end'),
           onTapCancel: logger('cancel'),
         });
-        return <div ref={ref} listeners={listener} />;
+        return <div ref={ref} DEPRECATED_flareListeners={listener} />;
       };
       ReactDOM.render(<Component />, container);
       document.elementFromPoint = () => ref.current;
@@ -646,7 +646,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
         const listener = useTap({onTapCancel, onTapUpdate});
         return (
           <div ref={parentRef}>
-            <div ref={ref} listeners={listener} />
+            <div ref={ref} DEPRECATED_flareListeners={listener} />
             <span ref={siblingRef} />
           </div>
         );
@@ -800,7 +800,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
             preventDefault: shouldPreventDefault,
           });
           return (
-            <a href="#" ref={ref} listeners={listener}>
+            <a href="#" ref={ref} DEPRECATED_flareListeners={listener}>
               <div ref={innerRef} />
             </a>
           );

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -124,7 +124,7 @@ import {
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork';
 import {runWithPriority, NormalPriority} from './SchedulerWithReactIntegration';
-import {updateEventListeners} from './ReactFiberEvents';
+import {updateLegacyEventListeners} from './ReactFiberEvents';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -1361,10 +1361,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           );
         }
         if (enableFlareAPI) {
-          const prevListeners = oldProps.listeners;
-          const nextListeners = newProps.listeners;
+          const prevListeners = oldProps.DEPRECATED_flareListeners;
+          const nextListeners = newProps.DEPRECATED_flareListeners;
           if (prevListeners !== nextListeners) {
-            updateEventListeners(nextListeners, finishedWork, null);
+            updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
         }
       }
@@ -1426,10 +1426,10 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         if (enableFlareAPI) {
           const newProps = finishedWork.memoizedProps;
           const oldProps = current !== null ? current.memoizedProps : newProps;
-          const prevListeners = oldProps.listeners;
-          const nextListeners = newProps.listeners;
+          const prevListeners = oldProps.DEPRECATED_flareListeners;
+          const nextListeners = newProps.DEPRECATED_flareListeners;
           if (prevListeners !== nextListeners) {
-            updateEventListeners(nextListeners, finishedWork, null);
+            updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -128,7 +128,7 @@ import {
 import {createFundamentalStateInstance} from './ReactFiberFundamental';
 import {Never} from './ReactFiberExpirationTime';
 import {resetChildFibers} from './ReactChildFiber';
-import {updateEventListeners} from './ReactFiberEvents';
+import {updateLegacyEventListeners} from './ReactFiberEvents';
 import {createScopeMethods} from './ReactFiberScope';
 
 function markUpdate(workInProgress: Fiber) {
@@ -686,8 +686,8 @@ function completeWork(
         );
 
         if (enableFlareAPI) {
-          const prevListeners = current.memoizedProps.listeners;
-          const nextListeners = newProps.listeners;
+          const prevListeners = current.memoizedProps.DEPRECATED_flareListeners;
+          const nextListeners = newProps.DEPRECATED_flareListeners;
           if (prevListeners !== nextListeners) {
             markUpdate(workInProgress);
           }
@@ -728,9 +728,9 @@ function completeWork(
             markUpdate(workInProgress);
           }
           if (enableFlareAPI) {
-            const listeners = newProps.listeners;
+            const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              updateEventListeners(
+              updateLegacyEventListeners(
                 listeners,
                 workInProgress,
                 rootContainerInstance,
@@ -752,9 +752,9 @@ function completeWork(
           workInProgress.stateNode = instance;
 
           if (enableFlareAPI) {
-            const listeners = newProps.listeners;
+            const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              updateEventListeners(
+              updateLegacyEventListeners(
                 listeners,
                 workInProgress,
                 rootContainerInstance,
@@ -1252,10 +1252,10 @@ function completeWork(
           workInProgress.stateNode = scopeInstance;
           scopeInstance.methods = createScopeMethods(type, scopeInstance);
           if (enableFlareAPI) {
-            const listeners = newProps.listeners;
+            const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
               const rootContainerInstance = getRootHostContainer();
-              updateEventListeners(
+              updateLegacyEventListeners(
                 listeners,
                 workInProgress,
                 rootContainerInstance,
@@ -1268,8 +1268,9 @@ function completeWork(
           }
         } else {
           if (enableFlareAPI) {
-            const prevListeners = current.memoizedProps.listeners;
-            const nextListeners = newProps.listeners;
+            const prevListeners =
+              current.memoizedProps.DEPRECATED_flareListeners;
+            const nextListeners = newProps.DEPRECATED_flareListeners;
             if (
               prevListeners !== nextListeners ||
               workInProgress.ref !== null

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -146,7 +146,7 @@ function updateEventListener(
   }
 }
 
-export function updateEventListeners(
+export function updateLegacyEventListeners(
   listeners: any,
   fiber: Fiber,
   rootContainerInstance: null | Container,

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -343,7 +343,7 @@ describe('ReactScope', () => {
           onKeyDown,
         });
         return (
-          <TestScope listeners={listener}>
+          <TestScope DEPRECATED_flareListeners={listener}>
             <div ref={ref} />
           </TestScope>
         );
@@ -361,7 +361,7 @@ describe('ReactScope', () => {
         });
         return (
           <div>
-            <TestScope listeners={listener}>
+            <TestScope DEPRECATED_flareListeners={listener}>
               <div ref={ref} />
             </TestScope>
           </div>

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -149,11 +149,11 @@ export function createInstance(
 ): Instance {
   let propsToUse = props;
   if (enableFlareAPI) {
-    if (props.listeners != null) {
-      // We want to remove the "listeners" prop
+    if (props.DEPRECATED_flareListeners != null) {
+      // We want to remove the "DEPRECATED_flareListeners" prop
       // as we don't want it in the test renderer's
       // instance props.
-      const {listeners, ...otherProps} = props; // eslint-disable-line
+      const {DEPRECATED_flareListeners, ...otherProps} = props; // eslint-disable-line
       propsToUse = otherProps;
     }
   }


### PR DESCRIPTION
This renames the `listeners` prop to `DEPRECATED_flareListeners`. This is for two reasons:

- to discourage internal usage of this experimental API
- to enable us to experiment with another event API that might make use of the `listeners` prop in the future