### PR TITLE
useTransition improvements

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -17,6 +17,7 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {HookEffectTag} from './ReactHookEffectTags';
 import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
+import type {TransitionInstance} from './ReactFiberTransition';
 import type {ReactPriorityLevel} from './SchedulerWithReactIntegration';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -53,11 +54,11 @@ import is from 'shared/objectIs';
 import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
 import {
-  UserBlockingPriority,
-  NormalPriority,
-  runWithPriority,
-  getCurrentPriorityLevel,
-} from './SchedulerWithReactIntegration';
+  startTransition,
+  requestCurrentTransition,
+  cancelPendingTransition,
+} from './ReactFiberTransition';
+import {getCurrentPriorityLevel} from './SchedulerWithReactIntegration';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -117,13 +118,10 @@ type Update<S, A> = {
 type UpdateQueue<S, A> = {
   last: Update<S, A> | null,
   dispatch: (A => mixed) | null,
+  pendingTransition: TransitionInstance | null,
   lastRenderedReducer: ((S, A) => S) | null,
   lastRenderedState: S | null,
 };
-
-type TransitionInstance = {|
-  pendingExpirationTime: ExpirationTime,
-|};
 
 export type HookType =
   | 'useState'
@@ -667,6 +665,7 @@ function mountReducer<S, I, A>(
   const queue = (hook.queue = {
     last: null,
     dispatch: null,
+    pendingTransition: null,
     lastRenderedReducer: reducer,
     lastRenderedState: (initialState: any),
   });
@@ -839,6 +838,7 @@ function mountState<S>(
   const queue = (hook.queue = {
     last: null,
     dispatch: null,
+    pendingTransition: null,
     lastRenderedReducer: basicStateReducer,
     lastRenderedState: (initialState: any),
   });
@@ -1176,89 +1176,14 @@ function updateDeferredValue<T>(
   return prevValue;
 }
 
-function startTransition(fiber, instance, config, callback) {
-  let resolvedConfig: SuspenseConfig | null =
-    config === undefined ? null : config;
-
-  // TODO: runWithPriority shouldn't be necessary here. React should manage its
-  // own concept of priority, and only consult Scheduler for updates that are
-  // scheduled from outside a React context.
-  const priorityLevel = getCurrentPriorityLevel();
-  runWithPriority(
-    priorityLevel < UserBlockingPriority ? UserBlockingPriority : priorityLevel,
-    () => {
-      const currentTime = requestCurrentTimeForUpdate();
-      const expirationTime = computeExpirationForFiber(
-        currentTime,
-        fiber,
-        null,
-      );
-      scheduleWork(fiber, expirationTime);
-    },
-  );
-  runWithPriority(
-    priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
-    () => {
-      const currentTime = requestCurrentTimeForUpdate();
-      let expirationTime = computeExpirationForFiber(
-        currentTime,
-        fiber,
-        resolvedConfig,
-      );
-      // Set the expiration time at which the pending transition will finish.
-      // Because there's only a single transition per useTransition hook, we
-      // don't need a queue here; we can cheat by only tracking the most
-      // recently scheduled transition.
-      // TODO: This trick depends on transition expiration times being
-      // monotonically decreasing in priority, but since expiration times
-      // currently correspond to `timeoutMs`, that might not be true if
-      // `timeoutMs` changes to something smaller before the previous transition
-      // resolves. But this is a temporary edge case, since we're about to
-      // remove the correspondence between `timeoutMs` and the expiration time.
-      const oldPendingExpirationTime = instance.pendingExpirationTime;
-      while (
-        oldPendingExpirationTime !== NoWork &&
-        oldPendingExpirationTime <= expirationTime
-      ) {
-        // Temporary hack to make pendingExpirationTime monotonically decreasing
-        if (resolvedConfig === null) {
-          resolvedConfig = {
-            timeoutMs: 5250,
-          };
-        } else {
-          resolvedConfig = {
-            timeoutMs: (resolvedConfig.timeoutMs | 0 || 5000) + 250,
-            busyDelayMs: resolvedConfig.busyDelayMs,
-            busyMinDurationMs: resolvedConfig.busyMinDurationMs,
-          };
-        }
-        expirationTime = computeExpirationForFiber(
-          currentTime,
-          fiber,
-          resolvedConfig,
-        );
-      }
-      instance.pendingExpirationTime = expirationTime;
-
-      scheduleWork(fiber, expirationTime);
-      const previousConfig = ReactCurrentBatchConfig.suspense;
-      ReactCurrentBatchConfig.suspense = resolvedConfig;
-      try {
-        callback();
-      } finally {
-        ReactCurrentBatchConfig.suspense = previousConfig;
-      }
-    },
-  );
-}
-
 function mountTransition(
   config: SuspenseConfig | void | null,
 ): [(() => void) => void, boolean] {
   const hook = mountWorkInProgressHook();
-
+  const fiber = ((currentlyRenderingFiber: any): Fiber);
   const instance: TransitionInstance = {
     pendingExpirationTime: NoWork,
+    fiber,
   };
   // TODO: Intentionally storing this on the queue field to avoid adding a new/
   // one; `queue` should be a union.
@@ -1270,15 +1195,9 @@ function mountTransition(
   // Then we don't have to recompute the callback whenever it changes. However,
   // if we don't end up changing the API, we should at least optimize this
   // to use the same hook instead of a separate hook just for the callback.
-  const start = mountCallback(
-    startTransition.bind(
-      null,
-      ((currentlyRenderingFiber: any): Fiber),
-      instance,
-      config,
-    ),
-    [config],
-  );
+  const start = mountCallback(startTransition.bind(null, instance, config), [
+    config,
+  ]);
 
   const resolvedExpirationTime = NoWork;
   hook.memoizedState = {
@@ -1368,15 +1287,9 @@ function updateTransition(
     resolvedExpirationTime: newResolvedExpirationTime,
   };
 
-  const start = updateCallback(
-    startTransition.bind(
-      null,
-      ((currentlyRenderingFiber: any): Fiber),
-      instance,
-      config,
-    ),
-    [config],
-  );
+  const start = updateCallback(startTransition.bind(null, instance, config), [
+    config,
+  ]);
 
   return [start, newIsPending];
 }
@@ -1438,6 +1351,7 @@ function dispatchAction<S, A>(
   } else {
     const currentTime = requestCurrentTimeForUpdate();
     const suspenseConfig = requestCurrentSuspenseConfig();
+    const transition = requestCurrentTransition();
     const expirationTime = computeExpirationForFiber(
       currentTime,
       fiber,
@@ -1518,6 +1432,20 @@ function dispatchAction<S, A>(
         warnIfNotCurrentlyActingUpdatesInDev(fiber);
       }
     }
+
+    if (transition !== null) {
+      const prevPendingTransition = queue.pendingTransition;
+      if (transition !== prevPendingTransition) {
+        queue.pendingTransition = transition;
+        if (prevPendingTransition !== null) {
+          // There's already a pending transition on this queue. The new
+          // transition supersedes the old one. Turn of the `isPending` state
+          // of the previous transition.
+          cancelPendingTransition(prevPendingTransition);
+        }
+      }
+    }
+
     scheduleWork(fiber, expirationTime);
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -121,6 +121,10 @@ type UpdateQueue<S, A> = {
   lastRenderedState: S | null,
 };
 
+type TransitionInstance = {|
+  pendingExpirationTime: ExpirationTime,
+|};
+
 export type HookType =
   | 'useState'
   | 'useReducer'
@@ -776,7 +780,6 @@ function updateReducer<S, I, A>(
         }
       } else {
         // This update does have sufficient priority.
-
         // Mark the event time of this update as relevant to this render pass.
         // TODO: This should ideally use the true event time of this update rather than
         // its priority which is a derived and not reverseable value.
@@ -798,6 +801,7 @@ function updateReducer<S, I, A>(
           newState = reducer(newState, action);
         }
       }
+
       prevUpdate = update;
       update = update.next;
     } while (update !== null && update !== first);
@@ -1172,21 +1176,74 @@ function updateDeferredValue<T>(
   return prevValue;
 }
 
-function startTransition(setPending, config, callback) {
+function startTransition(fiber, instance, config, callback) {
+  let resolvedConfig: SuspenseConfig | null =
+    config === undefined ? null : config;
+
+  // TODO: runWithPriority shouldn't be necessary here. React should manage its
+  // own concept of priority, and only consult Scheduler for updates that are
+  // scheduled from outside a React context.
   const priorityLevel = getCurrentPriorityLevel();
   runWithPriority(
     priorityLevel < UserBlockingPriority ? UserBlockingPriority : priorityLevel,
     () => {
-      setPending(true);
+      const currentTime = requestCurrentTimeForUpdate();
+      const expirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        null,
+      );
+      scheduleWork(fiber, expirationTime);
     },
   );
   runWithPriority(
     priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
     () => {
+      const currentTime = requestCurrentTimeForUpdate();
+      let expirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        resolvedConfig,
+      );
+      // Set the expiration time at which the pending transition will finish.
+      // Because there's only a single transition per useTransition hook, we
+      // don't need a queue here; we can cheat by only tracking the most
+      // recently scheduled transition.
+      // TODO: This trick depends on transition expiration times being
+      // monotonically decreasing in priority, but since expiration times
+      // currently correspond to `timeoutMs`, that might not be true if
+      // `timeoutMs` changes to something smaller before the previous transition
+      // resolves. But this is a temporary edge case, since we're about to
+      // remove the correspondence between `timeoutMs` and the expiration time.
+      const oldPendingExpirationTime = instance.pendingExpirationTime;
+      while (
+        oldPendingExpirationTime !== NoWork &&
+        oldPendingExpirationTime <= expirationTime
+      ) {
+        // Temporary hack to make pendingExpirationTime monotonically decreasing
+        if (resolvedConfig === null) {
+          resolvedConfig = {
+            timeoutMs: 5250,
+          };
+        } else {
+          resolvedConfig = {
+            timeoutMs: (resolvedConfig.timeoutMs | 0 || 5000) + 250,
+            busyDelayMs: resolvedConfig.busyDelayMs,
+            busyMinDurationMs: resolvedConfig.busyMinDurationMs,
+          };
+        }
+        expirationTime = computeExpirationForFiber(
+          currentTime,
+          fiber,
+          resolvedConfig,
+        );
+      }
+      instance.pendingExpirationTime = expirationTime;
+
+      scheduleWork(fiber, expirationTime);
       const previousConfig = ReactCurrentBatchConfig.suspense;
-      ReactCurrentBatchConfig.suspense = config === undefined ? null : config;
+      ReactCurrentBatchConfig.suspense = resolvedConfig;
       try {
-        setPending(false);
         callback();
       } finally {
         ReactCurrentBatchConfig.suspense = previousConfig;
@@ -1198,23 +1255,130 @@ function startTransition(setPending, config, callback) {
 function mountTransition(
   config: SuspenseConfig | void | null,
 ): [(() => void) => void, boolean] {
-  const [isPending, setPending] = mountState(false);
-  const start = mountCallback(startTransition.bind(null, setPending, config), [
-    setPending,
-    config,
-  ]);
+  const hook = mountWorkInProgressHook();
+
+  const instance: TransitionInstance = {
+    pendingExpirationTime: NoWork,
+  };
+  // TODO: Intentionally storing this on the queue field to avoid adding a new/
+  // one; `queue` should be a union.
+  hook.queue = (instance: any);
+
+  const isPending = false;
+
+  // TODO: Consider passing `config` to `startTransition` instead of the hook.
+  // Then we don't have to recompute the callback whenever it changes. However,
+  // if we don't end up changing the API, we should at least optimize this
+  // to use the same hook instead of a separate hook just for the callback.
+  const start = mountCallback(
+    startTransition.bind(
+      null,
+      ((currentlyRenderingFiber: any): Fiber),
+      instance,
+      config,
+    ),
+    [config],
+  );
+
+  const resolvedExpirationTime = NoWork;
+  hook.memoizedState = {
+    isPending,
+
+    // Represents the last processed expiration time.
+    resolvedExpirationTime,
+  };
+
   return [start, isPending];
 }
 
 function updateTransition(
   config: SuspenseConfig | void | null,
 ): [(() => void) => void, boolean] {
-  const [isPending, setPending] = updateState(false);
-  const start = updateCallback(startTransition.bind(null, setPending, config), [
-    setPending,
-    config,
-  ]);
-  return [start, isPending];
+  const hook = updateWorkInProgressHook();
+
+  const instance: TransitionInstance = (hook.queue: any);
+
+  const pendingExpirationTime = instance.pendingExpirationTime;
+  const oldState = hook.memoizedState;
+  const oldIsPending = oldState.isPending;
+  const oldResolvedExpirationTime = oldState.resolvedExpirationTime;
+
+  // Check if the most recent transition is pending. The following logic is
+  // a little confusing, but it conceptually maps to same logic used to process
+  // state update queues (see: updateReducer). We're cheating a bit because
+  // we know that there is only ever a single pending transition, and the last
+  // one always wins. So we don't need to maintain an actual queue of updates;
+  // we only need to track 1) which is the most recent pending level 2) did
+  // we already resolve
+  //
+  // Note: This could be even simpler if we used a commit effect to mark when a
+  // pending transition is resolved. The cleverness that follows is meant to
+  // avoid the overhead of an extra effect; however, if this ends up being *too*
+  // clever, an effect probably isn't that bad, since it would only fire once
+  // per transition.
+  let newIsPending;
+  let newResolvedExpirationTime;
+
+  if (pendingExpirationTime === NoWork) {
+    // There are no pending transitions. Reset all fields.
+    newIsPending = false;
+    newResolvedExpirationTime = NoWork;
+  } else {
+    // There is a pending transition. It may or may not have resolved. Compare
+    // the time at which we last resolved to the pending time. If the pending
+    // time is in the future, then we're still pending.
+    if (
+      oldResolvedExpirationTime === NoWork ||
+      oldResolvedExpirationTime > pendingExpirationTime
+    ) {
+      // We have not already resolved at the pending time. Check if this render
+      // includes the pending level.
+      if (renderExpirationTime <= pendingExpirationTime) {
+        // This render does include the pending level. Mark it as resolved.
+        newIsPending = false;
+        newResolvedExpirationTime = renderExpirationTime;
+      } else {
+        // This render does not include the pending level. Still pending.
+        newIsPending = true;
+        newResolvedExpirationTime = oldResolvedExpirationTime;
+      }
+    } else {
+      // Already resolved at this expiration time.
+      newIsPending = false;
+      newResolvedExpirationTime = oldResolvedExpirationTime;
+    }
+  }
+
+  if (newIsPending !== oldIsPending) {
+    markWorkInProgressReceivedUpdate();
+  } else if (oldIsPending === false) {
+    // This is a trick to mutate the instance without a commit effect. If
+    // neither the current nor work-in-progress hook are pending, and there's no
+    // pending transition at a lower priority (which we know because there can
+    // only be one pending level per useTransition hook), then we can be certain
+    // there are no pending transitions even if this render does not finish.
+    // It's similar to the trick we use for eager setState bailouts. Like that
+    // optimization, this should have no semantic effect.
+    instance.pendingExpirationTime = NoWork;
+    newResolvedExpirationTime = NoWork;
+  }
+
+  hook.memoizedState = {
+    isPending: newIsPending,
+    resolvedExpirationTime: newResolvedExpirationTime,
+  };
+
+  const start = updateCallback(
+    startTransition.bind(
+      null,
+      ((currentlyRenderingFiber: any): Fiber),
+      instance,
+      config,
+    ),
+    [config],
+  );
+
+  return [start, newIsPending];
 }
 
 function dispatchAction<S, A>(

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -52,6 +52,7 @@ import warning from 'shared/warning';
 import getComponentName from 'shared/getComponentName';
 import is from 'shared/objectIs';
 import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork';
+import {SuspendOnTask} from './ReactFiberThrow';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
 import {
   startTransition,
@@ -761,7 +762,10 @@ function updateReducer<S, I, A>(
     let prevUpdate = baseUpdate;
     let update = first;
     let didSkip = false;
+    let lastProcessedTransitionTime = NoWork;
+    let lastSkippedTransitionTime = NoWork;
     do {
+      const suspenseConfig = update.suspenseConfig;
       const updateExpirationTime = update.expirationTime;
       if (updateExpirationTime < renderExpirationTime) {
         // Priority is insufficient. Skip this update. If this is the first
@@ -777,6 +781,16 @@ function updateReducer<S, I, A>(
           remainingExpirationTime = updateExpirationTime;
           markUnprocessedUpdateTime(remainingExpirationTime);
         }
+
+        if (suspenseConfig !== null) {
+          // This update is part of a transition
+          if (
+            lastSkippedTransitionTime === NoWork ||
+            lastSkippedTransitionTime > updateExpirationTime
+          ) {
+            lastSkippedTransitionTime = updateExpirationTime;
+          }
+        }
       } else {
         // This update does have sufficient priority.
         // Mark the event time of this update as relevant to this render pass.
@@ -785,10 +799,7 @@ function updateReducer<S, I, A>(
         // TODO: We should skip this update if it was already committed but currently
         // we have no way of detecting the difference between a committed and suspended
         // update here.
-        markRenderEventTimeAndConfig(
-          updateExpirationTime,
-          update.suspenseConfig,
-        );
+        markRenderEventTimeAndConfig(updateExpirationTime, suspenseConfig);
 
         // Process this update.
         if (update.eagerReducer === reducer) {
@@ -799,11 +810,31 @@ function updateReducer<S, I, A>(
           const action = update.action;
           newState = reducer(newState, action);
         }
+
+        if (suspenseConfig !== null) {
+          // This update is part of a transition
+          if (
+            lastProcessedTransitionTime === NoWork ||
+            lastProcessedTransitionTime > updateExpirationTime
+          ) {
+            lastProcessedTransitionTime = updateExpirationTime;
+          }
+        }
       }
 
       prevUpdate = update;
       update = update.next;
     } while (update !== null && update !== first);
+
+    if (
+      lastProcessedTransitionTime !== NoWork &&
+      lastSkippedTransitionTime !== NoWork
+    ) {
+      // There are multiple updates scheduled on this queue, but only some of
+      // them were processed. To avoid showing an intermediate state, abort
+      // the current render and restart at a level that includes them all.
+      throw new SuspendOnTask(lastSkippedTransitionTime);
+    }
 
     if (!didSkip) {
       newBaseUpdate = prevUpdate;

--- a/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
@@ -9,6 +9,7 @@
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
+// TODO: Remove React.unstable_withSuspenseConfig and move this to the renderer
 const {ReactCurrentBatchConfig} = ReactSharedInternals;
 
 export type SuspenseConfig = {|

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -62,6 +62,12 @@ import {Sync} from './ReactFiberExpirationTime';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
+// Throw an object with this type to abort the current render and restart at
+// a different level.
+export function SuspendOnTask(expirationTime: ExpirationTime) {
+  this.expirationTime = expirationTime;
+}
+
 function createRootErrorUpdate(
   fiber: Fiber,
   errorInfo: CapturedValue<mixed>,

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from './ReactFiber';
+import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
+
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+import {
+  UserBlockingPriority,
+  NormalPriority,
+  runWithPriority,
+  getCurrentPriorityLevel,
+} from './SchedulerWithReactIntegration';
+import {
+  scheduleUpdateOnFiber,
+  computeExpirationForFiber,
+  requestCurrentTimeForUpdate,
+} from './ReactFiberWorkLoop';
+import {NoWork} from './ReactFiberExpirationTime';
+
+const {ReactCurrentBatchConfig} = ReactSharedInternals;
+
+export type TransitionInstance = {|
+  pendingExpirationTime: ExpirationTime,
+  fiber: Fiber,
+|};
+
+// Inside `startTransition`, this is the transition instance that corresponds to
+// the `useTransition` hook.
+let currentTransition: TransitionInstance | null = null;
+
+// Inside `startTransition`, this is the expiration time of the update that
+// turns on `isPending`. We also use it to turn off the `isPending` of previous
+// transitions, if they exists.
+let userBlockingExpirationTime = NoWork;
+
+export function requestCurrentTransition(): TransitionInstance | null {
+  return currentTransition;
+}
+
+export function startTransition(
+  transitionInstance: TransitionInstance,
+  config: SuspenseConfig | null | void,
+  callback: () => void,
+) {
+  const fiber = transitionInstance.fiber;
+
+  let resolvedConfig: SuspenseConfig | null =
+    config === undefined ? null : config;
+
+  // TODO: runWithPriority shouldn't be necessary here. React should manage its
+  // own concept of priority, and only consult Scheduler for updates that are
+  // scheduled from outside a React context.
+  const priorityLevel = getCurrentPriorityLevel();
+  runWithPriority(
+    priorityLevel < UserBlockingPriority ? UserBlockingPriority : priorityLevel,
+    () => {
+      const currentTime = requestCurrentTimeForUpdate();
+      userBlockingExpirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        null,
+      );
+      scheduleUpdateOnFiber(fiber, userBlockingExpirationTime);
+    },
+  );
+  runWithPriority(
+    priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
+    () => {
+      const currentTime = requestCurrentTimeForUpdate();
+      let expirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        resolvedConfig,
+      );
+      // Set the expiration time at which the pending transition will finish.
+      // Because there's only a single transition per useTransition hook, we
+      // don't need a queue here; we can cheat by only tracking the most
+      // recently scheduled transition.
+      // TODO: This trick depends on transition expiration times being
+      // monotonically decreasing in priority, but since expiration times
+      // currently correspond to `timeoutMs`, that might not be true if
+      // `timeoutMs` changes to something smaller before the previous transition
+      // resolves. But this is a temporary edge case, since we're about to
+      // remove the correspondence between `timeoutMs` and the expiration time.
+      const oldPendingExpirationTime = transitionInstance.pendingExpirationTime;
+      while (
+        oldPendingExpirationTime !== NoWork &&
+        oldPendingExpirationTime <= expirationTime
+      ) {
+        // Temporary hack to make pendingExpirationTime monotonically decreasing
+        if (resolvedConfig === null) {
+          resolvedConfig = {
+            timeoutMs: 5250,
+          };
+        } else {
+          resolvedConfig = {
+            timeoutMs: (resolvedConfig.timeoutMs | 0 || 5000) + 250,
+            busyDelayMs: resolvedConfig.busyDelayMs,
+            busyMinDurationMs: resolvedConfig.busyMinDurationMs,
+          };
+        }
+        expirationTime = computeExpirationForFiber(
+          currentTime,
+          fiber,
+          resolvedConfig,
+        );
+      }
+      transitionInstance.pendingExpirationTime = expirationTime;
+
+      scheduleUpdateOnFiber(fiber, expirationTime);
+      const previousConfig = ReactCurrentBatchConfig.suspense;
+      const previousTransition = currentTransition;
+      ReactCurrentBatchConfig.suspense = resolvedConfig;
+      currentTransition = transitionInstance;
+      try {
+        callback();
+      } finally {
+        ReactCurrentBatchConfig.suspense = previousConfig;
+        currentTransition = previousTransition;
+        userBlockingExpirationTime = NoWork;
+      }
+    },
+  );
+}
+
+export function cancelPendingTransition(prevTransition: TransitionInstance) {
+  // Turn off the `isPending` state of the previous transition, at the same
+  // priority we use to turn on the `isPending` state of the current transition.
+  prevTransition.pendingExpirationTime = NoWork;
+  scheduleUpdateOnFiber(prevTransition.fiber, userBlockingExpirationTime);
+}

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
@@ -152,4 +152,324 @@ describe('ReactTransition', () => {
       expect(root).toMatchRenderedOutput('Tab 3');
     },
   );
+
+  it.experimental(
+    'when multiple transitions update the same queue, only the most recent one is considered pending',
+    async () => {
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      const Tab = React.forwardRef(({label, setTab}, ref) => {
+        const [startTransition, isPending] = useTransition(CONFIG);
+
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            go() {
+              startTransition(() => setTab(label));
+            },
+          }),
+          [label],
+        );
+
+        return (
+          <Text text={'Tab ' + label + (isPending ? ' (pending...)' : '')} />
+        );
+      });
+
+      const tabButtonA = React.createRef(null);
+      const tabButtonB = React.createRef(null);
+      const tabButtonC = React.createRef(null);
+
+      const ContentA = createAsyncText('A');
+      const ContentB = createAsyncText('B');
+      const ContentC = createAsyncText('C');
+
+      function App() {
+        const [tab, setTab] = useState('A');
+
+        let content;
+        switch (tab) {
+          case 'A':
+            content = <ContentA />;
+            break;
+          case 'B':
+            content = <ContentB />;
+            break;
+          case 'C':
+            content = <ContentC />;
+            break;
+          default:
+            content = <ContentA />;
+            break;
+        }
+
+        return (
+          <>
+            <ul>
+              <li>
+                <Tab ref={tabButtonA} label="A" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonB} label="B" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonC} label="C" setTab={setTab} />
+              </li>
+            </ul>
+            <Suspense fallback={<Text text="Loading..." />}>{content}</Suspense>
+          </>
+        );
+      }
+
+      // Initial render
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(<App />);
+        await ContentA.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Navigate to tab B
+      await act(async () => {
+        tabButtonB.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        'Tab B (pending...)',
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [B]',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B (pending...)</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Before B resolves, navigate to tab C. B should no longer be pending.
+      await act(async () => {
+        tabButtonC.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        // Turn `isPending` off for tab B, and on for tab C
+        'Tab B',
+        'Tab C (pending...)',
+        // Try finishing the transition
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [C]',
+        'Loading...',
+      ]);
+      // Tab B is no longer pending. Only C.
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading C
+      await act(async () => {
+        ContentC.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          C
+        </>,
+      );
+    },
+  );
+
+  // Same as previous test, but for class update queue.
+  it.experimental(
+    'when multiple transitions update the same queue, only the most recent one is considered pending (classes)',
+    async () => {
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      const Tab = React.forwardRef(({label, setTab}, ref) => {
+        const [startTransition, isPending] = useTransition(CONFIG);
+
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            go() {
+              startTransition(() => setTab(label));
+            },
+          }),
+          [label],
+        );
+
+        return (
+          <Text text={'Tab ' + label + (isPending ? ' (pending...)' : '')} />
+        );
+      });
+
+      const tabButtonA = React.createRef(null);
+      const tabButtonB = React.createRef(null);
+      const tabButtonC = React.createRef(null);
+
+      const ContentA = createAsyncText('A');
+      const ContentB = createAsyncText('B');
+      const ContentC = createAsyncText('C');
+
+      class App extends React.Component {
+        state = {tab: 'A'};
+        setTab = tab => {
+          this.setState({tab});
+        };
+
+        render() {
+          let content;
+          switch (this.state.tab) {
+            case 'A':
+              content = <ContentA />;
+              break;
+            case 'B':
+              content = <ContentB />;
+              break;
+            case 'C':
+              content = <ContentC />;
+              break;
+            default:
+              content = <ContentA />;
+              break;
+          }
+
+          return (
+            <>
+              <ul>
+                <li>
+                  <Tab ref={tabButtonA} label="A" setTab={this.setTab} />
+                </li>
+                <li>
+                  <Tab ref={tabButtonB} label="B" setTab={this.setTab} />
+                </li>
+                <li>
+                  <Tab ref={tabButtonC} label="C" setTab={this.setTab} />
+                </li>
+              </ul>
+              <Suspense fallback={<Text text="Loading..." />}>
+                {content}
+              </Suspense>
+            </>
+          );
+        }
+      }
+
+      // Initial render
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(<App />);
+        await ContentA.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Navigate to tab B
+      await act(async () => {
+        tabButtonB.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        'Tab B (pending...)',
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [B]',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B (pending...)</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Before B resolves, navigate to tab C. B should no longer be pending.
+      await act(async () => {
+        tabButtonC.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        // Turn `isPending` off for tab B, and on for tab C
+        'Tab B',
+        'Tab C (pending...)',
+        // Try finishing the transition
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [C]',
+        'Loading...',
+      ]);
+      // Tab B is no longer pending. Only C.
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading C
+      await act(async () => {
+        ContentC.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          C
+        </>,
+      );
+    },
+  );
 });

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
@@ -27,6 +27,7 @@ describe('ReactTransition', () => {
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     ReactFeatureFlags.enableSchedulerTracing = true;
     ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
@@ -460,6 +461,181 @@ describe('ReactTransition', () => {
         ContentC.resolve();
       });
       expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          C
+        </>,
+      );
+    },
+  );
+
+  // TODO: Same behavior for classes
+  it.experimental(
+    'when multiple transitions update the same queue, only the most recent ' +
+      'one is allowed to finish (no intermediate states)',
+    async () => {
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      const Tab = React.forwardRef(({label, setTab}, ref) => {
+        const [startTransition, isPending] = useTransition(CONFIG);
+
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            go() {
+              startTransition(() => setTab(label));
+            },
+          }),
+          [label],
+        );
+
+        return (
+          <Text text={'Tab ' + label + (isPending ? ' (pending...)' : '')} />
+        );
+      });
+
+      const tabButtonA = React.createRef(null);
+      const tabButtonB = React.createRef(null);
+      const tabButtonC = React.createRef(null);
+
+      const ContentA = createAsyncText('A');
+      const ContentB = createAsyncText('B');
+      const ContentC = createAsyncText('C');
+
+      function App() {
+        Scheduler.unstable_yieldValue('App');
+
+        const [tab, setTab] = useState('A');
+
+        let content;
+        switch (tab) {
+          case 'A':
+            content = <ContentA />;
+            break;
+          case 'B':
+            content = <ContentB />;
+            break;
+          case 'C':
+            content = <ContentC />;
+            break;
+          default:
+            content = <ContentA />;
+            break;
+        }
+
+        return (
+          <>
+            <ul>
+              <li>
+                <Tab ref={tabButtonA} label="A" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonB} label="B" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonC} label="C" setTab={setTab} />
+              </li>
+            </ul>
+            <Suspense fallback={<Text text="Loading..." />}>{content}</Suspense>
+          </>
+        );
+      }
+
+      // Initial render
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(<App />);
+        await ContentA.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['App', 'Tab A', 'Tab B', 'Tab C', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Navigate to tab B
+      await act(async () => {
+        tabButtonB.current.go();
+        expect(Scheduler).toFlushAndYieldThrough([
+          // Turn on B's pending state
+          'Tab B (pending...)',
+          // Partially render B
+          'App',
+          'Tab A',
+          'Tab B',
+        ]);
+
+        // While we're still in the middle of rendering B, switch to C.
+        tabButtonC.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        // Toggle the pending flags
+        'Tab B',
+        'Tab C (pending...)',
+
+        // Start rendering B...
+        'App',
+        // ...but bail out, since C is more recent. These should not be logged:
+        // 'Tab A',
+        // 'Tab B',
+        // 'Tab C (pending...)',
+        // 'Suspend! [B]',
+        // 'Loading...',
+
+        // Now render C
+        'App',
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [C]',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading B
+      await act(async () => {
+        ContentB.resolve();
+      });
+      // Should not switch to tab B because we've since clicked on C.
+      expect(Scheduler).toHaveYielded([]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading C
+      await act(async () => {
+        ContentC.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['App', 'Tab A', 'Tab B', 'Tab C', 'C']);
       expect(root).toMatchRenderedOutput(
         <>
           <ul>


### PR DESCRIPTION
Stack of improvements to `useTransition`. Some of these will require a refactor of our "expiration time" model, and will therefore have implications beyond the scope of `useTransition`.

I'm planning to land this in stages. The first few commits are useful even before I start changing the expiration time model. They also block a concurrent mode release. Whereas the expiration times refactor is riskier, and it's possible they won't block the initial release.

On the other hand, breaking these changes into too many parts may be *more* risky, because instead of one batched risky change we'd have many individual risky changes.

For now I'll push everything to this branch. Once I'm further along I'll decide how to split it up.

## Summary

Not a comprehensive summary. I'll keep updating this section as I work.

### Changes that do not depend on expiration time refactor

- [x] When multiple transitions update the same queue, only the most recent
one should be considered pending. Example: If I switch tabs multiple times, only the last tab I click should display a pending state (e.g. an inline spinner).
  - Only affects `useTransition`. Could land this on its own, though it's most useful when combined with the next item.
- [x] When multiple transitions update the same queue, only the most recent one should be allowed to finish. Do not display intermediate states. Example: if you click on multiple tabs in quick succession, we should not switch to any tab that isn't the last one you clicked.

### Changes that do depend on expiration time refactor

TODO