### PR TITLE
Make HostComponent inexact

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -119,10 +119,7 @@ export type NativeMethods = {
 };
 
 export type NativeMethodsMixinType = NativeMethods;
-export type HostComponent<T> = AbstractComponent<
-  T,
-  $ReadOnly<$Exact<NativeMethods>>,
->;
+export type HostComponent<T> = AbstractComponent<T, $ReadOnly<NativeMethods>>;
 
 type SecretInternalsType = {
   NativeMethodsMixin: NativeMethodsMixinType,


### PR DESCRIPTION
We need HostComponent to be inexact so that Flow will let us add additional imperative methods to this in cases like TextInput. This change was already made in FBSource in D18458408 with sign off from @jbrown215. Landing this in the React repo so that future syncs don't have this difference. 

