### PR TITLE
[Fresh] Fix an infinite loop in an edge case

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -154,6 +154,22 @@ function resolveFamily(type) {
   return updatedFamiliesByType.get(type);
 }
 
+// If we didn't care about IE11, we could use new Map/Set(iterable).
+function cloneMap<K, V>(map: Map<K, V>): Map<K, V> {
+  let clone = new Map();
+  map.forEach((value, key) => {
+    clone.set(key, value);
+  });
+  return clone;
+}
+function cloneSet<T>(set: Set<T>): Set<T> {
+  let clone = new Set();
+  set.forEach(value => {
+    clone.add(value);
+  });
+  return clone;
+}
+
 export function performReactRefresh(): RefreshUpdate | null {
   if (__DEV__) {
     if (pendingUpdates.length === 0) {
@@ -200,9 +216,9 @@ export function performReactRefresh(): RefreshUpdate | null {
     // If we don't do this, there is a risk they will be mutated while
     // we iterate over them. For example, trying to recover a failed root
     // may cause another root to be added to the failed list -- an infinite loop.
-    let failedRootsSnapshot = new Map(failedRoots);
-    let mountedRootsSnapshot = new Set(mountedRoots);
-    let helpersByRootSnapshot = new Map(helpersByRoot);
+    let failedRootsSnapshot = cloneMap(failedRoots);
+    let mountedRootsSnapshot = cloneSet(mountedRoots);
+    let helpersByRootSnapshot = cloneMap(helpersByRoot);
 
     failedRootsSnapshot.forEach((element, root) => {
       const helpers = helpersByRootSnapshot.get(root);


### PR DESCRIPTION
A good old mutation-while-iterating kind of bug. These maps and sets can be mutated during a commit, so we can't just `forEach` here. Otherwise we risk running into an infinite loop where processing each next item causes more items to be added to the list.

Added a regression test. Verified this fixes a problem on WWW.