### PR TITLE
useTransition improvements

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -190,7 +190,7 @@ const classComponentUpdater = {
       suspenseConfig,
     );
 
-    const update = createUpdate(expirationTime, suspenseConfig);
+    const update = createUpdate(currentTime, expirationTime, suspenseConfig);
     update.payload = payload;
     if (callback !== undefined && callback !== null) {
       if (__DEV__) {
@@ -212,7 +212,7 @@ const classComponentUpdater = {
       suspenseConfig,
     );
 
-    const update = createUpdate(expirationTime, suspenseConfig);
+    const update = createUpdate(currentTime, expirationTime, suspenseConfig);
     update.tag = ReplaceState;
     update.payload = payload;
 
@@ -236,7 +236,7 @@ const classComponentUpdater = {
       suspenseConfig,
     );
 
-    const update = createUpdate(expirationTime, suspenseConfig);
+    const update = createUpdate(currentTime, expirationTime, suspenseConfig);
     update.tag = ForceUpdate;
 
     if (callback !== undefined && callback !== null) {

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -85,16 +85,13 @@ export function computeAsyncExpiration(
   );
 }
 
-export function computeSuspenseExpiration(
+export function computeSuspenseTimeout(
   currentTime: ExpirationTime,
   timeoutMs: number,
 ): ExpirationTime {
-  // TODO: Should we warn if timeoutMs is lower than the normal pri expiration time?
-  return computeExpirationBucket(
-    currentTime,
-    timeoutMs,
-    LOW_PRIORITY_BATCH_SIZE,
-  );
+  const currentTimeMs = expirationTimeToMs(currentTime);
+  const deadlineMs = currentTimeMs + timeoutMs;
+  return msToExpirationTime(deadlineMs);
 }
 
 // We intentionally set a higher expiration time for interactive updates in

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -217,7 +217,7 @@ export function propagateContextChange(
 
           if (fiber.tag === ClassComponent) {
             // Schedule a force update on the work-in-progress.
-            const update = createUpdate(renderExpirationTime, null);
+            const update = createUpdate(NoWork, renderExpirationTime, null);
             update.tag = ForceUpdate;
             // TODO: Because we don't have a work-in-progress, this will add the
             // update to the current fiber, too, which means it will persist even if

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -269,7 +269,7 @@ export function updateContainer(
     }
   }
 
-  const update = createUpdate(expirationTime, suspenseConfig);
+  const update = createUpdate(currentTime, expirationTime, suspenseConfig);
   // Caution: React DevTools currently depends on this property
   // being called "element".
   update.payload = {element};

--- a/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseConfig.js
@@ -9,6 +9,7 @@
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
+// TODO: Remove React.unstable_withSuspenseConfig and move this to the renderer
 const {ReactCurrentBatchConfig} = ReactSharedInternals;
 
 export type SuspenseConfig = {|

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -57,7 +57,7 @@ import {
   checkForWrongSuspensePriorityInDEV,
 } from './ReactFiberWorkLoop';
 
-import {Sync} from './ReactFiberExpirationTime';
+import {Sync, NoWork} from './ReactFiberExpirationTime';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
@@ -72,7 +72,7 @@ function createRootErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   expirationTime: ExpirationTime,
 ): Update<mixed> {
-  const update = createUpdate(expirationTime, null);
+  const update = createUpdate(NoWork, expirationTime, null);
   // Unmount the root by rendering null.
   update.tag = CaptureUpdate;
   // Caution: React DevTools currently depends on this property
@@ -91,7 +91,7 @@ function createClassErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   expirationTime: ExpirationTime,
 ): Update<mixed> {
-  const update = createUpdate(expirationTime, null);
+  const update = createUpdate(NoWork, expirationTime, null);
   update.tag = CaptureUpdate;
   const getDerivedStateFromError = fiber.type.getDerivedStateFromError;
   if (typeof getDerivedStateFromError === 'function') {
@@ -267,7 +267,7 @@ function throwException(
               // When we try rendering again, we should not reuse the current fiber,
               // since it's known to be in an inconsistent state. Use a force update to
               // prevent a bail out.
-              const update = createUpdate(Sync, null);
+              const update = createUpdate(NoWork, Sync, null);
               update.tag = ForceUpdate;
               enqueueUpdate(sourceFiber, update);
             }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -61,6 +61,12 @@ import {Sync} from './ReactFiberExpirationTime';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
+// Throw an object with this type to abort the current render and restart at
+// a different level.
+export function SuspendOnTask(expirationTime: ExpirationTime) {
+  this.retryTime = expirationTime;
+}
+
 function createRootErrorUpdate(
   fiber: Fiber,
   errorInfo: CapturedValue<mixed>,

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -61,12 +61,6 @@ import {Sync, NoWork} from './ReactFiberExpirationTime';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
-// Throw an object with this type to abort the current render and restart at
-// a different level.
-export function SuspendOnTask(expirationTime: ExpirationTime) {
-  this.retryTime = expirationTime;
-}
-
 function createRootErrorUpdate(
   fiber: Fiber,
   errorInfo: CapturedValue<mixed>,

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from './ReactFiber';
+import type {ExpirationTime} from './ReactFiberExpirationTime';
+import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
+
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+
+import {
+  UserBlockingPriority,
+  NormalPriority,
+  runWithPriority,
+  getCurrentPriorityLevel,
+} from './SchedulerWithReactIntegration';
+import {
+  scheduleUpdateOnFiber,
+  computeExpirationForFiber,
+  requestCurrentTimeForUpdate,
+} from './ReactFiberWorkLoop';
+import {NoWork} from './ReactFiberExpirationTime';
+
+const {ReactCurrentBatchConfig} = ReactSharedInternals;
+
+export type TransitionInstance = {|
+  pendingExpirationTime: ExpirationTime,
+  fiber: Fiber,
+|};
+
+// Inside `startTransition`, this is the transition instance that corresponds to
+// the `useTransition` hook.
+let currentTransition: TransitionInstance | null = null;
+
+// Inside `startTransition`, this is the expiration time of the update that
+// turns on `isPending`. We also use it to turn off the `isPending` of previous
+// transitions, if they exists.
+let userBlockingExpirationTime = NoWork;
+
+export function requestCurrentTransition(): TransitionInstance | null {
+  return currentTransition;
+}
+
+export function startTransition(
+  transitionInstance: TransitionInstance,
+  config: SuspenseConfig | null | void,
+  callback: () => void,
+) {
+  const fiber = transitionInstance.fiber;
+
+  let resolvedConfig: SuspenseConfig | null =
+    config === undefined ? null : config;
+
+  // TODO: runWithPriority shouldn't be necessary here. React should manage its
+  // own concept of priority, and only consult Scheduler for updates that are
+  // scheduled from outside a React context.
+  const priorityLevel = getCurrentPriorityLevel();
+  runWithPriority(
+    priorityLevel < UserBlockingPriority ? UserBlockingPriority : priorityLevel,
+    () => {
+      const currentTime = requestCurrentTimeForUpdate();
+      userBlockingExpirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        null,
+      );
+      scheduleUpdateOnFiber(fiber, userBlockingExpirationTime);
+    },
+  );
+  runWithPriority(
+    priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
+    () => {
+      const currentTime = requestCurrentTimeForUpdate();
+      let expirationTime = computeExpirationForFiber(
+        currentTime,
+        fiber,
+        resolvedConfig,
+      );
+      // Set the expiration time at which the pending transition will finish.
+      // Because there's only a single transition per useTransition hook, we
+      // don't need a queue here; we can cheat by only tracking the most
+      // recently scheduled transition.
+      // TODO: This trick depends on transition expiration times being
+      // monotonically decreasing in priority, but since expiration times
+      // currently correspond to `timeoutMs`, that might not be true if
+      // `timeoutMs` changes to something smaller before the previous transition
+      // resolves. But this is a temporary edge case, since we're about to
+      // remove the correspondence between `timeoutMs` and the expiration time.
+      const oldPendingExpirationTime = transitionInstance.pendingExpirationTime;
+      while (
+        oldPendingExpirationTime !== NoWork &&
+        oldPendingExpirationTime <= expirationTime
+      ) {
+        // Temporary hack to make pendingExpirationTime monotonically decreasing
+        if (resolvedConfig === null) {
+          resolvedConfig = {
+            timeoutMs: 5250,
+          };
+        } else {
+          resolvedConfig = {
+            timeoutMs: (resolvedConfig.timeoutMs | 0 || 5000) + 250,
+            busyDelayMs: resolvedConfig.busyDelayMs,
+            busyMinDurationMs: resolvedConfig.busyMinDurationMs,
+          };
+        }
+        expirationTime = computeExpirationForFiber(
+          currentTime,
+          fiber,
+          resolvedConfig,
+        );
+      }
+      transitionInstance.pendingExpirationTime = expirationTime;
+
+      scheduleUpdateOnFiber(fiber, expirationTime);
+      const previousConfig = ReactCurrentBatchConfig.suspense;
+      const previousTransition = currentTransition;
+      ReactCurrentBatchConfig.suspense = resolvedConfig;
+      currentTransition = transitionInstance;
+      try {
+        callback();
+      } finally {
+        ReactCurrentBatchConfig.suspense = previousConfig;
+        currentTransition = previousTransition;
+        userBlockingExpirationTime = NoWork;
+      }
+    },
+  );
+}
+
+export function cancelPendingTransition(prevTransition: TransitionInstance) {
+  // Turn off the `isPending` state of the previous transition, at the same
+  // priority we use to turn on the `isPending` state of the current transition.
+  prevTransition.pendingExpirationTime = NoWork;
+  scheduleUpdateOnFiber(prevTransition.fiber, userBlockingExpirationTime);
+}

--- a/packages/react-reconciler/src/ReactFiberTransition.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.js
@@ -8,10 +8,12 @@
  */
 
 import type {Fiber} from './ReactFiber';
+import type {UpdateQueue, Update} from './ReactFiberHooks';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import is from 'shared/objectIs';
 
 import {
   UserBlockingPriority,
@@ -23,27 +25,487 @@ import {
   scheduleUpdateOnFiber,
   computeExpirationForFiber,
   requestCurrentTimeForUpdate,
+  warnIfNotScopedWithMatchingAct,
+  warnIfNotCurrentlyActingUpdatesInDev,
+  scheduleWork,
 } from './ReactFiberWorkLoop';
 import {NoWork} from './ReactFiberExpirationTime';
+import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
+import {
+  requestRenderPhaseUpdate,
+  setInvalidNestedHooksDispatcher,
+} from './ReactFiberHooks';
+import {
+  createUpdate,
+  ReplaceState,
+  ForceUpdate,
+  enqueueUpdate,
+} from './ReactUpdateQueue';
+import {get as getInstance} from 'shared/ReactInstanceMap';
+import {isMounted} from 'react-reconciler/reflection';
+import {preventIntermediateStates} from 'shared/ReactFeatureFlags';
 
-const {ReactCurrentBatchConfig} = ReactSharedInternals;
+const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
 export type TransitionInstance = {|
-  pendingExpirationTime: ExpirationTime,
+  version: number,
+  pendingTime: ExpirationTime,
+  resolvedTime: ExpirationTime,
   fiber: Fiber,
 |};
+
+type Dispatch = <S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+) => void;
+
+type ClassSetState = (
+  inst: any,
+  payload: mixed,
+  callback: ?() => mixed,
+) => void;
+type ClassReplaceState = (
+  inst: any,
+  payload: mixed,
+  callback: ?() => mixed,
+) => void;
+type ClassForceUpdate = (inst: any, callback: ?() => mixed) => void;
+
+// The implementation of dispatch, setState, et al can be swapped out at
+// runtime, e.g. when calling `startTransition`. These references point to
+// the current implementation.
+let dispatchImpl: Dispatch = dispatchImplDefault;
+let classSetStateImpl: ClassSetState = classSetStateImplDefault;
+let classReplaceStateImpl: ClassReplaceState = classReplaceStateImplDefault;
+let classForceUpdateImpl: ClassForceUpdate = classForceUpdateImplDefault;
 
 // Inside `startTransition`, this is the transition instance that corresponds to
 // the `useTransition` hook.
 let currentTransition: TransitionInstance | null = null;
-
+// The event time of the current transition.
+let currentTransitionEventTime: ExpirationTime = NoWork;
 // Inside `startTransition`, this is the expiration time of the update that
 // turns on `isPending`. We also use it to turn off the `isPending` of previous
 // transitions, if they exists.
-let userBlockingExpirationTime = NoWork;
+let currentTransitionPendingTime: ExpirationTime = NoWork;
+// The expiration time of the current transition. This is accumulated during
+// `startTransition` because it depends on whether the current transition
+// overlaps with any previous transitions.
+let currentTransitionResolvedTime: ExpirationTime = NoWork;
 
-export function requestCurrentTransition(): TransitionInstance | null {
-  return currentTransition;
+let dispatchContinuations: Array<
+  (ExpirationTime, ExpirationTime, SuspenseConfig | null) => void,
+> | null = null;
+
+let warnOnInvalidCallback;
+if (__DEV__) {
+  const didWarnOnInvalidCallback = new Set();
+
+  warnOnInvalidCallback = function(callback: mixed, callerName: string) {
+    if (callback === null || typeof callback === 'function') {
+      return;
+    }
+    const key = callerName + '_' + (callback: any);
+    if (!didWarnOnInvalidCallback.has(key)) {
+      didWarnOnInvalidCallback.add(key);
+      console.error(
+        '%s(...): Expected the last optional `callback` argument to be a ' +
+          'function. Instead received: %s.',
+        callerName,
+        callback,
+      );
+    }
+  };
+}
+
+export function dispatch<S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+): void {
+  if (__DEV__) {
+    if (typeof arguments[3] === 'function') {
+      console.error(
+        "State updates from the useState() and useReducer() Hooks don't " +
+          'support the second callback argument. To execute a side effect ' +
+          'after rendering, declare it in the component body with useEffect().',
+      );
+    }
+  }
+
+  dispatchImpl(fiber, queue, action);
+}
+
+export const classComponentUpdater = {
+  isMounted,
+  enqueueSetState(inst: any, payload: mixed, callback: ?() => mixed) {
+    classSetStateImpl(inst, payload, callback);
+  },
+  enqueueReplaceState(inst: any, payload: mixed, callback: ?() => mixed) {
+    classReplaceStateImpl(inst, payload, callback);
+  },
+  enqueueForceUpdate(inst: any, callback: ?() => mixed) {
+    classForceUpdateImpl(inst, callback);
+  },
+};
+
+function dispatchImplDefault<S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+) {
+  if (__DEV__) {
+    if (typeof arguments[3] === 'function') {
+      console.error(
+        "State updates from the useState() and useReducer() Hooks don't support the " +
+          'second callback argument. To execute a side effect after ' +
+          'rendering, declare it in the component body with useEffect().',
+      );
+    }
+  }
+  const eventTime = requestCurrentTimeForUpdate();
+  const suspenseConfig = requestCurrentSuspenseConfig();
+  const expirationTime = computeExpirationForFiber(
+    eventTime,
+    fiber,
+    suspenseConfig,
+  );
+  dispatchForExpirationTime(
+    fiber,
+    queue,
+    action,
+    eventTime,
+    expirationTime,
+    suspenseConfig,
+  );
+}
+
+function dispatchForExpirationTime<S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+  eventTime: ExpirationTime,
+  expirationTime: ExpirationTime,
+  suspenseConfig: SuspenseConfig | null,
+) {
+  const update: Update<S, A> = {
+    eventTime,
+    expirationTime,
+    suspenseConfig,
+    action,
+    eagerReducer: null,
+    eagerState: null,
+    next: (null: any),
+  };
+
+  if (__DEV__) {
+    update.priority = getCurrentPriorityLevel();
+  }
+
+  // Append the update to the end of the list.
+  const pending = queue.pending;
+  if (pending === null) {
+    // This is the first update. Create a circular list.
+    update.next = update;
+  } else {
+    update.next = pending.next;
+    pending.next = update;
+  }
+  queue.pending = update;
+
+  const alternate = fiber.alternate;
+  if (
+    fiber.expirationTime === NoWork &&
+    (alternate === null || alternate.expirationTime === NoWork)
+  ) {
+    // The queue is currently empty, which means we can eagerly compute the
+    // next state before entering the render phase. If the new state is the
+    // same as the current state, we may be able to bail out entirely.
+    const lastRenderedReducer = queue.lastRenderedReducer;
+    if (lastRenderedReducer !== null) {
+      const prevDispatcher = __DEV__ ? setInvalidNestedHooksDispatcher() : null;
+      try {
+        const currentState: S = (queue.lastRenderedState: any);
+        const eagerState = lastRenderedReducer(currentState, action);
+        // Stash the eagerly computed state, and the reducer used to compute
+        // it, on the update object. If the reducer hasn't changed by the
+        // time we enter the render phase, then the eager state can be used
+        // without calling the reducer again.
+        update.eagerReducer = lastRenderedReducer;
+        update.eagerState = eagerState;
+        if (is(eagerState, currentState)) {
+          // Fast path. We can bail out without scheduling React to re-render.
+          // It's still possible that we'll need to rebase this update later,
+          // if the component re-renders for a different reason and by that
+          // time the reducer has changed.
+          return;
+        }
+      } catch (error) {
+        // Suppress the error. It will throw again in the render phase.
+      } finally {
+        if (__DEV__) {
+          ReactCurrentDispatcher.current = prevDispatcher;
+        }
+      }
+    }
+  }
+  if (__DEV__) {
+    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+    if ('undefined' !== typeof jest) {
+      warnIfNotScopedWithMatchingAct(fiber);
+      warnIfNotCurrentlyActingUpdatesInDev(fiber);
+    }
+  }
+
+  scheduleWork(fiber, expirationTime);
+}
+
+function dispatchImplRenderPhase<S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+) {
+  const update = requestRenderPhaseUpdate(fiber, action);
+  if (update === null) {
+    // This is an update on a fiber other than the one that is currently
+    // rendering. Fallback to default implementation
+    // TODO: This is undefined behavior. It should either warn or throw.
+    dispatchImplDefault(fiber, queue, action);
+    return;
+  }
+
+  // Append the update to the end of the list.
+  const pending = queue.pending;
+  if (pending === null) {
+    // This is the first update. Create a circular list.
+    update.next = update;
+  } else {
+    update.next = pending.next;
+    pending.next = update;
+  }
+  queue.pending = update;
+}
+
+function dispatchImplInsideTransition<S, A>(
+  fiber: Fiber,
+  queue: UpdateQueue<S, A>,
+  action: A,
+) {
+  const transition: TransitionInstance = (currentTransition: any);
+  setTransition(queue, transition);
+
+  const continuation = dispatchForExpirationTime.bind(
+    null,
+    fiber,
+    queue,
+    action,
+  );
+  if (dispatchContinuations === null) {
+    dispatchContinuations = [continuation];
+  } else {
+    dispatchContinuations.push(continuation);
+  }
+}
+
+export function setRenderPhaseDispatchImpl(): Dispatch {
+  const prev = dispatchImpl;
+  dispatchImpl = dispatchImplRenderPhase;
+  return prev;
+}
+
+export function restoreDispatchImpl(prevDispatchImpl: Dispatch): void {
+  dispatchImpl = prevDispatchImpl;
+}
+
+function classSetStateImplDefault(inst, payload, callback) {
+  const fiber = getInstance(inst);
+  const eventTime = requestCurrentTimeForUpdate();
+  const suspenseConfig = requestCurrentSuspenseConfig();
+  const expirationTime = computeExpirationForFiber(
+    eventTime,
+    fiber,
+    suspenseConfig,
+  );
+  classSetStateForExpirationTime(
+    fiber,
+    payload,
+    callback,
+    eventTime,
+    expirationTime,
+    suspenseConfig,
+  );
+}
+
+function classReplaceStateImplDefault(inst, payload, callback) {
+  const fiber = getInstance(inst);
+  const eventTime = requestCurrentTimeForUpdate();
+  const suspenseConfig = requestCurrentSuspenseConfig();
+  const expirationTime = computeExpirationForFiber(
+    eventTime,
+    fiber,
+    suspenseConfig,
+  );
+  classReplaceStateForExpirationTime(
+    fiber,
+    payload,
+    callback,
+    eventTime,
+    expirationTime,
+    suspenseConfig,
+  );
+}
+
+function classForceUpdateImplDefault(inst, callback) {
+  const fiber = getInstance(inst);
+  const eventTime = requestCurrentTimeForUpdate();
+  const suspenseConfig = requestCurrentSuspenseConfig();
+  const expirationTime = computeExpirationForFiber(
+    eventTime,
+    fiber,
+    suspenseConfig,
+  );
+  classForceUpdateForExpirationTime(
+    fiber,
+    callback,
+    eventTime,
+    expirationTime,
+    suspenseConfig,
+  );
+}
+
+function classSetStateForExpirationTime(
+  fiber,
+  payload,
+  callback,
+  eventTime,
+  expirationTime,
+  suspenseConfig,
+) {
+  const update = createUpdate(eventTime, expirationTime, suspenseConfig);
+  update.payload = payload;
+  if (callback !== undefined && callback !== null) {
+    if (__DEV__) {
+      warnOnInvalidCallback(callback, 'setState');
+    }
+    update.callback = callback;
+  }
+  enqueueUpdate(fiber, update);
+  scheduleWork(fiber, expirationTime);
+}
+
+function classReplaceStateForExpirationTime(
+  fiber,
+  payload,
+  callback,
+  eventTime,
+  expirationTime,
+  suspenseConfig,
+) {
+  const update = createUpdate(eventTime, expirationTime, suspenseConfig);
+  update.tag = ReplaceState;
+  update.payload = payload;
+  if (callback !== undefined && callback !== null) {
+    if (__DEV__) {
+      warnOnInvalidCallback(callback, 'replaceState');
+    }
+    update.callback = callback;
+  }
+  enqueueUpdate(fiber, update);
+  scheduleWork(fiber, expirationTime);
+}
+
+function classForceUpdateForExpirationTime(
+  fiber,
+  callback,
+  eventTime,
+  expirationTime,
+  suspenseConfig,
+) {
+  const update = createUpdate(eventTime, expirationTime, suspenseConfig);
+  update.tag = ForceUpdate;
+  if (callback !== undefined && callback !== null) {
+    if (__DEV__) {
+      warnOnInvalidCallback(callback, 'forceUpdate');
+    }
+    update.callback = callback;
+  }
+  enqueueUpdate(fiber, update);
+  scheduleWork(fiber, expirationTime);
+}
+
+function classSetStateImplInsideTransition(inst, payload, callback) {
+  const fiber = getInstance(inst);
+  const updateQueue = fiber.updateQueue;
+  const sharedQueue = updateQueue !== null ? updateQueue.shared : null;
+  if (sharedQueue === null) {
+    // TODO: Fire warning for update on unmounted component
+    return;
+  }
+
+  const transition: TransitionInstance = (currentTransition: any);
+  setTransition(sharedQueue, transition);
+
+  const continuation = classSetStateForExpirationTime.bind(
+    null,
+    fiber,
+    payload,
+    callback,
+  );
+  if (dispatchContinuations === null) {
+    dispatchContinuations = [continuation];
+  } else {
+    dispatchContinuations.push(continuation);
+  }
+}
+
+function classReplaceStateImplInsideTransition(inst, payload, callback) {
+  const fiber = getInstance(inst);
+  const updateQueue = fiber.updateQueue;
+  const sharedQueue = updateQueue !== null ? updateQueue.shared : null;
+  if (sharedQueue === null) {
+    // TODO: Fire warning for update on unmounted component
+    return;
+  }
+
+  const transition: TransitionInstance = (currentTransition: any);
+  setTransition(sharedQueue, transition);
+
+  const continuation = classReplaceStateForExpirationTime.bind(
+    null,
+    fiber,
+    payload,
+    callback,
+  );
+  if (dispatchContinuations === null) {
+    dispatchContinuations = [continuation];
+  } else {
+    dispatchContinuations.push(continuation);
+  }
+}
+
+function classForceUpdateImplInsideTransition(inst, callback) {
+  const fiber = getInstance(inst);
+  const updateQueue = fiber.updateQueue;
+  const sharedQueue = updateQueue !== null ? updateQueue.shared : null;
+  if (sharedQueue === null) {
+    // TODO: Fire warning for update on unmounted component
+    return;
+  }
+
+  const transition: TransitionInstance = (currentTransition: any);
+  setTransition(sharedQueue, transition);
+
+  const continuation = classForceUpdateForExpirationTime.bind(
+    null,
+    fiber,
+    callback,
+  );
+  if (dispatchContinuations === null) {
+    dispatchContinuations = [continuation];
+  } else {
+    dispatchContinuations.push(continuation);
+  }
 }
 
 export function startTransition(
@@ -51,12 +513,21 @@ export function startTransition(
   config: SuspenseConfig | null | void,
   callback: () => void,
 ) {
+  if (dispatchImpl === dispatchImplRenderPhase) {
+    // Wrapping an update in `startTransition` has no effect in the
+    // render phase.
+    // TODO: This should warn.
+    callback();
+    return;
+  }
+
+  const suspenseConfig = config === undefined ? null : config;
   const fiber = transitionInstance.fiber;
 
-  const resolvedConfig: SuspenseConfig | null =
-    config === undefined ? null : config;
-
-  const currentTime = requestCurrentTimeForUpdate();
+  // Don't need to reset this at the end because it's impossible to read
+  // from outside of a `startTransition` callback.
+  currentTransitionEventTime = requestCurrentTimeForUpdate();
+  currentTransitionResolvedTime = NoWork;
 
   // TODO: runWithPriority shouldn't be necessary here. React should manage its
   // own concept of priority, and only consult Scheduler for updates that are
@@ -65,51 +536,110 @@ export function startTransition(
   runWithPriority(
     priorityLevel < UserBlockingPriority ? UserBlockingPriority : priorityLevel,
     () => {
-      userBlockingExpirationTime = computeExpirationForFiber(
-        currentTime,
+      currentTransitionPendingTime = computeExpirationForFiber(
+        currentTransitionEventTime,
         fiber,
         null,
       );
-      scheduleUpdateOnFiber(fiber, userBlockingExpirationTime);
     },
   );
   runWithPriority(
     priorityLevel > NormalPriority ? NormalPriority : priorityLevel,
     () => {
-      let expirationTime = computeExpirationForFiber(
-        currentTime,
-        fiber,
-        resolvedConfig,
-      );
-      // Set the expiration time at which the pending transition will finish.
-      // Because there's only a single transition per useTransition hook, we
-      // don't need a queue here; we can cheat by only tracking the most
-      // recently scheduled transition.
-      const oldPendingExpirationTime = transitionInstance.pendingExpirationTime;
-      if (oldPendingExpirationTime === expirationTime) {
-        expirationTime -= 1;
-      }
-      transitionInstance.pendingExpirationTime = expirationTime;
-
-      scheduleUpdateOnFiber(fiber, expirationTime);
       const previousConfig = ReactCurrentBatchConfig.suspense;
       const previousTransition = currentTransition;
-      ReactCurrentBatchConfig.suspense = resolvedConfig;
+      const previousDispatchContinuations = dispatchContinuations;
+      const previousDispatchImpl = dispatchImpl;
+      const previousClassSetStateImpl = classSetStateImpl;
+      const previousClassReplaceStateImpl = classReplaceStateImpl;
+      const previousClassForceUpdateImpl = classForceUpdateImpl;
+      ReactCurrentBatchConfig.suspense = suspenseConfig;
       currentTransition = transitionInstance;
+      dispatchContinuations = null;
+      dispatchImpl = dispatchImplInsideTransition;
+      classSetStateImpl = classSetStateImplInsideTransition;
+      classReplaceStateImpl = classReplaceStateImplInsideTransition;
+      classForceUpdateImpl = classForceUpdateImplInsideTransition;
       try {
         callback();
       } finally {
+        if (currentTransitionResolvedTime === NoWork) {
+          // This transition did not overlap with any previous transitions.
+          // Compute a new concurrent expiration time.
+          currentTransitionResolvedTime = computeExpirationForFiber(
+            currentTransitionEventTime,
+            fiber,
+            suspenseConfig,
+          );
+        }
+
+        // Set the expiration time at which the pending transition will finish.
+        // Because there's only a single transition per useTransition hook, we
+        // don't need a queue here; we can cheat by only tracking the most
+        // recently scheduled transition.
+        transitionInstance.pendingTime = currentTransitionPendingTime;
+        transitionInstance.resolvedTime = currentTransitionResolvedTime;
+        transitionInstance.version++;
+
+        const continuations = dispatchContinuations;
+        const eventTime = currentTransitionEventTime;
+        const pendingTime = currentTransitionPendingTime;
+        const resolvedTime = currentTransitionResolvedTime;
+
         ReactCurrentBatchConfig.suspense = previousConfig;
         currentTransition = previousTransition;
-        userBlockingExpirationTime = NoWork;
+        dispatchContinuations = previousDispatchContinuations;
+        dispatchImpl = previousDispatchImpl;
+        classSetStateImpl = previousClassSetStateImpl;
+        classReplaceStateImpl = previousClassReplaceStateImpl;
+        classForceUpdateImpl = previousClassForceUpdateImpl;
+        currentTransitionPendingTime = NoWork;
+
+        if (continuations !== null) {
+          // Don't need to schedule work at the resolved time because the
+          // pending time is always higher priority.
+          scheduleUpdateOnFiber(fiber, pendingTime);
+
+          // These continuations are internal functions that should never throw,
+          // but just in case, do them at the very end, after all the
+          // clean-up code.
+          for (let i = 0; i < continuations.length; i++) {
+            const continuation = continuations[i];
+            continuation(eventTime, resolvedTime, suspenseConfig);
+          }
+        }
       }
     },
   );
 }
 
-export function cancelPendingTransition(prevTransition: TransitionInstance) {
-  // Turn off the `isPending` state of the previous transition, at the same
-  // priority we use to turn on the `isPending` state of the current transition.
-  prevTransition.pendingExpirationTime = NoWork;
-  scheduleUpdateOnFiber(prevTransition.fiber, userBlockingExpirationTime);
+function setTransition(
+  queue: {pendingTransition: TransitionInstance | null},
+  transition: TransitionInstance,
+) {
+  const prevTransition = queue.pendingTransition;
+  if (transition !== prevTransition) {
+    queue.pendingTransition = transition;
+    if (prevTransition !== null) {
+      // There's already a pending transition on this queue. The new transition
+      // supersedes the old one. Turn of the `isPending` state of the
+      // previous transition.
+
+      // Track the expiration time of the superseded transition. If there are
+      // multiple, choose the highest priority one.
+      if (preventIntermediateStates) {
+        const resolvedTime = prevTransition.resolvedTime;
+        if (currentTransitionResolvedTime < resolvedTime) {
+          currentTransitionResolvedTime = resolvedTime;
+        }
+      }
+
+      // Turn off the `isPending` state of the previous transition, at the same
+      // priority we use to turn on the `isPending` state of the
+      // current transition.
+      prevTransition.resolvedTime = currentTransitionPendingTime;
+      prevTransition.version++;
+      scheduleUpdateOnFiber(prevTransition.fiber, currentTransitionPendingTime);
+    }
+  }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -114,9 +114,9 @@ import {
   expirationTimeToMs,
   computeInteractiveExpiration,
   computeAsyncExpiration,
-  computeSuspenseExpiration,
-  inferPriorityFromExpirationTime,
+  computeSuspenseTimeout,
   LOW_PRIORITY_EXPIRATION,
+  inferPriorityFromExpirationTime,
   Batched,
   Idle,
 } from './ReactFiberExpirationTime';
@@ -183,6 +183,7 @@ import {
   clearCaughtError,
 } from 'shared/ReactErrorUtils';
 import {onCommitRoot} from './ReactFiberDevToolsHook';
+import {requestCurrentTransition} from './ReactFiberTransition';
 
 const ceil = Math.ceil;
 
@@ -234,7 +235,7 @@ let workInProgressRootFatalError: mixed = null;
 // This is conceptually a time stamp but expressed in terms of an ExpirationTime
 // because we deal mostly with expiration times in the hot path, so this avoids
 // the conversion happening in the hot path.
-let workInProgressRootLatestProcessedExpirationTime: ExpirationTime = Sync;
+let workInProgressRootLatestProcessedEventTime: ExpirationTime = Sync;
 let workInProgressRootLatestSuspenseTimeout: ExpirationTime = Sync;
 let workInProgressRootCanSuspendUsingConfig: null | SuspenseConfig = null;
 // The work left over by components that were visited during this render. Only
@@ -333,11 +334,13 @@ export function computeExpirationForFiber(
 
   let expirationTime;
   if (suspenseConfig !== null) {
-    // Compute an expiration time based on the Suspense timeout.
-    expirationTime = computeSuspenseExpiration(
-      currentTime,
-      suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION,
-    );
+    // This is a transition
+    const transitionInstance = requestCurrentTransition();
+    if (transitionInstance !== null) {
+      expirationTime = transitionInstance.pendingExpirationTime;
+    } else {
+      expirationTime = computeAsyncExpiration(currentTime);
+    }
   } else {
     // Compute an expiration time based on the Scheduler priority.
     switch (priorityLevel) {
@@ -794,7 +797,7 @@ function finishConcurrentRender(
       // have a new loading state ready. We want to ensure that we commit
       // that as soon as possible.
       const hasNotProcessedNewUpdates =
-        workInProgressRootLatestProcessedExpirationTime === Sync;
+        workInProgressRootLatestProcessedEventTime === Sync;
       if (
         hasNotProcessedNewUpdates &&
         // do not delay if we're inside an act() scope
@@ -906,34 +909,19 @@ function finishConcurrentRender(
           // can use as the timeout.
           msUntilTimeout =
             expirationTimeToMs(workInProgressRootLatestSuspenseTimeout) - now();
-        } else if (workInProgressRootLatestProcessedExpirationTime === Sync) {
+        } else if (workInProgressRootLatestProcessedEventTime === Sync) {
           // This should never normally happen because only new updates
           // cause delayed states, so we should have processed something.
           // However, this could also happen in an offscreen tree.
           msUntilTimeout = 0;
         } else {
-          // If we don't have a suspense config, we're going to use a
-          // heuristic to determine how long we can suspend.
-          const eventTimeMs: number = inferTimeFromExpirationTime(
-            workInProgressRootLatestProcessedExpirationTime,
+          // If we didn't process a suspense config, compute a JND based on
+          // the amount of time elapsed since the most recent event time.
+          const eventTimeMs = expirationTimeToMs(
+            workInProgressRootLatestProcessedEventTime,
           );
-          const currentTimeMs = now();
-          const timeUntilExpirationMs =
-            expirationTimeToMs(expirationTime) - currentTimeMs;
-          let timeElapsed = currentTimeMs - eventTimeMs;
-          if (timeElapsed < 0) {
-            // We get this wrong some time since we estimate the time.
-            timeElapsed = 0;
-          }
-
-          msUntilTimeout = jnd(timeElapsed) - timeElapsed;
-
-          // Clamp the timeout to the expiration time. TODO: Once the
-          // event time is exact instead of inferred from expiration time
-          // we don't need this.
-          if (timeUntilExpirationMs < msUntilTimeout) {
-            msUntilTimeout = timeUntilExpirationMs;
-          }
+          const timeElapsedMs = now() - eventTimeMs;
+          msUntilTimeout = jnd(timeElapsedMs) - timeElapsedMs;
         }
 
         // Don't bother with a very short suspense time.
@@ -961,7 +949,7 @@ function finishConcurrentRender(
           flushSuspenseFallbacksInTests &&
           IsThisRendererActing.current
         ) &&
-        workInProgressRootLatestProcessedExpirationTime !== Sync &&
+        workInProgressRootLatestProcessedEventTime !== Sync &&
         workInProgressRootCanSuspendUsingConfig !== null
       ) {
         // If we have exceeded the minimum loading delay, which probably
@@ -969,7 +957,7 @@ function finishConcurrentRender(
         // a bit longer to ensure that the spinner is shown for
         // enough time.
         const msUntilTimeout = computeMsUntilSuspenseLoadingDelay(
-          workInProgressRootLatestProcessedExpirationTime,
+          workInProgressRootLatestProcessedEventTime,
           expirationTime,
           workInProgressRootCanSuspendUsingConfig,
         );
@@ -1273,7 +1261,7 @@ function prepareFreshStack(root, expirationTime) {
   renderExpirationTime = expirationTime;
   workInProgressRootExitStatus = RootIncomplete;
   workInProgressRootFatalError = null;
-  workInProgressRootLatestProcessedExpirationTime = Sync;
+  workInProgressRootLatestProcessedEventTime = Sync;
   workInProgressRootLatestSuspenseTimeout = Sync;
   workInProgressRootCanSuspendUsingConfig = null;
   workInProgressRootNextUnprocessedUpdateTime = NoWork;
@@ -1384,23 +1372,30 @@ export function markCommitTimeOfFallback() {
 }
 
 export function markRenderEventTimeAndConfig(
-  expirationTime: ExpirationTime,
+  eventTime: ExpirationTime,
   suspenseConfig: null | SuspenseConfig,
 ): void {
-  if (
-    expirationTime < workInProgressRootLatestProcessedExpirationTime &&
-    expirationTime > Idle
-  ) {
-    workInProgressRootLatestProcessedExpirationTime = expirationTime;
-  }
-  if (suspenseConfig !== null) {
-    if (
-      expirationTime < workInProgressRootLatestSuspenseTimeout &&
-      expirationTime > Idle
-    ) {
-      workInProgressRootLatestSuspenseTimeout = expirationTime;
-      // Most of the time we only have one config and getting wrong is not bad.
-      workInProgressRootCanSuspendUsingConfig = suspenseConfig;
+  // Anything lower pri than Idle is not an update, so we should skip it.
+  if (eventTime > Idle) {
+    // Track the most recent event time of all updates processed in this batch.
+    if (workInProgressRootLatestProcessedEventTime > eventTime) {
+      workInProgressRootLatestProcessedEventTime = eventTime;
+    }
+
+    // Track the largest/latest timeout deadline in this batch.
+    // TODO: If there are two transitions in the same batch, shouldn't we
+    // choose the smaller one? Maybe this is because when an intermediate
+    // transition is superseded, we should ignore its suspense config, but
+    // we don't currently.
+    if (suspenseConfig !== null) {
+      // If `timeoutMs` is not specified, we default to 5 seconds.
+      // TODO: Should this default to a JND instead?
+      const timeoutMs = suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION;
+      const timeoutTime = computeSuspenseTimeout(eventTime, timeoutMs);
+      if (timeoutTime < workInProgressRootLatestSuspenseTimeout) {
+        workInProgressRootLatestSuspenseTimeout = timeoutTime;
+        workInProgressRootCanSuspendUsingConfig = suspenseConfig;
+      }
     }
   }
 }
@@ -1456,27 +1451,6 @@ export function renderHasNotSuspendedYet(): boolean {
   // If something errored or completed, we can't really be sure,
   // so those are false.
   return workInProgressRootExitStatus === RootIncomplete;
-}
-
-function inferTimeFromExpirationTime(expirationTime: ExpirationTime): number {
-  // We don't know exactly when the update was scheduled, but we can infer an
-  // approximate start time from the expiration time.
-  const earliestExpirationTimeMs = expirationTimeToMs(expirationTime);
-  return earliestExpirationTimeMs - LOW_PRIORITY_EXPIRATION;
-}
-
-function inferTimeFromExpirationTimeWithSuspenseConfig(
-  expirationTime: ExpirationTime,
-  suspenseConfig: SuspenseConfig,
-): number {
-  // We don't know exactly when the update was scheduled, but we can infer an
-  // approximate start time from the expiration time by subtracting the timeout
-  // that was added to the event time.
-  const earliestExpirationTimeMs = expirationTimeToMs(expirationTime);
-  return (
-    earliestExpirationTimeMs -
-    (suspenseConfig.timeoutMs | 0 || LOW_PRIORITY_EXPIRATION)
-  );
 }
 
 // The work loop is an extremely hot path. Tell Closure not to inline it.
@@ -2374,7 +2348,7 @@ export function pingSuspendedRoot(
     if (
       workInProgressRootExitStatus === RootSuspendedWithDelay ||
       (workInProgressRootExitStatus === RootSuspended &&
-        workInProgressRootLatestProcessedExpirationTime === Sync &&
+        workInProgressRootLatestProcessedEventTime === Sync &&
         now() - globalMostRecentFallbackTime < FALLBACK_THROTTLE_MS)
     ) {
       // Restart from the root. Don't need to schedule a ping because
@@ -2519,10 +2493,7 @@ function computeMsUntilSuspenseLoadingDelay(
 
   // Compute the time until this render pass would expire.
   const currentTimeMs: number = now();
-  const eventTimeMs: number = inferTimeFromExpirationTimeWithSuspenseConfig(
-    mostRecentEventTime,
-    suspenseConfig,
-  );
+  const eventTimeMs: number = expirationTimeToMs(mostRecentEventTime);
   const timeElapsed = currentTimeMs - eventTimeMs;
   if (timeElapsed <= busyDelayMs) {
     // If we haven't yet waited longer than the initial delay, we don't

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -2199,6 +2199,9 @@ describe('ReactHooksWithNoopRenderer', () => {
           span('Before... Pending: true'),
         ]);
 
+        // Resolve the promise. The whole tree has now completed. However,
+        // because we exceeded the busy threshold, we won't commit the
+        // result yet.
         Scheduler.unstable_advanceTime(1000);
         await advanceTimers(1000);
         expect(Scheduler).toHaveYielded([
@@ -2209,13 +2212,16 @@ describe('ReactHooksWithNoopRenderer', () => {
           span('Before... Pending: true'),
         ]);
 
-        Scheduler.unstable_advanceTime(1000);
-        await advanceTimers(1000);
+        // Advance time until just before the `busyMinDuration` threshold.
+        Scheduler.unstable_advanceTime(999);
+        await advanceTimers(999);
         expect(ReactNoop.getChildren()).toEqual([
           span('Before... Pending: true'),
         ]);
-        Scheduler.unstable_advanceTime(250);
-        await advanceTimers(250);
+
+        // Advance time just a bit more. Now we complete the transition.
+        Scheduler.unstable_advanceTime(1);
+        await advanceTimers(1);
         expect(ReactNoop.getChildren()).toEqual([
           span('After... Pending: false'),
         ]);

--- a/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspensePlaceholder-test.internal.js
@@ -498,6 +498,13 @@ describe('ReactSuspensePlaceholder', () => {
             </Suspense>
           </>,
         );
+
+        // TODO: This is here only to shift us into the next JND bucket. A
+        // consequence of AsyncText relying on the same timer queue as React's
+        // internal Suspense timer. We should decouple our AsyncText helpers
+        // from timers.
+        Scheduler.unstable_advanceTime(100);
+
         expect(Scheduler).toFlushAndYield([
           'App',
           'Suspending',

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
@@ -88,8 +88,10 @@ describe('ReactTransition', () => {
         start();
 
         expect(Scheduler).toFlushAndYield([
+          // Render pending state
           'Pending...',
           '(empty)',
+          // Try rendering transition
           'Suspend! [Async]',
           'Loading...',
         ]);
@@ -100,6 +102,88 @@ describe('ReactTransition', () => {
       });
       expect(Scheduler).toHaveYielded(['Async']);
       expect(root).toMatchRenderedOutput('Async');
+    },
+  );
+
+  it.experimental(
+    'isPending turns off immediately if `startTransition` does not include any updates',
+    async () => {
+      let startTransition;
+      function App() {
+        const [_startTransition, isPending] = useTransition();
+        startTransition = _startTransition;
+        return <Text text={'Pending: ' + isPending} />;
+      }
+
+      const root = ReactNoop.createRoot();
+
+      await act(async () => {
+        root.render(<App />);
+      });
+      expect(Scheduler).toHaveYielded(['Pending: false']);
+      expect(root).toMatchRenderedOutput('Pending: false');
+
+      await act(async () => {
+        startTransition(() => {
+          // No-op
+        });
+      });
+      expect(Scheduler).toHaveYielded([
+        // Pending state is turned on then immediately back off
+        // TODO: As an optimization, we could avoid turning on the pending
+        // state entirely.
+        'Pending: true',
+        'Pending: false',
+      ]);
+      expect(root).toMatchRenderedOutput('Pending: false');
+    },
+  );
+
+  it.experimental(
+    'works if two transitions happen one right after the other',
+    async () => {
+      // Tests an implementation path where two transitions get batched into the
+      // same render. This is an edge case in our current expiration times
+      // implementation but will be the normal case if/when we replace expiration
+      // times with a different model that puts all transitions into the same
+      // batch by default.
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      let setTab;
+      let startTransition;
+      function App() {
+        const [tab, _setTab] = useState(1);
+        const [_startTransition, isPending] = useTransition(CONFIG);
+        startTransition = _startTransition;
+        setTab = _setTab;
+        return (
+          <Text text={'Tab ' + tab + (isPending ? ' (pending...)' : '')} />
+        );
+      }
+
+      const root = ReactNoop.createRoot();
+
+      await act(async () => {
+        root.render(<App />);
+      });
+      expect(Scheduler).toHaveYielded(['Tab 1']);
+      expect(root).toMatchRenderedOutput('Tab 1');
+
+      await act(async () => {
+        startTransition(() => setTab(2));
+      });
+      expect(Scheduler).toHaveYielded(['Tab 1 (pending...)', 'Tab 2']);
+      expect(root).toMatchRenderedOutput('Tab 2');
+
+      // Because time has not advanced, this will fall into the same bucket
+      // as the previous transition.
+      await act(async () => {
+        startTransition(() => setTab(3));
+      });
+      expect(Scheduler).toHaveYielded(['Tab 2 (pending...)', 'Tab 3']);
+      expect(root).toMatchRenderedOutput('Tab 3');
     },
   );
 });

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
@@ -186,4 +186,324 @@ describe('ReactTransition', () => {
       expect(root).toMatchRenderedOutput('Tab 3');
     },
   );
+
+  it.experimental(
+    'when multiple transitions update the same queue, only the most recent one is considered pending',
+    async () => {
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      const Tab = React.forwardRef(({label, setTab}, ref) => {
+        const [startTransition, isPending] = useTransition(CONFIG);
+
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            go() {
+              startTransition(() => setTab(label));
+            },
+          }),
+          [label],
+        );
+
+        return (
+          <Text text={'Tab ' + label + (isPending ? ' (pending...)' : '')} />
+        );
+      });
+
+      const tabButtonA = React.createRef(null);
+      const tabButtonB = React.createRef(null);
+      const tabButtonC = React.createRef(null);
+
+      const ContentA = createAsyncText('A');
+      const ContentB = createAsyncText('B');
+      const ContentC = createAsyncText('C');
+
+      function App() {
+        const [tab, setTab] = useState('A');
+
+        let content;
+        switch (tab) {
+          case 'A':
+            content = <ContentA />;
+            break;
+          case 'B':
+            content = <ContentB />;
+            break;
+          case 'C':
+            content = <ContentC />;
+            break;
+          default:
+            content = <ContentA />;
+            break;
+        }
+
+        return (
+          <>
+            <ul>
+              <li>
+                <Tab ref={tabButtonA} label="A" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonB} label="B" setTab={setTab} />
+              </li>
+              <li>
+                <Tab ref={tabButtonC} label="C" setTab={setTab} />
+              </li>
+            </ul>
+            <Suspense fallback={<Text text="Loading..." />}>{content}</Suspense>
+          </>
+        );
+      }
+
+      // Initial render
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(<App />);
+        await ContentA.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Navigate to tab B
+      await act(async () => {
+        tabButtonB.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        'Tab B (pending...)',
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [B]',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B (pending...)</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Before B resolves, navigate to tab C. B should no longer be pending.
+      await act(async () => {
+        tabButtonC.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        // Turn `isPending` off for tab B, and on for tab C
+        'Tab B',
+        'Tab C (pending...)',
+        // Try finishing the transition
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [C]',
+        'Loading...',
+      ]);
+      // Tab B is no longer pending. Only C.
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading C
+      await act(async () => {
+        ContentC.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          C
+        </>,
+      );
+    },
+  );
+
+  // Same as previous test, but for class update queue.
+  it.experimental(
+    'when multiple transitions update the same queue, only the most recent one is considered pending (classes)',
+    async () => {
+      const CONFIG = {
+        timeoutMs: 100000,
+      };
+
+      const Tab = React.forwardRef(({label, setTab}, ref) => {
+        const [startTransition, isPending] = useTransition(CONFIG);
+
+        React.useImperativeHandle(
+          ref,
+          () => ({
+            go() {
+              startTransition(() => setTab(label));
+            },
+          }),
+          [label],
+        );
+
+        return (
+          <Text text={'Tab ' + label + (isPending ? ' (pending...)' : '')} />
+        );
+      });
+
+      const tabButtonA = React.createRef(null);
+      const tabButtonB = React.createRef(null);
+      const tabButtonC = React.createRef(null);
+
+      const ContentA = createAsyncText('A');
+      const ContentB = createAsyncText('B');
+      const ContentC = createAsyncText('C');
+
+      class App extends React.Component {
+        state = {tab: 'A'};
+        setTab = tab => {
+          this.setState({tab});
+        };
+
+        render() {
+          let content;
+          switch (this.state.tab) {
+            case 'A':
+              content = <ContentA />;
+              break;
+            case 'B':
+              content = <ContentB />;
+              break;
+            case 'C':
+              content = <ContentC />;
+              break;
+            default:
+              content = <ContentA />;
+              break;
+          }
+
+          return (
+            <>
+              <ul>
+                <li>
+                  <Tab ref={tabButtonA} label="A" setTab={this.setTab} />
+                </li>
+                <li>
+                  <Tab ref={tabButtonB} label="B" setTab={this.setTab} />
+                </li>
+                <li>
+                  <Tab ref={tabButtonC} label="C" setTab={this.setTab} />
+                </li>
+              </ul>
+              <Suspense fallback={<Text text="Loading..." />}>
+                {content}
+              </Suspense>
+            </>
+          );
+        }
+      }
+
+      // Initial render
+      const root = ReactNoop.createRoot();
+      await act(async () => {
+        root.render(<App />);
+        await ContentA.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'A']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Navigate to tab B
+      await act(async () => {
+        tabButtonB.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        'Tab B (pending...)',
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [B]',
+        'Loading...',
+      ]);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B (pending...)</li>
+            <li>Tab C</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Before B resolves, navigate to tab C. B should no longer be pending.
+      await act(async () => {
+        tabButtonC.current.go();
+      });
+      expect(Scheduler).toHaveYielded([
+        // Turn `isPending` off for tab B, and on for tab C
+        'Tab B',
+        'Tab C (pending...)',
+        // Try finishing the transition
+        'Tab A',
+        'Tab B',
+        'Tab C',
+        'Suspend! [C]',
+        'Loading...',
+      ]);
+      // Tab B is no longer pending. Only C.
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C (pending...)</li>
+          </ul>
+          A
+        </>,
+      );
+
+      // Finish loading C
+      await act(async () => {
+        ContentC.resolve();
+      });
+      expect(Scheduler).toHaveYielded(['Tab A', 'Tab B', 'Tab C', 'C']);
+      expect(root).toMatchRenderedOutput(
+        <>
+          <ul>
+            <li>Tab A</li>
+            <li>Tab B</li>
+            <li>Tab C</li>
+          </ul>
+          C
+        </>,
+      );
+    },
+  );
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -91,6 +91,8 @@ export const enableTrustedTypesIntegration = false;
 // Flag to turn event.target and event.currentTarget in ReactNative from a reactTag to a component instance
 export const enableNativeTargetAsInstance = false;
 
+export const preventIntermediateStates = __EXPERIMENTAL__;
+
 // --------------------------
 // Future APIs to be deprecated
 // --------------------------

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -47,6 +47,7 @@ export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const preventIntermediateStates = __EXPERIMENTAL__;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -42,6 +42,7 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const preventIntermediateStates = __EXPERIMENTAL__;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -42,6 +42,7 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const preventIntermediateStates = __EXPERIMENTAL__;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -42,6 +42,7 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const preventIntermediateStates = __EXPERIMENTAL__;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -40,6 +40,7 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const preventIntermediateStates = __EXPERIMENTAL__;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -17,6 +17,7 @@ export const {
   enableTrustedTypesIntegration,
   enableSelectiveHydration,
   enableTrainModelFix,
+  preventIntermediateStates,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data


### PR DESCRIPTION
- [x] When multiple transitions update the same queue, only the most recent
one should be considered pending. Example: If I switch tabs multiple times, only the last tab I click should display a pending state (e.g. an inline spinner).
- [x] When multiple transitions update the same queue, only the most recent one should be allowed to finish. Do not display intermediate states. Example: if you click on multiple tabs in quick succession, we should not switch to any tab that isn't the last one you clicked.

Here's the CodeSandbox I'm using to test the changes: https://codesandbox.io/s/elastic-hawking-69381. It's a tab switcher. Switch tabs and pay attention to the pending spinners.
