### PR TITLE
[react-interactions] Fix memory leak in event responder system

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -72,6 +72,7 @@ describe('DOMEventResponderSystem', () => {
     jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableFlareAPI = true;
+    ReactFeatureFlags.enableScopeAPI = true;
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -528,6 +529,53 @@ describe('DOMEventResponderSystem', () => {
         return <button />;
       } else if (test === 4) {
         return <button DEPRECATED_flareListeners={listener} />;
+      }
+    }
+
+    ReactDOM.render(<Test test={0} />, container);
+    ReactDOM.render(null, container);
+    expect(onUnmountFired).toEqual(1);
+
+    ReactDOM.render(<Test test={0} />, container);
+    ReactDOM.render(<Test test={1} />, container);
+    expect(onUnmountFired).toEqual(2);
+
+    ReactDOM.render(<Test test={0} />, container);
+    ReactDOM.render(<Test test={2} />, container);
+    expect(onUnmountFired).toEqual(3);
+
+    ReactDOM.render(<Test test={0} />, container);
+    ReactDOM.render(<Test test={3} />, container);
+    expect(onUnmountFired).toEqual(4);
+
+    ReactDOM.render(<Test test={0} />, container);
+    ReactDOM.render(<Test test={4} />, container);
+    expect(onUnmountFired).toEqual(4);
+  });
+
+  it('the event responder onUnmount() function should fire using scopes', () => {
+    let onUnmountFired = 0;
+
+    const TestScope = React.unstable_createScope();
+    const TestResponder = createEventResponder({
+      targetEventTypes: [],
+      onUnmount: () => {
+        onUnmountFired++;
+      },
+    });
+
+    function Test({test}) {
+      const listener = React.unstable_useResponder(TestResponder, {});
+      if (test === 0) {
+        return <TestScope DEPRECATED_flareListeners={[listener]} />;
+      } else if (test === 1) {
+        return <TestScope DEPRECATED_flareListeners={null} />;
+      } else if (test === 2) {
+        return <TestScope DEPRECATED_flareListeners={[]} />;
+      } else if (test === 3) {
+        return <TestScope />;
+      } else if (test === 4) {
+        return <TestScope DEPRECATED_flareListeners={listener} />;
       }
     }
 

--- a/packages/react-reconciler/src/ReactFiberEvents.js
+++ b/packages/react-reconciler/src/ReactFiberEvents.js
@@ -163,7 +163,7 @@ export function updateLegacyEventListeners(
     }
     let respondersMap = dependencies.responders;
     if (respondersMap === null) {
-      respondersMap = new Map();
+      dependencies.responders = respondersMap = new Map();
     }
     if (isArray(listeners)) {
       for (let i = 0, length = listeners.length; i < length; i++) {
@@ -217,4 +217,20 @@ export function createResponderListener(
     Object.freeze(eventResponderListener);
   }
   return eventResponderListener;
+}
+
+export function unmountResponderListeners(fiber: Fiber) {
+  const dependencies = fiber.dependencies;
+
+  if (dependencies !== null) {
+    const respondersMap = dependencies.responders;
+    if (respondersMap !== null) {
+      const responderInstances = Array.from(respondersMap.values());
+      for (let i = 0, length = responderInstances.length; i < length; i++) {
+        const responderInstance = responderInstances[i];
+        unmountResponderInstance(responderInstance);
+      }
+      dependencies.responders = null;
+    }
+  }
 }


### PR DESCRIPTION
This should fix some issues with leaking fibers from root events in the event responder system. Specifically:

- Unsure we unmount listeners on Scope Nodes
- Unsure we memoize the responders map back on fibers