### PR TITLE
[react-interactions] Refine virtual click detection for FF+JAWS

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -489,6 +489,11 @@ function updateIsPressWithinResponderRegion(
 // clicks (NVDA, Jaws, VoiceOver) do not have co-ords associated with the click
 // event and "detail" is always 0 (where normal clicks are > 0)
 function isScreenReaderVirtualClick(nativeEvent): boolean {
+  // JAWS/NVDA with Firefox.
+  if (nativeEvent.mozInputSource === 0 && nativeEvent.isTrusted) {
+    return true;
+  }
+  // Chrome
   return (
     nativeEvent.detail === 0 &&
     nativeEvent.screenX === 0 &&

--- a/packages/react-interactions/events/src/dom/shared/index.js
+++ b/packages/react-interactions/events/src/dom/shared/index.js
@@ -79,5 +79,9 @@ export function hasModifierKey(event: ReactDOMResponderEvent): boolean {
 // where only the "virtual" click lacks a pointerType field.
 export function isVirtualClick(event: ReactDOMResponderEvent): boolean {
   const nativeEvent: any = event.nativeEvent;
+  // JAWS/NVDA with Firefox.
+  if (nativeEvent.mozInputSource === 0 && nativeEvent.isTrusted) {
+    return true;
+  }
   return nativeEvent.detail === 0 && !nativeEvent.pointerType;
 }


### PR DESCRIPTION
After lots of internal testing, we found that JAWS with FF results in a case we didn't previously capture as a virtual click. Specifically, the `detail` property is `1` using JAWS but `mozInputSource` is `0`. We actually have this logic internally at FB, so it's reusing that (see https://fburl.com/diffusion/i2aajhpr).