### PR TITLE
fix(ReactElement): display warning for reserved default props

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -403,13 +403,17 @@ export function createElement(type, config, children) {
   if (type && type.defaultProps) {
     const defaultProps = type.defaultProps;
     for (propName in defaultProps) {
-      if (
-        props[propName] === undefined &&
-        propName !== 'ref' &&
-        propName !== 'key'
-      ) {
+      if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];
       }
+      warningWithoutStack(
+        propName !== 'ref' && propName !== 'key',
+        '%s: %s is not a valid default prop to set. ' +
+          'Please remove this from your default props definition. ' +
+          'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
+        type.displayName || type.name || 'Unkown',
+        propName,
+      );
     }
   }
   if (__DEV__) {

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -406,14 +406,17 @@ export function createElement(type, config, children) {
       if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];
       }
-      warningWithoutStack(
-        propName !== 'ref' && propName !== 'key',
-        '%s: %s is not a valid default prop to set. ' +
-          'Please remove this from your default props definition. ' +
-          'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
-        type.displayName || type.name || 'Unkown',
-        propName,
-      );
+      if (__DEV__) {
+        if (propName === 'ref' || propName === 'key') {
+          console.error(
+            '%s: %s is not a valid default prop to set. ' +
+              'Please remove this from your default props definition. ' +
+              'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
+            type.displayName || type.name || 'Unkown',
+            propName,
+          );
+        }
+      }
     }
   }
   if (__DEV__) {

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -246,11 +246,7 @@ export function jsx(type, config, maybeKey) {
   if (type && type.defaultProps) {
     const defaultProps = type.defaultProps;
     for (propName in defaultProps) {
-      if (
-        props[propName] === undefined &&
-        propName !== 'ref' &&
-        propName !== 'key'
-      ) {
+      if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];
       }
     }
@@ -407,7 +403,11 @@ export function createElement(type, config, children) {
   if (type && type.defaultProps) {
     const defaultProps = type.defaultProps;
     for (propName in defaultProps) {
-      if (props[propName] === undefined) {
+      if (
+        props[propName] === undefined &&
+        propName !== 'ref' &&
+        propName !== 'key'
+      ) {
         props[propName] = defaultProps[propName];
       }
     }

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -409,9 +409,8 @@ export function createElement(type, config, children) {
       if (__DEV__) {
         if (propName === 'ref' || propName === 'key') {
           console.error(
-            '%s: %s is not a valid default prop to set. ' +
-              'Please remove this from your default props definition. ' +
-              'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
+            '%s: `%s` is not a valid default prop name. ' +
+              'Please remove this from your default props definition. ',
             type.displayName || type.name || 'Unkown',
             propName,
           );

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -246,7 +246,11 @@ export function jsx(type, config, maybeKey) {
   if (type && type.defaultProps) {
     const defaultProps = type.defaultProps;
     for (propName in defaultProps) {
-      if (props[propName] === undefined) {
+      if (
+        props[propName] === undefined &&
+        propName !== 'ref' &&
+        propName !== 'key'
+      ) {
         props[propName] = defaultProps[propName];
       }
     }

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -358,6 +358,21 @@ describe('ReactElement', () => {
     expect(instance.props.fruit).toBe('persimmon');
   });
 
+  it('should not map key property from default props', () => {
+    class Component extends React.Component {
+      render() {
+        return <div>{this.props.key}</div>;
+      }
+    }
+
+    Component.defaultProps = {key: 'test key'};
+
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<Component />, container);
+
+    expect(instance.props.key).toBe(undefined);
+  });
+
   // NOTE: We're explicitly not using JSX here. This is intended to test
   // classic JS without JSX.
   it('should normalize props with default values', () => {

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -358,19 +358,26 @@ describe('ReactElement', () => {
     expect(instance.props.fruit).toBe('persimmon');
   });
 
-  it('should not map key property from default props', () => {
+  // NOTE: We're explicitly not using JSX here. This is intended to test
+  // classic JS without JSX.
+  it('should display a warning when mapping key to a default prop', () => {
     class Component extends React.Component {
       render() {
-        return <div>{this.props.key}</div>;
+        return React.createElement('div', null, this.props.key);
       }
     }
 
     Component.defaultProps = {key: 'test key'};
 
     const container = document.createElement('div');
-    const instance = ReactDOM.render(<Component />, container);
-
-    expect(instance.props.key).toBe(undefined);
+    expect(() =>
+      ReactDOM.render(React.createElement(Component), container),
+    ).toWarnDev(
+      'Component: key is not a valid default prop to set. ' +
+        'Please remove this from your default props definition. ' +
+        'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
+      {withoutStack: true},
+    );
   });
 
   // NOTE: We're explicitly not using JSX here. This is intended to test

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -360,10 +360,10 @@ describe('ReactElement', () => {
 
   // NOTE: We're explicitly not using JSX here. This is intended to test
   // classic JS without JSX.
-  it('should display a warning when mapping key to a default prop', () => {
+  it('should display a warning when mapping a key to a default prop', () => {
     class Component extends React.Component {
       render() {
-        return React.createElement('div', null, this.props.key);
+        return React.createElement('div', null);
       }
     }
 
@@ -373,9 +373,8 @@ describe('ReactElement', () => {
     expect(() =>
       ReactDOM.render(React.createElement(Component), container),
     ).toErrorDev(
-      'Component: key is not a valid default prop to set. ' +
-        'Please remove this from your default props definition. ' +
-        'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',
+      'Component: `key` is not a valid default prop name. ' +
+        'Please remove this from your default props definition. ',
       {withoutStack: true},
     );
   });

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -372,7 +372,7 @@ describe('ReactElement', () => {
     const container = document.createElement('div');
     expect(() =>
       ReactDOM.render(React.createElement(Component), container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Component: key is not a valid default prop to set. ' +
         'Please remove this from your default props definition. ' +
         'Note: the value is still being set, but this behavior will most likely be deprecated in future releases.',


### PR DESCRIPTION
This displays a warning whenever an end user specifies `key` or `ref` in their default props definition.

Fixes #17393

EDIT: Changed purpose of pull request to not introduce any breaking changes.