### PR TITLE
react-test-renderer: improve findByType() error message

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -42,6 +42,7 @@ import {
   ScopeComponent,
 } from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
+import getComponentName from 'shared/getComponentName';
 import ReactVersion from 'shared/ReactVersion';
 
 import {getPublicInstance} from './ReactTestHostConfig';
@@ -346,7 +347,7 @@ class ReactTestInstance {
   findByType(type: any): ReactTestInstance {
     return expectOne(
       this.findAllByType(type, {deep: false}),
-      `with node type: "${type.displayName || type.name}"`,
+      `with node type: "${getComponentName(type)}"`,
     );
   }
 

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -347,7 +347,7 @@ class ReactTestInstance {
   findByType(type: any): ReactTestInstance {
     return expectOne(
       this.findAllByType(type, {deep: false}),
-      `with node type: "${getComponentName(type)}"`,
+      `with node type: "${getComponentName(type) || 'Unknown'}"`,
     );
   }
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1022,4 +1022,14 @@ describe('ReactTestRenderer', () => {
     expect(Scheduler).toFlushWithoutYielding();
     ReactTestRenderer.create(<App />);
   });
+
+  it('calling findByType() with an invalid component will fall back to "Unknown" for component name', () => {
+    const App = () => null;
+    const renderer = ReactTestRenderer.create(<App />);
+    const NonComponent = {};
+
+    expect(() => {
+      renderer.root.findByType(NonComponent);
+    }).toThrowError(`No instances found with node type: "Unknown"`);
+  });
 });


### PR DESCRIPTION
I noticed that The `findByType()` method throws unhelpful error messages when using a string as the `type` argument. For example:

```
testInstance.findByType('span');
// Expected 1 but found 2 instances with node type: "undefined"
```
I am also running into this when searching for components using `React.memo`. My solution was to use `getComponentName()`. Thanks!
