### PR TITLE
Fix appearance of devtool scrollbar in darkmode

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/DevTools.css
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.css
@@ -52,3 +52,17 @@
     display: none;
   }
 }
+
+::-webkit-scrollbar-thumb  {
+  background-color: var(--color-scroll-thumb);
+  border-radius: 2px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: var(--color-scroll-track);
+  border-left: 1px solid var(--color-border);
+}
+
+::-webkit-scrollbar {
+  width: 14px;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -323,6 +323,8 @@ function updateThemeVariables(
   updateStyleHelper(theme, 'color-record-inactive', documentElements);
   updateStyleHelper(theme, 'color-color-scroll-thumb', documentElements);
   updateStyleHelper(theme, 'color-color-scroll-track', documentElements);
+  updateStyleHelper(theme, 'color-scroll-thumb', documentElements);
+  updateStyleHelper(theme, 'color-scroll-track', documentElements);
   updateStyleHelper(theme, 'color-search-match', documentElements);
   updateStyleHelper(theme, 'color-shadow', documentElements);
   updateStyleHelper(theme, 'color-search-match-current', documentElements);


### PR DESCRIPTION
Fixed an issue where the devtool scrollbar didn't change its appearance based 
on light/dark mode.

[Issue #17084 ]

It should be noted that for some users the scrollbar is already switching between 
dark and light mode. However, this appears to be caused by either a Chrome or 
OS version, and as such the scrollbar differs from user to user. This change would 
ensure that all users have the same scrollbar and that it properly switches color 
based on the user's selected theme.

I've tried to maintain a similar shape and size to the original Chrome devtools 
scrollbar while using the already defined scrollbar color variables in React 
(Already used for Firefox).

---

_Chrome Devtools scrollbar_
<img width="250" alt="ChromeScrollbar" src="https://user-images.githubusercontent.com/24208371/69707194-93281480-10f9-11ea-8e68-f12c94fb319f.png">

_New React dark mode scrollbar_
<img width="250" alt="ReactScrollbarDark" src="https://user-images.githubusercontent.com/24208371/69707200-96bb9b80-10f9-11ea-9015-3733a06e318d.png">

_New React light mode scrollbar_
<img width="250" alt="ReactScrollbarLight" src="https://user-images.githubusercontent.com/24208371/69707239-a63ae480-10f9-11ea-9a69-122703ec4efc.png">