### PR TITLE
Remove dependency on local git checkout from build process

### DIFF
--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -1,7 +1,7 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
 const {
-  getGitHubURL,
+  GITHUB_URL,
   getVersionString,
 } = require('react-devtools-extensions/utils');
 
@@ -15,7 +15,6 @@ const builtModulesDir = resolve(__dirname, '..', '..', 'build', 'node_modules');
 
 const __DEV__ = NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 module.exports = {

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -1,7 +1,7 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
 const {
-  getGitHubURL,
+  GITHUB_URL,
   getVersionString,
 } = require('react-devtools-extensions/utils');
 
@@ -15,7 +15,6 @@ const builtModulesDir = resolve(__dirname, '..', '..', 'build', 'node_modules');
 
 const __DEV__ = NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 module.exports = {

--- a/packages/react-devtools-extensions/package.json
+++ b/packages/react-devtools-extensions/package.json
@@ -1,5 +1,4 @@
 {
-
   "name": "react-devtools-extensions",
   "version": "0.0.0",
   "private": true,
@@ -26,18 +25,18 @@
     "babel-core": "^7.0.0-bridge",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.4",
-    "chrome-launch": "^1.1.4",
     "child-process-promise": "^2.2.1",
-    "css-loader": "^1.0.1",
+    "chrome-launch": "^1.1.4",
     "crx": "^5.0.0",
+    "css-loader": "^1.0.1",
     "firefox-profile": "^1.0.2",
     "node-libs-browser": "0.5.3",
     "nullthrows": "^1.0.0",
     "raw-loader": "^3.1.0",
     "style-loader": "^0.23.1",
     "web-ext": "^3.0.0",
-    "webpack": "^4.26.0",
-    "webpack-cli": "^3.1.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.3.1"
   }
 }

--- a/packages/react-devtools-extensions/utils.js
+++ b/packages/react-devtools-extensions/utils.js
@@ -2,25 +2,17 @@ const {execSync} = require('child_process');
 const {readFileSync} = require('fs');
 const {resolve} = require('path');
 
+const GITHUB_URL = 'https://github.com/facebook/react';
+
 function getGitCommit() {
-  return execSync('git show -s --format=%h')
-    .toString()
-    .trim();
-}
-
-function getGitHubURL() {
-  // TODO potentially replace this with an fb.me URL (assuming it can forward the query params)
-  const url = execSync('git remote get-url origin')
-    .toString()
-    .trim();
-
-  if (url.startsWith('https://')) {
-    return url.replace('.git', '');
-  } else {
-    return url
-      .replace(':', '/')
-      .replace('git@', 'https://')
-      .replace('.git', '');
+  try {
+    return execSync('git show -s --format=%h')
+      .toString()
+      .trim();
+  } catch (error) {
+    // Mozilla runs this command from a git archive.
+    // In that context, there is no Git revision.
+    return null;
   }
 }
 
@@ -36,4 +28,8 @@ function getVersionString() {
   return `${packageVersion}-${commit}`;
 }
 
-module.exports = {getGitCommit, getGitHubURL, getVersionString};
+module.exports = {
+  GITHUB_URL,
+  getGitCommit,
+  getVersionString,
+};

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -2,7 +2,7 @@
 
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
-const {getGitHubURL, getVersionString} = require('./utils');
+const {GITHUB_URL, getVersionString} = require('./utils');
 
 const NODE_ENV = process.env.NODE_ENV;
 if (!NODE_ENV) {
@@ -14,7 +14,6 @@ const builtModulesDir = resolve(__dirname, '..', '..', 'build', 'node_modules');
 
 const __DEV__ = NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 module.exports = {

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -2,7 +2,7 @@
 
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
-const {getGitHubURL, getVersionString} = require('./utils');
+const {GITHUB_URL, getVersionString} = require('./utils');
 
 const NODE_ENV = process.env.NODE_ENV;
 if (!NODE_ENV) {
@@ -14,7 +14,6 @@ const builtModulesDir = resolve(__dirname, '..', '..', 'build', 'node_modules');
 
 const __DEV__ = NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 module.exports = {

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -38,8 +38,8 @@
     "css-loader": "^1.0.1",
     "raw-loader": "^3.1.0",
     "style-loader": "^0.23.1",
-    "webpack": "^4.26.0",
-    "webpack-cli": "^3.1.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.3.1"
   }
 }

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -1,7 +1,7 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
 const {
-  getGitHubURL,
+  GITHUB_URL,
   getVersionString,
 } = require('react-devtools-extensions/utils');
 
@@ -13,7 +13,6 @@ if (!NODE_ENV) {
 
 const __DEV__ = true; // NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 module.exports = {

--- a/packages/react-devtools-shell/package.json
+++ b/packages/react-devtools-shell/package.json
@@ -26,8 +26,8 @@
     "css-loader": "^1.0.1",
     "raw-loader": "^3.1.0",
     "style-loader": "^0.23.1",
-    "webpack": "^4.26.0",
-    "webpack-cli": "^3.1.2",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.3.1"
   }
 }

--- a/packages/react-devtools-shell/webpack.config.js
+++ b/packages/react-devtools-shell/webpack.config.js
@@ -1,7 +1,7 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
 const {
-  getGitHubURL,
+  GITHUB_URL,
   getVersionString,
 } = require('react-devtools-extensions/utils');
 
@@ -21,7 +21,6 @@ const builtModulesDir = resolve(__dirname, '..', '..', 'build', 'node_modules');
 
 const __DEV__ = NODE_ENV === 'development';
 
-const GITHUB_URL = getGitHubURL();
 const DEVTOOLS_VERSION = getVersionString();
 
 const config = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13157,10 +13157,10 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-cli@^3.1.2:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.6.tgz#2c8c399a2642133f8d736a359007a052e060032c"
-  integrity sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==
+webpack-cli@^3.3.10:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
+  integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
   dependencies:
     chalk "2.4.2"
     cross-spawn "6.0.5"
@@ -13238,35 +13238,6 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
-
-webpack@^4.26.0:
-  version "4.39.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.39.2.tgz#c9aa5c1776d7c309d1b3911764f0288c8c2816aa"
-  integrity sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==
-  dependencies:
-    "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/helper-module-context" "1.8.5"
-    "@webassemblyjs/wasm-edit" "1.8.5"
-    "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.2.1"
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^4.1.0"
-    eslint-scope "^4.0.3"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^2.4.0"
-    loader-utils "^1.2.3"
-    memory-fs "^0.4.1"
-    micromatch "^3.1.10"
-    mkdirp "^0.5.1"
-    neo-async "^2.6.1"
-    node-libs-browser "^2.2.1"
-    schema-utils "^1.0.0"
-    tapable "^1.1.3"
-    terser-webpack-plugin "^1.4.1"
-    watchpack "^1.6.0"
-    webpack-sources "^1.4.1"
 
 webpack@^4.41.2:
   version "4.41.2"


### PR DESCRIPTION
Update build steps so Mozilla reviewers can build DevTools from local Git archive without an error:
* Remove unnecessary build-time parsing of GitHub URL now that the project has been migrated to the main React repo.
* Try/catch guard around Git revision parsing to avoid build failure.

Also updated the Webpack dependencies to account for changes made in #17379