### PR TITLE
Change DevTools hook warning message

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -35,7 +35,9 @@ env.beforeEach(() => {
   // $FlowFixMe
   console.error = (...args) => {
     const firstArg = args[0];
-    if (firstArg === 'Warning: React DevTools encountered an error: %s') {
+    if (
+      firstArg === 'Warning: React instrumentation encountered an error: %s'
+    ) {
       // Rethrow errors from React.
       throw args[1];
     } else if (

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -67,7 +67,7 @@ export function injectInternals(internals: Object): boolean {
               hasLoggedError = true;
               warningWithoutStack(
                 false,
-                'React DevTools encountered an error: %s',
+                'React instrumentation encountered an error: %s',
                 err,
               );
             }
@@ -93,7 +93,7 @@ export function injectInternals(internals: Object): boolean {
           hasLoggedError = true;
           warningWithoutStack(
             false,
-            'React DevTools encountered an error: %s',
+            'React instrumentation encountered an error: %s',
             err,
           );
         }
@@ -107,7 +107,7 @@ export function injectInternals(internals: Object): boolean {
           hasLoggedError = true;
           warningWithoutStack(
             false,
-            'React DevTools encountered an error: %s',
+            'React instrumentation encountered an error: %s',
             err,
           );
         }
@@ -118,7 +118,7 @@ export function injectInternals(internals: Object): boolean {
     if (__DEV__) {
       warningWithoutStack(
         false,
-        'React DevTools encountered an error: %s.',
+        'React instrumentation encountered an error: %s.',
         err,
       );
     }


### PR DESCRIPTION
Out of these 4 devtools injection points, 3 are used by Fast Refresh, and 3 are used by DevTools. These usage points are overlapping, and it's possible more tooling would use them in the future. Since we can't determine which injection consumer errored, let's make the error message more generic.