### PR TITLE
Fix string object rendering

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -482,7 +482,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     newChild: any,
     expirationTime: ExpirationTime,
   ): Fiber | null {
-    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
+    if (
+      typeof newChild === 'string' ||
+      typeof newChild === 'number' ||
+      newChild instanceof String
+    ) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
       // node.
@@ -551,7 +555,11 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     const key = oldFiber !== null ? oldFiber.key : null;
 
-    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
+    if (
+      typeof newChild === 'string' ||
+      typeof newChild === 'number' ||
+      newChild instanceof String
+    ) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
       // node.
@@ -636,7 +644,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     newChild: any,
     expirationTime: ExpirationTime,
   ): Fiber | null {
-    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
+    if (
+      typeof newChild === 'string' ||
+      typeof newChild === 'number' ||
+      newChild instanceof String
+    ) {
       // Text nodes don't have keys, so we neither have to check the old nor
       // new node for the key. If both are text nodes, they match.
       const matchedFiber = existingChildren.get(newIdx) || null;
@@ -1292,7 +1304,11 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     }
 
-    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
+    if (
+      typeof newChild === 'string' ||
+      typeof newChild === 'number' ||
+      newChild instanceof String
+    ) {
       return placeSingleChild(
         reconcileSingleTextNode(
           returnFiber,

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -485,7 +485,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (
       typeof newChild === 'string' ||
       typeof newChild === 'number' ||
-      newChild instanceof String
+      (newChild && typeof newChild.valueOf() === 'string')
     ) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
@@ -558,7 +558,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (
       typeof newChild === 'string' ||
       typeof newChild === 'number' ||
-      newChild instanceof String
+      (newChild && typeof newChild.valueOf() === 'string')
     ) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
@@ -647,7 +647,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (
       typeof newChild === 'string' ||
       typeof newChild === 'number' ||
-      newChild instanceof String
+      (newChild && typeof newChild.valueOf() === 'string')
     ) {
       // Text nodes don't have keys, so we neither have to check the old nor
       // new node for the key. If both are text nodes, they match.
@@ -1307,7 +1307,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (
       typeof newChild === 'string' ||
       typeof newChild === 'number' ||
-      newChild instanceof String
+      (newChild && typeof newChild.valueOf() === 'string')
     ) {
       return placeSingleChild(
         reconcileSingleTextNode(

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -482,7 +482,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     newChild: any,
     expirationTime: ExpirationTime,
   ): Fiber | null {
-    if (typeof newChild === 'string' || typeof newChild === 'number') {
+    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
       // node.
@@ -551,7 +551,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     const key = oldFiber !== null ? oldFiber.key : null;
 
-    if (typeof newChild === 'string' || typeof newChild === 'number') {
+    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
       // Text nodes don't have keys. If the previous node is implicitly keyed
       // we can continue to replace it without aborting even if it is not a text
       // node.
@@ -636,7 +636,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     newChild: any,
     expirationTime: ExpirationTime,
   ): Fiber | null {
-    if (typeof newChild === 'string' || typeof newChild === 'number') {
+    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
       // Text nodes don't have keys, so we neither have to check the old nor
       // new node for the key. If both are text nodes, they match.
       const matchedFiber = existingChildren.get(newIdx) || null;
@@ -1292,7 +1292,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     }
 
-    if (typeof newChild === 'string' || typeof newChild === 'number') {
+    if (typeof newChild === 'string' || typeof newChild === 'number' || newChild instanceof String) {
       return placeSingleChild(
         reconcileSingleTextNode(
           returnFiber,


### PR DESCRIPTION
This PR fixes: #17476.

This is an example that fixes the issue. 

By design, it seem as rendering Objects are not allowed.
Typical render warning for objects. `Objects are not valid as a React child`

But because a string object is iterable, it get rendered with `reconcileChildrenIterator`

This has been used for inspiration of how to check for string
https://stackoverflow.com/q/4059147/815507
I could have used `newChild instanceof String` but thought that might be too expensive to use.

This PR works because `toString()` is applied by the existing code snipped.
`'' + newChild,`