### PR TITLE
add 'rollup-plugin-json-parse'

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "rollup": "^0.52.1",
     "rollup-plugin-babel": "^4.0.1",
     "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-json-parse": "^1.1.4",
     "rollup-plugin-node-resolve": "^2.1.1",
     "rollup-plugin-prettier": "^0.3.0",
     "rollup-plugin-replace": "^2.0.0",

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -7,6 +7,7 @@ const commonjs = require('rollup-plugin-commonjs');
 const prettier = require('rollup-plugin-prettier');
 const replace = require('rollup-plugin-replace');
 const stripBanner = require('rollup-plugin-strip-banner');
+const rollupJsonParse = require('rollup-plugin-json-parse');
 const chalk = require('chalk');
 const path = require('path');
 const resolve = require('rollup-plugin-node-resolve');
@@ -359,6 +360,8 @@ function getPlugins(
     }),
     // Compile to ES5.
     babel(getBabelConfig(updateBabelOptions, bundleType)),
+    // Convert large compatible objects to a string inside `JSON.parse`
+    rollupJsonParse(),
     // Remove 'use strict' from individual source files.
     {
       transform(source) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,6 +1554,11 @@ acorn@^6.0.1, acorn@^6.0.7, acorn@^6.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
   integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
 
+acorn@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
 adbkit-logcat@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/adbkit-logcat/-/adbkit-logcat-1.1.0.tgz#01d7f9b0cef9093a30bcb3b007efff301508962f"
@@ -7817,7 +7822,7 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
-jsesc@^2.5.1:
+jsesc@^2.5.1, jsesc@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
@@ -8414,6 +8419,13 @@ magic-string@0.22.4, magic-string@^0.22.4:
   integrity sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==
   dependencies:
     vlq "^0.2.1"
+
+magic-string@^0.25.4:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.4.tgz#325b8a0a79fc423db109b77fd5a19183b7ba5143"
+  integrity sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -11036,6 +11048,15 @@ rollup-plugin-commonjs@^8.2.6:
     resolve "^1.4.0"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-json-parse@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json-parse/-/rollup-plugin-json-parse-1.1.4.tgz#797188d86d8f9bb9d86516d0ac0e58f79afe4079"
+  integrity sha512-j68Hnab/9mDuY919+zEChZPUNBnseiBRlYF6SSwNVQvZs20IrJvoG30eG2q4RLSgVlNPyFk8ctUWD5gsIpXOTg==
+  dependencies:
+    acorn "^7.1.0"
+    jsesc "^2.5.2"
+    magic-string "^0.25.4"
+
 rollup-plugin-node-resolve@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.1.1.tgz#cbb783b0d15b02794d58915350b2f0d902b8ddc8"
@@ -11850,6 +11871,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz#e30a74f0402bad09807640d39e971090a08ce1e9"
+  integrity sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==
 
 spawn-sync@1.0.15:
   version "1.0.15"


### PR DESCRIPTION
This adds [rollup-plugin-json-parse](https://github.com/tjenkinson/rollup-plugin-json-parse), which is configured to convert large objects to strings that are `JSON.parse`'d. This [should actually increase performance](https://github.com/tjenkinson/rollup-plugin-json-parse#why)

[Click here to see the diff of the build when the plugin is added](https://github.com/facebook/react/commit/ce13149c788706ed5a57213c071e8ebe7c8555f6)

Interesting to see that the real size goes up slightly, but the gzipped size is actually smaller.

Would be interesting if to see if it actually makes a speed difference here. Do you have any benchmarks that could be run?