### PR TITLE
[react-interactions] Add experimental ReactDOM Listener API

### DIFF
--- a/packages/legacy-events/EventSystemFlags.js
+++ b/packages/legacy-events/EventSystemFlags.js
@@ -11,7 +11,8 @@ export type EventSystemFlags = number;
 
 export const PLUGIN_EVENT_SYSTEM = 1;
 export const RESPONDER_EVENT_SYSTEM = 1 << 1;
-export const IS_PASSIVE = 1 << 2;
-export const IS_ACTIVE = 1 << 3;
-export const PASSIVE_NOT_SUPPORTED = 1 << 4;
-export const IS_REPLAYED = 1 << 5;
+export const LISTENER_EVENT_SYSTEM = 1 << 2;
+export const IS_PASSIVE = 1 << 3;
+export const IS_ACTIVE = 1 << 4;
+export const PASSIVE_NOT_SUPPORTED = 1 << 5;
+export const IS_REPLAYED = 1 << 6;

--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -17,7 +17,7 @@ import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
 export type EventTypes = {[key: string]: DispatchConfig};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -10,7 +10,7 @@ import {
   restoreStateIfNeeded,
 } from './ReactControlledComponent';
 
-import {enableFlareAPI} from 'shared/ReactFeatureFlags';
+import {enableFlareAPI, enableListenerAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 
 // Used as a way to call batchedUpdates when we don't have a reference to
@@ -118,7 +118,7 @@ export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
   // behaviour as we had before this change, so the risks are low.
   if (
     !isInsideEventHandler &&
-    (!enableFlareAPI ||
+    ((!enableFlareAPI && !enableListenerAPI) ||
       (timeStamp === 0 || lastFlushedEventTimeStamp !== timeStamp))
   ) {
     lastFlushedEventTimeStamp = timeStamp;

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -426,7 +426,7 @@ export function unhideTextInstance(textInstance, text): void {
   // Noop
 }
 
-export function mountResponderInstance(
+export function mountDeprecatedFlareResponderInstance(
   responder: ReactEventResponder<any, any>,
   responderInstance: ReactEventResponderInstance<any, any>,
   props: Object,
@@ -436,7 +436,7 @@ export function mountResponderInstance(
   throw new Error('Not yet implemented.');
 }
 
-export function unmountResponderInstance(
+export function unmountDeprecatedFlareResponderInstance(
   responderInstance: ReactEventResponderInstance<any, any>,
 ): void {
   throw new Error('Not yet implemented.');
@@ -468,4 +468,20 @@ export function getInstanceFromNode(node) {
 
 export function beforeRemoveInstance(instance) {
   // noop
+}
+
+export function prepareListener(listener: any, rootContainerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function diffListeners(pendingListener: any, memoizedListener: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function unmountListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -20,6 +20,11 @@ import {
   unmountComponentAtNode,
 } from './ReactDOMLegacy';
 import {createRoot, createBlockingRoot, isValidContainer} from './ReactDOMRoot';
+import {
+  createListener,
+  createRootListener,
+  setEventPriority,
+} from './ReactDOMListener';
 
 import {
   batchedEventUpdates,
@@ -55,7 +60,10 @@ import ReactVersion from 'shared/ReactVersion';
 import invariant from 'shared/invariant';
 import lowPriorityWarningWithoutStack from 'shared/lowPriorityWarningWithoutStack';
 import warningWithoutStack from 'shared/warningWithoutStack';
-import {exposeConcurrentModeAPIs} from 'shared/ReactFeatureFlags';
+import {
+  exposeConcurrentModeAPIs,
+  enableListenerAPI,
+} from 'shared/ReactFeatureFlags';
 
 import {
   getInstanceFromNode,
@@ -193,6 +201,12 @@ if (exposeConcurrentModeAPIs) {
       queueExplicitHydrationTarget(target);
     }
   };
+}
+
+if (enableListenerAPI) {
+  ReactDOM.unstable_createListener = createListener;
+  ReactDOM.unstable_createRootListener = createRootListener;
+  ReactDOM.unstable_setEventPriority = setEventPriority;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/client/ReactDOMListener.js
+++ b/packages/react-dom/src/client/ReactDOMListener.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {EventPriority} from 'shared/ReactTypes';
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
+
+import {hasBadMapPolyfill} from 'shared/hasBadMapPolyfill';
+import {customEventPriorities} from '../events/DOMEventListenerSystem';
+
+type ReactDOMListenerOptions = {
+  capture?: boolean,
+  passive?: boolean,
+};
+
+function createReactListener(
+  type: string,
+  callback: mixed => void,
+  isRootListener: boolean,
+  options?: ReactDOMListenerOptions,
+): ReactDOMListener {
+  let capture = false;
+  let passive = true;
+
+  if (options) {
+    const optionsCapture = options.capture;
+    if (optionsCapture != null) {
+      capture = optionsCapture;
+    }
+    const optionsPassive = options.passive;
+    if (optionsPassive != null) {
+      passive = optionsPassive;
+    }
+  }
+
+  const reactListener = {
+    callback,
+    capture,
+    type,
+    passive,
+    root: isRootListener,
+  };
+  if (__DEV__ && !hasBadMapPolyfill) {
+    Object.freeze(reactListener);
+  }
+  return reactListener;
+}
+
+export function createListener(
+  type: string,
+  callback: mixed => void,
+  options?: ReactDOMListenerOptions,
+): ReactDOMListener {
+  const isRootListener = false;
+  return createReactListener(type, callback, isRootListener, options);
+}
+
+export function createRootListener(
+  type: string,
+  callback: mixed => void,
+  options?: ReactDOMListenerOptions,
+): ReactDOMListener {
+  const isRootListener = true;
+  return createReactListener(type, callback, isRootListener, options);
+}
+
+export function setEventPriority(type: string, priority: EventPriority): void {
+  customEventPriorities.set(type, priority);
+}

--- a/packages/react-dom/src/events/DOMEventListenerSystem.js
+++ b/packages/react-dom/src/events/DOMEventListenerSystem.js
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+import {
+  type EventSystemFlags,
+  IS_PASSIVE,
+  PASSIVE_NOT_SUPPORTED,
+} from 'legacy-events/EventSystemFlags';
+import type {ReactListenerInstance, EventPriority} from 'shared/ReactTypes';
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
+
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import {
+  batchedEventUpdates,
+  discreteUpdates,
+  flushDiscreteUpdatesIfNeeded,
+  executeUserEventHandler,
+} from 'legacy-events/ReactGenericBatching';
+import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
+import {getEventPriority} from './SimpleEventPlugin';
+
+import {
+  ContinuousEvent,
+  UserBlockingEvent,
+  DiscreteEvent,
+} from 'shared/ReactTypes';
+import {HostComponent, ScopeComponent} from 'shared/ReactWorkTags';
+
+// Intentionally not named imports because Rollup would use dynamic dispatch for
+// CommonJS interop named imports.
+import * as Scheduler from 'scheduler';
+
+const {
+  unstable_UserBlockingPriority: UserBlockingPriority,
+  unstable_runWithPriority: runWithPriority,
+} = Scheduler;
+const arrayFrom = Array.from;
+
+type EventProperties = {|
+  currentTarget: null | Document | Element,
+  eventPhase: 0 | 1 | 2 | 3,
+  stopImmediatePropagation: boolean,
+  stopPropagation: boolean,
+|};
+
+type RootEventListenerInstance = {|
+  active: Set<ReactListenerInstance<ReactDOMListener>>,
+  passive: Set<ReactListenerInstance<ReactDOMListener>>,
+|};
+
+type DOMListenerInstance = {|
+  capture: Array<ReactListenerInstance<ReactDOMListener>>,
+  bubble: Array<ReactListenerInstance<ReactDOMListener>>,
+|};
+
+type RootEventListenerInstances = Map<string, RootEventListenerInstance>;
+
+const rootCaptureEventListenerInstances: RootEventListenerInstances = new Map();
+const rootBubbleEventListenerInstances: RootEventListenerInstances = new Map();
+
+export const customEventPriorities: Map<string, EventPriority> = new Map();
+
+function getEventPriorityForType(type: string): EventPriority {
+  return customEventPriorities.get(type) || getEventPriority((type: any));
+}
+
+function getTargetListenerInstances(
+  eventType: string,
+  target: null | Fiber,
+  isPassive: boolean,
+): DOMListenerInstance {
+  const captureEventListeners = [];
+  const bubbleEventListeners = [];
+  let lastHostComponent = null;
+  let propagationDepth = 0;
+
+  let currentFiber = target;
+  while (currentFiber !== null) {
+    const {dependencies, tag} = currentFiber;
+    if (
+      (tag === HostComponent || tag === ScopeComponent) &&
+      dependencies !== null
+    ) {
+      if (tag === HostComponent) {
+        // Get the host component (DOM element) from the fiber
+        lastHostComponent = currentFiber.stateNode;
+      }
+      const listeners = dependencies.listeners;
+      if (listeners !== null) {
+        let listenerInstance = listeners.firstInstance;
+        while (listenerInstance !== null) {
+          const listener = listenerInstance.listener;
+          if (
+            listener.root === false &&
+            listener.type === eventType &&
+            listener.passive === isPassive
+          ) {
+            listenerInstance.currentTarget = lastHostComponent;
+            listenerInstance.propagationDepth = propagationDepth;
+            if (listener.capture) {
+              captureEventListeners.push(listenerInstance);
+            } else {
+              bubbleEventListeners.push(listenerInstance);
+            }
+          }
+          listenerInstance = listenerInstance.next;
+        }
+        propagationDepth++;
+      }
+    }
+    currentFiber = currentFiber.return;
+  }
+  return {capture: captureEventListeners, bubble: bubbleEventListeners};
+}
+
+function monkeyPatchNativeEvent(nativeEvent: any): EventProperties {
+  if (nativeEvent._reactEventProperties) {
+    return nativeEvent._reactEventProperties;
+  }
+  const eventProperties = {
+    currentTarget: null,
+    eventPhase: 0,
+    stopImmediatePropagation: false,
+    stopPropagation: false,
+  };
+  // $FlowFixMe: prevent Flow complaining about needing a value
+  Object.defineProperty(nativeEvent, 'currentTarget', {
+    get() {
+      return eventProperties.currentTarget;
+    },
+  });
+  // $FlowFixMe: prevent Flow complaning about needing a value
+  Object.defineProperty(nativeEvent, 'eventPhase', {
+    get() {
+      return eventProperties.eventPhase;
+    },
+  });
+  nativeEvent.stopPropagation = () => {
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent.stopImmediatePropagation = () => {
+    eventProperties.stopImmediatePropagation = true;
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent._reactEventProperties = eventProperties;
+  return eventProperties;
+}
+
+function dispatchEvent(
+  listenerInstance: ReactListenerInstance<ReactDOMListener>,
+  eventProperties: EventProperties,
+  nativeEvent: AnyNativeEvent,
+  document: Document | null,
+): void {
+  const callback = listenerInstance.listener.callback;
+  // For root instances, the currentTarget will be null,
+  // which for those cases means we should use the document.
+  eventProperties.currentTarget = listenerInstance.currentTarget || document;
+  listenerInstance.currentTarget = null;
+  executeUserEventHandler(callback, nativeEvent);
+}
+
+function shouldStopPropagation(
+  eventProperties: EventProperties,
+  lastPropagationDepth: void | number,
+  propagationDepth: number,
+): boolean {
+  return (
+    (eventProperties.stopPropagation === true &&
+      lastPropagationDepth !== propagationDepth) ||
+    eventProperties.stopImmediatePropagation === true
+  );
+}
+
+function dispatchCaptureEventListeners(
+  eventProperties: EventProperties,
+  listenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  nativeEvent: AnyNativeEvent,
+  document: Document | null,
+) {
+  const end = listenerInstances.length - 1;
+  let lastPropagationDepth;
+  for (let i = end; i >= 0; i--) {
+    const listenerInstance = listenerInstances[i];
+    const {propagationDepth} = listenerInstance;
+    if (
+      // When document is not null, we know its a root event
+      (document === null || i === end) &&
+      shouldStopPropagation(
+        eventProperties,
+        lastPropagationDepth,
+        propagationDepth,
+      )
+    ) {
+      return;
+    }
+    dispatchEvent(listenerInstance, eventProperties, nativeEvent, document);
+    lastPropagationDepth = propagationDepth;
+  }
+}
+
+function dispatchBubbleEventListeners(
+  eventProperties: EventProperties,
+  listenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  nativeEvent: AnyNativeEvent,
+  document: Document | null,
+) {
+  const length = listenerInstances.length;
+  let lastPropagationDepth;
+  for (let i = 0; i < length; i++) {
+    const listenerInstance = listenerInstances[i];
+    const {propagationDepth} = listenerInstance;
+    if (
+      // When document is not null, we know its a root event
+      (document === null || i === 0) &&
+      shouldStopPropagation(
+        eventProperties,
+        lastPropagationDepth,
+        propagationDepth,
+      )
+    ) {
+      return;
+    }
+    dispatchEvent(listenerInstance, eventProperties, nativeEvent, document);
+    lastPropagationDepth = propagationDepth;
+  }
+}
+
+function dispatchEventListenersByPhase(
+  captureTargetListenerInstances: Array<
+    ReactListenerInstance<ReactDOMListener>,
+  >,
+  bubbleTargetListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  rootCaptureListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  rootBubbleListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  nativeEvent: AnyNativeEvent,
+): void {
+  // We only pass this variable to root instance dispatchers
+  // below. This is because the currentTarget of root dispatches
+  // must be the current owner document.
+  const document = (nativeEvent.target: any).ownerDocument;
+  const eventProperties = monkeyPatchNativeEvent(nativeEvent);
+  // Capture phase
+  eventProperties.eventPhase = 1;
+  // Dispatch capture root event listeners
+  dispatchCaptureEventListeners(
+    eventProperties,
+    rootCaptureListenerInstances,
+    nativeEvent,
+    document,
+  );
+  // Dispatch capture target event listeners
+  dispatchCaptureEventListeners(
+    eventProperties,
+    captureTargetListenerInstances,
+    nativeEvent,
+    null,
+  );
+  eventProperties.stopImmediatePropagation = false;
+  eventProperties.stopPropagation = false;
+  // Bubble phase
+  eventProperties.eventPhase = 3;
+  // Dispatch bubble target event listeners
+  dispatchBubbleEventListeners(
+    eventProperties,
+    bubbleTargetListenerInstances,
+    nativeEvent,
+    null,
+  );
+  // Dispatch bubble root event listeners
+  dispatchBubbleEventListeners(
+    eventProperties,
+    rootBubbleListenerInstances,
+    nativeEvent,
+    document,
+  );
+}
+
+function dispatchEventListenersAtPriority(
+  eventType: string,
+  captureTargetListenerInstances: Array<
+    ReactListenerInstance<ReactDOMListener>,
+  >,
+  bubbleTargetListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  rootCaptureListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  rootBubbleListenerInstances: Array<ReactListenerInstance<ReactDOMListener>>,
+  nativeEvent: AnyNativeEvent,
+): void {
+  const eventPriority = getEventPriorityForType(eventType);
+  switch (eventPriority) {
+    case DiscreteEvent: {
+      flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+      discreteUpdates(() =>
+        dispatchEventListenersByPhase(
+          captureTargetListenerInstances,
+          bubbleTargetListenerInstances,
+          rootCaptureListenerInstances,
+          rootBubbleListenerInstances,
+          nativeEvent,
+        ),
+      );
+      break;
+    }
+    case UserBlockingEvent: {
+      runWithPriority(UserBlockingPriority, () =>
+        dispatchEventListenersByPhase(
+          captureTargetListenerInstances,
+          bubbleTargetListenerInstances,
+          rootCaptureListenerInstances,
+          rootBubbleListenerInstances,
+          nativeEvent,
+        ),
+      );
+      break;
+    }
+    case ContinuousEvent: {
+      dispatchEventListenersByPhase(
+        captureTargetListenerInstances,
+        bubbleTargetListenerInstances,
+        rootCaptureListenerInstances,
+        rootBubbleListenerInstances,
+        nativeEvent,
+      );
+      break;
+    }
+  }
+}
+
+function getRootListenerInstances(
+  type: string,
+  passive: boolean,
+  capture: boolean,
+): Set<ReactListenerInstance<ReactDOMListener>> {
+  const rootEventListenerInstances = capture
+    ? rootCaptureEventListenerInstances
+    : rootBubbleEventListenerInstances;
+  let listenerInstances = rootEventListenerInstances.get(type);
+
+  if (listenerInstances === undefined) {
+    listenerInstances = {
+      active: new Set(),
+      passive: new Set(),
+    };
+    rootEventListenerInstances.set(type, listenerInstances);
+  }
+  return passive ? listenerInstances.passive : listenerInstances.active;
+}
+
+export function dispatchEventForListenerEventSystem(
+  eventType: string,
+  targetFiber: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+  eventSystemFlags: EventSystemFlags,
+): void {
+  const isPassiveEvent = (eventSystemFlags & IS_PASSIVE) !== 0;
+  const isNativePassiveSupported =
+    (eventSystemFlags & PASSIVE_NOT_SUPPORTED) === 0;
+  // We only get passed the isNativePassiveSupported flag when passive
+  // was request on the DOM event listener, but because of browser support
+  // it was not possible to use it.
+  const isPassive = isPassiveEvent || !isNativePassiveSupported;
+  // Get target event listeners in their propagation order (non root events)
+  const {
+    capture: captureTargetListenerInstances,
+    bubble: bubbleTargetListenerInstances,
+  } = getTargetListenerInstances(eventType, targetFiber, isPassive);
+  const rootCaptureListenerInstances = arrayFrom(
+    getRootListenerInstances(eventType, isPassive, true),
+  );
+  const rootBubbleListenerInstances = arrayFrom(
+    getRootListenerInstances(eventType, isPassive, false),
+  );
+  if (
+    captureTargetListenerInstances.length !== 0 ||
+    bubbleTargetListenerInstances.length !== 0 ||
+    rootCaptureListenerInstances.length !== 0 ||
+    rootBubbleListenerInstances.length !== 0
+  ) {
+    batchedEventUpdates(() =>
+      dispatchEventListenersAtPriority(
+        eventType,
+        captureTargetListenerInstances,
+        bubbleTargetListenerInstances,
+        rootCaptureListenerInstances,
+        rootBubbleListenerInstances,
+        nativeEvent,
+      ),
+    );
+  }
+}
+
+function getRootListenerInstancesForInstance(
+  listenerInstance: ReactListenerInstance<ReactDOMListener>,
+): Set<ReactListenerInstance<ReactDOMListener>> {
+  const {capture, passive, type} = listenerInstance.listener;
+  return getRootListenerInstances(type, passive, capture);
+}
+
+export function addRootListenerInstance(
+  listenerInstance: ReactListenerInstance<ReactDOMListener>,
+): void {
+  const listenerInstances = getRootListenerInstancesForInstance(
+    listenerInstance,
+  );
+  listenerInstances.add(listenerInstance);
+}
+
+export function removeRootListenerInstance(
+  listenerInstance: ReactListenerInstance<ReactDOMListener>,
+): void {
+  const listenerInstances = getRootListenerInstancesForInstance(
+    listenerInstance,
+  );
+  listenerInstances.delete(listenerInstance);
+}

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -30,7 +30,7 @@ import {
 } from 'react-reconciler/reflection';
 import {
   attemptToDispatchEvent,
-  addResponderEventSystemEvent,
+  addListenerSystemEvent,
 } from './ReactDOMEventListener';
 import {
   getListenerMapForElement,
@@ -222,7 +222,7 @@ function trapReplayableEvent(
     const topLevelTypeString = unsafeCastDOMTopLevelTypeToString(topLevelType);
     const passiveEventKey = topLevelTypeString + '_passive';
     if (!listenerMap.has(passiveEventKey)) {
-      const listener = addResponderEventSystemEvent(
+      const listener = addListenerSystemEvent(
         document,
         topLevelTypeString,
         true,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -236,15 +236,17 @@ const knownHTMLTopLevelTypes: Array<DOMTopLevelEventType> = [
   DOMTopLevelEventTypes.TOP_WAITING,
 ];
 
+export function getEventPriority(topLevelType: TopLevelType): EventPriority {
+  const config = topLevelEventsToDispatchConfig[topLevelType];
+  return config !== undefined ? config.eventPriority : ContinuousEvent;
+}
+
 const SimpleEventPlugin: PluginModule<MouseEvent> & {
   getEventPriority: (topLevelType: TopLevelType) => EventPriority,
 } = {
   eventTypes: eventTypes,
 
-  getEventPriority(topLevelType: TopLevelType): EventPriority {
-    const config = topLevelEventsToDispatchConfig[topLevelType];
-    return config !== undefined ? config.eventPriority : ContinuousEvent;
-  },
+  getEventPriority,
 
   extractEvents: function(
     topLevelType: TopLevelType,

--- a/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test-internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test-internal.js
@@ -1,0 +1,859 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let ReactDOMServer;
+let ReactTestRenderer;
+let Scheduler;
+
+function dispatchEvent(element, type) {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  element.dispatchEvent(event);
+}
+
+function dispatchClickEvent(element) {
+  dispatchEvent(element, 'click');
+}
+
+describe('DOMEventListenerSystem', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableListenerAPI = true;
+    ReactFeatureFlags.enableScopeAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+    Scheduler = require('scheduler');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('can mount and render correctly with the ReactTestRenderer', () => {
+    jest.resetModules();
+    const clickEvent = jest.fn();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableListenerAPI = true;
+    React = require('react');
+    ReactTestRenderer = require('react-test-renderer');
+
+    function Test() {
+      const listener = ReactDOM.unstable_createListener('click', clickEvent);
+
+      return <div listeners={listener}>Hello world</div>;
+    }
+    const renderer = ReactTestRenderer.create(<Test />);
+    expect(renderer).toMatchRenderedOutput(<div>Hello world</div>);
+  });
+
+  it('can render correctly with the ReactDOMServer', () => {
+    const clickEvent = jest.fn();
+
+    function Test() {
+      const listener = ReactDOM.unstable_createListener('click', clickEvent);
+
+      return <div listeners={listener}>Hello world</div>;
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
+  });
+
+  it('can render correctly with the ReactDOMServer hydration', () => {
+    const clickEvent = jest.fn();
+    const ref = React.createRef();
+
+    function Test() {
+      const listener = ReactDOM.unstable_createListener('click', clickEvent);
+
+      return (
+        <div>
+          <span listeners={listener} ref={ref}>
+            Hello world
+          </span>
+        </div>
+      );
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(
+      `<div data-reactroot=""><span>Hello world</span></div>`,
+    );
+    container.innerHTML = output;
+    ReactDOM.hydrate(<Test />, container);
+    dispatchClickEvent(ref.current);
+    expect(clickEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly work for a basic "click" listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+    const divRef = React.createRef();
+    const buttonRef = React.createRef();
+
+    function Test() {
+      const listener = ReactDOM.unstable_createListener('click', clickEvent);
+
+      return (
+        <button listeners={listener} ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    expect(container.innerHTML).toBe('<button><div>Click me!</div></button>');
+
+    // Clicking the button should trigger the event callback
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: divRef.current,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering the container and clicking should work
+    ReactDOM.render(<Test />, container);
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(2);
+
+    // Clicking the button should also work
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(log[2]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: buttonRef.current,
+    });
+  });
+
+  it('should correctly handle many nested target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn();
+    const targetListerner3 = jest.fn();
+    const targetListerner4 = jest.fn();
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+        {capture: true},
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+        {capture: true},
+      );
+      const listerner3 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner3,
+      );
+      const listerner4 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner4,
+      );
+
+      return (
+        <button
+          listeners={[
+            [listerner1],
+            undefined,
+            [listerner2, null, [[listerner3]], listerner4],
+          ]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+
+    function Test2() {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+      const listerner3 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner3,
+      );
+      const listerner4 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner4,
+      );
+
+      return (
+        <button
+          listeners={[
+            [listerner1],
+            undefined,
+            [listerner2, null, [[listerner3]], listerner4],
+          ]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test2 />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(2);
+    expect(targetListerner2).toHaveBeenCalledTimes(2);
+    expect(targetListerner3).toHaveBeenCalledTimes(2);
+    expect(targetListerner4).toHaveBeenCalledTimes(2);
+  });
+
+  it('should correctly work for a basic "click" root listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+
+    function Test() {
+      const listener = ReactDOM.unstable_createRootListener(
+        'click',
+        clickEvent,
+      );
+
+      return <button listeners={listener}>Click anything!</button>;
+    }
+    ReactDOM.render(<Test />, container);
+    expect(container.innerHTML).toBe('<button>Click anything!</button>');
+
+    // Clicking outside the button should trigger the event callback
+    dispatchClickEvent(document.body);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: document,
+      target: document.body,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering and clicking the body should work again
+    ReactDOM.render(<Test />, container);
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(2);
+  });
+
+  it('should correctly handle event propagation in the correct order', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    const log = [];
+
+    function Test() {
+      const captureRoot = ReactDOM.unstable_createRootListener(
+        'click',
+        e => {
+          log.push({
+            root: true,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        },
+        {capture: true},
+      );
+      const captureBubble = ReactDOM.unstable_createRootListener('click', e => {
+        log.push({
+          root: true,
+          eventPhase: e.eventPhase,
+          currentTarget: e.currentTarget,
+          target: e.target,
+        });
+      });
+      const bubbleButton = ReactDOM.unstable_createListener('click', e => {
+        log.push({
+          root: false,
+          eventPhase: e.eventPhase,
+          currentTarget: e.currentTarget,
+          target: e.target,
+        });
+      });
+      const captureButton = ReactDOM.unstable_createListener(
+        'click',
+        e => {
+          log.push({
+            root: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        },
+        {capture: true},
+      );
+      const bubbleDiv = ReactDOM.unstable_createListener('click', e => {
+        log.push({
+          root: false,
+          eventPhase: e.eventPhase,
+          currentTarget: e.currentTarget,
+          target: e.target,
+        });
+      });
+      const captureDiv = ReactDOM.unstable_createListener(
+        'click',
+        e => {
+          log.push({
+            root: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        },
+        {capture: true},
+      );
+
+      return (
+        <button
+          listeners={[captureRoot, captureBubble, bubbleButton, captureButton]}
+          ref={buttonRef}>
+          <div
+            listeners={[captureRoot, captureBubble, bubbleDiv, captureDiv]}
+            ref={divRef}>
+            Click me!
+          </div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+
+    expect(log).toEqual([
+      {
+        root: true,
+        eventPhase: 1,
+        currentTarget: document,
+        target: divRef.current,
+      },
+      {
+        root: true,
+        eventPhase: 1,
+        currentTarget: document,
+        target: divRef.current,
+      },
+      {
+        root: false,
+        eventPhase: 1,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        root: false,
+        eventPhase: 1,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        root: false,
+        eventPhase: 3,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        root: false,
+        eventPhase: 3,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        root: true,
+        eventPhase: 3,
+        currentTarget: document,
+        target: divRef.current,
+      },
+      {
+        root: true,
+        eventPhase: 3,
+        currentTarget: document,
+        target: divRef.current,
+      },
+    ]);
+  });
+
+  it('should correctly handle stopImmediatePropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopImmediatePropagation());
+    const targetListerner2 = jest.fn(e => e.stopImmediatePropagation());
+    const rootListerner1 = jest.fn();
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+        {capture: true},
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+      const listerner3 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner1,
+      );
+
+      return (
+        <button
+          listeners={[listerner1, listerner2, listerner3]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner1).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for based target events', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    let clickEvent = jest.fn();
+
+    function Test() {
+      const bubbleButton = ReactDOM.unstable_createListener(
+        'click',
+        clickEvent,
+      );
+      const bubbleDiv = ReactDOM.unstable_createListener('click', e => {
+        e.stopPropagation();
+      });
+
+      return (
+        <button listeners={bubbleButton} ref={buttonRef}>
+          <div listeners={bubbleDiv} ref={divRef}>
+            Click me!
+          </div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for mixed capture/bubbling target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+        {capture: true},
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+        {capture: true},
+      );
+      const listerner3 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner3,
+      );
+      const listerner4 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner4,
+      );
+
+      return (
+        <button
+          listeners={[listerner1, listerner2, listerner3, listerner4]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+      const listerner3 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner3,
+      );
+      const listerner4 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner4,
+      );
+
+      return (
+        <button
+          listeners={[listerner1, listerner2, listerner3, listerner4]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner1,
+        {capture: true},
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+        {capture: true},
+      );
+      const listerner3 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner2,
+      );
+      const listerner4 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+
+      return (
+        <button
+          listeners={[listerner1, listerner2, listerner3, listerner4]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner1).toHaveBeenCalledTimes(0);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for root listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const rootListerner3 = jest.fn(e => e.stopPropagation());
+    const rootListerner4 = jest.fn();
+
+    function Test() {
+      const listerner1 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner1,
+        {capture: true},
+      );
+      const listerner2 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner2,
+        {capture: true},
+      );
+      const listerner3 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner3,
+      );
+      const listerner4 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner4,
+      );
+
+      return (
+        <button
+          listeners={[listerner1, listerner2, listerner3, listerner4]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner3).toHaveBeenCalledTimes(1);
+    expect(rootListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle updating listeners to empty', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn();
+
+    function Test({toggle}) {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+
+      return (
+        <button
+          listeners={toggle ? [listerner1, listerner2] : []}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test toggle={true} />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+
+    ReactDOM.render(<Test toggle={false} />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle updating target listeners size', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn();
+
+    function Test({toggle}) {
+      const listerner1 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner1,
+      );
+      const listerner2 = ReactDOM.unstable_createListener(
+        'click',
+        targetListerner2,
+      );
+
+      return (
+        <button
+          listeners={toggle ? [listerner1] : [listerner1, listerner2]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test toggle={true} />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(0);
+
+    ReactDOM.render(<Test toggle={false} />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(2);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+
+    ReactDOM.render(<Test toggle={true} />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(3);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle updating root listeners size', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn();
+    const rootListerner2 = jest.fn();
+
+    function Test({toggle}) {
+      const listerner1 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner1,
+      );
+      const listerner2 = ReactDOM.unstable_createRootListener(
+        'click',
+        rootListerner2,
+      );
+
+      return (
+        <button
+          listeners={toggle ? [listerner1] : [listerner1, listerner2]}
+          ref={buttonRef}>
+          Click me!
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test toggle={true} />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(0);
+
+    ReactDOM.render(<Test toggle={false} />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(2);
+    expect(rootListerner2).toHaveBeenCalledTimes(1);
+
+    ReactDOM.render(<Test toggle={true} />, container);
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(3);
+    expect(rootListerner2).toHaveBeenCalledTimes(1);
+  });
+
+  it.experimental('should work with concurrent mode updates', async () => {
+    const log = [];
+    const ref = React.createRef();
+
+    function Test({counter}) {
+      const listener = ReactDOM.unstable_createListener('click', () => {
+        log.push({counter});
+      });
+
+      Scheduler.unstable_yieldValue('Test');
+      return (
+        <button listeners={listener} ref={ref}>
+          Press me
+        </button>
+      );
+    }
+
+    let root = ReactDOM.createRoot(container);
+    root.render(<Test counter={0} />);
+    expect(Scheduler).toFlushAndYield(['Test']);
+
+    // Click the button
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Increase counter
+    root.render(<Test counter={1} />);
+    // Yield before committing
+    expect(Scheduler).toFlushAndYieldThrough(['Test']);
+
+    // Click the button again
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Commit
+    expect(Scheduler).toFlushAndYield([]);
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 1}]);
+  });
+});

--- a/packages/react-dom/src/events/checkPassiveEvents.js
+++ b/packages/react-dom/src/events/checkPassiveEvents.js
@@ -8,13 +8,13 @@
  */
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import {enableFlareAPI} from 'shared/ReactFeatureFlags';
+import {enableFlareAPI, enableListenerAPI} from 'shared/ReactFeatureFlags';
 
 export let passiveBrowserEventsSupported = false;
 
 // Check if browser support events with passive listeners
 // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
-if (enableFlareAPI && canUseDOM) {
+if ((enableFlareAPI || enableListenerAPI) && canUseDOM) {
   try {
     const options = {};
     // $FlowFixMe: Ignore Flow complaining about needing a value

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -33,6 +33,7 @@ import {
   enableFundamentalAPI,
   enableFlareAPI,
   enableScopeAPI,
+  enableListenerAPI,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -371,6 +372,9 @@ function createOpenTagMarkup(
       continue;
     }
     if (enableFlareAPI && propKey === 'DEPRECATED_flareListeners') {
+      continue;
+    }
+    if (enableListenerAPI && propKey === 'listeners') {
       continue;
     }
     let propValue = props[propKey];

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -8,7 +8,7 @@
  */
 
 import warning from 'shared/warning';
-import {enableFlareAPI} from 'shared/ReactFeatureFlags';
+import {enableFlareAPI, enableListenerAPI} from 'shared/ReactFeatureFlags';
 
 type PropertyType = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
@@ -223,6 +223,9 @@ const reservedProps = [
 ];
 if (enableFlareAPI) {
   reservedProps.push('DEPRECATED_flareListeners');
+}
+if (enableListenerAPI) {
+  reservedProps.push('listeners');
 }
 
 reservedProps.forEach(name => {

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -7,7 +7,7 @@
 
 import checkPropTypes from 'prop-types/checkPropTypes';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {enableFlareAPI} from 'shared/ReactFeatureFlags';
+import {enableFlareAPI, enableListenerAPI} from 'shared/ReactFeatureFlags';
 
 let ReactDebugCurrentFrame = null;
 
@@ -36,7 +36,8 @@ if (__DEV__) {
         props.readOnly ||
         props.disabled ||
         props[propName] == null ||
-        (enableFlareAPI && props.DEPRECATED_flareListeners)
+        (enableFlareAPI && props.DEPRECATED_flareListeners) ||
+        (enableListenerAPI && props.listeners)
       ) {
         return null;
       }
@@ -53,7 +54,8 @@ if (__DEV__) {
         props.readOnly ||
         props.disabled ||
         props[propName] == null ||
-        (enableFlareAPI && props.DEPRECATED_flareListeners)
+        (enableFlareAPI && props.DEPRECATED_flareListeners) ||
+        (enableListenerAPI && props.listeners)
       ) {
         return null;
       }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -78,6 +78,7 @@ type ReactNativeEventResponder = ReactEventResponder<
 >;
 
 type Node = Object;
+export type ReactListenerType = Object;
 export type Type = string;
 export type Props = Object;
 export type Instance = {
@@ -443,7 +444,7 @@ export function replaceContainerChildren(
   newChildren: ChildSet,
 ): void {}
 
-export function mountResponderInstance(
+export function mountDeprecatedFlareResponderInstance(
   responder: ReactNativeEventResponder,
   responderInstance: ReactNativeEventResponderInstance,
   props: Object,
@@ -459,7 +460,7 @@ export function mountResponderInstance(
   }
 }
 
-export function unmountResponderInstance(
+export function unmountDeprecatedFlareResponderInstance(
   responderInstance: ReactNativeEventResponderInstance,
 ): void {
   if (enableFlareAPI) {
@@ -498,4 +499,20 @@ export function getInstanceFromNode(node) {
 
 export function beforeRemoveInstance(instance) {
   // noop
+}
+
+export function prepareListener(listener: any, rootContainerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function diffListeners(pendingListener: any, memoizedListener: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function unmountListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -46,6 +46,7 @@ type ReactNativeEventResponder = ReactEventResponder<
   ReactNativeResponderContext,
 >;
 
+export type ReactListenerType = Object;
 export type Type = string;
 export type Props = Object;
 export type Container = number;
@@ -495,7 +496,7 @@ export function unhideTextInstance(
   throw new Error('Not yet implemented.');
 }
 
-export function mountResponderInstance(
+export function mountDeprecatedFlareResponderInstance(
   responder: ReactNativeEventResponder,
   responderInstance: ReactNativeEventResponderInstance,
   props: Object,
@@ -505,7 +506,7 @@ export function mountResponderInstance(
   throw new Error('Not yet implemented.');
 }
 
-export function unmountResponderInstance(
+export function unmountDeprecatedFlareResponderInstance(
   responderInstance: ReactNativeEventResponderInstance,
 ): void {
   throw new Error('Not yet implemented.');
@@ -537,4 +538,20 @@ export function getInstanceFromNode(node) {
 
 export function beforeRemoveInstance(instance) {
   // noop
+}
+
+export function prepareListener(listener: any, rootContainerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function diffListeners(pendingListener: any, memoizedListener: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function commitListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
+}
+
+export function unmountListenerInstance(listenerInstance: any) {
+  throw new Error('Not yet implemented.');
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -374,11 +374,11 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     warnsIfNotActing: true,
     supportsHydration: false,
 
-    mountResponderInstance(): void {
+    mountDeprecatedFlareResponderInstance(): void {
       // NO-OP
     },
 
-    unmountResponderInstance(): void {
+    unmountDeprecatedFlareResponderInstance(): void {
       // NO-OP
     },
 
@@ -434,6 +434,22 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     },
 
     getInstanceFromNode() {
+      throw new Error('Not yet implemented.');
+    },
+
+    prepareListener(listener: any, rootContainerInstance: any) {
+      throw new Error('Not yet implemented.');
+    },
+
+    diffListeners(pendingListener: any, memoizedListener: any) {
+      throw new Error('Not yet implemented.');
+    },
+
+    commitListenerInstance(listenerInstance: any) {
+      throw new Error('Not yet implemented.');
+    },
+
+    unmountListenerInstance(listenerInstance: any) {
       throw new Error('Not yet implemented.');
     },
   };

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -16,6 +16,7 @@ import type {
   ReactEventResponderInstance,
   ReactFundamentalComponent,
   ReactScope,
+  ReactListenerInstance,
 } from 'shared/ReactTypes';
 import type {RootTag} from 'shared/ReactRootTags';
 import type {WorkTag} from 'shared/ReactWorkTags';
@@ -62,6 +63,7 @@ import {
 } from 'shared/ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 
+import type {ReactListenerType} from './ReactFiberHostConfig';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
 import {
   resolveClassForHotReloading,
@@ -118,6 +120,13 @@ export type Dependencies = {
     ReactEventResponder<any, any>,
     ReactEventResponderInstance<any, any>,
   > | null,
+  listeners: null | ListenersObject,
+};
+
+export type ListenersObject = {
+  firstInstance: ReactListenerInstance<ReactListenerType> | null,
+  memoized: Array<ReactListenerType> | null,
+  pending: Array<ReactListenerType> | null,
 };
 
 // A Fiber is work on a Component that needs to be done or was done. There can
@@ -461,7 +470,9 @@ export function createWorkInProgress(
       : {
           expirationTime: currentDependencies.expirationTime,
           firstContext: currentDependencies.firstContext,
+          // TODO remove responders once we remove React Flare
           responders: currentDependencies.responders,
+          listeners: currentDependencies.listeners,
         };
 
   // These will be overridden during the parent's reconciliation
@@ -556,7 +567,9 @@ export function resetWorkInProgress(
         : {
             expirationTime: currentDependencies.expirationTime,
             firstContext: currentDependencies.firstContext,
+            // TODO remove responders once we remove React Flare
             responders: currentDependencies.responders,
+            listeners: currentDependencies.listeners,
           };
 
     if (enableProfilerTimer) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -33,6 +33,7 @@ import {
   enableFundamentalAPI,
   enableSuspenseCallback,
   enableScopeAPI,
+  enableListenerAPI,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -126,7 +127,8 @@ import {runWithPriority, NormalPriority} from './SchedulerWithReactIntegration';
 import {
   updateLegacyEventListeners,
   unmountResponderListeners,
-} from './ReactFiberEvents';
+} from './ReactFiberDeprecatedFlareEvents';
+import {commitListeners, unmountListeners} from './ReactFiberListenerEvents';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -797,6 +799,9 @@ function commitUnmount(
         unmountResponderListeners(current);
         beforeRemoveInstance(current.stateNode);
       }
+      if (enableListenerAPI) {
+        unmountListeners(current);
+      }
       safelyDetachRef(current);
       return;
     }
@@ -836,6 +841,9 @@ function commitUnmount(
     case ScopeComponent: {
       if (enableFlareAPI) {
         unmountResponderListeners(current);
+      }
+      if (enableListenerAPI) {
+        unmountListeners(current);
       }
       if (enableScopeAPI) {
         safelyDetachRef(current);
@@ -1356,6 +1364,9 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
             updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
         }
+        if (enableListenerAPI) {
+          commitListeners(finishedWork);
+        }
       }
       return;
     }
@@ -1420,6 +1431,9 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           if (prevListeners !== nextListeners || current === null) {
             updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
+        }
+        if (enableListenerAPI) {
+          commitListeners(finishedWork);
         }
       }
       return;

--- a/packages/react-reconciler/src/ReactFiberDeprecatedFlareEvents.js
+++ b/packages/react-reconciler/src/ReactFiberDeprecatedFlareEvents.js
@@ -16,8 +16,8 @@ import type {
 } from 'shared/ReactTypes';
 
 import {
-  mountResponderInstance,
-  unmountResponderInstance,
+  mountDeprecatedFlareResponderInstance,
+  unmountDeprecatedFlareResponderInstance,
 } from './ReactFiberHostConfig';
 import {NoWork} from './ReactFiberExpirationTime';
 
@@ -82,7 +82,7 @@ function mountEventResponder(
     }
   }
 
-  mountResponderInstance(
+  mountDeprecatedFlareResponderInstance(
     responder,
     responderInstance,
     responderProps,
@@ -159,6 +159,7 @@ export function updateLegacyEventListeners(
         expirationTime: NoWork,
         firstContext: null,
         responders: new Map(),
+        listeners: null,
       };
     }
     let respondersMap = dependencies.responders;
@@ -197,7 +198,7 @@ export function updateLegacyEventListeners(
           const responderInstance = ((respondersMap.get(
             mountedResponder,
           ): any): ReactEventResponderInstance<any, any>);
-          unmountResponderInstance(responderInstance);
+          unmountDeprecatedFlareResponderInstance(responderInstance);
           respondersMap.delete(mountedResponder);
         }
       }
@@ -228,7 +229,7 @@ export function unmountResponderListeners(fiber: Fiber) {
       const responderInstances = Array.from(respondersMap.values());
       for (let i = 0, length = responderInstances.length; i < length; i++) {
         const responderInstance = responderInstances[i];
-        unmountResponderInstance(responderInstance);
+        unmountDeprecatedFlareResponderInstance(responderInstance);
       }
       dependencies.responders = null;
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -22,7 +22,7 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 
 import {NoWork} from './ReactFiberExpirationTime';
 import {readContext} from './ReactFiberNewContext';
-import {createResponderListener} from './ReactFiberEvents';
+import {createResponderListener} from './ReactFiberDeprecatedFlareEvents';
 import {
   Update as UpdateEffect,
   Passive as PassiveEffect,

--- a/packages/react-reconciler/src/ReactFiberListenerEvents.js
+++ b/packages/react-reconciler/src/ReactFiberListenerEvents.js
@@ -1,0 +1,367 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber, ListenersObject, Dependencies} from './ReactFiber';
+import type {Container, ReactListenerType} from './ReactFiberHostConfig';
+import type {ReactListenerInstance} from 'shared/ReactTypes';
+
+import {NoWork} from './ReactFiberExpirationTime';
+import {
+  diffListeners,
+  prepareListener,
+  commitListenerInstance,
+  unmountListenerInstance,
+} from './ReactFiberHostConfig';
+
+import {HostComponent, HostRoot} from 'shared/ReactWorkTags';
+import {Update} from 'shared/ReactSideEffectTags';
+
+const isArray = Array.isArray;
+
+function isListener(possibleListener: any) {
+  return (
+    possibleListener != null &&
+    typeof possibleListener.type === 'string' &&
+    typeof possibleListener.callback === 'function'
+  );
+}
+
+function markUpdate(workInProgress: Fiber) {
+  // Tag the fiber with an update effect. This turns a Placement into
+  // a PlacementAndUpdate.
+  workInProgress.effectTag |= Update;
+}
+
+function getRootContainerInstance(
+  rootContainerInstance: null | Container,
+  fiber: Fiber,
+): Container {
+  let rootInstance = rootContainerInstance;
+
+  if (!rootInstance) {
+    let node = fiber;
+    while (node !== null) {
+      const tag = node.tag;
+      if (tag === HostComponent) {
+        rootInstance = node.stateNode;
+        break;
+      } else if (tag === HostRoot) {
+        rootInstance = node.stateNode.containerInfo;
+        break;
+      }
+      node = node.return;
+    }
+  }
+
+  return ((rootInstance: any): Container);
+}
+
+function createListenerInstance(
+  listener: ReactListenerType,
+): ReactListenerInstance<ReactListenerType> {
+  return {
+    currentTarget: null,
+    listener,
+    next: null,
+    propagationDepth: 0,
+  };
+}
+
+function recursivelyNormalizeListenerValues(
+  values: any,
+  normalizedListeners: Array<ReactListenerType>,
+): void {
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+
+    if (isArray(value)) {
+      recursivelyNormalizeListenerValues(value, normalizedListeners);
+    } else if (isListener(value)) {
+      normalizedListeners.push(((value: any): ReactListenerType));
+    }
+  }
+}
+
+function normalizeListenerValues(values: any): Array<ReactListenerType> | null {
+  if (values == null) {
+    return null;
+  } else if (isListener(values)) {
+    return [((values: any): ReactListenerType)];
+  }
+  const normalizedListeners = [];
+  recursivelyNormalizeListenerValues(values, normalizedListeners);
+  if (normalizedListeners.length === 0) {
+    return null;
+  }
+  return normalizedListeners;
+}
+
+function getListenersObjectFromFiber(
+  fiber: Fiber,
+  writeIfNotExist: boolean,
+): ListenersObject | null {
+  let dependencies = fiber.dependencies;
+  if (dependencies === null) {
+    if (!writeIfNotExist) {
+      return null;
+    }
+    if (dependencies === null) {
+      dependencies = fiber.dependencies = {
+        expirationTime: NoWork,
+        firstContext: null,
+        responders: null,
+        listeners: {
+          firstInstance: null,
+          memoized: null,
+          pending: null,
+        },
+      };
+    }
+  }
+  let listenersObject = dependencies.listeners;
+  if (listenersObject === null) {
+    if (!writeIfNotExist) {
+      return null;
+    }
+    dependencies.listeners = listenersObject = {
+      firstInstance: null,
+      memoized: null,
+      pending: null,
+    };
+  }
+  return listenersObject;
+}
+
+export function reconcileListeners(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  possibleRootContainerInstance: null | Container,
+): void {
+  const prevtListeners =
+    current === null ? null : current.memoizedProps.listeners;
+  const nextListeners = workInProgress.pendingProps.listeners;
+
+  if (prevtListeners === nextListeners) {
+    return;
+  }
+  // We then normalize the listeners – flattening any
+  // nested arrays and removing non-listeners entirely.
+  // Note: this is a new array, we don't mutate the original.
+  const pendingListeners = normalizeListenerValues(nextListeners);
+
+  // First, we get the listeners object from the Fiber.
+  // If we don't have one, we create one by passing true
+  // as the second argument.
+  const listenersObject = ((getListenersObjectFromFiber(
+    workInProgress,
+    true,
+  ): any): ListenersObject);
+  const memoizedListeners = listenersObject.memoized;
+
+  if (memoizedListeners === pendingListeners) {
+    return;
+  }
+  const memoizedListenersLength =
+    memoizedListeners === null ? 0 : memoizedListeners.length;
+
+  // We need the container instance so that we can
+  // pass this to the render upon calling out to a
+  // renderer upon mounting a listener instance.
+  const rootContainerInstance = getRootContainerInstance(
+    possibleRootContainerInstance,
+    workInProgress,
+  );
+
+  // We use the needsUpdate flag to mark the fiber as needing
+  // to create the listener instances in the commit phase.
+  let needsUpdate = false;
+
+  if (pendingListeners === null) {
+    if (memoizedListenersLength > 0) {
+      needsUpdate = true;
+    }
+  } else {
+    const pendingListenersLength = pendingListeners.length;
+
+    // If we have more memoized listeners than we have pending,
+    // then we need to unmount some of them in the commit phase,
+    // so we mark this as needing an update.
+    if (memoizedListenersLength > pendingListenersLength) {
+      needsUpdate = true;
+    }
+    for (let i = 0; i < pendingListenersLength; i++) {
+      const pendingListener = pendingListeners[i];
+      // If the current index is equal or more than the length of the
+      // memoized listeners, then that means we need to mount this
+      // listener. If we are on initial render, then we can optimize
+      // things and skip the commit phase if the listener is not a root.
+      // We do this in prepareListener (which returns true/false).
+      if (i >= memoizedListenersLength) {
+        const requiresUpdate = prepareListener(
+          pendingListener,
+          rootContainerInstance,
+        );
+        if (requiresUpdate || current !== null) {
+          needsUpdate = true;
+        }
+      } else if (
+        diffListeners(
+          pendingListener,
+          ((memoizedListeners: any): Array<ReactListenerType>)[i],
+        )
+      ) {
+        prepareListener(pendingListener, rootContainerInstance);
+        needsUpdate = true;
+      }
+    }
+  }
+
+  if (needsUpdate) {
+    // We need to complete the listener reconcilation in the commit phase.
+    listenersObject.pending = pendingListeners;
+    markUpdate(workInProgress);
+  } else if (pendingListeners !== null) {
+    // If we have no updates and we are the initial completion
+    // phase, we can apply a fast path that doesn't require
+    // an additional commit phase to complete the reconcilation.
+    const skipCommitCallbacks = true;
+    mountAllPendingListeners(
+      listenersObject,
+      pendingListeners,
+      skipCommitCallbacks,
+    );
+  }
+}
+
+function mountPendingListener(
+  listenersObject: ListenersObject,
+  pendingListener: ReactListenerType,
+  prevInstance: null | ReactListenerInstance<ReactListenerType>,
+  skipCommitCallbacks?: boolean,
+): ReactListenerInstance<ReactListenerType> {
+  const listenerInstance = createListenerInstance(pendingListener);
+  if (!skipCommitCallbacks) {
+    commitListenerInstance(listenerInstance);
+  }
+  if (prevInstance === null) {
+    listenersObject.firstInstance = listenerInstance;
+  } else {
+    prevInstance.next = listenerInstance;
+  }
+  return listenerInstance;
+}
+
+function mountAllPendingListeners(
+  listenersObject: ListenersObject,
+  pendingListeners: Array<ReactListenerType>,
+  skipCommitCallbacks?: boolean,
+): void {
+  let currentInstance = null;
+  for (let i = 0; i < pendingListeners.length; i++) {
+    currentInstance = mountPendingListener(
+      listenersObject,
+      pendingListeners[i],
+      currentInstance,
+      skipCommitCallbacks,
+    );
+  }
+  listenersObject.memoized = pendingListeners;
+}
+
+export function commitListeners(finishedWork: Fiber): void {
+  const listenersObject = getListenersObjectFromFiber(finishedWork, false);
+
+  if (listenersObject !== null) {
+    const pendingListeners = listenersObject.pending;
+    let firstInstance = listenersObject.firstInstance;
+    let currentInstance = null;
+    let prevInstance = null;
+    let visitedInstances = null;
+    listenersObject.pending = null;
+
+    if (pendingListeners !== null) {
+      if (firstInstance === null) {
+        mountAllPendingListeners(listenersObject, pendingListeners);
+        return;
+      }
+      visitedInstances = new Set();
+      currentInstance = firstInstance;
+
+      // Diff the pending listeners with the memoized listeners on the
+      // existing instances. In this phase, we only update and add
+      // instances, we don't remove any instances. We mark all instances
+      // we visit along the way, so we know what instances to remove
+      // in the next phase.
+      listenersObject.memoized = pendingListeners;
+      for (let i = 0; i < pendingListeners.length; i++) {
+        const pendingListener = pendingListeners[i];
+
+        // If the current instance is null, we need to mount
+        // a new instance
+        if (currentInstance === null) {
+          const newInstance = mountPendingListener(
+            listenersObject,
+            pendingListener,
+            prevInstance,
+          );
+          visitedInstances.add(newInstance);
+          prevInstance = currentInstance;
+          currentInstance = newInstance;
+        } else {
+          const memoizedListener = currentInstance.listener;
+
+          if (diffListeners(pendingListener, memoizedListener)) {
+            unmountListenerInstance(currentInstance);
+            // Rather than create a new listener instance, we just
+            // replace the properties of the instance.
+            currentInstance.listener = pendingListener;
+            // We then commit the update instance
+            commitListenerInstance(currentInstance);
+          }
+          visitedInstances.add(currentInstance);
+          prevInstance = currentInstance;
+          currentInstance = currentInstance.next;
+        }
+      }
+    }
+    // Now we handle the removal of any instances that were removed
+    // as a delta of the memoized and pending listeners.
+    currentInstance = listenersObject.firstInstance;
+    prevInstance = null;
+
+    // We iterate through all the existing instances and see if they
+    // were marked as visited in the previous phase.
+    while (currentInstance !== null) {
+      if (visitedInstances === null || !visitedInstances.has(currentInstance)) {
+        unmountListenerInstance(currentInstance);
+        if (prevInstance === null) {
+          listenersObject.firstInstance = currentInstance.next;
+        } else {
+          prevInstance.next = currentInstance.next;
+        }
+      } else {
+        prevInstance = currentInstance;
+      }
+      currentInstance = currentInstance.next;
+    }
+  }
+}
+
+export function unmountListeners(fiber: Fiber): void {
+  const listenersObject = getListenersObjectFromFiber(fiber, false);
+
+  if (listenersObject !== null) {
+    let instance = listenersObject.firstInstance;
+    while (instance !== null) {
+      unmountListenerInstance(instance);
+      instance = instance.next;
+    }
+    ((fiber.dependencies: any): Dependencies).listeners = null;
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -383,6 +383,7 @@ export function readContext<T>(
         expirationTime: NoWork,
         firstContext: contextItem,
         responders: null,
+        listeners: null,
       };
     } else {
       // Append a new context item.

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -61,8 +61,10 @@ export const warnsIfNotActing = $$$hostConfig.warnsIfNotActing;
 export const supportsMutation = $$$hostConfig.supportsMutation;
 export const supportsPersistence = $$$hostConfig.supportsPersistence;
 export const supportsHydration = $$$hostConfig.supportsHydration;
-export const mountResponderInstance = $$$hostConfig.mountResponderInstance;
-export const unmountResponderInstance = $$$hostConfig.unmountResponderInstance;
+export const mountDeprecatedFlareResponderInstance =
+  $$$hostConfig.mountDeprecatedFlareResponderInstance;
+export const unmountDeprecatedFlareResponderInstance =
+  $$$hostConfig.unmountDeprecatedFlareResponderInstance;
 export const getFundamentalComponentInstance =
   $$$hostConfig.getFundamentalComponentInstance;
 export const mountFundamentalComponent =
@@ -71,6 +73,9 @@ export const shouldUpdateFundamentalComponent =
   $$$hostConfig.shouldUpdateFundamentalComponent;
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
 export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
+export const prepareListener = $$$hostConfig.prepareListener;
+export const diffListeners = $$$hostConfig.diffListeners;
+export const ReactListenerType = $$$hostConfig.ReactListenerType;
 
 // -------------------
 //      Mutation
@@ -94,6 +99,8 @@ export const updateFundamentalComponent =
   $$$hostConfig.updateFundamentalComponent;
 export const unmountFundamentalComponent =
   $$$hostConfig.unmountFundamentalComponent;
+export const commitListenerInstance = $$$hostConfig.commitListenerInstance;
+export const unmountListenerInstance = $$$hostConfig.unmountListenerInstance;
 
 // -------------------
 //     Persistence

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -15,8 +15,9 @@ import type {
   ReactFundamentalComponentInstance,
 } from 'shared/ReactTypes';
 
-import {enableFlareAPI} from 'shared/ReactFeatureFlags';
+import {enableFlareAPI, enableListenerAPI} from 'shared/ReactFeatureFlags';
 
+export type ReactListenerType = Object;
 export type Type = string;
 export type Props = Object;
 export type Container = {|
@@ -154,6 +155,15 @@ export function createInstance(
       // as we don't want it in the test renderer's
       // instance props.
       const {DEPRECATED_flareListeners, ...otherProps} = props; // eslint-disable-line
+      propsToUse = otherProps;
+    }
+  }
+  if (enableListenerAPI) {
+    if (props.listeners != null) {
+      // We want to remove the "listeners" prop
+      // as we don't want it in the test renderer's
+      // instance props.
+      const {listeners, ...otherProps} = propsToUse; // eslint-disable-line
       propsToUse = otherProps;
     }
   }
@@ -298,7 +308,7 @@ export function unhideTextInstance(
   textInstance.isHidden = false;
 }
 
-export function mountResponderInstance(
+export function mountDeprecatedFlareResponderInstance(
   responder: ReactEventResponder<any, any>,
   responderInstance: ReactEventResponderInstance<any, any>,
   props: Object,
@@ -308,7 +318,7 @@ export function mountResponderInstance(
   // noop
 }
 
-export function unmountResponderInstance(
+export function unmountDeprecatedFlareResponderInstance(
   responderInstance: ReactEventResponderInstance<any, any>,
 ): void {
   // noop
@@ -369,5 +379,24 @@ export function getInstanceFromNode(mockNode: Object) {
 }
 
 export function beforeRemoveInstance(instance) {
+  // noop
+}
+
+export function prepareListener(listener: any, rootContainerInstance: any) {
+  // noop
+}
+
+export function diffListeners(
+  pendingListener: any,
+  memoizedListener: any,
+): boolean {
+  return true;
+}
+
+export function commitListenerInstance(listenerInstance: any): void {
+  // noop
+}
+
+export function unmountListenerInstance(listenerInstance: any) {
   // noop
 }

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -73,3 +73,11 @@ export type ReactDOMResponderContext = {
   enqueueStateRestore(Element | Document): void,
   getResponderNode(): Element | null,
 };
+
+export type ReactDOMListener = {|
+  callback: mixed => void,
+  capture: boolean,
+  type: string,
+  passive: boolean,
+  root: boolean,
+|};

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -54,6 +54,9 @@ export const warnAboutShorthandPropertyCollision = false;
 // Experimental React Flare event system and event components support.
 export const enableFlareAPI = false;
 
+// Experimental Listener API and event system support.
+export const enableListenerAPI = false;
+
 // Experimental Host Component support.
 export const enableFundamentalAPI = false;
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -182,3 +182,10 @@ export type ReactScopeInstance = {|
   fiber: Object,
   methods: null | ReactScopeMethods,
 |};
+
+export type ReactListenerInstance<L> = {|
+  currentTarget: null | Object,
+  listener: L,
+  next: null | ReactListenerInstance<L>,
+  propagationDepth: number,
+|};

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -32,6 +32,7 @@ export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -26,6 +26,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -26,6 +26,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -26,6 +26,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -24,6 +24,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const enableSchedulerDebugging = false;
 export const disableJavaScriptURLs = false;
 export const enableFlareAPI = true;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = true;
 export const enableJSXTransformAPI = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -74,6 +74,8 @@ function updateFlagOutsideOfReactCallStack() {
 
 export const enableFlareAPI = true;
 
+export const enableListenerAPI = false;
+
 export const enableFundamentalAPI = false;
 
 export const enableScopeAPI = true;


### PR DESCRIPTION
This PR adds the experimental Listener API to React behind a flag. Note: For now this is only intended to be used internally at Facebook, and we have no initial plans to ship this to open source.

The listener API includes its own React event system that leverages the lessons learned from the existing event system and that of the experimental React Flare event system. There are three new APIs that are added to `react-dom`:

- `ReactDOM.unstable_createListener`
- `ReactDOM.unstable_createRootListener`
- `ReactDOM.unstable_addEventPriority`

The Listener API works in a similar way to the DOM's `addEventListener` API, except this API returns a special React Listener object that can be supplied to elements via the internal `listeners` prop. An example of this follows:

```jsx
import React from 'react';
import {unstable_createListener} from 'react-dom';

function ClickableButton({ text }) {
  const click = unstable_createListener('click', event => {
    console.log('You clicked the button, event');
  });

  return (
    <button listeners={click}>{text}</button>
  ); 
}
```

## Listener Options

Both the `createListener` and `createRootListener` APIs support an optional third argument for specifying listener options. There are two boolean options that can be specified, `capture` and `passive`. Here's an example to demonstrate this:

```jsx
function ClickableButton({ text }) {
  const options = {
    capture: true, // capture is `false` by default
    passive: true, // passive is `true` by default
  };
  const click = unstable_createListener('click', event => {
    console.log('You clicked the button, event');
  }, options);

  return (
    <button listeners={click}>{text}</button>
  ); 
}
```

## Root Listeners

Sometimes, it's ideal to attach listeners to the root document of an app, so events can be captured that don't hit a specific target element. For these cases, the `createRootListener` API can be used:

```jsx
import React from 'react';
import {unstable_createRootListener} from 'react-dom';

function ClickableButton({ text }) {
  const click = unstable_createRootListener('click', event => {
    console.log('You clicked the button, event');
  });

  return (
    <button listeners={click}>{text}</button>
  ); 
}
```

## Combining multiple listeners

Elements support having multiple listeners, even of the same type on an element, to do this, arrays can be used (and nested) to supply many listeners. Listeners of the same type will execute in array order of how they're supplied to the element:

```jsx
function ClickableButton({ text }) {
  const click = unstable_createListener('click', event => {
    ...
  });
  const click2 = unstable_createListener('click', event => {
    ...
  });

  return (
    <button listeners={[click, click2]}>{text}</button>
  ); 
}
```

## Event Object

Unlike the existing React event system, the Listener API supplies only the native object to event callbacks – there are no Synthetic Events. The only caveat is that the native objects get monkey-patched by React, with several of the properties and methods on the event object replaced with alternatives that interface with React's event delegation and propagation system. Calling `stopPropagation` on the monkey-patched event object will not trigger the native `stopPropagation` method (unlike the existing React event system, which does), but rather prevent propagation through React's propagation system only.

## Event Flushing

With the Listener API, we don't flush on the native event triggering unless we have React Listeners that are actually triggered, this should help reduce needlessly flushing work when the event has no actual action.

This PR depends on https://github.com/facebook/react/pull/17513