### PR TITLE
[react-interactions] Upgrade passive event listeners to active listeners

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -14,7 +14,6 @@ import warning from 'shared/warning';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import warningWithoutStack from 'shared/warningWithoutStack';
 import endsWith from 'shared/endsWith';
-import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 import {setListenToResponderEventTypes} from '../events/DOMEventResponderSystem';
 
 import {
@@ -63,9 +62,12 @@ import {
 import {
   listenTo,
   trapBubbledEvent,
-  getListeningSetForElement,
+  getListenerMapForElement,
 } from '../events/ReactBrowserEventEmitter';
-import {trapEventForResponderEventSystem} from '../events/ReactDOMEventListener.js';
+import {
+  addResponderEventSystemEvent,
+  removeActiveResponderEventSystemEvent,
+} from '../events/ReactDOMEventListener.js';
 import {mediaEventTypes} from '../events/DOMTopLevelEventTypes';
 import {
   createDangerousStringForStyles,
@@ -1307,12 +1309,12 @@ export function restoreControlledState(
 
 export function listenToEventResponderEventTypes(
   eventTypes: Array<string>,
-  element: Element | Document,
+  document: Document,
 ): void {
   if (enableFlareAPI) {
     // Get the listening Set for this element. We use this to track
     // what events we're listening to.
-    const listeningSet = getListeningSetForElement(element);
+    const listenerMap = getListenerMapForElement(document);
 
     // Go through each target event type of the event responder
     for (let i = 0, length = eventTypes.length; i < length; ++i) {
@@ -1322,13 +1324,35 @@ export function listenToEventResponderEventTypes(
       const targetEventType = isPassive
         ? eventType
         : eventType.substring(0, eventType.length - 7);
-      if (!listeningSet.has(eventKey)) {
-        trapEventForResponderEventSystem(
-          element,
-          ((targetEventType: any): DOMTopLevelEventType),
+      if (!listenerMap.has(eventKey)) {
+        if (isPassive) {
+          const activeKey = targetEventType + '_active';
+          // If we have an active event listener, do not register
+          // a passive event listener. We use the same active event
+          // listener.
+          if (listenerMap.has(activeKey)) {
+            continue;
+          }
+        } else {
+          // If we have a passive event listener, remove the
+          // existing passive event listener before we add the
+          // active event listener.
+          const passiveKey = targetEventType + '_passive';
+          const passiveListener = listenerMap.get(passiveKey);
+          if (passiveListener != null) {
+            removeActiveResponderEventSystemEvent(
+              document,
+              targetEventType,
+              passiveListener,
+            );
+          }
+        }
+        const eventListener = addResponderEventSystemEvent(
+          document,
+          targetEventType,
           isPassive,
         );
-        listeningSet.add(eventKey);
+        listenerMap.set(eventKey, eventListener);
       }
     }
   }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1312,7 +1312,7 @@ export function listenToEventResponderEventTypes(
   document: Document,
 ): void {
   if (enableFlareAPI) {
-    // Get the listening Set for this element. We use this to track
+    // Get the listening Map for this element. We use this to track
     // what events we're listening to.
     const listenerMap = getListenerMapForElement(document);
 

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -156,7 +156,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
           phase: 'bubble',
         });
       },
@@ -185,7 +184,6 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
         phase: 'bubble',
       },
     ]);
@@ -216,7 +214,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
           phase: 'bubble',
         });
       },
@@ -242,7 +239,6 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: true,
-        passiveSupported: true,
         phase: 'bubble',
       },
     ]);
@@ -260,7 +256,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
           phase: 'bubble',
         });
       },
@@ -296,7 +291,6 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
         phase: 'bubble',
       },
     ]);
@@ -327,7 +321,6 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
         phase: 'bubble',
       },
     ]);
@@ -634,7 +627,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
           phase: 'root',
         });
       },
@@ -656,7 +648,6 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
         phase: 'root',
       },
     ]);
@@ -675,7 +666,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
         });
       },
     });
@@ -687,7 +677,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
         });
       },
     });
@@ -717,12 +706,10 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
       },
       {
         name: 'click',
         passive: false,
-        passiveSupported: true,
       },
     ]);
   });
@@ -739,7 +726,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
         });
       },
     });
@@ -751,7 +737,6 @@ describe('DOMEventResponderSystem', () => {
         eventLog.push({
           name: event.type,
           passive: event.passive,
-          passiveSupported: event.passiveSupported,
         });
       },
     });
@@ -778,12 +763,10 @@ describe('DOMEventResponderSystem', () => {
       {
         name: 'click',
         passive: false,
-        passiveSupported: false,
       },
       {
         name: 'click',
         passive: false,
-        passiveSupported: true,
       },
     ]);
 

--- a/packages/react-interactions/events/README.md
+++ b/packages/react-interactions/events/README.md
@@ -28,7 +28,6 @@ type ResponderEvent = {|
   pointerType: string,
   type: string,
   passive: boolean,
-  passiveSupported: boolean,
 |};
 
 type CustomEvent = {

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -27,7 +27,6 @@ export type PointerType =
 export type ReactDOMResponderEvent = {
   nativeEvent: AnyNativeEvent,
   passive: boolean,
-  passiveSupported: boolean,
   pointerType: PointerType,
   target: Element | Document,
   type: string,


### PR DESCRIPTION
One of the long standing things we've wanted to do when working on React Flare, was to be able to upgrade passive event listeners to active event listeners where possible. This removes the need to have two separate event listeners attached to the document at the same time.

If we first attach an active listener of a given type, and then later try to add a passive listener of the same type, we don't both – instead we handle the logic for both active and passive events inside the same active event listener. Furthermore, if we first attach a passive event for a given type, and then later try to add an active listener of the same type, we first remove the passive listener from the DOM and then we add the active listener to the DOM.

The logic in the responder system might seem a little convoluted because of how responders target/root events are designed. Thankfully, this won't be the case with the Listener API and we use a much simpler control flow when dealing with events with that API.

I also remove the responder logic for `passiveSupported` as it no longer felt relevant given this change, plus it was never used in any event responders. To enable the changes, we change the Listener Set to a Listener Map, so we can store the event listener callback we used when setting up the DOM event listener (this enables us to remove it again later).