### PR TITLE
[react-interactions] Move Flare event registration to commit phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1352,7 +1352,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         if (enableFlareAPI) {
           const prevListeners = oldProps.DEPRECATED_flareListeners;
           const nextListeners = newProps.DEPRECATED_flareListeners;
-          if (prevListeners !== nextListeners) {
+          if (prevListeners !== nextListeners || current === null) {
             updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
         }
@@ -1417,7 +1417,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           const oldProps = current !== null ? current.memoizedProps : newProps;
           const prevListeners = oldProps.DEPRECATED_flareListeners;
           const nextListeners = newProps.DEPRECATED_flareListeners;
-          if (prevListeners !== nextListeners) {
+          if (prevListeners !== nextListeners || current === null) {
             updateLegacyEventListeners(nextListeners, finishedWork, null);
           }
         }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -128,7 +128,6 @@ import {
 import {createFundamentalStateInstance} from './ReactFiberFundamental';
 import {Never} from './ReactFiberExpirationTime';
 import {resetChildFibers} from './ReactChildFiber';
-import {updateLegacyEventListeners} from './ReactFiberEvents';
 import {createScopeMethods} from './ReactFiberScope';
 
 function markUpdate(workInProgress: Fiber) {
@@ -730,11 +729,7 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              updateLegacyEventListeners(
-                listeners,
-                workInProgress,
-                rootContainerInstance,
-              );
+              markUpdate(workInProgress);
             }
           }
         } else {
@@ -754,11 +749,7 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              updateLegacyEventListeners(
-                listeners,
-                workInProgress,
-                rootContainerInstance,
-              );
+              markUpdate(workInProgress);
             }
           }
 
@@ -1254,12 +1245,7 @@ function completeWork(
           if (enableFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              const rootContainerInstance = getRootHostContainer();
-              updateLegacyEventListeners(
-                listeners,
-                workInProgress,
-                rootContainerInstance,
-              );
+              markUpdate(workInProgress);
             }
           }
           if (workInProgress.ref !== null) {


### PR DESCRIPTION
This PR fixes an issue that can lead to memory leaks with the Flare event system. Specifically, the Flare event system has the notion of "root events" that are meant to be triggered when an incoming dispatched event gets bubbled to the document. Upon hitting the document, we then check a global Map, to see if there are any active event responders listening to the given type of event coming through.

The issue is that this Map can't be GC'd when DOM nodes are detached and removed, because we need to iterate over the Map's values to get all active responders that listen to root events. Normally, this wouldn't be an issue, but because of the heuristics as to how React reconciles responders differently depending on initial render vs update render, the root events can be subscribed to, but never used due to unwinding and other characteristics within the reconciliation processes. The expectation is that things that occur in initial render should be effects that can be unwound simply due to the nature of the garbage collector, but because of the nature of how root events work – this will never be the case (we need to be able to iterate over root events on any given incoming dispatch event, which means we can't use a WeakMap or WeakSet).

In the ideal world, no root event listeners should be created on initial render. Unfortunately, this is likely to be a more complex and feature breaking change to make at this point given the requirements of the Focus and FocusWithin event responders, which both make use of root events on initial mount. This PR tackles the problem in a somewhat brute-force approach, by moving all React Flare responders to the commit phase, at the compromise of more commit phase work vs the benefit of no leaking of the root event Map.

I believe this is probably the best short-term solution, and a lesson we can take forward in ironing out kinks with the newer Listener API. We can also, in the short-term, possibly come up with a way of remove root events from event responders on initial mount and finding a way to make them work conditionally, but this will likely take a larger period of time. In the interests of unblocking this memory leak, this seems the most sane path forward at this point.