### PR TITLE
Add DEV warning for when a non-function is passed to useMemo

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -257,6 +257,23 @@ function checkDepsAreArrayDev(deps: mixed) {
   }
 }
 
+function checkArgumentIsFunctionDev(arg: mixed) {
+  if (__DEV__) {
+    if (typeof arg !== 'function') {
+      // Verify argument is a function, for example; useMemo cannot take an object as first argument.
+      // This wouldn't be a problem for those using a type checker, but it's not an obvious mistake.
+      // See https://github.com/facebook/react/issues/16589
+      warning(
+        false,
+        '%s received an argument that is not a function (instead, received `%s`). When ' +
+          'specified, this argument must be a function.',
+        currentHookNameInDev,
+        typeof arg,
+      );
+    }
+  }
+}
+
 function warnOnHookMismatchInDev(currentHookName: HookType) {
   if (__DEV__) {
     const componentName = getComponentName(currentlyRenderingFiber.type);
@@ -1474,6 +1491,7 @@ if (__DEV__) {
       currentHookNameInDev = 'useMemo';
       mountHookTypesDev();
       checkDepsAreArrayDev(deps);
+      checkArgumentIsFunctionDev(create);
       const prevDispatcher = ReactCurrentDispatcher.current;
       ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnMountInDEV;
       try {


### PR DESCRIPTION
Before, the following would throw a TypeError for createNext() not being a function:

```
function App() {
  const memoized = React.useMemo({ foo: "bar" }, []);
  return <div>{memoized.foo}</div>;
}
```

Now we have a DEV warning that's more helpful:

```
Warning: useMemo received an argument that is not a function (instead, received `object`). When specified, this argument must be a function.
    in App (at src/index.js:7)
```

Addresses #16589 