### PR TITLE
HostText needs to copy over from current if it is unchanged

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -536,6 +536,8 @@ if (supportsMutation) {
       // We'll have to mark it as having an effect, even though we won't use the effect for anything.
       // This lets the parents know that at least one of their children has changed.
       markUpdate(workInProgress);
+    } else {
+      workInProgress.stateNode = current.stateNode;
     }
   };
 } else {


### PR DESCRIPTION
stateNode is not one of the fields that gets copied over by createWorkInProgress.

This is bad for persistent mode since it's not the same instance.

In HostComponent we happened to always end up transferring the current stateNode when we bail.
However, we didn't do this for HostText.

Found by @JoshuaGross in Fabric.

TODO: Unit tests.