### PR TITLE
Move scheduleHydration to root prototype

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -481,8 +481,8 @@ describe('ReactDOMServerSelectiveHydration', () => {
     expect(Scheduler).toHaveYielded([]);
 
     // Increase priority of B and then C.
-    ReactDOM.unstable_scheduleHydration(spanB);
-    ReactDOM.unstable_scheduleHydration(spanC);
+    root.unstable_scheduleHydration(spanB);
+    root.unstable_scheduleHydration(spanC);
 
     // We should prioritize hydrating C first because the last added
     // gets highest priority followed by the next added.

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -70,7 +70,6 @@ import {
   setAttemptUserBlockingHydration,
   setAttemptContinuousHydration,
   setAttemptHydrationAtCurrentPriority,
-  queueExplicitHydrationTarget,
 } from '../events/ReactDOMEventReplaying';
 
 setAttemptSynchronousHydration(attemptSynchronousHydration);
@@ -187,12 +186,6 @@ if (exposeConcurrentModeAPIs) {
   ReactDOM.unstable_discreteUpdates = discreteUpdates;
   ReactDOM.unstable_flushDiscreteUpdates = flushDiscreteUpdates;
   ReactDOM.unstable_flushControlled = flushControlled;
-
-  ReactDOM.unstable_scheduleHydration = target => {
-    if (target) {
-      queueExplicitHydrationTarget(target);
-    }
-  };
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -34,7 +34,10 @@ import {
   markContainerAsRoot,
   unmarkContainerAsRoot,
 } from './ReactDOMComponentTree';
-import {eagerlyTrapReplayableEvents} from '../events/ReactDOMEventReplaying';
+import {
+  eagerlyTrapReplayableEvents,
+  queueExplicitHydrationTarget,
+} from '../events/ReactDOMEventReplaying';
 import {
   ELEMENT_NODE,
   COMMENT_NODE,
@@ -86,6 +89,14 @@ ReactDOMRoot.prototype.unmount = ReactDOMBlockingRoot.prototype.unmount = functi
       cb();
     }
   });
+};
+
+// This only applies to createRoot since Blocking Mode doesn't have a notion
+// of priorities.
+ReactDOMRoot.prototype.unstable_scheduleHydration = target => {
+  if (target) {
+    queueExplicitHydrationTarget(target);
+  }
 };
 
 function createRootImpl(


### PR DESCRIPTION
We don't technically need the root since we'll find it through the DOM but we do need the root to have been created before we call this.

This API makes that a bit clearer. This was even asked about before so seems reasonable.

The only unfortunate thing is that it's not possible to do a generic scroll or event driven hydration without having access to a root.