### PR TITLE
[react-interactions] fix Press/Tap behavior for virtual middle clicks

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -626,6 +626,9 @@ const pressResponderImpl = {
           state.responderRegionOnDeactivation = null;
           state.isPressWithinResponderRegion = true;
           state.buttons = nativeEvent.buttons;
+          if (nativeEvent.button === 1) {
+            state.buttons = 4;
+          }
           dispatchPressStartEvents(event, context, props, state);
           addRootEventTypes(context, state);
         } else {

--- a/packages/react-interactions/events/src/dom/Tap.js
+++ b/packages/react-interactions/events/src/dom/Tap.js
@@ -520,10 +520,14 @@ const responderImpl = {
           }
 
           const activate = shouldActivate(event);
-          const activateAuxiliary = isAuxiliary(nativeEvent.buttons, event);
+          const buttons =
+            nativeEvent.button === 1
+              ? buttonsEnum.auxiliary
+              : nativeEvent.buttons;
+          const activateAuxiliary = isAuxiliary(buttons, event);
 
           if (activate || activateAuxiliary) {
-            state.buttons = nativeEvent.buttons;
+            state.buttons = buttons;
             state.pointerType = event.pointerType;
             state.responderTarget = context.getResponderNode();
             addRootEventTypes(rootEventTypes, context, state);

--- a/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {
+  buttonType,
   buttonsType,
   createEventTarget,
   describeWithPointerEvent,
@@ -126,7 +127,30 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
     it('is called after middle-button pointer down', () => {
       const target = createEventTarget(ref.current);
       const pointerType = 'mouse';
-      target.pointerdown({buttons: buttonsType.auxiliary, pointerType});
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: buttonsType.auxiliary,
+        pointerType,
+      });
+      target.pointerup({pointerType});
+      expect(onPressStart).toHaveBeenCalledTimes(1);
+      expect(onPressStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buttons: buttonsType.auxiliary,
+          pointerType: 'mouse',
+          type: 'pressstart',
+        }),
+      );
+    });
+
+    it('is called after virtual middle-button pointer down', () => {
+      const target = createEventTarget(ref.current);
+      const pointerType = 'mouse';
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: 0,
+        pointerType,
+      });
       target.pointerup({pointerType});
       expect(onPressStart).toHaveBeenCalledTimes(1);
       expect(onPressStart).toHaveBeenCalledWith(
@@ -212,7 +236,26 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
     it('is called after middle-button pointer up', () => {
       const target = createEventTarget(ref.current);
       target.pointerdown({
+        button: buttonType.auxiliary,
         buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
+      target.pointerup({pointerType: 'mouse'});
+      expect(onPressEnd).toHaveBeenCalledTimes(1);
+      expect(onPressEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buttons: buttonsType.auxiliary,
+          pointerType: 'mouse',
+          type: 'pressend',
+        }),
+      );
+    });
+
+    it('is called after virtual middle-button pointer up', () => {
+      const target = createEventTarget(ref.current);
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: 0,
         pointerType: 'mouse',
       });
       target.pointerup({pointerType: 'mouse'});
@@ -356,7 +399,19 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
     it('is not called after middle-button press', () => {
       const target = createEventTarget(ref.current);
       target.pointerdown({
+        button: buttonType.auxiliary,
         buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
+      target.pointerup({pointerType: 'mouse'});
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('is not called after virtual middle-button press', () => {
+      const target = createEventTarget(ref.current);
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: 0,
         pointerType: 'mouse',
       });
       target.pointerup({pointerType: 'mouse'});

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {
+  buttonType,
   buttonsType,
   createEventTarget,
   setPointerEvent,
@@ -122,6 +123,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     it('is called after middle-button pointer down', () => {
       const target = createEventTarget(ref.current);
       target.pointerdown({
+        button: buttonType.auxiliary,
         buttons: buttonsType.auxiliary,
         pointerType: 'mouse',
       });
@@ -140,6 +142,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const target = createEventTarget(node);
       target.setBoundingClientRect({x: 0, y: 0, width: 100, height: 100});
       target.pointerdown({
+        button: buttonType.auxiliary,
         buttons: buttonsType.auxiliary,
         pointerType: 'mouse',
       });
@@ -368,6 +371,17 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       const target = createEventTarget(ref.current);
       target.pointerdown({
         buttons: buttonsType.auxiliary,
+        pointerType: 'mouse',
+      });
+      target.pointerup({pointerType: 'mouse'});
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('is not called after virtual middle-button press', () => {
+      const target = createEventTarget(ref.current);
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: 0,
         pointerType: 'mouse',
       });
       target.pointerup({pointerType: 'mouse'});

--- a/packages/react-interactions/events/src/dom/__tests__/Tap-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Tap-test.internal.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {
+  buttonType,
   buttonsType,
   createEventTarget,
   describeWithPointerEvent,
@@ -209,19 +210,21 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
 
     test('auxiliary-button pointer up', () => {
       const pointerType = 'mouse';
+      const button = buttonType.auxiliary;
       const buttons = buttonsType.auxiliary;
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons, pointerType});
-      target.pointerup({buttons, pointerType});
+      target.pointerdown({button, buttons, pointerType});
+      target.pointerup({button, buttons, pointerType});
       expect(onAuxiliaryTap).toHaveBeenCalledTimes(1);
     });
 
     test('modifier-button pointer up', () => {
       const pointerType = 'mouse';
+      const button = buttonType.primary;
       const buttons = buttonsType.primary;
       const target = createEventTarget(ref.current);
-      target.pointerdown({buttons, pointerType});
-      target.pointerup({buttons, metaKey: true, pointerType});
+      target.pointerdown({button, buttons, pointerType});
+      target.pointerup({button, buttons, metaKey: true, pointerType});
       expect(onAuxiliaryTap).toHaveBeenCalledTimes(1);
     });
   });
@@ -243,6 +246,7 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
     testWithPointerType('pointer down', pointerType => {
       const target = createEventTarget(ref.current);
       const nativeEvent = {
+        button: buttonType.primary,
         buttons: buttonsType.primary,
         pageX: 10,
         pageY: 10,
@@ -287,11 +291,12 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
     test('second pointer on target', () => {
       const pointerType = 'touch';
       const target = createEventTarget(ref.current);
+      const button = buttonType.primary;
       const buttons = buttonsType.primary;
-      target.pointerdown({buttons, pointerId: 1, pointerType});
+      target.pointerdown({button, buttons, pointerId: 1, pointerType});
       expect(onTapStart).toHaveBeenCalledTimes(1);
       if (hasPointerEvents) {
-        target.pointerdown({buttons, pointerId: 2, pointerType});
+        target.pointerdown({button, buttons, pointerId: 2, pointerType});
       } else {
         // TouchEvents
         target.pointerdown([{pointerId: 1}, {pointerId: 2}]);
@@ -301,29 +306,67 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
 
     testWithPointerType('ignored buttons and modifiers', pointerType => {
       const target = createEventTarget(ref.current);
-      const {auxiliary, eraser, primary, secondary} = buttonsType;
       if (pointerType !== 'touch') {
         // right-click
-        target.pointerdown({buttons: secondary, pointerType});
+        target.pointerdown({
+          button: buttonType.secondary,
+          buttons: buttonsType.secondary,
+          pointerType,
+        });
         target.pointerup();
         // middle-click
-        target.pointerdown({buttons: auxiliary, pointerType});
+        target.pointerdown({
+          button: buttonType.auxiliary,
+          buttons: buttonsType.auxiliary,
+          pointerType,
+        });
+        target.pointerup();
+        // virtual middle-click with misleading 'buttons' value
+        target.pointerdown({
+          button: buttonType.auxiliary,
+          buttons: 0,
+          pointerType,
+        });
         target.pointerup();
         // pen eraser
-        target.pointerdown({buttons: eraser, pointerType});
+        target.pointerdown({
+          button: buttonType.eraser,
+          buttons: buttonsType.eraser,
+          pointerType,
+        });
         target.pointerup();
       }
       // alt-click
-      target.pointerdown({buttons: primary, altKey: true, pointerType});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+        altKey: true,
+        pointerType,
+      });
       target.pointerup();
       // ctrl-click
-      target.pointerdown({buttons: primary, ctrlKey: true, pointerType});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+        ctrlKey: true,
+        pointerType,
+      });
       target.pointerup();
       // meta-click
-      target.pointerdown({buttons: primary, metaKey: true, pointerType});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+        metaKey: true,
+        pointerType,
+      });
       target.pointerup();
       // shift-click
-      target.pointerdown({buttons: primary, shiftKey: true, pointerType});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+        shiftKey: true,
+        pointerType,
+      });
       target.pointerup();
 
       expect(onTapStart).toHaveBeenCalledTimes(0);
@@ -346,9 +389,11 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
 
     testWithPointerType('pointer up', pointerType => {
       const target = createEventTarget(ref.current);
+      const button = buttonType.primary;
       const buttons = buttonsType.primary;
-      target.pointerdown({buttons, pointerType});
+      target.pointerdown({button, buttons, pointerType});
       target.pointerup({
+        button,
         buttons,
         pageX: 10,
         pageY: 10,
@@ -424,11 +469,13 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
         const pointerType = 'touch';
         const target = createEventTarget(ref.current);
         const offTarget = createEventTarget(container);
+        const button = buttonType.primary;
         const buttons = buttonsType.primary;
 
-        target.pointerdown({buttons, pointerId: 1, pointerType});
-        offTarget.pointerdown({buttons, pointerId: 2, pointerType});
+        target.pointerdown({button, buttons, pointerId: 1, pointerType});
+        offTarget.pointerdown({button, buttons, pointerId: 2, pointerType});
         offTarget.pointerup({
+          button,
           buttons,
           pageX: 10,
           pageY: 10,
@@ -443,28 +490,57 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
 
     test('ignored buttons and modifiers', () => {
       const target = createEventTarget(ref.current);
-      const primary = buttonsType.primary;
       // right-click
-      target.pointerdown({buttons: buttonsType.secondary});
-      target.pointerup({buttons: buttonsType.secondary});
+      target.pointerdown({
+        button: buttonType.secondary,
+        buttons: buttonsType.secondary,
+      });
+      target.pointerup({
+        button: buttonType.secondary,
+        buttons: buttonsType.secondary,
+      });
       // middle-click
-      target.pointerdown({buttons: buttonsType.auxiliary});
-      target.pointerup({buttons: buttonsType.auxiliary});
+      target.pointerdown({
+        button: buttonType.auxiliary,
+        buttons: buttonsType.auxiliary,
+      });
+      target.pointerup({
+        button: buttonType.auxiliary,
+        buttons: buttonsType.auxiliary,
+      });
       // pen eraser
-      target.pointerdown({buttons: buttonsType.eraser});
-      target.pointerup({buttons: buttonsType.eraser});
+      target.pointerdown({
+        button: buttonType.eraser,
+        buttons: buttonsType.eraser,
+      });
+      target.pointerup({
+        button: buttonType.eraser,
+        buttons: buttonsType.eraser,
+      });
       // alt-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({altKey: true});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+      });
+      target.pointerup({altKey: true, button: buttonType.primary});
       // ctrl-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({ctrlKey: true});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+      });
+      target.pointerup({ctrlKey: true, button: buttonType.primary});
       // meta-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({metaKey: true});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+      });
+      target.pointerup({metaKey: true, button: buttonType.primary});
       // shift-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({shiftKey: true});
+      target.pointerdown({
+        button: buttonType.primary,
+        buttons: buttonsType.primary,
+      });
+      target.pointerup({shiftKey: true, button: buttonType.primary});
 
       expect(onTapEnd).toHaveBeenCalledTimes(0);
     });
@@ -560,9 +636,10 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
         const pointerType = 'touch';
         const target = createEventTarget(ref.current);
         const offTarget = createEventTarget(container);
+        const button = buttonType.primary;
         const buttons = buttonsType.primary;
-        target.pointerdown({buttons, pointerId: 1, pointerType});
-        offTarget.pointerdown({buttons, pointerId: 2, pointerType});
+        target.pointerdown({button, buttons, pointerId: 1, pointerType});
+        offTarget.pointerdown({button, buttons, pointerId: 2, pointerType});
         target.pointermove({pointerId: 1, pointerType, x: 10, y: 10});
         expect(onTapUpdate).toHaveBeenCalledTimes(1);
         offTarget.pointermove({pointerId: 2, pointerType, x: 10, y: 10});
@@ -691,10 +768,11 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
     test('second pointer on target', () => {
       const pointerType = 'touch';
       const target = createEventTarget(ref.current);
+      const button = buttonType.primary;
       const buttons = buttonsType.primary;
-      target.pointerdown({buttons, pointerId: 1, pointerType});
+      target.pointerdown({button, buttons, pointerId: 1, pointerType});
       if (hasPointerEvents) {
-        target.pointerdown({buttons, pointerId: 2, pointerType});
+        target.pointerdown({button, buttons, pointerId: 2, pointerType});
       } else {
         // TouchEvents
         target.pointerdown([{pointerId: 1}, {pointerId: 2}]);
@@ -707,9 +785,10 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
         const pointerType = 'touch';
         const target = createEventTarget(ref.current);
         const offTarget = createEventTarget(container);
+        const button = buttonType.primary;
         const buttons = buttonsType.primary;
-        target.pointerdown({buttons, pointerId: 1, pointerType});
-        offTarget.pointerdown({buttons, pointerId: 2, pointerType});
+        target.pointerdown({button, buttons, pointerId: 1, pointerType});
+        offTarget.pointerdown({button, buttons, pointerId: 2, pointerType});
         expect(onTapCancel).toHaveBeenCalledTimes(0);
       });
     }
@@ -728,19 +807,20 @@ describeWithPointerEvent('Tap responder', hasPointerEvents => {
 
     test('ignored modifiers', () => {
       const target = createEventTarget(ref.current);
-      const primary = buttonsType.primary;
+      const button = buttonType.primary;
+      const buttons = buttonsType.primary;
       // alt-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({altKey: true});
+      target.pointerdown({button, buttons});
+      target.pointerup({altKey: true, button});
       // ctrl-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({ctrlKey: true});
+      target.pointerdown({button, buttons});
+      target.pointerup({ctrlKey: true, button});
       // meta-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({metaKey: true});
+      target.pointerdown({button, buttons});
+      target.pointerup({metaKey: true, button});
       // shift-click
-      target.pointerdown({buttons: primary});
-      target.pointerup({shiftKey: true});
+      target.pointerdown({buttons});
+      target.pointerup({shiftKey: true, button});
 
       expect(onTapCancel).toHaveBeenCalledTimes(4);
     });

--- a/packages/react-interactions/events/src/dom/testing-library/domEnvironment.js
+++ b/packages/react-interactions/events/src/dom/testing-library/domEnvironment.js
@@ -65,6 +65,34 @@ export const platform = {
 };
 
 /**
+ * Button property
+ * This property only guarantees to indicate which buttons are pressed during events caused by pressing or
+ * releasing one or multiple buttons. As such, it is not reliable for events such as 'mouseenter', 'mouseleave',
+ * 'mouseover', 'mouseout' or 'mousemove'. Furthermore, the semantics differ for PointerEvent, where the value
+ * for 'pointermove' will always be -1.
+ */
+
+export const buttonType = {
+  // no change since last event
+  none: -1,
+  // left-mouse
+  // touch contact
+  // pen contact
+  primary: 0,
+  // right-mouse
+  // pen barrel button
+  secondary: 2,
+  // middle mouse
+  auxiliary: 1,
+  // back mouse
+  back: 3,
+  // forward mouse
+  forward: 4,
+  // pen eraser
+  eraser: 5,
+};
+
+/**
  * Buttons bitmask
  */
 

--- a/packages/react-interactions/events/src/dom/testing-library/domEventSequences.js
+++ b/packages/react-interactions/events/src/dom/testing-library/domEventSequences.js
@@ -10,7 +10,12 @@
 'use strict';
 
 import * as domEvents from './domEvents';
-import {buttonsType, hasPointerEvent, platform} from './domEnvironment';
+import {
+  buttonType,
+  buttonsType,
+  hasPointerEvent,
+  platform,
+} from './domEnvironment';
 
 function emptyFunction() {}
 
@@ -33,31 +38,45 @@ export function contextmenu(
   if (pointerType === 'touch') {
     if (hasPointerEvent()) {
       dispatch(
-        domEvents.pointerdown({buttons: buttonsType.primary, pointerType}),
+        domEvents.pointerdown({
+          button: buttonType.primary,
+          buttons: buttonsType.primary,
+          pointerType,
+        }),
       );
     }
     dispatch(domEvents.touchstart());
     dispatch(
-      domEvents.contextmenu({buttons: buttonsType.none, preventDefault}),
+      domEvents.contextmenu({
+        button: buttonType.primary,
+        buttons: buttonsType.none,
+        preventDefault,
+      }),
     );
   } else if (pointerType === 'mouse') {
     if (modified === true) {
+      const button = buttonType.primary;
       const buttons = buttonsType.primary;
       const ctrlKey = true;
       if (hasPointerEvent()) {
-        dispatch(domEvents.pointerdown({buttons, ctrlKey, pointerType}));
+        dispatch(
+          domEvents.pointerdown({button, buttons, ctrlKey, pointerType}),
+        );
       }
-      dispatch(domEvents.mousedown({buttons, ctrlKey}));
+      dispatch(domEvents.mousedown({button, buttons, ctrlKey}));
       if (platform.get() === 'mac') {
-        dispatch(domEvents.contextmenu({buttons, ctrlKey, preventDefault}));
+        dispatch(
+          domEvents.contextmenu({button, buttons, ctrlKey, preventDefault}),
+        );
       }
     } else {
+      const button = buttonType.secondary;
       const buttons = buttonsType.secondary;
       if (hasPointerEvent()) {
-        dispatch(domEvents.pointerdown({buttons, pointerType}));
+        dispatch(domEvents.pointerdown({button, buttons, pointerType}));
       }
-      dispatch(domEvents.mousedown({buttons}));
-      dispatch(domEvents.contextmenu({buttons, preventDefault}));
+      dispatch(domEvents.mousedown({button, buttons}));
+      dispatch(domEvents.contextmenu({button, buttons, preventDefault}));
     }
   }
 }
@@ -84,7 +103,11 @@ export function pointerdown(target, defaultPayload) {
     // Arrays are for multi-touch only
     dispatch(domEvents.touchstart(defaultPayload));
   } else {
-    const payload = {buttons: buttonsType.primary, ...defaultPayload};
+    const payload = {
+      button: buttonType.primary,
+      buttons: buttonsType.primary,
+      ...defaultPayload,
+    };
     if (pointerType === 'mouse') {
       if (hasPointerEvent()) {
         dispatch(domEvents.pointerover(payload));

--- a/packages/react-interactions/events/src/dom/testing-library/domEvents.js
+++ b/packages/react-interactions/events/src/dom/testing-library/domEvents.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-import {buttonsType} from './domEnvironment';
+import {buttonType, buttonsType} from './domEnvironment';
 
 /**
  * Native event object mocks for higher-level events.
@@ -65,6 +65,7 @@ function createPointerEvent(
   type,
   {
     altKey = false,
+    button = buttonType.none,
     buttons = buttonsType.none,
     ctrlKey = false,
     detail = 1,
@@ -98,6 +99,7 @@ function createPointerEvent(
 
   return createEvent(type, {
     altKey,
+    button,
     buttons,
     clientX: x,
     clientY: y,
@@ -164,6 +166,7 @@ function createMouseEvent(
   type,
   {
     altKey = false,
+    button = buttonType.none,
     buttons = buttonsType.none,
     ctrlKey = false,
     detail = 1,
@@ -187,6 +190,7 @@ function createMouseEvent(
 
   return createEvent(type, {
     altKey,
+    button,
     buttons,
     clientX: x,
     clientY: y,
@@ -297,7 +301,10 @@ export function blur({relatedTarget} = {}) {
 }
 
 export function click(payload) {
-  return createMouseEvent('click', payload);
+  return createMouseEvent('click', {
+    button: buttonType.primary,
+    ...payload,
+  });
 }
 
 export function contextmenu(payload) {
@@ -383,6 +390,7 @@ export function pointercancel(payload) {
 export function pointerdown(payload) {
   const isTouch = payload != null && payload.pointerType === 'touch';
   return createPointerEvent('pointerdown', {
+    button: buttonType.primary,
     buttons: buttonsType.primary,
     pressure: isTouch ? 1 : 0.5,
     ...payload,
@@ -398,7 +406,10 @@ export function pointerleave(payload) {
 }
 
 export function pointermove(payload) {
-  return createPointerEvent('pointermove', payload);
+  return createPointerEvent('pointermove', {
+    ...payload,
+    button: buttonType.none,
+  });
 }
 
 export function pointerout(payload) {
@@ -411,6 +422,7 @@ export function pointerover(payload) {
 
 export function pointerup(payload) {
   return createPointerEvent('pointerup', {
+    button: buttonType.primary,
     ...payload,
     buttons: buttonsType.none,
     pressure: 0,
@@ -422,13 +434,18 @@ export function pointerup(payload) {
  */
 
 export function mousedown(payload) {
-  // The value of 'buttons' for 'mousedown' must not be 0
+  // The value of 'button' and 'buttons' for 'mousedown' must not be none.
+  const button =
+    payload == null || payload.button === buttonType.none
+      ? buttonType.primary
+      : payload.button;
   const buttons =
-    payload == null || payload.buttons === 0
+    payload == null || payload.buttons === buttonsType.none
       ? buttonsType.primary
       : payload.buttons;
   return createMouseEvent('mousedown', {
     ...payload,
+    button,
     buttons,
   });
 }
@@ -455,6 +472,7 @@ export function mouseover(payload) {
 
 export function mouseup(payload) {
   return createMouseEvent('mouseup', {
+    button: buttonType.primary,
     ...payload,
     buttons: buttonsType.none,
   });

--- a/packages/react-interactions/events/src/dom/testing-library/index.js
+++ b/packages/react-interactions/events/src/dom/testing-library/index.js
@@ -12,6 +12,7 @@
 import * as domEvents from './domEvents';
 import * as domEventSequences from './domEventSequences';
 import {
+  buttonType,
   buttonsType,
   hasPointerEvent,
   setPointerEvent,
@@ -160,6 +161,7 @@ function testWithPointerType(message, testFn) {
 }
 
 export {
+  buttonType,
   buttonsType,
   createEventTarget,
   describeWithPointerEvent,


### PR DESCRIPTION
Tools like BetterTouchTool for macOS trigger middle-clicks with a 'buttons'
value that doesn't correspond to the middle-mouse button. To account for this
we also inspect the value of 'button'.

Close #17367