### PR TITLE
React.unstable_avoidThisRender()

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {Thenable} from 'react-reconciler/src/ReactFiberWorkLoop';
+
 import type {
   ReactContext,
   ReactProviderType,
@@ -276,6 +278,10 @@ const Dispatcher: DispatcherType = {
   useResponder,
   useTransition,
   useDeferredValue,
+
+  avoidThisRender(thenable: Thenable) {
+    // no-op
+  },
 };
 
 // Inspect

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -11,6 +11,9 @@ import type {
   Dispatcher as DispatcherType,
   TimeoutConfig,
 } from 'react-reconciler/src/ReactFiberHooks';
+
+import type {Thenable} from 'react-reconciler/src/ReactFiberWorkLoop';
+
 import type {ThreadID} from './ReactThreadIDAllocator';
 import type {
   ReactContext,
@@ -499,4 +502,7 @@ export const Dispatcher: DispatcherType = {
   useResponder,
   useDeferredValue,
   useTransition,
+  avoidThisRender(thenable: Thenable) {
+    // todo: this should trigger a fallback on SSR
+  },
 };

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1461,6 +1461,7 @@ function commitSuspenseComponent(finishedWork: Fiber) {
   if (enableSuspenseCallback && newState !== null) {
     const suspenseCallback = finishedWork.memoizedProps.suspenseCallback;
     if (typeof suspenseCallback === 'function') {
+      // TODO - what should suspenseCallback do if it's only images/avoidedThenables?
       const thenables: Set<Thenable> | null = (finishedWork.updateQueue: any);
       if (thenables !== null) {
         suspenseCallback(new Set(thenables));

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -232,6 +232,8 @@ function tryHydrate(fiber, nextInstance) {
           const suspenseState: SuspenseState = {
             dehydrated: suspenseInstance,
             retryTime: Never,
+            // TODO - This doesn't seem right... But we add it to appease flow.
+            didAvoidRenderTime: Never,
           };
           fiber.memoizedState = suspenseState;
           // Store the dehydrated fragment as a child fiber.

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -40,6 +40,7 @@ export type SuspenseState = {|
   // Never is the default for dehydrated boundaries.
   // NoWork is the default for normal boundaries, which turns into "normal" pri.
   retryTime: ExpirationTime,
+  didAvoidRenderTime: ExpirationTime,
 |};
 
 export type SuspenseListTailMode = 'collapsed' | 'hidden' | void;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -127,6 +127,7 @@ import {
   throwException,
   createRootErrorUpdate,
   createClassErrorUpdate,
+  avoidThisRenderImpl,
 } from './ReactFiberThrow';
 import {
   commitBeforeMutationLifeCycles as commitBeforeMutationEffectOnFiber,
@@ -448,7 +449,10 @@ export const scheduleWork = scheduleUpdateOnFiber;
 // work without treating it as a typical update that originates from an event;
 // e.g. retrying a Suspense boundary isn't an update, but it does schedule work
 // on a fiber.
-function markUpdateTimeFromFiberToRoot(fiber, expirationTime) {
+function markUpdateTimeFromFiberToRoot(
+  fiber: Fiber,
+  expirationTime: ExpirationTime,
+) {
   // Update the source fiber's expiration time
   if (fiber.expirationTime < expirationTime) {
     fiber.expirationTime = expirationTime;
@@ -1274,6 +1278,23 @@ function prepareFreshStack(root, expirationTime) {
     ReactStrictModeWarnings.discardPendingWarnings();
     componentsThatTriggeredHighPriSuspend = null;
   }
+}
+
+export function avoidThisRender(value: Thenable) {
+  invariant(
+    workInProgressRoot !== null &&
+      workInProgress !== null &&
+      workInProgress.return !== null,
+    'unstable_avoidThisRender() should not be called outside render. ' +
+      'This is likely a bug in React. Please file an issue.',
+  );
+  avoidThisRenderImpl(
+    workInProgressRoot,
+    workInProgress.return,
+    workInProgress,
+    value,
+    renderExpirationTime,
+  );
 }
 
 function handleError(root, thrownValue) {

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {Thenable} from 'react-reconciler/src/ReactFiberWorkLoop';
+
 import React from 'react';
 import {isForwardRef, isMemo, ForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
@@ -414,6 +416,10 @@ class ReactShallowRenderer {
       useResponder,
       useTransition,
       useDeferredValue,
+      avoidThisRender(thenable: Thenable) {
+        // no op for the shallow renderer, for now
+        // this is actually a problem because tests won't match actual behaviour.
+      },
     };
   }
 

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -43,7 +43,9 @@ import {
   useResponder,
   useTransition,
   useDeferredValue,
+  unstable_avoidThisRender,
 } from './ReactHooks';
+
 import {withSuspenseConfig} from './ReactBatchConfig';
 import {
   createElementWithValidation,
@@ -64,6 +66,7 @@ import {
   enableScopeAPI,
   exposeConcurrentModeAPIs,
   enableChunksAPI,
+  enableAvoidThisRenderAPI,
 } from 'shared/ReactFeatureFlags';
 const React = {
   Children: {
@@ -149,6 +152,10 @@ if (enableJSXTransformAPI) {
     // for now we can ship identical prod functions
     React.jsxs = jsx;
   }
+}
+
+if (enableAvoidThisRenderAPI) {
+  React.unstable_avoidThisRender = unstable_avoidThisRender;
 }
 
 export default React;

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {Thenable} from 'react-reconciler/src/ReactFiberWorkLoop';
 import type {
   ReactContext,
   ReactEventResponder,
@@ -168,4 +169,12 @@ export function useTransition(
 export function useDeferredValue<T>(value: T, config: ?Object): T {
   const dispatcher = resolveDispatcher();
   return dispatcher.useDeferredValue(value, config);
+}
+
+export function unstable_avoidThisRender(thenable: Thenable) {
+  // this currently generates the wrong error message (ie, the hooks one)
+  // but we'll unify error messages later.
+  const dispatcher = resolveDispatcher();
+
+  return dispatcher.avoidThisRender(thenable);
 }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -97,3 +97,5 @@ export const enableTrustedTypesIntegration = false;
 
 // Flag to turn event.target and event.currentTarget in ReactNative from a reactTag to a component instance
 export const enableNativeTargetAsInstance = false;
+
+export const enableAvoidThisRenderAPI = __EXPERIMENTAL__;

--- a/packages/shared/ReactSideEffectTags.js
+++ b/packages/shared/ReactSideEffectTags.js
@@ -10,28 +10,31 @@
 export type SideEffectTag = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoEffect = /*              */ 0b0000000000000;
-export const PerformedWork = /*         */ 0b0000000000001;
+export const NoEffect = /*              */ 0b00000000000000;
+export const PerformedWork = /*         */ 0b00000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*             */ 0b0000000000010;
-export const Update = /*                */ 0b0000000000100;
-export const PlacementAndUpdate = /*    */ 0b0000000000110;
-export const Deletion = /*              */ 0b0000000001000;
-export const ContentReset = /*          */ 0b0000000010000;
-export const Callback = /*              */ 0b0000000100000;
-export const DidCapture = /*            */ 0b0000001000000;
-export const Ref = /*                   */ 0b0000010000000;
-export const Snapshot = /*              */ 0b0000100000000;
-export const Passive = /*               */ 0b0001000000000;
-export const Hydrating = /*             */ 0b0010000000000;
-export const HydratingAndUpdate = /*    */ 0b0010000000100;
+export const Placement = /*             */ 0b00000000000010;
+export const Update = /*                */ 0b00000000000100;
+export const PlacementAndUpdate = /*    */ 0b00000000000110;
+export const Deletion = /*              */ 0b00000000001000;
+export const ContentReset = /*          */ 0b00000000010000;
+export const Callback = /*              */ 0b00000000100000;
+export const DidCapture = /*            */ 0b00000001000000;
+export const Ref = /*                   */ 0b00000010000000;
+export const Snapshot = /*              */ 0b00000100000000;
+export const Passive = /*               */ 0b00001000000000;
+export const Hydrating = /*             */ 0b00010000000000;
+export const HydratingAndUpdate = /*    */ 0b00010000000100;
 
 // Passive & Update & Callback & Ref & Snapshot
-export const LifecycleEffectMask = /*   */ 0b0001110100100;
+export const LifecycleEffectMask = /*   */ 0b00001110100100;
 
 // Union of all host effects
-export const HostEffectMask = /*        */ 0b0011111111111;
+export const HostEffectMask = /*        */ 0b00011111111111;
 
-export const Incomplete = /*            */ 0b0100000000000;
-export const ShouldCapture = /*         */ 0b1000000000000;
+export const Incomplete = /*            */ 0b00100000000000;
+export const ShouldCapture = /*         */ 0b01000000000000;
+
+// set by unstable_avoidThisRender
+export const SoftCapture = /*           */ 0b10000000000000;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -46,6 +46,8 @@ export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 
+export const enableAvoidThisRenderAPI = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -41,6 +41,8 @@ export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 
+export const enableAvoidThisRenderAPI = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -41,6 +41,8 @@ export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 
+export const enableAvoidThisRenderAPI = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -41,6 +41,8 @@ export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 
+export const enableAvoidThisRenderAPI = false;
+
 // Only used in www builds.
 export function addUserTimingListener() {
   invariant(false, 'Not implemented.');

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -95,3 +95,5 @@ export const enableNativeTargetAsInstance = false;
 type Check<_X, Y: _X, X: Y = _X> = null;
 // eslint-disable-next-line no-unused-expressions
 (null: Check<FeatureFlagsShimType, FeatureFlagsType>);
+
+export const enableAvoidThisRenderAPI = __EXPERIMENTAL__;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -344,5 +344,8 @@
   "343": "ReactDOMServer does not yet support scope components.",
   "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
   "345": "Root did not complete. This is a bug in React.",
-  "346": "An event responder context was used outside of an event cycle."
+  "346": "An event responder context was used outside of an event cycle.",
+  "347": "unstable_avoidThisRender can only be called inside the body of a function component, or inside the render() method of a class component. One of these may be true:\n1. You might have mismatching versions of React and the renderer (such as React DOM)\n2. You called it outside React's render phase\n3. You might have more than one copy of React in the same app\n",
+  "348": "unstable_avoidThisRender() should not be called outside render. This is likely a bug in React. Please file an issue.",
+  "349": "unstable_avoidThisRender can only be called inside of the body of a function component, or during render() of a class component."
 }


### PR DESCRIPTION
Introduces React.unstable_avoidThisRender(). 

This is one step towards implementing first class suspending behaviour for static resources like images/stylesheets. 

One of the problems with doing this naively in "userland", is because React is so aggressive on rerendering when the thenables resolve, we end up doing a bunch of unneeded rerenders. This sequence of PRs is to optimize the paths React executes in such cases.


How it's implemented
---

(There might be errors/a lack of understanding in this description)

`unstable_avoidThisRender()` is called during the render phase, which is similar to the 'throw' phase (without the actual throwing). When this happens:
- we look for the nearest Suspense boundary (that satisfies hasInvisibleParentBoundary === true), 
- and mark it's `effectTag` as `SoftCapture` (which is a variant of `DidCapture` for avoided renders). 
- We also attach a ping listener for cleaning up if the thenable resolves before we commit that boundary.

(These steps are similar to what we'd call if you threw an actual promise; ie - `throwException()`)

Soon after this, `completeWork` is called for the marked Suspense boundary. We use this instant to mark the boundary as expired, and return itself to render itself again.

Soon after, beginWork is called for that boundary. `SoftCapture` tells us that boundary has suspended. We clear the effectTag, initialize suspenseState/memoizedState on that boundary, and set `expirationTime` and `memoizedState.didAvoidRenderTime` as `renderExpirationTime - 1`; ie - we mark that boundary as 'expiring very soon'. 

Soon `unstable_avoidThisRender()` is called again, setting the effectTag back to `SoftCapture`. (This time in completeWork, we see that the effectTag and memoizedState are set, so can bypass returning itself.) 

After committing, the content rerender happens. (???) 

This time, in `completeWork()`, we call `renderDidSuspendDelayIfPossible()` to set the exit status on the tree. Currently, the actual content gets committed.

That's ...it? In the next PR, we'll add a new exitStatus, and actually show the fallback, passing the commented out tests in `ReactSuspenseWithNoopRenderer-test.internal.js`


TODO: address this review comment https://github.com/facebook/react/pull/17556/files#r358883141