### PR TITLE
Hold on to the lastNativeEvent weakly so as not to retain fibers belonging to long-ago unmounted DOM nodes

### DIFF
--- a/packages/react-dom/src/events/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/EnterLeaveEventPlugin.js
@@ -42,11 +42,11 @@ const eventTypes = {
   },
 };
 
-// We track the lastNativeEvent to ensure that when we encounter
-// cases where we process the same nativeEvent multiple times,
-// which can happen when have multiple ancestors, that we don't
-// duplicate enter
-let lastNativeEvent;
+// We track the native events we've seen to ensure that when we encounter cases
+// where we process the same nativeEvent multiple times, which can happen when
+// have multiple ancestors, that we don't duplicate enter.
+const seenNativeEvents =
+  typeof WeakSet === 'function' ? new WeakSet() : new Set();
 
 const EnterLeaveEventPlugin = {
   eventTypes: eventTypes,
@@ -169,11 +169,18 @@ const EnterLeaveEventPlugin = {
 
     accumulateEnterLeaveDispatches(leave, enter, from, to);
 
-    if (nativeEvent === lastNativeEvent) {
-      lastNativeEvent = null;
+    if (seenNativeEvents.has(nativeEvent)) {
+      if (seenNativeEvents instanceof Set) {
+        seenNativeEvents.clear();
+      } else {
+        seenNativeEvents.delete(nativeEvent);
+      }
       return [leave];
     }
-    lastNativeEvent = nativeEvent;
+    if (seenNativeEvents instanceof Set) {
+      seenNativeEvents.clear();
+    }
+    seenNativeEvents.add(nativeEvent);
 
     return [leave, enter];
   },


### PR DESCRIPTION
The event that we store in `lastNativeEvent` has a reference to its related DOM nodes which has a reference to some `FiberNode` instances. When a component unmounts we don't want to retain any of that.

This PR stores the `lastNativeEvents` that we've seen in a `WeakSet` so as not to cause them to be retained. Where `WeakSet` is not supported, we use a shim that does what the old thing used to do (and leaks like it too).

Here's a snapshot of one of these leaks in the Chrome Memory profiler. `tk` is `FiberNode` and `tl` is `lastNativeEvent`.

<img width="697" alt="Screen Shot 2019-12-11 at 5 54 58 PM" src="https://user-images.githubusercontent.com/13243/70675938-6d455880-1c3f-11ea-9463-17ead835eb8d.png">

This aims to address #17580. Credit for the idea to use `WeakSet` goes to @bgirard!