### PR TITLE
Fix for the standalone devtools not responding to clicks.

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/DevTools.css
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.css
@@ -29,6 +29,7 @@
 .TabContent {
   flex: 1 1 100%;
   overflow: auto;
+  -webkit-app-region: no-drag;
 }
 
 .DevToolsVersion {


### PR DESCRIPTION
Fixes issues [17522 ](https://github.com/facebook/react/issues/17522)and [17532](https://github.com/facebook/react/issues/17532)
The React Standalone Devtools seem unresponsive / frozen due to being unable to click on the components or profiler child divs (the tree inspector).
This is due to `-webkit-app-region: drag` being applied to the whole container of the react-devtools, electron swallows all the click events on any element with the drag attribute attached. 

It's a simple fix, just add `-webkit-app-region:no-drag` to any items that need to be interacted with. 
 _The above fix had already been highlighted in issue thread - 17522._ 
