### PR TITLE
[react-events] Remove lastNativeEvent in favor of EventSystemFlags

### DIFF
--- a/packages/legacy-events/EventSystemFlags.js
+++ b/packages/legacy-events/EventSystemFlags.js
@@ -15,3 +15,4 @@ export const IS_PASSIVE = 1 << 2;
 export const IS_ACTIVE = 1 << 3;
 export const PASSIVE_NOT_SUPPORTED = 1 << 4;
 export const IS_REPLAYED = 1 << 5;
+export const IS_FIRST_ANCESTOR = 1 << 6;

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -49,6 +49,7 @@ import {
   IS_PASSIVE,
   IS_ACTIVE,
   PASSIVE_NOT_SUPPORTED,
+  IS_FIRST_ANCESTOR,
 } from 'legacy-events/EventSystemFlags';
 
 import {
@@ -175,13 +176,19 @@ function handleTopLevel(bookKeeping: BookKeepingInstance) {
     const eventTarget = getEventTarget(bookKeeping.nativeEvent);
     const topLevelType = ((bookKeeping.topLevelType: any): DOMTopLevelEventType);
     const nativeEvent = ((bookKeeping.nativeEvent: any): AnyNativeEvent);
+    let eventSystemFlags = bookKeeping.eventSystemFlags;
+
+    // If this is the first ancestor, we mark it on the system flags
+    if (i === 0) {
+      eventSystemFlags |= IS_FIRST_ANCESTOR;
+    }
 
     runExtractedPluginEventsInBatch(
       topLevelType,
       targetInst,
       nativeEvent,
       eventTarget,
-      bookKeeping.eventSystemFlags,
+      eventSystemFlags,
     );
   }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/17582.

Notably, this removes the usage of storing the `lastNativeEvent` in a binding in the EnterLeavePlugin module – which can leak memory. Instead, we utilize the EventSystemFlags system which was recently exposed to EventPlugins by @sebmarkbage's work on the event replay system.

We mark when the EventPlugin is handling the first ancestor on the flags directly, meaning we don't need to monkey patch the native events or use WeakSets/Sets to achieve the goal – removing the use case of `lastNativeEvent`.