### PR TITLE
[react-interactions] Mock touchend event should use empty array for "touches"

### DIFF
--- a/packages/react-interactions/events/src/dom/testing-library/domEvents.js
+++ b/packages/react-interactions/events/src/dom/testing-library/domEvents.js
@@ -273,7 +273,7 @@ function createTouchEvent(type, payload) {
     },
   );
 
-  const activeTouches = type !== 'touchend' ? touches : null;
+  const activeTouches = type !== 'touchend' ? touches : [];
 
   return createEvent(type, {
     altKey,


### PR DESCRIPTION
The 'touches' value should be an empty array rather than 'null'