### PR TITLE
Rename toWarnDev -> toErrorDev, toLowPriorityWarnDev -> toWarnDev

### DIFF
--- a/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.internal.js
@@ -452,7 +452,7 @@ describe('createSubscription', () => {
           },
           () => null,
         );
-      }).toWarnDev('Subscription must specify a getCurrentValue function', {
+      }).toErrorDev('Subscription must specify a getCurrentValue function', {
         withoutStack: true,
       });
     });
@@ -465,7 +465,7 @@ describe('createSubscription', () => {
           },
           () => null,
         );
-      }).toWarnDev('Subscription must specify a subscribe function', {
+      }).toErrorDev('Subscription must specify a subscribe function', {
         withoutStack: true,
       });
     });

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -420,7 +420,7 @@ describe('ReactARTComponents', () => {
       ReactTestRenderer.create(
         <Circle stroke="green" strokeWidth={3} fill="blue" />,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `radius` is marked as required in `Circle`, ' +
         'but its value is `undefined`.' +
         '\n    in Circle (at **)',
@@ -437,7 +437,7 @@ describe('ReactARTComponents', () => {
   it('should warn if width/height is missing on a Rectangle component', () => {
     expect(() =>
       ReactTestRenderer.create(<Rectangle stroke="green" fill="blue" />),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: Failed prop type: The prop `width` is marked as required in `Rectangle`, ' +
         'but its value is `undefined`.' +
         '\n    in Rectangle (at **)',
@@ -462,7 +462,7 @@ describe('ReactARTComponents', () => {
   });
 
   it('should warn if outerRadius/startAngle/endAngle is missing on a Wedge component', () => {
-    expect(() => ReactTestRenderer.create(<Wedge fill="blue" />)).toWarnDev([
+    expect(() => ReactTestRenderer.create(<Wedge fill="blue" />)).toErrorDev([
       'Warning: Failed prop type: The prop `outerRadius` is marked as required in `Wedge`, ' +
         'but its value is `undefined`.' +
         '\n    in Wedge (at **)',

--- a/packages/react-cache/src/__tests__/ReactCache-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCache-test.internal.js
@@ -172,7 +172,7 @@ describe('ReactCache', () => {
     if (__DEV__) {
       expect(() => {
         expect(Scheduler).toFlushAndYield(['App', 'Loading...']);
-      }).toWarnDev([
+      }).toErrorDev([
         'Invalid key type. Expected a string, number, symbol, or ' +
           'boolean, but instead received: Hi,100\n\n' +
           'To use non-primitive values as keys, you must pass a hash ' +

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -98,7 +98,7 @@ describe('CSSPropertyOperations', () => {
 
     const root = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+    expect(() => ReactDOM.render(<Comp />, root)).toErrorDev(
       'Warning: Unsupported style property background-color. Did you mean backgroundColor?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
@@ -121,7 +121,7 @@ describe('CSSPropertyOperations', () => {
     const root = document.createElement('div');
     ReactDOM.render(<Comp />, root);
 
-    expect(() => ReactDOM.render(<Comp style={styles} />, root)).toWarnDev([
+    expect(() => ReactDOM.render(<Comp style={styles} />, root)).toErrorDev([
       'Warning: Unsupported style property -ms-transform. Did you mean msTransform?' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
@@ -150,7 +150,7 @@ describe('CSSPropertyOperations', () => {
 
     const root = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev([
+    expect(() => ReactDOM.render(<Comp />, root)).toErrorDev([
       // msTransform is correct already and shouldn't warn
       'Warning: Unsupported vendor-prefixed style property oTransform. ' +
         'Did you mean OTransform?' +
@@ -183,7 +183,7 @@ describe('CSSPropertyOperations', () => {
 
     const root = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev([
+    expect(() => ReactDOM.render(<Comp />, root)).toErrorDev([
       "Warning: Style property values shouldn't contain a semicolon. " +
         'Try "backgroundColor: blue" instead.' +
         '\n    in div (at **)' +
@@ -206,7 +206,7 @@ describe('CSSPropertyOperations', () => {
 
     const root = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+    expect(() => ReactDOM.render(<Comp />, root)).toErrorDev(
       'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',
@@ -235,7 +235,7 @@ describe('CSSPropertyOperations', () => {
 
     const root = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Comp />, root)).toWarnDev(
+    expect(() => ReactDOM.render(<Comp />, root)).toErrorDev(
       'Warning: `Infinity` is an invalid value for the `fontSize` css style property.' +
         '\n    in div (at **)' +
         '\n    in Comp (at **)',

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -183,7 +183,7 @@ describe('DOMPropertyOperations', () => {
           <input type="text" onChange={function() {}} />,
           container,
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'A component is changing a controlled input of type text to be uncontrolled',
       );
       if (disableInputAttributeSyncing) {

--- a/packages/react-dom/src/__tests__/EventPluginHub-test.js
+++ b/packages/react-dom/src/__tests__/EventPluginHub-test.js
@@ -27,7 +27,7 @@ describe('EventPluginHub', () => {
       node = ReactTestUtils.renderIntoDocument(
         <div onClick="not a function" />,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Expected `onClick` listener to be a function, instead got a value of `string` type.',
     );
     expect(() => ReactTestUtils.SimulateNative.click(node)).toThrowError(

--- a/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
+++ b/packages/react-dom/src/__tests__/ReactChildReconciler-test.js
@@ -65,7 +65,7 @@ describe('ReactChildReconciler', () => {
           <h1>{iterableFunction}</h1>
         </div>,
       );
-    }).toWarnDev('Functions are not valid as a React child');
+    }).toErrorDev('Functions are not valid as a React child');
 
     expect(node.innerHTML).toContain(''); // h1
   });
@@ -77,7 +77,7 @@ describe('ReactChildReconciler', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted — the behavior is unsupported and ' +
@@ -104,7 +104,7 @@ describe('ReactChildReconciler', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toErrorDev(
       'Encountered two children with the same key, `1`. ' +
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
@@ -124,7 +124,7 @@ describe('ReactChildReconciler', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +
         'duplicated and/or omitted — the behavior is unsupported and ' +
@@ -151,7 +151,7 @@ describe('ReactChildReconciler', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toErrorDev(
       'Encountered two children with the same key, `1`. ' +
         'Keys should be unique so that components maintain their identity ' +
         'across updates. Non-unique keys may cause children to be ' +

--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -397,7 +397,7 @@ describe('ReactComponent', () => {
   it('throws usefully when rendering badly-typed elements', () => {
     const X = undefined;
     expect(() => {
-      expect(() => ReactTestUtils.renderIntoDocument(<X />)).toWarnDev(
+      expect(() => ReactTestUtils.renderIntoDocument(<X />)).toErrorDev(
         'React.createElement: type is invalid -- expected a string (for built-in components) ' +
           'or a class/function (for composite components) but got: undefined.',
       );
@@ -412,7 +412,7 @@ describe('ReactComponent', () => {
 
     const Y = null;
     expect(() => {
-      expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toWarnDev(
+      expect(() => ReactTestUtils.renderIntoDocument(<Y />)).toErrorDev(
         'React.createElement: type is invalid -- expected a string (for built-in components) ' +
           'or a class/function (for composite components) but got: null.',
       );
@@ -442,7 +442,7 @@ describe('ReactComponent', () => {
     }
 
     expect(() => {
-      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev(
+      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev(
         'React.createElement: type is invalid -- expected a string (for built-in components) ' +
           'or a class/function (for composite components) but got: undefined.',
       );
@@ -572,7 +572,7 @@ describe('ReactComponent', () => {
         return Foo;
       }
       const container = document.createElement('div');
-      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Foo />, container)).toErrorDev(
         'Warning: Functions are not valid as a React child. This may happen if ' +
           'you return a Component instead of <Component /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
@@ -587,7 +587,7 @@ describe('ReactComponent', () => {
         }
       }
       const container = document.createElement('div');
-      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Foo />, container)).toErrorDev(
         'Warning: Functions are not valid as a React child. This may happen if ' +
           'you return a Component instead of <Component /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
@@ -604,7 +604,7 @@ describe('ReactComponent', () => {
         );
       }
       const container = document.createElement('div');
-      expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Foo />, container)).toErrorDev(
         'Warning: Functions are not valid as a React child. This may happen if ' +
           'you return a Component instead of <Component /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +
@@ -649,7 +649,7 @@ describe('ReactComponent', () => {
       let component;
       expect(() => {
         component = ReactDOM.render(<Foo />, container);
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Functions are not valid as a React child. This may happen if ' +
           'you return a Component instead of <Component /> from render. ' +
           'Or maybe you meant to call this function rather than return it.\n' +

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -697,7 +697,7 @@ describe('ReactComponentLifeCycle', () => {
       expect(() => ReactDOM.render(<Component />, container)).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',
@@ -735,7 +735,7 @@ describe('ReactComponentLifeCycle', () => {
       ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',
@@ -803,7 +803,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillUpdate has been renamed',
@@ -853,7 +853,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(['componentWillMount has been renamed'], {
+    }).toWarnDev(['componentWillMount has been renamed'], {
       withoutStack: true,
     });
 
@@ -876,7 +876,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(['componentWillReceiveProps has been renamed'], {
+    }).toWarnDev(['componentWillReceiveProps has been renamed'], {
       withoutStack: true,
     });
   });
@@ -908,7 +908,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillUpdate has been renamed',
@@ -956,7 +956,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(['componentWillMount has been renamed'], {
+    }).toWarnDev(['componentWillMount has been renamed'], {
       withoutStack: true,
     });
 
@@ -978,7 +978,7 @@ describe('ReactComponentLifeCycle', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(['componentWillReceiveProps has been renamed'], {
+    }).toWarnDev(['componentWillReceiveProps has been renamed'], {
       withoutStack: true,
     });
   });
@@ -1111,9 +1111,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const div = document.createElement('div');
-    expect(() =>
-      ReactDOM.render(<MyComponent foo="bar" />, div),
-    ).toLowPriorityWarnDev(
+    expect(() => ReactDOM.render(<MyComponent foo="bar" />, div)).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',
@@ -1382,9 +1380,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const container = document.createElement('div');
-    expect(() =>
-      ReactDOM.render(<MyComponent x={1} />, container),
-    ).toLowPriorityWarnDev(
+    expect(() => ReactDOM.render(<MyComponent x={1} />, container)).toWarnDev(
       [
         /* eslint-disable max-len */
         `Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

--- a/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponentLifeCycle-test.js
@@ -211,7 +211,7 @@ describe('ReactComponentLifeCycle', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<StatefulComponent />);
-    }).toWarnDev(
+    }).toErrorDev(
       'StatefulComponent: It is not recommended to assign props directly to state ' +
         "because updates to props won't be reflected in state. " +
         'In most cases, it is better to use props directly.',
@@ -234,7 +234,7 @@ describe('ReactComponentLifeCycle', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<StatefulComponent />);
-    }).toWarnDev(
+    }).toErrorDev(
       "Warning: Can't call setState on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
@@ -269,7 +269,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
-    }).toWarnDev('Component is accessing isMounted inside its render()');
+    }).toErrorDev('Component is accessing isMounted inside its render()');
   });
 
   it('should correctly determine if a null component is mounted', () => {
@@ -296,7 +296,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       const instance = ReactTestUtils.renderIntoDocument(element);
       expect(instance._isMounted()).toBeTruthy();
-    }).toWarnDev('Component is accessing isMounted inside its render()');
+    }).toErrorDev('Component is accessing isMounted inside its render()');
   });
 
   it('isMounted should return false when unmounted', () => {
@@ -334,7 +334,7 @@ describe('ReactComponentLifeCycle', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<Component />);
-    }).toWarnDev('Component is accessing findDOMNode inside its render()');
+    }).toErrorDev('Component is accessing findDOMNode inside its render()');
   });
 
   it('should carry through each of the phases of setup', () => {
@@ -398,7 +398,7 @@ describe('ReactComponentLifeCycle', () => {
     let instance;
     expect(() => {
       instance = ReactDOM.render(<LifeCycleComponent />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'LifeCycleComponent is accessing isMounted inside its render() function',
     );
 
@@ -694,7 +694,7 @@ describe('ReactComponentLifeCycle', () => {
 
     const container = document.createElement('div');
     expect(() => {
-      expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Component />, container)).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.',
       );
     }).toLowPriorityWarnDev(
@@ -732,7 +732,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<Component value={1} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.',
       );
     }).toLowPriorityWarnDev(
@@ -767,7 +767,9 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<Component value={1} />, container)).toWarnDev(
+    expect(() =>
+      ReactDOM.render(<Component value={1} />, container),
+    ).toErrorDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.',
     );
     ReactDOM.render(<Component value={2} />, container);
@@ -792,7 +794,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<AllLegacyLifecycles />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'AllLegacyLifecycles uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -820,7 +822,7 @@ describe('ReactComponentLifeCycle', () => {
       }
     }
 
-    expect(() => ReactDOM.render(<WillMount />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<WillMount />, container)).toErrorDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
         'WillMount uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
         '  UNSAFE_componentWillMount\n\n' +
@@ -843,7 +845,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<WillMountAndUpdate />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'WillMountAndUpdate uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -867,7 +869,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     expect(() => {
-      expect(() => ReactDOM.render(<WillReceiveProps />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<WillReceiveProps />, container)).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'WillReceiveProps uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
           '  componentWillReceiveProps\n\n' +
@@ -897,7 +899,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<AllLegacyLifecycles />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'AllLegacyLifecycles uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -924,7 +926,7 @@ describe('ReactComponentLifeCycle', () => {
       }
     }
 
-    expect(() => ReactDOM.render(<WillMount />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<WillMount />, container)).toErrorDev(
       'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
         'WillMount uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
         '  UNSAFE_componentWillMount\n\n' +
@@ -946,7 +948,7 @@ describe('ReactComponentLifeCycle', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<WillMountAndUpdate />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'WillMountAndUpdate uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -969,7 +971,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     expect(() => {
-      expect(() => ReactDOM.render(<WillReceiveProps />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<WillReceiveProps />, container)).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'WillReceiveProps uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
           '  componentWillReceiveProps\n\n' +
@@ -1019,7 +1021,7 @@ describe('ReactComponentLifeCycle', () => {
     const div = document.createElement('div');
     expect(() =>
       ReactDOM.render(<Parent ref={c => c && log.push('ref')} />, div),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: The <Parent /> component appears to be a function component that returns a class instance. ' +
         'Change Parent to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -1050,7 +1052,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const div = document.createElement('div');
-    expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent />, div)).toErrorDev(
       'MyComponent.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
     );
@@ -1070,7 +1072,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const div = document.createElement('div');
-    expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent />, div)).toErrorDev(
       '`MyComponent` uses `getDerivedStateFromProps` but its initial state is ' +
         'undefined. This is not recommended. Instead, define the initial state by ' +
         'assigning an object to `this.state` in the constructor of `MyComponent`. ' +
@@ -1340,7 +1342,7 @@ describe('ReactComponentLifeCycle', () => {
 
     const div = document.createElement('div');
     ReactDOM.render(<MyComponent value="foo" />, div);
-    expect(() => ReactDOM.render(<MyComponent value="bar" />, div)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent value="bar" />, div)).toErrorDev(
       'MyComponent.getSnapshotBeforeUpdate(): A snapshot value (or null) must ' +
         'be returned. You have returned undefined.',
     );
@@ -1360,7 +1362,7 @@ describe('ReactComponentLifeCycle', () => {
     }
 
     const div = document.createElement('div');
-    expect(() => ReactDOM.render(<MyComponent />, div)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent />, div)).toErrorDev(
       'MyComponent: getSnapshotBeforeUpdate() should be used with componentDidUpdate(). ' +
         'This component defines getSnapshotBeforeUpdate() only.',
     );

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -165,7 +165,7 @@ describe('ReactCompositeComponent', () => {
     // Old API based on heuristic
     let container = document.createElement('div');
     container.innerHTML = markup;
-    expect(() => ReactDOM.render(<Parent />, container)).toLowPriorityWarnDev(
+    expect(() => ReactDOM.render(<Parent />, container)).toWarnDev(
       'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
         'will stop working in React v17. Replace the ReactDOM.render() call ' +
         'with ReactDOM.hydrate() if you want React to attach to the server HTML.',

--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -118,7 +118,7 @@ describe('ReactCompositeComponent', () => {
     }
 
     const el = document.createElement('div');
-    expect(() => ReactDOM.render(<Child test="test" />, el)).toWarnDev(
+    expect(() => ReactDOM.render(<Child test="test" />, el)).toErrorDev(
       'Warning: The <Child /> component appears to be a function component that returns a class instance. ' +
         'Change Child to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -281,7 +281,7 @@ describe('ReactCompositeComponent', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<MyComponent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent />, container)).toErrorDev(
       "Warning: Can't call forceUpdate on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
@@ -305,7 +305,7 @@ describe('ReactCompositeComponent', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<MyComponent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<MyComponent />, container)).toErrorDev(
       "Warning: Can't call setState on a component that is not yet mounted. " +
         'This is a no-op, but it might indicate a bug in your application. ' +
         'Instead, assign to `this.state` directly or define a `state = {};` ' +
@@ -335,7 +335,7 @@ describe('ReactCompositeComponent', () => {
 
     ReactDOM.unmountComponentAtNode(container);
 
-    expect(() => instance.forceUpdate()).toWarnDev(
+    expect(() => instance.forceUpdate()).toErrorDev(
       "Warning: Can't perform a React state update on an unmounted " +
         'component. This is a no-op, but it indicates a memory leak in your ' +
         'application. To fix, cancel all subscriptions and asynchronous ' +
@@ -382,7 +382,7 @@ describe('ReactCompositeComponent', () => {
 
     expect(() => {
       instance.setState({value: 2});
-    }).toWarnDev(
+    }).toErrorDev(
       "Warning: Can't perform a React state update on an unmounted " +
         'component. This is a no-op, but it indicates a memory leak in your ' +
         'application. To fix, cancel all subscriptions and asynchronous ' +
@@ -433,7 +433,7 @@ describe('ReactCompositeComponent', () => {
       expect(() => {
         ReactDOM.render(<ClassWithRenderNotExtended />, container);
       }).toThrow(TypeError);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
@@ -468,7 +468,7 @@ describe('ReactCompositeComponent', () => {
 
     expect(() => {
       instance = ReactDOM.render(<Component />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Cannot update during an existing state transition (such as within ' +
         '`render`). Render methods should be a pure function of props and state.',
     );
@@ -516,7 +516,7 @@ describe('ReactCompositeComponent', () => {
 
     expect(() => {
       instance = ReactDOM.render(<Component />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: setState(...): Cannot call setState() inside getChildContext()',
     );
 
@@ -591,7 +591,7 @@ describe('ReactCompositeComponent', () => {
 
     const instance = ReactTestUtils.renderIntoDocument(<Component />);
 
-    expect(() => instance.setState({bogus: true})).toWarnDev(
+    expect(() => instance.setState({bogus: true})).toErrorDev(
       'Warning: Component.shouldComponentUpdate(): Returned undefined instead of a ' +
         'boolean value. Make sure to return true or false.',
     );
@@ -606,7 +606,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Component has a method called ' +
         'componentDidUnmount(). But there is no such lifecycle method. ' +
         'Did you mean componentWillUnmount()?',
@@ -622,7 +622,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Component has a method called ' +
         'componentDidReceiveProps(). But there is no such lifecycle method. ' +
         'If you meant to update the state in response to changing props, ' +
@@ -643,7 +643,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Setting defaultProps as an instance property on Component is not supported ' +
         'and will be ignored. Instead, define defaultProps as a static property on Component.',
     );
@@ -1131,7 +1131,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Outer />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Outer />)).toErrorDev(
       'Render methods should be a pure function of props and state; ' +
         'triggering nested component updates from render is not allowed. If ' +
         'necessary, trigger nested updates in componentDidUpdate.\n\nCheck the ' +
@@ -1424,7 +1424,7 @@ describe('ReactCompositeComponent', () => {
       }
     }
 
-    expect(() => ReactDOM.render(<Foo idx="qwe" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo idx="qwe" />, container)).toErrorDev(
       'Foo(...): When calling super() in `Foo`, make sure to pass ' +
         "up the same props that your component's constructor was passed.",
     );
@@ -1725,7 +1725,7 @@ describe('ReactCompositeComponent', () => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTextInvalidConstructor />);
       }).toThrow();
-    }).toWarnDev([
+    }).toErrorDev([
       // Expect two errors because invokeGuardedCallback will dispatch an error event,
       // Causing the warning to be logged again.
       'Warning: RenderTextInvalidConstructor(...): No `render` method found on the returned component instance: ' +
@@ -1748,7 +1748,7 @@ describe('ReactCompositeComponent', () => {
     const container = document.createElement('div');
     expect(() => {
       ReactDOM.render(<Bad />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'It looks like Bad is reassigning its own `this.props` while rendering. ' +
         'This is not supported and can lead to confusing bugs.',
     );
@@ -1761,7 +1761,7 @@ describe('ReactCompositeComponent', () => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<RenderTestUndefinedRender />);
       }).toThrow();
-    }).toWarnDev([
+    }).toErrorDev([
       // Expect two errors because invokeGuardedCallback will dispatch an error event,
       // Causing the warning to be logged again.
       'Warning: RenderTestUndefinedRender(...): No `render` method found on the returned ' +

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -406,7 +406,7 @@ describe('ReactCompositeComponent-state', () => {
     const container = document.createElement('div');
     ReactDOM.render(<Test />, container);
     // Update
-    expect(() => ReactDOM.render(<Test />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Test />, container)).toErrorDev(
       'Warning: Test.componentWillReceiveProps(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
@@ -447,7 +447,7 @@ describe('ReactCompositeComponent-state', () => {
 
     // Mount
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<Test />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Test />, container)).toErrorDev(
       'Warning: Test.componentWillMount(): Assigning directly to ' +
         "this.state is deprecated (except inside a component's constructor). " +
         'Use setState instead.',
@@ -472,7 +472,7 @@ describe('ReactCompositeComponent-state', () => {
     }
 
     const el = document.createElement('div');
-    expect(() => ReactDOM.render(<Child />, el)).toWarnDev(
+    expect(() => ReactDOM.render(<Child />, el)).toErrorDev(
       'Warning: The <Child /> component appears to be a function component that returns a class instance. ' +
         'Change Child to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +

--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -139,7 +139,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, 'no');
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
@@ -151,7 +151,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, {foo: 'bar'});
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -163,7 +163,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, new Foo());
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -192,7 +192,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, 'no');
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
@@ -205,7 +205,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, {foo: 'bar'});
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -218,7 +218,7 @@ describe('ReactDOM', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<A />, myDiv, new Foo());
-      }).toWarnDev(
+      }).toErrorDev(
         'render(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -484,7 +484,7 @@ describe('ReactDOM', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<App />, container)).toWarnDev([
+    expect(() => ReactDOM.render(<App />, container)).toErrorDev([
       // ReactDOM(App > div > span)
       'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in span (at **)\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -42,7 +42,7 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('changes values true, false to null, and also warns once', () => {
-      expect(() => testUnknownAttributeAssignment(true, null)).toWarnDev(
+      expect(() => testUnknownAttributeAssignment(true, null)).toErrorDev(
         'Received `true` for a non-boolean attribute `unknown`.\n\n' +
           'If you want to write it to the DOM, pass a string instead: ' +
           'unknown="true" or unknown={value.toString()}.\n' +
@@ -71,7 +71,7 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('coerces NaN to strings and warns', () => {
-      expect(() => testUnknownAttributeAssignment(NaN, 'NaN')).toWarnDev(
+      expect(() => testUnknownAttributeAssignment(NaN, 'NaN')).toErrorDev(
         'Warning: Received NaN for the `unknown` attribute. ' +
           'If this is expected, cast the value to a string.\n' +
           '    in div (at **)',
@@ -90,7 +90,7 @@ describe('ReactDOM unknown attribute', () => {
     });
 
     it('removes symbols and warns', () => {
-      expect(() => testUnknownAttributeRemoval(Symbol('foo'))).toWarnDev(
+      expect(() => testUnknownAttributeRemoval(Symbol('foo'))).toErrorDev(
         'Warning: Invalid value for prop `unknown` on <div> tag. Either remove it ' +
           'from the element, or pass a string or number value to keep it ' +
           'in the DOM. For details, see https://fb.me/react-attribute-behavior\n' +
@@ -101,7 +101,7 @@ describe('ReactDOM unknown attribute', () => {
     it('removes functions and warns', () => {
       expect(() =>
         testUnknownAttributeRemoval(function someFunction() {}),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid value for prop `unknown` on <div> tag. Either remove ' +
           'it from the element, or pass a string or number value to ' +
           'keep it in the DOM. For details, see ' +
@@ -115,7 +115,7 @@ describe('ReactDOM unknown attribute', () => {
 
       expect(() =>
         ReactDOM.render(<div helloWorld="something" />, el),
-      ).toWarnDev(
+      ).toErrorDev(
         'React does not recognize the `helloWorld` prop on a DOM element. ' +
           'If you intentionally want it to appear in the DOM as a custom ' +
           'attribute, spell it as lowercase `helloworld` instead. ' +

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -150,7 +150,7 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div foo={() => {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid value for prop `foo` on <div> tag. Either remove it ' +
           'from the element, or pass a string or number value to keep ' +
           'it in the DOM. For details, see https://fb.me/react-attribute-behavior' +
@@ -162,7 +162,7 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div foo={() => {}} baz={() => {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid values for props `foo`, `baz` on <div> tag. Either remove ' +
           'them from the element, or pass a string or number value to keep ' +
           'them in the DOM. For details, see https://fb.me/react-attribute-behavior' +
@@ -174,7 +174,7 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onDblClick={() => {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid event handler property `onDblClick`. Did you mean `onDoubleClick`?\n    in div (at **)',
       );
     });
@@ -183,14 +183,14 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onUnknown="alert(&quot;hack&quot;)" />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
       expect(() =>
         ReactDOM.render(<div onunknown="alert(&quot;hack&quot;)" />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
@@ -200,7 +200,7 @@ describe('ReactDOMComponent', () => {
           <div on-unknown="alert(&quot;hack&quot;)" />,
           container,
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
@@ -211,21 +211,21 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<div onUnknown={function() {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `onUnknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onUnknown')).toBe(false);
       expect(container.firstChild.onUnknown).toBe(undefined);
       expect(() =>
         ReactDOM.render(<div onunknown={function() {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `onunknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('onunknown')).toBe(false);
       expect(container.firstChild.onunknown).toBe(undefined);
       expect(() =>
         ReactDOM.render(<div on-unknown={function() {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Unknown event handler property `on-unknown`. It will be ignored.\n    in div (at **)',
       );
       expect(container.firstChild.hasAttribute('on-unknown')).toBe(false);
@@ -234,7 +234,7 @@ describe('ReactDOMComponent', () => {
 
     it('should warn for badly cased React attributes', () => {
       const container = document.createElement('div');
-      expect(() => ReactDOM.render(<div CHILDREN="5" />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<div CHILDREN="5" />, container)).toErrorDev(
         'Warning: Invalid DOM property `CHILDREN`. Did you mean `children`?\n    in div (at **)',
       );
       expect(container.firstChild.getAttribute('CHILDREN')).toBe('5');
@@ -253,7 +253,7 @@ describe('ReactDOMComponent', () => {
     it('should warn nicely about NaN in style', () => {
       const style = {fontSize: NaN};
       const div = document.createElement('div');
-      expect(() => ReactDOM.render(<span style={style} />, div)).toWarnDev(
+      expect(() => ReactDOM.render(<span style={style} />, div)).toErrorDev(
         'Warning: `NaN` is an invalid value for the `fontSize` css style property.' +
           '\n    in span (at **)',
       );
@@ -572,7 +572,7 @@ describe('ReactDOMComponent', () => {
           expect(result1.toLowerCase()).not.toContain('onclick');
           expect(result2.toLowerCase()).not.toContain('script');
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
@@ -596,7 +596,7 @@ describe('ReactDOMComponent', () => {
           expect(result1.toLowerCase()).not.toContain('onclick');
           expect(result2.toLowerCase()).not.toContain('script');
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
@@ -626,7 +626,7 @@ describe('ReactDOMComponent', () => {
           );
           expect(container.firstChild.attributes.length).toBe(0);
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
@@ -656,7 +656,7 @@ describe('ReactDOMComponent', () => {
           );
           expect(container.firstChild.attributes.length).toBe(0);
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
@@ -687,7 +687,7 @@ describe('ReactDOMComponent', () => {
           );
           expect(container.firstChild.attributes.length).toBe(0);
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></div><script>alert("hi")</script>`',
       ]);
@@ -718,7 +718,7 @@ describe('ReactDOMComponent', () => {
           );
           expect(container.firstChild.attributes.length).toBe(0);
         }
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: Invalid attribute name: `blah" onclick="beevil" noise="hi`',
         'Warning: Invalid attribute name: `></x-foo-component><script>alert("hi")</script>`',
       ]);
@@ -969,7 +969,7 @@ describe('ReactDOMComponent', () => {
       const container = document.createElement('div');
       expect(() =>
         ReactDOM.render(<button is={function() {}} />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Received a `function` for a string attribute `is`. If this is expected, cast ' +
           'the value to a string.',
       );
@@ -1133,7 +1133,7 @@ describe('ReactDOMComponent', () => {
 
       expect(() => {
         returnedValue = ReactDOMServer.renderToString(<Container />);
-      }).toWarnDev(
+      }).toErrorDev(
         '<BR /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
@@ -1149,7 +1149,7 @@ describe('ReactDOMComponent', () => {
 
       expect(() =>
         ReactTestUtils.renderIntoDocument(React.createElement('IMG')),
-      ).toWarnDev(
+      ).toErrorDev(
         '<IMG /> is using incorrect casing. ' +
           'Use PascalCase for React components, ' +
           'or lowercase for HTML elements.',
@@ -1159,7 +1159,7 @@ describe('ReactDOMComponent', () => {
     it('should warn on props reserved for future use', () => {
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div aria="hello" />),
-      ).toWarnDev(
+      ).toErrorDev(
         'The `aria` attribute is reserved for future use in React. ' +
           'Pass individual `aria-` attributes instead.',
       );
@@ -1182,11 +1182,11 @@ describe('ReactDOMComponent', () => {
         };
         Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
 
-        expect(() => ReactTestUtils.renderIntoDocument(<bar />)).toWarnDev(
+        expect(() => ReactTestUtils.renderIntoDocument(<bar />)).toErrorDev(
           'The tag <bar> is unrecognized in this browser',
         );
         // Test deduplication
-        expect(() => ReactTestUtils.renderIntoDocument(<foo />)).toWarnDev(
+        expect(() => ReactTestUtils.renderIntoDocument(<foo />)).toErrorDev(
           'The tag <foo> is unrecognized in this browser',
         );
         ReactTestUtils.renderIntoDocument(<foo />);
@@ -1199,7 +1199,7 @@ describe('ReactDOMComponent', () => {
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         expect(() =>
           ReactTestUtils.renderIntoDocument(<hasOwnProperty />),
-        ).toWarnDev([
+        ).toErrorDev([
           '<hasOwnProperty /> is using incorrect casing. ' +
             'Use PascalCase for React components, ' +
             'or lowercase for HTML elements.',
@@ -1260,7 +1260,7 @@ describe('ReactDOMComponent', () => {
           }
         }
         const node = document.createElement('div');
-        expect(() => ReactDOM.render(<ShadyComponent />, node)).toWarnDev(
+        expect(() => ReactDOM.render(<ShadyComponent />, node)).toErrorDev(
           'ShadyComponent is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
         );
@@ -1280,7 +1280,7 @@ describe('ReactDOMComponent', () => {
           return container;
         };
 
-        expect(() => mountComponent({is: 'custom-shady-div'})).toWarnDev(
+        expect(() => mountComponent({is: 'custom-shady-div'})).toErrorDev(
           'A component is using shady DOM. Using shady DOM with React can ' +
             'cause things to break subtly.',
         );
@@ -1312,7 +1312,7 @@ describe('ReactDOMComponent', () => {
             </menu>,
             container,
           );
-        }).toWarnDev('The tag <menuitem> is unrecognized in this browser.');
+        }).toErrorDev('The tag <menuitem> is unrecognized in this browser.');
       }).toThrowError(
         'menuitem is a void element tag and must neither have `children` nor use ' +
           '`dangerouslySetInnerHTML`.',
@@ -1330,13 +1330,13 @@ describe('ReactDOMComponent', () => {
     it('should validate against use of innerHTML', () => {
       expect(() =>
         mountComponent({innerHTML: '<span>Hi Jim!</span>'}),
-      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
+      ).toErrorDev('Directly setting property `innerHTML` is not permitted. ');
     });
 
     it('should validate against use of innerHTML without case sensitivity', () => {
       expect(() =>
         mountComponent({innerhtml: '<span>Hi Jim!</span>'}),
-      ).toWarnDev('Directly setting property `innerHTML` is not permitted. ');
+      ).toErrorDev('Directly setting property `innerHTML` is not permitted. ');
     });
 
     it('should validate use of dangerouslySetInnerHTML', () => {
@@ -1366,7 +1366,7 @@ describe('ReactDOMComponent', () => {
     it('should warn about contentEditable and children', () => {
       expect(() =>
         mountComponent({contentEditable: true, children: ''}),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: A component is `contentEditable` and contains `children` ' +
           'managed by React. It is now your responsibility to guarantee that ' +
           'none of those nodes are unexpectedly modified or duplicated. This ' +
@@ -1544,7 +1544,7 @@ describe('ReactDOMComponent', () => {
           </div>,
           container,
         );
-      }).toWarnDev('contentEditable');
+      }).toErrorDev('contentEditable');
     });
 
     it('should validate against invalid styles', () => {
@@ -1663,7 +1663,7 @@ describe('ReactDOMComponent', () => {
             <tr />
           </div>,
         );
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
           '<div>.' +
           '\n    in tr (at **)' +
@@ -1685,7 +1685,7 @@ describe('ReactDOMComponent', () => {
           </span>,
           p,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: validateDOMNesting(...): <p> cannot appear as a descendant ' +
           'of <p>.' +
           // There is no outer `p` here because root container is not part of the stack.
@@ -1711,7 +1711,7 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev([
+      expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev([
         'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
           '<table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated ' +
           'by the browser.' +
@@ -1763,7 +1763,7 @@ describe('ReactDOMComponent', () => {
       function App1() {
         return <Viz1 />;
       }
-      expect(() => ReactTestUtils.renderIntoDocument(<App1 />)).toWarnDev(
+      expect(() => ReactTestUtils.renderIntoDocument(<App1 />)).toErrorDev(
         '\n    in tr (at **)' +
           '\n    in Row (at **)' +
           '\n    in FancyRow (at **)' +
@@ -1781,7 +1781,7 @@ describe('ReactDOMComponent', () => {
       function App2() {
         return <Viz2 />;
       }
-      expect(() => ReactTestUtils.renderIntoDocument(<App2 />)).toWarnDev(
+      expect(() => ReactTestUtils.renderIntoDocument(<App2 />)).toErrorDev(
         '\n    in tr (at **)' +
           '\n    in Row (at **)' +
           '\n    in FancyRow (at **)' +
@@ -1797,7 +1797,7 @@ describe('ReactDOMComponent', () => {
             <FancyRow />
           </FancyTable>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         '\n    in tr (at **)' +
           '\n    in Row (at **)' +
           '\n    in FancyRow (at **)' +
@@ -1812,7 +1812,7 @@ describe('ReactDOMComponent', () => {
             <FancyRow />
           </table>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         '\n    in tr (at **)' +
           '\n    in Row (at **)' +
           '\n    in FancyRow (at **)' +
@@ -1825,7 +1825,7 @@ describe('ReactDOMComponent', () => {
             <tr />
           </FancyTable>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         '\n    in tr (at **)' +
           '\n    in table (at **)' +
           '\n    in Table (at **)' +
@@ -1846,7 +1846,7 @@ describe('ReactDOMComponent', () => {
             </div>
           </Link>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         '\n    in a (at **)' +
           '\n    in Link (at **)' +
           '\n    in div (at **)' +
@@ -1860,7 +1860,7 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(
           React.createElement('input', {type: 'text', tabindex: '1'}),
         );
-      }).toWarnDev('tabIndex');
+      }).toErrorDev('tabIndex');
     });
 
     it('should warn about incorrect casing on event handlers (ssr)', () => {
@@ -1868,7 +1868,7 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(
           React.createElement('input', {type: 'text', oninput: '1'}),
         );
-      }).toWarnDev(
+      }).toErrorDev(
         'Invalid event handler property `oninput`. ' +
           'React events use the camelCase naming convention, ' +
           // Note: we don't know the right event name so we
@@ -1890,7 +1890,7 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('input', {type: 'text', tabindex: '1'}),
         );
-      }).toWarnDev('tabIndex');
+      }).toErrorDev('tabIndex');
     });
 
     it('should warn about incorrect casing on event handlers', () => {
@@ -1898,12 +1898,12 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('input', {type: 'text', oninput: '1'}),
         );
-      }).toWarnDev('onInput');
+      }).toErrorDev('onInput');
       expect(() => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('input', {type: 'text', onKeydown: '1'}),
         );
-      }).toWarnDev('onKeyDown');
+      }).toErrorDev('onKeyDown');
     });
 
     it('should warn about class', () => {
@@ -1911,7 +1911,7 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('div', {class: 'muffins'}),
         );
-      }).toWarnDev('className');
+      }).toErrorDev('className');
     });
 
     it('should warn about class (ssr)', () => {
@@ -1919,7 +1919,7 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(
           React.createElement('div', {class: 'muffins'}),
         );
-      }).toWarnDev('className');
+      }).toErrorDev('className');
     });
 
     it('should warn about props that are no longer supported', () => {
@@ -1927,12 +1927,12 @@ describe('ReactDOMComponent', () => {
 
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onFocusIn={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onFocusOut={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
     });
@@ -1941,12 +1941,12 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div />);
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onfocusin={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div onfocusout={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
     });
@@ -1955,12 +1955,12 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<div />);
       expect(() =>
         ReactDOMServer.renderToString(<div onFocusIn={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onFocusOut={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
     });
@@ -1969,12 +1969,12 @@ describe('ReactDOMComponent', () => {
       ReactDOMServer.renderToString(<div />);
       expect(() =>
         ReactDOMServer.renderToString(<div onfocusin={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
       expect(() =>
         ReactDOMServer.renderToString(<div onfocusout={() => {}} />),
-      ).toWarnDev(
+      ).toErrorDev(
         'React uses onFocus and onBlur instead of onFocusIn and onFocusOut.',
       );
     });
@@ -1982,12 +1982,12 @@ describe('ReactDOMComponent', () => {
     it('gives source code refs for unknown prop warning', () => {
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div class="paladin" />),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expect(() =>
         ReactTestUtils.renderIntoDocument(<input type="text" onclick="1" />),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid event handler property `onclick`. Did you mean ' +
           '`onClick`?\n    in input (at **)',
       );
@@ -1996,12 +1996,12 @@ describe('ReactDOMComponent', () => {
     it('gives source code refs for unknown prop warning (ssr)', () => {
       expect(() =>
         ReactDOMServer.renderToString(<div class="paladin" />),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
       expect(() =>
         ReactDOMServer.renderToString(<input type="text" oninput="1" />),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid event handler property `oninput`. ' +
           // Note: we don't know the right event name so we
           // use a generic one (onClick) as a suggestion.
@@ -2018,7 +2018,7 @@ describe('ReactDOMComponent', () => {
       ReactTestUtils.renderIntoDocument(<div className="paladin" />, container);
       expect(() =>
         ReactTestUtils.renderIntoDocument(<div class="paladin" />, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `class`. Did you mean `className`?\n    in div (at **)',
       );
     });
@@ -2034,7 +2034,7 @@ describe('ReactDOMComponent', () => {
             <div className="foo6" />
           </div>,
         ),
-      ).toWarnDev([
+      ).toErrorDev([
         'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
         'Invalid event handler property `onclick`. Did you mean `onClick`?\n    in strong (at **)',
       ]);
@@ -2051,7 +2051,7 @@ describe('ReactDOMComponent', () => {
             <div className="foo6" />
           </div>,
         ),
-      ).toWarnDev([
+      ).toErrorDev([
         'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
         'Invalid event handler property `onclick`. ' +
           'React events use the camelCase naming convention, for example `onClick`.' +
@@ -2101,7 +2101,7 @@ describe('ReactDOMComponent', () => {
 
       expect(() =>
         ReactTestUtils.renderIntoDocument(<Parent />, container),
-      ).toWarnDev([
+      ).toErrorDev([
         'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
         'Invalid event handler property `onclick`. Did you mean `onClick`?\n    in strong (at **)',
       ]);
@@ -2149,7 +2149,7 @@ describe('ReactDOMComponent', () => {
 
       expect(() =>
         ReactDOMServer.renderToString(<Parent />, container),
-      ).toWarnDev([
+      ).toErrorDev([
         'Invalid DOM property `class`. Did you mean `className`?\n    in span (at **)',
         'Invalid event handler property `onclick`. ' +
           'React events use the camelCase naming convention, for example `onClick`.' +
@@ -2162,7 +2162,7 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('label', {for: 'test'}),
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
 
@@ -2170,7 +2170,7 @@ describe('ReactDOMComponent', () => {
         ReactTestUtils.renderIntoDocument(
           React.createElement('input', {type: 'text', autofocus: true}),
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
@@ -2180,14 +2180,14 @@ describe('ReactDOMComponent', () => {
         ReactDOMServer.renderToString(
           React.createElement('label', {for: 'test'}),
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `for`. Did you mean `htmlFor`?\n    in label',
       );
       expect(() =>
         ReactDOMServer.renderToString(
           React.createElement('input', {type: 'text', autofocus: true}),
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid DOM property `autofocus`. Did you mean `autoFocus`?\n    in input',
       );
     });
@@ -2222,7 +2222,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div class="test" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Invalid DOM property `class`. Did you mean `className`?',
       );
 
@@ -2233,7 +2233,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div cLASS="test" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Invalid DOM property `cLASS`. Did you mean `className`?',
       );
 
@@ -2248,7 +2248,7 @@ describe('ReactDOMComponent', () => {
             <text arabic-form="initial" />
           </svg>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Invalid DOM property `arabic-form`. Did you mean `arabicForm`?',
       );
       const text = el.querySelector('text');
@@ -2303,7 +2303,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Received `true` for a non-boolean attribute `whatever`.\n\n' +
           'If you want to write it to the DOM, pass a string instead: ' +
           'whatever="true" or whatever={value.toString()}.',
@@ -2317,7 +2317,7 @@ describe('ReactDOMComponent', () => {
       expect(() => {
         // eslint-disable-next-line react/jsx-boolean-value
         el = ReactTestUtils.renderIntoDocument(<div whatever />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Received `true` for a non-boolean attribute `whatever`.\n\n' +
           'If you want to write it to the DOM, pass a string instead: ' +
           'whatever="true" or whatever={value.toString()}.',
@@ -2336,7 +2336,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div whatever={() => {}} />);
-      }).toWarnDev('Warning: Invalid value for prop `whatever` on <div> tag');
+      }).toErrorDev('Warning: Invalid value for prop `whatever` on <div> tag');
 
       expect(el.hasAttribute('whatever')).toBe(false);
     });
@@ -2350,7 +2350,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div data-fooBar="true" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'React does not recognize the `data-fooBar` prop on a DOM element. ' +
           'If you intentionally want it to appear in the DOM as a custom ' +
           'attribute, spell it as lowercase `data-foobar` instead. ' +
@@ -2365,7 +2365,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div fooBar="true" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'React does not recognize the `fooBar` prop on a DOM element. ' +
           'If you intentionally want it to appear in the DOM as a custom ' +
           'attribute, spell it as lowercase `foobar` instead. ' +
@@ -2380,7 +2380,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div whatever={NaN} />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Received NaN for the `whatever` attribute. If this is ' +
           'expected, cast the value to a string.\n    in div',
       );
@@ -2393,7 +2393,7 @@ describe('ReactDOMComponent', () => {
       ReactDOM.render(<div whatever={0} />, container);
       expect(() =>
         ReactDOM.render(<div whatever={() => {}} />, container),
-      ).toWarnDev('Warning: Invalid value for prop `whatever` on <div> tag.');
+      ).toErrorDev('Warning: Invalid value for prop `whatever` on <div> tag.');
       const el = container.firstChild;
       expect(el.hasAttribute('whatever')).toBe(false);
     });
@@ -2402,7 +2402,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div SiZe="30" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Invalid DOM property `SiZe`. Did you mean `size`?',
       );
 
@@ -2475,7 +2475,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div whatever={true} />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Received `true` for a non-boolean attribute `whatever`.\n\n' +
           'If you want to write it to the DOM, pass a string instead: ' +
           'whatever="true" or whatever={value.toString()}.',
@@ -2509,7 +2509,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div hidden="false" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Received the string `false` for the boolean attribute `hidden`. ' +
           'The browser will interpret it as a truthy value. ' +
           'Did you mean hidden={false}?',
@@ -2522,7 +2522,7 @@ describe('ReactDOMComponent', () => {
       let el;
       expect(() => {
         el = ReactTestUtils.renderIntoDocument(<div hidden="true" />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Received the string `true` for the boolean attribute `hidden`. ' +
           'Although this works, it will not work as expected if you pass the string "false". ' +
           'Did you mean hidden={true}?',
@@ -2541,7 +2541,7 @@ describe('ReactDOMComponent', () => {
             <font-face x-height={false} />
           </svg>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: Invalid DOM property `x-height`. Did you mean `xHeight`',
       );
 
@@ -2558,7 +2558,7 @@ describe('ReactDOMComponent', () => {
             <font-face whatever={false} />
           </svg>,
         );
-      }).toWarnDev(
+      }).toErrorDev(
         'Received `false` for a non-boolean attribute `whatever`.\n\n' +
           'If you want to write it to the DOM, pass a string instead: ' +
           'whatever="false" or whatever={value.toString()}.\n\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponentTree-test.js
@@ -177,7 +177,7 @@ describe('ReactDOMComponentTree', () => {
 
     const component = <Controlled />;
     const instance = ReactDOM.render(component, container);
-    expect(() => simulateInput(instance.a, finishValue)).toWarnDev(
+    expect(() => simulateInput(instance.a, finishValue)).toErrorDev(
       'Warning: A component is changing an uncontrolled input of ' +
         'type text to be controlled. Input elements should not ' +
         'switch from uncontrolled to controlled (or vice versa). ' +
@@ -190,7 +190,7 @@ describe('ReactDOMComponentTree', () => {
   it('finds instance of node that is attempted to be unmounted', () => {
     const component = <div />;
     const node = ReactDOM.render(<div>{component}</div>, container);
-    expect(() => ReactDOM.unmountComponentAtNode(node)).toWarnDev(
+    expect(() => ReactDOM.unmountComponentAtNode(node)).toErrorDev(
       "unmountComponentAtNode(): The node you're attempting to unmount " +
         'was rendered by React and is not a top-level container. You may ' +
         'have accidentally passed in a React root node instead of its ' +
@@ -207,7 +207,7 @@ describe('ReactDOMComponentTree', () => {
     );
     const anotherComponent = <div />;
     const instance = ReactDOM.render(component, container);
-    expect(() => ReactDOM.render(anotherComponent, instance)).toWarnDev(
+    expect(() => ReactDOM.render(anotherComponent, instance)).toErrorDev(
       'render(...): Replacing React-rendered children with a new root ' +
         'component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state ' +

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -257,7 +257,7 @@ describe('ReactDOMFiber', () => {
         </div>,
         container,
       ),
-    ).toLowPriorityWarnDev(
+    ).toWarnDev(
       'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
         'and will be removed in React 17+. Update your code to use ' +
         'ReactDOM.createPortal() instead. It has the exact same API, ' +

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -1002,7 +1002,7 @@ describe('ReactDOMFiber', () => {
         return <div onClick="woops" />;
       }
     }
-    expect(() => ReactDOM.render(<Example />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Example />, container)).toErrorDev(
       'Expected `onClick` listener to be a function, instead got a value of `string` type.\n' +
         '    in div (at **)\n' +
         '    in Example (at **)',
@@ -1015,7 +1015,7 @@ describe('ReactDOMFiber', () => {
         return <div onClick={false} />;
       }
     }
-    expect(() => ReactDOM.render(<Example />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Example />, container)).toErrorDev(
       'Expected `onClick` listener to be a function, instead got `false`.\n\n' +
         'If you used to conditionally omit it with onClick={condition && value}, ' +
         'pass onClick={condition ? value : undefined} instead.\n' +
@@ -1048,7 +1048,7 @@ describe('ReactDOMFiber', () => {
         super();
         expect(() => {
           node.click();
-        }).toWarnDev(
+        }).toErrorDev(
           'Warning: unstable_flushDiscreteUpdates: Cannot flush updates when React is already rendering.',
         );
       }
@@ -1133,7 +1133,7 @@ describe('ReactDOMFiber', () => {
     expect(() => {
       expect(() =>
         ReactDOM.render(<div key="2">baz</div>, container),
-      ).toWarnDev(
+      ).toErrorDev(
         'render(...): ' +
           'It looks like the React-rendered content of this container was ' +
           'removed without using React. This is not supported and will ' +
@@ -1151,7 +1151,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('<div>bar</div>');
     // then we mess with the DOM before an update
     container.innerHTML = '<div>MEOW.</div>';
-    expect(() => ReactDOM.render(<div>baz</div>, container)).toWarnDev(
+    expect(() => ReactDOM.render(<div>baz</div>, container)).toErrorDev(
       'render(...): ' +
         'It looks like the React-rendered content of this container was ' +
         'removed without using React. This is not supported and will ' +
@@ -1168,7 +1168,7 @@ describe('ReactDOMFiber', () => {
     expect(container.innerHTML).toBe('<div>bar</div>');
     // then we mess with the DOM before an update
     container.innerHTML = '';
-    expect(() => ReactDOM.render(<div>baz</div>, container)).toWarnDev(
+    expect(() => ReactDOM.render(<div>baz</div>, container)).toErrorDev(
       'render(...): ' +
         'It looks like the React-rendered content of this container was ' +
         'removed without using React. This is not supported and will ' +

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -53,7 +53,7 @@ describe('ReactDOMInput', () => {
   it('should warn for controlled value of 0 with missing onChange', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value={0} />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Failed prop type: You provided a `value` prop to a form field without an `onChange` handler.',
     );
   });
@@ -61,7 +61,7 @@ describe('ReactDOMInput', () => {
   it('should warn for controlled value of "" with missing onChange', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="" />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Failed prop type: You provided a `value` prop to a form field without an `onChange` handler.',
     );
   });
@@ -69,7 +69,7 @@ describe('ReactDOMInput', () => {
   it('should warn for controlled value of "0" with missing onChange', () => {
     expect(() => {
       ReactDOM.render(<input type="text" value="0" />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Failed prop type: You provided a `value` prop to a form field without an `onChange` handler.',
     );
   });
@@ -77,7 +77,7 @@ describe('ReactDOMInput', () => {
   it('should warn for controlled value of false with missing onChange', () => {
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={false} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler.',
     );
   });
@@ -94,7 +94,7 @@ describe('ReactDOMInput', () => {
         <input type="checkbox" checked={false} readOnly={false} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Failed prop type: You provided a `checked` prop to a form field without an `onChange` handler. ' +
         'This will render a read-only field. If the field should be mutable use `defaultChecked`. ' +
         'Otherwise, set either `onChange` or `readOnly`.',
@@ -120,7 +120,7 @@ describe('ReactDOMInput', () => {
 
     expect(() => {
       node = ReactDOM.render(<input type="text" value="lion" />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Failed prop type: You provided a `value` prop to a form field without an `onChange` handler.',
     );
 
@@ -301,7 +301,7 @@ describe('ReactDOMInput', () => {
     let stub;
     expect(() => {
       stub = ReactDOM.render(<Stub />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'You provided a `value` prop to a form field ' +
         'without an `onChange` handler.',
     );
@@ -368,7 +368,7 @@ describe('ReactDOMInput', () => {
 
     expect(() => {
       stub = ReactDOM.render(<Stub />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'You provided a `value` prop to a form field ' +
         'without an `onChange` handler.',
     );
@@ -474,7 +474,7 @@ describe('ReactDOMInput', () => {
     expect(node.value).toBe('0');
     expect(() =>
       ReactDOM.render(<input type="text" defaultValue="1" />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'A component is changing a controlled input of type ' +
         'text to be uncontrolled.',
     );
@@ -853,7 +853,7 @@ describe('ReactDOMInput', () => {
         <input type="submit" value={undefined} onChange={emptyFunction} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'A component is changing a controlled input of type ' +
         'submit to be uncontrolled.',
     );
@@ -873,7 +873,7 @@ describe('ReactDOMInput', () => {
         <input type="reset" value={undefined} onChange={emptyFunction} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'A component is changing a controlled input of type ' +
         'reset to be uncontrolled.',
     );
@@ -920,7 +920,7 @@ describe('ReactDOMInput', () => {
     let stub = <input type="submit" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
-    }).toWarnDev('`value` prop on `input` should not be null');
+    }).toErrorDev('`value` prop on `input` should not be null');
     const node = container.firstChild;
 
     // Note: it shouldn't be an empty string
@@ -935,7 +935,7 @@ describe('ReactDOMInput', () => {
     let stub = <input type="reset" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
-    }).toWarnDev('`value` prop on `input` should not be null');
+    }).toErrorDev('`value` prop on `input` should not be null');
     const node = container.firstChild;
 
     // Note: it shouldn't be an empty string
@@ -1167,7 +1167,7 @@ describe('ReactDOMInput', () => {
         <input type="text" value="zoink" readOnly={false} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: You provided a `value` prop to a form ' +
         'field without an `onChange` handler. This will render a read-only ' +
         'field. If the field should be mutable use `defaultValue`. ' +
@@ -1198,7 +1198,7 @@ describe('ReactDOMInput', () => {
   it('should warn if value is null', () => {
     expect(() =>
       ReactDOM.render(<input type="text" value={null} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
@@ -1219,7 +1219,7 @@ describe('ReactDOMInput', () => {
         />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'A component contains an input of type radio with both checked and defaultChecked props. ' +
         'Input elements must be either controlled or uncontrolled ' +
         '(specify either the checked prop, or the defaultChecked prop, but not ' +
@@ -1246,7 +1246,7 @@ describe('ReactDOMInput', () => {
         <input type="text" value="foo" defaultValue="bar" readOnly={true} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'A component contains an input of type text with both value and defaultValue props. ' +
         'Input elements must be either controlled or uncontrolled ' +
         '(specify either the value prop, or the defaultValue prop, but not ' +
@@ -1267,7 +1267,7 @@ describe('ReactDOMInput', () => {
       <input type="text" value="controlled" onChange={emptyFunction} />
     );
     ReactDOM.render(stub, container);
-    expect(() => ReactDOM.render(<input type="text" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<input type="text" />, container)).toErrorDev(
       'Warning: A component is changing a controlled input of type text to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1283,7 +1283,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="text" value={null} />, container),
-    ).toWarnDev([
+    ).toErrorDev([
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` for uncontrolled components',
       'Warning: A component is changing a controlled input of type text to be uncontrolled. ' +
@@ -1304,7 +1304,7 @@ describe('ReactDOMInput', () => {
         <input type="text" defaultValue="uncontrolled" />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type text to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1318,7 +1318,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="text" value="controlled" />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type text to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1329,13 +1329,13 @@ describe('ReactDOMInput', () => {
 
   it('should warn if uncontrolled input (value is null) switches to controlled', () => {
     const stub = <input type="text" value={null} />;
-    expect(() => ReactDOM.render(stub, container)).toWarnDev(
+    expect(() => ReactDOM.render(stub, container)).toErrorDev(
       '`value` prop on `input` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` for uncontrolled components.',
     );
     expect(() =>
       ReactDOM.render(<input type="text" value="controlled" />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type text to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1351,7 +1351,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type checkbox to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1367,7 +1367,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={null} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type checkbox to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1386,7 +1386,7 @@ describe('ReactDOMInput', () => {
         <input type="checkbox" defaultChecked={true} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type checkbox to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1400,7 +1400,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type checkbox to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1414,7 +1414,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="checkbox" checked={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type checkbox to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1426,7 +1426,7 @@ describe('ReactDOMInput', () => {
   it('should warn if controlled radio switches to uncontrolled (checked is undefined)', () => {
     const stub = <input type="radio" checked={true} onChange={emptyFunction} />;
     ReactDOM.render(stub, container);
-    expect(() => ReactDOM.render(<input type="radio" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<input type="radio" />, container)).toErrorDev(
       'Warning: A component is changing a controlled input of type radio to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1440,7 +1440,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={null} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type radio to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1454,7 +1454,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" defaultChecked={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type radio to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1468,7 +1468,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type radio to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1482,7 +1482,7 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(stub, container);
     expect(() =>
       ReactDOM.render(<input type="radio" checked={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing an uncontrolled input of type radio to be controlled. ' +
         'Input elements should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1534,7 +1534,7 @@ describe('ReactDOMInput', () => {
     );
     expect(() =>
       ReactDOM.render(<input type="radio" value="value" />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is changing a controlled input of type radio to be uncontrolled. ' +
         'Input elements should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled input ' +
@@ -1816,7 +1816,7 @@ describe('ReactDOMInput', () => {
     }
 
     it('reverts the value attribute to the initial value', () => {
-      expect(renderInputWithStringThenWithUndefined).toWarnDev(
+      expect(renderInputWithStringThenWithUndefined).toErrorDev(
         'Input elements should not switch from controlled to ' +
           'uncontrolled (or vice versa).',
       );
@@ -1828,7 +1828,7 @@ describe('ReactDOMInput', () => {
     });
 
     it('preserves the value property', () => {
-      expect(renderInputWithStringThenWithUndefined).toWarnDev(
+      expect(renderInputWithStringThenWithUndefined).toErrorDev(
         'Input elements should not switch from controlled to ' +
           'uncontrolled (or vice versa).',
       );
@@ -1865,7 +1865,7 @@ describe('ReactDOMInput', () => {
     }
 
     it('reverts the value attribute to the initial value', () => {
-      expect(renderInputWithStringThenWithNull).toWarnDev([
+      expect(renderInputWithStringThenWithNull).toErrorDev([
         '`value` prop on `input` should not be null. ' +
           'Consider using an empty string to clear the component ' +
           'or `undefined` for uncontrolled components.',
@@ -1880,7 +1880,7 @@ describe('ReactDOMInput', () => {
     });
 
     it('preserves the value property', () => {
-      expect(renderInputWithStringThenWithNull).toWarnDev([
+      expect(renderInputWithStringThenWithNull).toErrorDev([
         '`value` prop on `input` should not be null. ' +
           'Consider using an empty string to clear the component ' +
           'or `undefined` for uncontrolled components.',
@@ -1898,7 +1898,7 @@ describe('ReactDOMInput', () => {
           <input value={Symbol('foobar')} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -1916,7 +1916,7 @@ describe('ReactDOMInput', () => {
           <input value={Symbol('foobar')} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -1958,7 +1958,7 @@ describe('ReactDOMInput', () => {
           <input value={() => {}} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -1976,7 +1976,7 @@ describe('ReactDOMInput', () => {
           <input value={() => {}} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');

--- a/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInvalidARIAHook-test.js
@@ -29,7 +29,7 @@ describe('ReactDOMInvalidARIAHook', () => {
       mountComponent({'aria-label': 'Bumble bees'});
     });
     it('should warn for one invalid aria-* prop', () => {
-      expect(() => mountComponent({'aria-badprop': 'maybe'})).toWarnDev(
+      expect(() => mountComponent({'aria-badprop': 'maybe'})).toErrorDev(
         'Warning: Invalid aria prop `aria-badprop` on <div> tag. ' +
           'For details, see https://fb.me/invalid-aria-prop',
       );
@@ -40,14 +40,14 @@ describe('ReactDOMInvalidARIAHook', () => {
           'aria-badprop': 'Very tall trees',
           'aria-malprop': 'Turbulent seas',
         }),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: Invalid aria props `aria-badprop`, `aria-malprop` on <div> ' +
           'tag. For details, see https://fb.me/invalid-aria-prop',
       );
     });
     it('should warn for an improperly cased aria-* prop', () => {
       // The valid attribute name is aria-haspopup.
-      expect(() => mountComponent({'aria-hasPopup': 'true'})).toWarnDev(
+      expect(() => mountComponent({'aria-hasPopup': 'true'})).toErrorDev(
         'Warning: Unknown ARIA attribute `aria-hasPopup`. ' +
           'Did you mean `aria-haspopup`?',
       );
@@ -55,7 +55,7 @@ describe('ReactDOMInvalidARIAHook', () => {
 
     it('should warn for use of recognized camel case aria attributes', () => {
       // The valid attribute name is aria-haspopup.
-      expect(() => mountComponent({ariaHasPopup: 'true'})).toWarnDev(
+      expect(() => mountComponent({ariaHasPopup: 'true'})).toErrorDev(
         'Warning: Invalid ARIA attribute `ariaHasPopup`. ' +
           'Did you mean `aria-haspopup`?',
       );
@@ -63,7 +63,7 @@ describe('ReactDOMInvalidARIAHook', () => {
 
     it('should warn for use of unrecognized camel case aria attributes', () => {
       // The valid attribute name is aria-haspopup.
-      expect(() => mountComponent({ariaSomethingInvalid: 'true'})).toWarnDev(
+      expect(() => mountComponent({ariaSomethingInvalid: 'true'})).toErrorDev(
         'Warning: Invalid ARIA attribute `ariaSomethingInvalid`. ARIA ' +
           'attributes follow the pattern aria-* and must be lowercase.',
       );

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -41,7 +41,7 @@ describe('ReactDOMOption', () => {
     let node;
     expect(() => {
       node = ReactTestUtils.renderIntoDocument(el);
-    }).toWarnDev(
+    }).toErrorDev(
       'Only strings and numbers are supported as <option> children.\n' +
         '    in option (at **)',
     );
@@ -118,7 +118,7 @@ describe('ReactDOMOption', () => {
           <span />
         </option>,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Only strings and numbers are supported as <option> children.',
     );
     expect(node.innerHTML).toBe('hello[object Object]');

--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -81,7 +81,7 @@ describe('ReactDOMRoot', () => {
         <span />
       </div>,
     );
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev('Extra attributes');
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev('Extra attributes');
   });
 
   it('does not clear existing children', async () => {
@@ -118,7 +118,7 @@ describe('ReactDOMRoot', () => {
     expect(container.textContent).toEqual('Hi');
     expect(() => {
       ReactDOM.render(<div>Bye</div>, container);
-    }).toWarnDev(
+    }).toErrorDev(
       [
         // We care about this warning:
         'You are calling ReactDOM.render() on a container that was previously ' +
@@ -141,7 +141,7 @@ describe('ReactDOMRoot', () => {
     expect(container.textContent).toEqual('Hi');
     expect(() => {
       ReactDOM.hydrate(<div>Hi</div>, container);
-    }).toWarnDev(
+    }).toErrorDev(
       [
         // We care about this warning:
         'You are calling ReactDOM.hydrate() on a container that was previously ' +
@@ -162,7 +162,7 @@ describe('ReactDOMRoot', () => {
     let unmounted = false;
     expect(() => {
       unmounted = ReactDOM.unmountComponentAtNode(container);
-    }).toWarnDev(
+    }).toErrorDev(
       [
         // We care about this warning:
         'You are calling ReactDOM.unmountComponentAtNode() on a container that was previously ' +
@@ -191,7 +191,7 @@ describe('ReactDOMRoot', () => {
     let unmounted = false;
     expect(() => {
       unmounted = ReactDOM.unmountComponentAtNode(container);
-    }).toWarnDev('Did you mean to call root.unmount()?', {withoutStack: true});
+    }).toErrorDev('Did you mean to call root.unmount()?', {withoutStack: true});
     expect(unmounted).toBe(false);
     Scheduler.unstable_flushAll();
     expect(container.textContent).toEqual('Hi');
@@ -204,7 +204,7 @@ describe('ReactDOMRoot', () => {
     ReactDOM.render(<div>Hi</div>, container);
     expect(() => {
       ReactDOM.createRoot(container);
-    }).toWarnDev(
+    }).toErrorDev(
       'You are calling ReactDOM.createRoot() on a container that was previously ' +
         'passed to ReactDOM.render(). This is not supported.',
       {withoutStack: true},
@@ -215,7 +215,7 @@ describe('ReactDOMRoot', () => {
     ReactDOM.createRoot(container);
     expect(() => {
       ReactDOM.createRoot(container);
-    }).toWarnDev(
+    }).toErrorDev(
       'You are calling ReactDOM.createRoot() on a container that ' +
         'has already been passed to createRoot() before. Instead, call ' +
         'root.render() on the existing root instead if you want to update it.',

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -610,7 +610,7 @@ describe('ReactDOMSelect', () => {
           <option value="test" />
         </select>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       '`value` prop on `select` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
@@ -633,7 +633,7 @@ describe('ReactDOMSelect', () => {
       );
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<App />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<App />)).toErrorDev(
       'Use the `defaultValue` or `value` props on <select> instead of ' +
         'setting `selected` on <option>.',
     );
@@ -648,7 +648,7 @@ describe('ReactDOMSelect', () => {
           <option value="test" />
         </select>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       '`value` prop on `select` should not be null. ' +
         'Consider using an empty array when `multiple` is ' +
         'set to `true` to clear the component or `undefined` ' +
@@ -695,7 +695,7 @@ describe('ReactDOMSelect', () => {
           <option value="gorilla">A gorilla!</option>
         </select>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Select elements must be either controlled or uncontrolled ' +
         '(specify either the value prop, or the defaultValue prop, but not ' +
         'both). Decide between using a controlled or uncontrolled select ' +
@@ -847,7 +847,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -863,7 +863,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -889,7 +889,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -905,7 +905,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -933,7 +933,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -949,7 +949,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('');
     });
@@ -965,7 +965,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 
@@ -991,7 +991,7 @@ describe('ReactDOMSelect', () => {
             <option value="giraffe">A giraffe!</option>
           </select>,
         );
-      }).toWarnDev('Invalid value for prop `value`');
+      }).toErrorDev('Invalid value for prop `value`');
 
       expect(node.value).toBe('monkey');
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -606,7 +606,7 @@ describe('ReactDOMServerIntegration', () => {
         // so that it gets deduplicated later, and doesn't fail the test.
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
-        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.');
+        }).toErrorDev('The tag <nonstandard> is unrecognized in this browser.');
 
         const e = await render(<nonstandard foo="bar" />);
         expect(e.getAttribute('foo')).toBe('bar');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -146,7 +146,7 @@ describe('ReactDOMServerIntegration', () => {
         // so that it gets deduplicated later, and doesn't fail the test.
         expect(() => {
           ReactDOM.render(<nonstandard />, document.createElement('div'));
-        }).toWarnDev('The tag <nonstandard> is unrecognized in this browser.');
+        }).toErrorDev('The tag <nonstandard> is unrecognized in this browser.');
 
         const e = await render(<nonstandard>Text</nonstandard>);
         expect(e.tagName).toBe('NONSTANDARD');
@@ -982,7 +982,7 @@ describe('ReactDOMServerIntegration', () => {
           let EmptyComponent = {};
           expect(() => {
             EmptyComponent = <EmptyComponent />;
-          }).toWarnDev(
+          }).toErrorDev(
             'Warning: React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: object. You likely forgot to export your ' +
@@ -1006,7 +1006,7 @@ describe('ReactDOMServerIntegration', () => {
           let NullComponent = null;
           expect(() => {
             NullComponent = <NullComponent />;
-          }).toWarnDev(
+          }).toErrorDev(
             'Warning: React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: null.',
@@ -1024,7 +1024,7 @@ describe('ReactDOMServerIntegration', () => {
           let UndefinedComponent = undefined;
           expect(() => {
             UndefinedComponent = <UndefinedComponent />;
-          }).toWarnDev(
+          }).toErrorDev(
             'Warning: React.createElement: type is invalid -- expected a string ' +
               '(for built-in components) or a class/function (for composite ' +
               'components) but got: undefined. You likely forgot to export your ' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -170,7 +170,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
   });
 
   runTests(itRenders, itRenders, fn =>
-    expect(fn).toWarnDev(
+    expect(fn).toErrorDev(
       'Warning: A future version of React will block javascript: URLs as a security precaution. ' +
         'Use event handlers instead if you can. If you need to generate unsafe HTML try using ' +
         'dangerouslySetInnerHTML instead. React was passed "javascript:notfine".\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -225,9 +225,9 @@ describe('ReactDOMServerLifecycles', () => {
       }
     }
 
-    expect(() =>
-      ReactDOMServer.renderToString(<Component />),
-    ).toLowPriorityWarnDev('componentWillMount has been renamed');
+    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+      'componentWillMount has been renamed',
+    );
     expect(log).toEqual(['componentWillMount', 'UNSAFE_componentWillMount']);
   });
 
@@ -279,9 +279,9 @@ describe('ReactDOMServerLifecycles', () => {
       }
     }
 
-    expect(() =>
-      ReactDOMServer.renderToString(<Component />),
-    ).toLowPriorityWarnDev('componentWillMount has been renamed');
+    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+      'componentWillMount has been renamed',
+    );
   });
 
   it('should warn about deprecated lifecycle hooks', () => {
@@ -292,9 +292,9 @@ describe('ReactDOMServerLifecycles', () => {
       }
     }
 
-    expect(() =>
-      ReactDOMServer.renderToString(<Component />),
-    ).toLowPriorityWarnDev('componentWillMount has been renamed');
+    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+      'componentWillMount has been renamed',
+    );
 
     // De-duped
     ReactDOMServer.renderToString(<Component />);

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -180,7 +180,7 @@ describe('ReactDOMServerLifecycles', () => {
       }
     }
 
-    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+    expect(() => ReactDOMServer.renderToString(<Component />)).toErrorDev(
       'Component.getDerivedStateFromProps(): A valid state object (or null) must ' +
         'be returned. You have returned undefined.',
     );
@@ -199,7 +199,7 @@ describe('ReactDOMServerLifecycles', () => {
       }
     }
 
-    expect(() => ReactDOMServer.renderToString(<Component />)).toWarnDev(
+    expect(() => ReactDOMServer.renderToString(<Component />)).toErrorDev(
       '`Component` uses `getDerivedStateFromProps` but its initial state is ' +
         'undefined. This is not recommended. Instead, define the initial state by ' +
         'assigning an object to `this.state` in the constructor of `Component`. ' +
@@ -257,7 +257,7 @@ describe('ReactDOMServerLifecycles', () => {
       expect(ReactDOMServer.renderToStaticMarkup(<Outer />)).toBe(
         '<div>1-2</div>',
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: setState(...): Can only update a mounting component. This ' +
         'usually means you called setState() outside componentWillMount() on ' +
         'the server. This is a no-op.\n\n' +

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -341,7 +341,7 @@ describe('ReactDOMServerPartialHydration', () => {
       act(() => {
         ReactDOM.hydrate(<App />, container);
       });
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Cannot hydrate Suspense in legacy mode. Switch from ' +
         'ReactDOM.hydrate(element, container) to ' +
         'ReactDOM.createBlockingRoot(container, { hydrate: true })' +

--- a/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMShorthandCSSPropertyCollision-test.internal.js
@@ -27,7 +27,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     ReactDOM.render(<div style={{font: 'foo', fontStyle: 'bar'}} />, container);
     expect(() =>
       ReactDOM.render(<div style={{font: 'foo'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender (fontStyle) ' +
         'when a conflicting property is set (font) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
@@ -45,7 +45,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         <div style={{font: 'qux', fontStyle: 'baz'}} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Updating a style property during rerender (font) when ' +
         'a conflicting property is set (fontStyle) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
@@ -55,7 +55,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     );
     expect(() =>
       ReactDOM.render(<div style={{fontStyle: 'baz'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender (font) when ' +
         'a conflicting property is set (fontStyle) can lead to styling ' +
         "bugs. To avoid this, don't mix shorthand and non-shorthand " +
@@ -72,7 +72,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     );
     expect(() =>
       ReactDOM.render(<div style={{background: 'yellow'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender ' +
         '(backgroundPosition) when a conflicting property is set ' +
         "(background) can lead to styling bugs. To avoid this, don't mix " +
@@ -91,7 +91,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     );
     expect(() =>
       ReactDOM.render(<div style={{backgroundPosition: 'top'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender (background) ' +
         'when a conflicting property is set (backgroundPosition) can lead ' +
         "to styling bugs. To avoid this, don't mix shorthand and " +
@@ -107,7 +107,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     );
     expect(() =>
       ReactDOM.render(<div style={{borderLeft: '1px solid red'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender (borderStyle) ' +
         'when a conflicting property is set (borderLeft) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +
@@ -120,7 +120,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
         <div style={{borderStyle: 'dashed', borderLeft: '1px solid red'}} />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Updating a style property during rerender (borderStyle) ' +
         'when a conflicting property is set (borderLeft) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +
@@ -135,7 +135,7 @@ describe('ReactDOMShorthandCSSPropertyCollision', () => {
     );
     expect(() =>
       ReactDOM.render(<div style={{borderStyle: 'dotted'}} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Removing a style property during rerender (borderLeft) ' +
         'when a conflicting property is set (borderStyle) can lead to ' +
         "styling bugs. To avoid this, don't mix shorthand and " +

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -294,7 +294,7 @@ describe('ReactDOMTextarea', () => {
 
     expect(() => {
       node = renderTextarea(stub, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
 
@@ -346,7 +346,7 @@ describe('ReactDOMTextarea', () => {
     let node;
     expect(() => {
       node = renderTextarea(<textarea>{17}</textarea>);
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
     expect(node.value).toBe('17');
@@ -356,7 +356,7 @@ describe('ReactDOMTextarea', () => {
     let node;
     expect(() => {
       node = renderTextarea(<textarea>{false}</textarea>);
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
     expect(node.value).toBe('false');
@@ -371,7 +371,7 @@ describe('ReactDOMTextarea', () => {
     let node;
     expect(() => {
       node = renderTextarea(<textarea>{obj}</textarea>);
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
     expect(node.value).toBe('sharkswithlasers');
@@ -387,7 +387,7 @@ describe('ReactDOMTextarea', () => {
           </textarea>,
         ),
       ).toThrow('<textarea> can only have at most one child');
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
 
@@ -401,7 +401,7 @@ describe('ReactDOMTextarea', () => {
             </textarea>,
           )),
       ).not.toThrow();
-    }).toWarnDev(
+    }).toErrorDev(
       'Use the `defaultValue` or `value` props instead of setting children on <textarea>.',
     );
 
@@ -417,7 +417,7 @@ describe('ReactDOMTextarea', () => {
   it('should warn if value is null', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(<textarea value={null} />),
-    ).toWarnDev(
+    ).toErrorDev(
       '`value` prop on `textarea` should not be null. ' +
         'Consider using an empty string to clear the component or `undefined` ' +
         'for uncontrolled components.',
@@ -433,7 +433,7 @@ describe('ReactDOMTextarea', () => {
     );
     expect(() =>
       ReactTestUtils.renderIntoDocument(<InvalidComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'InvalidComponent contains a textarea with both value and defaultValue props. ' +
         'Textarea elements must be either controlled or uncontrolled ' +
         '(specify either the value prop, or the defaultValue prop, but not ' +
@@ -501,7 +501,7 @@ describe('ReactDOMTextarea', () => {
           <textarea value={Symbol('foobar')} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -514,7 +514,7 @@ describe('ReactDOMTextarea', () => {
           <textarea onChange={() => {}}>{Symbol('foo')}</textarea>,
           container,
         ),
-      ).toWarnDev('Use the `defaultValue` or `value` props');
+      ).toErrorDev('Use the `defaultValue` or `value` props');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -528,7 +528,7 @@ describe('ReactDOMTextarea', () => {
           <textarea value={Symbol('foo')} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -562,7 +562,7 @@ describe('ReactDOMTextarea', () => {
           <textarea value={() => {}} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -575,7 +575,7 @@ describe('ReactDOMTextarea', () => {
           <textarea onChange={() => {}}>{() => {}}</textarea>,
           container,
         ),
-      ).toWarnDev('Use the `defaultValue` or `value` props');
+      ).toErrorDev('Use the `defaultValue` or `value` props');
       const node = container.firstChild;
 
       expect(node.value).toBe('');
@@ -589,7 +589,7 @@ describe('ReactDOMTextarea', () => {
           <textarea value={() => {}} onChange={() => {}} />,
           container,
         ),
-      ).toWarnDev('Invalid value for prop `value`');
+      ).toErrorDev('Invalid value for prop `value`');
       const node = container.firstChild;
 
       expect(node.value).toBe('');

--- a/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.internal.js
@@ -40,7 +40,7 @@ describe('ReactDeprecationWarnings', () => {
     };
 
     ReactNoop.render(<FunctionalComponent />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Warning: FunctionalComponent: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
@@ -60,7 +60,7 @@ describe('ReactDeprecationWarnings', () => {
     }
 
     ReactNoop.render(<Component />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Warning: Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -653,7 +653,7 @@ describe('ReactErrorBoundaries', () => {
         </ErrorBoundary>,
         container,
       ),
-    ).toWarnDev('The above error occurred in the <BrokenRender> component:', {
+    ).toErrorDev('The above error occurred in the <BrokenRender> component:', {
       logAllErrors: true,
     });
 
@@ -808,7 +808,7 @@ describe('ReactErrorBoundaries', () => {
         </ErrorBoundary>,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
         'returns a class instance. ' +
         'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
@@ -2072,7 +2072,7 @@ describe('ReactErrorBoundaries', () => {
 
     try {
       let container = document.createElement('div');
-      expect(() => ReactDOM.render(<X />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<X />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
           '(for composite components) but got: null.',
@@ -2082,7 +2082,7 @@ describe('ReactErrorBoundaries', () => {
     }
     try {
       let container = document.createElement('div');
-      expect(() => ReactDOM.render(<Y />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Y />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
           '(for composite components) but got: undefined.',
@@ -2240,7 +2240,7 @@ describe('ReactErrorBoundaries', () => {
         </InvalidErrorBoundary>,
         container,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'InvalidErrorBoundary: Error boundaries should implement getDerivedStateFromError(). ' +
         'In that method, return a state update to display an error message or fallback UI.',
     );

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -108,7 +108,7 @@ describe('ReactFunctionComponent', () => {
 
     expect(() =>
       ReactDOM.render(<FunctionComponentWithChildContext />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'FunctionComponentWithChildContext: Function ' +
         'components do not support getDerivedStateFromProps.',
     );
@@ -130,7 +130,7 @@ describe('ReactFunctionComponent', () => {
         <FunctionComponentWithChildContext name="A" />,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'FunctionComponentWithChildContext(...): childContextTypes cannot ' +
         'be defined on a function component.',
     );
@@ -188,7 +188,7 @@ describe('ReactFunctionComponent', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ParentUsingStringRef />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
@@ -226,7 +226,7 @@ describe('ReactFunctionComponent', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ParentUsingFunctionRef />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
@@ -257,7 +257,7 @@ describe('ReactFunctionComponent', () => {
       instance1 = ReactTestUtils.renderIntoDocument(
         <AnonymousParentUsingJSX />,
       );
-    }).toWarnDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Warning: Function components cannot be given refs.');
     // Should be deduped (offending element is on the same line):
     instance1.forceUpdate();
     // Should also be deduped (offending element is on the same line):
@@ -281,13 +281,13 @@ describe('ReactFunctionComponent', () => {
       instance2 = ReactTestUtils.renderIntoDocument(
         <AnonymousParentNotUsingJSX />,
       );
-    }).toWarnDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Warning: Function components cannot be given refs.');
     // Should be deduped (same internal instance, no additional warnings)
     instance2.forceUpdate();
     // Could not be deduped (different internal instance):
     expect(() =>
       ReactTestUtils.renderIntoDocument(<AnonymousParentNotUsingJSX />),
-    ).toWarnDev('Warning: Function components cannot be given refs.');
+    ).toErrorDev('Warning: Function components cannot be given refs.');
 
     // When owner doesn't use JSX, but is named, we warn once per owner name
     class NamedParentNotUsingJSX extends React.Component {
@@ -301,7 +301,7 @@ describe('ReactFunctionComponent', () => {
     let instance3;
     expect(() => {
       instance3 = ReactTestUtils.renderIntoDocument(<NamedParentNotUsingJSX />);
-    }).toWarnDev('Warning: Function components cannot be given refs.');
+    }).toErrorDev('Warning: Function components cannot be given refs.');
     // Should be deduped (same owner name, no additional warnings):
     instance3.forceUpdate();
     // Should also be deduped (same owner name, no additional warnings):
@@ -332,7 +332,7 @@ describe('ReactFunctionComponent', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Parent />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Parent />)).toErrorDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
@@ -357,7 +357,7 @@ describe('ReactFunctionComponent', () => {
       return <div>{[<span />]}</div>;
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toErrorDev(
       'Each child in a list should have a unique "key" prop.\n\n' +
         'Check the render method of `Child`.',
     );
@@ -372,7 +372,7 @@ describe('ReactFunctionComponent', () => {
     Child.defaultProps = {test: 2};
     Child.propTypes = {test: PropTypes.string};
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toErrorDev(
       'Warning: Failed prop type: Invalid prop `test` of type `number` ' +
         'supplied to `Child`, expected `string`.\n' +
         '    in Child (at **)',

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -90,7 +90,7 @@ describe('ReactLegacyContextDisabled', () => {
         </LegacyProvider>,
         container,
       );
-    }).toWarnDev([
+    }).toErrorDev([
       'LegacyProvider uses the legacy childContextTypes API which is no longer supported. ' +
         'Use React.createContext() instead.',
       'LegacyClsConsumer uses the legacy contextTypes API which is no longer supported. ' +

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -675,7 +675,7 @@ describe('ReactLegacyErrorBoundaries', () => {
         </BothErrorBoundaries>,
         container,
       ),
-    ).toWarnDev('The above error occurred in the <BrokenRender> component', {
+    ).toErrorDev('The above error occurred in the <BrokenRender> component', {
       logAllErrors: true,
     });
 
@@ -840,7 +840,7 @@ describe('ReactLegacyErrorBoundaries', () => {
         </ErrorBoundary>,
         container,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: The <BrokenComponentWillMountWithContext /> component appears to be a function component that ' +
         'returns a class instance. ' +
         'Change BrokenComponentWillMountWithContext to a class that extends React.Component instead. ' +
@@ -2079,7 +2079,7 @@ describe('ReactLegacyErrorBoundaries', () => {
 
     try {
       let container = document.createElement('div');
-      expect(() => ReactDOM.render(<X />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<X />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
           '(for composite components) but got: null.',
@@ -2089,7 +2089,7 @@ describe('ReactLegacyErrorBoundaries', () => {
     }
     try {
       let container = document.createElement('div');
-      expect(() => ReactDOM.render(<Y />, container)).toWarnDev(
+      expect(() => ReactDOM.render(<Y />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
           '(for composite components) but got: undefined.',
@@ -2114,7 +2114,7 @@ describe('ReactLegacyErrorBoundaries', () => {
         </div>,
         container,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'ErrorBoundary: Error boundaries should implement getDerivedStateFromError()',
     );
     expect(container.firstChild.textContent).toBe('Sibling');

--- a/packages/react-dom/src/__tests__/ReactMount-test.js
+++ b/packages/react-dom/src/__tests__/ReactMount-test.js
@@ -59,7 +59,7 @@ describe('ReactMount', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(Component)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(Component)).toErrorDev(
       'Functions are not valid as a React child. ' +
         'This may happen if you return a Component instead of <Component /> from render. ' +
         'Or maybe you meant to call this function rather than return it.',
@@ -125,7 +125,7 @@ describe('ReactMount', () => {
     const container = document.createElement('container');
     container.innerHTML = ReactDOMServer.renderToString(<div />) + ' ';
 
-    expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
+    expect(() => ReactDOM.hydrate(<div />, container)).toErrorDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
       {withoutStack: true},
     );
@@ -135,7 +135,7 @@ describe('ReactMount', () => {
     const container = document.createElement('container');
     container.innerHTML = ' ' + ReactDOMServer.renderToString(<div />);
 
-    expect(() => ReactDOM.hydrate(<div />, container)).toWarnDev(
+    expect(() => ReactDOM.hydrate(<div />, container)).toErrorDev(
       'Did not expect server HTML to contain the text node " " in <container>.',
     );
   });
@@ -153,7 +153,7 @@ describe('ReactMount', () => {
 
     expect(() =>
       ReactDOM.render(<div />, iFrame.contentDocument.body),
-    ).toWarnDev(
+    ).toErrorDev(
       'Rendering components directly into document.body is discouraged',
       {withoutStack: true},
     );
@@ -171,7 +171,7 @@ describe('ReactMount', () => {
         <div>This markup contains an nbsp entity: &nbsp; client text</div>,
         div,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Server: "This markup contains an nbsp entity:   server text" ' +
         'Client: "This markup contains an nbsp entity:   client text"',
     );
@@ -195,7 +195,7 @@ describe('ReactMount', () => {
     // Test that blasting away children throws a warning
     const rootNode = container.firstChild;
 
-    expect(() => ReactDOM.render(<span />, rootNode)).toWarnDev(
+    expect(() => ReactDOM.render(<span />, rootNode)).toErrorDev(
       'Warning: render(...): Replacing React-rendered children with a new ' +
         'root component. If you intended to update the children of this node, ' +
         'you should instead have the existing children update their state and ' +
@@ -223,7 +223,7 @@ describe('ReactMount', () => {
     // Make sure ReactDOM and ReactDOMOther are different copies
     expect(ReactDOM).not.toEqual(ReactDOMOther);
 
-    expect(() => ReactDOMOther.unmountComponentAtNode(container)).toWarnDev(
+    expect(() => ReactDOMOther.unmountComponentAtNode(container)).toErrorDev(
       "Warning: unmountComponentAtNode(): The node you're attempting to unmount " +
         'was rendered by another copy of React.',
       {withoutStack: true},

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -50,7 +50,7 @@ describe('ReactMount', () => {
 
     // Test that unmounting at a root node gives a helpful warning
     const rootDiv = mainContainerDiv.firstChild;
-    expect(() => ReactDOM.unmountComponentAtNode(rootDiv)).toWarnDev(
+    expect(() => ReactDOM.unmountComponentAtNode(rootDiv)).toErrorDev(
       "Warning: unmountComponentAtNode(): The node you're attempting to " +
         'unmount was rendered by React and is not a top-level container. You ' +
         'may have accidentally passed in a React root node instead of its ' +
@@ -73,7 +73,7 @@ describe('ReactMount', () => {
 
     // Test that unmounting at a non-root node gives a different warning
     const nonRootDiv = mainContainerDiv.firstChild.firstChild;
-    expect(() => ReactDOM.unmountComponentAtNode(nonRootDiv)).toWarnDev(
+    expect(() => ReactDOM.unmountComponentAtNode(nonRootDiv)).toErrorDev(
       "Warning: unmountComponentAtNode(): The node you're attempting to " +
         'unmount was rendered by React and is not a top-level container. ' +
         'Instead, have the parent component update its state and rerender in ' +

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -204,7 +204,7 @@ describe('ReactMultiChild', () => {
           <Parent>{[<div key="1" />, <div key="1" />]}</Parent>,
           container,
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Encountered two children with the same key, `1`. ' +
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
@@ -264,7 +264,7 @@ describe('ReactMultiChild', () => {
           <Parent>{createIterable([<div key="1" />, <div key="1" />])}</Parent>,
           container,
         ),
-      ).toWarnDev(
+      ).toErrorDev(
         'Encountered two children with the same key, `1`. ' +
           'Keys should be unique so that components maintain their identity ' +
           'across updates. Non-unique keys may cause children to be ' +
@@ -285,7 +285,7 @@ describe('ReactMultiChild', () => {
       }
     }
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<Parent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Parent />, container)).toErrorDev(
       'Warning: Using Maps as children is unsupported and will likely yield ' +
         'unexpected results. Convert it to a sequence/iterable of keyed ' +
         'ReactElements instead.\n' +
@@ -303,7 +303,7 @@ describe('ReactMultiChild', () => {
     const div = document.createElement('div');
     expect(() => {
       ReactDOM.render(<Foo />, div);
-    }).toWarnDev(
+    }).toErrorDev(
       'Using Generators as children is unsupported and will likely yield ' +
         'unexpected results because enumerating a generator mutates it. You may ' +
         'convert it to an array with `Array.from()` or the `[...spread]` operator ' +

--- a/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
@@ -161,7 +161,7 @@ describe('ReactMultiChildText', () => {
         [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
         ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
       ]);
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: Each child in a list should have a unique "key" prop.',
       'Warning: Each child in a list should have a unique "key" prop.',
     ]);

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -203,7 +203,7 @@ describe('rendering React components at document', () => {
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
           {withoutStack: true},
         );
-      }).toWarnDev('Warning: Text content did not match.');
+      }).toErrorDev('Warning: Text content did not match.');
     });
 
     it('should throw on full document render w/ no markup', () => {
@@ -369,7 +369,7 @@ describe('rendering React components at document', () => {
     it('renders over an existing text child without throwing', () => {
       const container = document.createElement('div');
       container.textContent = 'potato';
-      expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toWarnDev(
+      expect(() => ReactDOM.hydrate(<div>parsnip</div>, container)).toErrorDev(
         'Expected server HTML to contain a matching <div> in <div>.',
       );
       expect(container.textContent).toBe('parsnip');
@@ -396,7 +396,7 @@ describe('rendering React components at document', () => {
 
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Warning: Text content did not match.');
+      ).toErrorDev('Warning: Text content did not match.');
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 
@@ -419,7 +419,7 @@ describe('rendering React components at document', () => {
       // getTestDocument() has an extra <meta> that we didn't render.
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toWarnDev('Did not expect server HTML to contain a <meta> in <head>.');
+      ).toErrorDev('Did not expect server HTML to contain a <meta> in <head>.');
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -35,7 +35,7 @@ describe('rendering React components at document', () => {
 
   describe('with old implicit hydration API', () => {
     function expectDeprecationWarningWithFiber(callback) {
-      expect(callback).toLowPriorityWarnDev(
+      expect(callback).toWarnDev(
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
@@ -197,7 +197,7 @@ describe('rendering React components at document', () => {
       expect(() => {
         expect(() =>
           ReactDOM.render(<Component text="Hello world" />, testDocument),
-        ).toLowPriorityWarnDev(
+        ).toWarnDev(
           'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
             'will stop working in React v17. Replace the ReactDOM.render() call ' +
             'with ReactDOM.hydrate() if you want React to attach to the server HTML.',

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -188,7 +188,7 @@ describe('ReactDOMServer', () => {
               <span unknown="test" />
             </div>,
           )),
-      ).toWarnDev(['React does not recognize the `hasOwnProperty` prop']);
+      ).toErrorDev(['React does not recognize the `hasOwnProperty` prop']);
       expect(html).toContain('<span unknown="test">');
     });
   });
@@ -644,7 +644,7 @@ describe('ReactDOMServer', () => {
     }
 
     ReactDOMServer.renderToString(<Foo />);
-    expect(() => jest.runOnlyPendingTimers()).toWarnDev(
+    expect(() => jest.runOnlyPendingTimers()).toErrorDev(
       'Warning: setState(...): Can only update a mounting component.' +
         ' This usually means you called setState() outside componentWillMount() on the server.' +
         ' This is a no-op.\n\nPlease check the code for the Foo component.',
@@ -672,7 +672,7 @@ describe('ReactDOMServer', () => {
     }
 
     ReactDOMServer.renderToString(<Baz />);
-    expect(() => jest.runOnlyPendingTimers()).toWarnDev(
+    expect(() => jest.runOnlyPendingTimers()).toErrorDev(
       'Warning: forceUpdate(...): Can only update a mounting component. ' +
         'This usually means you called forceUpdate() outside componentWillMount() on the server. ' +
         'This is a no-op.\n\nPlease check the code for the Baz component.',
@@ -819,7 +819,7 @@ describe('ReactDOMServer', () => {
           </svg>
         </div>,
       ),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: <inPUT /> is using incorrect casing. ' +
         'Use PascalCase for React components, ' +
         'or lowercase for HTML elements.',
@@ -833,7 +833,7 @@ describe('ReactDOMServer', () => {
   it('should warn about contentEditable and children', () => {
     expect(() =>
       ReactDOMServer.renderToString(<div contentEditable={true} children="" />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component is `contentEditable` and contains `children` ' +
         'managed by React. It is now your responsibility to guarantee that ' +
         'none of those nodes are unexpectedly modified or duplicated. This ' +
@@ -852,7 +852,7 @@ describe('ReactDOMServer', () => {
       expect(() =>
         ReactDOMServer.renderToString(<ClassWithRenderNotExtended />),
       ).toThrow(TypeError);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: The <ClassWithRenderNotExtended /> component appears to have a render method, ' +
         "but doesn't extend React.Component. This is likely to cause errors. " +
         'Change ClassWithRenderNotExtended to extend React.Component instead.',
@@ -921,7 +921,7 @@ describe('ReactDOMServer', () => {
       );
     }
 
-    expect(() => ReactDOMServer.renderToString(<App />)).toWarnDev([
+    expect(() => ReactDOMServer.renderToString(<App />)).toErrorDev([
       'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in span (at **)\n' +
         '    in b (at **)\n' +
@@ -970,7 +970,7 @@ describe('ReactDOMServer', () => {
       );
     }
 
-    expect(() => ReactDOMServer.renderToString(<App />)).toWarnDev([
+    expect(() => ReactDOMServer.renderToString(<App />)).toErrorDev([
       // ReactDOMServer(App > div > span)
       'Invalid ARIA attribute `ariaTypo`. ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in span (at **)\n' +
@@ -1017,7 +1017,7 @@ describe('ReactDOMServer', () => {
 
     expect(() => {
       ReactDOMServer.renderToString(<ComponentA />);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: ComponentA defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Consumer instead?',
@@ -1028,7 +1028,7 @@ describe('ReactDOMServer', () => {
 
     expect(() => {
       ReactDOMServer.renderToString(<ComponentB />);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: ComponentB defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Provider instead?',
@@ -1062,7 +1062,7 @@ describe('ReactDOMServer', () => {
       expect(() => {
         ReactDOMServer.renderToString(<Foo />);
       }).toThrow("Cannot read property 'world' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to undefined. ' +
@@ -1088,7 +1088,7 @@ describe('ReactDOMServer', () => {
       expect(() => {
         ReactDOMServer.renderToString(<Foo />);
       }).toThrow("Cannot read property 'hello' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to an object with keys {x, y}.',
@@ -1107,7 +1107,7 @@ describe('ReactDOMServer', () => {
       expect(() => {
         ReactDOMServer.renderToString(<Foo />);
       }).toThrow("Cannot read property 'world' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to a string.',

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -81,7 +81,7 @@ describe('ReactDOMServerHydration', () => {
 
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="x" />, element);
-      }).toLowPriorityWarnDev(
+      }).toWarnDev(
         'render(): Calling ReactDOM.render() to hydrate server-rendered markup ' +
           'will stop working in React v17. Replace the ReactDOM.render() call ' +
           'with ReactDOM.hydrate() if you want React to attach to the server HTML.',
@@ -355,12 +355,12 @@ describe('ReactDOMServerHydration', () => {
     const element = document.createElement('div');
     expect(() => {
       element.innerHTML = ReactDOMServer.renderToString(markup);
-    }).toLowPriorityWarnDev('componentWillMount has been renamed');
+    }).toWarnDev('componentWillMount has been renamed');
     expect(element.textContent).toBe('Hi');
 
     expect(() => {
       ReactDOM.hydrate(markup, element);
-    }).toLowPriorityWarnDev('componentWillMount has been renamed', {
+    }).toWarnDev('componentWillMount has been renamed', {
       withoutStack: true,
     });
     expect(element.textContent).toBe('Hi');

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -104,7 +104,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.render(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
+      }).toErrorDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -187,7 +187,7 @@ describe('ReactDOMServerHydration', () => {
       element.innerHTML = lastMarkup;
       expect(() => {
         instance = ReactDOM.hydrate(<TestComponent name="y" />, element);
-      }).toWarnDev('Text content did not match. Server: "x" Client: "y"');
+      }).toErrorDev('Text content did not match. Server: "x" Client: "y"');
       expect(mountCount).toEqual(4);
       expect(element.innerHTML.length > 0).toBe(true);
       expect(element.innerHTML).not.toEqual(lastMarkup);
@@ -248,7 +248,7 @@ describe('ReactDOMServerHydration', () => {
 
     expect(() =>
       ReactDOM.hydrate(<button autoFocus={false}>client</button>, element),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Text content did not match. Server: "server" Client: "client"',
     );
 
@@ -270,7 +270,7 @@ describe('ReactDOMServerHydration', () => {
         />,
         element,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration:none;color:black;height:10px" Client: ' +
         '"text-decoration:none;color:white;height:10px"',
@@ -317,7 +317,7 @@ describe('ReactDOMServerHydration', () => {
         />,
         element,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Prop `style` did not match. Server: ' +
         '"text-decoration: none; color: black; height: 10px;" Client: ' +
         '"text-decoration:none;color:black;height:10px"',
@@ -521,7 +521,7 @@ describe('ReactDOMServerHydration', () => {
         </React.Suspense>,
         element,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Did not expect server HTML to contain a <div> in <div>.',
       {withoutStack: true},
     );

--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -53,9 +53,7 @@ describe('ReactTestUtils', () => {
     MockedComponent.prototype.render = jest.fn();
 
     // Patch it up so it returns its children.
-    expect(() =>
-      ReactTestUtils.mockComponent(MockedComponent),
-    ).toLowPriorityWarnDev(
+    expect(() => ReactTestUtils.mockComponent(MockedComponent)).toWarnDev(
       'ReactTestUtils.mockComponent() is deprecated. ' +
         'Use shallow rendering or jest.mock() instead.\n\n' +
         'See https://fb.me/test-utils-mock-component for more information.',

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -108,7 +108,7 @@ describe('ReactTestUtils.act()', () => {
     it('does not warn in legacy mode', () => {
       expect(() => {
         ReactDOM.render(<App />, document.createElement('div'));
-      }).toWarnDev([]);
+      }).toErrorDev([]);
     });
 
     it('warns in strict mode', () => {
@@ -119,7 +119,7 @@ describe('ReactTestUtils.act()', () => {
           </React.StrictMode>,
           document.createElement('div'),
         );
-      }).toWarnDev([
+      }).toErrorDev([
         'An update to App ran an effect, but was not wrapped in act(...)',
         'An update to App ran an effect, but was not wrapped in act(...)',
       ]);
@@ -130,7 +130,7 @@ describe('ReactTestUtils.act()', () => {
         const root = ReactDOM.createBlockingRoot(document.createElement('div'));
         root.render(<App />);
         Scheduler.unstable_flushAll();
-      }).toWarnDev([
+      }).toErrorDev([
         'An update to App ran an effect, but was not wrapped in act(...)',
         'An update to App ran an effect, but was not wrapped in act(...)',
       ]);
@@ -141,7 +141,7 @@ describe('ReactTestUtils.act()', () => {
         const root = ReactDOM.createRoot(document.createElement('div'));
         root.render(<App />);
         Scheduler.unstable_flushAll();
-      }).toWarnDev([
+      }).toErrorDev([
         'An update to App ran an effect, but was not wrapped in act(...)',
         'An update to App ran an effect, but was not wrapped in act(...)',
       ]);
@@ -270,7 +270,7 @@ function runActTests(label, render, unmount, rerender) {
           render(<App />, container);
         });
 
-        expect(() => setValue(1)).toWarnDev([
+        expect(() => setValue(1)).toErrorDev([
           'An update to App inside a test was not wrapped in act(...).',
         ]);
       });
@@ -384,13 +384,13 @@ function runActTests(label, render, unmount, rerender) {
       });
 
       it('warns if you return a value inside act', () => {
-        expect(() => act(() => null)).toWarnDev(
+        expect(() => act(() => null)).toErrorDev(
           [
             'The callback passed to act(...) function must return undefined, or a Promise.',
           ],
           {withoutStack: true},
         );
-        expect(() => act(() => 123)).toWarnDev(
+        expect(() => act(() => 123)).toErrorDev(
           [
             'The callback passed to act(...) function must return undefined, or a Promise.',
           ],
@@ -399,7 +399,7 @@ function runActTests(label, render, unmount, rerender) {
       });
 
       it('warns if you try to await a sync .act call', () => {
-        expect(() => act(() => {}).then(() => {})).toWarnDev(
+        expect(() => act(() => {}).then(() => {})).toErrorDev(
           [
             'Do not await the result of calling act(...) with sync logic, it is not a Promise.',
           ],

--- a/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.internal.js
@@ -31,14 +31,14 @@ afterEach(() => {
 it('should warn in legacy mode', () => {
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
-  }).toWarnDev(
+  }).toErrorDev(
     ['Starting from React v17, the "scheduler" module will need to be mocked'],
     {withoutStack: true},
   );
   // does not warn twice
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
-  }).toWarnDev([]);
+  }).toErrorDev([]);
 });
 
 it('does not warn if Scheduler is mocked', () => {
@@ -52,5 +52,5 @@ it('does not warn if Scheduler is mocked', () => {
   // This should not warn
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
-  }).toWarnDev([]);
+  }).toErrorDev([]);
 });

--- a/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactUnmockedSchedulerWarning-test.js
@@ -24,13 +24,13 @@ beforeEach(() => {
 it('does not warn when rendering in legacy mode', () => {
   expect(() => {
     ReactDOM.render(<App />, document.createElement('div'));
-  }).toWarnDev([]);
+  }).toErrorDev([]);
 });
 
 it.experimental('should warn when rendering in concurrent mode', () => {
   expect(() => {
     ReactDOM.createRoot(document.createElement('div')).render(<App />);
-  }).toWarnDev(
+  }).toErrorDev(
     'In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' +
       'to guarantee consistent behaviour across tests and browsers.',
     {withoutStack: true},
@@ -38,13 +38,13 @@ it.experimental('should warn when rendering in concurrent mode', () => {
   // does not warn twice
   expect(() => {
     ReactDOM.createRoot(document.createElement('div')).render(<App />);
-  }).toWarnDev([]);
+  }).toErrorDev([]);
 });
 
 it.experimental('should warn when rendering in blocking mode', () => {
   expect(() => {
     ReactDOM.createBlockingRoot(document.createElement('div')).render(<App />);
-  }).toWarnDev(
+  }).toErrorDev(
     'In Concurrent or Sync modes, the "scheduler" module needs to be mocked ' +
       'to guarantee consistent behaviour across tests and browsers.',
     {withoutStack: true},
@@ -52,5 +52,5 @@ it.experimental('should warn when rendering in blocking mode', () => {
   // does not warn twice
   expect(() => {
     ReactDOM.createBlockingRoot(document.createElement('div')).render(<App />);
-  }).toWarnDev([]);
+  }).toErrorDev([]);
 });

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -863,7 +863,7 @@ describe('ReactUpdates', () => {
     let component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => {
-      expect(() => component.setState({}, 'no')).toWarnDev(
+      expect(() => component.setState({}, 'no')).toErrorDev(
         'setState(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
@@ -873,7 +873,7 @@ describe('ReactUpdates', () => {
     );
     component = ReactTestUtils.renderIntoDocument(<A />);
     expect(() => {
-      expect(() => component.setState({}, {foo: 'bar'})).toWarnDev(
+      expect(() => component.setState({}, {foo: 'bar'})).toErrorDev(
         'setState(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -906,7 +906,7 @@ describe('ReactUpdates', () => {
     let component = ReactTestUtils.renderIntoDocument(<A />);
 
     expect(() => {
-      expect(() => component.forceUpdate('no')).toWarnDev(
+      expect(() => component.forceUpdate('no')).toErrorDev(
         'forceUpdate(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: no.',
       );
@@ -916,7 +916,7 @@ describe('ReactUpdates', () => {
     );
     component = ReactTestUtils.renderIntoDocument(<A />);
     expect(() => {
-      expect(() => component.forceUpdate({foo: 'bar'})).toWarnDev(
+      expect(() => component.forceUpdate({foo: 'bar'})).toErrorDev(
         'forceUpdate(...): Expected the last optional `callback` argument to be ' +
           'a function. Instead received: [object Object].',
       );
@@ -1229,7 +1229,7 @@ describe('ReactUpdates', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<Foo />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo />, container)).toErrorDev(
       'Cannot update during an existing state transition',
     );
     expect(ops).toEqual(['base: 0, memoized: 0', 'base: 1, memoized: 1']);

--- a/packages/react-dom/src/__tests__/findDOMNode-test.js
+++ b/packages/react-dom/src/__tests__/findDOMNode-test.js
@@ -117,7 +117,7 @@ describe('findDOMNode', () => {
     );
 
     let match;
-    expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
+    expect(() => (match = ReactDOM.findDOMNode(parent))).toErrorDev([
       'Warning: findDOMNode is deprecated in StrictMode. ' +
         'findDOMNode was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -147,7 +147,7 @@ describe('findDOMNode', () => {
     );
 
     let match;
-    expect(() => (match = ReactDOM.findDOMNode(parent))).toWarnDev([
+    expect(() => (match = ReactDOM.findDOMNode(parent))).toErrorDev([
       'Warning: findDOMNode is deprecated in StrictMode. ' +
         'findDOMNode was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +

--- a/packages/react-dom/src/__tests__/refs-test.js
+++ b/packages/react-dom/src/__tests__/refs-test.js
@@ -169,7 +169,7 @@ describe('factory components', () => {
     let inst;
     expect(
       () => (inst = ReactTestUtils.renderIntoDocument(<Comp />)),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: The <Comp /> component appears to be a function component that returns a class instance. ' +
         'Change Comp to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -69,7 +69,7 @@ module.exports = function(initModules) {
       console.error.calls.reset();
     } else {
       // TODO: Rewrite tests that use this helper to enumerate expected errors.
-      // This will enable the helper to use the .toWarnDev() matcher instead of spying.
+      // This will enable the helper to use the .toErrorDev() matcher instead of spying.
       spyOnDev(console, 'error');
     }
 

--- a/packages/react-dom/src/__tests__/validateDOMNesting-test.js
+++ b/packages/react-dom/src/__tests__/validateDOMNesting-test.js
@@ -28,7 +28,7 @@ function expectWarnings(tags, warnings = [], withoutStack = 0) {
     element = <Tag>{element}</Tag>;
   }
 
-  expect(() => ReactDOM.render(element, container)).toWarnDev(warnings, {
+  expect(() => ReactDOM.render(element, container)).toErrorDev(warnings, {
     withoutStack,
   });
 }

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -216,7 +216,7 @@ describe('when Trusted Types are available in global object', () => {
       }
       expect(() => {
         ReactDOM.render(<Component />, container);
-      }).toWarnDev(
+      }).toErrorDev(
         "Warning: Using 'dangerouslySetInnerHTML' in an svg element with " +
           'Trusted Types enabled in an Internet Explorer will cause ' +
           'the trusted value to be converted to string. Assigning string ' +
@@ -231,7 +231,7 @@ describe('when Trusted Types are available in global object', () => {
   it('should warn once when rendering script tag in jsx on client', () => {
     expect(() => {
       ReactDOM.render(<script>alert("I am not executed")</script>, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Encountered a script tag while rendering React component. ' +
         'Scripts inside React components are never executed when rendering ' +
         'on the client. Consider using template tag instead ' +

--- a/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventResponderSystem-test.internal.js
@@ -274,7 +274,7 @@ describe('DOMEventResponderSystem', () => {
 
     expect(() => {
       ReactDOM.render(<Test />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Duplicate event responder "TestEventResponder" found in event listeners. ' +
         'Event listeners passed to elements cannot use the same event responder more than once.',
     );
@@ -707,7 +707,7 @@ describe('DOMEventResponderSystem', () => {
       };
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: isDefaultPrevented() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
         ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isDefaultPrevented() }`',
@@ -719,7 +719,7 @@ describe('DOMEventResponderSystem', () => {
       };
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: isPropagationStopped() is not available on event objects created from event responder modules ' +
         '(React Flare).' +
         ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.isPropagationStopped() }`',
@@ -731,7 +731,7 @@ describe('DOMEventResponderSystem', () => {
       };
       ReactDOM.render(<Test />, container);
       dispatchClickEvent(buttonRef.current);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: nativeEvent is not available on event objects created from event responder modules ' +
         '(React Flare).' +
         ' Try wrapping in a conditional, i.e. `if (event.type !== "press") { event.nativeEvent }`',

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -151,15 +151,15 @@ describe('SyntheticEvent', () => {
       'See https://fb.me/react-event-pooling for more information.';
 
     // once for each property accessed
-    expect(() => expect(syntheticEvent.type).toBe(null)).toWarnDev(
+    expect(() => expect(syntheticEvent.type).toBe(null)).toErrorDev(
       getExpectedWarning('type'),
       {withoutStack: true},
     );
-    expect(() => expect(syntheticEvent.nativeEvent).toBe(null)).toWarnDev(
+    expect(() => expect(syntheticEvent.nativeEvent).toBe(null)).toErrorDev(
       getExpectedWarning('nativeEvent'),
       {withoutStack: true},
     );
-    expect(() => expect(syntheticEvent.target).toBe(null)).toWarnDev(
+    expect(() => expect(syntheticEvent.target).toBe(null)).toErrorDev(
       getExpectedWarning('target'),
       {withoutStack: true},
     );
@@ -185,7 +185,7 @@ describe('SyntheticEvent', () => {
 
     expect(() => {
       syntheticEvent.type = 'MouseEvent';
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're setting the property `type` on a " +
         'released/nullified synthetic event. This is effectively a no-op. If you must ' +
@@ -211,7 +211,7 @@ describe('SyntheticEvent', () => {
     event.initEvent('click', true, true);
     node.dispatchEvent(event);
 
-    expect(() => syntheticEvent.preventDefault()).toWarnDev(
+    expect(() => syntheticEvent.preventDefault()).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `preventDefault` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +
@@ -238,7 +238,7 @@ describe('SyntheticEvent', () => {
 
     node.dispatchEvent(event);
 
-    expect(() => syntheticEvent.stopPropagation()).toWarnDev(
+    expect(() => syntheticEvent.stopPropagation()).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `stopPropagation` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +
@@ -266,7 +266,7 @@ describe('SyntheticEvent', () => {
 
     expect(() =>
       expect(syntheticEvent.isPropagationStopped()).toBe(false),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `isPropagationStopped` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +
@@ -294,7 +294,7 @@ describe('SyntheticEvent', () => {
 
     expect(() =>
       expect(syntheticEvent.isDefaultPrevented()).toBe(false),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the method `isDefaultPrevented` on a " +
         'released/nullified synthetic event. This is a no-op function. If you must ' +
@@ -316,7 +316,7 @@ describe('SyntheticEvent', () => {
     // access a property to cause the warning
     expect(() => {
       event.nativeEvent; // eslint-disable-line no-unused-expressions
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: This synthetic event is reused for performance reasons. If ' +
         "you're seeing this, you're accessing the property `nativeEvent` on a " +
         'released/nullified synthetic event. This is set to null. If you must ' +
@@ -338,7 +338,7 @@ describe('SyntheticEvent', () => {
     const eventHandler = e => {
       expect(() => {
         e.foo = 'bar';
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: This synthetic event is reused for performance reasons. If ' +
           "you're seeing this, you're adding a new property in the synthetic " +
           'event object. The property is never released. ' +

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -243,7 +243,7 @@ describe('ReactFabric', () => {
 
       expect(() => {
         viewRef.setNativeProps({});
-      }).toWarnDev([SET_NATIVE_PROPS_NOT_SUPPORTED_MESSAGE], {
+      }).toErrorDev([SET_NATIVE_PROPS_NOT_SUPPORTED_MESSAGE], {
         withoutStack: true,
       });
 
@@ -251,7 +251,7 @@ describe('ReactFabric', () => {
 
       expect(() => {
         viewRef.setNativeProps({foo: 'baz'});
-      }).toWarnDev([SET_NATIVE_PROPS_NOT_SUPPORTED_MESSAGE], {
+      }).toErrorDev([SET_NATIVE_PROPS_NOT_SUPPORTED_MESSAGE], {
         withoutStack: true,
       });
       expect(UIManager.updateView).not.toBeCalled();
@@ -329,7 +329,7 @@ describe('ReactFabric', () => {
       expect(nativeFabricUIManager.dispatchCommand).not.toBeCalled();
       expect(() => {
         ReactFabric.dispatchCommand(viewRef, 'updateCommand', [10, 20]);
-      }).toWarnDev([DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT], {
+      }).toErrorDev([DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT], {
         withoutStack: true,
       });
 
@@ -503,7 +503,7 @@ describe('ReactFabric', () => {
 
       expect(() => {
         viewRef.measureLayout(otherRef, successCallback, failureCallback);
-      }).toWarnDev(
+      }).toErrorDev(
         [
           'Warning: measureLayout on components using NativeMethodsMixin ' +
             'or ReactNative.NativeComponent is not currently supported in Fabric. ' +
@@ -1005,7 +1005,7 @@ describe('ReactFabric', () => {
     let match;
     expect(
       () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -1043,7 +1043,7 @@ describe('ReactFabric', () => {
     let match;
     expect(
       () => (match = ReactFabric.findHostInstance_DEPRECATED(parent)),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -1078,7 +1078,7 @@ describe('ReactFabric', () => {
     ReactFabric.render(<ContainsStrictModeChild ref={n => (parent = n)} />, 11);
 
     let match;
-    expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
+    expect(() => (match = ReactFabric.findNodeHandle(parent))).toErrorDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -1114,7 +1114,7 @@ describe('ReactFabric', () => {
     );
 
     let match;
-    expect(() => (match = ReactFabric.findNodeHandle(parent))).toWarnDev([
+    expect(() => (match = ReactFabric.findNodeHandle(parent))).toErrorDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -174,7 +174,7 @@ describe('ReactNative', () => {
       expect(UIManager.dispatchViewManagerCommand).not.toBeCalled();
       expect(() => {
         ReactNative.dispatchCommand(viewRef, 'updateCommand', [10, 20]);
-      }).toWarnDev([DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT], {
+      }).toErrorDev([DISPATCH_COMMAND_REQUIRES_HOST_COMPONENT], {
         withoutStack: true,
       });
 
@@ -565,7 +565,7 @@ describe('ReactNative', () => {
     let match;
     expect(
       () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -603,7 +603,7 @@ describe('ReactNative', () => {
     let match;
     expect(
       () => (match = ReactNative.findHostInstance_DEPRECATED(parent)),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: findHostInstance_DEPRECATED is deprecated in StrictMode. ' +
         'findHostInstance_DEPRECATED was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -638,7 +638,7 @@ describe('ReactNative', () => {
     ReactNative.render(<ContainsStrictModeChild ref={n => (parent = n)} />, 11);
 
     let match;
-    expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
+    expect(() => (match = ReactNative.findNodeHandle(parent))).toErrorDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of ContainsStrictModeChild which renders StrictMode children. ' +
         'Instead, add a ref directly to the element you want to reference. ' +
@@ -674,7 +674,7 @@ describe('ReactNative', () => {
     );
 
     let match;
-    expect(() => (match = ReactNative.findNodeHandle(parent))).toWarnDev([
+    expect(() => (match = ReactNative.findNodeHandle(parent))).toErrorDev([
       'Warning: findNodeHandle is deprecated in StrictMode. ' +
         'findNodeHandle was passed an instance of IsInStrictMode which is inside StrictMode. ' +
         'Instead, add a ref directly to the element you want to reference. ' +

--- a/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ErrorBoundaryReconciliation-test.internal.js
@@ -68,7 +68,7 @@ describe('ErrorBoundaryReconciliation', () => {
           </ErrorBoundary>,
         );
         Scheduler.unstable_flushAll();
-      }).toWarnDev(isConcurrent ? ['invalid', 'invalid'] : ['invalid']);
+      }).toErrorDev(isConcurrent ? ['invalid', 'invalid'] : ['invalid']);
       const Fallback = fallbackTagName;
       expect(renderer).toMatchRenderedOutput(<Fallback prop="ErrorBoundary" />);
     }

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -708,7 +708,7 @@ describe('ReactFragment', () => {
     expect(Scheduler).toFlushWithoutYielding();
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
@@ -752,12 +752,12 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
@@ -765,7 +765,7 @@ describe('ReactFragment', () => {
     expect(ReactNoop.getChildren()).toEqual([span(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -269,7 +269,7 @@ describe('ReactHooks', () => {
           throw new Error('Expected to ignore the callback.');
         }),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'State updates from the useState() and useReducer() Hooks ' +
         "don't support the second callback argument. " +
         'To execute a side effect after rendering, ' +
@@ -303,7 +303,7 @@ describe('ReactHooks', () => {
           throw new Error('Expected to ignore the callback.');
         }),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'State updates from the useState() and useReducer() Hooks ' +
         "don't support the second callback argument. " +
         'To execute a side effect after rendering, ' +
@@ -613,7 +613,7 @@ describe('ReactHooks', () => {
     expect(Scheduler).toHaveYielded(['Did commit: A']);
     expect(() => {
       root.update(<App dependencies={['A', 'B']} />);
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: The final argument passed to useLayoutEffect changed size ' +
         'between renders. The order and size of this array must remain ' +
         'constant.\n\n' +
@@ -639,7 +639,7 @@ describe('ReactHooks', () => {
 
     expect(() => {
       root.update(<App text="Hello" hasDeps={false} />);
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: useMemo received a final argument during this render, but ' +
         'not during the previous render. Even though the final argument is ' +
         'optional, its type cannot change between renders.',
@@ -661,7 +661,7 @@ describe('ReactHooks', () => {
       act(() => {
         ReactTestRenderer.create(<App deps={'hello'} />);
       });
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: useEffect received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
       'Warning: useLayoutEffect received a final argument that is not an array (instead, received `string`). ' +
@@ -675,7 +675,7 @@ describe('ReactHooks', () => {
       act(() => {
         ReactTestRenderer.create(<App deps={100500} />);
       });
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: useEffect received a final argument that is not an array (instead, received `number`). ' +
         'When specified, the final argument must be an array.',
       'Warning: useLayoutEffect received a final argument that is not an array (instead, received `number`). ' +
@@ -689,7 +689,7 @@ describe('ReactHooks', () => {
       act(() => {
         ReactTestRenderer.create(<App deps={{}} />);
       });
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: useEffect received a final argument that is not an array (instead, received `object`). ' +
         'When specified, the final argument must be an array.',
       'Warning: useLayoutEffect received a final argument that is not an array (instead, received `object`). ' +
@@ -717,7 +717,7 @@ describe('ReactHooks', () => {
 
     expect(() => {
       ReactTestRenderer.create(<App deps={'hello'} />);
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: useImperativeHandle received a final argument that is not an array (instead, received `string`). ' +
         'When specified, the final argument must be an array.',
     ]);
@@ -737,20 +737,20 @@ describe('ReactHooks', () => {
     }
 
     const root1 = ReactTestRenderer.create(null);
-    expect(() => root1.update(<App return={17} />)).toWarnDev([
+    expect(() => root1.update(<App return={17} />)).toErrorDev([
       'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up. You returned: 17',
     ]);
 
     const root2 = ReactTestRenderer.create(null);
-    expect(() => root2.update(<App return={null} />)).toWarnDev([
+    expect(() => root2.update(<App return={null} />)).toErrorDev([
       'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up. You returned null. If your ' +
         'effect does not require clean up, return undefined (or nothing).',
     ]);
 
     const root3 = ReactTestRenderer.create(null);
-    expect(() => root3.update(<App return={Promise.resolve()} />)).toWarnDev([
+    expect(() => root3.update(<App return={Promise.resolve()} />)).toErrorDev([
       'Warning: An effect function must not return anything besides a ' +
         'function, which is used for clean-up.\n\n' +
         'It looks like you wrote useEffect(async () => ...) or returned a Promise.',
@@ -845,7 +845,7 @@ describe('ReactHooks', () => {
       expect(() => {
         ReactTestRenderer.create(<App />);
       }).toThrow('create is not a function');
-    }).toWarnDev([
+    }).toErrorDev([
       'Expected useImperativeHandle() first argument to either be a ' +
         'ref callback or React.createRef() object. ' +
         'Instead received: an object with keys {focus}.',
@@ -865,7 +865,7 @@ describe('ReactHooks', () => {
 
     expect(() => {
       ReactTestRenderer.create(<App />);
-    }).toWarnDev([
+    }).toErrorDev([
       'Expected useImperativeHandle() second argument to be a function ' +
         'that creates a handle. Instead received: object.',
     ]);
@@ -933,7 +933,7 @@ describe('ReactHooks', () => {
       });
       return null;
     }
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev(
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks.',
     );
   });
@@ -951,7 +951,7 @@ describe('ReactHooks', () => {
       }, []);
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev(
       'Context can only be read while React is rendering',
     );
   });
@@ -973,7 +973,7 @@ describe('ReactHooks', () => {
       }, []);
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev(
       'Context can only be read while React is rendering',
     );
     expect(firstRead).toBe('light');
@@ -1044,7 +1044,7 @@ describe('ReactHooks', () => {
       return null;
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev([
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev([
       'Context can only be read while React is rendering',
     ]);
   });
@@ -1082,7 +1082,7 @@ describe('ReactHooks', () => {
           <Cls />
         </>,
       ),
-    ).toWarnDev(['Context can only be read while React is rendering']);
+    ).toErrorDev(['Context can only be read while React is rendering']);
   });
 
   it('warns when calling hooks inside useReducer', () => {
@@ -1104,7 +1104,7 @@ describe('ReactHooks', () => {
       expect(() => {
         ReactTestRenderer.create(<App />);
       }).toThrow('Rendered more hooks than during the previous render.');
-    }).toWarnDev([
+    }).toErrorDev([
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
       'Warning: React has detected a change in the order of Hooks called by App. ' +
@@ -1127,7 +1127,7 @@ describe('ReactHooks', () => {
       });
       return null;
     }
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev(
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks.',
     );
   });
@@ -1167,7 +1167,7 @@ describe('ReactHooks', () => {
           <App />
         </Boundary>,
       );
-    }).toWarnDev([
+    }).toErrorDev([
       // We see it twice due to replay
       'Context can only be read while React is rendering',
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
@@ -1202,7 +1202,7 @@ describe('ReactHooks', () => {
           <App />
         </Boundary>,
       );
-    }).toWarnDev([
+    }).toErrorDev([
       // We see it twice due to replay
       'Context can only be read while React is rendering',
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
@@ -1224,7 +1224,7 @@ describe('ReactHooks', () => {
       }, []);
     }
 
-    expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<App />)).toErrorDev(
       'Context can only be read while React is rendering',
     );
   });
@@ -1343,7 +1343,7 @@ describe('ReactHooks', () => {
     expect(renderCount).toBe(1);
 
     renderCount = 0;
-    expect(() => renderer.update(<Factory />)).toWarnDev(
+    expect(() => renderer.update(<Factory />)).toErrorDev(
       'Warning: The <Factory /> component appears to be a function component that returns a class instance. ' +
         'Change Factory to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -1557,7 +1557,7 @@ describe('ReactHooks', () => {
             // This is okay as far as this test is concerned.
             // We just want to verify that warnings are always logged.
           }
-        }).toWarnDev([
+        }).toErrorDev([
           'Warning: React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -1608,7 +1608,7 @@ describe('ReactHooks', () => {
             // This is okay as far as this test is concerned.
             // We just want to verify that warnings are always logged.
           }
-        }).toWarnDev([
+        }).toErrorDev([
           'Warning: React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -1688,7 +1688,7 @@ describe('ReactHooks', () => {
             // This is okay as far as this test is concerned.
             // We just want to verify that warnings are always logged.
           }
-        }).toWarnDev([
+        }).toErrorDev([
           'Warning: React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -1730,7 +1730,7 @@ describe('ReactHooks', () => {
         expect(() => root.update(<App update={true} />)).toThrow(
           'custom error',
         );
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: React has detected a change in the order of Hooks called by App. ' +
           'This will lead to bugs and errors if not fixed. For more information, ' +
           'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -1816,7 +1816,7 @@ describe('ReactHooks', () => {
     expect(() => {
       globalListener();
       globalListener();
-    }).toWarnDev([
+    }).toErrorDev([
       'An update to C inside a test was not wrapped in act',
       'An update to C inside a test was not wrapped in act',
       // Note: should *not* warn about updates on unmounted component.

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -195,7 +195,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           '3. You might have more than one copy of React in the same app\n' +
           'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: The <Counter /> component appears to be a function component that returns a class instance. ' +
         'Change Counter to a class that extends React.Component instead. ' +
         "If you can't use a class try assigning the prototype on the function as a workaround. " +
@@ -319,7 +319,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toFlushWithoutYielding();
       ReactNoop.render(null);
       expect(Scheduler).toFlushWithoutYielding();
-      expect(() => act(() => _updateCount(1))).toWarnDev(
+      expect(() => act(() => _updateCount(1))).toErrorDev(
         "Warning: Can't perform a React state update on an unmounted " +
           'component. This is a no-op, but it indicates a memory leak in your ' +
           'application. To fix, cancel all subscriptions and asynchronous ' +
@@ -986,7 +986,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         );
         expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-      }).toWarnDev(['An update to Counter ran an effect']);
+      }).toErrorDev(['An update to Counter ran an effect']);
 
       // A discrete event forces the passive effect to be flushed --
       // updateCount(1) happens first, so 2 wins.
@@ -1000,7 +1000,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Will set count to 1']);
       expect(() => {
         expect(Scheduler).toFlushAndYield(['Count: 2']);
-      }).toWarnDev([
+      }).toErrorDev([
         'An update to Counter ran an effect',
         'An update to Counter ran an effect',
       ]);
@@ -1049,7 +1049,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         );
         expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
         expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-      }).toWarnDev(['An update to Counter ran an effect']);
+      }).toErrorDev(['An update to Counter ran an effect']);
 
       expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
 
@@ -1065,7 +1065,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       expect(Scheduler).toHaveYielded(['Will set count to 1']);
       expect(() => {
         expect(Scheduler).toFlushAndYield(['Count: 2']);
-      }).toWarnDev([
+      }).toErrorDev([
         'An update to Counter ran an effect',
         'An update to Counter ran an effect',
       ]);
@@ -2271,7 +2271,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         expect(() => {
           expect(Scheduler).toFlushAndYield(['A: 2, B: 3, C: 0']);
         }).toThrow('Rendered more hooks than during the previous render');
-      }).toWarnDev([
+      }).toErrorDev([
         'Warning: React has detected a change in the order of Hooks called by App. ' +
           'This will lead to bugs and errors if not fixed. For more information, ' +
           'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
@@ -2367,7 +2367,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           expect(() => {
             expect(Scheduler).toFlushAndYield([]);
           }).toThrow('Rendered more hooks than during the previous render');
-        }).toWarnDev([
+        }).toErrorDev([
           'Warning: React has detected a change in the order of Hooks called by App. ' +
             'This will lead to bugs and errors if not fixed. For more information, ' +
             'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -1912,7 +1912,7 @@ describe('ReactIncremental', () => {
         'ShowLocale {"locale":"fr"}',
         'ShowBoth {"locale":"fr"}',
       ]),
-    ).toWarnDev(
+    ).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -1969,7 +1969,7 @@ describe('ReactIncremental', () => {
         'ShowBoth {"locale":"en","route":"/about"}',
         'ShowBoth {"locale":"en"}',
       ]),
-    ).toWarnDev(
+    ).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2000,7 +2000,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Recurse />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2039,7 +2039,7 @@ describe('ReactIncremental', () => {
     };
 
     ReactNoop.render(<Recurse />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       [
         'Warning: The <Recurse /> component appears to be a function component that returns a class instance. ' +
           'Change Recurse to a class that extends React.Component instead. ' +
@@ -2113,7 +2113,7 @@ describe('ReactIncremental', () => {
         'Intl {}',
         'ShowLocale {"locale":"ru"}',
       ]),
-    ).toWarnDev(
+    ).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2194,7 +2194,7 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Intl>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2288,7 +2288,7 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Stateful>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2359,7 +2359,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2411,7 +2411,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2424,7 +2424,7 @@ describe('ReactIncremental', () => {
     instance.setState({
       throwError: true,
     });
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Error boundaries should implement getDerivedStateFromError()',
     );
   });
@@ -2461,7 +2461,7 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<MyComponent />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       [
         'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
         'Legacy context API has been detected within a strict-mode tree.\n\n' +
@@ -2612,7 +2612,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2676,7 +2676,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2749,7 +2749,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2832,7 +2832,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.\n\n' +
@@ -2938,7 +2938,7 @@ describe('ReactIncremental', () => {
       ReactNoop.render(<Boundary />);
       expect(() => {
         expect(Scheduler).toFlushWithoutYielding();
-      }).toWarnDev(
+      }).toErrorDev(
         ['Legacy context API has been detected within a strict-mode tree'],
         {withoutStack: true},
       );

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1148,7 +1148,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <Connector />
       </Provider>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Legacy context API has been detected within a strict-mode tree.\n\n' +
         'The old API will be supported in all 16.x releases, but ' +
         'applications using it should migrate to the new version.\n\n' +
@@ -1183,7 +1183,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender />
       </ErrorBoundary>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev([
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
       'Warning: React.createElement: type is invalid -- expected a string',
       // React retries once on error
       'Warning: React.createElement: type is invalid -- expected a string',
@@ -1232,7 +1232,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <BrokenRender fail={true} />
       </ErrorBoundary>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev([
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
       'Warning: React.createElement: type is invalid -- expected a string',
       // React retries once on error
       'Warning: React.createElement: type is invalid -- expected a string',
@@ -1252,7 +1252,7 @@ describe('ReactIncrementalErrorHandling', () => {
 
   it('recovers from uncaught reconciler errors', () => {
     const InvalidType = undefined;
-    expect(() => ReactNoop.render(<InvalidType />)).toWarnDev(
+    expect(() => ReactNoop.render(<InvalidType />)).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string',
       {withoutStack: true},
     );
@@ -1645,7 +1645,7 @@ describe('ReactIncrementalErrorHandling', () => {
     ReactNoop.render(<Provider />);
     expect(() => {
       expect(Scheduler).toFlushAndThrow('Oops!');
-    }).toWarnDev(
+    }).toErrorDev(
       [
         'Warning: The <Provider /> component appears to be a function component that returns a class instance. ' +
           'Change Provider to a class that extends React.Component instead. ' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -22,7 +22,7 @@ describe('ReactIncrementalErrorLogging', () => {
     Scheduler = require('scheduler');
   });
 
-  // Note: in this test file we won't be using toWarnDev() matchers
+  // Note: in this test file we won't be using toErrorDev() matchers
   // because they filter out precisely the messages we want to test for.
   let oldConsoleError;
   beforeEach(() => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalPerf-test.internal.js
@@ -324,7 +324,7 @@ describe('ReactDebugFiberPerf', () => {
       </Parent>,
     );
     addComment('Should not print a warning');
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       [
         'Using UNSAFE_componentWillMount in strict mode is not recommended',
         'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
@@ -364,7 +364,7 @@ describe('ReactDebugFiberPerf', () => {
     }
     ReactNoop.render(<AllLifecycles />);
     addComment('Mount');
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       [
         'Using UNSAFE_componentWillMount in strict mode is not recommended',
         'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -75,7 +75,7 @@ describe('ReactIncrementalReflection', () => {
     // Render the rest and commit the updates.
     expect(() =>
       expect(Scheduler).toFlushAndYield(['componentDidMount: true']),
-    ).toWarnDev(
+    ).toErrorDev(
       'Using UNSAFE_componentWillMount in strict mode is not recommended',
       {withoutStack: true},
     );
@@ -114,7 +114,7 @@ describe('ReactIncrementalReflection', () => {
     }
 
     ReactNoop.render(<Foo mount={true} />);
-    expect(() => expect(Scheduler).toFlushAndYield(['Component'])).toWarnDev(
+    expect(() => expect(Scheduler).toFlushAndYield(['Component'])).toErrorDev(
       'Using UNSAFE_componentWillMount in strict mode is not recommended',
       {withoutStack: true},
     );
@@ -219,7 +219,7 @@ describe('ReactIncrementalReflection', () => {
 
     expect(() =>
       expect(Scheduler).toFlushAndYield([['componentDidMount', span()]]),
-    ).toWarnDev(
+    ).toErrorDev(
       [
         'Using UNSAFE_componentWillMount in strict mode is not recommended',
         'Using UNSAFE_componentWillUpdate in strict mode is not recommended',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.internal.js
@@ -1201,7 +1201,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo show={true} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +
@@ -1265,7 +1265,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Warning: A string ref, "bar", has been found within a strict mode tree.',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -345,7 +345,7 @@ describe('ReactIncrementalUpdates', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
       {withoutStack: true},
     );
@@ -383,7 +383,7 @@ describe('ReactIncrementalUpdates', () => {
       return {a: 'a'};
     });
 
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
       'An update (setState, replaceState, or forceUpdate) was scheduled ' +
         'from inside an update function. Update functions should be pure, ' +
         'with zero side-effects. Consider using componentDidUpdate or a ' +

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -525,7 +525,7 @@ describe('ReactLazy', () => {
     const LazyText = lazy(() => fakeImport(T));
     expect(() => {
       LazyText.defaultProps = {outer: 'Bye'};
-    }).toWarnDev(
+    }).toErrorDev(
       'React.lazy(...): It is not supported to assign `defaultProps` to ' +
         'a lazy component import. Either specify them where the component ' +
         'is defined, or create a wrapping component around it.',
@@ -626,7 +626,7 @@ describe('ReactLazy', () => {
     const LazyText = lazy(() => fakeImport(Text));
     expect(() => {
       LazyText.propTypes = {hello: () => {}};
-    }).toWarnDev(
+    }).toErrorDev(
       'React.lazy(...): It is not supported to assign `propTypes` to ' +
         'a lazy component import. Either specify them where the component ' +
         'is defined, or create a wrapping component around it.',
@@ -638,7 +638,7 @@ describe('ReactLazy', () => {
     const LazyAdd = lazy(() => fakeImport(Add));
     expect(() => {
       LazyAdd.propTypes = {};
-    }).toWarnDev(
+    }).toErrorDev(
       'React.lazy(...): It is not supported to assign `propTypes` to ' +
         'a lazy component import. Either specify them where the component ' +
         'is defined, or create a wrapping component around it.',
@@ -661,7 +661,7 @@ describe('ReactLazy', () => {
     await Promise.resolve();
     expect(() => {
       Scheduler.unstable_flushAll();
-    }).toWarnDev([
+    }).toErrorDev([
       'Invalid prop `inner` of type `string` supplied to `Add`, expected `number`.',
     ]);
     expect(root).toMatchRenderedOutput('22');
@@ -674,7 +674,7 @@ describe('ReactLazy', () => {
         </Suspense>,
       );
       expect(Scheduler).toFlushWithoutYielding();
-    }).toWarnDev(
+    }).toErrorDev(
       'Invalid prop `inner` of type `boolean` supplied to `Add`, expected `number`.',
     );
     expect(root).toMatchRenderedOutput('0');
@@ -846,7 +846,7 @@ describe('ReactLazy', () => {
     await Promise.resolve();
     expect(() => {
       expect(Scheduler).toFlushAndYield(['Inner default text']);
-    }).toWarnDev(
+    }).toErrorDev(
       'The prop `text` is marked as required in `T`, but its value is `undefined`',
     );
     expect(root).toMatchRenderedOutput('Inner default text');
@@ -859,7 +859,7 @@ describe('ReactLazy', () => {
         </Suspense>,
       );
       expect(Scheduler).toFlushAndYield([null]);
-    }).toWarnDev(
+    }).toErrorDev(
       'The prop `text` is marked as required in `T`, but its value is `null`',
     );
     expect(root).toMatchRenderedOutput(null);
@@ -888,7 +888,7 @@ describe('ReactLazy', () => {
 
     expect(() => {
       expect(Scheduler).toFlushAndYield(['A', 'B']);
-    }).toWarnDev('    in Text (at **)\n' + '    in Foo (at **)');
+    }).toErrorDev('    in Text (at **)\n' + '    in Foo (at **)');
     expect(root).toMatchRenderedOutput(<div>AB</div>);
   });
 
@@ -1086,6 +1086,6 @@ describe('ReactLazy', () => {
     await Promise.resolve();
     expect(() => {
       expect(Scheduler).toFlushAndYield([]);
-    }).toWarnDev('Function components cannot be given refs');
+    }).toErrorDev('Function components cannot be given refs');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.internal.js
@@ -56,7 +56,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev([
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
@@ -74,7 +74,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev([
+    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
@@ -311,7 +311,7 @@ describe('memo', () => {
       });
 
       it('warns if the first argument is undefined', () => {
-        expect(() => memo()).toWarnDev(
+        expect(() => memo()).toErrorDev(
           'memo: The first argument must be a component. Instead ' +
             'received: undefined',
           {withoutStack: true},
@@ -319,7 +319,7 @@ describe('memo', () => {
       });
 
       it('warns if the first argument is null', () => {
-        expect(() => memo(null)).toWarnDev(
+        expect(() => memo(null)).toErrorDev(
           'memo: The first argument must be a component. Instead ' +
             'received: null',
           {withoutStack: true},
@@ -337,7 +337,7 @@ describe('memo', () => {
         expect(() => {
           ReactNoop.render(<Fn inner="2" />);
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev(
+        }).toErrorDev(
           'Invalid prop `inner` of type `string` supplied to `FnInner`, expected `number`.',
         );
 
@@ -345,7 +345,7 @@ describe('memo', () => {
         expect(() => {
           ReactNoop.render(<Fn inner={false} />);
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev(
+        }).toErrorDev(
           'Invalid prop `inner` of type `boolean` supplied to `FnInner`, expected `number`.',
         );
       });
@@ -361,7 +361,7 @@ describe('memo', () => {
         expect(() => {
           ReactNoop.render(<Fn outer="3" />);
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev(
+        }).toErrorDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `string` supplied to `FnInner`, expected `number`.',
         );
@@ -370,7 +370,7 @@ describe('memo', () => {
         expect(() => {
           ReactNoop.render(<Fn outer={false} />);
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev(
+        }).toErrorDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `boolean` supplied to `FnInner`, expected `number`.',
         );
@@ -397,7 +397,7 @@ describe('memo', () => {
         expect(() => {
           ReactNoop.render(<Outer inner="2" middle="3" outer="4" />);
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev([
+        }).toErrorDev([
           'Invalid prop `outer` of type `string` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `string` supplied to `Inner`, expected `number`.',
           'Invalid prop `inner` of type `string` supplied to `Inner`, expected `number`.',
@@ -409,7 +409,7 @@ describe('memo', () => {
             <Outer inner={false} middle={false} outer={false} />,
           );
           expect(Scheduler).toFlushWithoutYielding();
-        }).toWarnDev([
+        }).toErrorDev([
           'Invalid prop `outer` of type `boolean` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `boolean` supplied to `Inner`, expected `number`.',
           'Invalid prop `inner` of type `boolean` supplied to `Inner`, expected `number`.',

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -56,7 +56,7 @@ describe('ReactNewContext', () => {
         let contextValue;
         expect(() => {
           contextValue = useContext(Context, observedBits);
-        }).toWarnDev(
+        }).toErrorDev(
           observedBits !== undefined
             ? 'useContext() second argument is reserved for future use in React. ' +
               `Passing it is not supported. You passed: ${observedBits}.`
@@ -72,7 +72,7 @@ describe('ReactNewContext', () => {
       let contextValue;
       expect(() => {
         contextValue = useContext(Context, observedBits);
-      }).toWarnDev(
+      }).toErrorDev(
         observedBits !== undefined
           ? 'useContext() second argument is reserved for future use in React. ' +
             `Passing it is not supported. You passed: ${observedBits}.`
@@ -88,7 +88,7 @@ describe('ReactNewContext', () => {
       let contextValue;
       expect(() => {
         contextValue = useContext(Context, observedBits);
-      }).toWarnDev(
+      }).toErrorDev(
         observedBits !== undefined
           ? 'useContext() second argument is reserved for future use in React. ' +
             `Passing it is not supported. You passed: ${observedBits}.`
@@ -1068,7 +1068,7 @@ describe('ReactNewContext', () => {
 
       // Update
       ReactNoop.render(<App value={2} />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
         'calculateChangedBits: Expected the return value to be a 31-bit ' +
           'integer. Instead received: 4294967295',
       );
@@ -1195,7 +1195,7 @@ describe('ReactNewContext', () => {
       );
       expect(() => {
         expect(Scheduler).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
-      }).toWarnDev(
+      }).toErrorDev(
         'Legacy context API has been detected within a strict-mode tree.\n\n' +
           'The old API will be supported in all 16.x releases, but applications ' +
           'using it should migrate to the new version.\n\n' +
@@ -1481,7 +1481,7 @@ describe('ReactNewContext', () => {
       }
 
       ReactNoop.render(<Cls />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev([
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
         'Context can only be read while React is rendering',
         'Cannot update during an existing state transition',
       ]);
@@ -1495,7 +1495,7 @@ describe('ReactNewContext', () => {
         return [Context].map(useContext);
       }
       ReactNoop.render(<Foo />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
         'useContext() second argument is reserved for future ' +
           'use in React. Passing it is not supported. ' +
           'You passed: 0.\n\n' +
@@ -1529,7 +1529,7 @@ describe('ReactNewContext', () => {
         return useContext(Context.Consumer);
       }
       ReactNoop.render(<Foo />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
         'Calling useContext(Context.Consumer) is not supported, may cause bugs, ' +
           'and will be removed in a future major release. ' +
           'Did you mean to call useContext(Context) instead?',
@@ -1543,7 +1543,7 @@ describe('ReactNewContext', () => {
         return null;
       }
       ReactNoop.render(<Foo />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toWarnDev(
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
         'Calling useContext(Context.Provider) is not supported. ' +
           'Did you mean to call useContext(Context) instead?',
       );
@@ -1844,7 +1844,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     expect(() => {
       ReactNoop.render(<Component />);
       expect(Scheduler).toFlushWithoutYielding();
-    }).toWarnDev(
+    }).toErrorDev(
       'Rendering <Context> directly is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
@@ -1891,7 +1891,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     expect(() => {
       ReactNoop.render(<Component />);
       expect(Scheduler).toFlushWithoutYielding();
-    }).toWarnDev(
+    }).toErrorDev(
       'Rendering <Context.Consumer.Consumer> is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Consumer> instead?',
     );
@@ -1915,7 +1915,7 @@ Context fuzz tester error! Copy and paste the following line into the test suite
     expect(() => {
       ReactNoop.render(<Component />);
       expect(Scheduler).toFlushWithoutYielding();
-    }).toWarnDev(
+    }).toErrorDev(
       'Rendering <Context.Consumer.Provider> is not supported and will be removed in ' +
         'a future major release. Did you mean to render <Context.Provider> instead?',
     );

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.internal.js
@@ -60,7 +60,7 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(elementBadType);
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: Unexpected type for suspenseCallback.',
     ]);
 
@@ -71,7 +71,7 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(elementMissingCallback);
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([]);
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([]);
   });
 
   it('1 then 0 suspense callback', () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -58,7 +58,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: "something" is not a supported revealOrder on ' +
         '<SuspenseList />. Did you mean "together", "forwards" or "backwards"?' +
         '\n    in SuspenseList (at **)' +
@@ -77,7 +77,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: "TOGETHER" is not a valid value for revealOrder on ' +
         '<SuspenseList />. Use lowercase "together" instead.' +
         '\n    in SuspenseList (at **)' +
@@ -96,7 +96,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: "forward" is not a valid value for revealOrder on ' +
         '<SuspenseList />. React uses the -s suffix in the spelling. ' +
         'Use "forwards" instead.' +
@@ -128,7 +128,7 @@ describe('ReactSuspenseList', () => {
       </Foo>,
     );
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: A single row was passed to a <SuspenseList revealOrder="forwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
@@ -148,7 +148,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: A single row was passed to a <SuspenseList revealOrder="backwards" />. ' +
         'This is not useful since it needs multiple rows. ' +
         'Did you mean to pass multiple children or an array?' +
@@ -173,7 +173,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo items={['A', 'B']} />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: A nested array was passed to row #0 in <SuspenseList />. ' +
         'Wrap it in an additional SuspenseList to configure its revealOrder: ' +
         '<SuspenseList revealOrder=...> ... ' +
@@ -1354,7 +1354,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: "collapse" is not a supported value for tail on ' +
         '<SuspenseList />. Did you mean "collapsed" or "hidden"?' +
         '\n    in SuspenseList (at **)' +
@@ -1373,7 +1373,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: <SuspenseList tail="collapsed" /> is only valid if ' +
         'revealOrder is "forwards" or "backwards". ' +
         'Did you mean to specify revealOrder="forwards"?' +

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -103,7 +103,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(() => Scheduler.unstable_flushAll()).toWarnDev([
+    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
       'Warning: maxDuration has been removed from React. ' +
         'Remove the maxDuration prop.' +
         '\n    in Suspense (at **)' +
@@ -1898,7 +1898,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           () => _setShow(true),
         );
       });
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: App triggered a user-blocking update that suspended.' + '\n\n',
       {withoutStack: true},
     );
@@ -1930,7 +1930,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           () => show(),
         );
       });
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: App triggered a user-blocking update that suspended.' + '\n\n',
       {withoutStack: true},
     );
@@ -1997,7 +1997,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
             () => _setShow(true),
           );
         });
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: A triggered a user-blocking update that suspended.' + '\n\n',
         {withoutStack: true},
       );

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -1317,7 +1317,7 @@ describe('ReactFreshIntegration', () => {
 
             export default Parent;
           `);
-        }).toWarnDev(
+        }).toErrorDev(
           'The <Parent /> component appears to be a function component ' +
             'that returns a class instance.',
         );

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -1195,7 +1195,7 @@ describe('ReactShallowRenderer', () => {
     }
 
     const shallowRenderer = createRenderer();
-    expect(() => shallowRenderer.render(<SimpleComponent />)).toWarnDev(
+    expect(() => shallowRenderer.render(<SimpleComponent />)).toErrorDev(
       'Warning: Failed context type: The context `name` is marked as ' +
         'required in `SimpleComponent`, but its value is `undefined`.\n' +
         '    in SimpleComponent (at **)',
@@ -1216,7 +1216,7 @@ describe('ReactShallowRenderer', () => {
     const shallowRenderer = createRenderer();
     expect(() =>
       shallowRenderer.render(React.createElement(SimpleComponent, {name: 123})),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: Invalid prop `name` of type `number` ' +
         'supplied to `SimpleComponent`, expected `string`.\n' +
         '    in SimpleComponent',
@@ -1344,7 +1344,7 @@ describe('ReactShallowRenderer', () => {
 
     const renderAndVerifyWarningAndError = (Component, typeString) => {
       expect(() => {
-        expect(() => shallowRenderer.render(<Component />)).toWarnDev(
+        expect(() => shallowRenderer.render(<Component />)).toErrorDev(
           'React.createElement: type is invalid -- expected a string ' +
             '(for built-in components) or a class/function (for composite components) ' +
             `but got: ${typeString}.`,
@@ -1555,7 +1555,7 @@ describe('ReactShallowRenderer', () => {
       expect(() => {
         const SomeComponent = React.forwardRef(SomeMemoComponent);
         shallowRenderer.render(<SomeComponent ref={testRef} />);
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: forwardRef requires a render function but received ' +
           'a `memo` component. Instead of forwardRef(memo(...)), use ' +
           'memo(forwardRef(...))',

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
@@ -1242,7 +1242,7 @@ describe('ReactShallowRendererMemo', () => {
     );
 
     const shallowRenderer = createRenderer();
-    expect(() => shallowRenderer.render(<SimpleComponent />)).toWarnDev(
+    expect(() => shallowRenderer.render(<SimpleComponent />)).toErrorDev(
       'Warning: Failed context type: The context `name` is marked as ' +
         'required in `SimpleComponent`, but its value is `undefined`.\n' +
         '    in SimpleComponent (at **)',
@@ -1265,7 +1265,7 @@ describe('ReactShallowRendererMemo', () => {
     const shallowRenderer = createRenderer();
     expect(() =>
       shallowRenderer.render(React.createElement(SimpleComponent, {name: 123})),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: Invalid prop `name` of type `number` ' +
         'supplied to `SimpleComponent`, expected `string`.\n' +
         '    in SimpleComponent',
@@ -1401,7 +1401,7 @@ describe('ReactShallowRendererMemo', () => {
 
     const renderAndVerifyWarningAndError = (Component, typeString) => {
       expect(() => {
-        expect(() => shallowRenderer.render(<Component />)).toWarnDev(
+        expect(() => shallowRenderer.render(<Component />)).toErrorDev(
           'React.createElement: type is invalid -- expected a string ' +
             '(for built-in components) or a class/function (for composite components) ' +
             `but got: ${typeString}.`,

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -281,7 +281,7 @@ describe('ReactTestRenderer', () => {
       }
     }
     ReactTestRenderer.create(<Baz />);
-    expect(() => ReactTestRenderer.create(<Foo />)).toWarnDev(
+    expect(() => ReactTestRenderer.create(<Foo />)).toErrorDev(
       'Warning: Function components cannot be given refs. Attempts ' +
         'to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.js
@@ -34,7 +34,7 @@ describe('ReactTestRenderer', () => {
       expect(() => {
         ReactTestRenderer.create(ReactDOM.createPortal('foo', container));
       }).toThrow();
-    }).toWarnDev('An invalid container has been provided.', {
+    }).toErrorDev('An invalid container has been provided.', {
       withoutStack: true,
     });
   });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
@@ -50,7 +50,7 @@ describe('ReactTestRenderer.act()', () => {
 
     expect(() => {
       setCtr(1);
-    }).toWarnDev([
+    }).toErrorDev([
       'An update to App inside a test was not wrapped in act(...)',
     ]);
   });

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -319,7 +319,7 @@ describe('ReactChildren', () => {
     });
 
     let instance;
-    expect(() => (instance = <div>{threeDivIterable}</div>)).toWarnDev(
+    expect(() => (instance = <div>{threeDivIterable}</div>)).toErrorDev(
       'Warning: Each child in a list should have a unique "key" prop.',
     );
 
@@ -903,7 +903,7 @@ describe('ReactChildren', () => {
 
       expect(() =>
         ReactTestUtils.renderIntoDocument(<ComponentReturningArray />),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: ' +
           'Each child in a list should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.' +
@@ -924,7 +924,7 @@ describe('ReactChildren', () => {
     it('warns for keys for arrays at the top level', () => {
       expect(() =>
         ReactTestUtils.renderIntoDocument([<div />, <div />]),
-      ).toWarnDev(
+      ).toErrorDev(
         'Warning: ' +
           'Each child in a list should have a unique "key" prop.' +
           ' See https://fb.me/react-warning-keys for more information.',

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -51,7 +51,7 @@ describe 'ReactCoffeeScriptClass', ->
       expect(->
         ReactDOM.render React.createElement(Foo), container
       ).toThrow()
-    ).toWarnDev([
+    ).toErrorDev([
       # A failed component renders twice in DEV
       'No `render` method found on the returned component instance',
       'No `render` method found on the returned component instance',
@@ -126,7 +126,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.'
+    ).toErrorDev 'Foo: getDerivedStateFromProps() is defined as an instance method and will be ignored. Instead, declare it as a static method.'
     undefined
 
   it 'warns if getDerivedStateFromError is not static', ->
@@ -137,7 +137,7 @@ describe 'ReactCoffeeScriptClass', ->
         {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getDerivedStateFromError() is defined as an instance method and will be ignored. Instead, declare it as a static method.'
+    ).toErrorDev 'Foo: getDerivedStateFromError() is defined as an instance method and will be ignored. Instead, declare it as a static method.'
     undefined
 
   it 'warns if getSnapshotBeforeUpdate is static', ->
@@ -148,7 +148,7 @@ describe 'ReactCoffeeScriptClass', ->
       {}
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.'
+    ).toErrorDev 'Foo: getSnapshotBeforeUpdate() is defined as a static method and will be ignored. Instead, declare it as an instance method.'
     undefined
 
   it 'warns if state not initialized before static getDerivedStateFromProps', ->
@@ -163,7 +163,7 @@ describe 'ReactCoffeeScriptClass', ->
       }
     expect(->
       ReactDOM.render(React.createElement(Foo, foo: 'foo'), container)
-    ).toWarnDev (
+    ).toErrorDev (
       '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
       'undefined. This is not recommended. Instead, define the initial state by ' +
       'assigning an object to `this.state` in the constructor of `Foo`. ' +
@@ -267,7 +267,7 @@ describe 'ReactCoffeeScriptClass', ->
 
       expect(->
         test React.createElement(Foo), 'SPAN', ''
-      ).toWarnDev('Foo.state: must be set to an object or null')
+      ).toErrorDev('Foo.state: must be set to an object or null')
     undefined
 
   it 'should render with null in the initial state property', ->
@@ -409,7 +409,7 @@ describe 'ReactCoffeeScriptClass', ->
 
     expect(->
       test React.createElement(Foo), 'SPAN', 'foo'
-    ).toWarnDev([
+    ).toErrorDev([
       'getInitialState was defined on Foo, a plain JavaScript class.',
       'getDefaultProps was defined on Foo, a plain JavaScript class.',
       'propTypes was defined as an instance property on Foo.',
@@ -448,7 +448,7 @@ describe 'ReactCoffeeScriptClass', ->
 
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: NamedComponent has a method called componentShouldUpdate().
        Did you mean shouldComponentUpdate()? The name is phrased as a
        question because the function is expected to return a value.'
@@ -466,7 +466,7 @@ describe 'ReactCoffeeScriptClass', ->
 
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: NamedComponent has a method called componentWillRecieveProps().
        Did you mean componentWillReceiveProps()?'
     )
@@ -483,7 +483,7 @@ describe 'ReactCoffeeScriptClass', ->
 
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: NamedComponent has a method called UNSAFE_componentWillRecieveProps().
        Did you mean UNSAFE_componentWillReceiveProps()?'
     )

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -494,13 +494,13 @@ describe 'ReactCoffeeScriptClass', ->
       test Inner(name: 'foo'), 'DIV', 'foo'
     expect(->
       expect(-> instance.replaceState {}).toThrow()
-    ).toLowPriorityWarnDev(
+    ).toWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true}
     )
     expect(->
       expect(-> instance.isMounted()).toThrow()
-    ).toLowPriorityWarnDev(
+    ).toWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true}
     )

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -154,7 +154,7 @@ describe('ReactContextValidator', () => {
       foo: PropTypes.string.isRequired,
     };
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Failed context type: ' +
         'The context `foo` is marked as required in `Component`, but its value ' +
         'is `undefined`.\n' +
@@ -200,7 +200,7 @@ describe('ReactContextValidator', () => {
       ReactTestUtils.renderIntoDocument(
         <ComponentInFooNumberContext fooValue={123} />,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed context type: ' +
         'Invalid context `foo` of type `number` supplied ' +
         'to `Component`, expected `string`.\n' +
@@ -226,7 +226,7 @@ describe('ReactContextValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<Component testContext={{bar: 123}} />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed child context type: ' +
         'The child context `foo` is marked as required in `Component`, but its ' +
         'value is `undefined`.\n' +
@@ -235,7 +235,7 @@ describe('ReactContextValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<Component testContext={{foo: 123}} />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed child context type: ' +
         'Invalid child context `foo` of type `number` ' +
         'supplied to `Component`, expected `string`.\n' +
@@ -265,7 +265,7 @@ describe('ReactContextValidator', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
         '`Context.Provider`, but its value is `undefined`.\n' +
         '    in Component (at **)',
@@ -292,7 +292,7 @@ describe('ReactContextValidator', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toErrorDev(
       'Warning: ComponentA.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentA or remove childContextTypes from it.',
@@ -301,7 +301,7 @@ describe('ReactContextValidator', () => {
     // Warnings should be deduped by component type
     ReactTestUtils.renderIntoDocument(<ComponentA />);
 
-    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toErrorDev(
       'Warning: ComponentB.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define ' +
         'getChildContext() on ComponentB or remove childContextTypes from it.',
@@ -348,7 +348,7 @@ describe('ReactContextValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ParentContextProvider />),
-    ).toWarnDev([
+    ).toErrorDev([
       'Warning: MiddleMissingContext.childContextTypes is specified but there is no ' +
         'getChildContext() method on the instance. You can either define getChildContext() ' +
         'on MiddleMissingContext or remove childContextTypes from it.',
@@ -508,7 +508,7 @@ describe('ReactContextValidator', () => {
           <ComponentA />
         </ParentContextProvider>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: ComponentA declares both contextTypes and contextType static properties. ' +
         'The legacy contextTypes property will be ignored.',
     );
@@ -526,7 +526,7 @@ describe('ReactContextValidator', () => {
           <ComponentB />
         </ParentContextProvider>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: ComponentB declares both contextTypes and contextType static properties. ' +
         'The legacy contextTypes property will be ignored.',
     );
@@ -551,7 +551,7 @@ describe('ReactContextValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<ComponentA />);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: ComponentA defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Consumer instead?',
@@ -562,7 +562,7 @@ describe('ReactContextValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<ComponentB />);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: ComponentB defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'Did you accidentally pass the Context.Provider instead?',
@@ -595,7 +595,7 @@ describe('ReactContextValidator', () => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<Foo />);
       }).toThrow("Cannot read property 'world' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to undefined. ' +
@@ -621,7 +621,7 @@ describe('ReactContextValidator', () => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<Foo />);
       }).toThrow("Cannot read property 'hello' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to an object with keys {x, y}.',
@@ -640,7 +640,7 @@ describe('ReactContextValidator', () => {
       expect(() => {
         ReactTestUtils.renderIntoDocument(<Foo />);
       }).toThrow("Cannot read property 'world' of undefined");
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo defines an invalid contextType. ' +
         'contextType should point to the Context object returned by React.createContext(). ' +
         'However, it is set to a string.',
@@ -660,14 +660,14 @@ describe('ReactContextValidator', () => {
     }
     ComponentB.contextType = Context;
 
-    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentA />)).toErrorDev(
       'Warning: ComponentA: Function components do not support contextType.',
     );
 
     // Warnings should be deduped by component type
     ReactTestUtils.renderIntoDocument(<ComponentA />);
 
-    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toErrorDev(
       'Warning: ComponentB: Function components do not support contextType.',
     );
   });

--- a/packages/react/src/__tests__/ReactCreateRef-test.js
+++ b/packages/react/src/__tests__/ReactCreateRef-test.js
@@ -37,7 +37,7 @@ describe('ReactCreateRef', () => {
           <div ref={{}} />
         </Wrapper>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Unexpected ref object provided for div. ' +
         'Use either a ref-setter function or React.createRef().\n' +
         '    in div (at **)\n' +
@@ -50,7 +50,7 @@ describe('ReactCreateRef', () => {
           <ExampleComponent ref={{}} />
         </Wrapper>,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Unexpected ref object provided for ExampleComponent. ' +
         'Use either a ref-setter function or React.createRef().\n' +
         '    in ExampleComponent (at **)\n' +

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -521,15 +521,11 @@ describe('ReactES6Class', () => {
 
   it('should throw AND warn when trying to access classic APIs', () => {
     const instance = test(<Inner name="foo" />, 'DIV', 'foo');
-    expect(() =>
-      expect(() => instance.replaceState({})).toThrow(),
-    ).toLowPriorityWarnDev(
+    expect(() => expect(() => instance.replaceState({})).toThrow()).toWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true},
     );
-    expect(() =>
-      expect(() => instance.isMounted()).toThrow(),
-    ).toLowPriorityWarnDev(
+    expect(() => expect(() => instance.isMounted()).toThrow()).toWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true},
     );

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -59,7 +59,7 @@ describe('ReactES6Class', () => {
     class Foo extends React.Component {}
     expect(() =>
       expect(() => ReactDOM.render(<Foo />, container)).toThrow(),
-    ).toWarnDev([
+    ).toErrorDev([
       // A failed component renders twice in DEV
       'Warning: Foo(...): No `render` method found on the returned component ' +
         'instance: you may have forgotten to define `render`.',
@@ -137,7 +137,7 @@ describe('ReactES6Class', () => {
         return <div />;
       }
     }
-    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toErrorDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
     );
@@ -152,7 +152,7 @@ describe('ReactES6Class', () => {
         return <div />;
       }
     }
-    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toErrorDev(
       'Foo: getDerivedStateFromError() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
     );
@@ -165,7 +165,7 @@ describe('ReactES6Class', () => {
         return <div />;
       }
     }
-    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toErrorDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
     );
@@ -183,7 +183,7 @@ describe('ReactES6Class', () => {
         return <div className={`${this.state.foo} ${this.state.bar}`} />;
       }
     }
-    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Foo foo="foo" />, container)).toErrorDev(
       '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
         'undefined. This is not recommended. Instead, define the initial state by ' +
         'assigning an object to `this.state` in the constructor of `Foo`. ' +
@@ -291,7 +291,7 @@ describe('ReactES6Class', () => {
           return <span />;
         }
       }
-      expect(() => test(<Foo />, 'SPAN', '')).toWarnDev(
+      expect(() => test(<Foo />, 'SPAN', '')).toErrorDev(
         'Foo.state: must be set to an object or null',
       );
     });
@@ -443,7 +443,7 @@ describe('ReactES6Class', () => {
       }
     }
 
-    expect(() => test(<Foo />, 'SPAN', 'foo')).toWarnDev([
+    expect(() => test(<Foo />, 'SPAN', 'foo')).toErrorDev([
       'getInitialState was defined on Foo, a plain JavaScript class.',
       'getDefaultProps was defined on Foo, a plain JavaScript class.',
       'propTypes was defined as an instance property on Foo.',
@@ -477,7 +477,7 @@ describe('ReactES6Class', () => {
       }
     }
 
-    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toWarnDev(
+    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
       'Warning: ' +
         'NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
@@ -495,7 +495,7 @@ describe('ReactES6Class', () => {
       }
     }
 
-    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toWarnDev(
+    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
       'Warning: ' +
         'NamedComponent has a method called componentWillRecieveProps(). Did ' +
         'you mean componentWillReceiveProps()?',
@@ -512,7 +512,7 @@ describe('ReactES6Class', () => {
       }
     }
 
-    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toWarnDev(
+    expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
       'Warning: ' +
         'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -75,7 +75,7 @@ describe('ReactElement', () => {
         );
       }
     }
-    expect(() => ReactDOM.render(<Parent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Parent />, container)).toErrorDev(
       'Child: `key` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
@@ -85,7 +85,7 @@ describe('ReactElement', () => {
 
   it('should warn when `key` is being accessed on a host element', () => {
     const element = <div key="3" />;
-    expect(() => void element.props.key).toWarnDev(
+    expect(() => void element.props.key).toErrorDev(
       'div: `key` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
@@ -110,7 +110,7 @@ describe('ReactElement', () => {
         );
       }
     }
-    expect(() => ReactDOM.render(<Parent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Parent />, container)).toErrorDev(
       'Child: `ref` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +

--- a/packages/react/src/__tests__/ReactElementClone-test.js
+++ b/packages/react/src/__tests__/ReactElementClone-test.js
@@ -259,7 +259,7 @@ describe('ReactElementClone', () => {
   it('warns for keys for arrays of elements in rest args', () => {
     expect(() =>
       React.cloneElement(<div />, null, [<div />, <div />]),
-    ).toWarnDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('does not warns for arrays of elements with keys', () => {
@@ -297,7 +297,7 @@ describe('ReactElementClone', () => {
     }
     expect(() =>
       ReactTestUtils.renderIntoDocument(React.createElement(GrandParent)),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: ' +
         'Invalid prop `color` of type `number` supplied to `Component`, ' +
         'expected `string`.\n' +

--- a/packages/react/src/__tests__/ReactElementJSX-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.internal.js
@@ -206,7 +206,7 @@ describe('ReactElement.jsx', () => {
         });
       }
     }
-    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toErrorDev(
       'Child: `key` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
@@ -218,7 +218,7 @@ describe('ReactElement.jsx', () => {
     const container = document.createElement('div');
     expect(() =>
       ReactDOM.render(React.jsxs('div', {children: 'foo'}, null), container),
-    ).toWarnDev(
+    ).toErrorDev(
       'React.jsx: Static children should always be an array. ' +
         'You are likely explicitly calling React.jsxs or React.jsxDEV. ' +
         'Use the Babel transform instead.',
@@ -228,7 +228,7 @@ describe('ReactElement.jsx', () => {
 
   it('should warn when `key` is being accessed on a host element', () => {
     const element = React.jsxs('div', {}, '3');
-    expect(() => void element.props.key).toWarnDev(
+    expect(() => void element.props.key).toErrorDev(
       'div: `key` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
@@ -251,7 +251,7 @@ describe('ReactElement.jsx', () => {
         });
       }
     }
-    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toErrorDev(
       'Child: `ref` is not a prop. Trying to access it will result ' +
         'in `undefined` being returned. If you need to access the same ' +
         'value within the child component, you should pass it as a different ' +
@@ -321,7 +321,7 @@ describe('ReactElement.jsx', () => {
         });
       }
     }
-    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toErrorDev(
       'Warning: Each child in a list should have a unique "key" prop.\n\n' +
         'Check the render method of `Parent`. See https://fb.me/react-warning-keys for more information.\n' +
         '    in Child (created by Parent)\n' +
@@ -343,7 +343,7 @@ describe('ReactElement.jsx', () => {
         });
       }
     }
-    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toWarnDev(
+    expect(() => ReactDOM.render(React.jsx(Parent, {}), container)).toErrorDev(
       'Warning: React.jsx: Spreading a key to JSX is a deprecated pattern. ' +
         'Explicitly pass a key after spreading props in your JSX call. ' +
         'E.g. <ComponentName {...props} key={key} />',

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -439,7 +439,7 @@ describe('ReactElementValidator', () => {
     }
 
     let TestFactory = React.createFactory(TestComponent);
-    expect(() => TestFactory.type).toLowPriorityWarnDev(
+    expect(() => TestFactory.type).toWarnDev(
       'Warning: Factory.type is deprecated. Access the class directly before ' +
         'passing it to createFactory.',
       {withoutStack: true},

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -42,7 +42,7 @@ describe('ReactElementValidator', () => {
 
     expect(() => {
       Component(null, [Component(), Component()]);
-    }).toWarnDev('Each child in a list should have a unique "key" prop.');
+    }).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('warns for keys for arrays of elements with owner info', () => {
@@ -64,7 +64,7 @@ describe('ReactElementValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(React.createElement(ComponentWrapper));
-    }).toWarnDev(
+    }).toErrorDev(
       'Each child in a list should have a unique "key" prop.' +
         '\n\nCheck the render method of `InnerClass`. ' +
         'It was passed a child from ComponentWrapper. ',
@@ -81,7 +81,7 @@ describe('ReactElementValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
         '"key" prop. See https://fb.me/react-warning-keys for more information.\n' +
         '    in div (at **)',
@@ -93,7 +93,7 @@ describe('ReactElementValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
         '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
         'https://fb.me/react-warning-keys for more information.\n' +
@@ -114,7 +114,7 @@ describe('ReactElementValidator', () => {
       return <Parent child={<Component />} />;
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
         '"key" prop.\n\nCheck the render method of `Component`. See ' +
         'https://fb.me/react-warning-keys for more information.\n' +
@@ -158,7 +158,7 @@ describe('ReactElementValidator', () => {
       },
     };
 
-    expect(() => Component(null, iterable)).toWarnDev(
+    expect(() => Component(null, iterable)).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
   });
@@ -217,7 +217,7 @@ describe('ReactElementValidator', () => {
     }
     expect(() => {
       ReactTestUtils.renderIntoDocument(React.createElement(ParentComp));
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Failed prop type: ' +
         'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
         'expected `string`.\n' +
@@ -238,7 +238,7 @@ describe('ReactElementValidator', () => {
       React.createElement(React.createElement(Foo));
       React.createElement(React.createElement(React.createContext().Consumer));
       React.createElement({$$typeof: 'non-react-thing'});
-    }).toWarnDev(
+    }).toErrorDev(
       [
         'Warning: React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function (for composite ' +
@@ -295,7 +295,7 @@ describe('ReactElementValidator', () => {
           'or a class/function (for composite components) but got: null.' +
           (__DEV__ ? '\n\nCheck the render method of `ParentComp`.' : ''),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: null.' +
@@ -314,7 +314,7 @@ describe('ReactElementValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(React.createElement(Component)),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
         '`Component`, but its value is `null`.\n' +
         '    in Component',
@@ -334,7 +334,7 @@ describe('ReactElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         React.createElement(Component, {prop: null}),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
         '`Component`, but its value is `null`.\n' +
         '    in Component',
@@ -356,7 +356,7 @@ describe('ReactElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         React.createElement(Component, {prop: 42}),
       );
-    }).toWarnDev([
+    }).toErrorDev([
       'Warning: Failed prop type: ' +
         'The prop `prop` is marked as required in `Component`, but its value ' +
         'is `undefined`.\n' +
@@ -387,7 +387,7 @@ describe('ReactElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         React.createElement(Component, {myProp: {value: 'hi'}}),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Component: type specification of prop `myProp` is invalid; ' +
         'the type checker function must return `null` or an `Error` but ' +
         'returned a function. You may have forgotten to pass an argument to ' +
@@ -411,7 +411,7 @@ describe('ReactElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         React.createElement(MisspelledPropTypesComponent, {prop: 'Hi'}),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
       {withoutStack: true},
@@ -427,7 +427,7 @@ describe('ReactElementValidator', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(React.createElement(Foo));
-    }).toWarnDev(
+    }).toErrorDev(
       'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
         'can only have `key` and `children` props.',
     );
@@ -504,7 +504,7 @@ describe('ReactElementValidator', () => {
     const Foo = undefined;
     expect(() => {
       void <Foo>{[<div />]}</Foo>;
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.js
@@ -48,7 +48,7 @@ describe('ReactJSXElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         <Component>{[<Component />, <Component />]}</Component>,
       ),
-    ).toWarnDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('warns for keys for arrays of elements with owner info', () => {
@@ -66,7 +66,7 @@ describe('ReactJSXElementValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<ComponentWrapper />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Each child in a list should have a unique "key" prop.' +
         '\n\nCheck the render method of `InnerComponent`. ' +
         'It was passed a child from ComponentWrapper. ',
@@ -88,7 +88,7 @@ describe('ReactJSXElementValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<Component>{iterable}</Component>),
-    ).toWarnDev('Each child in a list should have a unique "key" prop.');
+    ).toErrorDev('Each child in a list should have a unique "key" prop.');
   });
 
   it('does not warn for arrays of elements with keys', () => {
@@ -163,7 +163,7 @@ describe('ReactJSXElementValidator', () => {
         return <MyComp color={123} />;
       }
     }
-    expect(() => ReactTestUtils.renderIntoDocument(<ParentComp />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<ParentComp />)).toErrorDev(
       'Warning: Failed prop type: ' +
         'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
         'expected `string`.\n' +
@@ -195,7 +195,7 @@ describe('ReactJSXElementValidator', () => {
     ReactDOM.render(<ParentComp warn={false} />, container);
     expect(() =>
       ReactDOM.render(<ParentComp warn={true} />, container),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: ' +
         'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
         'expected `string`.\n' +
@@ -210,7 +210,7 @@ describe('ReactJSXElementValidator', () => {
     const Null = null;
     const True = true;
     const Div = 'div';
-    expect(() => void <Undefined />).toWarnDev(
+    expect(() => void <Undefined />).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
@@ -219,14 +219,14 @@ describe('ReactJSXElementValidator', () => {
         '\n\nCheck your code at **.',
       {withoutStack: true},
     );
-    expect(() => void <Null />).toWarnDev(
+    expect(() => void <Null />).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: null.' +
         '\n\nCheck your code at **.',
       {withoutStack: true},
     );
-    expect(() => void <True />).toWarnDev(
+    expect(() => void <True />).toErrorDev(
       'Warning: React.createElement: type is invalid -- expected a string ' +
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: boolean.' +
@@ -242,7 +242,7 @@ describe('ReactJSXElementValidator', () => {
 
     expect(() =>
       ReactTestUtils.renderIntoDocument(<RequiredPropComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
         '`RequiredPropComponent`, but its value is `null`.\n' +
         '    in RequiredPropComponent (at **)',
@@ -252,7 +252,7 @@ describe('ReactJSXElementValidator', () => {
   it('should not check the default for explicit null', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `prop` is marked as required in ' +
         '`RequiredPropComponent`, but its value is `null`.\n' +
         '    in RequiredPropComponent (at **)',
@@ -262,7 +262,7 @@ describe('ReactJSXElementValidator', () => {
   it('should check declared prop types', () => {
     expect(() =>
       ReactTestUtils.renderIntoDocument(<RequiredPropComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: ' +
         'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
         'its value is `undefined`.\n' +
@@ -270,7 +270,7 @@ describe('ReactJSXElementValidator', () => {
     );
     expect(() =>
       ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: ' +
         'Invalid prop `prop` of type `number` supplied to ' +
         '`RequiredPropComponent`, expected `string`.\n' +
@@ -296,7 +296,7 @@ describe('ReactJSXElementValidator', () => {
     };
     expect(() =>
       ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
         'function, usually from the `prop-types` package,',
     );
@@ -313,7 +313,7 @@ describe('ReactJSXElementValidator', () => {
     };
     expect(() =>
       ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'NullContextTypeComponent: context type `prop` is invalid; it must ' +
         'be a function, usually from the `prop-types` package,',
     );
@@ -330,7 +330,7 @@ describe('ReactJSXElementValidator', () => {
     });
     expect(() =>
       ReactTestUtils.renderIntoDocument(<GetDefaultPropsComponent />),
-    ).toWarnDev(
+    ).toErrorDev(
       'getDefaultProps is only used on classic React.createClass definitions.' +
         ' Use a static property named `defaultProps` instead.',
       {withoutStack: true},
@@ -350,7 +350,7 @@ describe('ReactJSXElementValidator', () => {
       ReactTestUtils.renderIntoDocument(
         <MisspelledPropTypesComponent prop="hi" />,
       ),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
         'instead of `propTypes`. Did you misspell the property assignment?',
       {withoutStack: true},
@@ -364,7 +364,7 @@ describe('ReactJSXElementValidator', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev(
       'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
         'can only have `key` and `children` props.',
     );
@@ -384,7 +384,7 @@ describe('ReactJSXElementValidator', () => {
       }
     }
 
-    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toWarnDev(
+    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev(
       'Invalid attribute `ref` supplied to `React.Fragment`.',
     );
   });
@@ -407,7 +407,7 @@ describe('ReactJSXElementValidator', () => {
           <span key="b">3</span>
         </>,
       ),
-    ).toWarnDev('Encountered two children with the same key, `a`.', {
+    ).toErrorDev('Encountered two children with the same key, `a`.', {
       withoutStack: true,
     });
   });

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -117,7 +117,7 @@ describe('Profiler', () => {
             it('should warn if required params are missing', () => {
               expect(() => {
                 ReactTestRenderer.create(<React.Profiler />);
-              }).toWarnDev(
+              }).toErrorDev(
                 'Profiler must specify an "id" string and "onRender" function as props',
                 {withoutStack: true},
               );

--- a/packages/react/src/__tests__/ReactPureComponent-test.js
+++ b/packages/react/src/__tests__/ReactPureComponent-test.js
@@ -74,7 +74,7 @@ describe('ReactPureComponent', () => {
     }
 
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Component />, container)).toErrorDev(
       'Warning: ' +
         'Component has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +
@@ -108,7 +108,7 @@ describe('ReactPureComponent', () => {
       }
     }
     const container = document.createElement('div');
-    expect(() => ReactDOM.render(<PureComponent />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<PureComponent />, container)).toErrorDev(
       'Warning: ' +
         'PureComponent has a method called shouldComponentUpdate(). ' +
         'shouldComponentUpdate should not be used when extending React.PureComponent. ' +

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -36,7 +36,7 @@ describe('ReactStrictMode', () => {
         </React.StrictMode>,
         container,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Invalid ARIA attribute `ariaTypo`. ' +
         'ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in div (at **)\n' +
@@ -56,7 +56,7 @@ describe('ReactStrictMode', () => {
           <Foo />
         </React.StrictMode>,
       );
-    }).toWarnDev(
+    }).toErrorDev(
       'Invalid ARIA attribute `ariaTypo`. ' +
         'ARIA attributes follow the pattern aria-* and must be lowercase.\n' +
         '    in div (at **)\n' +
@@ -399,7 +399,7 @@ describe('Concurrent Mode', () => {
       const container = document.createElement('div');
       const root = ReactDOM.createRoot(container);
       root.render(<AsyncRoot />);
-      expect(() => Scheduler.unstable_flushAll()).toWarnDev(
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev(
         [
           /* eslint-disable max-len */
           `Warning: Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://fb.me/react-unsafe-component-lifecycles for details.
@@ -457,7 +457,7 @@ Please update the following components: AsyncRoot`,
     root.render(<AsyncRoot />);
 
     expect(() => {
-      expect(() => Scheduler.unstable_flushAll()).toWarnDev(
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev(
         [
           /* eslint-disable max-len */
           `Warning: Using UNSAFE_componentWillMount in strict mode is not recommended and may indicate bugs in your code. See https://fb.me/react-unsafe-component-lifecycles for details.
@@ -535,13 +535,13 @@ Please update the following components: Parent`,
       const container = document.createElement('div');
       const root = ReactDOM.createRoot(container);
       root.render(<AsyncRoot foo={true} />);
-      expect(() => Scheduler.unstable_flushAll()).toWarnDev(
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev(
         'Using UNSAFE_componentWillMount in strict mode is not recommended',
         {withoutStack: true},
       );
 
       root.render(<AsyncRoot foo={false} />);
-      expect(() => Scheduler.unstable_flushAll()).toWarnDev(
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev(
         'Using UNSAFE_componentWillMount in strict mode is not recommended',
         {withoutStack: true},
       );
@@ -592,7 +592,7 @@ Please update the following components: Parent`,
 
     const container = document.createElement('div');
 
-    expect(() => ReactDOM.render(<SyncRoot />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<SyncRoot />, container)).toErrorDev(
       'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
       {withoutStack: true},
     );
@@ -743,7 +743,7 @@ describe('string refs', () => {
     const container = document.createElement('div');
     expect(() => {
       ReactDOM.render(<OuterComponent />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: A string ref, "somestring", has been found within a strict mode tree. ' +
         'String refs are a source of potential bugs and should be avoided. ' +
         'We recommend using useRef() or createRef() instead. ' +
@@ -785,7 +785,7 @@ describe('string refs', () => {
     const container = document.createElement('div');
     expect(() => {
       ReactDOM.render(<OuterComponent />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: A string ref, "somestring", has been found within a strict mode tree. ' +
         'String refs are a source of potential bugs and should be avoided. ' +
         'We recommend using useRef() or createRef() instead. ' +
@@ -864,7 +864,7 @@ describe('context legacy', () => {
     const container = document.createElement('div');
     expect(() => {
       ReactDOM.render(<Root />, container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Warning: Legacy context API has been detected within a strict-mode tree.' +
         '\n\nThe old API will be supported in all 16.x releases, but applications ' +
         'using it should migrate to the new version.' +

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -480,7 +480,7 @@ Please update the following components: AsyncRoot`,
         ],
         {withoutStack: true},
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         /* eslint-disable max-len */
         `Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -326,7 +326,7 @@ describe('ReactTypeScriptClass', function() {
       expect(() =>
         ReactDOM.render(React.createElement(Empty), container)
       ).toThrow()
-    ).toWarnDev([
+    ).toErrorDev([
       // A failed component renders twice in DEV
       'Warning: Empty(...): No `render` method found on the returned ' +
         'component instance: you may have forgotten to define `render`.',
@@ -390,7 +390,7 @@ describe('ReactTypeScriptClass', function() {
     }
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.'
     );
@@ -407,7 +407,7 @@ describe('ReactTypeScriptClass', function() {
     }
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo: getDerivedStateFromError() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.'
     );
@@ -423,7 +423,7 @@ describe('ReactTypeScriptClass', function() {
     }
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
-    }).toWarnDev(
+    }).toErrorDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.'
     );
@@ -445,7 +445,7 @@ describe('ReactTypeScriptClass', function() {
     }
     expect(function() {
       ReactDOM.render(React.createElement(Foo, {foo: 'foo'}), container);
-    }).toWarnDev(
+    }).toErrorDev(
       '`Foo` uses `getDerivedStateFromProps` but its initial state is ' +
       'undefined. This is not recommended. Instead, define the initial state by ' +
       'assigning an object to `this.state` in the constructor of `Foo`. ' +
@@ -505,13 +505,13 @@ describe('ReactTypeScriptClass', function() {
   });
 
   it('should warn with non-object in the initial state property', function() {
-    expect(() => test(React.createElement(ArrayState), 'SPAN', '')).toWarnDev(
+    expect(() => test(React.createElement(ArrayState), 'SPAN', '')).toErrorDev(
       'ArrayState.state: must be set to an object or null'
     );
-    expect(() => test(React.createElement(StringState), 'SPAN', '')).toWarnDev(
+    expect(() => test(React.createElement(StringState), 'SPAN', '')).toErrorDev(
       'StringState.state: must be set to an object or null'
     );
-    expect(() => test(React.createElement(NumberState), 'SPAN', '')).toWarnDev(
+    expect(() => test(React.createElement(NumberState), 'SPAN', '')).toErrorDev(
       'NumberState.state: must be set to an object or null'
     );
   });
@@ -581,7 +581,7 @@ describe('ReactTypeScriptClass', function() {
       getDefaultPropsWasCalled = false;
       expect(() =>
         test(React.createElement(ClassicProperties), 'SPAN', 'foo')
-      ).toWarnDev([
+      ).toErrorDev([
         'getInitialState was defined on ClassicProperties, ' +
           'a plain JavaScript class.',
         'getDefaultProps was defined on ClassicProperties, ' +
@@ -616,7 +616,7 @@ describe('ReactTypeScriptClass', function() {
   it('should warn when misspelling shouldComponentUpdate', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent1), 'SPAN', 'foo')
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: ' +
         'MisspelledComponent1 has a method called componentShouldUpdate(). Did ' +
         'you mean shouldComponentUpdate()? The name is phrased as a question ' +
@@ -627,7 +627,7 @@ describe('ReactTypeScriptClass', function() {
   it('should warn when misspelling componentWillReceiveProps', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent2), 'SPAN', 'foo')
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: ' +
         'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
         'Did you mean componentWillReceiveProps()?'
@@ -637,7 +637,7 @@ describe('ReactTypeScriptClass', function() {
   it('should warn when misspelling UNSAFE_componentWillReceiveProps', function() {
     expect(() =>
       test(React.createElement(MisspelledComponent3), 'SPAN', 'foo')
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: ' +
         'MisspelledComponent3 has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?'

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -652,13 +652,13 @@ describe('ReactTypeScriptClass', function() {
     );
     expect(() =>
       expect(() => instance.replaceState({})).toThrow()
-    ).toLowPriorityWarnDev(
+    ).toWarnDev(
       'replaceState(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true}
     );
     expect(() =>
       expect(() => instance.isMounted()).toThrow()
-    ).toLowPriorityWarnDev(
+    ).toWarnDev(
       'isMounted(...) is deprecated in plain JavaScript React classes',
       {withoutStack: true}
     );

--- a/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.internal.js
@@ -50,7 +50,7 @@ describe('create-react-class-integration', () => {
         render: () => null,
       });
 
-      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev(
+      expect(() => ReactNative.render(<View />, 1)).toWarnDev(
         'componentWillMount has been renamed',
         {withoutStack: true},
       );
@@ -64,7 +64,7 @@ describe('create-react-class-integration', () => {
         render: () => null,
       });
 
-      expect(() => ReactNative.render(<View />, 1)).toLowPriorityWarnDev(
+      expect(() => ReactNative.render(<View />, 1)).toWarnDev(
         'componentWillReceiveProps has been renamed',
         {withoutStack: true},
       );

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -555,7 +555,7 @@ describe('create-react-class-integration', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',
@@ -598,7 +598,7 @@ describe('create-react-class-integration', () => {
           'The above lifecycles should be removed. Learn more about this warning here:\n' +
           'https://fb.me/react-unsafe-component-lifecycles',
       );
-    }).toLowPriorityWarnDev(
+    }).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',
@@ -641,9 +641,7 @@ describe('create-react-class-integration', () => {
     });
 
     const div = document.createElement('div');
-    expect(() =>
-      ReactDOM.render(<Component foo="bar" />, div),
-    ).toLowPriorityWarnDev(
+    expect(() => ReactDOM.render(<Component foo="bar" />, div)).toWarnDev(
       [
         'componentWillMount has been renamed',
         'componentWillReceiveProps has been renamed',

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -63,7 +63,7 @@ describe('create-react-class-integration', () => {
           return <span>{this.props.prop}</span>;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Component: prop type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
@@ -81,7 +81,7 @@ describe('create-react-class-integration', () => {
           return <span>{this.props.prop}</span>;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Component: context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
@@ -99,7 +99,7 @@ describe('create-react-class-integration', () => {
           return <span>{this.props.prop}</span>;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Component: child context type `prop` is invalid; ' +
         'it must be a function, usually from React.PropTypes.',
       {withoutStack: true},
@@ -116,7 +116,7 @@ describe('create-react-class-integration', () => {
           return <div />;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
@@ -133,7 +133,7 @@ describe('create-react-class-integration', () => {
           return <div />;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: NamedComponent has a method called componentShouldUpdate(). Did you ' +
         'mean shouldComponentUpdate()? The name is phrased as a question ' +
         'because the function is expected to return a value.',
@@ -151,7 +151,7 @@ describe('create-react-class-integration', () => {
           return <div />;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
         'mean componentWillReceiveProps()?',
       {withoutStack: true},
@@ -168,7 +168,7 @@ describe('create-react-class-integration', () => {
           return <div />;
         },
       }),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: A component has a method called UNSAFE_componentWillRecieveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
       {withoutStack: true},
@@ -216,7 +216,7 @@ describe('create-react-class-integration', () => {
           return <div />;
         },
       }),
-    ).toWarnDev([
+    ).toErrorDev([
       'createClass(...): `mixins` is now a static property and should ' +
         'be defined inside "statics".',
       'createClass(...): `propTypes` is now a static property and should ' +
@@ -361,7 +361,7 @@ describe('create-react-class-integration', () => {
       },
     });
 
-    expect(() => expect(() => Component()).toThrow()).toWarnDev(
+    expect(() => expect(() => Component()).toThrow()).toErrorDev(
       'Warning: Something is calling a React component directly. Use a ' +
         'factory or JSX instead. See: https://fb.me/react-legacyfactory',
       {withoutStack: true},
@@ -453,7 +453,7 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Foo foo="foo" />, document.createElement('div')),
-    ).toWarnDev(
+    ).toErrorDev(
       'Foo: getDerivedStateFromProps() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
     );
@@ -471,7 +471,7 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Foo foo="foo" />, document.createElement('div')),
-    ).toWarnDev(
+    ).toErrorDev(
       'Foo: getDerivedStateFromError() is defined as an instance method ' +
         'and will be ignored. Instead, declare it as a static method.',
     );
@@ -491,7 +491,7 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Foo foo="foo" />, document.createElement('div')),
-    ).toWarnDev(
+    ).toErrorDev(
       'Foo: getSnapshotBeforeUpdate() is defined as a static method ' +
         'and will be ignored. Instead, declare it as an instance method.',
     );
@@ -511,7 +511,7 @@ describe('create-react-class-integration', () => {
     });
     expect(() =>
       ReactDOM.render(<Component />, document.createElement('div')),
-    ).toWarnDev(
+    ).toErrorDev(
       '`Component` uses `getDerivedStateFromProps` but its initial state is ' +
         'null. This is not recommended. Instead, define the initial state by ' +
         'assigning an object to `this.state` in the constructor of `Component`. ' +
@@ -546,7 +546,7 @@ describe('create-react-class-integration', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<Component />, document.createElement('div'));
-      }).toWarnDev(
+      }).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'Component uses getDerivedStateFromProps() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -589,7 +589,7 @@ describe('create-react-class-integration', () => {
     expect(() => {
       expect(() => {
         ReactDOM.render(<Component />, document.createElement('div'));
-      }).toWarnDev(
+      }).toErrorDev(
         'Unsafe legacy lifecycles will not be called for components using new component APIs.\n\n' +
           'Component uses getSnapshotBeforeUpdate() but also contains the following legacy lifecycles:\n' +
           '  componentWillMount\n' +
@@ -719,7 +719,7 @@ describe('create-react-class-integration', () => {
 
     const container = document.createElement('div');
 
-    expect(() => ReactDOM.render(<Component />, container)).toWarnDev(
+    expect(() => ReactDOM.render(<Component />, container)).toErrorDev(
       'Warning: MyComponent: isMounted is deprecated. Instead, make sure to ' +
         'clean up subscriptions and pending requests in componentWillUnmount ' +
         'to prevent memory leaks.',

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -118,7 +118,7 @@ describe('forwardRef', () => {
 
     expect(() =>
       ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `required` is marked as required in ' +
         '`ForwardRef(NamedFunction)`, but its value is `undefined`.\n' +
         '    in ForwardRef(NamedFunction) (at **)',
@@ -126,22 +126,22 @@ describe('forwardRef', () => {
   });
 
   it('should warn if not provided a callback during creation', () => {
-    expect(() => React.forwardRef(undefined)).toWarnDev(
+    expect(() => React.forwardRef(undefined)).toErrorDev(
       'forwardRef requires a render function but was given undefined.',
       {withoutStack: true},
     );
-    expect(() => React.forwardRef(null)).toWarnDev(
+    expect(() => React.forwardRef(null)).toErrorDev(
       'forwardRef requires a render function but was given null.',
       {withoutStack: true},
     );
-    expect(() => React.forwardRef('foo')).toWarnDev(
+    expect(() => React.forwardRef('foo')).toErrorDev(
       'forwardRef requires a render function but was given string.',
       {withoutStack: true},
     );
   });
 
   it('should warn if no render function is provided', () => {
-    expect(React.forwardRef).toWarnDev(
+    expect(React.forwardRef).toErrorDev(
       'forwardRef requires a render function but was given undefined.',
       {withoutStack: true},
     );
@@ -158,12 +158,12 @@ describe('forwardRef', () => {
     }
     renderWithDefaultProps.defaultProps = {};
 
-    expect(() => React.forwardRef(renderWithPropTypes)).toWarnDev(
+    expect(() => React.forwardRef(renderWithPropTypes)).toErrorDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
       {withoutStack: true},
     );
-    expect(() => React.forwardRef(renderWithDefaultProps)).toWarnDev(
+    expect(() => React.forwardRef(renderWithDefaultProps)).toErrorDev(
       'forwardRef render functions do not support propTypes or defaultProps. ' +
         'Did you accidentally pass a React component?',
       {withoutStack: true},
@@ -179,7 +179,7 @@ describe('forwardRef', () => {
   it('should warn if the render function provided does not use the forwarded ref parameter', () => {
     const arityOfOne = props => <div {...props} />;
 
-    expect(() => React.forwardRef(arityOfOne)).toWarnDev(
+    expect(() => React.forwardRef(arityOfOne)).toErrorDev(
       'forwardRef render functions accept exactly two parameters: props and ref. ' +
         'Did you forget to use the ref parameter?',
       {withoutStack: true},
@@ -194,7 +194,7 @@ describe('forwardRef', () => {
   it('should warn if the render function provided expects to use more than two parameters', () => {
     const arityOfThree = (props, ref, x) => <div {...props} ref={ref} x={x} />;
 
-    expect(() => React.forwardRef(arityOfThree)).toWarnDev(
+    expect(() => React.forwardRef(arityOfThree)).toErrorDev(
       'forwardRef render functions accept exactly two parameters: props and ref. ' +
         'Any additional parameter will be undefined.',
       {withoutStack: true},
@@ -223,7 +223,7 @@ describe('forwardRef', () => {
 
     expect(() =>
       ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />),
-    ).toWarnDev(
+    ).toErrorDev(
       'Warning: Failed prop type: The prop `required` is marked as required in ' +
         '`Foo`, but its value is `undefined`.\n' +
         '    in Foo (at **)',
@@ -364,7 +364,7 @@ describe('forwardRef', () => {
           return null;
         }),
       );
-    }).toWarnDev(
+    }).toErrorDev(
       [
         'Warning: forwardRef requires a render function but received a `memo` ' +
           'component. Instead of forwardRef(memo(...)), use ' +

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -211,13 +211,13 @@ describe('toErrorDev', () => {
   }
 });
 
-describe('toLowPriorityWarnDev', () => {
+describe('toWarnDev', () => {
   it('does not fail if a warning contains a stack', () => {
     expect(() => {
       if (__DEV__) {
         console.warn('Hello\n    in div');
       }
-    }).toLowPriorityWarnDev('Hello');
+    }).toWarnDev('Hello');
   });
 
   it('does not fail if all warnings contain a stack', () => {
@@ -227,7 +227,7 @@ describe('toLowPriorityWarnDev', () => {
         console.warn('Good day\n    in div');
         console.warn('Bye\n    in div');
       }
-    }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toWarnDev(['Hello', 'Good day', 'Bye']);
   });
 
   it('does not fail if warnings without stack explicitly opt out', () => {
@@ -235,14 +235,14 @@ describe('toLowPriorityWarnDev', () => {
       if (__DEV__) {
         console.warn('Hello');
       }
-    }).toLowPriorityWarnDev('Hello', {withoutStack: true});
+    }).toWarnDev('Hello', {withoutStack: true});
     expect(() => {
       if (__DEV__) {
         console.warn('Hello');
         console.warn('Good day');
         console.warn('Bye');
       }
-    }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
+    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
   });
 
   it('does not fail when expected stack-less warning number matches the actual one', () => {
@@ -252,7 +252,7 @@ describe('toLowPriorityWarnDev', () => {
         console.warn('Good day');
         console.warn('Bye\n    in div');
       }
-    }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 1});
+    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 1});
   });
 
   if (__DEV__) {
@@ -273,7 +273,7 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello');
-        }).toLowPriorityWarnDev('Hello');
+        }).toWarnDev('Hello');
       }, 'Received warning unexpectedly does not include a component stack');
     });
 
@@ -283,28 +283,28 @@ describe('toLowPriorityWarnDev', () => {
           console.warn('Hello\n    in div');
           console.warn('Good day\n    in div');
           console.warn('Bye');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toWarnDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello');
           console.warn('Good day\n    in div');
           console.warn('Bye\n    in div');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toWarnDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello\n    in div');
           console.warn('Good day');
           console.warn('Bye\n    in div');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toWarnDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello');
           console.warn('Good day');
           console.warn('Bye');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toWarnDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
     });
 
@@ -312,14 +312,14 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello\n    in div');
-        }).toLowPriorityWarnDev('Hello', {withoutStack: true});
+        }).toWarnDev('Hello', {withoutStack: true});
       }, 'Received warning unexpectedly includes a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hello\n    in div');
           console.warn('Good day');
           console.warn('Bye\n    in div');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye'], {
+        }).toWarnDev(['Hello', 'Good day', 'Bye'], {
           withoutStack: true,
         });
       }, 'Received warning unexpectedly includes a component stack');
@@ -331,7 +331,7 @@ describe('toLowPriorityWarnDev', () => {
           console.warn('Hello\n    in div');
           console.warn('Good day');
           console.warn('Bye\n    in div');
-        }).toLowPriorityWarnDev(['Hello', 'Good day', 'Bye'], {
+        }).toWarnDev(['Hello', 'Good day', 'Bye'], {
           withoutStack: 4,
         });
       }, 'Expected 4 warnings without a component stack but received 1');
@@ -341,17 +341,17 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi');
-        }).toLowPriorityWarnDev('Hi', {withoutStack: null});
+        }).toWarnDev('Hi', {withoutStack: null});
       }, 'Instead received object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi');
-        }).toLowPriorityWarnDev('Hi', {withoutStack: {}});
+        }).toWarnDev('Hi', {withoutStack: {}});
       }, 'Instead received object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi');
-        }).toLowPriorityWarnDev('Hi', {withoutStack: 'haha'});
+        }).toWarnDev('Hi', {withoutStack: 'haha'});
       }, 'Instead received string');
     });
 
@@ -359,13 +359,13 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi %s', 'Sara', 'extra');
-        }).toLowPriorityWarnDev('Hi', {withoutStack: true});
+        }).toWarnDev('Hi', {withoutStack: true});
       }, 'Received 2 arguments for a message with 1 placeholders');
 
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi %s');
-        }).toLowPriorityWarnDev('Hi', {withoutStack: true});
+        }).toWarnDev('Hi', {withoutStack: true});
       }, 'Received 0 arguments for a message with 1 placeholders');
     });
 
@@ -373,7 +373,7 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi %s%s', '\n    in div', '\n    in div');
-        }).toLowPriorityWarnDev('Hi');
+        }).toWarnDev('Hi');
       }, 'Received more than one component stack for a warning');
     });
 
@@ -381,28 +381,28 @@ describe('toLowPriorityWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
-        }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
+        }).toWarnDev('Hi', 'Bye');
+      }, 'toWarnDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
           console.warn('Bye \n    in div');
-        }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
-      expectToWarnAndToThrow(() => {
-        expect(() => {
-          console.warn('Hi \n    in div');
-          console.warn('Wow \n    in div');
-          console.warn('Bye \n    in div');
-        }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
+        }).toWarnDev('Hi', 'Bye');
+      }, 'toWarnDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
           console.warn('Wow \n    in div');
           console.warn('Bye \n    in div');
-        }).toLowPriorityWarnDev('Hi', 'Wow', 'Bye');
-      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
+        }).toWarnDev('Hi', 'Bye');
+      }, 'toWarnDev() second argument, when present, should be an object');
+      expectToWarnAndToThrow(() => {
+        expect(() => {
+          console.warn('Hi \n    in div');
+          console.warn('Wow \n    in div');
+          console.warn('Bye \n    in div');
+        }).toWarnDev('Hi', 'Wow', 'Bye');
+      }, 'toWarnDev() second argument, when present, should be an object');
     });
 
     it('fails on more than two arguments', () => {
@@ -411,8 +411,8 @@ describe('toLowPriorityWarnDev', () => {
           console.warn('Hi \n    in div');
           console.warn('Wow \n    in div');
           console.warn('Bye \n    in div');
-        }).toLowPriorityWarnDev('Hi', undefined, 'Bye');
-      }, 'toLowPriorityWarnDev() received more than two arguments.');
+        }).toWarnDev('Hi', undefined, 'Bye');
+      }, 'toWarnDev() received more than two arguments.');
     });
   }
 });

--- a/scripts/jest/matchers/__tests__/toWarnDev-test.js
+++ b/scripts/jest/matchers/__tests__/toWarnDev-test.js
@@ -9,13 +9,13 @@
 
 'use strict';
 
-describe('toWarnDev', () => {
+describe('toErrorDev', () => {
   it('does not fail if a warning contains a stack', () => {
     expect(() => {
       if (__DEV__) {
         console.error('Hello\n    in div');
       }
-    }).toWarnDev('Hello');
+    }).toErrorDev('Hello');
   });
 
   it('does not fail if all warnings contain a stack', () => {
@@ -25,7 +25,7 @@ describe('toWarnDev', () => {
         console.error('Good day\n    in div');
         console.error('Bye\n    in div');
       }
-    }).toWarnDev(['Hello', 'Good day', 'Bye']);
+    }).toErrorDev(['Hello', 'Good day', 'Bye']);
   });
 
   it('does not fail if warnings without stack explicitly opt out', () => {
@@ -33,14 +33,14 @@ describe('toWarnDev', () => {
       if (__DEV__) {
         console.error('Hello');
       }
-    }).toWarnDev('Hello', {withoutStack: true});
+    }).toErrorDev('Hello', {withoutStack: true});
     expect(() => {
       if (__DEV__) {
         console.error('Hello');
         console.error('Good day');
         console.error('Bye');
       }
-    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
+    }).toErrorDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
   });
 
   it('does not fail when expected stack-less warning number matches the actual one', () => {
@@ -50,7 +50,7 @@ describe('toWarnDev', () => {
         console.error('Good day');
         console.error('Bye\n    in div');
       }
-    }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 1});
+    }).toErrorDev(['Hello', 'Good day', 'Bye'], {withoutStack: 1});
   });
 
   if (__DEV__) {
@@ -71,7 +71,7 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
-        }).toWarnDev('Hello');
+        }).toErrorDev('Hello');
       }, 'Received warning unexpectedly does not include a component stack');
     });
 
@@ -81,28 +81,28 @@ describe('toWarnDev', () => {
           console.error('Hello\n    in div');
           console.error('Good day\n    in div');
           console.error('Bye');
-        }).toWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toErrorDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
           console.error('Good day\n    in div');
           console.error('Bye\n    in div');
-        }).toWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toErrorDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
-        }).toWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toErrorDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello');
           console.error('Good day');
           console.error('Bye');
-        }).toWarnDev(['Hello', 'Good day', 'Bye']);
+        }).toErrorDev(['Hello', 'Good day', 'Bye']);
       }, 'Received warning unexpectedly does not include a component stack');
     });
 
@@ -110,14 +110,14 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
-        }).toWarnDev('Hello', {withoutStack: true});
+        }).toErrorDev('Hello', {withoutStack: true});
       }, 'Received warning unexpectedly includes a component stack');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
-        }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
+        }).toErrorDev(['Hello', 'Good day', 'Bye'], {withoutStack: true});
       }, 'Received warning unexpectedly includes a component stack');
     });
 
@@ -127,7 +127,7 @@ describe('toWarnDev', () => {
           console.error('Hello\n    in div');
           console.error('Good day');
           console.error('Bye\n    in div');
-        }).toWarnDev(['Hello', 'Good day', 'Bye'], {withoutStack: 4});
+        }).toErrorDev(['Hello', 'Good day', 'Bye'], {withoutStack: 4});
       }, 'Expected 4 warnings without a component stack but received 1');
     });
 
@@ -135,17 +135,17 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
-        }).toWarnDev('Hi', {withoutStack: null});
+        }).toErrorDev('Hi', {withoutStack: null});
       }, 'Instead received object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
-        }).toWarnDev('Hi', {withoutStack: {}});
+        }).toErrorDev('Hi', {withoutStack: {}});
       }, 'Instead received object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi');
-        }).toWarnDev('Hi', {withoutStack: 'haha'});
+        }).toErrorDev('Hi', {withoutStack: 'haha'});
       }, 'Instead received string');
     });
 
@@ -153,13 +153,13 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s', 'Sara', 'extra');
-        }).toWarnDev('Hi', {withoutStack: true});
+        }).toErrorDev('Hi', {withoutStack: true});
       }, 'Received 2 arguments for a message with 1 placeholders');
 
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s');
-        }).toWarnDev('Hi', {withoutStack: true});
+        }).toErrorDev('Hi', {withoutStack: true});
       }, 'Received 0 arguments for a message with 1 placeholders');
     });
 
@@ -167,7 +167,7 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi %s%s', '\n    in div', '\n    in div');
-        }).toWarnDev('Hi');
+        }).toErrorDev('Hi');
       }, 'Received more than one component stack for a warning');
     });
 
@@ -175,28 +175,28 @@ describe('toWarnDev', () => {
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
-        }).toWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+        }).toErrorDev('Hi', 'Bye');
+      }, 'toErrorDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Bye \n    in div');
-        }).toWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
-      expectToWarnAndToThrow(() => {
-        expect(() => {
-          console.error('Hi \n    in div');
-          console.error('Wow \n    in div');
-          console.error('Bye \n    in div');
-        }).toWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+        }).toErrorDev('Hi', 'Bye');
+      }, 'toErrorDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.error('Hi \n    in div');
           console.error('Wow \n    in div');
           console.error('Bye \n    in div');
-        }).toWarnDev('Hi', 'Wow', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+        }).toErrorDev('Hi', 'Bye');
+      }, 'toErrorDev() second argument, when present, should be an object');
+      expectToWarnAndToThrow(() => {
+        expect(() => {
+          console.error('Hi \n    in div');
+          console.error('Wow \n    in div');
+          console.error('Bye \n    in div');
+        }).toErrorDev('Hi', 'Wow', 'Bye');
+      }, 'toErrorDev() second argument, when present, should be an object');
     });
 
     it('fails on more than two arguments', () => {
@@ -205,8 +205,8 @@ describe('toWarnDev', () => {
           console.error('Hi \n    in div');
           console.error('Wow \n    in div');
           console.error('Bye \n    in div');
-        }).toWarnDev('Hi', undefined, 'Bye');
-      }, 'toWarnDev() received more than two arguments.');
+        }).toErrorDev('Hi', undefined, 'Bye');
+      }, 'toErrorDev() received more than two arguments.');
     });
   }
 });
@@ -382,27 +382,27 @@ describe('toLowPriorityWarnDev', () => {
         expect(() => {
           console.warn('Hi \n    in div');
         }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
           console.warn('Bye \n    in div');
         }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
           console.warn('Wow \n    in div');
           console.warn('Bye \n    in div');
         }).toLowPriorityWarnDev('Hi', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
       expectToWarnAndToThrow(() => {
         expect(() => {
           console.warn('Hi \n    in div');
           console.warn('Wow \n    in div');
           console.warn('Bye \n    in div');
         }).toLowPriorityWarnDev('Hi', 'Wow', 'Bye');
-      }, 'toWarnDev() second argument, when present, should be an object');
+      }, 'toLowPriorityWarnDev() second argument, when present, should be an object');
     });
 
     it('fails on more than two arguments', () => {
@@ -412,7 +412,7 @@ describe('toLowPriorityWarnDev', () => {
           console.warn('Wow \n    in div');
           console.warn('Bye \n    in div');
         }).toLowPriorityWarnDev('Hi', undefined, 'Bye');
-      }, 'toWarnDev() received more than two arguments.');
+      }, 'toLowPriorityWarnDev() received more than two arguments.');
     });
   }
 });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -8,7 +8,7 @@ function normalizeCodeLocInfo(str) {
   return str && str.replace(/at .+?:\d+/g, 'at **');
 }
 
-const createMatcherFor = consoleMethod =>
+const createMatcherFor = (consoleMethod, matcherName) =>
   function matcher(callback, expectedMessages, options = {}) {
     if (__DEV__) {
       // Warn about incorrect usage of matcher.
@@ -16,7 +16,7 @@ const createMatcherFor = consoleMethod =>
         expectedMessages = [expectedMessages];
       } else if (!Array.isArray(expectedMessages)) {
         throw Error(
-          `toWarnDev() requires a parameter of type string or an array of strings ` +
+          `${matcherName}() requires a parameter of type string or an array of strings ` +
             `but was given ${typeof expectedMessages}.`
         );
       }
@@ -25,14 +25,14 @@ const createMatcherFor = consoleMethod =>
         (typeof options !== 'object' || Array.isArray(options))
       ) {
         throw new Error(
-          'toWarnDev() second argument, when present, should be an object. ' +
+          `${matcherName}() second argument, when present, should be an object. ` +
             'Did you forget to wrap the messages into an array?'
         );
       }
       if (arguments.length > 3) {
         // `matcher` comes from Jest, so it's more than 2 in practice
         throw new Error(
-          'toWarnDev() received more than two arguments. ' +
+          `${matcherName}() received more than two arguments. ` +
             'Did you forget to wrap the messages into an array?'
         );
       }
@@ -195,8 +195,8 @@ const createMatcherFor = consoleMethod =>
                 `Received warning unexpectedly includes a component stack:\n  ${this.utils.printReceived(
                   warningsWithComponentStack[0]
                 )}\nIf this warning intentionally includes the component stack, remove ` +
-                `{withoutStack: true} from the toWarnDev() call. If you have a mix of ` +
-                `warnings with and without stack in one toWarnDev() call, pass ` +
+                `{withoutStack: true} from the ${matcherName}() call. If you have a mix of ` +
+                `warnings with and without stack in one ${matcherName}() call, pass ` +
                 `{withoutStack: N} where N is the number of warnings without stacks.`,
               pass: false,
             };
@@ -210,13 +210,13 @@ const createMatcherFor = consoleMethod =>
                 `Received warning unexpectedly does not include a component stack:\n  ${this.utils.printReceived(
                   warningsWithoutComponentStack[0]
                 )}\nIf this warning intentionally omits the component stack, add ` +
-                `{withoutStack: true} to the toWarnDev() call.`,
+                `{withoutStack: true} to the ${matcherName} call.`,
               pass: false,
             };
           }
         } else {
           throw Error(
-            `The second argument for toWarnDev(), when specified, must be an object. It may have a ` +
+            `The second argument for ${matcherName}(), when specified, must be an object. It may have a ` +
               `property called "withoutStack" whose value may be undefined, boolean, or a number. ` +
               `Instead received ${typeof withoutStack}.`
           );
@@ -258,6 +258,7 @@ const createMatcherFor = consoleMethod =>
   };
 
 module.exports = {
-  toLowPriorityWarnDev: createMatcherFor('warn'),
-  toWarnDev: createMatcherFor('error'),
+  // TODO: rename this one.
+  toLowPriorityWarnDev: createMatcherFor('warn', 'toLowPriorityWarnDev'),
+  toErrorDev: createMatcherFor('error', 'toErrorDev'),
 };

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -258,7 +258,6 @@ const createMatcherFor = (consoleMethod, matcherName) =>
   };
 
 module.exports = {
-  // TODO: rename this one.
-  toLowPriorityWarnDev: createMatcherFor('warn', 'toLowPriorityWarnDev'),
+  toWarnDev: createMatcherFor('warn', 'toWarnDev'),
   toErrorDev: createMatcherFor('error', 'toErrorDev'),
 };

--- a/scripts/jest/typescript/jest.d.ts
+++ b/scripts/jest/typescript/jest.d.ts
@@ -21,7 +21,7 @@ interface Expect {
   not: Expect
   toThrow(message?: string): void
   toThrowError(message?: string): void
-  toWarnDev(message?: string | Array<string>, options?: any): void
+  toErrorDev(message?: string | Array<string>, options?: any): void
   toLowPriorityWarnDev(message?: string | Array<string>, options?: any): void
   toBe(value: any): void
   toEqual(value: any): void

--- a/scripts/jest/typescript/jest.d.ts
+++ b/scripts/jest/typescript/jest.d.ts
@@ -22,7 +22,7 @@ interface Expect {
   toThrow(message?: string): void
   toThrowError(message?: string): void
   toErrorDev(message?: string | Array<string>, options?: any): void
-  toLowPriorityWarnDev(message?: string | Array<string>, options?: any): void
+  toWarnDev(message?: string | Array<string>, options?: any): void
   toBe(value: any): void
   toEqual(value: any): void
   toBeFalsy(): void


### PR DESCRIPTION
Continues https://github.com/facebook/react/pull/17599.
Part of https://github.com/facebook/react/issues/16753.

This renames the matchers to match the console method names, now that we use console directly:

- `toWarnDev` -> `toErrorDev` (because it captures `console.error` calls)
- `toLowPriorityWarnDev` -> `toWarnDev` (because it captures `console.warn` calls)

I initially considered more explicit names like `toConsoleErrorDev` but it's annoying when it's used so much. Arguably there could be some confusion between `toThrow` and `toErrorDev`, but the `*Dev` suffix in my opinion is sufficient to remember which one does what.