### PR TITLE
DevTools context menu

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -4,11 +4,7 @@ import {createElement} from 'react';
 import {createRoot, flushSync} from 'react-dom';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
-import {
-  createViewElementSource,
-  getBrowserName,
-  getBrowserTheme,
-} from './utils';
+import {getBrowserName, getBrowserTheme} from './utils';
 import {LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY} from 'react-devtools-shared/src/constants';
 import {
   getSavedComponentFilters,
@@ -155,10 +151,54 @@ function createPanelIfReactLoaded() {
           },
         );
 
-        const viewElementSourceFunction = createViewElementSource(
-          bridge,
-          store,
-        );
+        const viewAttributeSourceFunction = (id, path) => {
+          const rendererID = store.getRendererIDForElement(id);
+          if (rendererID != null) {
+            // Ask the renderer interface to find the specified attribute,
+            // and store it as a global variable on the window.
+            bridge.send('viewAttributeSource', {id, path, rendererID});
+
+            setTimeout(() => {
+              // Ask Chrome to display the location of the attribute,
+              // assuming the renderer found a match.
+              chrome.devtools.inspectedWindow.eval(`
+                if (window.$attribute != null) {
+                  inspect(window.$attribute);
+                }
+              `);
+            }, 100);
+          }
+        };
+
+        const viewElementSourceFunction = id => {
+          const rendererID = store.getRendererIDForElement(id);
+          if (rendererID != null) {
+            // Ask the renderer interface to determine the component function,
+            // and store it as a global variable on the window
+            bridge.send('viewElementSource', {id, rendererID});
+
+            setTimeout(() => {
+              // Ask Chrome to display the location of the component function,
+              // or a render method if it is a Class (ideally Class instance, not type)
+              // assuming the renderer found one.
+              chrome.devtools.inspectedWindow.eval(`
+                if (window.$type != null) {
+                  if (
+                    window.$type &&
+                    window.$type.prototype &&
+                    window.$type.prototype.isReactComponent
+                  ) {
+                    // inspect Component.render, not constructor
+                    inspect(window.$type.prototype.render);
+                  } else {
+                    // inspect Functional Component
+                    inspect(window.$type);
+                  }
+                }
+              `);
+            }, 100);
+          }
+        };
 
         root = createRoot(document.createElement('div'));
 
@@ -170,11 +210,13 @@ function createPanelIfReactLoaded() {
               bridge,
               browserTheme: getBrowserTheme(),
               componentsPortalContainer,
+              enabledInspectedElementContextMenu: true,
               overrideTab,
               profilerPortalContainer,
               showTabBar: false,
-              warnIfUnsupportedVersionDetected: true,
               store,
+              warnIfUnsupportedVersionDetected: true,
+              viewAttributeSourceFunction,
               viewElementSourceFunction,
             }),
           );

--- a/packages/react-devtools-extensions/src/utils.js
+++ b/packages/react-devtools-extensions/src/utils.js
@@ -2,38 +2,6 @@
 
 const IS_CHROME = navigator.userAgent.indexOf('Firefox') < 0;
 
-export function createViewElementSource(bridge: Bridge, store: Store) {
-  return function viewElementSource(id) {
-    const rendererID = store.getRendererIDForElement(id);
-    if (rendererID != null) {
-      // Ask the renderer interface to determine the component function,
-      // and store it as a global variable on the window
-      bridge.send('viewElementSource', {id, rendererID});
-
-      setTimeout(() => {
-        // Ask Chrome to display the location of the component function,
-        // or a render method if it is a Class (ideally Class instance, not type)
-        // assuming the renderer found one.
-        chrome.devtools.inspectedWindow.eval(`
-          if (window.$type != null) {
-            if (
-              window.$type &&
-              window.$type.prototype &&
-              window.$type.prototype.isReactComponent
-            ) {
-              // inspect Component.render, not constructor
-              inspect(window.$type.prototype.render);
-            } else {
-              // inspect Functional Component
-              inspect(window.$type);
-            }
-          }
-        `);
-      }, 100);
-    }
-  };
-}
-
 export type BrowserName = 'Chrome' | 'Firefox';
 
 export function getBrowserName(): BrowserName {

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -14,6 +14,13 @@ import type {
 
 const env = jasmine.getEnv();
 env.beforeEach(() => {
+  global.mockClipboardCopy = jest.fn();
+
+  // Test environment doesn't support document methods like execCommand()
+  // Also once the backend components below have been required,
+  // it's too late for a test to mock the clipboard-js modules.
+  jest.mock('clipboard-js', () => ({copy: global.mockClipboardCopy}));
+
   // These files should be required (and re-reuired) before each test,
   // rather than imported at the head of the module.
   // That's because we reset modules between tests,

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -55,6 +55,12 @@ type ElementAndRendererID = {|
   rendererID: number,
 |};
 
+type StoreAsGlobalParams = {|
+  id: number,
+  path: Array<string | number>,
+  rendererID: number,
+|};
+
 type CopyElementParams = {|
   id: number,
   path: Array<string | number>,
@@ -147,6 +153,7 @@ export default class Agent extends EventEmitter<{|
     bridge.addListener('setTraceUpdatesEnabled', this.setTraceUpdatesEnabled);
     bridge.addListener('startProfiling', this.startProfiling);
     bridge.addListener('stopProfiling', this.stopProfiling);
+    bridge.addListener('storeAsGlobal', this.storeAsGlobal);
     bridge.addListener(
       'syncSelectionFromNativeElementsPanel',
       this.syncSelectionFromNativeElementsPanel,
@@ -423,6 +430,15 @@ export default class Agent extends EventEmitter<{|
       renderer.stopProfiling();
     }
     this._bridge.send('profilingStatus', this._isProfiling);
+  };
+
+  storeAsGlobal = ({id, path, rendererID}: StoreAsGlobalParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      renderer.storeAsGlobal(id, path);
+    }
   };
 
   updateAppendComponentStack = (appendComponentStack: boolean) => {

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -56,6 +56,7 @@ type ElementAndRendererID = {|
 |};
 
 type StoreAsGlobalParams = {|
+  count: number,
   id: number,
   path: Array<string | number>,
   rendererID: number,
@@ -432,12 +433,12 @@ export default class Agent extends EventEmitter<{|
     this._bridge.send('profilingStatus', this._isProfiling);
   };
 
-  storeAsGlobal = ({id, path, rendererID}: StoreAsGlobalParams) => {
+  storeAsGlobal = ({count, id, path, rendererID}: StoreAsGlobalParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
-      renderer.storeAsGlobal(id, path);
+      renderer.storeAsGlobal(id, path, count);
     }
   };
 

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -165,6 +165,7 @@ export default class Agent extends EventEmitter<{|
       this.updateAppendComponentStack,
     );
     bridge.addListener('updateComponentFilters', this.updateComponentFilters);
+    bridge.addListener('viewAttributeSource', this.viewAttributeSource);
     bridge.addListener('viewElementSource', this.viewElementSource);
 
     if (this._isProfiling) {
@@ -460,6 +461,15 @@ export default class Agent extends EventEmitter<{|
         (rendererID: any)
       ]: any): RendererInterface);
       renderer.updateComponentFilters(componentFilters);
+    }
+  };
+
+  viewAttributeSource = ({id, path, rendererID}: CopyElementParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      renderer.prepareViewAttributeSource(id, path);
     }
   };
 

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -55,6 +55,12 @@ type ElementAndRendererID = {|
   rendererID: number,
 |};
 
+type CopyElementParams = {|
+  id: number,
+  path: Array<string | number>,
+  rendererID: number,
+|};
+
 type InspectElementParams = {|
   id: number,
   path?: Array<string | number>,
@@ -126,6 +132,7 @@ export default class Agent extends EventEmitter<{|
 
     this._bridge = bridge;
 
+    bridge.addListener('copyElementPath', this.copyElementPath);
     bridge.addListener('getProfilingData', this.getProfilingData);
     bridge.addListener('getProfilingStatus', this.getProfilingStatus);
     bridge.addListener('getOwnersList', this.getOwnersList);
@@ -172,6 +179,15 @@ export default class Agent extends EventEmitter<{|
   get rendererInterfaces(): {[key: RendererID]: RendererInterface} {
     return this._rendererInterfaces;
   }
+
+  copyElementPath = ({id, path, rendererID}: CopyElementParams) => {
+    const renderer = this._rendererInterfaces[rendererID];
+    if (renderer == null) {
+      console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
+    } else {
+      renderer.copyElementPath(id, path);
+    }
+  };
 
   getInstanceAndStyle({
     id,

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -836,6 +836,16 @@ export function attach(
     }
   }
 
+  function prepareViewAttributeSource(
+    id: number,
+    path: Array<string | number>,
+  ): void {
+    const inspectedElement = inspectElementRaw(id);
+    if (inspectedElement !== null) {
+      window.$attribute = getInObject(inspectedElement, path);
+    }
+  }
+
   function prepareViewElementSource(id: number): void {
     const internalInstance = idToInternalInstanceMap.get(id);
     if (internalInstance == null) {
@@ -968,6 +978,7 @@ export function attach(
     inspectElement,
     logElementToConsole,
     overrideSuspense,
+    prepareViewAttributeSource,
     prepareViewElementSource,
     renderer,
     setInContext,

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -649,14 +649,19 @@ export function attach(
     }
   }
 
-  function storeAsGlobal(id: number, path: Array<string | number>): void {
+  function storeAsGlobal(
+    id: number,
+    path: Array<string | number>,
+    count: number,
+  ): void {
     const inspectedElement = inspectElementRaw(id);
     if (inspectedElement !== null) {
       const value = getInObject(inspectedElement, path);
+      const key = `$reactTemp${count}`;
 
-      window.$reactTemp = value;
+      window[key] = value;
 
-      console.log('$reactTemp');
+      console.log(key);
       console.log(value);
     }
   }

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {copy} from 'clipboard-js';
 import {
   ElementTypeClass,
   ElementTypeFunction,
@@ -16,7 +15,7 @@ import {
   ElementTypeOtherOrUnknown,
 } from 'react-devtools-shared/src/types';
 import {getUID, utfEncodeString, printOperationsArray} from '../../utils';
-import {cleanForBridge, copyWithSet, safeSerialize} from '../utils';
+import {cleanForBridge, copyToClipboard, copyWithSet} from '../utils';
 import {getDisplayName, getInObject} from 'react-devtools-shared/src/utils';
 import {
   __DEBUG__,
@@ -665,9 +664,7 @@ export function attach(
   function copyElementPath(id: number, path: Array<string | number>): void {
     const inspectedElement = inspectElementRaw(id);
     if (inspectedElement !== null) {
-      const value = getInObject(inspectedElement, path);
-
-      copy(safeSerialize(value));
+      copyToClipboard(getInObject(inspectedElement, path));
     }
   }
 

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import {copy} from 'clipboard-js';
 import {
   ElementTypeClass,
   ElementTypeFunction,
@@ -15,8 +16,8 @@ import {
   ElementTypeOtherOrUnknown,
 } from 'react-devtools-shared/src/types';
 import {getUID, utfEncodeString, printOperationsArray} from '../../utils';
-import {cleanForBridge, copyWithSet} from '../utils';
-import {getDisplayName} from 'react-devtools-shared/src/utils';
+import {cleanForBridge, copyWithSet, safeSerialize} from '../utils';
+import {getDisplayName, getInObject} from 'react-devtools-shared/src/utils';
 import {
   __DEBUG__,
   TREE_OPERATION_ADD,
@@ -649,6 +650,15 @@ export function attach(
     }
   }
 
+  function copyElementPath(id: number, path: Array<string | number>): void {
+    const inspectedElement = inspectElementRaw(id);
+    if (inspectedElement !== null) {
+      const value = getInObject(inspectedElement, path);
+
+      copy(safeSerialize(value));
+    }
+  }
+
   function inspectElement(
     id: number,
     path?: Array<string | number>,
@@ -927,6 +937,7 @@ export function attach(
 
   return {
     cleanup,
+    copyElementPath,
     flushInitialOperations,
     getBestMatchForTrackedPath,
     getFiberIDForNative: getInternalIDForNative,

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -650,6 +650,18 @@ export function attach(
     }
   }
 
+  function storeAsGlobal(id: number, path: Array<string | number>): void {
+    const inspectedElement = inspectElementRaw(id);
+    if (inspectedElement !== null) {
+      const value = getInObject(inspectedElement, path);
+
+      window.$reactTemp = value;
+
+      console.log('$reactTemp');
+      console.log(value);
+    }
+  }
+
   function copyElementPath(id: number, path: Array<string | number>): void {
     const inspectedElement = inspectElementRaw(id);
     if (inspectedElement !== null) {
@@ -964,6 +976,7 @@ export function attach(
     setTrackedPath,
     startProfiling,
     stopProfiling,
+    storeAsGlobal,
     updateComponentFilters,
   };
 }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2488,7 +2488,11 @@ export function attach(
     }
   }
 
-  function storeAsGlobal(id: number, path: Array<string | number>): void {
+  function storeAsGlobal(
+    id: number,
+    path: Array<string | number>,
+    count: number,
+  ): void {
     const isCurrent = isMostRecentlyInspectedElementCurrent(id);
 
     if (isCurrent) {
@@ -2496,10 +2500,11 @@ export function attach(
         ((mostRecentlyInspectedElement: any): InspectedElement),
         path,
       );
+      const key = `$reactTemp${count}`;
 
-      window.$reactTemp = value;
+      window[key] = value;
 
-      console.log('$reactTemp');
+      console.log(key);
       console.log(value);
     }
   }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -8,7 +8,6 @@
  */
 
 import {gte} from 'semver';
-import {copy} from 'clipboard-js';
 import {
   ComponentFilterDisplayName,
   ComponentFilterElementType,
@@ -35,7 +34,7 @@ import {
   utfEncodeString,
 } from 'react-devtools-shared/src/utils';
 import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
-import {cleanForBridge, copyWithSet, safeSerialize} from './utils';
+import {cleanForBridge, copyToClipboard, copyWithSet} from './utils';
 import {
   __DEBUG__,
   SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
@@ -2509,12 +2508,12 @@ export function attach(
     const isCurrent = isMostRecentlyInspectedElementCurrent(id);
 
     if (isCurrent) {
-      const value = getInObject(
-        ((mostRecentlyInspectedElement: any): InspectedElement),
-        path,
+      copyToClipboard(
+        getInObject(
+          ((mostRecentlyInspectedElement: any): InspectedElement),
+          path,
+        ),
       );
-
-      copy(safeSerialize(value));
     }
   }
 

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2113,6 +2113,19 @@ export function attach(
   }
   // END copied code
 
+  function prepareViewAttributeSource(
+    id: number,
+    path: Array<string | number>,
+  ): void {
+    const isCurrent = isMostRecentlyInspectedElementCurrent(id);
+    if (isCurrent) {
+      window.$attribute = getInObject(
+        ((mostRecentlyInspectedElement: any): InspectedElement),
+        path,
+      );
+    }
+  }
+
   function prepareViewElementSource(id: number): void {
     let fiber = idToFiberMap.get(id);
     if (fiber == null) {
@@ -3176,6 +3189,7 @@ export function attach(
     handleCommitFiberUnmount,
     inspectElement,
     logElementToConsole,
+    prepareViewAttributeSource,
     prepareViewElementSource,
     overrideSuspense,
     renderer,

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2489,6 +2489,22 @@ export function attach(
     }
   }
 
+  function storeAsGlobal(id: number, path: Array<string | number>): void {
+    const isCurrent = isMostRecentlyInspectedElementCurrent(id);
+
+    if (isCurrent) {
+      const value = getInObject(
+        ((mostRecentlyInspectedElement: any): InspectedElement),
+        path,
+      );
+
+      window.$reactTemp = value;
+
+      console.log('$reactTemp');
+      console.log(value);
+    }
+  }
+
   function copyElementPath(id: number, path: Array<string | number>): void {
     const isCurrent = isMostRecentlyInspectedElementCurrent(id);
 
@@ -3167,6 +3183,7 @@ export function attach(
     setTrackedPath,
     startProfiling,
     stopProfiling,
+    storeAsGlobal,
     updateComponentFilters,
   };
 }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -8,6 +8,7 @@
  */
 
 import {gte} from 'semver';
+import {copy} from 'clipboard-js';
 import {
   ComponentFilterDisplayName,
   ComponentFilterElementType,
@@ -34,7 +35,7 @@ import {
   utfEncodeString,
 } from 'react-devtools-shared/src/utils';
 import {sessionStorageGetItem} from 'react-devtools-shared/src/storage';
-import {cleanForBridge, copyWithSet} from './utils';
+import {cleanForBridge, copyWithSet, safeSerialize} from './utils';
 import {
   __DEBUG__,
   SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
@@ -2488,6 +2489,19 @@ export function attach(
     }
   }
 
+  function copyElementPath(id: number, path: Array<string | number>): void {
+    const isCurrent = isMostRecentlyInspectedElementCurrent(id);
+
+    if (isCurrent) {
+      const value = getInObject(
+        ((mostRecentlyInspectedElement: any): InspectedElement),
+        path,
+      );
+
+      copy(safeSerialize(value));
+    }
+  }
+
   function inspectElement(
     id: number,
     path?: Array<string | number>,
@@ -3129,6 +3143,7 @@ export function attach(
 
   return {
     cleanup,
+    copyElementPath,
     findNativeNodesForFiberID,
     flushInitialOperations,
     getBestMatchForTrackedPath,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -257,6 +257,7 @@ export type RendererInterface = {
   setTrackedPath: (path: Array<PathFrame> | null) => void,
   startProfiling: (recordChangeDescriptions: boolean) => void,
   stopProfiling: () => void,
+  storeAsGlobal: (id: number, path: Array<string | number>) => void,
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void,
 };
 

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -242,6 +242,10 @@ export type RendererInterface = {
   ) => InspectedElementPayload,
   logElementToConsole: (id: number) => void,
   overrideSuspense: (id: number, forceFallback: boolean) => void,
+  prepareViewAttributeSource: (
+    id: number,
+    path: Array<string | number>,
+  ) => void,
   prepareViewElementSource: (id: number) => void,
   renderer: ReactRenderer | null,
   setInContext: (id: number, path: Array<string | number>, value: any) => void,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -225,6 +225,7 @@ export type InstanceAndStyle = {|
 
 export type RendererInterface = {
   cleanup: () => void,
+  copyElementPath: (id: number, path: Array<string | number>) => void,
   findNativeNodesForFiberID: FindNativeNodesForFiberID,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -257,7 +257,11 @@ export type RendererInterface = {
   setTrackedPath: (path: Array<PathFrame> | null) => void,
   startProfiling: (recordChangeDescriptions: boolean) => void,
   stopProfiling: () => void,
-  storeAsGlobal: (id: number, path: Array<string | number>) => void,
+  storeAsGlobal: (
+    id: number,
+    path: Array<string | number>,
+    count: number,
+  ) => void,
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void,
 };
 

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -39,7 +39,7 @@ export function cleanForBridge(
 }
 
 export function copyToClipboard(value: any): void {
-  const safeToCopy = safeSerialize(value);
+  const safeToCopy = serializeToString(value);
   copy(safeToCopy === undefined ? 'undefined' : safeToCopy);
 }
 
@@ -59,8 +59,9 @@ export function copyWithSet(
   return updated;
 }
 
-export function safeSerialize(data: any): string {
+export function serializeToString(data: any): string {
   const cache = new Set();
+  // Use a custom replacer function to protect against circular references.
   return JSON.stringify(data, (key, value) => {
     if (typeof value === 'object' && value !== null) {
       if (cache.has(value)) {

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import {copy} from 'clipboard-js';
 import {dehydrate} from '../hydration';
 
 import type {DehydratedData} from 'react-devtools-shared/src/devtools/views/Components/types';
@@ -35,6 +36,11 @@ export function cleanForBridge(
   } else {
     return null;
   }
+}
+
+export function copyToClipboard(value: any): void {
+  const safeToCopy = safeSerialize(value);
+  copy(safeToCopy === undefined ? 'undefined' : safeToCopy);
 }
 
 export function copyWithSet(

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -52,3 +52,16 @@ export function copyWithSet(
   updated[key] = copyWithSet(obj[key], path, value, index + 1);
   return updated;
 }
+
+export function safeSerialize(data: any): string {
+  const cache = new Set();
+  return JSON.stringify(data, (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (cache.has(value)) {
+        return;
+      }
+      cache.add(value);
+    }
+    return value;
+  });
+}

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -56,6 +56,11 @@ type CopyElementPathParams = {|
   path: Array<string | number>,
 |};
 
+type ViewAttributeSourceParams = {|
+  ...ElementAndRendererID,
+  path: Array<string | number>,
+|};
+
 type InspectElementParams = {|
   ...ElementAndRendererID,
   path?: Array<string | number>,
@@ -130,6 +135,7 @@ type FrontendEvents = {|
   storeAsGlobal: [StoreAsGlobalParams],
   updateAppendComponentStack: [boolean],
   updateComponentFilters: [Array<ComponentFilter>],
+  viewAttributeSource: [ViewAttributeSourceParams],
   viewElementSource: [ElementAndRendererID],
 
   // React Native style editor plug-in.

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -61,6 +61,11 @@ type InspectElementParams = {|
   path?: Array<string | number>,
 |};
 
+type StoreAsGlobalParams = {|
+  ...ElementAndRendererID,
+  path: Array<string | number>,
+|};
+
 type NativeStyleEditor_RenameAttributeParams = {|
   ...ElementAndRendererID,
   oldName: string,
@@ -121,6 +126,7 @@ type FrontendEvents = {|
   startProfiling: [boolean],
   stopInspectingNative: [boolean],
   stopProfiling: [],
+  storeAsGlobal: [StoreAsGlobalParams],
   updateAppendComponentStack: [boolean],
   updateComponentFilters: [Array<ComponentFilter>],
   viewElementSource: [ElementAndRendererID],

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -51,6 +51,11 @@ type OverrideSuspense = {|
   forceFallback: boolean,
 |};
 
+type CopyElementPathParams = {|
+  ...ElementAndRendererID,
+  path: Array<string | number>,
+|};
+
 type InspectElementParams = {|
   ...ElementAndRendererID,
   path?: Array<string | number>,
@@ -95,6 +100,7 @@ type BackendEvents = {|
 
 type FrontendEvents = {|
   clearNativeElementHighlight: [],
+  copyElementPath: [CopyElementPathParams],
   getOwnersList: [ElementAndRendererID],
   getProfilingData: [{|rendererID: RendererID|}],
   getProfilingStatus: [],

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -63,6 +63,7 @@ type InspectElementParams = {|
 
 type StoreAsGlobalParams = {|
   ...ElementAndRendererID,
+  count: number,
   path: Array<string | number>,
 |};
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.css
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.css
@@ -1,0 +1,7 @@
+.ContextMenu {
+  position: absolute;
+  background-color: var(--color-context-background);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  z-index: 10000002;
+}

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import {createPortal} from 'react-dom';
-import {DataContext, RegistryContext} from './Contexts';
+import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenu.css';
 
@@ -120,9 +120,7 @@ export default function ContextMenu({children, id}: Props) {
   } else {
     return createPortal(
       <div ref={menuRef} className={styles.ContextMenu}>
-        <DataContext.Provider value={state.data}>
-          {children}
-        </DataContext.Provider>
+        {children(state.data)}
       </div>,
       containerRef.current,
     );

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
@@ -1,0 +1,121 @@
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import {createPortal} from 'react-dom';
+import {DataContext, RegistryContext} from './Contexts';
+
+import styles from './ContextMenu.css';
+
+function respositionToFit(element, pageX, pageY) {
+  if (element !== null) {
+    if (pageY + element.offsetHeight >= window.innerHeight) {
+      if (pageY - element.offsetHeight > 0) {
+        element.style.top = `${pageY - element.offsetHeight}px`;
+      } else {
+        element.style.top = '0px';
+      }
+    } else {
+      element.style.top = `${pageY}px`;
+    }
+
+    if (pageX + element.offsetWidth >= window.innerWidth) {
+      if (pageX - element.offsetWidth > 0) {
+        element.style.left = `${pageX - element.offsetWidth}px`;
+      } else {
+        element.style.left = '0px';
+      }
+    } else {
+      element.style.left = `${pageX}px`;
+    }
+  }
+}
+
+const HIDDEN_STATE = {
+  data: null,
+  isVisible: false,
+  pageX: 0,
+  pageY: 0,
+};
+
+type Props = {|
+  children: React$Node,
+  id: string,
+|};
+
+export default function ContextMenu({children, id}: Props) {
+  const {registerMenu} = useContext(RegistryContext);
+
+  const [state, setState] = useState(HIDDEN_STATE);
+
+  const containerRef = useRef(null);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    containerRef.current = document.createElement('div');
+    document.body.appendChild(containerRef.current);
+    return () => {
+      document.body.removeChild(containerRef.current);
+    };
+  }, []);
+
+  useEffect(
+    () => {
+      const showMenu = ({data, pageX, pageY}) => {
+        setState({data, isVisible: true, pageX, pageY});
+      };
+      const hideMenu = () => setState(HIDDEN_STATE);
+      return registerMenu(id, showMenu, hideMenu);
+    },
+    [id],
+  );
+
+  useLayoutEffect(
+    () => {
+      if (!state.isVisible) {
+        return;
+      }
+
+      const menu = menuRef.current;
+
+      const hide = event => {
+        if (!menu.contains(event.target)) {
+          setState(HIDDEN_STATE);
+        }
+      };
+
+      document.addEventListener('mousedown', hide);
+      document.addEventListener('touchstart', hide);
+      document.addEventListener('keydown', hide);
+
+      window.addEventListener('resize', hide);
+
+      respositionToFit(menu, state.pageX, state.pageY);
+
+      return () => {
+        document.removeEventListener('mousedown', hide);
+        document.removeEventListener('touchstart', hide);
+        document.removeEventListener('keydown', hide);
+
+        window.removeEventListener('resize', hide);
+      };
+    },
+    [state],
+  );
+
+  if (!state.isVisible) {
+    return null;
+  } else {
+    return createPortal(
+      <div ref={menuRef} className={styles.ContextMenu}>
+        <DataContext.Provider value={state.data}>
+          {children}
+        </DataContext.Provider>
+      </div>,
+      containerRef.current,
+    );
+  }
+}

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.css
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.css
@@ -1,0 +1,22 @@
+.ContextMenuItem {
+  display: flex;
+  align-items: center;
+  color: var(--color-context-text);
+  padding: 0.5rem 0.75rem;
+  cursor: default;
+  border-top: 1px solid var(--color-context-border);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sans-normal);
+}
+.ContextMenuItem:first-of-type {
+  border-top: none;
+}
+.ContextMenuItem:hover,
+.ContextMenuItem:focus {
+  outline: 0;
+  background-color: var(--color-context-background-hover);
+}
+.ContextMenuItem:active {
+  background-color: var(--color-context-background-selected);
+  color: var(--color-context-text-selected);
+}

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
@@ -1,0 +1,29 @@
+import React, {useContext} from 'react';
+import {DataContext, RegistryContext} from './Contexts';
+
+import styles from './ContextMenuItem.css';
+
+type Props = {|
+  children: React$Node,
+  onClick: Object => void,
+  title: string,
+|};
+
+export default function ContextMenuItem({children, onClick, title}: Props) {
+  const data = useContext(DataContext);
+  const {hideMenu} = useContext(RegistryContext);
+
+  const handleClick = event => {
+    onClick(data);
+    hideMenu();
+  };
+
+  return (
+    <div
+      className={styles.ContextMenuItem}
+      onClick={handleClick}
+      onTouchEnd={handleClick}>
+      {children}
+    </div>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
@@ -1,5 +1,5 @@
 import React, {useContext} from 'react';
-import {DataContext, RegistryContext} from './Contexts';
+import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenuItem.css';
 
@@ -10,11 +10,10 @@ type Props = {|
 |};
 
 export default function ContextMenuItem({children, onClick, title}: Props) {
-  const data = useContext(DataContext);
   const {hideMenu} = useContext(RegistryContext);
 
   const handleClick = event => {
-    onClick(data);
+    onClick();
     hideMenu();
   };
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
@@ -51,5 +51,3 @@ export const RegistryContext = createContext({
   showMenu,
   registerMenu,
 });
-
-export const DataContext = createContext(null);

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
@@ -1,0 +1,55 @@
+import {createContext} from 'react';
+
+export type ShowFn = ({data: Object, pageX: number, pageY: number}) => void;
+export type HideFn = () => void;
+
+const idToShowFnMap = new Map();
+const idToHideFnMap = new Map();
+
+let currentHideFn = null;
+
+function hideMenu() {
+  if (typeof currentHideFn === 'function') {
+    currentHideFn();
+  }
+}
+
+function showMenu({
+  data,
+  id,
+  pageX,
+  pageY,
+}: {|
+  data: Object,
+  id: string,
+  pageX: number,
+  pageY: number,
+|}) {
+  const showFn = idToShowFnMap.get(id);
+  if (typeof showFn === 'function') {
+    currentHideFn = idToHideFnMap.get(id);
+    showFn({data, pageX, pageY});
+  }
+}
+
+function registerMenu(id: string, showFn: ShowFn, hideFn: HideFn) {
+  if (idToShowFnMap.has(id)) {
+    throw Error(`Context menu with id "${id}" already registered.`);
+  }
+
+  idToShowFnMap.set(id, showFn);
+  idToHideFnMap.set(id, hideFn);
+
+  return function unregisterMenu() {
+    idToShowFnMap.delete(id, showFn);
+    idToHideFnMap.delete(id, hideFn);
+  };
+}
+
+export const RegistryContext = createContext({
+  hideMenu,
+  showMenu,
+  registerMenu,
+});
+
+export const DataContext = createContext(null);

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
@@ -12,9 +12,9 @@ export default function useContextMenu({data, id, ref}) {
           event.stopPropagation();
 
           const pageX =
-            event.clientX || (event.touches && event.touches[0].pageX);
+            event.pageX || (event.touches && event.touches[0].pageX);
           const pageY =
-            event.clientY || (event.touches && event.touches[0].pageY);
+            event.pageY || (event.touches && event.touches[0].pageY);
 
           showMenu({data, id, pageX, pageY});
         };

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
@@ -1,0 +1,32 @@
+import {useContext, useEffect} from 'react';
+import {RegistryContext} from './Contexts';
+
+export default function useContextMenu({data, id, ref}) {
+  const {showMenu} = useContext(RegistryContext);
+
+  useEffect(
+    () => {
+      if (ref.current !== null) {
+        const handleContextMenu = event => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          const pageX =
+            event.clientX || (event.touches && event.touches[0].pageX);
+          const pageY =
+            event.clientY || (event.touches && event.touches[0].pageY);
+
+          showMenu({data, id, pageX, pageY});
+        };
+
+        const trigger = ref.current;
+        trigger.addEventListener('contextmenu', handleContextMenu);
+
+        return () => {
+          trigger.removeEventListener('contextmenu', handleContextMenu);
+        };
+      }
+    },
+    [data, id, showMenu],
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
@@ -117,7 +117,15 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
   const contextMenuTriggerRef = useRef(null);
 
   useContextMenu({
-    data: ['hooks', ...path],
+    data: {
+      path: ['hooks', ...path],
+      type:
+        hook !== null &&
+        typeof hook === 'object' &&
+        hook.hasOwnProperty(meta.type)
+          ? hook[meta.type]
+          : typeof value,
+    },
     id: 'SelectedElement',
     ref: contextMenuTriggerRef,
   });

--- a/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
@@ -8,7 +8,7 @@
  */
 
 import {copy} from 'clipboard-js';
-import React, {useCallback, useContext, useState} from 'react';
+import React, {useCallback, useContext, useRef, useState} from 'react';
 import {BridgeContext, StoreContext} from '../context';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
@@ -18,6 +18,7 @@ import {InspectedElementContext} from './InspectedElementContext';
 import KeyValue from './KeyValue';
 import {serializeHooksForCopy} from '../utils';
 import styles from './HooksTree.css';
+import useContextMenu from '../../ContextMenu/useContextMenu';
 import {meta} from '../../../hydration';
 
 import type {InspectPath} from './SelectedElement';
@@ -113,6 +114,14 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
     [],
   );
 
+  const contextMenuTriggerRef = useRef(null);
+
+  useContextMenu({
+    data: ['hooks', ...path],
+    id: 'SelectedElement',
+    ref: contextMenuTriggerRef,
+  });
+
   if (hook.hasOwnProperty(meta.inspected)) {
     // This Hook is too deep and hasn't been hydrated.
     if (__DEV__) {
@@ -169,6 +178,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
         inspectPath={inspectPath}
         name="subHooks"
         path={path.concat(['subHooks'])}
+        pathRoot="hooks"
         value={subHooks}
       />
     );
@@ -176,7 +186,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
     if (isComplexDisplayValue) {
       return (
         <div className={styles.Hook}>
-          <div className={styles.NameValueRow}>
+          <div ref={contextMenuTriggerRef} className={styles.NameValueRow}>
             <ExpandCollapseToggle isOpen={isOpen} setIsOpen={setIsOpen} />
             <span
               onClick={toggleIsOpen}
@@ -191,6 +201,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
               inspectPath={inspectPath}
               name="DebugValue"
               path={path.concat(['value'])}
+              pathRoot="hooks"
               value={value}
             />
             {subHooksView}
@@ -200,7 +211,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
     } else {
       return (
         <div className={styles.Hook}>
-          <div className={styles.NameValueRow}>
+          <div ref={contextMenuTriggerRef} className={styles.NameValueRow}>
             <ExpandCollapseToggle isOpen={isOpen} setIsOpen={setIsOpen} />
             <span
               onClick={toggleIsOpen}
@@ -253,6 +264,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
             name={name}
             overrideValueFn={overrideValueFn}
             path={path.concat(['value'])}
+            pathRoot="hooks"
             value={value}
           />
         </div>
@@ -260,7 +272,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
     } else {
       return (
         <div className={styles.Hook}>
-          <div className={styles.NameValueRow}>
+          <div ref={contextMenuTriggerRef} className={styles.NameValueRow}>
             <span className={styles.ExpandCollapseToggleSpacer} />
             <span
               className={

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -13,6 +13,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
@@ -98,12 +99,19 @@ function InspectedElementContextController({children}: Props) {
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
 
+  const storeAsGlobalCount = useRef(1);
+
   // Ask the backend to store the value at the specified path as a global variable.
   const storeAsGlobal = useCallback<GetInspectedElementPath>(
     (id: number, path: Array<string | number>) => {
       const rendererID = store.getRendererIDForElement(id);
       if (rendererID !== null) {
-        bridge.send('storeAsGlobal', {id, path, rendererID});
+        bridge.send('storeAsGlobal', {
+          count: storeAsGlobalCount.current++,
+          id,
+          path,
+          rendererID,
+        });
       }
     },
     [bridge, store],

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -26,6 +26,7 @@ type Props = {|
   inspectPath?: InspectPath,
   label: string,
   overrideValueFn?: ?OverrideValueFn,
+  pathRoot: string,
   showWhenEmpty?: boolean,
   canAddEntries?: boolean,
 |};
@@ -35,6 +36,7 @@ export default function InspectedElementTree({
   inspectPath,
   label,
   overrideValueFn,
+  pathRoot,
   canAddEntries = false,
   showWhenEmpty = false,
 }: Props) {
@@ -88,6 +90,7 @@ export default function InspectedElementTree({
             <KeyValue
               key={name}
               alphaSort={true}
+              pathRoot={pathRoot}
               depth={1}
               inspectPath={inspectPath}
               name={name}

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -8,13 +8,14 @@
  */
 
 import React, {useEffect, useRef, useState} from 'react';
-import type {Element} from 'react';
 import EditableValue from './EditableValue';
 import ExpandCollapseToggle from './ExpandCollapseToggle';
 import {alphaSortEntries, getMetaValueLabel} from '../utils';
 import {meta} from '../../../hydration';
+import useContextMenu from '../../ContextMenu/useContextMenu';
 import styles from './KeyValue.css';
 
+import type {Element} from 'react';
 import type {InspectPath} from './SelectedElement';
 
 type OverrideValueFn = (path: Array<string | number>, value: any) => void;
@@ -28,6 +29,7 @@ type KeyValueProps = {|
   name: string,
   overrideValueFn?: ?OverrideValueFn,
   path: Array<any>,
+  pathRoot: string,
   value: any,
 |};
 
@@ -40,10 +42,12 @@ export default function KeyValue({
   name,
   overrideValueFn,
   path,
+  pathRoot,
   value,
 }: KeyValueProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const prevIsOpenRef = useRef(isOpen);
+  const contextMenuTriggerRef = useRef(null);
 
   const isInspectable =
     value !== null &&
@@ -67,6 +71,12 @@ export default function KeyValue({
   );
 
   const toggleIsOpen = () => setIsOpen(prevIsOpen => !prevIsOpen);
+
+  useContextMenu({
+    data: [pathRoot, ...path],
+    id: 'SelectedElement',
+    ref: contextMenuTriggerRef,
+  });
 
   const dataType = typeof value;
   const isSimpleType =
@@ -95,7 +105,13 @@ export default function KeyValue({
     const isEditable = typeof overrideValueFn === 'function' && !isReadOnly;
 
     children = (
-      <div key="root" className={styles.Item} hidden={hidden} style={style}>
+      <div
+        key="root"
+        path={path}
+        className={styles.Item}
+        hidden={hidden}
+        ref={contextMenuTriggerRef}
+        style={style}>
         <div className={styles.ExpandCollapseToggleSpacer} />
         <span className={isEditable ? styles.EditableName : styles.Name}>
           {name}
@@ -116,7 +132,12 @@ export default function KeyValue({
     !value.hasOwnProperty(meta.unserializable)
   ) {
     children = (
-      <div key="root" className={styles.Item} hidden={hidden} style={style}>
+      <div
+        ref={contextMenuTriggerRef}
+        key="root"
+        className={styles.Item}
+        hidden={hidden}
+        style={style}>
         {isInspectable ? (
           <ExpandCollapseToggle isOpen={isOpen} setIsOpen={setIsOpen} />
         ) : (
@@ -150,11 +171,13 @@ export default function KeyValue({
           name={index}
           overrideValueFn={overrideValueFn}
           path={path.concat(index)}
+          pathRoot={pathRoot}
           value={value[index]}
         />
       ));
       children.unshift(
         <div
+          ref={contextMenuTriggerRef}
           key={`${depth}-root`}
           className={styles.Item}
           hidden={hidden}
@@ -200,11 +223,13 @@ export default function KeyValue({
           name={key}
           overrideValueFn={overrideValueFn}
           path={path.concat(key)}
+          pathRoot={pathRoot}
           value={keyValue}
         />
       ));
       children.unshift(
         <div
+          ref={contextMenuTriggerRef}
           key={`${depth}-root`}
           className={styles.Item}
           hidden={hidden}

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -73,7 +73,15 @@ export default function KeyValue({
   const toggleIsOpen = () => setIsOpen(prevIsOpen => !prevIsOpen);
 
   useContextMenu({
-    data: [pathRoot, ...path],
+    data: {
+      path: [pathRoot, ...path],
+      type:
+        value !== null &&
+        typeof value === 'object' &&
+        value.hasOwnProperty(meta.type)
+          ? value[meta.type]
+          : typeof value,
+    },
     id: 'SelectedElement',
     ref: contextMenuTriggerRef,
   });

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.css
@@ -112,3 +112,7 @@
   margin-left: 0.5rem;
   padding: 0;
 }
+
+.ContextMenuIcon {
+  margin-right: 0.5rem;
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -10,7 +10,7 @@
 import {copy} from 'clipboard-js';
 import React, {Fragment, useCallback, useContext} from 'react';
 import {TreeDispatcherContext, TreeStateContext} from './TreeContext';
-import {BridgeContext, StoreContext} from '../context';
+import {BridgeContext, ContextMenuContext, StoreContext} from '../context';
 import ContextMenu from '../../ContextMenu/ContextMenu';
 import ContextMenuItem from '../../ContextMenu/ContextMenuItem';
 import Button from '../Button';
@@ -61,6 +61,7 @@ export default function SelectedElement(_: Props) {
     getInspectedElementPath,
     getInspectedElement,
     storeAsGlobal,
+    viewInspectedElementPath,
   } = useContext(InspectedElementContext);
 
   const element =
@@ -254,6 +255,7 @@ export default function SelectedElement(_: Props) {
           getInspectedElementPath={getInspectedElementPath}
           inspectedElement={inspectedElement}
           storeAsGlobal={storeAsGlobal}
+          viewInspectedElementPath={viewInspectedElementPath}
         />
       )}
     </div>
@@ -279,6 +281,7 @@ function InspectedElementView({
   getInspectedElementPath,
   inspectedElement,
   storeAsGlobal,
+  viewInspectedElementPath,
 }: InspectedElementViewProps) {
   const {id, type} = element;
   const {
@@ -297,6 +300,11 @@ function InspectedElementView({
   const {ownerID} = useContext(TreeStateContext);
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
+
+  const {
+    isEnabledForInspectedElement,
+    viewAttributeSourceFunction,
+  } = useContext(ContextMenuContext);
 
   const inspectContextPath = useCallback(
     (path: Array<string | number>) => {
@@ -432,20 +440,38 @@ function InspectedElementView({
         )}
       </div>
 
-      <ContextMenu id="SelectedElement">
-        <ContextMenuItem
-          onClick={path => copyInspectedElementPath(id, path)}
-          title="Copy value to clipboard">
-          <Icon className={styles.ContextMenuIcon} type="copy" /> Copy value to
-          clipboard
-        </ContextMenuItem>
-        <ContextMenuItem
-          onClick={path => storeAsGlobal(id, path)}
-          title="Store as global variable">
-          <Icon className={styles.ContextMenuIcon} type="code" /> Store as
-          global variable
-        </ContextMenuItem>
-      </ContextMenu>
+      {isEnabledForInspectedElement && (
+        <ContextMenu id="SelectedElement">
+          {data => (
+            <Fragment>
+              <ContextMenuItem
+                onClick={() => copyInspectedElementPath(id, data.path)}
+                title="Copy value to clipboard">
+                <Icon className={styles.ContextMenuIcon} type="copy" /> Copy
+                value to clipboard
+              </ContextMenuItem>
+              <ContextMenuItem
+                onClick={() => storeAsGlobal(id, data.path)}
+                title="Store as global variable">
+                <Icon
+                  className={styles.ContextMenuIcon}
+                  type="store-as-global-variable"
+                />{' '}
+                Store as global variable
+              </ContextMenuItem>
+              {viewAttributeSourceFunction !== null &&
+                data.type === 'function' && (
+                  <ContextMenuItem
+                    onClick={() => viewAttributeSourceFunction(id, data.path)}
+                    title="Go to definition">
+                    <Icon className={styles.ContextMenuIcon} type="code" /> Go
+                    to definition
+                  </ContextMenuItem>
+                )}
+            </Fragment>
+          )}
+        </ContextMenu>
+      )}
     </Fragment>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -20,7 +20,8 @@ export type IconType =
   | 'profiler'
   | 'ranked-chart'
   | 'search'
-  | 'settings';
+  | 'settings'
+  | 'store-as-global-variable';
 
 type Props = {|
   className?: string,
@@ -59,6 +60,9 @@ export default function Icon({className = '', type}: Props) {
       break;
     case 'settings':
       pathData = PATH_SETTINGS;
+      break;
+    case 'store-as-global-variable':
+      pathData = PATH_STORE_AS_GLOBAL_VARIABLE;
       break;
     default:
       console.warn(`Unsupported type "${type}" specified for Icon`);
@@ -131,4 +135,11 @@ const PATH_SETTINGS = `
   1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49
   1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 15.5c-1.93 0-3.5-1.57-3.5-3.5s1.57-3.5
   3.5-3.5 3.5 1.57 3.5 3.5-1.57 3.5-3.5 3.5z
+`;
+
+const PATH_STORE_AS_GLOBAL_VARIABLE = `
+  M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41
+  3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04
+  1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6
+  8h-4v-2h4v2zm0-4h-4v-2h4v2z
 `;

--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -12,7 +12,9 @@ import styles from './Icon.css';
 
 export type IconType =
   | 'arrow'
+  | 'code'
   | 'components'
+  | 'copy'
   | 'flame-chart'
   | 'interactions'
   | 'profiler'
@@ -31,8 +33,14 @@ export default function Icon({className = '', type}: Props) {
     case 'arrow':
       pathData = PATH_ARROW;
       break;
+    case 'code':
+      pathData = PATH_CODE;
+      break;
     case 'components':
       pathData = PATH_COMPONENTS;
+      break;
+    case 'copy':
+      pathData = PATH_COPY;
       break;
     case 'flame-chart':
       pathData = PATH_FLAME_CHART;
@@ -72,8 +80,17 @@ export default function Icon({className = '', type}: Props) {
 
 const PATH_ARROW = 'M8 5v14l11-7z';
 
+const PATH_CODE = `
+  M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z
+  `;
+
 const PATH_COMPONENTS =
   'M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z';
+
+const PATH_COPY = `
+  M3 13h2v-2H3v2zm0 4h2v-2H3v2zm2 4v-2H3a2 2 0 0 0 2 2zM3 9h2V7H3v2zm12 12h2v-2h-2v2zm4-18H9a2 2 0 0 0-2
+  2v10a2 2 0 0 0 2 2h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H9V5h10v10zm-8 6h2v-2h-2v2zm-4 0h2v-2H7v2z
+`;
 
 const PATH_FLAME_CHART = `
   M10.0650893,21.5040462 C7.14020814,20.6850349 5,18.0558698 5,14.9390244 C5,14.017627

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -313,6 +313,16 @@ function updateThemeVariables(
     'color-component-badge-count-inverted',
     documentElements,
   );
+  updateStyleHelper(theme, 'color-context-background', documentElements);
+  updateStyleHelper(theme, 'color-context-background-hover', documentElements);
+  updateStyleHelper(
+    theme,
+    'color-context-background-selected',
+    documentElements,
+  );
+  updateStyleHelper(theme, 'color-context-border', documentElements);
+  updateStyleHelper(theme, 'color-context-text', documentElements);
+  updateStyleHelper(theme, 'color-context-text-selected', documentElements);
   updateStyleHelper(theme, 'color-dim', documentElements);
   updateStyleHelper(theme, 'color-dimmer', documentElements);
   updateStyleHelper(theme, 'color-dimmest', documentElements);

--- a/packages/react-devtools-shared/src/devtools/views/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/context.js
@@ -10,6 +10,7 @@
 import {createContext} from 'react';
 import Store from '../store';
 
+import type {ViewAttributeSource} from 'react-devtools-shared/src/devtools/views/DevTools';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 
 export const BridgeContext = createContext<FrontendBridge>(
@@ -19,3 +20,14 @@ BridgeContext.displayName = 'BridgeContext';
 
 export const StoreContext = createContext<Store>(((null: any): Store));
 StoreContext.displayName = 'StoreContext';
+
+export type ContextMenuContextType = {|
+  isEnabledForInspectedElement: boolean,
+  viewAttributeSourceFunction?: ?ViewAttributeSource,
+|};
+
+export const ContextMenuContext = createContext<ContextMenuContextType>({
+  isEnabledForInspectedElement: false,
+  viewAttributeSourceFunction: null,
+});
+ContextMenuContext.displayName = 'ContextMenuContext';

--- a/packages/react-devtools-shared/src/devtools/views/root.css
+++ b/packages/react-devtools-shared/src/devtools/views/root.css
@@ -43,6 +43,12 @@
   --light-color-component-badge-background-inverted: rgba(255, 255, 255, 0.25);
   --light-color-component-badge-count: #777d88;
   --light-color-component-badge-count-inverted: rgba(255, 255, 255, 0.7);
+  --light-color-context-background: rgba(0,0,0,.9);
+  --light-color-context-background-hover: rgba(255, 255, 255, 0.1);
+  --light-color-context-background-selected: #178fb9;
+  --light-color-context-border: #3d424a;
+  --light-color-context-text: #ffffff;
+  --light-color-context-text-selected: #ffffff;
   --light-color-dim: #777d88;
   --light-color-dimmer: #cfd1d5;
   --light-color-dimmest: #eff0f1;
@@ -109,6 +115,12 @@
   --dark-color-component-badge-background-inverted: rgba(0, 0, 0, 0.25);
   --dark-color-component-badge-count: #8f949d;
   --dark-color-component-badge-count-inverted: rgba(255, 255, 255, 0.7);
+  --dark-color-context-background: rgba(255,255,255,.9);
+  --dark-color-context-background-hover: rgba(0, 136, 250, 0.1);
+  --dark-color-context-background-selected: #0088fa;
+  --dark-color-context-border: #eeeeee;
+  --dark-color-context-text: #000000;
+  --dark-color-context-text-selected: #ffffff;
   --dark-color-dim: #8f949d;
   --dark-color-dimmer: #777d88;
   --dark-color-dimmest: #4f5766;

--- a/packages/react-devtools-shell/src/app/InspectableElements/CircularReferences.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CircularReferences.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React from 'react';
+
+const arrayOne = [];
+const arrayTwo = [];
+arrayTwo.push(arrayOne);
+arrayOne.push(arrayTwo);
+
+const objectOne = {};
+const objectTwo = {objectOne};
+objectOne.objectTwo = objectTwo;
+
+export default function CircularReferences() {
+  return <ChildComponent arrayOne={arrayOne} objectOne={objectOne} />;
+}
+
+function ChildComponent(props: any) {
+  return null;
+}

--- a/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
@@ -9,6 +9,7 @@
 
 import React, {Fragment} from 'react';
 import UnserializableProps from './UnserializableProps';
+import CircularReferences from './CircularReferences';
 import Contexts from './Contexts';
 import CustomHooks from './CustomHooks';
 import CustomObject from './CustomObject';
@@ -27,6 +28,7 @@ export default function InspectableElements() {
       <Contexts />
       <CustomHooks />
       <CustomObject />
+      <CircularReferences />
     </Fragment>
   );
 }

--- a/packages/react-devtools-shell/src/app/InspectableElements/SimpleValues.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/SimpleValues.js
@@ -9,6 +9,8 @@
 
 import React from 'react';
 
+function noop() {}
+
 export default function SimpleValues() {
   return (
     <ChildComponent
@@ -21,6 +23,7 @@ export default function SimpleValues() {
       infinity={Infinity}
       true={true}
       false={false}
+      function={noop}
     />
   );
 }

--- a/packages/react-devtools-shell/src/devtools.js
+++ b/packages/react-devtools-shell/src/devtools.js
@@ -55,6 +55,7 @@ inject('dist/app.js', () => {
       root.render(
         createElement(DevTools, {
           browserTheme: 'light',
+          enabledInspectedElementContextMenu: true,
           showTabBar: true,
           warnIfLegacyBackendDetected: true,
           warnIfUnsupportedVersionDetected: true,


### PR DESCRIPTION
Inspired by built-in browser console options, this PR adds the ability to copy specific props/state/context/hooks values to the clipboard and to store them in a global variables (`$reactTemp`).

## Checklist
- [x] Add context menu component and hook.
- [x] Add backend commands for copying variables, storing global values, and inspecting attributes (works similarly to pre-existing pattern for inspecting React components).
- [x] Wire up context menu and backend commands to enable interacting with selected element props/state/hooks/context.
- [x] Add unit tests to cover new behavior.
- [x] Add `DevTools` props for enabling new behavior per environment. (Disabled for React Native for now.)

## New context menu options
![Copy and store-as-global demo video](https://user-images.githubusercontent.com/29597/71118140-56958900-218c-11ea-92a9-5a0c121ddf62.gif)

## Works for nested values
![Demo of inspecting arbitrary props](https://user-images.githubusercontent.com/29597/70856262-4aa87f00-1e8d-11ea-986f-5950e5859e95.gif)
