### PR TITLE
fix(dev-tools): fix show correct displayName with forwardRef in Dev Tools

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -364,18 +364,9 @@ export function getInternalReactConstants(
       case IndeterminateComponent:
         return getDisplayName(resolvedType);
       case ForwardRef:
-        // maybe set `displayName` after `React.forwardRef()`
-        //
-        // ```
-        // const Component = React.forwardRef(WrapComponent);
-        // Component.displayName = 'OtherName'
-        // ```
-        //
-        // `resolvedType` is `WrapComponent`
-        // `type` is Component
+        // Mirror https://github.com/facebook/react/blob/7c21bf72ace77094fd1910cc350a548287ef8350/packages/shared/getComponentName.js#L27-L37
         return (
           (type && type.displayName) ||
-          resolvedType.displayName ||
           getDisplayName(resolvedType, 'Anonymous')
         );
       case HostRoot:
@@ -388,11 +379,7 @@ export function getInternalReactConstants(
         return null;
       case MemoComponent:
       case SimpleMemoComponent:
-        if (elementType.displayName) {
-          return elementType.displayName;
-        } else {
-          return getDisplayName(resolvedType, 'Anonymous');
-        }
+        return getDisplayName(resolvedType, 'Anonymous');
       case SuspenseComponent:
         return 'Suspense';
       case SuspenseListComponent:

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -364,8 +364,19 @@ export function getInternalReactConstants(
       case IndeterminateComponent:
         return getDisplayName(resolvedType);
       case ForwardRef:
+        // maybe set `displayName` after `React.forwardRef()`
+        //
+        // ```
+        // const Component = React.forwardRef(WrapComponent);
+        // Component.displayName = 'OtherName'
+        // ```
+        //
+        // `resolvedType` is `WrapComponent`
+        // `type` is Component
         return (
-          resolvedType.displayName || getDisplayName(resolvedType, 'Anonymous')
+          (type && type.displayName) ||
+          resolvedType.displayName ||
+          getDisplayName(resolvedType, 'Anonymous')
         );
       case HostRoot:
         return null;

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -347,7 +347,7 @@ export function getInternalReactConstants(
 
   // NOTICE Keep in sync with shouldFilterFiber() and other get*ForFiber methods
   function getDisplayNameForFiber(fiber: Fiber): string | null {
-    const {elementType, type, tag} = fiber;
+    const {type, tag} = fiber;
 
     let resolvedType = type;
     if (typeof type === 'object' && type !== null) {


### PR DESCRIPTION
allow set `displayName` after `React.forwardRef()`,

makesure Dev Tools show displayName as same as `getWrappedName` in `shared/getComponentName.js`.

It seems like a regressive bug and fixed in legacy react-devtools(https://github.com/facebook/react-devtools/pull/1154/files), but back now.

refs: 
- https://github.com/facebook/react-devtools/pull/1154/files
- emotion-js/emotion#1692

## **Before in React DevTools:**

![image](https://user-images.githubusercontent.com/15135943/70863953-778d8c80-1f88-11ea-9fca-07b58cd50b06.png)

## **After fixed in React DevTools**

![image](https://user-images.githubusercontent.com/15135943/70863947-6c3a6100-1f88-11ea-8bea-ce4baaf90a96.png)

