### PR TITLE
Use zero-fill right shift instead of Math.floor

### DIFF
--- a/packages/scheduler/src/SchedulerMinHeap.js
+++ b/packages/scheduler/src/SchedulerMinHeap.js
@@ -41,7 +41,7 @@ export function pop(heap: Heap): Node | null {
 function siftUp(heap, node, i) {
   let index = i;
   while (true) {
-    const parentIndex = Math.floor((index - 1) / 2);
+    const parentIndex = (index - 1) >>> 1;
     const parent = heap[parentIndex];
     if (parent !== undefined && compare(parent, node) > 0) {
       // The parent is larger. Swap positions.


### PR DESCRIPTION
For positive numbers, binary displacement is better.
