### PR TITLE
Fix test_build_devtools CI job to run test-build-devtools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,7 @@ jobs:
       - *run_yarn
       - run:
           environment:
-            RELEASE_CHANNEL: stable
+            RELEASE_CHANNEL: experimental
           command: yarn test-build-devtools --maxWorkers=2
 
   test_dom_fixtures:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ workflows:
             - build
       - test_build_devtools:
           requires:
-            - build
+            - build_experimental
       - test_dom_fixtures:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ jobs:
       - run:
           environment:
             RELEASE_CHANNEL: stable
-          command: yarn test-build --maxWorkers=2
+          command: yarn test-build-devtools --maxWorkers=2
 
   test_dom_fixtures:
     docker: *docker

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -514,6 +514,7 @@ describe('InspectedElementContext', () => {
     const arrayOfArrays = [[['abc', 123, true], []]];
     const div = document.createElement('div');
     const exampleFunction = () => {};
+    const exampleDateISO = '2019-12-31T23:42:42.000Z';
     const setShallow = new Set(['abc', 123]);
     const mapShallow = new Map([['name', 'Brian'], ['food', 'sushi']]);
     const setOfSets = new Set([new Set(['a', 'b', 'c']), new Set([1, 2, 3])]);
@@ -542,7 +543,7 @@ describe('InspectedElementContext', () => {
           // eslint-disable-next-line no-undef
           big_int={BigInt(123)}
           data_view={dataView}
-          date={new Date(123)}
+          date={new Date(exampleDateISO)}
           fn={exampleFunction}
           html_element={div}
           immutable={immutableMap}
@@ -634,11 +635,11 @@ describe('InspectedElementContext', () => {
 
     expect(date[meta.inspectable]).toBe(false);
     expect(date[meta.type]).toBe('date');
-    expect(date[meta.preview_long]).toBe(
-      'Wed Dec 31 1969 16:00:00 GMT-0800 (Pacific Standard Time)',
+    expect(new Date(date[meta.preview_long]).toISOString()).toBe(
+      exampleDateISO,
     );
-    expect(date[meta.preview_short]).toBe(
-      'Wed Dec 31 1969 16:00:00 GMT-0800 (Pacific Standard Time)',
+    expect(new Date(date[meta.preview_short]).toISOString()).toBe(
+      exampleDateISO,
     );
 
     expect(fn[meta.inspectable]).toBe(false);

--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -14,7 +14,13 @@ const packages = readdirSync(packagesRoot).filter(dir => {
     return false;
   }
   const packagePath = join(packagesRoot, dir, 'package.json');
-  return statSync(packagePath).isFile();
+  let stat;
+  try {
+    stat = statSync(packagePath);
+  } catch (err) {
+    return false;
+  }
+  return stat.isFile();
 });
 
 // Create a module map to point React packages to the build output

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -11,7 +11,13 @@ const packages = readdirSync(packagesRoot).filter(dir => {
     return false;
   }
   const packagePath = join(packagesRoot, dir, 'package.json');
-  return statSync(packagePath).isFile();
+  let stat;
+  try {
+    stat = statSync(packagePath);
+  } catch (err) {
+    return false;
+  }
+  return stat.isFile();
 });
 
 // Create a module map to point React packages to the build output

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -68,11 +68,14 @@ module.exports = {
       // for test files, we also apply the async-await transform, but we want to
       // make sure we don't accidentally apply that transform to product code.
       const isTestFile = !!filePath.match(/\/__tests__\//);
+      const isInDevToolsPackages = !!filePath.match(
+        /\/packages\/react-devtools.*\//
+      );
       const testOnlyPlugins = [pathToBabelPluginAsyncToGenerator];
-      const sourceOnlyPlugins =
-        process.env.NODE_ENV === 'development'
-          ? [pathToBabelPluginReplaceConsoleCalls]
-          : [];
+      const sourceOnlyPlugins = [];
+      if (process.env.NODE_ENV === 'development' && !isInDevToolsPackages) {
+        sourceOnlyPlugins.push(pathToBabelPluginReplaceConsoleCalls);
+      }
       const plugins = (isTestFile ? testOnlyPlugins : sourceOnlyPlugins).concat(
         babelOptions.plugins
       );


### PR DESCRIPTION
We're testing the wrong thing in this job. Probably bad copy paste.
As a result, regressions like https://github.com/facebook/react/pull/17599 creep in.

First commit is a small fix that fixes running it locally after a package got renamed. (The command crashed for me locally otherwise, which made verifying the fix annoying.)

The second commit makes the right command run on CI. It fails, as expected.

The third commit fixes https://github.com/facebook/react/issues/17630.