### PR TITLE
[Fast Refresh] Support injecting runtime after renderer executes

### DIFF
--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -277,6 +277,8 @@ export function installHook(target: any): DevToolsHook | null {
   const hook: DevToolsHook = {
     rendererInterfaces,
     listeners,
+
+    // Fast Refresh for web relies on this.
     renderers,
 
     emit,


### PR DESCRIPTION
I think this fixes https://github.com/facebook/react/issues/17626 and https://github.com/facebook/react/issues/17552.

I was assuming that Fresh runtime always executes before the renderer. But on the web this won't be the case if you load React from CDN and *then* run your webpack bundle (https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/13). And separating `<script>` tags can be annoying and complicated.

Instead, we can handle the simple case — when ReactDOM executes before the webpack bundle — gracefully. The DevTools global hook already has a [renderers map](https://github.com/facebook/react/blob/36a6e29bb3eead85e3500ba7269cbcd55516a8fb/packages/react-devtools-shared/src/hook.js#L280) so all we need to connect to them is to read from it. In fact that's how DevTools backends themselves [connect to already injected renderers](https://github.com/facebook/react/blob/36a6e29bb3eead85e3500ba7269cbcd55516a8fb/packages/react-devtools-shared/src/backend/index.js#L85-L86).

This still doesn't handle the case where you mount some roots *before* injecting the runtime. In that case they won't be "visible" to Fresh. Arguably this is more of a corner case and I wouldn't bother solving this yet. The webpack plugin should be able to ensure that injection happens before the actual app code runs.

I added a regression test.