### PR TITLE
[react-interactions] Add Listener API + useEvent hook

### DIFF
--- a/packages/legacy-events/EventSystemFlags.js
+++ b/packages/legacy-events/EventSystemFlags.js
@@ -11,8 +11,9 @@ export type EventSystemFlags = number;
 
 export const PLUGIN_EVENT_SYSTEM = 1;
 export const RESPONDER_EVENT_SYSTEM = 1 << 1;
-export const IS_PASSIVE = 1 << 2;
-export const IS_ACTIVE = 1 << 3;
-export const PASSIVE_NOT_SUPPORTED = 1 << 4;
-export const IS_REPLAYED = 1 << 5;
-export const IS_FIRST_ANCESTOR = 1 << 6;
+export const LISTENER_EVENT_SYSTEM = 1 << 2;
+export const IS_PASSIVE = 1 << 3;
+export const IS_ACTIVE = 1 << 4;
+export const PASSIVE_NOT_SUPPORTED = 1 << 5;
+export const IS_REPLAYED = 1 << 6;
+export const IS_FIRST_ANCESTOR = 1 << 7;

--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -17,7 +17,7 @@ import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
 export type EventTypes = {[key: string]: DispatchConfig, ...};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -122,12 +122,8 @@ export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
   if (
     !isInsideEventHandler &&
     ((!enableDeprecatedFlareAPI && !enableListenerAPI) ||
-<<<<<<< HEAD
-      (timeStamp === 0 || lastFlushedEventTimeStamp !== timeStamp))
-=======
       timeStamp === 0 ||
       lastFlushedEventTimeStamp !== timeStamp)
->>>>>>> Fix prettier
   ) {
     lastFlushedEventTimeStamp = timeStamp;
     flushDiscreteUpdatesImpl();

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -122,7 +122,12 @@ export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
   if (
     !isInsideEventHandler &&
     ((!enableDeprecatedFlareAPI && !enableListenerAPI) ||
+<<<<<<< HEAD
       (timeStamp === 0 || lastFlushedEventTimeStamp !== timeStamp))
+=======
+      timeStamp === 0 ||
+      lastFlushedEventTimeStamp !== timeStamp)
+>>>>>>> Fix prettier
   ) {
     lastFlushedEventTimeStamp = timeStamp;
     flushDiscreteUpdatesImpl();

--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -10,7 +10,10 @@ import {
   restoreStateIfNeeded,
 } from './ReactControlledComponent';
 
-import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableDeprecatedFlareAPI,
+  enableListenerAPI,
+} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 
 // Used as a way to call batchedUpdates when we don't have a reference to
@@ -118,9 +121,8 @@ export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
   // behaviour as we had before this change, so the risks are low.
   if (
     !isInsideEventHandler &&
-    (!enableDeprecatedFlareAPI ||
-      timeStamp === 0 ||
-      lastFlushedEventTimeStamp !== timeStamp)
+    ((!enableDeprecatedFlareAPI && !enableListenerAPI) ||
+      (timeStamp === 0 || lastFlushedEventTimeStamp !== timeStamp))
   ) {
     lastFlushedEventTimeStamp = timeStamp;
     flushDiscreteUpdatesImpl();

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -469,3 +469,26 @@ export function getInstanceFromNode(node) {
 export function beforeRemoveInstance(instance) {
   // noop
 }
+
+export function registerListenerEvent(
+  event: any,
+  rootContainerInstance: Container,
+): void {
+  // noop
+}
+
+export function attachListenerToInstance(listener: any): any {
+  // noop
+}
+
+export function detachListenerFromInstance(listener: any): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
+  // noop
+}

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -485,10 +485,6 @@ export function detachListenerFromInstance(listener: any): any {
   // noop
 }
 
-export function validateReactListenerDeleteListener(instance): void {
-  // noop
-}
-
-export function validateReactListenerMapListener(instance, listener): void {
+export function validateReactListenerMapSetListener(instance, listener): void {
   // noop
 }

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -240,6 +240,17 @@ function useResponder(
   };
 }
 
+const noOp = () => {};
+
+function useEvent(options: any): any {
+  hookLog.push({primitive: 'Event', stackError: new Error(), value: options});
+  return {
+    clear: noOp,
+    listen: noOp,
+    unlisten: noOp,
+  };
+}
+
 function useTransition(
   config: SuspenseConfig | null | void,
 ): [(() => void) => void, boolean] {
@@ -277,6 +288,7 @@ const Dispatcher: DispatcherType = {
   useResponder,
   useTransition,
   useDeferredValue,
+  useEvent,
 };
 
 // Inspect

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -242,8 +242,8 @@ function useResponder(
 
 const noOp = () => {};
 
-function useEvent(options: any): any {
-  hookLog.push({primitive: 'Event', stackError: new Error(), value: options});
+function useEvent(event: any): any {
+  hookLog.push({primitive: 'Event', stackError: new Error(), value: event});
   return {
     clear: noOp,
     listen: noOp,

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -60,6 +60,7 @@ import {
   disableUnstableRenderSubtreeIntoContainer,
   warnUnstableRenderSubtreeIntoContainer,
   isTestEnvironment,
+  enableListenerAPI,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -77,6 +78,7 @@ import {
   setAttemptHydrationAtCurrentPriority,
   queueExplicitHydrationTarget,
 } from '../events/ReactDOMEventReplaying';
+import {useEvent} from './ReactDOMEventListenerHooks';
 
 setAttemptSynchronousHydration(attemptSynchronousHydration);
 setAttemptUserBlockingHydration(attemptUserBlockingHydration);
@@ -217,6 +219,10 @@ if (!disableUnstableCreatePortal) {
     }
     return createPortal(...args);
   };
+}
+
+if (enableListenerAPI) {
+  ReactDOM.unstable_useEvent = useEvent;
 }
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1344,15 +1344,14 @@ export function listenToEventResponderEventTypes(
   }
 }
 
-export function listenToEventListener(
+export function listenToListenerSystemEvent(
   type: string,
   passive: boolean,
-  document: Document,
 ): void {
   if (enableListenerAPI) {
     // Get the listening Map for this element. We use this to track
     // what events we're listening to.
-    const listenerMap = getListenerMapForElement(document);
+    const listenerMap = getListenerMapForElement(window);
     const passiveKey = type + '_passive';
     const activeKey = type + '_active';
     const eventKey = passive ? passiveKey : activeKey;
@@ -1374,7 +1373,7 @@ export function listenToEventListener(
           }
         }
       }
-      const eventListener = addListenerSystemEvent(document, type, passive);
+      const eventListener = addListenerSystemEvent(window, type, passive);
       listenerMap.set(eventKey, eventListener);
     }
   }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
+
 import {
   HostComponent,
   HostText,
@@ -166,10 +168,15 @@ export function updateFiberProps(node, props) {
   node[internalEventHandlersKey] = props;
 }
 
-export function getListenersFromNode(node) {
+export function getListenersFromNode(
+  node: HTMLElement | Document,
+): null | ReactDOMListener {
   return node[internalEventListenersKey] || null;
 }
 
-export function initListenersSet(node, value) {
+export function initListenersSet(
+  node: HTMLElement | Document,
+  value: Set<ReactDOMListener>,
+): void {
   node[internalEventListenersKey] = value;
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -20,6 +20,7 @@ const randomKey = Math.random()
   .slice(2);
 const internalInstanceKey = '__reactInternalInstance$' + randomKey;
 const internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
+const internalEventListenersKey = '__reactEventListeners$' + randomKey;
 const internalContainerInstanceKey = '__reactContainere$' + randomKey;
 
 export function precacheFiberNode(hostInst, node) {
@@ -163,4 +164,12 @@ export function getFiberCurrentPropsFromNode(node) {
 
 export function updateFiberProps(node, props) {
   node[internalEventHandlersKey] = props;
+}
+
+export function getListenersFromNode(node) {
+  return node[internalEventListenersKey] || null;
+}
+
+export function initListenersSet(node, value) {
+  node[internalEventListenersKey] = value;
 }

--- a/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
+++ b/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {EventPriority} from 'shared/ReactTypes';
 import type {
   ReactDOMListenerEvent,
   ReactDOMListenerMap,
@@ -23,7 +24,7 @@ const ReactCurrentDispatcher =
 type EventOptions = {|
   capture?: boolean,
   passive?: boolean,
-  priority?: number,
+  priority?: EventPriority,
 |};
 
 function resolveDispatcher() {
@@ -50,9 +51,9 @@ export function useEvent(
   let priority = getEventPriorityForListenerSystem((type: any));
 
   if (options != null) {
-    const optionsCapture = options && options.capture;
-    const optionsPassive = options && options.passive;
-    const optionsPriority = options && options.priority;
+    const optionsCapture = options.capture;
+    const optionsPassive = options.passive;
+    const optionsPriority = options.priority;
 
     if (typeof optionsCapture === 'boolean') {
       capture = optionsCapture;

--- a/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
+++ b/packages/react-dom/src/client/ReactDOMEventListenerHooks.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  ReactDOMListenerEvent,
+  ReactDOMListenerMap,
+} from 'shared/ReactDOMTypes';
+
+import React from 'react';
+import invariant from 'shared/invariant';
+import {getEventPriorityForListenerSystem} from '../events/DOMEventProperties';
+
+const ReactCurrentDispatcher =
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    .ReactCurrentDispatcher;
+
+type EventOptions = {|
+  capture?: boolean,
+  passive?: boolean,
+  priority?: number,
+|};
+
+function resolveDispatcher() {
+  const dispatcher = ReactCurrentDispatcher.current;
+  invariant(
+    dispatcher !== null,
+    'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+      ' one of the following reasons:\n' +
+      '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+      '2. You might be breaking the Rules of Hooks\n' +
+      '3. You might have more than one copy of React in the same app\n' +
+      'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+  );
+  return dispatcher;
+}
+
+export function useEvent(
+  type: string,
+  options?: EventOptions,
+): ReactDOMListenerMap {
+  const dispatcher = resolveDispatcher();
+  let capture = false;
+  let passive = false;
+  let priority = getEventPriorityForListenerSystem((type: any));
+
+  if (options != null) {
+    const optionsCapture = options && options.capture;
+    const optionsPassive = options && options.passive;
+    const optionsPriority = options && options.priority;
+
+    if (typeof optionsCapture === 'boolean') {
+      capture = optionsCapture;
+    }
+    if (typeof optionsPassive === 'boolean') {
+      passive = optionsPassive;
+    }
+    if (typeof optionsPriority === 'number') {
+      priority = optionsPriority;
+    }
+  }
+  const event: ReactDOMListenerEvent = {
+    capture,
+    passive,
+    priority,
+    type,
+  };
+  return dispatcher.useEvent(event);
+}

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1105,52 +1105,37 @@ export function detachListenerFromInstance(listener: ReactDOMListener): void {
   }
 }
 
-function validateListenerInstance(instance, methodString): boolean {
-  if (
-    instance &&
-    (instance === window || getClosestInstanceFromNode(instance))
-  ) {
-    return true;
-  }
-  if (__DEV__) {
-    if (instance && (instance: any).nodeType === DOCUMENT_NODE) {
-      console.warn(
-        'Event listener method %s() from useEvent() hook requires the first argument to be a valid' +
-          ' DOM node that was rendered and managed by React or a "window" object. It looks like' +
-          ' you supplied a "document" node, instead use the "window" object.',
-        methodString,
-      );
-    } else {
-      console.warn(
-        'Event listener method %s() from useEvent() hook requires the first argument to be a valid' +
-          ' DOM node that was rendered and managed by React or a "window" object. If this is' +
-          ' from a ref, ensure the ref value has been set before attaching.',
-        methodString,
-      );
-    }
-  }
-  return false;
-}
-
-export function validateReactListenerDeleteListener(
+export function validateReactListenerMapSetListener(
   instance: EventTarget,
-): boolean {
-  return validateListenerInstance(instance, 'deleteListener');
-}
-
-export function validateReactListenerMapListener(
-  instance: EventTarget,
-  listener: Event => void,
+  listener: ?(Event) => void,
 ): boolean {
   if (enableListenerAPI) {
-    if (validateListenerInstance(instance, 'setListener')) {
-      if (typeof listener === 'function') {
+    if (
+      instance &&
+      (instance === window || getClosestInstanceFromNode(instance))
+    ) {
+      if (listener == null || typeof listener === 'function') {
         return true;
       }
       if (__DEV__) {
         console.warn(
           'Event listener method setListener() from useEvent() hook requires the second argument' +
-            ' to be valid function callback.',
+            ' to be either a valid function callback or null/undefined.',
+        );
+      }
+    }
+    if (__DEV__) {
+      if (instance && (instance: any).nodeType === DOCUMENT_NODE) {
+        console.warn(
+          'Event listener method setListener() from useEvent() hook requires the first argument to be a valid' +
+            ' DOM node that was rendered and managed by React or a "window" object. It looks like' +
+            ' you supplied a "document" node, instead use the "window" object.',
+        );
+      } else {
+        console.warn(
+          'Event listener method setListener() from useEvent() hook requires the first argument to be a valid' +
+            ' DOM node that was rendered and managed by React or a "window" object. If this is' +
+            ' from a ref, ensure the ref value has been set before attaching.',
         );
       }
     }

--- a/packages/react-dom/src/events/DOMEventListenerSystem.js
+++ b/packages/react-dom/src/events/DOMEventListenerSystem.js
@@ -1,0 +1,353 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
+import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
+
+import {
+  ContinuousEvent,
+  UserBlockingEvent,
+  DiscreteEvent,
+} from 'shared/ReactTypes';
+import {HostComponent} from 'shared/ReactWorkTags';
+import {
+  batchedEventUpdates,
+  discreteUpdates,
+  flushDiscreteUpdatesIfNeeded,
+  executeUserEventHandler,
+} from 'legacy-events/ReactGenericBatching';
+
+// Intentionally not named imports because Rollup would use dynamic dispatch for
+// CommonJS interop named imports.
+import * as Scheduler from 'scheduler';
+import {enableListenerAPI} from 'shared/ReactFeatureFlags';
+import {
+  initListenersSet,
+  getListenersFromNode,
+} from '../client/ReactDOMComponentTree';
+
+const {
+  unstable_UserBlockingPriority: UserBlockingPriority,
+  unstable_runWithPriority: runWithPriority,
+} = Scheduler;
+const arrayFrom = Array.from;
+
+type EventProperties = {|
+  currentTarget: null | Document | Element,
+  eventPhase: number,
+  stopImmediatePropagation: boolean,
+  stopPropagation: boolean,
+|};
+
+const documentCaptureListeners = new Map();
+const documentBubbleListeners = new Map();
+
+function monkeyPatchNativeEvent(nativeEvent: any): EventProperties {
+  if (nativeEvent._reactEventProperties) {
+    const eventProperties = nativeEvent._reactEventProperties;
+    eventProperties.stopImmediatePropagation = false;
+    eventProperties.stopPropagation = false;
+    return eventProperties;
+  }
+  const eventProperties = {
+    currentTarget: null,
+    eventPhase: 0,
+    stopImmediatePropagation: false,
+    stopPropagation: false,
+  };
+  // $FlowFixMe: prevent Flow complaining about needing a value
+  Object.defineProperty(nativeEvent, 'currentTarget', {
+    get() {
+      return eventProperties.currentTarget;
+    },
+  });
+  // $FlowFixMe: prevent Flow complaning about needing a value
+  Object.defineProperty(nativeEvent, 'eventPhase', {
+    get() {
+      return eventProperties.eventPhase;
+    },
+  });
+  nativeEvent.stopPropagation = () => {
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent.stopImmediatePropagation = () => {
+    eventProperties.stopImmediatePropagation = true;
+    eventProperties.stopPropagation = true;
+  };
+  nativeEvent._reactEventProperties = eventProperties;
+  return eventProperties;
+}
+
+function getElementListeners(
+  eventType: string,
+  target: null | Fiber,
+): [Array<ReactDOMListener>, Array<ReactDOMListener>] {
+  const captureListeners = [];
+  const bubbleListeners = [];
+  let propagationDepth = 0;
+
+  let currentFiber = target;
+  while (currentFiber !== null) {
+    const {tag} = currentFiber;
+    if (tag === HostComponent) {
+      const hostInstance = currentFiber.stateNode;
+      const listenersSet = getListenersFromNode(hostInstance);
+
+      if (listenersSet !== null) {
+        const listeners = Array.from(listenersSet);
+        for (let i = 0; i < listeners.length; i++) {
+          const listener = listeners[i];
+          const {capture, type} = listener.event;
+          if (type === eventType) {
+            listener.depth = propagationDepth;
+            if (capture === true) {
+              captureListeners.push(listener);
+            } else {
+              bubbleListeners.push(listener);
+            }
+          }
+        }
+        propagationDepth++;
+      }
+    }
+    currentFiber = currentFiber.return;
+  }
+  return [captureListeners, bubbleListeners];
+}
+
+function getDocumentListenerSet(
+  type: string,
+  capture: boolean,
+): Set<ReactDOMListener> {
+  const delegatedEventListeners = capture
+    ? documentCaptureListeners
+    : documentBubbleListeners;
+  let listenersSet = delegatedEventListeners.get(type);
+
+  if (listenersSet === undefined) {
+    listenersSet = new Set();
+    delegatedEventListeners.set(type, listenersSet);
+  }
+  return listenersSet;
+}
+
+function dispatchListener(
+  listener: ReactDOMListener,
+  eventProperties: EventProperties,
+  nativeEvent: AnyNativeEvent,
+): void {
+  const callback = listener.callback;
+  eventProperties.currentTarget = listener.instance;
+  executeUserEventHandler(callback, nativeEvent);
+}
+
+function dispatchListenerAtPriority(
+  listener: ReactDOMListener,
+  eventProperties: EventProperties,
+  nativeEvent: AnyNativeEvent,
+) {
+  // The callback can either null or undefined, if so we skip dispatching it
+  if (listener.callback == null) {
+    return;
+  }
+  switch (listener.event.priority) {
+    case DiscreteEvent: {
+      flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+      discreteUpdates(() =>
+        dispatchListener(listener, eventProperties, nativeEvent),
+      );
+      break;
+    }
+    case UserBlockingEvent: {
+      runWithPriority(UserBlockingPriority, () =>
+        dispatchListener(listener, eventProperties, nativeEvent),
+      );
+      break;
+    }
+    case ContinuousEvent: {
+      dispatchListener(listener, eventProperties, nativeEvent);
+      break;
+    }
+  }
+}
+
+function shouldStopPropagation(
+  eventProperties: EventProperties,
+  lastPropagationDepth: void | number,
+  propagationDepth: number,
+): boolean {
+  return (
+    (eventProperties.stopPropagation === true &&
+      lastPropagationDepth !== propagationDepth) ||
+    eventProperties.stopImmediatePropagation === true
+  );
+}
+
+function dispatchCaptureListeners(
+  eventProperties: EventProperties,
+  listeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+  isDocumentListener: boolean,
+) {
+  const end = listeners.length - 1;
+  let lastPropagationDepth;
+  for (let i = end; i >= 0; i--) {
+    const listener = listeners[i];
+    const {depth} = listener;
+    if (
+      (!isDocumentListener || i === end) &&
+      shouldStopPropagation(eventProperties, lastPropagationDepth, depth)
+    ) {
+      return;
+    }
+    dispatchListenerAtPriority(listener, eventProperties, nativeEvent);
+    lastPropagationDepth = depth;
+  }
+}
+
+function dispatchBubbleListeners(
+  eventProperties: EventProperties,
+  listeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+  isDocumentListener: boolean,
+) {
+  const length = listeners.length;
+  let lastPropagationDepth;
+  for (let i = 0; i < length; i++) {
+    const listener = listeners[i];
+    const {depth} = listener;
+    if (
+      // When document is not null, we know its a delegated event
+      (!isDocumentListener || i === 0) &&
+      shouldStopPropagation(eventProperties, lastPropagationDepth, depth)
+    ) {
+      return;
+    }
+    dispatchListenerAtPriority(listener, eventProperties, nativeEvent);
+    lastPropagationDepth = depth;
+  }
+}
+
+function dispatchListenersByPhase(
+  captureElementListeners: Array<ReactDOMListener>,
+  bubbleElementListeners: Array<ReactDOMListener>,
+  captureDocumentListeners: Array<ReactDOMListener>,
+  bubbleDocumentListeners: Array<ReactDOMListener>,
+  nativeEvent: AnyNativeEvent,
+): void {
+  const eventProperties = monkeyPatchNativeEvent(nativeEvent);
+  // Capture phase
+  eventProperties.eventPhase = 1;
+  // Dispatch capture delegated event listeners
+  dispatchCaptureListeners(
+    eventProperties,
+    captureDocumentListeners,
+    nativeEvent,
+    true,
+  );
+  // Dispatch capture target event listeners
+  dispatchCaptureListeners(
+    eventProperties,
+    captureElementListeners,
+    nativeEvent,
+    false,
+  );
+  eventProperties.stopPropagation = false;
+  eventProperties.stopImmediatePropagation = false;
+  // Bubble phase
+  eventProperties.eventPhase = 3;
+  // Dispatch bubble target event listeners
+  dispatchBubbleListeners(
+    eventProperties,
+    bubbleElementListeners,
+    nativeEvent,
+    false,
+  );
+  // Dispatch bubble delegated event listeners
+  dispatchBubbleListeners(
+    eventProperties,
+    bubbleDocumentListeners,
+    nativeEvent,
+    true,
+  );
+}
+
+export function dispatchEventForListenerEventSystem(
+  eventType: string,
+  targetFiber: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+): void {
+  if (enableListenerAPI) {
+    // Get target event listeners in their propagation order (non delegated events)
+    const [
+      captureElementListeners,
+      bubbleElementListeners,
+    ] = getElementListeners(eventType, targetFiber);
+    const captureDocumentListeners = arrayFrom(
+      getDocumentListenerSet(eventType, true),
+    );
+    const bubbleDocumentListeners = arrayFrom(
+      getDocumentListenerSet(eventType, false),
+    );
+
+    if (
+      captureElementListeners.length !== 0 ||
+      bubbleElementListeners.length !== 0 ||
+      captureDocumentListeners.length !== 0 ||
+      bubbleDocumentListeners.length !== 0
+    ) {
+      batchedEventUpdates(() =>
+        dispatchListenersByPhase(
+          captureElementListeners,
+          bubbleElementListeners,
+          captureDocumentListeners,
+          bubbleDocumentListeners,
+          nativeEvent,
+        ),
+      );
+    }
+  }
+}
+
+function getDocumentListenerSetForListener(
+  listener: ReactDOMListener,
+): Set<ReactDOMListener> {
+  const {capture, type} = listener.event;
+  return getDocumentListenerSet(type, capture);
+}
+
+export function attachDocumentListener(listener: ReactDOMListener): void {
+  const documentListenersSet = getDocumentListenerSetForListener(listener);
+  documentListenersSet.add(listener);
+}
+
+export function detachDocumentListener(listener: ReactDOMListener): void {
+  const documentListenersSet = getDocumentListenerSetForListener(listener);
+  documentListenersSet.delete(listener);
+}
+
+export function attachElementListener(listener: ReactDOMListener): void {
+  const {instance} = listener;
+  let listeners = getListenersFromNode(instance);
+
+  if (listeners === null) {
+    listeners = new Set();
+    initListenersSet(instance, listeners);
+  }
+  listeners.add(listener);
+}
+
+export function detachElementListener(listener: ReactDOMListener): void {
+  const {instance} = listener;
+  const listeners = getListenersFromNode(instance);
+
+  if (listeners !== null) {
+    listeners.delete(listener);
+  }
+}

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -223,3 +223,17 @@ export function getEventPriorityForPluginSystem(
   // for the event.
   return priority === undefined ? ContinuousEvent : priority;
 }
+
+export function getEventPriorityForListenerSystem(type: string): EventPriority {
+  const priority = eventPriorities.get(((type: any): TopLevelType));
+  if (priority !== undefined) {
+    return priority;
+  }
+  if (__DEV__) {
+    console.warn(
+      'The event "type" provided to useEffect() does not have a known priority type.' +
+        ' It is recommended to provide a "priority" option to specify a priority.',
+    );
+  }
+  return ContinuousEvent;
+}

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -231,7 +231,7 @@ export function getEventPriorityForListenerSystem(type: string): EventPriority {
   }
   if (__DEV__) {
     console.warn(
-      'The event "type" provided to useEffect() does not have a known priority type.' +
+      'The event "type" provided to useEvent() does not have a known priority type.' +
         ' It is recommended to provide a "priority" option to specify a priority.',
     );
   }

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -282,7 +282,7 @@ export function addListenerSystemEvent(
   topLevelType: string,
   passive: boolean,
 ): any => void {
-  let eventFlags = RESPONDER_EVENT_SYSTEM | LISTENER_EVENT_SYSTEM;
+  let eventFlags = LISTENER_EVENT_SYSTEM;
 
   // If passive option is not supported, then the event will be
   // active and not passive, but we flag it as using not being
@@ -307,13 +307,13 @@ export function addListenerSystemEvent(
   );
   if (passiveBrowserEventsSupported) {
     addEventCaptureListenerWithPassiveFlag(
-      document,
+      window,
       topLevelType,
       listener,
       passive,
     );
   } else {
-    addEventCaptureListener(document, topLevelType, listener);
+    addEventCaptureListener(window, topLevelType, listener);
   }
   return listener;
 }
@@ -324,12 +324,12 @@ export function removeListenerSystemEvent(
   listener: any => void,
 ) {
   if (passiveBrowserEventsSupported) {
-    document.removeEventListener(topLevelType, listener, {
+    window.removeEventListener(topLevelType, listener, {
       capture: true,
       passive: false,
     });
   } else {
-    document.removeEventListener(topLevelType, listener, true);
+    window.removeEventListener(topLevelType, listener, true);
   }
 }
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -46,6 +46,7 @@ import {
   type EventSystemFlags,
   PLUGIN_EVENT_SYSTEM,
   RESPONDER_EVENT_SYSTEM,
+  LISTENER_EVENT_SYSTEM,
   IS_PASSIVE,
   IS_ACTIVE,
   PASSIVE_NOT_SUPPORTED,
@@ -62,13 +63,17 @@ import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
 import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
-import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableDeprecatedFlareAPI,
+  enableListenerAPI,
+} from 'shared/ReactFeatureFlags';
 import {
   UserBlockingEvent,
   ContinuousEvent,
   DiscreteEvent,
 } from 'shared/ReactTypes';
 import {getEventPriorityForPluginSystem} from './DOMEventProperties';
+import {dispatchEventForListenerEventSystem} from './DOMEventListenerSystem';
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,
@@ -272,6 +277,62 @@ export function removeActiveResponderEventSystemEvent(
   }
 }
 
+export function addListenerSystemEvent(
+  document: Document,
+  topLevelType: string,
+  passive: boolean,
+): any => void {
+  let eventFlags = RESPONDER_EVENT_SYSTEM | LISTENER_EVENT_SYSTEM;
+
+  // If passive option is not supported, then the event will be
+  // active and not passive, but we flag it as using not being
+  // supported too. This way the responder event plugins know,
+  // and can provide polyfills if needed.
+  if (passive) {
+    if (passiveBrowserEventsSupported) {
+      eventFlags |= IS_PASSIVE;
+    } else {
+      eventFlags |= IS_ACTIVE;
+      eventFlags |= PASSIVE_NOT_SUPPORTED;
+      passive = false;
+    }
+  } else {
+    eventFlags |= IS_ACTIVE;
+  }
+  // Check if interactive and wrap in discreteUpdates
+  const listener = dispatchEvent.bind(
+    null,
+    ((topLevelType: any): DOMTopLevelEventType),
+    eventFlags,
+  );
+  if (passiveBrowserEventsSupported) {
+    addEventCaptureListenerWithPassiveFlag(
+      document,
+      topLevelType,
+      listener,
+      passive,
+    );
+  } else {
+    addEventCaptureListener(document, topLevelType, listener);
+  }
+  return listener;
+}
+
+export function removeListenerSystemEvent(
+  document: Document,
+  topLevelType: string,
+  listener: any => void,
+) {
+  if (passiveBrowserEventsSupported) {
+    document.removeEventListener(topLevelType, listener, {
+      capture: true,
+      passive: false,
+    });
+  } else {
+    document.removeEventListener(topLevelType, listener, true);
+  }
+}
+
 function trapEventForPluginEventSystem(
   element: Document | Element | Node,
   topLevelType: DOMTopLevelEventType,
@@ -401,7 +462,7 @@ export function dispatchEvent(
 
   // This is not replayable so we'll invoke it but without a target,
   // in case the event system needs to trace it.
-  if (enableDeprecatedFlareAPI) {
+  if (enableDeprecatedFlareAPI || enableListenerAPI) {
     if (eventSystemFlags & PLUGIN_EVENT_SYSTEM) {
       dispatchEventForPluginEventSystem(
         topLevelType,
@@ -418,6 +479,14 @@ export function dispatchEvent(
         nativeEvent,
         getEventTarget(nativeEvent),
         eventSystemFlags,
+      );
+    }
+    if (eventSystemFlags & LISTENER_EVENT_SYSTEM) {
+      // React Listener event system
+      dispatchEventForListenerEventSystem(
+        (topLevelType: any),
+        null,
+        nativeEvent,
       );
     }
   } else {
@@ -479,7 +548,7 @@ export function attemptToDispatchEvent(
     }
   }
 
-  if (enableDeprecatedFlareAPI) {
+  if (enableDeprecatedFlareAPI || enableListenerAPI) {
     if (eventSystemFlags & PLUGIN_EVENT_SYSTEM) {
       dispatchEventForPluginEventSystem(
         topLevelType,
@@ -496,6 +565,14 @@ export function attemptToDispatchEvent(
         nativeEvent,
         nativeEventTarget,
         eventSystemFlags,
+      );
+    }
+    if (eventSystemFlags & LISTENER_EVENT_SYSTEM) {
+      // React Listener event system
+      dispatchEventForListenerEventSystem(
+        (topLevelType: any),
+        targetInst,
+        nativeEvent,
       );
     }
   } else {

--- a/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
@@ -312,7 +312,7 @@ describe('DOMEventListenerSystem', () => {
     expect(targetListerner4).toHaveBeenCalledTimes(2);
   });
 
-  it('should correctly work for a basic "click" document listener', () => {
+  it('should correctly work for a basic "click" window listener', () => {
     const log = [];
     const clickEvent = jest.fn(event => {
       log.push({
@@ -327,7 +327,7 @@ describe('DOMEventListenerSystem', () => {
       const click = ReactDOM.unstable_useEvent('click');
 
       React.useEffect(() => {
-        click.setListener(document, clickEvent);
+        click.setListener(window, clickEvent);
       });
 
       return <button>Click anything!</button>;
@@ -342,7 +342,7 @@ describe('DOMEventListenerSystem', () => {
     expect(log[0]).toEqual({
       eventPhase: 3,
       type: 'click',
-      currentTarget: document,
+      currentTarget: window,
       target: document.body,
     });
 
@@ -367,7 +367,7 @@ describe('DOMEventListenerSystem', () => {
     const log = [];
 
     function Test() {
-      // Document
+      // Window
       const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
       const click2 = ReactDOM.unstable_useEvent('click');
       // Div
@@ -378,7 +378,7 @@ describe('DOMEventListenerSystem', () => {
       const click6 = ReactDOM.unstable_useEvent('click', {capture: true});
 
       React.useEffect(() => {
-        click1.setListener(document, e => {
+        click1.setListener(window, e => {
           log.push({
             bound: false,
             delegated: true,
@@ -387,7 +387,7 @@ describe('DOMEventListenerSystem', () => {
             target: e.target,
           });
         });
-        click2.setListener(document, e => {
+        click2.setListener(window, e => {
           log.push({
             bound: false,
             delegated: true,
@@ -452,7 +452,7 @@ describe('DOMEventListenerSystem', () => {
         bound: false,
         delegated: true,
         eventPhase: 1,
-        currentTarget: document,
+        currentTarget: window,
         target: divRef.current,
       },
       {
@@ -487,7 +487,7 @@ describe('DOMEventListenerSystem', () => {
         bound: false,
         delegated: true,
         eventPhase: 3,
-        currentTarget: document,
+        currentTarget: window,
         target: divRef.current,
       },
     ]);
@@ -507,7 +507,7 @@ describe('DOMEventListenerSystem', () => {
       React.useEffect(() => {
         click1.setListener(buttonRef.current, targetListerner1);
         click2.setListener(buttonRef.current, targetListerner2);
-        click3.setListener(document, targetListerner1);
+        click3.setListener(window, targetListerner1);
       });
 
       return <button ref={buttonRef}>Click me!</button>;
@@ -638,9 +638,9 @@ describe('DOMEventListenerSystem', () => {
       const click4 = ReactDOM.unstable_useEvent('click');
 
       React.useEffect(() => {
-        click1.setListener(document, rootListerner1);
+        click1.setListener(window, rootListerner1);
         click2.setListener(buttonRef.current, targetListerner1);
-        click3.setListener(document, rootListerner2);
+        click3.setListener(window, rootListerner2);
         click4.setListener(buttonRef.current, targetListerner2);
       });
 
@@ -672,10 +672,10 @@ describe('DOMEventListenerSystem', () => {
       const click4 = ReactDOM.unstable_useEvent('click');
 
       React.useEffect(() => {
-        click1.setListener(document, rootListerner1);
-        click2.setListener(document, rootListerner2);
-        click3.setListener(document, rootListerner3);
-        click4.setListener(document, rootListerner4);
+        click1.setListener(window, rootListerner1);
+        click2.setListener(window, rootListerner2);
+        click3.setListener(window, rootListerner3);
+        click4.setListener(window, rootListerner4);
       });
 
       return <button ref={buttonRef}>Click me!</button>;

--- a/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
@@ -210,14 +210,11 @@ describe('DOMEventListenerSystem', () => {
         click.setListener(buttonRef.current, clickEvent);
       });
 
-      React.useEffect(
-        () => {
-          if (off) {
-            click.setListener(buttonRef.current, null);
-          }
-        },
-        [off],
-      );
+      React.useEffect(() => {
+        if (off) {
+          click.setListener(buttonRef.current, null);
+        }
+      }, [off]);
 
       return (
         <button ref={buttonRef}>

--- a/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMEventListenerSystem-test.internal.js
@@ -1,0 +1,752 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let ReactDOMServer;
+let Scheduler;
+
+function dispatchEvent(element, type) {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  element.dispatchEvent(event);
+}
+
+function dispatchClickEvent(element) {
+  dispatchEvent(element, 'click');
+}
+
+describe('DOMEventListenerSystem', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableListenerAPI = true;
+    ReactFeatureFlags.enableScopeAPI = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
+    Scheduler = require('scheduler');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('can render correctly with the ReactDOMServer', () => {
+    const clickEvent = jest.fn();
+
+    function Test() {
+      const divRef = React.useRef(null);
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(divRef.current, clickEvent);
+      });
+
+      return <div ref={divRef}>Hello world</div>;
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
+  });
+
+  it('can render correctly with the ReactDOMServer hydration', () => {
+    const clickEvent = jest.fn();
+    const spanRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(spanRef.current, clickEvent);
+      });
+
+      return (
+        <div>
+          <span ref={spanRef}>Hello world</span>
+        </div>
+      );
+    }
+    const output = ReactDOMServer.renderToString(<Test />);
+    expect(output).toBe(
+      `<div data-reactroot=""><span>Hello world</span></div>`,
+    );
+    container.innerHTML = output;
+    ReactDOM.hydrate(<Test />, container);
+    Scheduler.unstable_flushAll();
+    dispatchClickEvent(spanRef.current);
+    expect(clickEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly work for a basic "click" listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+    const divRef = React.createRef();
+    const buttonRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(buttonRef.current, clickEvent);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button><div>Click me!</div></button>');
+
+    // Clicking the button should trigger the event callback
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: divRef.current,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering the container and clicking should work
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(2);
+
+    // Clicking the button should also work
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(log[2]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: buttonRef.current,
+      target: buttonRef.current,
+    });
+
+    function Test2({clickEvent2}) {
+      const click = ReactDOM.unstable_useEvent('click', clickEvent2);
+
+      React.useEffect(() => {
+        click.setListener(buttonRef.current, clickEvent2);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    let clickEvent2 = jest.fn();
+    ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent2).toBeCalledTimes(1);
+
+    // Reset the function we pass in, so it's different
+    clickEvent2 = jest.fn();
+    ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent2).toBeCalledTimes(1);
+  });
+
+  it('should correctly work for a basic "click" listener on the outer target', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+    const divRef = React.createRef();
+    const buttonRef = React.createRef();
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(divRef.current, clickEvent);
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button><div>Click me!</div></button>');
+
+    // Clicking the button should trigger the event callback
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: divRef.current,
+      target: divRef.current,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering the container and clicking should work
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toBeCalledTimes(2);
+
+    // Clicking the button should not work
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(clickEvent).toBeCalledTimes(2);
+  });
+
+  it('should correctly handle many nested target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn();
+    const targetListerner3 = jest.fn();
+    const targetListerner4 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+
+    function Test2() {
+      const click1 = ReactDOM.unstable_useEvent('click');
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test2 />, container);
+    Scheduler.unstable_flushAll();
+
+    buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(2);
+    expect(targetListerner2).toHaveBeenCalledTimes(2);
+    expect(targetListerner3).toHaveBeenCalledTimes(2);
+    expect(targetListerner4).toHaveBeenCalledTimes(2);
+  });
+
+  it('should correctly work for a basic "click" document listener', () => {
+    const log = [];
+    const clickEvent = jest.fn(event => {
+      log.push({
+        eventPhase: event.eventPhase,
+        type: event.type,
+        currentTarget: event.currentTarget,
+        target: event.target,
+      });
+    });
+
+    function Test() {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click.setListener(document, clickEvent);
+      });
+
+      return <button>Click anything!</button>;
+    }
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    expect(container.innerHTML).toBe('<button>Click anything!</button>');
+
+    // Clicking outside the button should trigger the event callback
+    dispatchClickEvent(document.body);
+    expect(log[0]).toEqual({
+      eventPhase: 3,
+      type: 'click',
+      currentTarget: document,
+      target: document.body,
+    });
+
+    // Unmounting the container and clicking should not work
+    ReactDOM.render(null, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(1);
+
+    // Re-rendering and clicking the body should work again
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    dispatchClickEvent(document.body);
+    expect(clickEvent).toBeCalledTimes(2);
+  });
+
+  it('should correctly handle event propagation in the correct order', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    const log = [];
+
+    function Test() {
+      // Document
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click');
+      // Div
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click', {capture: true});
+      // Button
+      const click5 = ReactDOM.unstable_useEvent('click');
+      const click6 = ReactDOM.unstable_useEvent('click', {capture: true});
+
+      React.useEffect(() => {
+        click1.setListener(document, e => {
+          log.push({
+            bound: false,
+            delegated: true,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click2.setListener(document, e => {
+          log.push({
+            bound: false,
+            delegated: true,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click3.setListener(divRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click4.setListener(divRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click5.setListener(buttonRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+        click6.setListener(buttonRef.current, e => {
+          log.push({
+            bound: true,
+            delegated: false,
+            eventPhase: e.eventPhase,
+            currentTarget: e.currentTarget,
+            target: e.target,
+          });
+        });
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+
+    expect(log).toEqual([
+      {
+        bound: false,
+        delegated: true,
+        eventPhase: 1,
+        currentTarget: document,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 1,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 1,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 3,
+        currentTarget: divRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: true,
+        delegated: false,
+        eventPhase: 3,
+        currentTarget: buttonRef.current,
+        target: divRef.current,
+      },
+      {
+        bound: false,
+        delegated: true,
+        eventPhase: 3,
+        currentTarget: document,
+        target: divRef.current,
+      },
+    ]);
+  });
+
+  it('should correctly handle stopImmediatePropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopImmediatePropagation());
+    const targetListerner2 = jest.fn(e => e.stopImmediatePropagation());
+    const rootListerner1 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(document, targetListerner1);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner1).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for based target events', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    let clickEvent = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {
+        bind: buttonRef,
+      });
+      const click2 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, clickEvent);
+        click2.setListener(divRef.current, e => {
+          e.stopPropagation();
+        });
+      });
+
+      return (
+        <button ref={buttonRef}>
+          <div ref={divRef}>Click me!</div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(clickEvent).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for mixed capture/bubbling target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for target listeners', () => {
+    const buttonRef = React.createRef();
+    const targetListerner1 = jest.fn(e => e.stopPropagation());
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+    const targetListerner3 = jest.fn(e => e.stopPropagation());
+    const targetListerner4 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click');
+      const click2 = ReactDOM.unstable_useEvent('click');
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(buttonRef.current, targetListerner1);
+        click2.setListener(buttonRef.current, targetListerner2);
+        click3.setListener(buttonRef.current, targetListerner3);
+        click4.setListener(buttonRef.current, targetListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(targetListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(targetListerner3).toHaveBeenCalledTimes(1);
+    expect(targetListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it('should correctly handle stopPropagation for mixed listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const targetListerner1 = jest.fn();
+    const targetListerner2 = jest.fn(e => e.stopPropagation());
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(document, rootListerner1);
+        click2.setListener(buttonRef.current, targetListerner1);
+        click3.setListener(document, rootListerner2);
+        click4.setListener(buttonRef.current, targetListerner2);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(targetListerner1).toHaveBeenCalledTimes(0);
+    expect(targetListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(0);
+  });
+
+  it('should correctly handle stopPropagation for delegated listeners', () => {
+    const buttonRef = React.createRef();
+    const rootListerner1 = jest.fn(e => e.stopPropagation());
+    const rootListerner2 = jest.fn();
+    const rootListerner3 = jest.fn(e => e.stopPropagation());
+    const rootListerner4 = jest.fn();
+
+    function Test() {
+      const click1 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click2 = ReactDOM.unstable_useEvent('click', {capture: true});
+      const click3 = ReactDOM.unstable_useEvent('click');
+      const click4 = ReactDOM.unstable_useEvent('click');
+
+      React.useEffect(() => {
+        click1.setListener(document, rootListerner1);
+        click2.setListener(document, rootListerner2);
+        click3.setListener(document, rootListerner3);
+        click4.setListener(document, rootListerner4);
+      });
+
+      return <button ref={buttonRef}>Click me!</button>;
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    Scheduler.unstable_flushAll();
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(rootListerner1).toHaveBeenCalledTimes(1);
+    expect(rootListerner2).toHaveBeenCalledTimes(1);
+    expect(rootListerner3).toHaveBeenCalledTimes(1);
+    expect(rootListerner4).toHaveBeenCalledTimes(1);
+  });
+
+  it.experimental('should work with concurrent mode updates', async () => {
+    const log = [];
+    const ref = React.createRef();
+
+    function Test({counter}) {
+      const click = ReactDOM.unstable_useEvent('click');
+
+      React.useLayoutEffect(() => {
+        click.setListener(ref.current, () => {
+          log.push({counter});
+        });
+      });
+
+      Scheduler.unstable_yieldValue('Test');
+      return <button ref={ref}>Press me</button>;
+    }
+
+    let root = ReactDOM.createRoot(container);
+    root.render(<Test counter={0} />);
+
+    // Dev double-render
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYield(['Test', 'Test']);
+    } else {
+      expect(Scheduler).toFlushAndYield(['Test']);
+    }
+
+    // Click the button
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Increase counter
+    root.render(<Test counter={1} />);
+    // Yield before committing
+    // Dev double-render
+    if (__DEV__) {
+      expect(Scheduler).toFlushAndYieldThrough(['Test', 'Test']);
+    } else {
+      expect(Scheduler).toFlushAndYieldThrough(['Test']);
+    }
+
+    // Click the button again
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 0}]);
+
+    // Clear log
+    log.length = 0;
+
+    // Commit
+    expect(Scheduler).toFlushAndYield([]);
+    dispatchClickEvent(ref.current);
+    expect(log).toEqual([{counter: 1}]);
+  });
+});

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -474,7 +474,7 @@ function useTransition(
   return [startTransition, false];
 }
 
-function useEvent(options: any): any {
+function useEvent(event: any): any {
   return {
     clear: noop,
     deleteListener: noop,

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -477,7 +477,6 @@ function useTransition(
 function useEvent(event: any): any {
   return {
     clear: noop,
-    deleteListener: noop,
     setListener: noop,
   };
 }

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -474,6 +474,14 @@ function useTransition(
   return [startTransition, false];
 }
 
+function useEvent(options: any): any {
+  return {
+    clear: noop,
+    deleteListener: noop,
+    setListener: noop,
+  };
+}
+
 function noop(): void {}
 
 export let currentThreadID: ThreadID = 0;
@@ -500,4 +508,5 @@ export const Dispatcher: DispatcherType = {
   useResponder,
   useDeferredValue,
   useTransition,
+  useEvent,
 };

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -473,7 +473,7 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(instance, event, callback): void {
+export function registerListenerEvent(event): void {
   // noop
 }
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -54,6 +54,11 @@ const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 let nextReactTag = 2;
 
 type Node = Object;
+
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Instance = {
@@ -465,5 +470,25 @@ export function getInstanceFromNode(node: any) {
 }
 
 export function beforeRemoveInstance(instance: any) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -485,10 +485,6 @@ export function detachListenerFromInstance(instance, event, callback): any {
   // noop
 }
 
-export function validateReactListenerDeleteListener(instance): void {
-  // noop
-}
-
-export function validateReactListenerMapListener(instance, listener): void {
+export function validateReactListenerMapSetListener(instance, listener): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -473,18 +473,29 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(event): void {
+export function registerListenerEvent(event: any): void {
   // noop
 }
 
-export function attachListenerToInstance(linstance, event, callback): any {
+export function attachListenerToInstance(
+  linstance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function detachListenerFromInstance(instance, event, callback): any {
+export function detachListenerFromInstance(
+  instance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function validateReactListenerMapSetListener(instance, listener): void {
+export function validateReactListenerMapSetListener(
+  instance: any,
+  listener: any,
+): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -537,10 +537,6 @@ export function detachListenerFromInstance(instance, event, callback): any {
   // noop
 }
 
-export function validateReactListenerDeleteListener(instance): void {
-  // noop
-}
-
-export function validateReactListenerMapListener(instance, listener): void {
+export function validateReactListenerMapSetListener(instance, listener): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -28,6 +28,10 @@ import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 
 const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Container = number;
@@ -518,5 +522,25 @@ export function getInstanceFromNode(node: any) {
 }
 
 export function beforeRemoveInstance(instance: any) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -525,18 +525,29 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(event): void {
+export function registerListenerEvent(event: any): void {
   // noop
 }
 
-export function attachListenerToInstance(linstance, event, callback): any {
+export function attachListenerToInstance(
+  linstance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function detachListenerFromInstance(instance, event, callback): any {
+export function detachListenerFromInstance(
+  instance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function validateReactListenerMapSetListener(instance, listener): void {
+export function validateReactListenerMapSetListener(
+  instance: any,
+  listener: any,
+): void {
   // noop
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -525,7 +525,7 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(instance, event, callback): void {
+export function registerListenerEvent(event): void {
   // noop
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -31,6 +31,7 @@ import {
   enableProfilerTimer,
   enableSuspenseServerRenderer,
   enableDeprecatedFlareAPI,
+  enableListenerAPI,
   enableFundamentalAPI,
   enableSuspenseCallback,
   enableScopeAPI,
@@ -824,6 +825,8 @@ function commitUnmount(
     case HostComponent: {
       if (enableDeprecatedFlareAPI) {
         unmountDeprecatedResponderListeners(current);
+      }
+      if (enableDeprecatedFlareAPI || enableListenerAPI) {
         beforeRemoveInstance(current.stateNode);
       }
       safelyDetachRef(current);

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -33,6 +33,7 @@ import {
   Passive as PassiveEffect,
 } from 'shared/ReactSideEffectTags';
 import {
+  NoEffect as NoHookEffect,
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
@@ -1600,6 +1601,7 @@ const HooksDispatcherOnRerender: Dispatcher = {
   useResponder: createDeprecatedResponderListener,
   useDeferredValue: rerenderDeferredValue,
   useTransition: rerenderTransition,
+  useEvent: updateEventListener,
 };
 
 let HooksDispatcherOnMountInDEV: Dispatcher | null = null;
@@ -2115,6 +2117,11 @@ if (__DEV__) {
       updateHookTypesDev();
       return rerenderTransition(config);
     },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      updateHookTypesDev();
+      return updateEventListener(event);
+    },
   };
 
   InvalidNestedHooksDispatcherOnMountInDEV = {
@@ -2519,6 +2526,12 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return rerenderTransition(config);
+    },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      warnInvalidHookAccess();
+      updateHookTypesDev();
+      return updateEventListener(event);
     },
   };
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -17,6 +17,12 @@ import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {HookEffectTag} from './ReactHookEffectTags';
 import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
 import type {ReactPriorityLevel} from './SchedulerWithReactIntegration';
+import type {
+  ReactListenerEvent,
+  ReactListenerMap,
+  ReactListener,
+  Container,
+} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
@@ -54,6 +60,15 @@ import {
   runWithPriority,
   getCurrentPriorityLevel,
 } from './SchedulerWithReactIntegration';
+import {
+  registerListenerEvent,
+  attachListenerToInstance,
+  detachListenerFromInstance,
+  validateReactListenerMapListener,
+  validateReactListenerDeleteListener,
+} from './ReactFiberHostConfig';
+import {getRootHostContainer} from './ReactFiberHostContext';
+import {enableListenerAPI} from 'shared/ReactFeatureFlags';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -97,6 +112,7 @@ export type Dispatcher = {|
   useTransition(
     config: SuspenseConfig | void | null,
   ): [(() => void) => void, boolean],
+  useEvent(event: ReactListenerEvent): ReactListenerMap,
 |};
 
 type Update<S, A> = {|
@@ -129,7 +145,8 @@ export type HookType =
   | 'useDebugValue'
   | 'useResponder'
   | 'useDeferredValue'
-  | 'useTransition';
+  | 'useTransition'
+  | 'useEvent';
 
 let didWarnAboutMismatchedHooksForComponent;
 if (__DEV__) {
@@ -1260,6 +1277,143 @@ function rerenderTransition(
   return [start, isPending];
 }
 
+function createReactListener(
+  event: ReactListenerEvent,
+  callback: Event => void,
+  instance: Container,
+  destroy: Container => void,
+): ReactListener {
+  return {
+    callback,
+    depth: 0,
+    destroy,
+    instance,
+    event,
+  };
+}
+
+const noOpMount = () => {};
+
+function validateNotInFunctionRender(): boolean {
+  if (currentlyRenderingFiber === null) {
+    return true;
+  }
+  if (__DEV__) {
+    console.warn(
+      'Event listener methods from useEvent() cannot be used during render.' +
+        ' These methods should be called in an effect or event callback outside the render.',
+    );
+  }
+  return false;
+}
+
+export function mountEventListener(
+  event: ReactListenerEvent,
+): ReactListenerMap {
+  if (enableListenerAPI) {
+    const hook = mountWorkInProgressHook();
+    const rootContainerInstance = getRootHostContainer();
+    registerListenerEvent(event, rootContainerInstance);
+
+    let listenerMap: Map<Container, ReactListener> = new Map();
+
+    const clear = (): void => {
+      if (validateNotInFunctionRender()) {
+        const listeners = Array.from(listenerMap.values());
+        for (let i = 0; i < listeners.length; i++) {
+          detachListenerFromInstance(listeners[i]);
+        }
+        listenerMap.clear();
+      }
+    };
+
+    const destroy = (instance: Container) => {
+      listenerMap.delete(instance);
+    };
+
+    const reactListenerMap: ReactListenerMap = {
+      clear,
+      deleteListener(instance: Container): void {
+        if (
+          validateNotInFunctionRender() &&
+          validateReactListenerDeleteListener(instance)
+        ) {
+          const listener = listenerMap.get(instance);
+          if (listener !== undefined) {
+            listenerMap.delete(instance);
+            detachListenerFromInstance(listener);
+          }
+        }
+      },
+      setListener(instance: Container, callback: Event => void): void {
+        if (
+          validateNotInFunctionRender() &&
+          validateReactListenerMapListener(instance, callback)
+        ) {
+          let listener = listenerMap.get(instance);
+          if (listener === undefined) {
+            listener = createReactListener(event, callback, instance, destroy);
+            listenerMap.set(instance, listener);
+          } else {
+            listener.callback = callback;
+          }
+          attachListenerToInstance(listener);
+        }
+      },
+    };
+    // In order to clear up upon the hook unmounting,
+    /// we ensure we push an effect that handles the use-case.
+    currentlyRenderingFiber.effectTag |= UpdateEffect;
+    pushEffect(NoHookEffect, noOpMount, clear, null);
+    hook.memoizedState = [reactListenerMap, event, clear];
+    return reactListenerMap;
+  }
+  // To make Flow not complain
+  return (undefined: any);
+}
+
+export function updateEventListener(
+  event: ReactListenerEvent,
+): ReactListenerMap {
+  if (enableListenerAPI) {
+    const hook = updateWorkInProgressHook();
+    const [reactListenerMap, memoizedEvent, clear] = hook.memoizedState;
+    if (__DEV__) {
+      if (memoizedEvent.type !== event.type) {
+        console.warn(
+          'The event type argument passed to the useEvent() hook was different between renders.' +
+            ' The event type is static and should never change between renders.',
+        );
+      }
+      if (memoizedEvent.capture !== event.capture) {
+        console.warn(
+          'The "capture" option passed to the useEvent() hook was different between renders.' +
+            ' The "capture" option is static and should never change between renders.',
+        );
+      }
+      if (memoizedEvent.priority !== event.priority) {
+        console.warn(
+          'The "priority" option passed to the useEvent() hook was different between renders.' +
+            ' The "priority" option is static and should never change between renders.',
+        );
+      }
+      if (memoizedEvent.passive !== event.passive) {
+        console.warn(
+          'The "passive" option passed to the useEvent() hook was different between renders.' +
+            ' The "passive" option is static and should never change between renders.',
+        );
+      }
+    }
+    // In order to clear up upon the hook unmounting,
+    /// we ensure we push an effect that handles the use-case.
+    currentlyRenderingFiber.effectTag |= UpdateEffect;
+    pushEffect(NoHookEffect, noOpMount, clear, null);
+    return reactListenerMap;
+  }
+  // To make Flow not complain
+  return (undefined: any);
+}
+
 function dispatchAction<S, A>(
   fiber: Fiber,
   queue: UpdateQueue<S, A>,
@@ -1385,6 +1539,7 @@ export const ContextOnlyDispatcher: Dispatcher = {
   useResponder: throwInvalidHookError,
   useDeferredValue: throwInvalidHookError,
   useTransition: throwInvalidHookError,
+  useEvent: throwInvalidHookError,
 };
 
 const HooksDispatcherOnMount: Dispatcher = {
@@ -1403,6 +1558,7 @@ const HooksDispatcherOnMount: Dispatcher = {
   useResponder: createDeprecatedResponderListener,
   useDeferredValue: mountDeferredValue,
   useTransition: mountTransition,
+  useEvent: mountEventListener,
 };
 
 const HooksDispatcherOnUpdate: Dispatcher = {
@@ -1421,6 +1577,7 @@ const HooksDispatcherOnUpdate: Dispatcher = {
   useResponder: createDeprecatedResponderListener,
   useDeferredValue: updateDeferredValue,
   useTransition: updateTransition,
+  useEvent: updateEventListener,
 };
 
 const HooksDispatcherOnRerender: Dispatcher = {
@@ -1588,6 +1745,11 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountTransition(config);
     },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      mountHookTypesDev();
+      return mountEventListener(event);
+    },
   };
 
   HooksDispatcherOnMountWithHookTypesInDEV = {
@@ -1705,6 +1867,11 @@ if (__DEV__) {
       updateHookTypesDev();
       return mountTransition(config);
     },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      updateHookTypesDev();
+      return mountEventListener(event);
+    },
   };
 
   HooksDispatcherOnUpdateInDEV = {
@@ -1821,6 +1988,11 @@ if (__DEV__) {
       currentHookNameInDev = 'useTransition';
       updateHookTypesDev();
       return updateTransition(config);
+    },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      updateHookTypesDev();
+      return updateEventListener(event);
     },
   };
 
@@ -2070,6 +2242,12 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountTransition(config);
     },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      warnInvalidHookAccess();
+      mountHookTypesDev();
+      return mountEventListener(event);
+    },
   };
 
   InvalidNestedHooksDispatcherOnUpdateInDEV = {
@@ -2200,6 +2378,12 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return updateTransition(config);
+    },
+    useEvent(event: ReactListenerEvent): ReactListenerMap {
+      currentHookNameInDev = 'useEvent';
+      warnInvalidHookAccess();
+      mountHookTypesDev();
+      return updateEventListener(event);
     },
   };
 

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -37,6 +37,9 @@ export opaque type UpdatePayload = mixed; // eslint-disable-line no-undef
 export opaque type ChildSet = mixed; // eslint-disable-line no-undef
 export opaque type TimeoutHandle = mixed; // eslint-disable-line no-undef
 export opaque type NoTimeout = mixed; // eslint-disable-line no-undef
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
 export type EventResponder = any;
 
 export const getPublicInstance = $$$hostConfig.getPublicInstance;
@@ -73,6 +76,11 @@ export const shouldUpdateFundamentalComponent =
   $$$hostConfig.shouldUpdateFundamentalComponent;
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
 export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
+export const registerListenerEvent = $$$hostConfig.registerListenerEvent;
+export const validateReactListenerDeleteListener =
+  $$$hostConfig.validateReactListenerDeleteListener;
+export const validateReactListenerMapListener =
+  $$$hostConfig.validateReactListenerMapListener;
 
 // -------------------
 //      Mutation
@@ -96,6 +104,9 @@ export const updateFundamentalComponent =
   $$$hostConfig.updateFundamentalComponent;
 export const unmountFundamentalComponent =
   $$$hostConfig.unmountFundamentalComponent;
+export const attachListenerToInstance = $$$hostConfig.attachListenerToInstance;
+export const detachListenerFromInstance =
+  $$$hostConfig.detachListenerFromInstance;
 
 // -------------------
 //     Persistence

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -77,10 +77,8 @@ export const shouldUpdateFundamentalComponent =
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
 export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
 export const registerListenerEvent = $$$hostConfig.registerListenerEvent;
-export const validateReactListenerDeleteListener =
-  $$$hostConfig.validateReactListenerDeleteListener;
-export const validateReactListenerMapListener =
-  $$$hostConfig.validateReactListenerMapListener;
+export const validateReactListenerMapSetListener =
+  $$$hostConfig.validateReactListenerMapSetListener;
 
 // -------------------
 //      Mutation

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -397,6 +397,14 @@ class ReactShallowRenderer {
       return value;
     };
 
+    const useEvent = () => {
+      return {
+        clear: noOp,
+        deleteListener: noOp,
+        setListener: noOp,
+      };
+    };
+
     return {
       readContext,
       useCallback: (identity: any),
@@ -415,6 +423,7 @@ class ReactShallowRenderer {
       useResponder,
       useTransition,
       useDeferredValue,
+      useEvent,
     };
   }
 

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -400,7 +400,6 @@ class ReactShallowRenderer {
     const useEvent = () => {
       return {
         clear: noOp,
-        deleteListener: noOp,
         setListener: noOp,
       };
     };

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -15,6 +15,10 @@ import type {
 
 import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
 
+export type ReactListenerEvent = Object;
+export type ReactListenerMap = Object;
+export type ReactListener = Object;
+
 export type Type = string;
 export type Props = Object;
 export type Container = {|
@@ -373,5 +377,25 @@ export function getInstanceFromNode(mockNode: Object) {
 }
 
 export function beforeRemoveInstance(instance: any) {
+  // noop
+}
+
+export function registerListenerEvent(instance, event, callback): void {
+  // noop
+}
+
+export function attachListenerToInstance(linstance, event, callback): any {
+  // noop
+}
+
+export function detachListenerFromInstance(instance, event, callback): any {
+  // noop
+}
+
+export function validateReactListenerDeleteListener(instance): void {
+  // noop
+}
+
+export function validateReactListenerMapListener(instance, listener): void {
   // noop
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -380,7 +380,7 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(instance, event, callback): void {
+export function registerListenerEvent(event): void {
   // noop
 }
 

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -392,10 +392,6 @@ export function detachListenerFromInstance(instance, event, callback): any {
   // noop
 }
 
-export function validateReactListenerDeleteListener(instance): void {
-  // noop
-}
-
-export function validateReactListenerMapListener(instance, listener): void {
+export function validateReactListenerMapSetListener(instance, listener): void {
   // noop
 }

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -380,18 +380,29 @@ export function beforeRemoveInstance(instance: any) {
   // noop
 }
 
-export function registerListenerEvent(event): void {
+export function registerListenerEvent(event: any): void {
   // noop
 }
 
-export function attachListenerToInstance(linstance, event, callback): any {
+export function attachListenerToInstance(
+  linstance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function detachListenerFromInstance(instance, event, callback): any {
+export function detachListenerFromInstance(
+  instance: any,
+  event: any,
+  callback: any,
+): any {
   // noop
 }
 
-export function validateReactListenerMapSetListener(instance, listener): void {
+export function validateReactListenerMapSetListener(
+  instance: any,
+  listener: any,
+): void {
   // noop
 }

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -87,8 +87,7 @@ export type ReactDOMListenerEvent = {|
 
 export type ReactDOMListenerMap = {|
   clear: () => void,
-  setListener: (instance: EventTarget, callback: (Event) => void) => void,
-  deleteListener: (instance: EventTarget) => void,
+  setListener: (instance: EventTarget, callback: ?(Event) => void) => void,
 |};
 
 export type ReactDOMListener = {|

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -81,17 +81,14 @@ export type RefObject = {current: null | mixed};
 export type ReactDOMListenerEvent = {|
   capture: boolean,
   passive: boolean,
-  priority: number,
+  priority: EventPriority,
   type: string,
 |};
 
 export type ReactDOMListenerMap = {|
   clear: () => void,
-  setListener: (
-    instance: Document | HTMLElement,
-    callback: (Event) => void,
-  ) => void,
-  deleteListener: (instance: Document | HTMLElement) => void,
+  setListener: (instance: EventTarget, callback: (Event) => void) => void,
+  deleteListener: (instance: EventTarget) => void,
 |};
 
 export type ReactDOMListener = {|
@@ -99,5 +96,5 @@ export type ReactDOMListener = {|
   depth: number,
   destroy: Document | (Element => void),
   event: ReactDOMListenerEvent,
-  instance: Document | Element,
+  instance: EventTarget,
 |};

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -75,3 +75,29 @@ export type ReactDOMResponderContext = {
   getResponderNode(): Element | null,
   ...
 };
+
+export type RefObject = {current: null | mixed};
+
+export type ReactDOMListenerEvent = {|
+  capture: boolean,
+  passive: boolean,
+  priority: number,
+  type: string,
+|};
+
+export type ReactDOMListenerMap = {|
+  clear: () => void,
+  setListener: (
+    instance: Document | HTMLElement,
+    callback: (Event) => void,
+  ) => void,
+  deleteListener: (instance: Document | HTMLElement) => void,
+|};
+
+export type ReactDOMListener = {|
+  callback: Event => void,
+  depth: number,
+  destroy: Document | (Element => void),
+  event: ReactDOMListenerEvent,
+  instance: Document | Element,
+|};

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -50,8 +50,11 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 
 export const warnAboutShorthandPropertyCollision = false;
 
-// Experimental React Flare event system and event components support.
+// Experimental React Flare event system.
 export const enableDeprecatedFlareAPI = false;
+
+// Experimental Listener system.
+export const enableListenerAPI = false;
 
 // Experimental Host Component support.
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -33,6 +33,7 @@ export const disableInputAttributeSyncing = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -25,6 +25,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const enableSchedulerDebugging = false;
 export const disableJavaScriptURLs = false;
 export const enableDeprecatedFlareAPI = true;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = true;
 export const enableJSXTransformAPI = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -27,6 +27,7 @@ export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
 export const warnAboutShorthandPropertyCollision = false;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
+export const enableListenerAPI = false;
 export const enableFundamentalAPI = false;
 export const enableScopeAPI = false;
 export const enableJSXTransformAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -78,6 +78,8 @@ function updateFlagOutsideOfReactCallStack() {
 
 export const enableDeprecatedFlareAPI = true;
 
+export const enableListenerAPI = true;
+
 export const enableFundamentalAPI = false;
 
 export const enableScopeAPI = true;


### PR DESCRIPTION
Note: This API is intentionally meant to be a low-level way of creating events and assigning listeners to them. It's meant to be verbose so larger building blocks can be created on top of them.

This PR is an alternative solution and system to that of my other PR: https://github.com/facebook/react/pull/17508. Specifically, based off feedback internally, I've tried to tackle some of the problems that were brought up with the `createListener` approach in https://github.com/facebook/react/pull/17508:

- `createListener` largely depended on events being registered in the commit phase, meaning that there would likely be issues around needing to flush more to ensure we register DOM events. The new approach enforces all events are registered unconditionally via hooks in the render phase, mitigating this issue.
- `createListener` allowed for listeners to update and change their properties between renders, which again is problematic for performance and would also require more flushes to ensure we have committed the latest version of each listener.
- `createListener` had a complex diffing process to ensure we stored the latest listeners, but this meant that the process had additional overhead and memory usage – which is no longer the case with this PR.
- `createListener` required listeners to be put on nodes via the `listeners` prop. Furthermore, it required using arrays to combine multiple listeners, which some felt was not idealistic and might be confusing during debugging as to which listeners occurred at which stages. Also, there was general dislike to introducing another internal prop – as it would mean we'd have to first forbid `listeners` and wait for React 17 to introduce these APIs, as they might be used in the wild for other reasons (custom elements).
- `createListener` didn't provide an idiomatic way to conditionally add/remove root events (they're called delegated events in this new PR). With the new approach, there's a streamlined approach to ensure this is easier to do, and by default, no root events can be added unconditionally, which is a code-smell and a good cause of memory leaks/performance issues.

Taking the above points into consideration, the design of this new event system aims at bringing the same capabilities as described in https://github.com/facebook/react/pull/17508 whilst also providing some other nice features, that should allow for bigger event sub-systems to be built on top.

## `ReactDOM.useEvent`

This hook allows for the registration to a native DOM event, similar to that of `addEventListener` on the web. `useEvent` takes a given event `type` and registers it to the DOM then returns an object unique to that event that allows listeners to be attached to their targets in an effect or another event handler. The object provides three different methods to setup and handle listeners:

- `setListener(target: window | element, listener: ?(Event => void))` set a listener to be active for a given DOM node. The node must be a DOM node managed by React or it can be the `window` node for delegation purposes. If the listener is `null` or `undefined` then we remove the given listener for that DOM node or `window` object.
- `clear()` remove all listeners

The hook takes three arguments:

- `type` the DOM event to listen to
- `options` an optional object allowing for additional properties to be defined on the event listener. The options are:
  - `passive` provide an optional flag that tells the listener to register a passive DOM event listener or an active DOM event listener
  - `capture` provide an optional flag that tells the listener callback to fire in the capture phase or the bubble phase
  - `priority` provide an optional Scheduler priority that allows React to correct schedule the listener callback to fire at the correct priority.

## Note

For propagation, the same rules of `stopPropagation` and `stopImmediatePropagation` apply to these event listeners. These methods are actually monkey-patched, as we use the actual native DOM events with this system and API, rather than Synthetic Events. `currentTarget` and `eventPhase` are also respectfully monkey-patched to co-ordinate and align with the propagation system involved internally within React.

Furthermore, all event listeners are passive by default. If is desired to called `event.preventDefault` on an event listener, then the event listener should be made active via the `passive` option.

## Examples

An example of a basic clickable button:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const buttonRef = useRef(null);
  const clickEvent = useEvent('click');

  useEffect(() => {
    clickEvent.setListener(buttonRef.current, onClick);
  });

  return <button ref={buttonRef}>{children}</button>;
}
```

If you want to listen to events that are delegated to the window, you can do that:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const clickEvent = useEvent('click');

  useEffect(() => {
    // Pass in `window`, which is supported with this API
    // Note: `window` is not supported, as React doesn't
    // listen to events that high up.
    clickEvent.setListener(window, onClick);
  });

  return <button>{children}</button>;
}
```

If you wanted to extract the verbosity out of this into a custom hook, then it's possible to do so:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function useClick(ref, onClick) {
  const clickEvent = useEvent('click');

  useEffect(() => {
    clickEvent.setListener(ref.current, onClick);
  });

  return buttonRef;
}

function Button({children}) {
  const buttonRef = useRef(null);
  useClick(buttonRef , () => {
    console.log('Hello world!')
  });
  return <button ref={buttonRef}>{children}</button>;
}
```

A more complex button that tracks when the button is being pressed with the mouse:

```jsx
import {useRef, useEffect} from 'react';
import {useEvent} from 'react-dom';

function Button({children, onClick}) {
  const buttonRef = useRef(null);
  const [pressed, setPressed] = useState(false);
  const click = useEvent('click');
  const mouseUp = useEvent('mouseup');
  const mouseDown = useEvent('mousedown');

  useEffect(() => {
    const button = buttonRef.current;

    const handleMouseUp = () => {
      setPressed(false);
    };
    const handleMouseDown = () => {
      setPressed(true); 
    };

    click.setListener(button, onClick);
    if (pressed) {
      mouseUp.setListener(button, handleMouseUp);
    } else {
      mouseDown.setListener(button, handleMouseDown);
    }

    return () => {
      click.setListener(button, null);
      mouseDown.setListener(button, null);
      mouseUp.setListener(button, null);
    };
  }, [pressed, onClick]);

  return (
    <button ref={buttonRef} className={pressed && 'pressed'}>
      {children}
    </button>
  );
}
```

## What about the DOM's `element.addEventListener`?

In many respects, this low-level API was intentionally designed to be a replacement for the DOM's `addEventListener`. Not only does this new Listener API provide many nice benefits, like auto-recycling listeners on unmount, but it should also help prevent bugs that will likely occur when `addEventListener` is used in conjunction with Concurrent Mode.

For a detailed list of differences, here are just some of the key benefits of the Listener API vs the DOM's `addEventListener`:

- The event listeners automatically get recycled upon unmount
- The event listeners correctly batch updates and flush previous ones correctly, as well as co-ordinating priority levels with the internal scheduler
- The event listeners allow for alignment with the propagation of other events in the React event system, something not possible with manual DOM event listeners
- The event listeners will correctly work with React Portals, Suspense and Concurrent Mode, native event listeners do not.
- By ensuring we use a hook, like useEvent, we can determine the event needed during server-side render and ensure those events are registered on initial hydration ahead of time. This makes it possible to "replay" those events before the components themselves have concurrently hydrated on the client.