### PR TITLE
[react-interactions] Remove batchedUpdates from responder lifecycles

### DIFF
--- a/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
@@ -445,9 +445,7 @@ export function mountEventResponder(
     const previousInstance = currentInstance;
     currentInstance = responderInstance;
     try {
-      batchedEventUpdates(() => {
-        onMount(eventResponderContext, props, state);
-      });
+      onMount(eventResponderContext, props, state);
     } finally {
       currentInstance = previousInstance;
     }
@@ -464,9 +462,7 @@ export function unmountEventResponder(
     const previousInstance = currentInstance;
     currentInstance = responderInstance;
     try {
-      batchedEventUpdates(() => {
-        onUnmount(eventResponderContext, props, state);
-      });
+      onUnmount(eventResponderContext, props, state);
     } finally {
       currentInstance = previousInstance;
     }


### PR DESCRIPTION
This PR removes the `batchedUpdates` wrapper from the Flare Responder lifecycle events – specifically `onMount` and `onUnmount`. The intention of having them here, was in case the responder dispatched user events that triggered state updates, which isn't the case.

By making this change, we fix an interesting bug to do with controlled components and inputting multi-byte characters in other languages. `batchedUpdates` has an interesting side-effect in that it calls `finishEventHandler` which in turn restores controlled component state and calls `flushDiscreteUpdatesImpl`, which is what causes this bug.