### PR TITLE
Null stateNode after unmount

### DIFF
--- a/packages/legacy-events/ReactControlledComponent.js
+++ b/packages/legacy-events/ReactControlledComponent.js
@@ -33,8 +33,12 @@ function restoreStateOfTarget(target) {
     'setRestoreImplementation() needs to be called to handle a target for controlled ' +
       'events. This error is likely caused by a bug in React. Please file an issue.',
   );
-  const props = getFiberCurrentPropsFromNode(internalInstance.stateNode);
-  restoreImpl(internalInstance.stateNode, internalInstance.type, props);
+  const stateNode = internalInstance.stateNode;
+  // Guard against Fiber being unmounted.
+  if (stateNode) {
+    const props = getFiberCurrentPropsFromNode(stateNode);
+    restoreImpl(internalInstance.stateNode, internalInstance.type, props);
+  }
 }
 
 export function setRestoreImplementation(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -905,6 +905,7 @@ function detachFiber(current: Fiber) {
   current.lastEffect = null;
   current.pendingProps = null;
   current.memoizedProps = null;
+  current.stateNode = null;
   if (alternate !== null) {
     detachFiber(alternate);
   }


### PR DESCRIPTION
For discussion purposes.

This change avoids a certain case where we over-retain Fibers after unmount:

In `detachFiber` we null out `child` and `sibling` pointers in an effort to clear references to the stale subtree, but-
1. We don't clear the `stateNode` pointer for host element fibers.
1. The `stateNode` has references to its previous host element children.
1. Each host element (the children) have references to their corresponding Fibers via the `__reactInternalInstance`* prop.

So we end up retaining the whole Fiber subtree through the single `stateNode` reference.

Although the cost of retaining these references is limited (e.g. it will go away the next time the parent fiber renders) it can still obscure investigations into other more serious, user space leaks.

An example of the previous behavior can be seen here:
https://codesandbox.io/s/sweet-leakey-rj2ii