### PR TITLE
Disable unsupported context menu options for Firefox

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -211,12 +211,15 @@ function createPanelIfReactLoaded() {
               browserTheme: getBrowserTheme(),
               componentsPortalContainer,
               enabledInspectedElementContextMenu: true,
+              enabledInspectedElementContextMenuCopy: isChrome,
               overrideTab,
               profilerPortalContainer,
               showTabBar: false,
               store,
               warnIfUnsupportedVersionDetected: true,
-              viewAttributeSourceFunction,
+              viewAttributeSourceFunction: isChrome
+                ? viewAttributeSourceFunction
+                : null,
               viewElementSourceFunction,
             }),
           );

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -303,6 +303,7 @@ function InspectedElementView({
 
   const {
     isEnabledForInspectedElement,
+    supportsCopyOperation,
     viewAttributeSourceFunction,
   } = useContext(ContextMenuContext);
 
@@ -444,12 +445,14 @@ function InspectedElementView({
         <ContextMenu id="SelectedElement">
           {data => (
             <Fragment>
-              <ContextMenuItem
-                onClick={() => copyInspectedElementPath(id, data.path)}
-                title="Copy value to clipboard">
-                <Icon className={styles.ContextMenuIcon} type="copy" /> Copy
-                value to clipboard
-              </ContextMenuItem>
+              {supportsCopyOperation && (
+                <ContextMenuItem
+                  onClick={() => copyInspectedElementPath(id, data.path)}
+                  title="Copy value to clipboard">
+                  <Icon className={styles.ContextMenuIcon} type="copy" /> Copy
+                  value to clipboard
+                </ContextMenuItem>
+              )}
               <ContextMenuItem
                 onClick={() => storeAsGlobal(id, data.path)}
                 title="Store as global variable">

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -54,6 +54,7 @@ export type Props = {|
   canViewElementSourceFunction?: ?CanViewElementSource,
   defaultTab?: TabID,
   enabledInspectedElementContextMenu?: boolean,
+  enabledInspectedElementContextMenuCopy?: boolean,
   showTabBar?: boolean,
   store: Store,
   warnIfLegacyBackendDetected?: boolean,
@@ -96,6 +97,7 @@ export default function DevTools({
   componentsPortalContainer,
   defaultTab = 'components',
   enabledInspectedElementContextMenu = false,
+  enabledInspectedElementContextMenuCopy = false,
   overrideTab,
   profilerPortalContainer,
   showTabBar = false,
@@ -121,9 +123,14 @@ export default function DevTools({
   const contextMenu = useMemo(
     () => ({
       isEnabledForInspectedElement: enabledInspectedElementContextMenu,
+      supportsCopyOperation: enabledInspectedElementContextMenuCopy,
       viewAttributeSourceFunction: viewAttributeSourceFunction || null,
     }),
-    [enabledInspectedElementContextMenu, viewAttributeSourceFunction],
+    [
+      enabledInspectedElementContextMenu,
+      enabledInspectedElementContextMenuCopy,
+      viewAttributeSourceFunction,
+    ],
   );
 
   useEffect(

--- a/packages/react-devtools-shared/src/devtools/views/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/context.js
@@ -23,11 +23,13 @@ StoreContext.displayName = 'StoreContext';
 
 export type ContextMenuContextType = {|
   isEnabledForInspectedElement: boolean,
+  supportsCopyOperation: boolean,
   viewAttributeSourceFunction?: ?ViewAttributeSource,
 |};
 
 export const ContextMenuContext = createContext<ContextMenuContextType>({
   isEnabledForInspectedElement: false,
+  supportsCopyOperation: false,
   viewAttributeSourceFunction: null,
 });
 ContextMenuContext.displayName = 'ContextMenuContext';

--- a/packages/react-devtools-shell/src/devtools.js
+++ b/packages/react-devtools-shell/src/devtools.js
@@ -56,6 +56,7 @@ inject('dist/app.js', () => {
         createElement(DevTools, {
           browserTheme: 'light',
           enabledInspectedElementContextMenu: true,
+          enabledInspectedElementContextMenuCopy: true,
           showTabBar: true,
           warnIfLegacyBackendDetected: true,
           warnIfUnsupportedVersionDetected: true,


### PR DESCRIPTION
Unfortunately the "copy to clipboard" and "go to definition" context menu options do not work for the Firefox add-on. I'm not sure why "go to definition" doesn't work. (Seems like it should but it just fails silently.) The clipboard option seems more obviously broken though.

We currently use [`document.execCommand("copy")`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) which works for Chrome but fails for Firefox with the following error:
![image](https://user-images.githubusercontent.com/29597/71217010-2d9af400-2271-11ea-9e43-077bb35638ce.png)

Unfortunately, using the newer [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write) fails for both browsers:
![image](https://user-images.githubusercontent.com/29597/71217023-38ee1f80-2271-11ea-902a-fff82f4005a9.png)

So for now it seems the best we can do is stick with the old `execCommand` API and disable the menu option for Firefox.

### Chrome demo
![Context menu in Chrome](https://user-images.githubusercontent.com/29597/71217856-0e519600-2274-11ea-930b-2e3a55c55104.gif)

### Firefox demo
![Context menu in Firefox](https://user-images.githubusercontent.com/29597/71217901-4c4eba00-2274-11ea-83fd-08928b7c8031.gif)
