### PR TITLE
[react-dom] Refactor event priority handling to its own module

### DIFF
--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {EventPriority} from 'shared/ReactTypes';
+import type {
+  TopLevelType,
+  DOMTopLevelEventType,
+} from 'legacy-events/TopLevelEventTypes';
+import type {DispatchConfig} from 'legacy-events/ReactSyntheticEventType';
+
+import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
+import {
+  DiscreteEvent,
+  UserBlockingEvent,
+  ContinuousEvent,
+} from 'shared/ReactTypes';
+
+// Needed for SimpleEventPlugin, rather than
+// do it in two places, which duplicates logic
+// and increases the bundle size, we do it all
+// here once. If we remove or refactor the
+// SimpleEventPlugin, we should also remove or
+// update the below line.
+export const simpleEventPluginEventTypes = {};
+
+export const topLevelEventsToDispatchConfig: Map<
+  TopLevelType,
+  DispatchConfig,
+> = new Map();
+
+const eventPriorities = new Map();
+
+// We store all the DOMTopLevelEventTypes and their React Types in pairs of two.
+// Furthermore, we ignore prettier so we can keep the formatting sane.
+
+// prettier-ignore
+const discreteEvents = [
+  DOMTopLevelEventTypes.TOP_BLUR, 'blur',
+  DOMTopLevelEventTypes.TOP_CANCEL, 'cancel',
+  DOMTopLevelEventTypes.TOP_CLICK, 'click',
+  DOMTopLevelEventTypes.TOP_CLOSE, 'close',
+  DOMTopLevelEventTypes.TOP_CONTEXT_MENU, 'contextMenu',
+  DOMTopLevelEventTypes.TOP_COPY, 'copy',
+  DOMTopLevelEventTypes.TOP_CUT, 'cut',
+  DOMTopLevelEventTypes.TOP_AUX_CLICK, 'auxClick',
+  DOMTopLevelEventTypes.TOP_DOUBLE_CLICK, 'doubleClick',
+  DOMTopLevelEventTypes.TOP_DRAG_END, 'dragEnd',
+  DOMTopLevelEventTypes.TOP_DRAG_START, 'dragStart',
+  DOMTopLevelEventTypes.TOP_DROP, 'drop',
+  DOMTopLevelEventTypes.TOP_FOCUS, 'focus',
+  DOMTopLevelEventTypes.TOP_INPUT, 'input',
+  DOMTopLevelEventTypes.TOP_INVALID, 'invalid',
+  DOMTopLevelEventTypes.TOP_KEY_DOWN, 'keyDown',
+  DOMTopLevelEventTypes.TOP_KEY_PRESS, 'keyPress',
+  DOMTopLevelEventTypes.TOP_KEY_UP, 'keyUp',
+  DOMTopLevelEventTypes.TOP_MOUSE_DOWN, 'mouseDown',
+  DOMTopLevelEventTypes.TOP_MOUSE_UP, 'mouseUp',
+  DOMTopLevelEventTypes.TOP_PASTE, 'paste',
+  DOMTopLevelEventTypes.TOP_PAUSE, 'pause',
+  DOMTopLevelEventTypes.TOP_PLAY, 'play',
+  DOMTopLevelEventTypes.TOP_POINTER_CANCEL, 'pointerCancel',
+  DOMTopLevelEventTypes.TOP_POINTER_DOWN, 'pointerDown',
+  DOMTopLevelEventTypes.TOP_POINTER_UP, 'pointerUp',
+  DOMTopLevelEventTypes.TOP_RATE_CHANGE, 'rateChange',
+  DOMTopLevelEventTypes.TOP_RESET, 'reset',
+  DOMTopLevelEventTypes.TOP_SEEKED, 'seeked',
+  DOMTopLevelEventTypes.TOP_SUBMIT, 'submit',
+  DOMTopLevelEventTypes.TOP_TOUCH_CANCEL, 'touchCancel',
+  DOMTopLevelEventTypes.TOP_TOUCH_END, 'touchEnd',
+  DOMTopLevelEventTypes.TOP_TOUCH_START, 'touchStart',
+  DOMTopLevelEventTypes.TOP_VOLUME_CHANGE, 'volumeChange',
+];
+
+// prettier-ignore
+const userBlockingEvents = [
+  DOMTopLevelEventTypes.TOP_DRAG, 'drag',
+  DOMTopLevelEventTypes.TOP_DRAG_ENTER, 'dragEnter',
+  DOMTopLevelEventTypes.TOP_DRAG_EXIT, 'dragExit',
+  DOMTopLevelEventTypes.TOP_DRAG_LEAVE, 'dragLeave',
+  DOMTopLevelEventTypes.TOP_DRAG_OVER, 'dragOver',
+  DOMTopLevelEventTypes.TOP_MOUSE_MOVE, 'mouseMove',
+  DOMTopLevelEventTypes.TOP_MOUSE_OUT, 'mouseOut',
+  DOMTopLevelEventTypes.TOP_MOUSE_OVER, 'mouseOver',
+  DOMTopLevelEventTypes.TOP_POINTER_MOVE, 'pointerMove',
+  DOMTopLevelEventTypes.TOP_POINTER_OUT, 'pointerOut',
+  DOMTopLevelEventTypes.TOP_POINTER_OVER, 'pointerOver',
+  DOMTopLevelEventTypes.TOP_SCROLL, 'scroll',
+  DOMTopLevelEventTypes.TOP_TOGGLE, 'toggle',
+  DOMTopLevelEventTypes.TOP_TOUCH_MOVE, 'touchMove',
+  DOMTopLevelEventTypes.TOP_WHEEL, 'wheel',
+];
+
+// prettier-ignore
+const continuousEvents = [
+  DOMTopLevelEventTypes.TOP_ABORT, 'abort',
+  DOMTopLevelEventTypes.TOP_ANIMATION_END, 'animationEnd',
+  DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION, 'animationIteration',
+  DOMTopLevelEventTypes.TOP_ANIMATION_START, 'animationStart',
+  DOMTopLevelEventTypes.TOP_CAN_PLAY, 'canPlay',
+  DOMTopLevelEventTypes.TOP_CAN_PLAY_THROUGH, 'canPlayThrough',
+  DOMTopLevelEventTypes.TOP_DURATION_CHANGE, 'durationChange',
+  DOMTopLevelEventTypes.TOP_EMPTIED, 'emptied',
+  DOMTopLevelEventTypes.TOP_ENCRYPTED, 'encrypted',
+  DOMTopLevelEventTypes.TOP_ENDED, 'ended',
+  DOMTopLevelEventTypes.TOP_ERROR, 'error',
+  DOMTopLevelEventTypes.TOP_GOT_POINTER_CAPTURE, 'gotPointerCapture',
+  DOMTopLevelEventTypes.TOP_LOAD, 'load',
+  DOMTopLevelEventTypes.TOP_LOADED_DATA, 'loadedData',
+  DOMTopLevelEventTypes.TOP_LOADED_METADATA, 'loadedMetadata',
+  DOMTopLevelEventTypes.TOP_LOAD_START, 'loadStart',
+  DOMTopLevelEventTypes.TOP_LOST_POINTER_CAPTURE, 'lostPointerCapture',
+  DOMTopLevelEventTypes.TOP_PLAYING, 'playing',
+  DOMTopLevelEventTypes.TOP_PROGRESS, 'progress',
+  DOMTopLevelEventTypes.TOP_SEEKING, 'seeking',
+  DOMTopLevelEventTypes.TOP_STALLED, 'stalled',
+  DOMTopLevelEventTypes.TOP_SUSPEND, 'suspend',
+  DOMTopLevelEventTypes.TOP_TIME_UPDATE, 'timeUpdate',
+  DOMTopLevelEventTypes.TOP_TRANSITION_END, 'transitionEnd',
+  DOMTopLevelEventTypes.TOP_WAITING, 'waiting',
+];
+
+/**
+ * Turns
+ * ['abort', ...]
+ * into
+ * eventTypes = {
+ *   'abort': {
+ *     phasedRegistrationNames: {
+ *       bubbled: 'onAbort',
+ *       captured: 'onAbortCapture',
+ *     },
+ *     dependencies: [TOP_ABORT],
+ *   },
+ *   ...
+ * };
+ * topLevelEventsToDispatchConfig = new Map([
+ *   [TOP_ABORT, { sameConfig }],
+ * ]);
+ */
+
+function processTopEventTypesByPriority(
+  eventTypes: Array<DOMTopLevelEventType | string>,
+  priority: EventPriority,
+): void {
+  // As the event types are in pairs of two, we need to iterate
+  // through in twos. The events are in pairs of two to save code
+  // and improve init perf of processing this array, as it will
+  // result in far fewer object allocations and property accesses
+  // if we only use three arrays to process all the categories of
+  // instead of tuples.
+  for (let i = 0; i < eventTypes.length; i += 2) {
+    const topEvent = ((eventTypes[i]: any): DOMTopLevelEventType);
+    const event = ((eventTypes[i + 1]: any): string);
+    const capitalizedEvent = event[0].toUpperCase() + event.slice(1);
+    const onEvent = 'on' + capitalizedEvent;
+
+    const config = {
+      phasedRegistrationNames: {
+        bubbled: onEvent,
+        captured: onEvent + 'Capture',
+      },
+      dependencies: [topEvent],
+      eventPriority: priority,
+    };
+    eventPriorities.set(topEvent, priority);
+    topLevelEventsToDispatchConfig.set(topEvent, config);
+    simpleEventPluginEventTypes[event] = config;
+  }
+}
+
+processTopEventTypesByPriority(discreteEvents, DiscreteEvent);
+processTopEventTypesByPriority(userBlockingEvents, UserBlockingEvent);
+processTopEventTypesByPriority(continuousEvents, ContinuousEvent);
+
+export function getEventPriorityForPluginSystem(
+  topLevelType: TopLevelType,
+): EventPriority {
+  const priority = eventPriorities.get(topLevelType);
+  // Default to a ContinuousEvent. Note: we might
+  // want to warn if we can't detect the priority
+  // for the event.
+  return priority === undefined ? ContinuousEvent : priority;
+}

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -59,7 +59,6 @@ import {
 } from './EventListener';
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
-import SimpleEventPlugin from './SimpleEventPlugin';
 import {getRawEventName} from './DOMTopLevelEventTypes';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
@@ -69,13 +68,12 @@ import {
   ContinuousEvent,
   DiscreteEvent,
 } from 'shared/ReactTypes';
+import {getEventPriorityForPluginSystem} from './DOMEventProperties';
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,
   unstable_runWithPriority: runWithPriority,
 } = Scheduler;
-
-const {getEventPriority} = SimpleEventPlugin;
 
 const CALLBACK_BOOKKEEPING_POOL_SIZE = 10;
 const callbackBookkeepingPool = [];
@@ -280,7 +278,7 @@ function trapEventForPluginEventSystem(
   capture: boolean,
 ): void {
   let listener;
-  switch (getEventPriority(topLevelType)) {
+  switch (getEventPriorityForPluginSystem(topLevelType)) {
     case DiscreteEvent:
       listener = dispatchDiscreteEvent.bind(
         null,

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -7,28 +7,23 @@
  * @flow
  */
 
-import type {EventPriority} from 'shared/ReactTypes';
 import type {
   TopLevelType,
   DOMTopLevelEventType,
 } from 'legacy-events/TopLevelEventTypes';
-import type {
-  DispatchConfig,
-  ReactSyntheticEvent,
-} from 'legacy-events/ReactSyntheticEventType';
+import type {ReactSyntheticEvent} from 'legacy-events/ReactSyntheticEventType';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import type {EventTypes, PluginModule} from 'legacy-events/PluginModuleType';
+import type {PluginModule} from 'legacy-events/PluginModuleType';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
-import {
-  DiscreteEvent,
-  UserBlockingEvent,
-  ContinuousEvent,
-} from 'shared/ReactTypes';
 import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
+import {
+  topLevelEventsToDispatchConfig,
+  simpleEventPluginEventTypes,
+} from './DOMEventProperties';
 
 import SyntheticAnimationEvent from './SyntheticAnimationEvent';
 import SyntheticClipboardEvent from './SyntheticClipboardEvent';
@@ -42,163 +37,6 @@ import SyntheticTransitionEvent from './SyntheticTransitionEvent';
 import SyntheticUIEvent from './SyntheticUIEvent';
 import SyntheticWheelEvent from './SyntheticWheelEvent';
 import getEventCharCode from './getEventCharCode';
-
-/**
- * Turns
- * ['abort', ...]
- * into
- * eventTypes = {
- *   'abort': {
- *     phasedRegistrationNames: {
- *       bubbled: 'onAbort',
- *       captured: 'onAbortCapture',
- *     },
- *     dependencies: [TOP_ABORT],
- *   },
- *   ...
- * };
- * topLevelEventsToDispatchConfig = new Map([
- *   [TOP_ABORT, { sameConfig }],
- * ]);
- */
-
-type EventTuple = [DOMTopLevelEventType, string, EventPriority];
-
-const eventTuples: Array<EventTuple> = [
-  // Discrete events
-  [DOMTopLevelEventTypes.TOP_BLUR, 'blur', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CANCEL, 'cancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CLICK, 'click', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CLOSE, 'close', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CONTEXT_MENU, 'contextMenu', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_COPY, 'copy', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_CUT, 'cut', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_AUX_CLICK, 'auxClick', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DOUBLE_CLICK, 'doubleClick', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_END, 'dragEnd', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_START, 'dragStart', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_DROP, 'drop', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_FOCUS, 'focus', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_INPUT, 'input', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_INVALID, 'invalid', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_DOWN, 'keyDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_PRESS, 'keyPress', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_KEY_UP, 'keyUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_DOWN, 'mouseDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_UP, 'mouseUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PASTE, 'paste', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PAUSE, 'pause', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_PLAY, 'play', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_CANCEL, 'pointerCancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_DOWN, 'pointerDown', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_UP, 'pointerUp', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_RATE_CHANGE, 'rateChange', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_RESET, 'reset', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_SEEKED, 'seeked', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_SUBMIT, 'submit', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_CANCEL, 'touchCancel', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_END, 'touchEnd', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_START, 'touchStart', DiscreteEvent],
-  [DOMTopLevelEventTypes.TOP_VOLUME_CHANGE, 'volumeChange', DiscreteEvent],
-
-  // User-blocking events
-  [DOMTopLevelEventTypes.TOP_DRAG, 'drag', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_ENTER, 'dragEnter', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_EXIT, 'dragExit', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_LEAVE, 'dragLeave', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_DRAG_OVER, 'dragOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_MOVE, 'mouseMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_OUT, 'mouseOut', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_MOUSE_OVER, 'mouseOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_MOVE, 'pointerMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_OUT, 'pointerOut', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_POINTER_OVER, 'pointerOver', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_SCROLL, 'scroll', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_TOGGLE, 'toggle', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_TOUCH_MOVE, 'touchMove', UserBlockingEvent],
-  [DOMTopLevelEventTypes.TOP_WHEEL, 'wheel', UserBlockingEvent],
-
-  // Continuous events
-  [DOMTopLevelEventTypes.TOP_ABORT, 'abort', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ANIMATION_END, 'animationEnd', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_ANIMATION_ITERATION,
-    'animationIteration',
-    ContinuousEvent,
-  ],
-  [
-    DOMTopLevelEventTypes.TOP_ANIMATION_START,
-    'animationStart',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_CAN_PLAY, 'canPlay', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_CAN_PLAY_THROUGH,
-    'canPlayThrough',
-    ContinuousEvent,
-  ],
-  [
-    DOMTopLevelEventTypes.TOP_DURATION_CHANGE,
-    'durationChange',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_EMPTIED, 'emptied', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ENCRYPTED, 'encrypted', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ENDED, 'ended', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_ERROR, 'error', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_GOT_POINTER_CAPTURE,
-    'gotPointerCapture',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_LOAD, 'load', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_LOADED_DATA, 'loadedData', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_LOADED_METADATA,
-    'loadedMetadata',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_LOAD_START, 'loadStart', ContinuousEvent],
-  [
-    DOMTopLevelEventTypes.TOP_LOST_POINTER_CAPTURE,
-    'lostPointerCapture',
-    ContinuousEvent,
-  ],
-  [DOMTopLevelEventTypes.TOP_PLAYING, 'playing', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_PROGRESS, 'progress', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_SEEKING, 'seeking', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_STALLED, 'stalled', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_SUSPEND, 'suspend', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_TIME_UPDATE, 'timeUpdate', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_TRANSITION_END, 'transitionEnd', ContinuousEvent],
-  [DOMTopLevelEventTypes.TOP_WAITING, 'waiting', ContinuousEvent],
-];
-
-const eventTypes: EventTypes = {};
-const topLevelEventsToDispatchConfig: {
-  [key: TopLevelType]: DispatchConfig,
-} = {};
-
-for (let i = 0; i < eventTuples.length; i++) {
-  const eventTuple = eventTuples[i];
-  const topEvent = eventTuple[0];
-  const event = eventTuple[1];
-  const eventPriority = eventTuple[2];
-
-  const capitalizedEvent = event[0].toUpperCase() + event.slice(1);
-  const onEvent = 'on' + capitalizedEvent;
-
-  const config = {
-    phasedRegistrationNames: {
-      bubbled: onEvent,
-      captured: onEvent + 'Capture',
-    },
-    dependencies: [topEvent],
-    eventPriority,
-  };
-  eventTypes[event] = config;
-  topLevelEventsToDispatchConfig[topEvent] = config;
-}
 
 // Only used in DEV for exhaustiveness validation.
 const knownHTMLTopLevelTypes: Array<DOMTopLevelEventType> = [
@@ -235,16 +73,10 @@ const knownHTMLTopLevelTypes: Array<DOMTopLevelEventType> = [
   DOMTopLevelEventTypes.TOP_WAITING,
 ];
 
-const SimpleEventPlugin: PluginModule<MouseEvent> & {
-  getEventPriority: (topLevelType: TopLevelType) => EventPriority,
-} = {
-  eventTypes: eventTypes,
-
-  getEventPriority(topLevelType: TopLevelType): EventPriority {
-    const config = topLevelEventsToDispatchConfig[topLevelType];
-    return config !== undefined ? config.eventPriority : ContinuousEvent;
-  },
-
+const SimpleEventPlugin: PluginModule<MouseEvent> = {
+  // simpleEventPluginEventTypes gets populated from
+  // the DOMEventProperties module.
+  eventTypes: simpleEventPluginEventTypes,
   extractEvents: function(
     topLevelType: TopLevelType,
     targetInst: null | Fiber,
@@ -252,7 +84,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> & {
     nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
   ): null | ReactSyntheticEvent {
-    const dispatchConfig = topLevelEventsToDispatchConfig[topLevelType];
+    const dispatchConfig = topLevelEventsToDispatchConfig.get(topLevelType);
     if (!dispatchConfig) {
       return null;
     }


### PR DESCRIPTION
The team have mentioned a bunch of times that it felt wrong that DOM Event Priority handling was all coupled with the SimpleEventPlugin, especially as might want to extend on the priorities with newer features and refactors in the future.

This PR breaks out the priority logic into a dedicated module and makes uses of Maps for faster lookups (I benchmarked before and after and Maps were consistently faster than object property lookups in Chrome and Safari, neutral in Firefox). We should also get a slight code size saving by some of the code golfing that I did whilst refactoring the code.