### PR TITLE
[react-test-renderer] Fix `findByType` broken for SimpleMemoComponent

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -321,8 +321,7 @@ describe('ReactHooksInspectionIntegration', () => {
     }
     let Foo = React.memo(InnerFoo);
     let renderer = ReactTestRenderer.create(<Foo />);
-    // TODO: Test renderer findByType is broken for memo. Have to search for the inner.
-    let childFiber = renderer.root.findByType(InnerFoo)._currentFiber();
+    let childFiber = renderer.root.findByType(Foo)._currentFiber();
     let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -307,6 +307,10 @@ class ReactTestInstance {
   }
 
   get type() {
+    if (this._fiber.tag === SimpleMemoComponent) {
+      return this._fiber.elementType;
+    }
+
     return this._fiber.type;
   }
 

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1032,4 +1032,30 @@ describe('ReactTestRenderer', () => {
       renderer.root.findByType(NonComponent);
     }).toThrowError(`No instances found with node type: "Unknown"`);
   });
+
+  it('supports SimpleMemoComponent with findByType', () => {
+    const App = () => null;
+    const SimpleMemoApp = React.memo(App);
+
+    const renderer = ReactTestRenderer.create(<SimpleMemoApp />);
+
+    const child = renderer.root.findByType(SimpleMemoApp);
+
+    expect(child.type).toBe(SimpleMemoApp);
+  });
+
+  it('supports MemoComponent with findByType', () => {
+    class App extends React.Component {
+      render() {
+        return null;
+      }
+    }
+    const MemoApp = React.memo(App);
+
+    const renderer = ReactTestRenderer.create(<MemoApp />);
+
+    const child = renderer.root.findByType(MemoApp);
+
+    expect(child.type).toBe(MemoApp);
+  });
 });


### PR DESCRIPTION
Fix #17301 .

The fix is simply check if the `tag` of the fiber node is `SimpleMemoComponent`, and check the `elementType` instead of `type`.

I'm not fully understand the difference between `elementType` and `type` in test-renderer though, looks like if we changed to always get the `elementType` instead of `type` would also work? Maybe it has something to do with `Lazy` and `Suspense`, but AFAIK `react-test-renderer` currently doesn't support them.