### PR TITLE
Fix various typos

### DIFF
--- a/fixtures/dom/src/components/fixtures/buttons/index.js
+++ b/fixtures/dom/src/components/fixtures/buttons/index.js
@@ -13,7 +13,7 @@ export default class ButtonTestCases extends React.Component {
       <FixtureSet title="Buttons">
         <TestCase
           title="onClick with disabled buttons"
-          description="The onClick event handler should not be invoked when clicking on a disabled buyaton">
+          description="The onClick event handler should not be invoked when clicking on a disabled button">
           <TestCase.Steps>
             <li>Click on the disabled button</li>
           </TestCase.Steps>

--- a/fixtures/dom/src/components/fixtures/selects/index.js
+++ b/fixtures/dom/src/components/fixtures/selects/index.js
@@ -172,7 +172,7 @@ class SelectFixture extends React.Component {
                 <option value="monkey">monkey</option>
                 <option value="lion">lion</option>
                 <option value="mongoose">mongoose</option>
-                <option value="tiger">tiget</option>
+                <option value="tiger">tiger</option>
               </select>
             </form>
           </div>

--- a/fixtures/tracing/test.js
+++ b/fixtures/tracing/test.js
@@ -95,7 +95,7 @@ trace('initial_render', performance.now(), () => {
   root.render(
     createElement(TestApp),
     wrap(() => {
-      log.app('commited');
+      log.app('committed');
     })
   );
 });

--- a/scripts/release/publish-commands/validate-skip-packages.js
+++ b/scripts/release/publish-commands/validate-skip-packages.js
@@ -29,10 +29,10 @@ const run = async ({cwd, packages, skipPackages}) => {
     }
 
     for (let dependency in dependencies) {
-      // Do we depend on a package thas has been skipped?
+      // Do we depend on a package that has been skipped?
       if (skipPackages.includes(dependency)) {
         const version = dependencies[dependency];
-        // Do we depend on a version of the package than has not been published to NPM?
+        // Do we depend on a version of the package that has not been published to NPM?
         const info = await execRead(`npm view ${dependency}@${version}`);
         if (!info) {
           console.log(


### PR DESCRIPTION
I came across a few typos in test fixtures and comments while experimenting with a source code spell checker. Apart from these, there don't appear to be other typos in fixtures/ or scripts/, so kudos :)