### PR TITLE
Added missing Flow type coverage to DevTools context menu

### DIFF
--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import React, {
   useContext,
   useEffect,
@@ -10,7 +19,7 @@ import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenu.css';
 
-function respositionToFit(element, pageX, pageY) {
+function respositionToFit(element: HTMLElement, pageX: number, pageY: number) {
   const ownerWindow = element.ownerDocument.defaultView;
   if (element !== null) {
     if (pageY + element.offsetHeight >= ownerWindow.innerHeight) {
@@ -43,7 +52,7 @@ const HIDDEN_STATE = {
 };
 
 type Props = {|
-  children: React$Node,
+  children: (data: Object) => React$Node,
   id: string,
 |};
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import React, {useContext} from 'react';
 import {RegistryContext} from './Contexts';
 
@@ -5,7 +14,7 @@ import styles from './ContextMenuItem.css';
 
 type Props = {|
   children: React$Node,
-  onClick: Object => void,
+  onClick: () => void,
   title: string,
 |};
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/Contexts.js
@@ -1,10 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import {createContext} from 'react';
 
-export type ShowFn = ({data: Object, pageX: number, pageY: number}) => void;
+export type ShowFn = ({|data: Object, pageX: number, pageY: number|}) => void;
 export type HideFn = () => void;
 
-const idToShowFnMap = new Map();
-const idToHideFnMap = new Map();
+const idToShowFnMap = new Map<string, ShowFn>();
+const idToHideFnMap = new Map<string, HideFn>();
 
 let currentHideFn = null;
 
@@ -41,8 +50,8 @@ function registerMenu(id: string, showFn: ShowFn, hideFn: HideFn) {
   idToHideFnMap.set(id, hideFn);
 
   return function unregisterMenu() {
-    idToShowFnMap.delete(id, showFn);
-    idToHideFnMap.delete(id, hideFn);
+    idToShowFnMap.delete(id);
+    idToHideFnMap.delete(id);
   };
 }
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
@@ -1,7 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import {useContext, useEffect} from 'react';
 import {RegistryContext} from './Contexts';
 
-export default function useContextMenu({data, id, ref}) {
+import type {ElementRef} from 'react';
+
+export default function useContextMenu({
+  data,
+  id,
+  ref,
+}: {|
+  data: Object,
+  id: string,
+  ref: ElementRef<HTMLElement>,
+|}) {
   const {showMenu} = useContext(RegistryContext);
 
   useEffect(


### PR DESCRIPTION
Oops. We should probably have a lint rule that complains if we forget to add the copyright+flow boilerplate to new files.

The `data` param should probably be a generic type, but I'm not sure how to satisfy Flow with the current top-level `idToShowFnMap` Map. At least this adds basic coverage (which was missing before, oops).