### PR TITLE
Make DevTools check document.contentType before injecting

### DIFF
--- a/packages/react-devtools-extensions/src/injectGlobalHook.js
+++ b/packages/react-devtools-extensions/src/injectGlobalHook.js
@@ -86,8 +86,14 @@ if (sessionStorageGetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY) === 'true') {
   injectCode(rendererCode);
 }
 
-// Inject a `__REACT_DEVTOOLS_GLOBAL_HOOK__` global so that React can detect that the
-// devtools are installed (and skip its suggestion to install the devtools).
-injectCode(
-  ';(' + installHook.toString() + '(window))' + saveNativeValues + detectReact,
-);
+// Inject a __REACT_DEVTOOLS_GLOBAL_HOOK__ global for React to interact with.
+// Only do this for HTML documents though, to avoid e.g. breaking syntax highlighting for XML docs.
+if (document.contentType === 'text/html') {
+  injectCode(
+    ';(' +
+      installHook.toString() +
+      '(window))' +
+      saveNativeValues +
+      detectReact,
+  );
+}


### PR DESCRIPTION
It should only inject the global hook into HTML documents. This will avoid breaking syntax highlighting for e.g. XML documents.

This fixes the following use case:
1. Install React DevTools add-on in Firefox Developer Edition.
1. Open an XML file (e.g. [www.w3schools.com/xml/note.xml](https://www.w3schools.com/xml/note.xml)).
1. Verify syntax highlighting works.

Note that if the React DevTools tab is already open before navigating to an XML document, syntax highlighting may not work.

Resolves #17620