### PR TITLE
Build and store DevTools artifacts in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,22 @@ jobs:
             - dist
             - sizes/*.json
 
+  build_devtools_and_process_artifacts:
+    docker: *docker
+    environment: *environment
+    parallelism: 20
+    steps:
+      - checkout
+      - attach_workspace: *attach_workspace
+      - *restore_yarn_cache
+      - *run_yarn
+      - run:
+          environment:
+            RELEASE_CHANNEL: experimental
+          command: ./scripts/circleci/pack_and_store_devtools_artifacts.sh
+      - store_artifacts:
+          path: ./build/devtools.tgz
+
   # These jobs are named differently so we can distinguish the stable and
   # and experimental artifacts
   process_artifacts: *process_artifacts
@@ -267,7 +283,7 @@ jobs:
             RELEASE_CHANNEL: experimental
           command: yarn test-build --maxWorkers=2
 
-  test_build_devtools:
+  test_devtools:
     docker: *docker
     environment: *environment
     steps:
@@ -402,7 +418,10 @@ workflows:
       - lint_build:
           requires:
             - build_experimental
-      - test_build_devtools:
+      - test_devtools:
+          requires:
+            - build_experimental
+      - build_devtools_and_process_artifacts:
           requires:
             - build_experimental
 

--- a/scripts/circleci/pack_and_store_devtools_artifacts.sh
+++ b/scripts/circleci/pack_and_store_devtools_artifacts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p build/devtools
+
+cd packages/react-devtools
+npm pack
+mv ./react-devtools*.tgz ../../build/devtools/
+
+cd ../react-devtools-core
+npm pack
+mv ./react-devtools-core*.tgz ../../build/devtools/
+
+cd ../react-devtools-inline
+npm pack
+mv ./react-devtools-inline*.tgz ../../build/devtools/
+
+cd ../react-devtools-extensions
+yarn build
+mv ./chrome/build/ReactDevTools.zip ../../build/devtools/chrome-extension.zip
+mv ./firefox/build/ReactDevTools.zip ../../build/devtools/firefox-extension.zip
+
+# Compress all DevTools artifacts into a single tarball for easy download
+tar -zcvf ../../build/devtools.tgz ../../build/devtools


### PR DESCRIPTION
Might as well leverage Circle CI to test our DevTools builds, and if we're doing that- we might as well store the artifacts as well. Maybe in the future, we should release DevTools directly from CI artifacts as well, like we do for NPM packages.

Let's see if these changes actually work... 😄