### PR TITLE
Fixed CircleCI DevTools build artifact tar internal structure

### DIFF
--- a/scripts/circleci/pack_and_store_devtools_artifacts.sh
+++ b/scripts/circleci/pack_and_store_devtools_artifacts.sh
@@ -22,4 +22,5 @@ mv ./chrome/build/ReactDevTools.zip ../../build/devtools/chrome-extension.zip
 mv ./firefox/build/ReactDevTools.zip ../../build/devtools/firefox-extension.zip
 
 # Compress all DevTools artifacts into a single tarball for easy download
-tar -zcvf ../../build/devtools.tgz ../../build/devtools
+cd ../../build/devtools
+tar -zcvf ../devtools.tgz .


### PR DESCRIPTION
Oops. Previously the `tar.gz` file had nested folders instead of it, which made it awkward to work with.