### PR TITLE
Partial fix DevTools Profiler "Could not find node…" error

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
@@ -118,5 +118,6 @@ describe('ProfilerStore', () => {
     const root = store.roots[0];
     const data = store.profilerStore.getDataForRoot(root);
     expect(data.commitData).toHaveLength(1);
+    expect(data.operations).toHaveLength(1);
   });
 });


### PR DESCRIPTION
DevTools records the following information while profiling:
1. A snapshot of the React tree when profiling started.
1. The [operations array](https://github.com/facebook/react/blob/master/packages/react-devtools/OVERVIEW.md#serializing-the-tree) for each commit.
1. Profiling metadata (e.g. durations, which values changed, etc.) for each commit.

It uses this information (snapshot + operations diff) to reconstruct the state of the application for a given commit as it's viewed in the Profiler UI. Because of this, it's very important that the operations and metadata arrays align. If they don't align, the profiler will be unable to correctly reconstruct the tree for a given commit, and it will likely throw errors (like "Could not find node…")

#16446 tracks a long-standing bug where the profiler is unable to correctly regenerate the tree for a commit. I believe it is because the two arrays I mentioned above are misaligned. I am still not entirely sure what causes the original bug, but I made it worse with PR #17253 by introducing another potential way for it to happen. This PR addresses that regression at least (and adds test coverage for it).

I will follow up this afternoon on the original #16446 issue. I think I may have [a lead](https://github.com/facebook/react/issues/16446#issuecomment-570289883) on what's happening at least, if not exactly an idea of how to reproduce it. I believe this fix is worth landing on its own though, since it seems to have made the bug easier to trigger.