### PR TITLE
[react-interactions] Fix Hover issues with portals

### DIFF
--- a/packages/react-interactions/events/src/dom/__tests__/Hover-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Hover-test.internal.js
@@ -193,6 +193,32 @@ describe.each(table)('Hover responder', hasPointerEvents => {
       target.pointerup({pointerType: 'touch'});
       expect(onHoverEnd).not.toBeCalled();
     });
+
+    it('should correctly work with React Portals', () => {
+      const portalNode = document.createElement('div');
+      const divRef = React.createRef();
+      const spanRef = React.createRef();
+
+      function Test() {
+        const listener = useHover({
+          onHoverEnd,
+        });
+        return (
+          <div ref={divRef} DEPRECATED_flareListeners={listener}>
+            {ReactDOM.createPortal(<span ref={spanRef} />, portalNode)}
+          </div>
+        );
+      }
+      ReactDOM.render(<Test />, container);
+      const div = createEventTarget(divRef.current);
+      div.pointerenter();
+      const span = createEventTarget(spanRef.current);
+      span.pointerexit();
+      expect(onHoverEnd).not.toBeCalled();
+      const body = createEventTarget(document.body);
+      body.pointerexit();
+      expect(onHoverEnd).toBeCalled();
+    });
   });
 
   describe('onHoverMove', () => {


### PR DESCRIPTION
This PR fixes an issue discovered internally with the Hover responder and React Portals. Specifically, the `onHoverEnd` events were not firing when we moved focus through a React Portal. The reason for this is because, by their nature, portal nodes are within other parts of the DOM tree, that are not linked to that of the "target" portion of the tree. That means, moving into a portal will be the last time we get a `pointerleave` event fire because we only track `pointerleave` for target events. We should instead be tracking this for root events, as portals are in another part of the document. I've also added a regression test that shows this error (will fail if you revert Hover.js).