### PR TITLE
DevTools: Replaced unsafe hasOwnProperty() calls

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -510,11 +510,6 @@ exports[`InspectedElementContext should support complex data types: 1: Inspected
     "object_of_objects": {
       "inner": {}
     },
-    "object_with_null_proto": {
-      "string": "abc",
-      "number": 123,
-      "boolean": true
-    },
     "react_element": {},
     "regexp": {},
     "set": {
@@ -546,6 +541,39 @@ exports[`InspectedElementContext should support custom objects with enumerable p
     "data": {
       "_number": 42,
       "number": 42
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should support objects with no prototype: 1: Inspected element 2 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "hooks": null,
+  "props": {
+    "object": {
+      "string": "abc",
+      "number": 123,
+      "boolean": true
+    }
+  },
+  "state": null
+}
+`;
+
+exports[`InspectedElementContext should support objects with overridden hasOwnProperty: 1: Inspected element 2 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "hooks": null,
+  "props": {
+    "object": {
+      "name": "blah",
+      "hasOwnProperty": true
     }
   },
   "state": null

--- a/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
@@ -151,11 +151,6 @@ Object {
     "object_of_objects": {
       "inner": {}
     },
-    "object_with_null_proto": {
-      "string": "abc",
-      "number": 123,
-      "boolean": true
-    },
     "react_element": {},
     "regexp": {},
     "set": {
@@ -191,6 +186,47 @@ Object {
     "data": {
       "_number": 42,
       "number": 42
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should support objects with no prototype: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "hooks": null,
+  "props": {
+    "object": {
+      "string": "abc",
+      "number": 123,
+      "boolean": true
+    }
+  },
+  "state": null
+},
+}
+`;
+
+exports[`InspectedElementContext should support objects with overridden hasOwnProperty: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "hooks": null,
+  "props": {
+    "object": {
+      "name": "blah",
+      "hasOwnProperty": true
     }
   },
   "state": null

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -78,7 +78,7 @@ export default function KeyValue({
       type:
         value !== null &&
         typeof value === 'object' &&
-        value.hasOwnProperty(meta.type)
+        hasOwnProperty.call(value, meta.type)
           ? value[meta.type]
           : typeof value,
     },
@@ -136,8 +136,8 @@ export default function KeyValue({
       </div>
     );
   } else if (
-    value.hasOwnProperty(meta.type) &&
-    !value.hasOwnProperty(meta.unserializable)
+    hasOwnProperty.call(value, meta.type) &&
+    !hasOwnProperty.call(value, meta.unserializable)
   ) {
     children = (
       <div

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -93,7 +93,7 @@ export function createRegExp(string: string): RegExp {
 }
 
 export function getMetaValueLabel(data: Object): string | null {
-  if (data.hasOwnProperty(meta.preview_long)) {
+  if (hasOwnProperty.call(data, meta.preview_long)) {
     return data[meta.preview_long];
   } else {
     return formatDataForPreview(data, true);

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -385,7 +385,7 @@ export function getDataType(data: Object): DataType {
       if (Array.isArray(data)) {
         return 'array';
       } else if (ArrayBuffer.isView(data)) {
-        return data.constructor.hasOwnProperty('BYTES_PER_ELEMENT')
+        return hasOwnProperty.call(data.constructor, 'BYTES_PER_ELEMENT')
           ? 'typed_array'
           : 'data_view';
       } else if (data.constructor && data.constructor.name === 'ArrayBuffer') {
@@ -490,7 +490,7 @@ export function formatDataForPreview(
   data: any,
   showFormattedValue: boolean,
 ): string {
-  if (data != null && data.hasOwnProperty(meta.type)) {
+  if (data != null && hasOwnProperty.call(data, meta.type)) {
     return showFormattedValue
       ? data[meta.preview_long]
       : data[meta.preview_short];
@@ -534,7 +534,7 @@ export function formatDataForPreview(
         }
         return `[${truncateForDisplay(formatted)}]`;
       } else {
-        const length = data.hasOwnProperty(meta.size)
+        const length = hasOwnProperty.call(data, meta.size)
           ? data[meta.size]
           : data.length;
         return `Array(${length})`;

--- a/packages/react-devtools-shell/src/app/InspectableElements/EdgeCaseObjects.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/EdgeCaseObjects.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React from 'react';
+
+const objectWithModifiedHasOwnProperty = {
+  foo: 'abc',
+  bar: 123,
+  hasOwnProperty: true,
+};
+
+const objectWithNullProto = Object.create(null);
+objectWithNullProto.foo = 'abc';
+objectWithNullProto.bar = 123;
+
+export default function EdgeCaseObjects() {
+  return (
+    <ChildComponent
+      objectWithModifiedHasOwnProperty={objectWithModifiedHasOwnProperty}
+      objectWithNullProto={objectWithNullProto}
+    />
+  );
+}
+
+function ChildComponent(props: any) {
+  return null;
+}

--- a/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
@@ -13,6 +13,7 @@ import CircularReferences from './CircularReferences';
 import Contexts from './Contexts';
 import CustomHooks from './CustomHooks';
 import CustomObject from './CustomObject';
+import EdgeCaseObjects from './EdgeCaseObjects.js';
 import NestedProps from './NestedProps';
 import SimpleValues from './SimpleValues';
 
@@ -28,6 +29,7 @@ export default function InspectableElements() {
       <Contexts />
       <CustomHooks />
       <CustomObject />
+      <EdgeCaseObjects />
       <CircularReferences />
     </Fragment>
   );

--- a/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
@@ -25,9 +25,6 @@ const immutable = Immutable.fromJS({
     xyz: 1,
   },
 });
-const objectWithNullProto = Object.create(null);
-objectWithNullProto.foo = 'abc';
-objectWithNullProto.bar = 123;
 
 export default function UnserializableProps() {
   return (
@@ -40,7 +37,6 @@ export default function UnserializableProps() {
       setOfSets={setOfSets}
       typedArray={typedArray}
       immutable={immutable}
-      objectWithNullProto={objectWithNullProto}
     />
   );
 }


### PR DESCRIPTION
DevTools previously called `value.hasOwnProperty('foo')` in several places with user-defined values. This could lead to runtime errors if those values had an overridden attribute. This commit replaces those calls with `hasOwnProperty.call(value, 'foo')` instead.

New test cases have been added.

Resolves #17761
Resolves half of #17764