### PR TITLE
Remove toString of dangerouslySetInnerHTML

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -85,7 +85,6 @@ import possibleStandardNames from '../shared/possibleStandardNames';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
 import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';
 import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
-import {toStringOrTrustedType} from './ToStringValue';
 
 import {
   enableDeprecatedFlareAPI,
@@ -787,10 +786,7 @@ export function diffProperties(
       const lastHtml = lastProp ? lastProp[HTML] : undefined;
       if (nextHtml != null) {
         if (lastHtml !== nextHtml) {
-          (updatePayload = updatePayload || []).push(
-            propKey,
-            toStringOrTrustedType(nextHtml),
-          );
+          (updatePayload = updatePayload || []).push(propKey, nextHtml);
         }
       } else {
         // TODO: It might be too late to clear this if we have children


### PR DESCRIPTION
As far as I can tell, the toString call was added here:

https://github.com/facebook/react/commit/caae627cd557812d28d11237b34bff6c661ea8bc#diff-5574f655d491348f422bca600ff6711dR887

However, we don't toString the HTML in the initial creation. Only updates. It was never really needed.

Subsequently when we added Trusted Types, this needed to be changed to a special call but we really should just always let it pass through.

_Interestingly we should probably always let values pass through except for
when we need to do something special with the string which is rare._