### PR TITLE
Scope dev tools wildcard styles within DevTools CSS class

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/DevTools.css
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.css
@@ -53,3 +53,9 @@
     display: none;
   }
 }
+
+.DevTools, .DevTools * {
+  box-sizing: border-box;
+
+  -webkit-font-smoothing: var(--font-smoothing);
+}

--- a/packages/react-devtools-shared/src/devtools/views/root.css
+++ b/packages/react-devtools-shared/src/devtools/views/root.css
@@ -182,9 +182,3 @@
   --interaction-commit-size: 10px;
   --interaction-label-width: 200px;
 }
-
-* {
-  box-sizing: border-box;
-
-  -webkit-font-smoothing: var(--font-smoothing);
-}


### PR DESCRIPTION
Previously, wildcard selector was used to apply global styles that are related to DevTools. However, due to the fact that wildcard selectors will be used throughout the website, `react-devtools-inline` package bleeds out its styles outside its scope. So, in this PR, I am scoping these styles within `DevTools` main container's class name.

In this PR, I have added selectors for DevTools class and all the items within DevTools class.

Applied styles were tested using React DevTools app (package: `react-devtools`) by inspecting them through Electron's chrome inspector.

Referencing issue: https://github.com/facebook/react/issues/16456
