### PR TITLE
Rename internal fields

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -18,9 +18,9 @@ import {getParentSuspenseInstance} from './ReactDOMHostConfig';
 const randomKey = Math.random()
   .toString(36)
   .slice(2);
-const internalInstanceKey = '__reactInternalInstance$' + randomKey;
-const internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
-const internalContainerInstanceKey = '__reactContainere$' + randomKey;
+const internalInstanceKey = '__reactFiber$' + randomKey;
+const internalEventHandlersKey = '__reactEvents$' + randomKey;
+const internalContainerInstanceKey = '__reactContainer$' + randomKey;
 
 export function precacheFiberNode(hostInst, node) {
   node[internalInstanceKey] = hostInst;

--- a/packages/shared/ReactInstanceMap.js
+++ b/packages/shared/ReactInstanceMap.js
@@ -21,17 +21,17 @@
  * supported we can rename it.
  */
 export function remove(key) {
-  key._reactInternalFiber = undefined;
+  key._reactInternals = undefined;
 }
 
 export function get(key) {
-  return key._reactInternalFiber;
+  return key._reactInternals;
 }
 
 export function has(key) {
-  return key._reactInternalFiber !== undefined;
+  return key._reactInternals !== undefined;
 }
 
 export function set(key, value) {
-  key._reactInternalFiber = value;
+  key._reactInternals = value;
 }


### PR DESCRIPTION
One day we'll use private fields for this but until then I'm just going to rename these every version until people get the hint.

This is actually better than if we change fields while keeping the same name. Because at least this will fail early (and often bailout) where as once found, people tend to assume that the data structure is there and as such throws random  errors to users.