### PR TITLE
[fail] move IsThisRendererActing to own namespace

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -169,8 +169,8 @@ const ReactDOM: Object = {
       dispatchEvent,
       runEventsInBatch,
       flushPassiveEffects,
-      IsThisRendererActing,
     ],
+    Tests: [IsThisRendererActing],
   },
 };
 

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -41,9 +41,14 @@ const [
   runEventsInBatch,
   /* eslint-disable no-unused-vars */
   flushPassiveEffects,
-  IsThisRendererActing,
   /* eslint-enable no-unused-vars */
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+
+/* eslint-disable no-unused-vars */
+const [
+  IsThisRendererActing,
+] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Tests;
+/* eslint-enable no-unused-vars */
 
 function Event(suffix) {}
 

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -31,8 +31,11 @@ const [
   runEventsInBatch,
   /* eslint-enable no-unused-vars */
   flushPassiveEffects,
-  IsThisRendererActing,
 ] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events;
+
+const [
+  IsThisRendererActing,
+] = ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Tests;
 
 const batchedUpdates = ReactDOM.unstable_batchedUpdates;
 


### PR DESCRIPTION
The `Events` namespace on the secret object might be disappearing, so `IsThisRendererActing` can't live on it anymore. This PR -
- moves `IsThisRendererActing` from `ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.Events` to `ReactDOM....Tests` 
