### PR TITLE
[react-interactions] Add DO_NOT_USE to Scope methods

### DIFF
--- a/packages/react-interactions/accessibility/README.md
+++ b/packages/react-interactions/accessibility/README.md
@@ -14,73 +14,10 @@ can be found [here](./docs).
 
 Note: React Scopes require the internal React flag `enableScopeAPI`.
 
-When creating a scope, a query function is required. The query function is used
-when collecting host nodes that match the criteria of the query function.
-
-```jsx
-// This query function only matches host nodes that have the type of "div"
-const queryFunction = (type: string, props: Object): boolean => {
-  if (type === 'div') {
-    return true;
-  }
-  return false;
-};
-
-// Create the scope with the queryFunction above
-const DivOnlyScope = React.unstable_createScope(queryFunction);
-
-// We can now use this in our components. We need to attach
-// a ref so we can get the matching host nodes.
-function MyComponent(props) {
-  const divOnlyScope = useRef(null);
-  return (
-    <DivOnlyScope ref={divOnlyScope}>
-      <div>DIV 1</div>
-      <div>DIV 2</div>
-      <div>DIV 3</div>
-    </DivOnlyScope>
-  );
-}
-
-// Using the ref, we can get the host nodes via getAllNodes()
-const divs = divOnlyScope.current.getAllNodes();
-
-// [<div>DIV 1</div>, <div>DIV 2</div>, <div>DIV 3</div>]
-console.log(divs);
-```
-
 ## React Scope Interface
 
 Scopes require a `ref` to access the internal interface of a particular scope.
 The internal interface (`ReactScopeInterface`) exposes the following scope API:
-
-### getChildren: () => null | Array<ReactScopeInterface>
-
-Returns an array of all child `ReactScopeInterface` nodes that are
-of scopes of the same type. Returns `null` if there are no child scope nodes.
-
-### getChildrenFromRoot: () => null | Array<ReactScopeInterface>
-
-Similar to `getChildren`, except this applies the same traversal from the root of the
-React internal tree instead of from the scope node position.
-
-### getParent: () => null | ReactScopeInterface
-
-Returns the parent `ReactScopeInterface` of the scope node or `null` if none exists.
-
-### getProps: () => Object
-
-Returns the current `props` object of the scope node.
-
-### getAllNodes: () => null | Array<HTMLElement>
-
-Returns an array of all child host nodes that successfully match when queried using the
-query function passed to the scope. Returns `null` if there are no matching host nodes.
-
-### getFirstNode: () => null | HTMLElement
-
-Returns the first child host node that successfully matches when queried using the
-query function passed to the scope. Returns `null` if there is no matching host node.
 
 ### containsNode: (node: HTMLElement) => boolean
 

--- a/packages/react-interactions/accessibility/docs/TabbableScopeQuery.md
+++ b/packages/react-interactions/accessibility/docs/TabbableScopeQuery.md
@@ -15,7 +15,7 @@ function FocusableNodeCollector(props) {
     const scope = scopeRef.current;
 
     if (scope) {
-      const tabFocusableNodes = scope.queryAllNodes(tabbableScopeQuery);
+      const tabFocusableNodes = scope.DO_NOT_USE_queryAllNodes(tabbableScopeQuery);
       if (tabFocusableNodes && props.onFocusableNodes) {
         props.onFocusableNodes(tabFocusableNodes);
       }

--- a/packages/react-interactions/accessibility/src/FocusContain.js
+++ b/packages/react-interactions/accessibility/src/FocusContain.js
@@ -71,7 +71,7 @@ export default function FocusContain({
       disabled !== true &&
       !scope.containsNode(document.activeElement)
     ) {
-      const fistElem = scope.queryFirstNode(scopeQuery);
+      const fistElem = scope.DO_NOT_USE_queryFirstNode(scopeQuery);
       if (fistElem !== null) {
         fistElem.focus();
       }

--- a/packages/react-interactions/accessibility/src/FocusGroup.js
+++ b/packages/react-interactions/accessibility/src/FocusGroup.js
@@ -35,7 +35,7 @@ function focusGroupItem(
   cell: ReactScopeMethods,
   event: KeyboardEvent,
 ): void {
-  const firstScopedNode = cell.queryFirstNode(scopeQuery);
+  const firstScopedNode = cell.DO_NOT_USE_queryFirstNode(scopeQuery);
   if (firstScopedNode !== null) {
     firstScopedNode.focus();
     event.preventDefault();
@@ -46,7 +46,7 @@ function getPreviousGroupItem(
   group: ReactScopeMethods,
   currentItem: ReactScopeMethods,
 ): null | ReactScopeMethods {
-  const items = group.getChildren();
+  const items = group.DO_NOT_USE_getChildren();
   if (items !== null) {
     const currentItemIndex = items.indexOf(currentItem);
     const wrap = getGroupProps(currentItem).wrap;
@@ -63,7 +63,7 @@ function getNextGroupItem(
   group: ReactScopeMethods,
   currentItem: ReactScopeMethods,
 ): null | ReactScopeMethods {
-  const items = group.getChildren();
+  const items = group.DO_NOT_USE_getChildren();
   if (items !== null) {
     const currentItemIndex = items.indexOf(currentItem);
     const wrap = getGroupProps(currentItem).wrap;
@@ -78,9 +78,9 @@ function getNextGroupItem(
 }
 
 function getGroupProps(currentCell: ReactScopeMethods): Object {
-  const group = currentCell.getParent();
+  const group = currentCell.DO_NOT_USE_getParent();
   if (group !== null) {
-    const groupProps = group.getProps();
+    const groupProps = group.DO_NOT_USE_getProps();
     if (groupProps && groupProps.type === 'group') {
       return groupProps;
     }
@@ -125,8 +125,8 @@ export function createFocusGroup(
       onKeyDown(event: KeyboardEvent): void {
         const currentItem = scopeRef.current;
         if (currentItem !== null) {
-          const group = currentItem.getParent();
-          const groupProps = group && group.getProps();
+          const group = currentItem.DO_NOT_USE_getParent();
+          const groupProps = group && group.DO_NOT_USE_getProps();
           if (group !== null && groupProps.type === 'group') {
             const portrait = groupProps.portrait;
             const key = event.key;
@@ -134,10 +134,12 @@ export function createFocusGroup(
             if (key === 'Tab') {
               const tabScopeQuery = getGroupProps(currentItem).tabScopeQuery;
               if (tabScopeQuery) {
-                const groupScope = currentItem.getParent();
+                const groupScope = currentItem.DO_NOT_USE_getParent();
                 if (groupScope) {
                   const activeNode = document.activeElement;
-                  const nodes = groupScope.queryAllNodes(tabScopeQuery);
+                  const nodes = groupScope.DO_NOT_USE_queryAllNodes(
+                    tabScopeQuery,
+                  );
                   for (let i = 0; i < nodes.length; i++) {
                     const node = nodes[i];
                     if (node !== activeNode) {

--- a/packages/react-interactions/accessibility/src/FocusManager.js
+++ b/packages/react-interactions/accessibility/src/FocusManager.js
@@ -16,7 +16,7 @@ export function focusFirst(
   scopeQuery: (type: string | Object, props: Object) => boolean,
   scope: ReactScopeMethods,
 ): void {
-  const firstNode = scope.queryFirstNode(scopeQuery);
+  const firstNode = scope.DO_NOT_USE_queryFirstNode(scopeQuery);
   if (firstNode) {
     focusElem(firstNode);
   }
@@ -101,7 +101,7 @@ export function focusPrevious(
 export function getNextScope(
   scope: ReactScopeMethods,
 ): null | ReactScopeMethods {
-  const allScopes = scope.getChildrenFromRoot();
+  const allScopes = scope.DO_NOT_USE_getChildrenFromRoot();
   if (allScopes === null) {
     return null;
   }
@@ -115,7 +115,7 @@ export function getNextScope(
 export function getPreviousScope(
   scope: ReactScopeMethods,
 ): null | ReactScopeMethods {
-  const allScopes = scope.getChildrenFromRoot();
+  const allScopes = scope.DO_NOT_USE_getChildrenFromRoot();
   if (allScopes === null) {
     return null;
   }

--- a/packages/react-interactions/accessibility/src/FocusTable.js
+++ b/packages/react-interactions/accessibility/src/FocusTable.js
@@ -42,7 +42,7 @@ function focusScope(
   cell: ReactScopeMethods,
   event?: KeyboardEvent,
 ): void {
-  const firstScopedNode = cell.queryFirstNode(scopeQuery);
+  const firstScopedNode = cell.DO_NOT_USE_queryFirstNode(scopeQuery);
   if (firstScopedNode !== null) {
     firstScopedNode.focus();
     if (event) {
@@ -58,13 +58,13 @@ function focusCellByColumnIndex(
   columnIndex: number,
   event?: KeyboardEvent,
 ): void {
-  const cells = row.getChildren();
+  const cells = row.DO_NOT_USE_getChildren();
   if (cells !== null) {
     let colSize = 0;
     for (let i = 0; i < cells.length; i++) {
       const cell = cells[i];
       if (cell) {
-        colSize += cell.getProps().colSpan || 1;
+        colSize += cell.DO_NOT_USE_getProps().colSpan || 1;
         if (colSize > columnIndex) {
           focusScope(scopeQuery, cell, event);
           return;
@@ -84,7 +84,7 @@ function getCellIndexes(
     if (cell === currentCell) {
       return [i, i + totalColSpan];
     }
-    const colSpan = cell.getProps().colSpan;
+    const colSpan = cell.DO_NOT_USE_getProps().colSpan;
     if (colSpan) {
       totalColSpan += colSpan - 1;
     }
@@ -93,9 +93,9 @@ function getCellIndexes(
 }
 
 function getRowCells(currentCell: ReactScopeMethods) {
-  const row = currentCell.getParent();
-  if (row !== null && row.getProps().type === 'row') {
-    const cells = row.getChildren();
+  const row = currentCell.DO_NOT_USE_getParent();
+  if (row !== null && row.DO_NOT_USE_getProps().type === 'row') {
+    const cells = row.DO_NOT_USE_getChildren();
     if (cells !== null) {
       const [rowIndex, rowIndexWithColSpan] = getCellIndexes(
         cells,
@@ -108,11 +108,11 @@ function getRowCells(currentCell: ReactScopeMethods) {
 }
 
 function getRows(currentCell: ReactScopeMethods) {
-  const row = currentCell.getParent();
-  if (row !== null && row.getProps().type === 'row') {
-    const table = row.getParent();
-    if (table !== null && table.getProps().type === 'table') {
-      const rows = table.getChildren();
+  const row = currentCell.DO_NOT_USE_getParent();
+  if (row !== null && row.DO_NOT_USE_getProps().type === 'row') {
+    const table = row.DO_NOT_USE_getParent();
+    if (table !== null && table.DO_NOT_USE_getProps().type === 'table') {
+      const rows = table.DO_NOT_USE_getChildren();
       if (rows !== null) {
         const columnIndex = rows.indexOf(row);
         return [rows, columnIndex];
@@ -127,11 +127,11 @@ function triggerNavigateOut(
   direction: 'left' | 'right' | 'up' | 'down',
   event,
 ): void {
-  const row = currentCell.getParent();
-  if (row !== null && row.getProps().type === 'row') {
-    const table = row.getParent();
+  const row = currentCell.DO_NOT_USE_getParent();
+  if (row !== null && row.DO_NOT_USE_getProps().type === 'row') {
+    const table = row.DO_NOT_USE_getParent();
     if (table !== null) {
-      const props = table.getProps();
+      const props = table.DO_NOT_USE_getProps();
       const onKeyboardOut = props.onKeyboardOut;
       if (props.type === 'table' && typeof onKeyboardOut === 'function') {
         onKeyboardOut(direction, event);
@@ -143,11 +143,11 @@ function triggerNavigateOut(
 }
 
 function getTableProps(currentCell: ReactScopeMethods): Object {
-  const row = currentCell.getParent();
-  if (row !== null && row.getProps().type === 'row') {
-    const table = row.getParent();
+  const row = currentCell.DO_NOT_USE_getParent();
+  if (row !== null && row.DO_NOT_USE_getProps().type === 'row') {
+    const table = row.DO_NOT_USE_getParent();
     if (table !== null) {
-      return table.getProps();
+      return table.DO_NOT_USE_getProps();
     }
   }
   return {};
@@ -207,12 +207,14 @@ export function createFocusTable(
         if (key === 'Tab') {
           const tabScopeQuery = getTableProps(currentCell).tabScopeQuery;
           if (tabScopeQuery) {
-            const rowScope = currentCell.getParent();
+            const rowScope = currentCell.DO_NOT_USE_getParent();
             if (rowScope) {
-              const tableScope = rowScope.getParent();
+              const tableScope = rowScope.DO_NOT_USE_getParent();
               if (tableScope) {
                 const activeNode = document.activeElement;
-                const nodes = tableScope.queryAllNodes(tabScopeQuery);
+                const nodes = tableScope.DO_NOT_USE_queryAllNodes(
+                  tabScopeQuery,
+                );
                 for (let i = 0; i < nodes.length; i++) {
                   const node = nodes[i];
                   if (node !== activeNode) {

--- a/packages/react-interactions/accessibility/src/__tests__/TabbableScopeQuery-test.internal.js
+++ b/packages/react-interactions/accessibility/src/__tests__/TabbableScopeQuery-test.internal.js
@@ -35,7 +35,7 @@ describe('TabbableScopeQuery', () => {
       container = null;
     });
 
-    it('queryAllNodes() works as intended', () => {
+    it('DO_NOT_USE_queryAllNodes() works as intended', () => {
       const scopeRef = React.createRef();
       const nodeRefA = React.createRef();
       const nodeRefB = React.createRef();
@@ -60,7 +60,7 @@ describe('TabbableScopeQuery', () => {
       }
 
       ReactDOM.render(<Test />, container);
-      let nodes = scopeRef.current.queryAllNodes(tabbableScopeQuery);
+      let nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(tabbableScopeQuery);
       expect(nodes).toEqual([
         nodeRefA.current,
         nodeRefB.current,

--- a/packages/react-interactions/accessibility/src/shared/getTabbableNodes.js
+++ b/packages/react-interactions/accessibility/src/shared/getTabbableNodes.js
@@ -19,7 +19,7 @@ export default function getTabbableNodes(
   number,
   null | HTMLElement,
 ] {
-  const tabbableNodes = scope.queryAllNodes(scopeQuery);
+  const tabbableNodes = scope.DO_NOT_USE_queryAllNodes(scopeQuery);
   if (tabbableNodes === null || tabbableNodes.length === 0) {
     return [null, null, null, 0, null];
   }

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -38,7 +38,7 @@ describe('ReactScope', () => {
       container = null;
     });
 
-    it('queryAllNodes() works as intended', () => {
+    it('DO_NOT_USE_queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -63,16 +63,16 @@ describe('ReactScope', () => {
       }
 
       ReactDOM.render(<Test toggle={true} />, container);
-      let nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      let nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
       ReactDOM.render(<Test toggle={false} />, container);
-      nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
       ReactDOM.render(null, container);
       expect(scopeRef.current).toBe(null);
     });
 
-    it('queryAllNodes() provides the correct host instance', () => {
+    it('DO_NOT_USE_queryAllNodes() provides the correct host instance', () => {
       const testScopeQuery = (type, props) => type === 'div';
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -97,28 +97,28 @@ describe('ReactScope', () => {
       }
 
       ReactDOM.render(<Test toggle={true} />, container);
-      let nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      let nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([divRef.current]);
       let filterQuery = (type, props, instance) =>
         instance === spanRef.current || testScopeQuery(type, props);
-      nodes = scopeRef.current.queryAllNodes(filterQuery);
+      nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(filterQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current]);
       filterQuery = (type, props, instance) =>
         [spanRef.current, aRef.current].includes(instance) ||
         testScopeQuery(type, props);
-      nodes = scopeRef.current.queryAllNodes(filterQuery);
+      nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(filterQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
       ReactDOM.render(<Test toggle={false} />, container);
       filterQuery = (type, props, instance) =>
         [spanRef.current, aRef.current].includes(instance) ||
         testScopeQuery(type, props);
-      nodes = scopeRef.current.queryAllNodes(filterQuery);
+      nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(filterQuery);
       expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
       ReactDOM.render(null, container);
       expect(scopeRef.current).toBe(null);
     });
 
-    it('queryFirstNode() works as intended', () => {
+    it('DO_NOT_USE_queryFirstNode() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -143,10 +143,10 @@ describe('ReactScope', () => {
       }
 
       ReactDOM.render(<Test toggle={true} />, container);
-      let node = scopeRef.current.queryFirstNode(testScopeQuery);
+      let node = scopeRef.current.DO_NOT_USE_queryFirstNode(testScopeQuery);
       expect(node).toEqual(divRef.current);
       ReactDOM.render(<Test toggle={false} />, container);
-      node = scopeRef.current.queryFirstNode(testScopeQuery);
+      node = scopeRef.current.DO_NOT_USE_queryFirstNode(testScopeQuery);
       expect(node).toEqual(aRef.current);
       ReactDOM.render(null, container);
       expect(scopeRef.current).toBe(null);
@@ -201,7 +201,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current.containsNode(emRef.current)).toBe(false);
     });
 
-    it('mixed getParent() and queryAllNodes() works as intended', () => {
+    it('mixed DO_NOT_USE_getParent() and queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const TestScope2 = React.unstable_createScope();
@@ -237,26 +237,26 @@ describe('ReactScope', () => {
       }
 
       ReactDOM.render(<Test />, container);
-      const dParent = refD.current.getParent();
+      const dParent = refD.current.DO_NOT_USE_getParent();
       expect(dParent).not.toBe(null);
-      expect(dParent.queryAllNodes(testScopeQuery)).toEqual([
+      expect(dParent.DO_NOT_USE_queryAllNodes(testScopeQuery)).toEqual([
         divA.current,
         spanB.current,
         divB.current,
       ]);
-      const cParent = refC.current.getParent();
+      const cParent = refC.current.DO_NOT_USE_getParent();
       expect(cParent).not.toBe(null);
-      expect(cParent.queryAllNodes(testScopeQuery)).toEqual([
+      expect(cParent.DO_NOT_USE_queryAllNodes(testScopeQuery)).toEqual([
         spanA.current,
         divA.current,
         spanB.current,
         divB.current,
       ]);
-      expect(refB.current.getParent()).toBe(null);
-      expect(refA.current.getParent()).toBe(null);
+      expect(refB.current.DO_NOT_USE_getParent()).toBe(null);
+      expect(refA.current.DO_NOT_USE_getParent()).toBe(null);
     });
 
-    it('getChildren() works as intended', () => {
+    it('DO_NOT_USE_getChildren() works as intended', () => {
       const TestScope = React.unstable_createScope();
       const TestScope2 = React.unstable_createScope();
       const refA = React.createRef();
@@ -291,13 +291,13 @@ describe('ReactScope', () => {
       }
 
       ReactDOM.render(<Test />, container);
-      const dChildren = refD.current.getChildren();
+      const dChildren = refD.current.DO_NOT_USE_getChildren();
       expect(dChildren).toBe(null);
-      const cChildren = refC.current.getChildren();
+      const cChildren = refC.current.DO_NOT_USE_getChildren();
       expect(cChildren).toBe(null);
-      const bChildren = refB.current.getChildren();
+      const bChildren = refB.current.DO_NOT_USE_getChildren();
       expect(bChildren).toEqual([refD.current]);
-      const aChildren = refA.current.getChildren();
+      const aChildren = refA.current.DO_NOT_USE_getChildren();
       expect(aChildren).toEqual([refC.current]);
     });
 
@@ -328,7 +328,7 @@ describe('ReactScope', () => {
       container.innerHTML = html;
       ReactDOM.hydrate(<Test />, container);
       const testScopeQuery = (type, props) => true;
-      const nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      const nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
     });
 
@@ -373,6 +373,34 @@ describe('ReactScope', () => {
       target.keydown({key: 'Q'});
       expect(onKeyDown).toHaveBeenCalledTimes(1);
     });
+
+    it('getChildContextValues() works as intended', () => {
+      const TestContext = React.createContext();
+      const TestScope = React.unstable_createScope();
+      const scopeRef = React.createRef();
+
+      function Test({toggle}) {
+        return toggle ? (
+          <TestScope ref={scopeRef}>
+            <TestContext.Provider value={1} />
+          </TestScope>
+        ) : (
+          <TestScope ref={scopeRef}>
+            <TestContext.Provider value={1} />
+            <TestContext.Provider value={2} />
+          </TestScope>
+        );
+      }
+
+      ReactDOM.render(<Test toggle={true} />, container);
+      let nodes = scopeRef.current.getChildContextValues(TestContext);
+      expect(nodes).toEqual([1]);
+      ReactDOM.render(<Test toggle={false} />, container);
+      nodes = scopeRef.current.getChildContextValues(TestContext);
+      expect(nodes).toEqual([1, 2]);
+      ReactDOM.render(null, container);
+      expect(scopeRef.current).toBe(null);
+    });
   });
 
   describe('ReactTestRenderer', () => {
@@ -382,7 +410,7 @@ describe('ReactScope', () => {
       ReactTestRenderer = require('react-test-renderer');
     });
 
-    it('queryAllNodes() works as intended', () => {
+    it('DO_NOT_USE_queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -411,14 +439,14 @@ describe('ReactScope', () => {
           return element;
         },
       });
-      let nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      let nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
       renderer.update(<Test toggle={false} />);
-      nodes = scopeRef.current.queryAllNodes(testScopeQuery);
+      nodes = scopeRef.current.DO_NOT_USE_queryAllNodes(testScopeQuery);
       expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
     });
 
-    it('queryFirstNode() works as intended', () => {
+    it('DO_NOT_USE_queryFirstNode() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const scopeRef = React.createRef();
@@ -447,10 +475,10 @@ describe('ReactScope', () => {
           return element;
         },
       });
-      let node = scopeRef.current.queryFirstNode(testScopeQuery);
+      let node = scopeRef.current.DO_NOT_USE_queryFirstNode(testScopeQuery);
       expect(node).toEqual(divRef.current);
       renderer.update(<Test toggle={false} />);
-      node = scopeRef.current.queryFirstNode(testScopeQuery);
+      node = scopeRef.current.DO_NOT_USE_queryFirstNode(testScopeQuery);
       expect(node).toEqual(aRef.current);
     });
 
@@ -507,7 +535,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current.containsNode(emRef.current)).toBe(false);
     });
 
-    it('mixed getParent() and queryAllNodes() works as intended', () => {
+    it('mixed DO_NOT_USE_getParent() and DO_NOT_USE_queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_createScope();
       const TestScope2 = React.unstable_createScope();
@@ -547,26 +575,26 @@ describe('ReactScope', () => {
           return element;
         },
       });
-      const dParent = refD.current.getParent();
+      const dParent = refD.current.DO_NOT_USE_getParent();
       expect(dParent).not.toBe(null);
-      expect(dParent.queryAllNodes(testScopeQuery)).toEqual([
+      expect(dParent.DO_NOT_USE_queryAllNodes(testScopeQuery)).toEqual([
         divA.current,
         spanB.current,
         divB.current,
       ]);
-      const cParent = refC.current.getParent();
+      const cParent = refC.current.DO_NOT_USE_getParent();
       expect(cParent).not.toBe(null);
-      expect(cParent.queryAllNodes(testScopeQuery)).toEqual([
+      expect(cParent.DO_NOT_USE_queryAllNodes(testScopeQuery)).toEqual([
         spanA.current,
         divA.current,
         spanB.current,
         divB.current,
       ]);
-      expect(refB.current.getParent()).toBe(null);
-      expect(refA.current.getParent()).toBe(null);
+      expect(refB.current.DO_NOT_USE_getParent()).toBe(null);
+      expect(refA.current.DO_NOT_USE_getParent()).toBe(null);
     });
 
-    it('getChildren() works as intended', () => {
+    it('DO_NOT_USE_getChildren() works as intended', () => {
       const TestScope = React.unstable_createScope();
       const TestScope2 = React.unstable_createScope();
       const refA = React.createRef();
@@ -605,13 +633,13 @@ describe('ReactScope', () => {
           return element;
         },
       });
-      const dChildren = refD.current.getChildren();
+      const dChildren = refD.current.DO_NOT_USE_getChildren();
       expect(dChildren).toBe(null);
-      const cChildren = refC.current.getChildren();
+      const cChildren = refC.current.DO_NOT_USE_getChildren();
       expect(cChildren).toBe(null);
-      const bChildren = refB.current.getChildren();
+      const bChildren = refB.current.DO_NOT_USE_getChildren();
       expect(bChildren).toEqual([refD.current]);
-      const aChildren = refA.current.getChildren();
+      const aChildren = refA.current.DO_NOT_USE_getChildren();
       expect(aChildren).toEqual([refC.current]);
     });
   });

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -171,17 +171,18 @@ export type ReactScope = {|
 |};
 
 export type ReactScopeMethods = {|
-  getChildren(): null | Array<ReactScopeMethods>,
-  getChildrenFromRoot(): null | Array<ReactScopeMethods>,
-  getParent(): null | ReactScopeMethods,
-  getProps(): Object,
-  queryAllNodes(
+  DO_NOT_USE_getChildren(): null | Array<ReactScopeMethods>,
+  DO_NOT_USE_getChildrenFromRoot(): null | Array<ReactScopeMethods>,
+  DO_NOT_USE_getParent(): null | ReactScopeMethods,
+  DO_NOT_USE_getProps(): Object,
+  DO_NOT_USE_queryAllNodes(
     (type: string | Object, props: Object, instance: Object) => boolean,
   ): null | Array<Object>,
-  queryFirstNode(
+  DO_NOT_USE_queryFirstNode(
     (type: string | Object, props: Object, instance: Object) => boolean,
   ): null | Object,
   containsNode(Object): boolean,
+  getChildContextValues: <T>(context: ReactContext<T>) => Array<T>,
 |};
 
 export type ReactScopeInstance = {|


### PR DESCRIPTION
In attempt to make it clearer about existing experimental APIs and their internal usage. In the long term, the Scopes API is expected to change/go-away but for now, given it's internal usage we'll have to find incremental ways to safely migrate to better options. This PR is one small step of many in order to do that. This PR makes the following changes:

- Adds a `DO_NOT_USE` prefix to most Scope API methods that are potentially dangerous and will likely change or go away.
- Provides a new experiemental method call `getChildContextValues` that attempts to work with existing React Context. It find the nearest child context values for a given type and returns them as part of an array. The idea is to internally use this approach and gradually deprecate and remove the DO_NOT_USE APIs.