### PR TITLE
Add support for Node v13 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "webpack": "^4.41.2"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x || 11.x || 12.x"
+    "node": "8.x || 9.x || 10.x || 11.x || 12.x || 13.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
## Summary

I can't build with Node v13 installed.
This should fix that
