### PR TITLE
Re-enabled DevTools context menu option in Firefox

### DIFF
--- a/packages/react-devtools-extensions/firefox/build.js
+++ b/packages/react-devtools-extensions/firefox/build.js
@@ -28,7 +28,7 @@ const main = async () => {
   console.log('WEB_EXT_FIREFOX=nightly yarn run test:firefox');
   console.log(chalk.gray('\n# You can test against older versions too:'));
   console.log(
-    'WEB_EXT_FIREFOX=/Applications/Firefox52.app/Contents/MacOS/firefox-bin yarn run test:firefox'
+    'WEB_EXT_FIREFOX=/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox-bin yarn run test:firefox'
   );
 };
 

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -216,9 +216,7 @@ function createPanelIfReactLoaded() {
               showTabBar: false,
               store,
               warnIfUnsupportedVersionDetected: true,
-              viewAttributeSourceFunction: isChrome
-                ? viewAttributeSourceFunction
-                : null,
+              viewAttributeSourceFunction,
               viewElementSourceFunction,
             }),
           );


### PR DESCRIPTION
This enables function prop (or state or hooks) to be inspected.

Resolves #17681