### PR TITLE
Add unstable_renderSubtreeIntoContainer and unstable_createPortal feature flags

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -13,6 +13,8 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const PropTypes = require('prop-types');
 
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+
 describe('ReactDOMFiber', () => {
   let container;
 
@@ -247,30 +249,32 @@ describe('ReactDOMFiber', () => {
   });
 
   // TODO: remove in React 17
-  it('should support unstable_createPortal alias', () => {
-    const portalContainer = document.createElement('div');
+  if (!ReactFeatureFlags.disableUnstableCreatePortal) {
+    it('should support unstable_createPortal alias', () => {
+      const portalContainer = document.createElement('div');
 
-    expect(() =>
-      ReactDOM.render(
-        <div>
-          {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
-        </div>,
-        container,
-      ),
-    ).toWarnDev(
-      'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
-        'and will be removed in React 17+. Update your code to use ' +
-        'ReactDOM.createPortal() instead. It has the exact same API, ' +
-        'but without the "unstable_" prefix.',
-      {withoutStack: true},
-    );
-    expect(portalContainer.innerHTML).toBe('<div>portal</div>');
-    expect(container.innerHTML).toBe('<div></div>');
+      expect(() =>
+        ReactDOM.render(
+          <div>
+            {ReactDOM.unstable_createPortal(<div>portal</div>, portalContainer)}
+          </div>,
+          container,
+        ),
+      ).toWarnDev(
+        'The ReactDOM.unstable_createPortal() alias has been deprecated, ' +
+          'and will be removed in React 17+. Update your code to use ' +
+          'ReactDOM.createPortal() instead. It has the exact same API, ' +
+          'but without the "unstable_" prefix.',
+        {withoutStack: true},
+      );
+      expect(portalContainer.innerHTML).toBe('<div>portal</div>');
+      expect(container.innerHTML).toBe('<div></div>');
 
-    ReactDOM.unmountComponentAtNode(container);
-    expect(portalContainer.innerHTML).toBe('');
-    expect(container.innerHTML).toBe('');
-  });
+      ReactDOM.unmountComponentAtNode(container);
+      expect(portalContainer.innerHTML).toBe('');
+      expect(container.innerHTML).toBe('');
+    });
+  }
 
   it('should render many portals', () => {
     const portalContainer1 = document.createElement('div');

--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -16,308 +16,322 @@ const ReactTestUtils = require('react-dom/test-utils');
 const renderSubtreeIntoContainer = require('react-dom')
   .unstable_renderSubtreeIntoContainer;
 
-describe('renderSubtreeIntoContainer', () => {
-  it('should pass context when rendering subtree elsewhere', () => {
-    const portal = document.createElement('div');
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string.isRequired,
-      };
+// Once this flag is always true, we should delete this test file
+if (ReactFeatureFlags.disableUnstableRenderSubtreeIntoContainer) {
+  describe('renderSubtreeIntoContainer', () => {
+    it('empty test', () => {
+      // Empty test to prevent "Your test suite must contain at least one test." error.
+    });
+  });
+} else {
+  describe('renderSubtreeIntoContainer', () => {
+    it('should pass context when rendering subtree elsewhere', () => {
+      const portal = document.createElement('div');
 
-      render() {
-        return <div>{this.context.foo}</div>;
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo}</div>;
+        }
       }
-    }
 
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: PropTypes.string.isRequired,
-      };
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: PropTypes.string.isRequired,
+        };
 
-      getChildContext() {
-        return {
-          foo: 'bar',
+        getChildContext() {
+          return {
+            foo: 'bar',
+          };
+        }
+
+        render() {
+          return null;
+        }
+
+        componentDidMount() {
+          expect(
+            function() {
+              renderSubtreeIntoContainer(this, <Component />, portal);
+            }.bind(this),
+          ).toWarnDev(
+            'ReactDOM.unstable_renderSubtreeIntoContainer() is deprecated and ' +
+              'will be removed in a future major release. Consider using React Portals instead.',
+          );
+        }
+      }
+
+      ReactTestUtils.renderIntoDocument(<Parent />);
+      expect(portal.firstChild.innerHTML).toBe('bar');
+    });
+
+    it('should throw if parentComponent is invalid', () => {
+      const portal = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo}</div>;
+        }
+      }
+
+      // ESLint is confused here and thinks Parent is unused, presumably because
+      // it is only used inside of the class body?
+      // eslint-disable-next-line no-unused-vars
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: PropTypes.string.isRequired,
+        };
+
+        getChildContext() {
+          return {
+            foo: 'bar',
+          };
+        }
+
+        render() {
+          return null;
+        }
+
+        componentDidMount() {
+          expect(function() {
+            renderSubtreeIntoContainer(<Parent />, <Component />, portal);
+          }).toThrowError('parentComponentmust be a valid React Component');
+        }
+      }
+    });
+
+    it('should update context if it changes due to setState', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const portal = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string.isRequired,
+          getFoo: PropTypes.func.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: PropTypes.string.isRequired,
+          getFoo: PropTypes.func.isRequired,
+        };
+
+        state = {
+          bar: 'initial',
+        };
+
+        getChildContext() {
+          return {
+            foo: this.state.bar,
+            getFoo: () => this.state.bar,
+          };
+        }
+
+        render() {
+          return null;
+        }
+
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <Component />, portal);
+        }
+
+        componentDidUpdate() {
+          renderSubtreeIntoContainer(this, <Component />, portal);
+        }
+      }
+
+      const instance = ReactDOM.render(<Parent />, container);
+      expect(portal.firstChild.innerHTML).toBe('initial-initial');
+      instance.setState({bar: 'changed'});
+      expect(portal.firstChild.innerHTML).toBe('changed-changed');
+    });
+
+    it('should update context if it changes due to re-render', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const portal = document.createElement('div');
+
+      class Component extends React.Component {
+        static contextTypes = {
+          foo: PropTypes.string.isRequired,
+          getFoo: PropTypes.func.isRequired,
+        };
+
+        render() {
+          return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
+        }
+      }
+
+      class Parent extends React.Component {
+        static childContextTypes = {
+          foo: PropTypes.string.isRequired,
+          getFoo: PropTypes.func.isRequired,
+        };
+
+        getChildContext() {
+          return {
+            foo: this.props.bar,
+            getFoo: () => this.props.bar,
+          };
+        }
+
+        render() {
+          return null;
+        }
+
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <Component />, portal);
+        }
+
+        componentDidUpdate() {
+          renderSubtreeIntoContainer(this, <Component />, portal);
+        }
+      }
+
+      ReactDOM.render(<Parent bar="initial" />, container);
+      expect(portal.firstChild.innerHTML).toBe('initial-initial');
+      ReactDOM.render(<Parent bar="changed" />, container);
+      expect(portal.firstChild.innerHTML).toBe('changed-changed');
+    });
+
+    it('should render portal with non-context-provider parent', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const portal = document.createElement('div');
+
+      class Parent extends React.Component {
+        render() {
+          return null;
+        }
+
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <div>hello</div>, portal);
+        }
+      }
+
+      ReactDOM.render(<Parent bar="initial" />, container);
+      expect(portal.firstChild.innerHTML).toBe('hello');
+    });
+
+    it('should get context through non-context-provider parent', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const portal = document.createElement('div');
+
+      class Parent extends React.Component {
+        render() {
+          return <Middle />;
+        }
+        getChildContext() {
+          return {value: this.props.value};
+        }
+        static childContextTypes = {
+          value: PropTypes.string.isRequired,
         };
       }
 
-      render() {
-        return null;
+      class Middle extends React.Component {
+        render() {
+          return null;
+        }
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <Child />, portal);
+        }
       }
 
-      componentDidMount() {
-        expect(
-          function() {
-            renderSubtreeIntoContainer(this, <Component />, portal);
-          }.bind(this),
-        ).not.toThrow();
+      class Child extends React.Component {
+        static contextTypes = {
+          value: PropTypes.string.isRequired,
+        };
+        render() {
+          return <div>{this.context.value}</div>;
+        }
       }
-    }
 
-    ReactTestUtils.renderIntoDocument(<Parent />);
-    expect(portal.firstChild.innerHTML).toBe('bar');
-  });
+      ReactDOM.render(<Parent value="foo" />, container);
+      expect(portal.textContent).toBe('foo');
+    });
 
-  it('should throw if parentComponent is invalid', () => {
-    const portal = document.createElement('div');
+    it('should get context through middle non-context-provider layer', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const portal1 = document.createElement('div');
+      const portal2 = document.createElement('div');
 
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.foo}</div>;
-      }
-    }
-
-    // ESLint is confused here and thinks Parent is unused, presumably because
-    // it is only used inside of the class body?
-    // eslint-disable-next-line no-unused-vars
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: PropTypes.string.isRequired,
-      };
-
-      getChildContext() {
-        return {
-          foo: 'bar',
+      class Parent extends React.Component {
+        render() {
+          return null;
+        }
+        getChildContext() {
+          return {value: this.props.value};
+        }
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <Middle />, portal1);
+        }
+        static childContextTypes = {
+          value: PropTypes.string.isRequired,
         };
       }
 
-      render() {
-        return null;
+      class Middle extends React.Component {
+        render() {
+          return null;
+        }
+        componentDidMount() {
+          renderSubtreeIntoContainer(this, <Child />, portal2);
+        }
       }
 
-      componentDidMount() {
-        expect(function() {
-          renderSubtreeIntoContainer(<Parent />, <Component />, portal);
-        }).toThrowError('parentComponentmust be a valid React Component');
-      }
-    }
-  });
-
-  it('should update context if it changes due to setState', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const portal = document.createElement('div');
-
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string.isRequired,
-        getFoo: PropTypes.func.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: PropTypes.string.isRequired,
-        getFoo: PropTypes.func.isRequired,
-      };
-
-      state = {
-        bar: 'initial',
-      };
-
-      getChildContext() {
-        return {
-          foo: this.state.bar,
-          getFoo: () => this.state.bar,
+      class Child extends React.Component {
+        static contextTypes = {
+          value: PropTypes.string.isRequired,
         };
+        render() {
+          return <div>{this.context.value}</div>;
+        }
       }
 
-      render() {
-        return null;
-      }
+      ReactDOM.render(<Parent value="foo" />, container);
+      expect(portal2.textContent).toBe('foo');
+    });
 
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
+    it('fails gracefully when mixing React 15 and 16', () => {
+      class C extends React.Component {
+        render() {
+          return <div />;
+        }
       }
-
-      componentDidUpdate() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
-    }
-
-    const instance = ReactDOM.render(<Parent />, container);
-    expect(portal.firstChild.innerHTML).toBe('initial-initial');
-    instance.setState({bar: 'changed'});
-    expect(portal.firstChild.innerHTML).toBe('changed-changed');
+      const c = ReactDOM.render(<C />, document.createElement('div'));
+      // React 15 calls this:
+      // https://github.com/facebook/react/blob/77b71fc3c4/src/renderers/dom/client/ReactMount.js#L478-L479
+      expect(() => {
+        c._reactInternalInstance._processChildContext({});
+      }).toThrow(
+        __DEV__
+          ? '_processChildContext is not available in React 16+. This likely ' +
+              'means you have multiple copies of React and are attempting to nest ' +
+              'a React 15 tree inside a React 16 tree using ' +
+              "unstable_renderSubtreeIntoContainer, which isn't supported. Try to " +
+              'make sure you have only one copy of React (and ideally, switch to ' +
+              'ReactDOM.createPortal).'
+          : "Cannot read property '_processChildContext' of undefined",
+      );
+    });
   });
-
-  it('should update context if it changes due to re-render', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const portal = document.createElement('div');
-
-    class Component extends React.Component {
-      static contextTypes = {
-        foo: PropTypes.string.isRequired,
-        getFoo: PropTypes.func.isRequired,
-      };
-
-      render() {
-        return <div>{this.context.foo + '-' + this.context.getFoo()}</div>;
-      }
-    }
-
-    class Parent extends React.Component {
-      static childContextTypes = {
-        foo: PropTypes.string.isRequired,
-        getFoo: PropTypes.func.isRequired,
-      };
-
-      getChildContext() {
-        return {
-          foo: this.props.bar,
-          getFoo: () => this.props.bar,
-        };
-      }
-
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
-
-      componentDidUpdate() {
-        renderSubtreeIntoContainer(this, <Component />, portal);
-      }
-    }
-
-    ReactDOM.render(<Parent bar="initial" />, container);
-    expect(portal.firstChild.innerHTML).toBe('initial-initial');
-    ReactDOM.render(<Parent bar="changed" />, container);
-    expect(portal.firstChild.innerHTML).toBe('changed-changed');
-  });
-
-  it('should render portal with non-context-provider parent', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const portal = document.createElement('div');
-
-    class Parent extends React.Component {
-      render() {
-        return null;
-      }
-
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <div>hello</div>, portal);
-      }
-    }
-
-    ReactDOM.render(<Parent bar="initial" />, container);
-    expect(portal.firstChild.innerHTML).toBe('hello');
-  });
-
-  it('should get context through non-context-provider parent', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const portal = document.createElement('div');
-
-    class Parent extends React.Component {
-      render() {
-        return <Middle />;
-      }
-      getChildContext() {
-        return {value: this.props.value};
-      }
-      static childContextTypes = {
-        value: PropTypes.string.isRequired,
-      };
-    }
-
-    class Middle extends React.Component {
-      render() {
-        return null;
-      }
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Child />, portal);
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        value: PropTypes.string.isRequired,
-      };
-      render() {
-        return <div>{this.context.value}</div>;
-      }
-    }
-
-    ReactDOM.render(<Parent value="foo" />, container);
-    expect(portal.textContent).toBe('foo');
-  });
-
-  it('should get context through middle non-context-provider layer', () => {
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const portal1 = document.createElement('div');
-    const portal2 = document.createElement('div');
-
-    class Parent extends React.Component {
-      render() {
-        return null;
-      }
-      getChildContext() {
-        return {value: this.props.value};
-      }
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Middle />, portal1);
-      }
-      static childContextTypes = {
-        value: PropTypes.string.isRequired,
-      };
-    }
-
-    class Middle extends React.Component {
-      render() {
-        return null;
-      }
-      componentDidMount() {
-        renderSubtreeIntoContainer(this, <Child />, portal2);
-      }
-    }
-
-    class Child extends React.Component {
-      static contextTypes = {
-        value: PropTypes.string.isRequired,
-      };
-      render() {
-        return <div>{this.context.value}</div>;
-      }
-    }
-
-    ReactDOM.render(<Parent value="foo" />, container);
-    expect(portal2.textContent).toBe('foo');
-  });
-
-  it('fails gracefully when mixing React 15 and 16', () => {
-    class C extends React.Component {
-      render() {
-        return <div />;
-      }
-    }
-    const c = ReactDOM.render(<C />, document.createElement('div'));
-    // React 15 calls this:
-    // https://github.com/facebook/react/blob/77b71fc3c4/src/renderers/dom/client/ReactMount.js#L478-L479
-    expect(() => {
-      c._reactInternalInstance._processChildContext({});
-    }).toThrow(
-      __DEV__
-        ? '_processChildContext is not available in React 16+. This likely ' +
-            'means you have multiple copies of React and are attempting to nest ' +
-            'a React 15 tree inside a React 16 tree using ' +
-            "unstable_renderSubtreeIntoContainer, which isn't supported. Try to " +
-            'make sure you have only one copy of React (and ideally, switch to ' +
-            'ReactDOM.createPortal).'
-        : "Cannot read property '_processChildContext' of undefined",
-    );
-  });
-});
+}

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -108,3 +108,9 @@ export const disableCreateFactory = false;
 
 // Disables children for <textarea> elements
 export const disableTextareaChildren = false;
+
+// Disables ReactDOM.unstable_renderSubtreeIntoContainer
+export const disableUnstableRenderSubtreeIntoContainer = false;
+
+// Disables ReactDOM.unstable_createPortal
+export const disableUnstableCreatePortal = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -47,6 +47,8 @@ export const enableTrainModelFix = false;
 export const enableTrustedTypesIntegration = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const disableUnstableRenderSubtreeIntoContainer = false;
+export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -42,6 +42,8 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const disableUnstableRenderSubtreeIntoContainer = false;
+export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -42,6 +42,8 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const disableUnstableRenderSubtreeIntoContainer = false;
+export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -42,6 +42,8 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const disableUnstableRenderSubtreeIntoContainer = false;
+export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -40,6 +40,8 @@ export const enableTrustedTypesIntegration = false;
 export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
+export const disableUnstableRenderSubtreeIntoContainer = false;
+export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -94,6 +94,10 @@ export const disableCreateFactory = false;
 
 export const disableTextareaChildren = false;
 
+export const disableUnstableRenderSubtreeIntoContainer = false;
+
+export const disableUnstableCreatePortal = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -30,6 +30,7 @@
 untyped-type-import=error
 
 [options]
+server.max_workers=4
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 


### PR DESCRIPTION
This PR adds two feature flags:

- `disableUnstableRenderSubtreeIntoContainer` for `ReactDOM.unstable_renderSubtreeIntoContainer`
- `disableUnstableCreatePortal` for `ReactDOM.unstable_createPortal`

These disable the relevant unstable/deprecated ReactDOM APIs. Additionally `ReactDOM.unstable_renderSubtreeIntoContainer` has a deprecation warning message as follows:

`The ReactDOM.unstable_renderSubtreeIntoContainer() is deprecated and will be removed in a future major release. Consider using React Portals instead.`

I also changed the flowconfig to have the follow config, otherwise CI fails on this PR:

`server.max_workers=4`