### PR TITLE
Remove call to finishHooks when doing a static render.

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -416,7 +416,7 @@ function resolve(
   child: mixed,
   context: Object,
   threadID: ThreadID,
-  makeStaticMarkup: boolean
+  makeStaticMarkup: boolean,
 ): {|
   child: mixed,
   context: Object,
@@ -957,7 +957,12 @@ class ReactDOMServerRenderer {
       return escapeTextForBrowser(text);
     } else {
       let nextChild;
-      ({child: nextChild, context} = resolve(child, context, this.threadID, this.makeStaticMarkup));
+      ({child: nextChild, context} = resolve(
+        child,
+        context,
+        this.threadID,
+        this.makeStaticMarkup,
+      ));
       if (nextChild === null || nextChild === false) {
         return '';
       } else if (!React.isValidElement(nextChild)) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -416,7 +416,7 @@ function resolve(
   child: mixed,
   context: Object,
   threadID: ThreadID,
-  makeStaticMarkup: Boolean
+  makeStaticMarkup: boolean
 ): {|
   child: mixed,
   context: Object,

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -416,6 +416,7 @@ function resolve(
   child: mixed,
   context: Object,
   threadID: ThreadID,
+  makeStaticMarkup: Boolean
 ): {|
   child: mixed,
   context: Object,
@@ -430,11 +431,11 @@ function resolve(
     if (typeof Component !== 'function') {
       break;
     }
-    processChild(element, Component);
+    processChild(element, Component, makeStaticMarkup);
   }
 
   // Extra closure so queue and replace can be captured properly
-  function processChild(element, Component) {
+  function processChild(element, Component, makeStaticMarkup) {
     const isClass = shouldConstruct(Component);
     const publicContext = processContext(Component, context, threadID, isClass);
 
@@ -532,7 +533,9 @@ function resolve(
       const componentIdentity = {};
       prepareToUseHooks(componentIdentity);
       inst = Component(element.props, publicContext, updater);
-      inst = finishHooks(Component, element.props, inst, publicContext);
+      if (!makeStaticMarkup) {
+        inst = finishHooks(Component, element.props, inst, publicContext);
+      }
 
       if (inst == null || inst.render == null) {
         child = inst;
@@ -954,7 +957,7 @@ class ReactDOMServerRenderer {
       return escapeTextForBrowser(text);
     } else {
       let nextChild;
-      ({child: nextChild, context} = resolve(child, context, this.threadID));
+      ({child: nextChild, context} = resolve(child, context, this.threadID, this.makeStaticMarkup));
       if (nextChild === null || nextChild === false) {
         return '';
       } else if (!React.isValidElement(nextChild)) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -431,11 +431,11 @@ function resolve(
     if (typeof Component !== 'function') {
       break;
     }
-    processChild(element, Component, makeStaticMarkup);
+    processChild(element, Component);
   }
 
   // Extra closure so queue and replace can be captured properly
-  function processChild(element, Component, makeStaticMarkup) {
+  function processChild(element, Component) {
     const isClass = shouldConstruct(Component);
     const publicContext = processContext(Component, context, threadID, isClass);
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
Fixes #16416 . If you had a `renderToStaticMarkup` or `renderToString` inside the hook, it would cause all the hooks to finish and set `workInProgressHook` to `null`. In this PR, I am trying to call the `finishHooks` only when we're not doing a static markup. 


## Test Plan
Its my first issue so I might have missed something. I ran `yarn test`, `yarn linc` and `yarn flow`, they are all passing. Also, I am not sure how to add a test for this.


