### PR TITLE
Update to flow 0.97

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "0.8.3",
     "filesize": "^6.0.1",
-    "flow-bin": "0.89",
+    "flow-bin": "0.97",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "20190301.0.0",

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -117,7 +117,8 @@ function useState<S>(
     hook !== null
       ? hook.memoizedState
       : typeof initialState === 'function'
-      ? initialState()
+      ? // $FlowFixMe: Flow doesn't like mixed types
+        initialState()
       : initialState;
   hookLog.push({primitive: 'State', stackError: new Error(), value: state});
   return [state, (action: BasicStateAction<S>) => {}];

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -247,6 +247,7 @@ function useContext<T>(
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
+  // $FlowFixMe: Flow doesn't like mixed types
   return typeof action === 'function' ? action(state) : action;
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -623,6 +623,7 @@ function createFunctionComponentUpdateQueue(): FunctionComponentUpdateQueue {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
+  // $FlowFixMe: Flow doesn't like mixed types
   return typeof action === 'function' ? action(state) : action;
 }
 
@@ -843,6 +844,7 @@ function mountState<S>(
 ): [S, Dispatch<BasicStateAction<S>>] {
   const hook = mountWorkInProgressHook();
   if (typeof initialState === 'function') {
+    // $FlowFixMe: Flow doesn't like mixed types
     initialState = initialState();
   }
   hook.memoizedState = hook.baseState = initialState;

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -173,6 +173,7 @@ function createHook(): Hook {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
+  // $FlowFixMe: Flow doesn't like mixed types
   return typeof action === 'function' ? action(state) : action;
 }
 

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -51,7 +51,7 @@ function getComponentName(type: mixed): string | null {
     }
   }
   if (typeof type === 'function') {
-    return type.displayName || type.name || null;
+    return (type: any).displayName || type.name || null;
   }
   if (typeof type === 'string') {
     return type;

--- a/packages/shared/objectIs.js
+++ b/packages/shared/objectIs.js
@@ -17,4 +17,7 @@ function is(x: any, y: any) {
   );
 }
 
-export default typeof Object.is === 'function' ? Object.is : is;
+const objectIs: (x: any, y: any) => boolean =
+  typeof Object.is === 'function' ? Object.is : is;
+
+export default objectIs;

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -50,4 +50,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [version]
-^0.89.0
+^0.97.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -5886,10 +5886,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.89:
-  version "0.89.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.89.0.tgz#6bd29c2af7e0f429797f820662f33749105c32fa"
-  integrity sha512-DkO4PsXYrl53V6G5+t5HbRMC5ajYUQej2LEGPUZ+j9okTb41Sn5j9vfxsCpXMEAslYnQoysHhYu4GUZsQX/DrQ==
+flow-bin@0.97:
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
+  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
## Summary

Updates to Flow 0.97.

[Flow made some changes](https://github.com/facebook/flow/issues/7702#issuecomment-491916906) when refining `mixed` to a function. But I don't understand how to fix our types to avoid this error, so I used `$FlowFixMe` to suppress them instead. Open to suggestions.

## Test Plan

`yarn flow dom`