### PR TITLE
Removed Root API callback params and added warnings

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -40,6 +40,35 @@ describe('ReactDOMRoot', () => {
     expect(container.textContent).toEqual('Hi');
   });
 
+  it('warns if a callback parameter is provided to render', () => {
+    const callback = jest.fn();
+    const root = ReactDOM.createRoot(container);
+    expect(() =>
+      root.render(<div>Hi</div>, callback),
+    ).toErrorDev(
+      'render(...): does not support the second callback argument. ' +
+        'To execute a side effect after rendering, declare it in a component body with useEffect().',
+      {withoutStack: true},
+    );
+    Scheduler.unstable_flushAll();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('warns if a callback parameter is provided to unmount', () => {
+    const callback = jest.fn();
+    const root = ReactDOM.createRoot(container);
+    root.render(<div>Hi</div>);
+    expect(() =>
+      root.unmount(callback),
+    ).toErrorDev(
+      'unmount(...): does not support a callback argument. ' +
+        'To execute a side effect after rendering, declare it in a component body with useEffect().',
+      {withoutStack: true},
+    );
+    Scheduler.unstable_flushAll();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
   it('unmounts children', () => {
     const root = ReactDOM.createRoot(container);
     root.render(<div>Hi</div>);

--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -16,11 +16,7 @@ import {
   isContainerMarkedAsRoot,
   unmarkContainerAsRoot,
 } from './ReactDOMComponentTree';
-import {
-  createLegacyRoot,
-  isValidContainer,
-  warnOnInvalidCallback,
-} from './ReactDOMRoot';
+import {createLegacyRoot, isValidContainer} from './ReactDOMRoot';
 import {ROOT_ATTRIBUTE_NAME} from '../shared/DOMProperty';
 import {
   DOCUMENT_NODE,
@@ -161,6 +157,19 @@ function legacyCreateRootFromDOMContainer(
         }
       : undefined,
   );
+}
+
+function warnOnInvalidCallback(callback: mixed, callerName: string): void {
+  if (__DEV__) {
+    if (callback !== null && typeof callback !== 'function') {
+      console.error(
+        '%s(...): Expected the last optional `callback` argument to be a ' +
+          'function. Instead received: %s.',
+        callerName,
+        callback,
+      );
+    }
+  }
 }
 
 function legacyRenderSubtreeIntoContainer(


### PR DESCRIPTION
The goal is to prevent introducing new uses of the update queue callback behavior (so that we can deprecate it later, as part of cleaning up legacy class component usage), Fortunately it looks like we weren't using these params internally anywhere, so I've just added tests that verify the new warning behavior.

I based the wording of this warning on a similar warning for hooks:
https://github.com/facebook/react/blob/cf0081263ced42ddebe0a0d868701890448bfd4b/packages/react-reconciler/src/ReactFiberHooks.js#L1265-L1278