### PR TITLE
Add semver dependency explicitly to DevTools

### DIFF
--- a/packages/react-devtools-shared/package.json
+++ b/packages/react-devtools-shared/package.json
@@ -15,6 +15,7 @@
     "local-storage-fallback": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^3.1.1",
-    "react-virtualized-auto-sizer": "^1.0.2"
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "semver": "^6.3.0"
   }
 }


### PR DESCRIPTION
I couldn't get DevTools running on master.

Turns out, there was a `semver` dependency [used](https://github.com/facebook/react/blob/b7f217d40c6c8c973c86fabceeda238b38662171/packages/react-devtools-shared/src/backend/renderer.js#L10) but not specified in `package.json`. It worked accidentally, but `semver` 7.x appears incompatible with webpack for whatever reason.

So I'm pinning it back to 6.x.

Test plan: I can compile DevTools now.