### PR TITLE
Fix Jest diff call

### DIFF
--- a/fixtures/dom/src/toWarnDev.js
+++ b/fixtures/dom/src/toWarnDev.js
@@ -1,7 +1,7 @@
 // copied from scripts/jest/matchers/toWarnDev.js
 'use strict';
 
-const jestDiff = require('jest-diff');
+const jestDiff = require('jest-diff').default;
 const util = require('util');
 
 function shouldIgnoreConsoleError(format, args) {

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const jestDiff = require('jest-diff');
+const jestDiff = require('jest-diff').default;
 const util = require('util');
 const shouldIgnoreConsoleError = require('../shouldIgnoreConsoleError');
 


### PR DESCRIPTION
Our warning matcher is broken after the upgrade. This is because the API has changed. This fixes the call.