### PR TITLE
Flush `useEffect` clean up functions in the passive effects phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -18,6 +18,7 @@ import type {Hook} from './ReactFiberHooks';
 
 import {
   warnAboutDeprecatedLifecycles,
+  deferPassiveEffectCleanupDuringUnmount,
   enableUserTimingAPI,
   enableSuspenseServerRenderer,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
@@ -257,6 +258,7 @@ let rootDoesHavePassiveEffects: boolean = false;
 let rootWithPendingPassiveEffects: FiberRoot | null = null;
 let pendingPassiveEffectsRenderPriority: ReactPriorityLevel = NoPriority;
 let pendingPassiveEffectsExpirationTime: ExpirationTime = NoWork;
+let pendingUnmountedPassiveEffectDestroyFunctions: Array<() => void> = [];
 
 let rootsWithPendingDiscreteUpdates: Map<
   FiberRoot,
@@ -2176,6 +2178,19 @@ export function flushPassiveEffects() {
   }
 }
 
+export function enqueuePendingPassiveEffectDestroyFn(
+  destroy: () => void,
+): void {
+  if (deferPassiveEffectCleanupDuringUnmount) {
+    pendingUnmountedPassiveEffectDestroyFunctions.push(destroy);
+    rootDoesHavePassiveEffects = true;
+    scheduleCallback(NormalPriority, () => {
+      flushPassiveEffects();
+      return null;
+    });
+  }
+}
+
 function flushPassiveEffectsImpl() {
   if (rootWithPendingPassiveEffects === null) {
     return false;
@@ -2192,6 +2207,20 @@ function flushPassiveEffectsImpl() {
   const prevExecutionContext = executionContext;
   executionContext |= CommitContext;
   const prevInteractions = pushInteractions(root);
+
+  if (deferPassiveEffectCleanupDuringUnmount) {
+    // Flush any pending passive effect destroy functions that belong to
+    // components that were unmounted during the most recent commit.
+    for (
+      let i = 0;
+      i < pendingUnmountedPassiveEffectDestroyFunctions.length;
+      i++
+    ) {
+      const destroy = pendingUnmountedPassiveEffectDestroyFunctions[i];
+      invokeGuardedCallback(null, destroy, null);
+    }
+    pendingUnmountedPassiveEffectDestroyFunctions.length = 0;
+  }
 
   // Note: This currently assumes there are no passive effects on the root
   // fiber, because the root is not part of its own effect list. This could

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2183,11 +2183,13 @@ export function enqueuePendingPassiveEffectDestroyFn(
 ): void {
   if (deferPassiveEffectCleanupDuringUnmount) {
     pendingUnmountedPassiveEffectDestroyFunctions.push(destroy);
-    rootDoesHavePassiveEffects = true;
-    scheduleCallback(NormalPriority, () => {
-      flushPassiveEffects();
-      return null;
-    });
+    if (!rootDoesHavePassiveEffects) {
+      rootDoesHavePassiveEffects = true;
+      scheduleCallback(NormalPriority, () => {
+        flushPassiveEffects();
+        return null;
+      });
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactHookEffectTags.js
+++ b/packages/react-reconciler/src/ReactHookEffectTags.js
@@ -9,12 +9,11 @@
 
 export type HookEffectTag = number;
 
-export const NoEffect = /*                   */ 0b000000000;
-export const UnmountSnapshot = /*            */ 0b000000010;
-export const UnmountMutation = /*            */ 0b000000100;
-export const MountMutation = /*              */ 0b000001000;
-export const UnmountLayout = /*              */ 0b000010000;
-export const MountLayout = /*                */ 0b000100000;
-export const MountPassive = /*               */ 0b001000000;
-export const UnmountPassive = /*             */ 0b010000000;
-export const NoEffectPassiveUnmountFiber = /**/ 0b100000000;
+export const NoEffect = /*  */ 0b000;
+
+// Represents whether effect should fire.
+export const HasEffect = /* */ 0b001;
+
+// Represents the phase in which the effect (not the clean-up) fires.
+export const Layout = /*    */ 0b010;
+export const Passive = /*   */ 0b100;

--- a/packages/react-reconciler/src/ReactHookEffectTags.js
+++ b/packages/react-reconciler/src/ReactHookEffectTags.js
@@ -9,11 +9,12 @@
 
 export type HookEffectTag = number;
 
-export const NoEffect = /*             */ 0b00000000;
-export const UnmountSnapshot = /*      */ 0b00000010;
-export const UnmountMutation = /*      */ 0b00000100;
-export const MountMutation = /*        */ 0b00001000;
-export const UnmountLayout = /*        */ 0b00010000;
-export const MountLayout = /*          */ 0b00100000;
-export const MountPassive = /*         */ 0b01000000;
-export const UnmountPassive = /*       */ 0b10000000;
+export const NoEffect = /*                   */ 0b000000000;
+export const UnmountSnapshot = /*            */ 0b000000010;
+export const UnmountMutation = /*            */ 0b000000100;
+export const MountMutation = /*              */ 0b000001000;
+export const UnmountLayout = /*              */ 0b000010000;
+export const MountLayout = /*                */ 0b000100000;
+export const MountPassive = /*               */ 0b001000000;
+export const UnmountPassive = /*             */ 0b010000000;
+export const NoEffectPassiveUnmountFiber = /**/ 0b100000000;

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -974,70 +974,69 @@ describe('ReactHooksWithNoopRenderer', () => {
     );
 
     it('defers passive effect destroy functions during unmount', () => {
-      function Child({count}) {
+      function Child({bar, foo}) {
         React.useEffect(() => {
-          Scheduler.unstable_yieldValue('passive create (no dependencies)');
+          Scheduler.unstable_yieldValue('passive bar create');
           return () => {
-            Scheduler.unstable_yieldValue('passive destroy (no dependencies)');
+            Scheduler.unstable_yieldValue('passive bar destroy');
           };
-        }, []);
+        }, [bar]);
         React.useLayoutEffect(() => {
-          Scheduler.unstable_yieldValue('layout create (no dependencies)');
+          Scheduler.unstable_yieldValue('layout bar create');
           return () => {
-            Scheduler.unstable_yieldValue('layout destroy (no dependencies)');
+            Scheduler.unstable_yieldValue('layout bar destroy');
           };
-        }, []);
+        }, [bar]);
         React.useEffect(() => {
-          Scheduler.unstable_yieldValue('passive create');
+          Scheduler.unstable_yieldValue('passive foo create');
           return () => {
-            Scheduler.unstable_yieldValue('passive destroy');
+            Scheduler.unstable_yieldValue('passive foo destroy');
           };
-        }, [count]);
+        }, [foo]);
         React.useLayoutEffect(() => {
-          Scheduler.unstable_yieldValue('layout create');
+          Scheduler.unstable_yieldValue('layout foo create');
           return () => {
-            Scheduler.unstable_yieldValue('layout destroy');
+            Scheduler.unstable_yieldValue('layout foo destroy');
           };
-        }, [count]);
+        }, [foo]);
         Scheduler.unstable_yieldValue('render');
         return null;
       }
 
       act(() => {
-        ReactNoop.render(<Child count={1} />, () =>
+        ReactNoop.render(<Child bar={1} foo={1} />, () =>
           Scheduler.unstable_yieldValue('Sync effect'),
         );
         expect(Scheduler).toFlushAndYieldThrough([
           'render',
-          'layout create (no dependencies)',
-          'layout create',
+          'layout bar create',
+          'layout foo create',
           'Sync effect',
         ]);
         // Effects are deferred until after the commit
         expect(Scheduler).toFlushAndYield([
-          'passive create (no dependencies)',
-          'passive create',
+          'passive bar create',
+          'passive foo create',
         ]);
       });
 
-      // HACK
-      // This update is kind of gross since it exists to test an internal implementation detail:
+      // This update is exists to test an internal implementation detail:
       // Effects without updating dependencies lose their layout/passive tag during an update.
       // A special type of no-update tag (NoEffectPassiveUnmountFiber) is used to track these for later.
       act(() => {
-        ReactNoop.render(<Child count={2} />, () =>
+        ReactNoop.render(<Child bar={1} foo={2} />, () =>
           Scheduler.unstable_yieldValue('Sync effect'),
         );
         expect(Scheduler).toFlushAndYieldThrough([
           'render',
-          'layout destroy',
-          'layout create',
+          'layout foo destroy',
+          'layout foo create',
           'Sync effect',
         ]);
         // Effects are deferred until after the commit
         expect(Scheduler).toFlushAndYield([
-          'passive destroy',
-          'passive create',
+          'passive foo destroy',
+          'passive foo create',
         ]);
       });
 
@@ -1047,14 +1046,14 @@ describe('ReactHooksWithNoopRenderer', () => {
           Scheduler.unstable_yieldValue('Sync effect'),
         );
         expect(Scheduler).toFlushAndYieldThrough([
-          'layout destroy (no dependencies)',
-          'layout destroy',
+          'layout bar destroy',
+          'layout foo destroy',
           'Sync effect',
         ]);
         // Effects are deferred until after the commit
         expect(Scheduler).toFlushAndYield([
-          'passive destroy (no dependencies)',
-          'passive destroy',
+          'passive bar destroy',
+          'passive foo destroy',
         ]);
       });
     });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1022,7 +1022,6 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       // This update is exists to test an internal implementation detail:
       // Effects without updating dependencies lose their layout/passive tag during an update.
-      // A special type of no-update tag (NoEffectPassiveUnmountFiber) is used to track these for later.
       act(() => {
         ReactNoop.render(<Child bar={1} foo={2} />, () =>
           Scheduler.unstable_yieldValue('Sync effect'),

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -21,6 +21,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
     ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
     ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
+    ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount = true;
     React = require('react');
     Fragment = React.Fragment;
     ReactNoop = require('react-noop-renderer');
@@ -1617,8 +1618,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(Scheduler).toFlushAndYield([
       'B',
       'Destroy Layout Effect [Loading...]',
-      'Destroy Effect [Loading...]',
       'Layout Effect [B]',
+      'Destroy Effect [Loading...]',
       'Effect [B]',
     ]);
 
@@ -1654,9 +1655,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     expect(Scheduler).toFlushAndYield([
       'B2',
       'Destroy Layout Effect [Loading...]',
-      'Destroy Effect [Loading...]',
       'Destroy Layout Effect [B]',
       'Layout Effect [B2]',
+      'Destroy Effect [Loading...]',
       'Destroy Effect [B]',
       'Effect [B2]',
     ]);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -91,6 +91,12 @@ export const enableTrustedTypesIntegration = false;
 // Flag to turn event.target and event.currentTarget in ReactNative from a reactTag to a component instance
 export const enableNativeTargetAsInstance = false;
 
+// Controls behavior of deferred effect destroy functions during unmount.
+// Previously these functions were run during commit (along with layout effects).
+// Ideally we should delay these until after commit for performance reasons.
+// This flag provides a killswitch if that proves to break existing code somehow.
+export const deferPassiveEffectCleanupDuringUnmount = true;
+
 // --------------------------
 // Future APIs to be deprecated
 // --------------------------

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -95,7 +95,7 @@ export const enableNativeTargetAsInstance = false;
 // Previously these functions were run during commit (along with layout effects).
 // Ideally we should delay these until after commit for performance reasons.
 // This flag provides a killswitch if that proves to break existing code somehow.
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // --------------------------
 // Future APIs to be deprecated

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -50,6 +50,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
+export const deferPassiveEffectCleanupDuringUnmount = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -50,7 +50,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -45,6 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
+export const deferPassiveEffectCleanupDuringUnmount = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -45,7 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -45,6 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
+export const deferPassiveEffectCleanupDuringUnmount = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -45,7 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -45,6 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
+export const deferPassiveEffectCleanupDuringUnmount = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -45,7 +45,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -43,6 +43,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
+export const deferPassiveEffectCleanupDuringUnmount = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -43,7 +43,7 @@ export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = true;
+export const deferPassiveEffectCleanupDuringUnmount = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -15,6 +15,7 @@ export const {
   debugRenderPhaseSideEffectsForStrictMode,
   disableInputAttributeSyncing,
   enableTrustedTypesIntegration,
+  deferPassiveEffectCleanupDuringUnmount,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data


### PR DESCRIPTION
This PR cleans up our hook effect tags and also fixes the case where we were too eagerly flushing passive effect destroy functions on unmount. (As a side effect, we are also now reliably able to distinguish between passive and layout effects during unmount, which will improve the new Profiler methods added in #17910.)

The two major changes in this PR are:
* 9a38b12: Defer passive destroy functions during an unmount until other passive effects are flushed.
* 1c6be34: Cleanup effect tags.

This is a change in behavior/timing for destroy functions so it may cause code to break unexpectedly. For this reason, it has been added behind a killswitch feature flag (`deferPassiveEffectCleanupDuringUnmount`).

I've also identified some follow up work for passive effects, but to keep this PR small and easy to review, I've just added a TODO for this and will be tracking it with a separate issue, #17945.