### PR TITLE
fix: BigInt serialize issue in devtools copy to clipboard

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -81,6 +81,10 @@ export function serializeToString(data: any): string {
       }
       cache.add(value);
     }
+    // $FlowFixMe
+    if (typeof value === 'bigint') {
+      return value.toString() + 'n';
+    }
     return value;
   });
 }

--- a/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
@@ -31,6 +31,8 @@ const immutable = Immutable.fromJS({
     xyz: 1,
   },
 });
+// $FlowFixMe
+const bigInt = BigInt(123); // eslint-disable-line no-undef
 
 export default function UnserializableProps() {
   return (
@@ -43,6 +45,7 @@ export default function UnserializableProps() {
       setOfSets={setOfSets}
       typedArray={typedArray}
       immutable={immutable}
+      bigInt={bigInt}
     />
   );
 }


### PR DESCRIPTION
Fixes  #17895

- [x] Checking data type `bigint` and convert it to a string.
- [x] Tested in `react-devtools-shell` with BigInt props and also BigInt with nested props. 👍 
