### PR TITLE
Add ReactDOM.unstable_renderSubtreeIntoContainer warning flag

### DIFF
--- a/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
+++ b/packages/react-dom/src/__tests__/renderSubtreeIntoContainer-test.js
@@ -56,14 +56,18 @@ if (ReactFeatureFlags.disableUnstableRenderSubtreeIntoContainer) {
         }
 
         componentDidMount() {
-          expect(
-            function() {
-              renderSubtreeIntoContainer(this, <Component />, portal);
-            }.bind(this),
-          ).toWarnDev(
-            'ReactDOM.unstable_renderSubtreeIntoContainer() is deprecated and ' +
-              'will be removed in a future major release. Consider using React Portals instead.',
-          );
+          if (ReactFeatureFlags.warnUnstableRenderSubtreeIntoContainer) {
+            expect(
+              function() {
+                renderSubtreeIntoContainer(this, <Component />, portal);
+              }.bind(this),
+            ).toWarnDev(
+              'ReactDOM.unstable_renderSubtreeIntoContainer() is deprecated and ' +
+                'will be removed in a future major release. Consider using React Portals instead.',
+            );
+          } else {
+            renderSubtreeIntoContainer(this, <Component />, portal);
+          }
         }
       }
 

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -57,6 +57,7 @@ import {
   exposeConcurrentModeAPIs,
   disableUnstableCreatePortal,
   disableUnstableRenderSubtreeIntoContainer,
+  warnUnstableRenderSubtreeIntoContainer,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -179,7 +180,10 @@ if (exposeConcurrentModeAPIs) {
 if (!disableUnstableRenderSubtreeIntoContainer) {
   ReactDOM.unstable_renderSubtreeIntoContainer = function(...args) {
     if (__DEV__) {
-      if (!didWarnAboutUnstableRenderSubtreeIntoContainer) {
+      if (
+        warnUnstableRenderSubtreeIntoContainer &&
+        !didWarnAboutUnstableRenderSubtreeIntoContainer
+      ) {
         didWarnAboutUnstableRenderSubtreeIntoContainer = true;
         console.warn(
           'ReactDOM.unstable_renderSubtreeIntoContainer() is deprecated ' +

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -111,6 +111,8 @@ export const disableTextareaChildren = false;
 
 // Disables ReactDOM.unstable_renderSubtreeIntoContainer
 export const disableUnstableRenderSubtreeIntoContainer = false;
+// We should remove this flag once the above flag becomes enabled
+export const warnUnstableRenderSubtreeIntoContainer = false;
 
 // Disables ReactDOM.unstable_createPortal
 export const disableUnstableCreatePortal = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -48,6 +48,7 @@ export const enableTrustedTypesIntegration = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -43,6 +43,7 @@ export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -43,6 +43,7 @@ export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -43,6 +43,7 @@ export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -41,6 +41,7 @@ export const enableNativeTargetAsInstance = false;
 export const disableCreateFactory = false;
 export const disableTextareaChildren = false;
 export const disableUnstableRenderSubtreeIntoContainer = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 
 // Only used in www builds.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -97,6 +97,8 @@ export const disableTextareaChildren = false;
 
 export const disableUnstableRenderSubtreeIntoContainer = false;
 
+export const warnUnstableRenderSubtreeIntoContainer = false;
+
 export const disableUnstableCreatePortal = false;
 
 // Flow magic to verify the exports of this file match the original version.


### PR DESCRIPTION
This adds a flag that enables the warning for `unstable_renderSubtreeIntoContainer`. The default behavior for 16.x should be that the warning does not fire.