### PR TITLE
StrictMode should call sCU twice in DEV

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -262,6 +262,15 @@ function checkShouldComponentUpdate(
 ) {
   const instance = workInProgress.stateNode;
   if (typeof instance.shouldComponentUpdate === 'function') {
+    if (__DEV__) {
+      if (
+        debugRenderPhaseSideEffectsForStrictMode &&
+        workInProgress.mode & StrictMode
+      ) {
+        // Invoke the function an extra time to help detect side-effects.
+        instance.shouldComponentUpdate(newProps, newState, nextContext);
+      }
+    }
     startPhaseTimer(workInProgress, 'shouldComponentUpdate');
     const shouldUpdate = instance.shouldComponentUpdate(
       newProps,

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -138,6 +138,7 @@ describe('ReactStrictMode', () => {
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
         'shouldComponentUpdate',
+        'shouldComponentUpdate',
         'render',
         'render',
         'componentDidUpdate',
@@ -165,6 +166,7 @@ describe('ReactStrictMode', () => {
       expect(log).toEqual([
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
+        'shouldComponentUpdate',
         'shouldComponentUpdate',
       ]);
     } else {
@@ -283,6 +285,7 @@ describe('ReactStrictMode', () => {
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
         'shouldComponentUpdate',
+        'shouldComponentUpdate',
         'render',
         'render',
         'componentDidUpdate',
@@ -304,6 +307,7 @@ describe('ReactStrictMode', () => {
       expect(log).toEqual([
         'getDerivedStateFromProps',
         'getDerivedStateFromProps',
+        'shouldComponentUpdate',
         'shouldComponentUpdate',
       ]);
     } else {


### PR DESCRIPTION
This was an oversight before. Even our docs suggested that sCU should be called twice:
https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects