### PR TITLE
Simplify Continuous Hydration Targets

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -14,6 +14,7 @@ import {createEventTarget} from 'dom-event-testing-library';
 let React;
 let ReactDOM;
 let ReactDOMServer;
+let ReactTestUtils;
 let Scheduler;
 let Suspense;
 let usePress;
@@ -102,6 +103,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
+    ReactTestUtils = require('react-dom/test-utils');
     Scheduler = require('scheduler');
     Suspense = React.Suspense;
     usePress = require('react-interactions/events/press').usePress;
@@ -816,5 +818,111 @@ describe('ReactDOMServerSelectiveHydration', () => {
     // We should prioritize hydrating C first because the last added
     // gets highest priority followed by the next added.
     expect(Scheduler).toFlushAndYield(['App', 'C', 'B', 'A']);
+  });
+
+  it('hydrates before an update even if hydration moves away from it', async () => {
+    function Child({text}) {
+      Scheduler.unstable_yieldValue(text);
+      return <span>{text}</span>;
+    }
+    let ChildWithBoundary = React.memo(function({text}) {
+      return (
+        <Suspense fallback="Loading...">
+          <Child text={text} />
+          <Child text={text.toLowerCase()} />
+        </Suspense>
+      );
+    });
+
+    function App({a}) {
+      Scheduler.unstable_yieldValue('App');
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('Commit');
+      });
+      return (
+        <div>
+          <ChildWithBoundary text={a} />
+          <ChildWithBoundary text="B" />
+          <ChildWithBoundary text="C" />
+        </div>
+      );
+    }
+
+    let finalHTML = ReactDOMServer.renderToString(<App a="A" />);
+
+    expect(Scheduler).toHaveYielded(['App', 'A', 'a', 'B', 'b', 'C', 'c']);
+
+    let container = document.createElement('div');
+    container.innerHTML = finalHTML;
+
+    // We need this to be in the document since we'll dispatch events on it.
+    document.body.appendChild(container);
+
+    let spanA = container.getElementsByTagName('span')[0];
+    let spanB = container.getElementsByTagName('span')[2];
+    let spanC = container.getElementsByTagName('span')[4];
+
+    let root = ReactDOM.createRoot(container, {hydrate: true});
+    ReactTestUtils.act(() => {
+      root.render(<App a="A" />);
+
+      // Hydrate the shell.
+      expect(Scheduler).toFlushAndYieldThrough(['App', 'Commit']);
+
+      // Render an update at Idle priority that needs to update A.
+      Scheduler.unstable_runWithPriority(
+        Scheduler.unstable_IdlePriority,
+        () => {
+          root.render(<App a="AA" />);
+        },
+      );
+
+      // Start rendering. This will force the first boundary to hydrate
+      // by scheduling it at one higher pri than Idle.
+      expect(Scheduler).toFlushAndYieldThrough(['App', 'A']);
+
+      // Hover over A which (could) schedule at one higher pri than Idle.
+      dispatchMouseHoverEvent(spanA, null);
+
+      // Before, we're done we now switch to hover over B.
+      // This is meant to test that this doesn't cause us to forget that
+      // we still have to hydrate A. The first boundary.
+      // This also tests that we don't do the -1 down-prioritization of
+      // continuous hover events because that would decrease its priority
+      // to Idle.
+      dispatchMouseHoverEvent(spanB, spanA);
+
+      // Also click C to prioritize that even higher which resets the
+      // priority levels.
+      dispatchClickEvent(spanC);
+
+      expect(Scheduler).toHaveYielded([
+        // Hydrate C first since we clicked it.
+        'C',
+        'c',
+      ]);
+
+      expect(Scheduler).toFlushAndYield([
+        // Finish hydration of A since we forced it to hydrate.
+        'A',
+        'a',
+        // Also, hydrate B since we hovered over it.
+        // It's not important which one comes first. A or B.
+        // As long as they both happen before the Idle update.
+        'B',
+        'b',
+        // Begin the Idle update again.
+        'App',
+        'AA',
+        'aa',
+        'Commit',
+      ]);
+    });
+
+    let spanA2 = container.getElementsByTagName('span')[0];
+    // This is supposed to have been hydrated, not replaced.
+    expect(spanA).toBe(spanA2);
+
+    document.body.removeChild(container);
   });
 });

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -32,10 +32,9 @@ export const Never = 1;
 // Idle is slightly higher priority than Never. It must completely finish in
 // order to be consistent.
 export const Idle = 2;
-// Continuous Hydration is a moving priority. It is slightly higher than Idle
-// and is used to increase priority of hover targets. It is increasing with
-// each usage so that last always wins.
-let ContinuousHydration = 3;
+// Continuous Hydration is slightly higher than Idle and is used to increase
+// priority of hover targets.
+export const ContinuousHydration = 3;
 export const Sync = MAX_SIGNED_31_BIT_INT;
 export const Batched = Sync - 1;
 
@@ -117,15 +116,6 @@ export function computeInteractiveExpiration(currentTime: ExpirationTime) {
     HIGH_PRIORITY_EXPIRATION,
     HIGH_PRIORITY_BATCH_SIZE,
   );
-}
-
-export function computeContinuousHydrationExpiration(
-  currentTime: ExpirationTime,
-) {
-  // Each time we ask for a new one of these we increase the priority.
-  // This ensures that the last one always wins since we can't deprioritize
-  // once we've scheduled work already.
-  return ContinuousHydration++;
 }
 
 export function inferPriorityFromExpirationTime(

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -76,8 +76,8 @@ import {
 import {StrictMode} from './ReactTypeOfMode';
 import {
   Sync,
+  ContinuousHydration,
   computeInteractiveExpiration,
-  computeContinuousHydrationExpiration,
 } from './ReactFiberExpirationTime';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
 import {
@@ -384,11 +384,8 @@ export function attemptContinuousHydration(fiber: Fiber): void {
     // Suspense.
     return;
   }
-  let expTime = computeContinuousHydrationExpiration(
-    requestCurrentTimeForUpdate(),
-  );
-  scheduleWork(fiber, expTime);
-  markRetryTimeIfNotHydrated(fiber, expTime);
+  scheduleWork(fiber, ContinuousHydration);
+  markRetryTimeIfNotHydrated(fiber, ContinuousHydration);
 }
 
 export function attemptHydrationAtCurrentPriority(fiber: Fiber): void {


### PR DESCRIPTION
Let’s use a constant priority for this. This helps us avoid restarting a render when switching targets and simplifies the model.

The downside is that now we're not down-prioritizing the previous hover target. However, we think that's ok because it'll only do one level too much and then stop.

I also add test meant to show why it's tricky to merge both hydration levels. Having both levels co-exist works. However, if we deprioritize hydration using a single level, we might deprioritize the wrong thing.

It also tests that we don't down-prioritize if we're changing the hover in the middle of doing continuous priority work. We don't do the -1 trick for these and so we don't have to consider that in the new model. Just that we shouldn't start doing that.
