### PR TITLE
Add beforeRemoveInstance method to ReactNoop

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -437,6 +437,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     getInstanceFromNode() {
       throw new Error('Not yet implemented.');
     },
+
+    beforeRemoveInstance(instance: any): void {
+      // NO-OP
+    },
   };
 
   const hostConfig = useMutation


### PR DESCRIPTION
The ReactNoop renderer is missing the `beforeRemoveInstance` method, which causes some tests to fail when the flare flag is enabled by default, this method should be added for consistency, even if it is a no-op.