### PR TITLE
[Scheduler] shouldYield should always return false from inside an expired task

### DIFF
--- a/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/ChangeEventPlugin-test.internal.js
@@ -779,6 +779,7 @@ describe('ChangeEventPlugin', () => {
 
           // 3s should be enough to expire the updates
           Scheduler.unstable_advanceTime(3000);
+          expect(Scheduler).toFlushExpired([]);
           expect(container.textContent).toEqual('hovered');
         });
       },

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -540,7 +540,7 @@ describe('ReactIncrementalUpdates', () => {
 
       // All the updates should render and commit in a single batch.
       Scheduler.unstable_advanceTime(10000);
-      expect(Scheduler).toHaveYielded(['Render: goodbye']);
+      expect(Scheduler).toFlushExpired(['Render: goodbye']);
       // Passive effect
       expect(Scheduler).toFlushAndYield(['Commit: goodbye']);
     });
@@ -645,7 +645,7 @@ describe('ReactIncrementalUpdates', () => {
 
       // All the updates should render and commit in a single batch.
       Scheduler.unstable_advanceTime(10000);
-      expect(Scheduler).toHaveYielded([
+      expect(Scheduler).toFlushExpired([
         'Render: goodbye',
         'Commit: goodbye',
         'Render: goodbye',

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -848,7 +848,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Suspense>,
     );
     Scheduler.unstable_advanceTime(10000);
-    expect(Scheduler).toHaveYielded([
+    expect(Scheduler).toFlushExpired([
       'Suspend! [A]',
       'Suspend! [B]',
       'Loading...',
@@ -987,7 +987,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     Scheduler.unstable_advanceTime(10000);
     jest.advanceTimersByTime(10000);
 
-    expect(Scheduler).toHaveYielded([
+    expect(Scheduler).toFlushExpired([
       'Suspend! [goodbye]',
       'Loading...',
       'Commit: goodbye',

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -117,14 +117,14 @@ describe('Scheduler', () => {
 
     // Advance by just a bit more to expire the user blocking callbacks
     Scheduler.unstable_advanceTime(1);
-    expect(Scheduler).toHaveYielded([
+    expect(Scheduler).toFlushExpired([
       'B (did timeout: true)',
       'C (did timeout: true)',
     ]);
 
     // Expire A
     Scheduler.unstable_advanceTime(4600);
-    expect(Scheduler).toHaveYielded(['A (did timeout: true)']);
+    expect(Scheduler).toFlushExpired(['A (did timeout: true)']);
 
     // Flush the rest without expiring
     expect(Scheduler).toFlushAndYield([
@@ -140,7 +140,7 @@ describe('Scheduler', () => {
     expect(Scheduler).toHaveYielded([]);
 
     Scheduler.unstable_advanceTime(1);
-    expect(Scheduler).toHaveYielded(['A']);
+    expect(Scheduler).toFlushExpired(['A']);
   });
 
   it('continues working on same task after yielding', () => {
@@ -217,7 +217,7 @@ describe('Scheduler', () => {
 
     // Advance time by just a bit more. This should expire all the remaining work.
     Scheduler.unstable_advanceTime(1);
-    expect(Scheduler).toHaveYielded(['C', 'D']);
+    expect(Scheduler).toFlushExpired(['C', 'D']);
   });
 
   it('continuations are interrupted by higher priority work', () => {
@@ -705,7 +705,7 @@ describe('Scheduler', () => {
 
       // Now it expires
       Scheduler.unstable_advanceTime(1);
-      expect(Scheduler).toHaveYielded(['A']);
+      expect(Scheduler).toFlushExpired(['A']);
     });
 
     it('cancels a delayed task', () => {

--- a/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.mock.js
@@ -201,13 +201,10 @@ export function unstable_yieldValue(value: mixed): void {
 
 export function unstable_advanceTime(ms: number) {
   currentTime += ms;
-  if (!isFlushing) {
-    if (scheduledTimeout !== null && timeoutTime <= currentTime) {
-      scheduledTimeout(currentTime);
-      timeoutTime = -1;
-      scheduledTimeout = null;
-    }
-    unstable_flushExpired();
+  if (scheduledTimeout !== null && timeoutTime <= currentTime) {
+    scheduledTimeout(currentTime);
+    timeoutTime = -1;
+    scheduledTimeout = null;
   }
 }
 


### PR DESCRIPTION
## Based on #17967

The current behavior of shouldYield is unspecified except in cases that happen to be relied on by the React work loop's implementation. However, some of the unspecified cases are important and the consequences of assuming the wrong behavior are really bad.

For example, it's natural to assume that `shouldYield` returns false when called from within an expired task. But the current behavior usually does that, unless there's a higher priority task or a main thread task (i.e. at the end of the 5ms message loop interval).

This fixes `shouldYield` so that it always returns false inside an expired task, regardless of the other tasks in the queue.