### PR TITLE
Fix release script artifact path.

### DIFF
--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -12,7 +12,7 @@ const theme = require('../theme');
 const run = async ({build, cwd}) => {
   const artifacts = await getArtifactsList(build);
   const nodeModulesArtifact = artifacts.find(
-    entry => entry.path === 'home/circleci/project/node_modules.tgz'
+    entry => entry.path.endsWith('node_modules.tgz')
   );
 
   if (!nodeModulesArtifact) {


### PR DESCRIPTION
Circle CI seems to have changed the reported artifact path which broke our scripts. I noticed this morning that older builds (e.g. [77063](https://circleci.com/api/v1.1/project/github/facebook/react/77063)) were able to be downloaded but newer builds (e.g. [82919](https://circleci.com/api/v1.1/project/github/facebook/react/82919)) were not.

Tracing through this...

### [77063](https://circleci.com/api/v1.1/project/github/facebook/react/77063)
* build metadata: https://circleci.com/api/v1.1/project/github/facebook/react/77063
* workflow metadata: https://circleci.com/api/v2/workflow/49350fad-76a5-4412-8a01-db166945ff5c/job
* job artifact metadata: https://circleci.com/api/v1.1/project/github/facebook/react/77061/artifacts
* artifact path: `"home/circleci/project/node_modules.tgz"`

### [82919](https://circleci.com/api/v1.1/project/github/facebook/react/82919)
* build metadata: https://circleci.com/api/v1.1/project/github/facebook/react/82919
* workflow metadata: https://circleci.com/api/v2/workflow/e405fb21-3eae-425c-9a3b-1a7a7da8bd08/job
* job artifact metadata: https://circleci.com/api/v1.1/project/github/facebook/react/82917/artifacts
* artifact path: `"node_modules.tgz"`

So...something changed how they report the path (presumably on Circle CI's side). This PR updates our release script to be a little more loose in how it identifies that artifact.