### PR TITLE
Portals trigger Suspense boundaries in SSR and only render on client

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -324,17 +324,19 @@ describe('ReactDOMServerHydration', () => {
     );
   });
 
-  it('should throw rendering portals on the server', () => {
-    const div = document.createElement('div');
-    expect(() => {
-      ReactDOMServer.renderToString(
-        <div>{ReactDOM.createPortal(<div />, div)}</div>,
+  if (!__EXPERIMENTAL__) {
+    it('should throw rendering portals on the server', () => {
+      const div = document.createElement('div');
+      expect(() => {
+        ReactDOMServer.renderToString(
+          <div>{ReactDOM.createPortal(<div />, div)}</div>,
+        );
+      }).toThrow(
+        'Portals are not currently supported by the server renderer. ' +
+          'Render them conditionally so that they only appear on the client render.',
       );
-    }).toThrow(
-      'Portals are not currently supported by the server renderer. ' +
-        'Render them conditionally so that they only appear on the client render.',
-    );
-  });
+    });
+  }
 
   it('should be able to render and hydrate Mode components', () => {
     class ComponentWithWarning extends React.Component {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -908,7 +908,6 @@ class ReactDOMServerRenderer {
               if (err === REACT_PORTAL_TYPE) {
                 invariant(
                   this.suspenseDepth > 0,
-                  // TODO: include component name. This is a bit tricky with current factoring.
                   'Portals must have a fallback UI when being rendered on the server.\n' +
                     '\n' +
                     'Add a <Suspense fallback=...> component higher in the tree to ' +

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -975,13 +975,12 @@ class ReactDOMServerRenderer {
         if (nextChild != null && nextChild.$$typeof != null) {
           // Catch unexpected special types early.
           const $$typeof = nextChild.$$typeof;
-          // LUNA
           if ($$typeof === REACT_PORTAL_TYPE) {
             if (enableSuspenseServerRenderer) {
               throw $$typeof;
             } else {
               invariant(
-                $$typeof !== REACT_PORTAL_TYPE,
+                false,
                 'Portals are not currently supported by the server renderer. ' +
                   'Render them conditionally so that they only appear on the client render.',
               );

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -900,16 +900,30 @@ class ReactDOMServerRenderer {
         try {
           outBuffer += this.render(child, frame.context, frame.domNamespace);
         } catch (err) {
-          if (err != null && typeof err.then === 'function') {
+          if (
+            err != null &&
+            (typeof err.then === 'function' || err === REACT_PORTAL_TYPE)
+          ) {
             if (enableSuspenseServerRenderer) {
-              invariant(
-                this.suspenseDepth > 0,
-                // TODO: include component name. This is a bit tricky with current factoring.
-                'A React component suspended while rendering, but no fallback UI was specified.\n' +
-                  '\n' +
-                  'Add a <Suspense fallback=...> component higher in the tree to ' +
-                  'provide a loading indicator or placeholder to display.',
-              );
+              if (err === REACT_PORTAL_TYPE) {
+                invariant(
+                  this.suspenseDepth > 0,
+                  // TODO: include component name. This is a bit tricky with current factoring.
+                  'Portals must have a fallback UI when being rendered on the server.\n' +
+                    '\n' +
+                    'Add a <Suspense fallback=...> component higher in the tree to ' +
+                    'provide a loading indicator or placeholder to display.',
+                );
+              } else {
+                invariant(
+                  this.suspenseDepth > 0,
+                  // TODO: include component name. This is a bit tricky with current factoring.
+                  'A React component suspended while rendering, but no fallback UI was specified.\n' +
+                    '\n' +
+                    'Add a <Suspense fallback=...> component higher in the tree to ' +
+                    'provide a loading indicator or placeholder to display.',
+                );
+              }
               suspended = true;
             } else {
               invariant(false, 'ReactDOMServer does not yet support Suspense.');
@@ -961,11 +975,18 @@ class ReactDOMServerRenderer {
         if (nextChild != null && nextChild.$$typeof != null) {
           // Catch unexpected special types early.
           const $$typeof = nextChild.$$typeof;
-          invariant(
-            $$typeof !== REACT_PORTAL_TYPE,
-            'Portals are not currently supported by the server renderer. ' +
-              'Render them conditionally so that they only appear on the client render.',
-          );
+          // LUNA
+          if ($$typeof === REACT_PORTAL_TYPE) {
+            if (enableSuspenseServerRenderer) {
+              throw $$typeof;
+            } else {
+              invariant(
+                $$typeof !== REACT_PORTAL_TYPE,
+                'Portals are not currently supported by the server renderer. ' +
+                  'Render them conditionally so that they only appear on the client render.',
+              );
+            }
+          }
           // Catch-all to prevent an infinite loop if React.Children.toArray() supports some new type.
           invariant(
             false,

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -344,5 +344,6 @@
   "343": "ReactDOMServer does not yet support scope components.",
   "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
   "345": "Root did not complete. This is a bug in React.",
-  "346": "An event responder context was used outside of an event cycle."
+  "346": "An event responder context was used outside of an event cycle.",
+  "347": "Portals must have a fallback UI when being rendered on the server.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display."
 }


### PR DESCRIPTION
Currently during SSR, rendering a Portal throws an error. However, in Concurrent Mode, if a Portal is wrapped in a Suspense boundary, instead of throwing an err, we want to trigger the closest Suspense fallback instead. Then during hydration, we can render the Portal. If a Portal isn't wrapped in a Suspense boundary, we will still throw an error to remain consistent with the previous implementation.