### PR TITLE
Portals trigger Suspense boundaries in SSR and only render on client

### DIFF
--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -324,17 +324,19 @@ describe('ReactDOMServerHydration', () => {
     );
   });
 
-  it('should throw rendering portals on the server', () => {
-    const div = document.createElement('div');
-    expect(() => {
-      ReactDOMServer.renderToString(
-        <div>{ReactDOM.createPortal(<div />, div)}</div>,
+  if (!__EXPERIMENTAL__) {
+    it('should throw rendering portals on the server', () => {
+      const div = document.createElement('div');
+      expect(() => {
+        ReactDOMServer.renderToString(
+          <div>{ReactDOM.createPortal(<div />, div)}</div>,
+        );
+      }).toThrow(
+        'Portals are not currently supported by the server renderer. ' +
+          'Render them conditionally so that they only appear on the client render.',
       );
-    }).toThrow(
-      'Portals are not currently supported by the server renderer. ' +
-        'Render them conditionally so that they only appear on the client render.',
-    );
-  });
+    });
+  }
 
   it('should be able to render and hydrate Mode components', () => {
     class ComponentWithWarning extends React.Component {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -344,5 +344,6 @@
   "343": "ReactDOMServer does not yet support scope components.",
   "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
   "345": "Root did not complete. This is a bug in React.",
-  "346": "An event responder context was used outside of an event cycle."
+  "346": "An event responder context was used outside of an event cycle.",
+  "347": "Portals must have a fallback UI when being rendered on the server.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display."
 }


### PR DESCRIPTION
Currently during SSR, rendering a Portal throws an error. However, in Concurrent Mode, if a Portal is wrapped in a Suspense boundary, instead of throwing an err, we want to trigger the closest Suspense fallback instead. Then during hydration, we can render the Portal. If a Portal isn't wrapped in a Suspense boundary, we will still throw an error to remain consistent with the previous implementation.

