### PR TITLE
Use testing builds for our own tests

### DIFF
--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -13,10 +13,7 @@ let TestRenderer;
 
 global.__DEV__ = process.env.NODE_ENV !== 'production';
 
-jest.mock('react-dom', () =>
-  require.requireActual('react-dom/cjs/react-dom-testing.development.js')
-);
-// we'll replace the above with react/testing and react-dom/testing right before the next minor
+jest.mock('react-dom', () => require.requireActual('react-dom/testing'));
 
 expect.extend(require('../toWarnDev'));
 

--- a/fixtures/dom/src/__tests__/wrong-act-test.js
+++ b/fixtures/dom/src/__tests__/wrong-act-test.js
@@ -18,10 +18,7 @@ let ARTTest;
 global.__DEV__ = process.env.NODE_ENV !== 'production';
 global.__EXPERIMENTAL__ = process.env.RELEASE_CHANNEL === 'experimental';
 
-jest.mock('react-dom', () =>
-  require.requireActual('react-dom/cjs/react-dom-testing.development.js')
-);
-// we'll replace the above with react/testing and react-dom/testing right before the next minor
+jest.mock('react-dom', () => require.requireActual('react-dom/testing'));
 
 expect.extend(require('../toWarnDev'));
 

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -30,6 +30,7 @@
     "README.md",
     "build-info.json",
     "index.js",
+    "testing.js",
     "profiling.js",
     "server.js",
     "server.browser.js",

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
@@ -13,7 +13,6 @@ let React;
 let ReactDOM;
 let Suspense;
 let ReactCache;
-let ReactTestUtils;
 let Scheduler;
 let TextResource;
 let act;
@@ -26,9 +25,8 @@ describe('ReactDOMSuspensePlaceholder', () => {
     React = require('react');
     ReactDOM = require('react-dom');
     ReactCache = require('react-cache');
-    ReactTestUtils = require('react-dom/test-utils');
     Scheduler = require('scheduler');
-    act = ReactTestUtils.act;
+    act = ReactDOM.act;
     Suspense = React.Suspense;
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/react-dom/testing.fb.js
+++ b/packages/react-dom/testing.fb.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const ReactDOMFB = require('./src/client/ReactDOMFB');
+
+// TODO: decide on the top-level export form.
+// This is hacky but makes it work with both Rollup and Jest.
+module.exports = ReactDOMFB.default || ReactDOMFB;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -7,6 +7,11 @@
  * @flow strict
  */
 
+/*
+  SYNC WITH forks/ReactFeatureFlags.testing.js
+  except isTestEnvironment = true
+*/
+
 export const enableUserTimingAPI = __DEV__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState

--- a/packages/shared/forks/ReactFeatureFlags.readonly.js
+++ b/packages/shared/forks/ReactFeatureFlags.readonly.js
@@ -9,4 +9,4 @@
 // It lets us determine whether we're running in Fire mode without making tests internal.
 const ReactFeatureFlags = require('../ReactFeatureFlags');
 // Forbid writes because this wouldn't work with bundle tests.
-module.exports = Object.freeze({...ReactFeatureFlags});
+module.exports = Object.freeze({...ReactFeatureFlags, isTestEnvironment: true});

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -47,7 +47,7 @@ export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
-export const isTestEnvironment = true; // this should probably *never* change
+export const isTestEnvironment = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -45,7 +45,7 @@ export const disableUnstableRenderSubtreeIntoContainer = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
-export const isTestEnvironment = true; // this should probably *never* change
+export const isTestEnvironment = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -4,58 +4,131 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict
  */
 
-import invariant from 'shared/invariant';
+/*
+  SYNC WITH ReactFeatureFlags.js
+  except isTestEnvironment = true
+*/
 
-import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
-import typeof * as PersistentFeatureFlagsType from './ReactFeatureFlags.persistent';
-
-export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableUserTimingAPI = __DEV__;
+
+// Helps identify side effects in render-phase lifecycle hooks and setState
+// reducers by double invoking them in Strict Mode.
+export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
+
+// To preserve the "Pause on caught exceptions" behavior of the debugger, we
+// replay the begin phase of a failed component inside invokeGuardedCallback.
+export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
+
+// Warn about deprecated, async-unsafe lifecycles; relates to RFC #6:
 export const warnAboutDeprecatedLifecycles = true;
-export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+
+// Gather advanced timing metrics for Profiler subtrees.
 export const enableProfilerTimer = __PROFILE__;
+
+// Trace which interactions trigger each commit.
 export const enableSchedulerTracing = __PROFILE__;
-export const enableSuspenseServerRenderer = false;
-export const enableSelectiveHydration = false;
-export const enableChunksAPI = false;
-export const disableJavaScriptURLs = false;
-export const disableInputAttributeSyncing = false;
-export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
-export const warnAboutShorthandPropertyCollision = false;
+
+// SSR experiments
+export const enableSuspenseServerRenderer = __EXPERIMENTAL__;
+export const enableSelectiveHydration = __EXPERIMENTAL__;
+
+// Flight experiments
+export const enableChunksAPI = __EXPERIMENTAL__;
+
+// Only used in www builds.
 export const enableSchedulerDebugging = false;
-export const enableDeprecatedFlareAPI = false;
-export const enableFundamentalAPI = false;
-export const enableScopeAPI = false;
-export const enableJSXTransformAPI = false;
-export const warnAboutUnmockedScheduler = false;
-export const flushSuspenseFallbacksInTests = true;
-export const enableSuspenseCallback = false;
-export const warnAboutDefaultPropsOnFunctionComponents = false;
-export const warnAboutStringRefs = false;
-export const disableLegacyContext = false;
-export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
-export const enableTrainModelFix = true;
-export const enableTrustedTypesIntegration = false;
-export const enableNativeTargetAsInstance = false;
-export const disableCreateFactory = false;
-export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
-export const disableUnstableRenderSubtreeIntoContainer = false;
-export const warnUnstableRenderSubtreeIntoContainer = false;
-export const disableUnstableCreatePortal = false;
-export const deferPassiveEffectCleanupDuringUnmount = false;
-export const isTestEnvironment = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {
-  invariant(false, 'Not implemented.');
+  throw new Error('Not implemented.');
 }
 
-// Flow magic to verify the exports of this file match the original version.
-// eslint-disable-next-line no-unused-vars
-type Check<_X, Y: _X, X: Y = _X> = null;
-// eslint-disable-next-line no-unused-expressions
-(null: Check<PersistentFeatureFlagsType, FeatureFlagsType>);
+// Disable javascript: URL strings in href for XSS protection.
+export const disableJavaScriptURLs = false;
+
+// These APIs will no longer be "unstable" in the upcoming 16.7 release,
+// Control this behavior with a flag to support 16.6 minor releases in the meanwhile.
+export const exposeConcurrentModeAPIs = __EXPERIMENTAL__;
+
+export const warnAboutShorthandPropertyCollision = false;
+
+// Experimental React Flare event system and event components support.
+export const enableDeprecatedFlareAPI = false;
+
+// Experimental Host Component support.
+export const enableFundamentalAPI = false;
+
+// Experimental Scope support.
+export const enableScopeAPI = false;
+
+// New API for JSX transforms to target - https://github.com/reactjs/rfcs/pull/107
+export const enableJSXTransformAPI = false;
+
+// We will enforce mocking scheduler with scheduler/unstable_mock at some point. (v17?)
+// Till then, we warn about the missing mock, but still fallback to a legacy mode compatible version
+export const warnAboutUnmockedScheduler = false;
+
+// For tests, we flush suspense fallbacks in an act scope;
+// *except* in some of our own tests, where we test incremental loading states.
+export const flushSuspenseFallbacksInTests = true;
+
+// Add a callback property to suspense to notify which promises are currently
+// in the update queue. This allows reporting and tracing of what is causing
+// the user to see a loading state.
+// Also allows hydration callbacks to fire when a dehydrated boundary gets
+// hydrated or deleted.
+export const enableSuspenseCallback = false;
+
+// Part of the simplification of React.createElement so we can eventually move
+// from React.createElement to React.jsx
+// https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md
+export const warnAboutDefaultPropsOnFunctionComponents = false;
+
+export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
+
+export const enableTrainModelFix = true;
+
+export const enableTrustedTypesIntegration = false;
+
+// Flag to turn event.target and event.currentTarget in ReactNative from a reactTag to a component instance
+export const enableNativeTargetAsInstance = false;
+
+// Controls behavior of deferred effect destroy functions during unmount.
+// Previously these functions were run during commit (along with layout effects).
+// Ideally we should delay these until after commit for performance reasons.
+// This flag provides a killswitch if that proves to break existing code somehow.
+export const deferPassiveEffectCleanupDuringUnmount = false;
+
+export const isTestEnvironment = true;
+
+// --------------------------
+// Future APIs to be deprecated
+// --------------------------
+
+// Prevent the value and checked attributes from syncing
+// with their related DOM properties
+export const disableInputAttributeSyncing = false;
+
+export const warnAboutStringRefs = false;
+
+export const disableLegacyContext = false;
+
+// Disables React.createFactory
+export const disableCreateFactory = false;
+
+// Disables children for <textarea> elements
+export const disableTextareaChildren = false;
+
+// Disables Maps as ReactElement children
+export const disableMapsAsChildren = false;
+
+// Disables ReactDOM.unstable_renderSubtreeIntoContainer
+export const disableUnstableRenderSubtreeIntoContainer = false;
+// We should remove this flag once the above flag becomes enabled
+export const warnUnstableRenderSubtreeIntoContainer = false;
+
+// Disables ReactDOM.unstable_createPortal
+export const disableUnstableCreatePortal = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -8,8 +8,8 @@
  */
 
 /*
-  SYNC WITH forks/ReactFeatureFlags.testing.www.js
-  except isTestEnvironment = false
+  SYNC WITH forks/ReactFeatureFlags.www.js
+  except isTestEnvironment = true
 */
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
@@ -109,7 +109,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 
 export const disableUnstableCreatePortal = false;
 
-export const isTestEnvironment = false;
+export const isTestEnvironment = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -177,6 +177,11 @@ inlinedHostConfigs.forEach(rendererInfo => {
   }
 });
 
+jest.mock('shared/ReactFeatureFlags', () =>
+  require.requireActual('shared/forks/ReactFeatureFlags.testing.js')
+);
+jest.mock('react-dom', () => require.requireActual('react-dom/testing'));
+
 // Make it possible to import this module inside
 // the React package itself.
 jest.mock('shared/ReactSharedInternals', () =>

--- a/scripts/jest/setupTests.build.js
+++ b/scripts/jest/setupTests.build.js
@@ -1,5 +1,7 @@
 'use strict';
 
+jest.mock('react-dom', () => require.requireActual(`react-dom/testing`));
+
 jest.mock('scheduler', () => require.requireActual('scheduler/unstable_mock'));
 jest.mock('scheduler/src/SchedulerHostConfig', () =>
   require.requireActual('scheduler/src/forks/SchedulerHostConfig.mock.js')

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -46,7 +46,7 @@ const forks = Object.freeze({
   // Without this fork, importing `shared/ReactSharedInternals` inside
   // the `react` package itself would not work due to a cyclical dependency.
   'shared/ReactSharedInternals': (bundleType, entry, dependencies) => {
-    if (entry === 'react' || entry === 'react/testing') {
+    if (entry === 'react') {
       return 'react/src/ReactSharedInternals';
     }
     if (dependencies.indexOf('react') === -1) {
@@ -107,8 +107,12 @@ const forks = Object.freeze({
         }
         return 'shared/forks/ReactFeatureFlags.test-renderer.js';
       case 'react-dom/testing':
-        return 'shared/forks/ReactFeatureFlags.testing.js';
-      case 'react/testing':
+        switch (bundleType) {
+          case FB_WWW_DEV:
+          case FB_WWW_PROD:
+          case FB_WWW_PROFILING:
+            return 'shared/forks/ReactFeatureFlags.testing.www.js';
+        }
         return 'shared/forks/ReactFeatureFlags.testing.js';
       default:
         switch (bundleType) {


### PR DESCRIPTION
Following up from #17915 where we generated testing builds for `react-dom`, this PR uses those builds for our own tests.

- fixes for fb builds: 
  - adds a ReactFeatureFlags fork where `isTestEnvironment:true`
  - adds a `.fb` fork for the `testing.js` entrypoint
- adds `isTestEnvironment: true` to `ReactFeatureFlags.readonly`
- with jest, mocks `react-dom` with the testing version, both for source and builds
- uses `ReactDOM.act` in one of these tests to verify it actually works

This also meant I had to add `testing.js` to `react-dom`'s `package.json` (so we can still run `yarn test-build`). If you feel strongly about not exposing this yet, maybe I could rename it to `testing_DO_NOT_USE.js`?

I'll write a post before I land this, but this setup has an annoyance. If you add a new feature flag, and run your tests, your test will probably fail, since it's likely you've not added it to the `.testing` forks. There's nothing to warn this except for flow. which might not be running. Open to ideas for syncing these forks. 