### PR TITLE
Fix Flow type for React Native

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeComponent.js
@@ -41,16 +41,12 @@ export default function(
    *
    * @abstract
    */
-  class ReactNativeComponent<Props, State = void> extends React.Component<
-    Props,
-    State,
-  > {
+  class ReactNativeComponent<Props> extends React.Component<Props> {
     /**
      * Due to bugs in Flow's handling of React.createClass, some fields already
      * declared in the base class need to be redeclared below.
      */
     props: Props;
-    state: State;
 
     /**
      * Removes focus. This is the opposite of `focus()`.

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -137,7 +137,7 @@ type SecretInternalsFabricType = {
  * Provide minimal Flow typing for the high-level RN API and call it a day.
  */
 export type ReactNativeType = {
-  NativeComponent: _InternalReactNativeComponentClass<{...}>,
+  NativeComponent: typeof ReactNativeComponent,
   findHostInstance_DEPRECATED(
     componentOrHandle: any,
   ): ?ElementRef<HostComponent<mixed>>,
@@ -157,7 +157,7 @@ export type ReactNativeType = {
 };
 
 export type ReactFabricType = {
-  NativeComponent: _InternalReactNativeComponentClass<{...}>,
+  NativeComponent: typeof ReactNativeComponent,
   findHostInstance_DEPRECATED(componentOrHandle: any): ?HostComponent<mixed>,
   findNodeHandle(componentOrHandle: any): ?number,
   dispatchCommand(handle: any, command: string, args: Array<any>): void,


### PR DESCRIPTION
I changed the external type in https://github.com/facebook/react/pull/17805 but my change was not backwards-compatible. This rolls my change back, and instead fixes the internal type to better agree with the external type.