### PR TITLE
Refactor unmountHostComponents to recursively unmount

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -421,12 +421,12 @@ export function removeChild(
 }
 
 export function removeChildFromContainer(
-  parentInstance: Container,
+  parentInstance: Instance | Container,
   child: Instance | TextInstance,
 ): void {
   recursivelyUncacheFiberNode(child);
   UIManager.manageChildren(
-    parentInstance, // containerID
+    ((parentInstance: any): Container), // containerID
     [], // moveFromIndices
     [], // moveToIndices
     [], // addChildReactTags

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -421,12 +421,12 @@ export function removeChild(
 }
 
 export function removeChildFromContainer(
-  parentInstance: Instance | Container,
+  parentInstance: Container,
   child: Instance | TextInstance,
 ): void {
   recursivelyUncacheFiberNode(child);
   UIManager.manageChildren(
-    ((parentInstance: any): Container), // containerID
+    parentInstance, // containerID
     [], // moveFromIndices
     [], // moveToIndices
     [], // addChildReactTags

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1232,6 +1232,7 @@ function unmountHostComponents(
           currentParent = parentStateNode.instance;
           currentParentIsContainer = false;
         }
+        break findParent;
     }
     parent = parent.return;
   }
@@ -1248,7 +1249,7 @@ function unmountHostComponents(
 
 function recursivelyUnmountHostNode(
   node: Fiber,
-  currentParent: Instance,
+  currentParent: Instance | Container,
   currentParentIsContainer: boolean,
   finishedRoot: FiberRoot,
   renderPriorityLevel: ReactPriorityLevel,
@@ -1259,9 +1260,9 @@ function recursivelyUnmountHostNode(
     // After all the children have unmounted, it is now safe to remove the
     // node from the tree.
     if (currentParentIsContainer) {
-      removeChildFromContainer(currentParent, stateNode);
+      removeChildFromContainer(((currentParent: any): Container), stateNode);
     } else {
-      removeChild(currentParent, stateNode);
+      removeChild(((currentParent: any): Instance), stateNode);
     }
     // Don't visit children because we already visited them.
   } else if (enableFundamentalAPI && tag === FundamentalComponent) {
@@ -1270,9 +1271,12 @@ function recursivelyUnmountHostNode(
     // After all the children have unmounted, it is now safe to remove the
     // node from the tree.
     if (currentParentIsContainer) {
-      removeChildFromContainer(currentParent, fundamentalNode);
+      removeChildFromContainer(
+        ((currentParent: any): Container),
+        fundamentalNode,
+      );
     } else {
-      removeChild(currentParent, fundamentalNode);
+      removeChild(((currentParent: any): Instance), fundamentalNode);
     }
   } else if (enableSuspenseServerRenderer && tag === DehydratedFragment) {
     if (enableSuspenseCallback) {
@@ -1286,9 +1290,12 @@ function recursivelyUnmountHostNode(
     }
     // Delete the dehydrated suspense boundary and all of its content.
     if (currentParentIsContainer) {
-      clearSuspenseBoundaryFromContainer(currentParent, stateNode);
+      clearSuspenseBoundaryFromContainer(
+        ((currentParent: any): Container),
+        stateNode,
+      );
     } else {
-      clearSuspenseBoundary(currentParent, stateNode);
+      clearSuspenseBoundary(((currentParent: any): Instance), stateNode);
     }
   } else if (tag === HostPortal) {
     const child = node.child;
@@ -1322,7 +1329,7 @@ function recursivelyUnmountHostNode(
 
 function recursivelyUnmountHostNodeChildren(
   child: Fiber,
-  currentParent: Instance,
+  currentParent: Instance | Container,
   currentParentIsContainer: boolean,
   finishedRoot: FiberRoot,
   renderPriorityLevel: ReactPriorityLevel,


### PR DESCRIPTION
This PR refactors the logice in `unmountHostComponents` so that we instead recursively traverse the nodes as we unmount them. I noticed that `unmountHostComponents` was a hot function during the commit phase, and this should improve the runtime performance slightly, as we no longer need to mutate the fields on the fibers to point to different return pointers.