### PR TITLE
Ignore react-native-web in Flow checks

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -10,6 +10,7 @@
 .*/node_modules/chrome-devtools-frontend/.*
 .*/node_modules/devtools-timeline-model/.*
 .*/node_modules/create-react-class/.*
+.*/node_modules/react-native-web/.*
 .*/__mocks__/.*
 .*/__tests__/.*
 


### PR DESCRIPTION
@bvaughn says this causes sporadic failures. We don't intend to check it.