### PR TITLE
Tweak comment wording

### DIFF
--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -43,7 +43,7 @@ const MAGIC_NUMBER_OFFSET = Batched - 1;
 
 // 1 unit of expiration time represents 10ms.
 export function msToExpirationTime(ms: number): ExpirationTime {
-  // Always subtract an offset so that we don't clash with the magic number for NoWork.
+  // Always add an offset so that we don't clash with the magic number for NoWork.
   return MAGIC_NUMBER_OFFSET - ((ms / UNIT_SIZE) | 0);
 }
 

--- a/packages/react-reconciler/src/ReactFiberExpirationTime.js
+++ b/packages/react-reconciler/src/ReactFiberExpirationTime.js
@@ -43,7 +43,7 @@ const MAGIC_NUMBER_OFFSET = Batched - 1;
 
 // 1 unit of expiration time represents 10ms.
 export function msToExpirationTime(ms: number): ExpirationTime {
-  // Always add an offset so that we don't clash with the magic number for NoWork.
+  // Always subtract from the offset so that we don't clash with the magic number for NoWork.
   return MAGIC_NUMBER_OFFSET - ((ms / UNIT_SIZE) | 0);
 }
 


### PR DESCRIPTION
Reverts facebook/react#17825

I don't think this is a "grammar fix". This is a semantic change to what the comment says. It's misleading because the `MAGIC_NUMBER_OFFSET` is still being *added*, not subtracted. `A - B` does not mean "subtract `A`".

In general, changing the meaning of comments should be done very carefully because misleading comments are especially dangerous. Ideally, it's best to double-check what the author meant.