### PR TITLE
`disableLegacyContext` as a dynamic flag for www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -17,6 +17,7 @@ export const {
   enableTrustedTypesIntegration,
   deferPassiveEffectCleanupDuringUnmount,
   warnAboutShorthandPropertyCollision,
+  disableLegacyContext,
 } = require('ReactFeatureFlags');
 
 // In www, we have experimental support for gathering data
@@ -33,7 +34,6 @@ export const enableSchedulerDebugging = true;
 
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const warnAboutDeprecatedLifecycles = true;
-export const disableLegacyContext = false;
 export const warnAboutStringRefs = false;
 export const warnAboutDefaultPropsOnFunctionComponents = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;


### PR DESCRIPTION
This PR makes `disableLegacyContext` a dynamic feature flag for fb/www. For FB internal usage only.
