### PR TITLE
Move getIsHydrating from FB fork to Experimental flag

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -37,6 +37,7 @@ import {
   attemptHydrationAtCurrentPriority,
   act,
 } from 'react-reconciler/inline.dom';
+import {getIsHydrating} from 'react-reconciler/src/ReactFiberHydrationContext';
 import {createPortal as createPortalImpl} from 'shared/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import {setBatchingImplementation} from 'legacy-events/ReactGenericBatching';
@@ -179,6 +180,8 @@ if (exposeConcurrentModeAPIs) {
       queueExplicitHydrationTarget(target);
     }
   };
+
+  ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.getIsHydrating = getIsHydrating;
 }
 
 if (!disableUnstableRenderSubtreeIntoContainer) {

--- a/packages/react-dom/src/client/ReactDOMFB.js
+++ b/packages/react-dom/src/client/ReactDOMFB.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import {getIsHydrating} from 'react-reconciler/src/ReactFiberHydrationContext';
 import {addUserTimingListener} from 'shared/ReactFeatureFlags';
 
 import ReactDOM from './ReactDOM';
@@ -26,8 +25,6 @@ Object.assign(
     },
     // Perf experiment
     addUserTimingListener,
-
-    getIsHydrating,
   },
 );
 


### PR DESCRIPTION
This has no actual impact except that getIsHydrating is on the secrets object for everyone, and not just FB. This would let us completely get rid of the forked FB-specific entry point in the modern version. Instead of the forked entry point, we will use feature flags to remove individual features.