### PR TITLE
Change build from babylon to babel

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -410,7 +410,7 @@ function getPlugins(
     // Note that this plugin must be called after closure applies DCE.
     isProduction && stripUnusedImports(pureExternalModules),
     // Add the whitespace back if necessary.
-    shouldStayReadable && prettier({parser: 'babylon'}),
+    shouldStayReadable && prettier({parser: 'babel'}),
     // License and haste headers, top-level `if` blocks.
     {
       transformBundle(source) {

--- a/scripts/shared/__tests__/evalToString-test.js
+++ b/scripts/shared/__tests__/evalToString-test.js
@@ -7,10 +7,9 @@
 'use strict';
 
 const evalToString = require('../evalToString');
-const babylon = require('babylon');
+const parser = require('@babel/parser');
 
-const parse = source =>
-  babylon.parse(`(${source});`).program.body[0].expression; // quick way to get an exp node
+const parse = source => parser.parse(`(${source});`).program.body[0].expression; // quick way to get an exp node
 
 const parseAndEval = source => evalToString(parse(source));
 


### PR DESCRIPTION
After we upgraded Babel, we no longer use the Babylon parser as it was renamed. We should update this as this will likely break in the future.