### PR TITLE
Remove legacy www config from Rollup build

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -541,11 +541,6 @@ async function createBundle(bundle, bundleType) {
       bundle.moduleType,
       pureExternalModules
     ),
-    // We can't use getters in www.
-    legacy:
-      bundleType === FB_WWW_DEV ||
-      bundleType === FB_WWW_PROD ||
-      bundleType === FB_WWW_PROFILING,
   };
   const [mainOutputPath, ...otherOutputPaths] = Packaging.getBundleOutputPaths(
     bundleType,


### PR DESCRIPTION
This PR removes the `legacy` config setting on our Rollup builds for www bundles. It's been a while since we last investigated the differences between having legacy enabled vs not, as the only visible differences between bundles seems to be the usage of `Object.freeze` on the export, as shown:

Before:
```js
var React$2 = (Object.freeze || Object)({
  default: React
});
```

After:
```js
var React$2 = Object.freeze({	
  default: React	
});
```

The comment in the code from before, "We can't use getters in www.", seems to no longer be relevant too as the getters in the code remain the same between builds.