### PR TITLE
Revert "Remove legacy www config from Rollup build"

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -541,6 +541,11 @@ async function createBundle(bundle, bundleType) {
       bundle.moduleType,
       pureExternalModules
     ),
+    // We can't use getters in www.
+    legacy:
+      bundleType === FB_WWW_DEV ||
+      bundleType === FB_WWW_PROD ||
+      bundleType === FB_WWW_PROFILING,
   };
   const [mainOutputPath, ...otherOutputPaths] = Packaging.getBundleOutputPaths(
     bundleType,


### PR DESCRIPTION
Reverts #18016

This change caused a Makehaste failure for syncs:
```
Cannot transform 'shared/react/ReactEventsFocus-dev.js': TypeError: Unsupported function type: ObjectMethod
...
```
The specific syntax change that causes the failure is going from this:
```js
var Focus = (Object.freeze || Object)({
  passiveBrowserEventsSupported: passiveBrowserEventsSupported,
```
to this:
```js
var Focus = Object.freeze({
  get passiveBrowserEventsSupported() {
    return passiveBrowserEventsSupported;
  },
```
