### PR TITLE
Do not export passiveBrowserEventsSupported from Focus module

### DIFF
--- a/packages/react-interactions/events/src/dom/Focus.js
+++ b/packages/react-interactions/events/src/dom/Focus.js
@@ -81,7 +81,7 @@ const isMac =
     ? /^Mac/.test(window.navigator.platform)
     : false;
 
-export let passiveBrowserEventsSupported = false;
+let passiveBrowserEventsSupported = false;
 
 const canUseDOM: boolean = !!(
   typeof window !== 'undefined' &&


### PR DESCRIPTION
We should not be exporting `passiveBrowserEventsSupported` from this module.