### PR TITLE
Revert "Remove legacy www config from Rollup build"

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -541,6 +541,11 @@ async function createBundle(bundle, bundleType) {
       bundle.moduleType,
       pureExternalModules
     ),
+    // We can't use getters in www.
+    legacy:
+      bundleType === FB_WWW_DEV ||
+      bundleType === FB_WWW_PROD ||
+      bundleType === FB_WWW_PROFILING,
   };
   const [mainOutputPath, ...otherOutputPaths] = Packaging.getBundleOutputPaths(
     bundleType,


### PR DESCRIPTION
Reverts facebook/react#18016

I think we still need to do this. https://github.com/facebook/react/pull/18022 just solved one specific case, and we happen to not have more cases at the moment. But if making a change to the code can cause this problem to reappear, the problem is not solved.