### PR TITLE
Change string refs in function component message

### DIFF
--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -159,7 +159,7 @@ describe('ReactFunctionComponent', () => {
       ReactTestUtils.renderIntoDocument(<Child test="test" />);
     }).toThrowError(
       __DEV__
-        ? 'Function components cannot have refs.'
+        ? 'Function components cannot have string refs. We recommend using useRef() instead.'
         : // It happens because we don't save _owner in production for
           // function components.
           'Element ref was specified as a string (me) but no owner was set. This could happen for one of' +

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -163,8 +163,10 @@ function coerceRef(
         const ownerFiber = ((owner: any): Fiber);
         invariant(
           ownerFiber.tag === ClassComponent,
-          'Function components cannot have refs. ' +
-            'Did you mean to use React.forwardRef()?',
+          'Function components cannot have string refs. ' +
+            'We recommend using useRef() instead. ' +
+            'Learn more about using refs safely here: ' +
+            'https://fb.me/react-strict-mode-string-ref',
         );
         inst = ownerFiber.stateNode;
       }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -307,7 +307,7 @@
   "306": "Element type is invalid. Received a promise that resolves to: %s. Lazy element type must resolve to a class or function.%s",
   "307": "Hooks can only be called inside the body of a function component. (https://fb.me/react-invalid-hook-call)",
   "308": "Context can only be read while React is rendering. In classes, you can read it in the render method or getDerivedStateFromProps. In function components, you can read it directly in the function body, but not inside Hooks like useReducer() or useMemo().",
-  "309": "Function components cannot have refs. Did you mean to use React.forwardRef()?",
+  "309": "Function components cannot have string refs. We recommend using useRef() instead. Learn more about using refs safely here: https://fb.me/react-strict-mode-string-ref",
   "310": "Rendered more hooks than during the previous render.",
   "311": "Should have a queue. This is likely a bug in React. Please file an issue.",
   "312": "Rendered more hooks than during the previous render",


### PR DESCRIPTION
This should refer to string refs specifically. The forwardRef part doesn't make any sense in this case. I think this was just an oversight. This case is when a string ref is used _from_ a function component, not _on_ a function component.