### PR TITLE
alias React.jsxDEV to React.jsx in prod builds (behind a feature flag)

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -65,6 +65,7 @@ import {
   exposeConcurrentModeAPIs,
   enableChunksAPI,
   disableCreateFactory,
+  jsxDEVIncluded,
 } from 'shared/ReactFeatureFlags';
 const React = {
   Children: {
@@ -152,6 +153,9 @@ if (enableJSXTransformAPI) {
     // we may want to special case jsxs internally to take advantage of static children.
     // for now we can ship identical prod functions
     React.jsxs = jsx;
+    if (jsxDEVIncluded) {
+      React.jsxDEV = jsx;
+    }
   }
 }
 

--- a/packages/react/src/__tests__/ReactJSXElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactJSXElementValidator-test.internal.js
@@ -1,0 +1,436 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+// THIS IS A FORK! DO NOT EDIT DIRECTLY.
+// This is copied verbatim from ReactJSXElementValidator-test.js
+// to test a very specific scenario; that React.jsxDEV works
+// exactly as React.jsx with a production build
+
+// To that end, there are 2 changes in beforeEach():
+// ReactFeatureFlags.jsxDEVIncluded = true
+// and
+// React.jsx = React.jsxDEV
+
+// The test suite might drift behind the original, which may be fine?
+// (Since this might be temporary)
+
+// TODO: All these warnings should become static errors using Flow instead
+// of dynamic errors when using JSX with Flow.
+let React;
+let ReactDOM;
+let ReactTestUtils;
+let ReactFeatureFlags;
+let PropTypes;
+
+describe('ReactJSXElementValidator: jsxDEVIncluded', () => {
+  let Component;
+  let RequiredPropComponent;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.jsxDEVIncluded = true;
+    PropTypes = require('prop-types');
+    React = require('react');
+    React.jsx = React.jsxDEV;
+    ReactDOM = require('react-dom');
+    ReactTestUtils = require('react-dom/test-utils');
+
+    Component = class extends React.Component {
+      render() {
+        return <div />;
+      }
+    };
+
+    RequiredPropComponent = class extends React.Component {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    };
+    RequiredPropComponent.displayName = 'RequiredPropComponent';
+    RequiredPropComponent.propTypes = {prop: PropTypes.string.isRequired};
+  });
+
+  it('warns for keys for arrays of elements in children position', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <Component>{[<Component />, <Component />]}</Component>,
+      ),
+    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  });
+
+  it('warns for keys for arrays of elements with owner info', () => {
+    class InnerComponent extends React.Component {
+      render() {
+        return <Component>{this.props.childSet}</Component>;
+      }
+    }
+
+    class ComponentWrapper extends React.Component {
+      render() {
+        return <InnerComponent childSet={[<Component />, <Component />]} />;
+      }
+    }
+
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<ComponentWrapper />),
+    ).toErrorDev(
+      'Each child in a list should have a unique "key" prop.' +
+        '\n\nCheck the render method of `InnerComponent`. ' +
+        'It was passed a child from ComponentWrapper. ',
+    );
+  });
+
+  it('warns for keys for iterables of elements in rest args', () => {
+    const iterable = {
+      '@@iterator': function() {
+        let i = 0;
+        return {
+          next: function() {
+            const done = ++i > 2;
+            return {value: done ? undefined : <Component />, done: done};
+          },
+        };
+      },
+    };
+
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<Component>{iterable}</Component>),
+    ).toErrorDev('Each child in a list should have a unique "key" prop.');
+  });
+
+  it('does not warn for arrays of elements with keys', () => {
+    ReactTestUtils.renderIntoDocument(
+      <Component>{[<Component key="#1" />, <Component key="#2" />]}</Component>,
+    );
+  });
+
+  it('does not warn for iterable elements with keys', () => {
+    const iterable = {
+      '@@iterator': function() {
+        let i = 0;
+        return {
+          next: function() {
+            const done = ++i > 2;
+            return {
+              value: done ? undefined : <Component key={'#' + i} />,
+              done: done,
+            };
+          },
+        };
+      },
+    };
+
+    ReactTestUtils.renderIntoDocument(<Component>{iterable}</Component>);
+  });
+
+  it('does not warn for numeric keys in entry iterable as a child', () => {
+    const iterable = {
+      '@@iterator': function() {
+        let i = 0;
+        return {
+          next: function() {
+            const done = ++i > 2;
+            return {value: done ? undefined : [i, <Component />], done: done};
+          },
+        };
+      },
+    };
+    iterable.entries = iterable['@@iterator'];
+
+    ReactTestUtils.renderIntoDocument(<Component>{iterable}</Component>);
+  });
+
+  it('does not warn when the element is directly as children', () => {
+    ReactTestUtils.renderIntoDocument(
+      <Component>
+        <Component />
+        <Component />
+      </Component>,
+    );
+  });
+
+  it('does not warn when the child array contains non-elements', () => {
+    void (<Component>{[{}, {}]}</Component>);
+  });
+
+  it('should give context for PropType errors in nested components.', () => {
+    // In this test, we're making sure that if a proptype error is found in a
+    // component, we give a small hint as to which parent instantiated that
+    // component as per warnings about key usage in ReactElementValidator.
+    class MyComp extends React.Component {
+      render() {
+        return <div>My color is {this.color}</div>;
+      }
+    }
+    MyComp.propTypes = {
+      color: PropTypes.string,
+    };
+    class ParentComp extends React.Component {
+      render() {
+        return <MyComp color={123} />;
+      }
+    }
+    expect(() => ReactTestUtils.renderIntoDocument(<ParentComp />)).toErrorDev(
+      'Warning: Failed prop type: ' +
+        'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
+        'expected `string`.\n' +
+        '    in MyComp (at **)\n' +
+        '    in ParentComp (at **)',
+    );
+  });
+
+  it('should update component stack after receiving next element', () => {
+    function MyComp() {
+      return null;
+    }
+    MyComp.propTypes = {
+      color: PropTypes.string,
+    };
+    function MiddleComp(props) {
+      return <MyComp color={props.color} />;
+    }
+    function ParentComp(props) {
+      if (props.warn) {
+        // This element has a source thanks to JSX.
+        return <MiddleComp color={42} />;
+      }
+      // This element has no source.
+      return React.createElement(MiddleComp, {color: 'blue'});
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<ParentComp warn={false} />, container);
+    expect(() =>
+      ReactDOM.render(<ParentComp warn={true} />, container),
+    ).toErrorDev(
+      'Warning: Failed prop type: ' +
+        'Invalid prop `color` of type `number` supplied to `MyComp`, ' +
+        'expected `string`.\n' +
+        '    in MyComp (at **)\n' +
+        '    in MiddleComp (at **)\n' +
+        '    in ParentComp (at **)',
+    );
+  });
+
+  it('gives a helpful error when passing null, undefined, or boolean', () => {
+    const Undefined = undefined;
+    const Null = null;
+    const True = true;
+    const Div = 'div';
+    expect(
+      () => void (<Undefined />),
+    ).toErrorDev(
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: undefined. You likely forgot to export your ' +
+        "component from the file it's defined in, or you might have mixed up " +
+        'default and named imports.' +
+        '\n\nCheck your code at **.',
+      {withoutStack: true},
+    );
+    expect(
+      () => void (<Null />),
+    ).toErrorDev(
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: null.' +
+        '\n\nCheck your code at **.',
+      {withoutStack: true},
+    );
+    expect(
+      () => void (<True />),
+    ).toErrorDev(
+      'Warning: React.createElement: type is invalid -- expected a string ' +
+        '(for built-in components) or a class/function (for composite ' +
+        'components) but got: boolean.' +
+        '\n\nCheck your code at **.',
+      {withoutStack: true},
+    );
+    // No error expected
+    void (<Div />);
+  });
+
+  it('should check default prop values', () => {
+    RequiredPropComponent.defaultProps = {prop: null};
+
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<RequiredPropComponent />),
+    ).toErrorDev(
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+        '`RequiredPropComponent`, but its value is `null`.\n' +
+        '    in RequiredPropComponent (at **)',
+    );
+  });
+
+  it('should not check the default for explicit null', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={null} />),
+    ).toErrorDev(
+      'Warning: Failed prop type: The prop `prop` is marked as required in ' +
+        '`RequiredPropComponent`, but its value is `null`.\n' +
+        '    in RequiredPropComponent (at **)',
+    );
+  });
+
+  it('should check declared prop types', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<RequiredPropComponent />),
+    ).toErrorDev(
+      'Warning: Failed prop type: ' +
+        'The prop `prop` is marked as required in `RequiredPropComponent`, but ' +
+        'its value is `undefined`.\n' +
+        '    in RequiredPropComponent (at **)',
+    );
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop={42} />),
+    ).toErrorDev(
+      'Warning: Failed prop type: ' +
+        'Invalid prop `prop` of type `number` supplied to ' +
+        '`RequiredPropComponent`, expected `string`.\n' +
+        '    in RequiredPropComponent (at **)',
+    );
+
+    // Should not error for strings
+    ReactTestUtils.renderIntoDocument(<RequiredPropComponent prop="string" />);
+  });
+
+  it('should warn on invalid prop types', () => {
+    // Since there is no prevalidation step for ES6 classes, there is no hook
+    // for us to issue a warning earlier than element creation when the error
+    // actually occurs. Since this step is skipped in production, we should just
+    // warn instead of throwing for this case.
+    class NullPropTypeComponent extends React.Component {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    }
+    NullPropTypeComponent.propTypes = {
+      prop: null,
+    };
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<NullPropTypeComponent />),
+    ).toErrorDev(
+      'NullPropTypeComponent: prop type `prop` is invalid; it must be a ' +
+        'function, usually from the `prop-types` package,',
+    );
+  });
+
+  it('should warn on invalid context types', () => {
+    class NullContextTypeComponent extends React.Component {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    }
+    NullContextTypeComponent.contextTypes = {
+      prop: null,
+    };
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<NullContextTypeComponent />),
+    ).toErrorDev(
+      'NullContextTypeComponent: context type `prop` is invalid; it must ' +
+        'be a function, usually from the `prop-types` package,',
+    );
+  });
+
+  it('should warn if getDefaultProps is specified on the class', () => {
+    class GetDefaultPropsComponent extends React.Component {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    }
+    GetDefaultPropsComponent.getDefaultProps = () => ({
+      prop: 'foo',
+    });
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(<GetDefaultPropsComponent />),
+    ).toErrorDev(
+      'getDefaultProps is only used on classic React.createClass definitions.' +
+        ' Use a static property named `defaultProps` instead.',
+      {withoutStack: true},
+    );
+  });
+
+  it('should warn if component declares PropTypes instead of propTypes', () => {
+    class MisspelledPropTypesComponent extends React.Component {
+      render() {
+        return <span>{this.props.prop}</span>;
+      }
+    }
+    MisspelledPropTypesComponent.PropTypes = {
+      prop: PropTypes.string,
+    };
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <MisspelledPropTypesComponent prop="hi" />,
+      ),
+    ).toErrorDev(
+      'Warning: Component MisspelledPropTypesComponent declared `PropTypes` ' +
+        'instead of `propTypes`. Did you misspell the property assignment?',
+      {withoutStack: true},
+    );
+  });
+
+  it('warns for fragments with illegal attributes', () => {
+    class Foo extends React.Component {
+      render() {
+        return <React.Fragment a={1}>hello</React.Fragment>;
+      }
+    }
+
+    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev(
+      'Invalid prop `a` supplied to `React.Fragment`. React.Fragment ' +
+        'can only have `key` and `children` props.',
+    );
+  });
+
+  it('warns for fragments with refs', () => {
+    class Foo extends React.Component {
+      render() {
+        return (
+          <React.Fragment
+            ref={bar => {
+              this.foo = bar;
+            }}>
+            hello
+          </React.Fragment>
+        );
+      }
+    }
+
+    expect(() => ReactTestUtils.renderIntoDocument(<Foo />)).toErrorDev(
+      'Invalid attribute `ref` supplied to `React.Fragment`.',
+    );
+  });
+
+  it('does not warn for fragments of multiple elements without keys', () => {
+    ReactTestUtils.renderIntoDocument(
+      <>
+        <span>1</span>
+        <span>2</span>
+      </>,
+    );
+  });
+
+  it('warns for fragments of multiple elements with same key', () => {
+    expect(() =>
+      ReactTestUtils.renderIntoDocument(
+        <>
+          <span key="a">1</span>
+          <span key="a">2</span>
+          <span key="b">3</span>
+        </>,
+      ),
+    ).toErrorDev('Encountered two children with the same key, `a`.', {
+      withoutStack: true,
+    });
+  });
+});

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -99,6 +99,9 @@ export const deferPassiveEffectCleanupDuringUnmount = false;
 
 export const isTestEnvironment = false;
 
+// define React.jsx even in production builds (aliased to .jsx)
+export const jsxDEVIncluded = false;
+
 // --------------------------
 // Future APIs to be deprecated
 // --------------------------

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -53,6 +53,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = false;
+export const jsxDEVIncluded = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -48,6 +48,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = false;
+export const jsxDEVIncluded = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.persistent.js
+++ b/packages/shared/forks/ReactFeatureFlags.persistent.js
@@ -48,6 +48,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = false;
+export const jsxDEVIncluded = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -48,6 +48,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = true; // this should probably *never* change
+export const jsxDEVIncluded = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -46,6 +46,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = true; // this should probably *never* change
+export const jsxDEVIncluded = true;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -48,6 +48,7 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const disableUnstableCreatePortal = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;
 export const isTestEnvironment = true;
+export const jsxDEVIncluded = false;
 
 // Only used in www builds.
 export function addUserTimingListener() {

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -106,6 +106,8 @@ export const disableUnstableCreatePortal = false;
 
 export const isTestEnvironment = false;
 
+export const jsxDEVIncluded = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;


### PR DESCRIPTION
For FB, we need to make it so React.jsxDEV calls 'work' even with prod builds. Setting this PR up as a possible option/discussion point, while I add some more tests.

For testing, I forked `ReactJSXElementValidator-test.js` to `ReactJSXElementValidator-test.internal.js`, turned on the feature flag, and aliased `React.jsx` with `React.jsxDEV`. 

These tests will run in test-source and test-source-prod; if we change the function signature in the future, then one of these should fail. 

My understanding is this might be a bit of a stop gap while we figure out a solution for FB, so this might not be necessary in the future. 