### PR TITLE
Add component stack parser

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugTools.js
+++ b/packages/react-debug-tools/src/ReactDebugTools.js
@@ -8,5 +8,6 @@
  */
 
 import {inspectHooks, inspectHooksOfFiber} from './ReactDebugHooks';
+import {parseErrorInfo} from './ReactErrorInfoParser';
 
-export {inspectHooks, inspectHooksOfFiber};
+export {inspectHooks, inspectHooksOfFiber, parseErrorInfo};

--- a/packages/react-debug-tools/src/ReactErrorInfoParser.js
+++ b/packages/react-debug-tools/src/ReactErrorInfoParser.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const FRAME_RE = /\n {4}in (.+?)(?: \(created by (.+?)\)| \(at (.*)\:([0-9]+?)\))?$/gm;
+
+type DescribedFiber = {
+  +name: string,
+  +source: ?{+fileName: string, +lineNumber: number, ...},
+  +owner: ?{+name: string, ...},
+  ...
+};
+
+type ParsedErrorInfo = {
+  +componentStack: $ReadOnlyArray<DescribedFiber>,
+  ...
+};
+
+export function parseErrorInfo({
+  componentStack,
+}: {
+  +componentStack: string,
+  ...
+}): ParsedErrorInfo {
+  const result = {componentStack: []};
+  let match;
+  while ((match = FRAME_RE.exec(componentStack))) {
+    const [, name, ownerName, sourceFileName, sourceLineNumber] = match;
+    result.componentStack.push({
+      name,
+      owner: ownerName != null ? {name: ownerName} : null,
+      source:
+        sourceFileName != null
+          ? {
+              fileName: normalizeFileName(sourceFileName),
+              lineNumber: Number.parseInt(sourceLineNumber, 10),
+            }
+          : null,
+    });
+  }
+  return result;
+}
+
+function normalizeFileName(fileName: string): string {
+  // DevTools injects zero-width spaces to control formatting in the console.
+  return fileName.replace(/\u200B/g, '');
+}

--- a/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let parseErrorInfo;
+
+describe('Component stack trace parsing', () => {
+  beforeEach(() => {
+    React = require('react');
+    ReactDOM = require('react-dom');
+    parseErrorInfo = require('react-debug-tools').parseErrorInfo;
+  });
+
+  it('should parse filenames and line numbers', () => {
+    class Component extends React.Component {
+      render() {
+        return [<span>a</span>, <span>b</span>];
+      }
+    }
+
+    spyOnDev(console, 'error');
+    const container = document.createElement('div');
+    const fileNames = {
+      '': '',
+      '/': '',
+      '\\': '',
+      Foo: 'Foo',
+      'Bar/Foo': 'Foo',
+      'Bar\\Foo': 'Foo',
+      'Baz/Bar/Foo': 'Foo',
+      'Baz\\Bar\\Foo': 'Foo',
+
+      'Foo.js': 'Foo.js',
+      'Foo.jsx': 'Foo.jsx',
+      '/Foo.js': 'Foo.js',
+      '/Foo.jsx': 'Foo.jsx',
+      '\\Foo.js': 'Foo.js',
+      '\\Foo.jsx': 'Foo.jsx',
+      'Bar/Foo.js': 'Foo.js',
+      'Bar/Foo.jsx': 'Foo.jsx',
+      'Bar\\Foo.js': 'Foo.js',
+      'Bar\\Foo.jsx': 'Foo.jsx',
+      '/Bar/Foo.js': 'Foo.js',
+      '/Bar/Foo.jsx': 'Foo.jsx',
+      '\\Bar\\Foo.js': 'Foo.js',
+      '\\Bar\\Foo.jsx': 'Foo.jsx',
+      'Bar/Baz/Foo.js': 'Foo.js',
+      'Bar/Baz/Foo.jsx': 'Foo.jsx',
+      'Bar\\Baz\\Foo.js': 'Foo.js',
+      'Bar\\Baz\\Foo.jsx': 'Foo.jsx',
+      '/Bar/Baz/Foo.js': 'Foo.js',
+      '/Bar/Baz/Foo.jsx': 'Foo.jsx',
+      '\\Bar\\Baz\\Foo.js': 'Foo.js',
+      '\\Bar\\Baz\\Foo.jsx': 'Foo.jsx',
+      'C:\\funny long (path)/Foo.js': 'Foo.js',
+      'C:\\funny long (path)/Foo.jsx': 'Foo.jsx',
+
+      'index.js': 'index.js',
+      'index.jsx': 'index.jsx',
+      '/index.js': 'index.js',
+      '/index.jsx': 'index.jsx',
+      '\\index.js': 'index.js',
+      '\\index.jsx': 'index.jsx',
+      'Bar/index.js': 'Bar/index.js',
+      'Bar/index.jsx': 'Bar/index.jsx',
+      'Bar\\index.js': 'Bar/index.js',
+      'Bar\\index.jsx': 'Bar/index.jsx',
+      '/Bar/index.js': 'Bar/index.js',
+      '/Bar/index.jsx': 'Bar/index.jsx',
+      '\\Bar\\index.js': 'Bar/index.js',
+      '\\Bar\\index.jsx': 'Bar/index.jsx',
+      'Bar/Baz/index.js': 'Baz/index.js',
+      'Bar/Baz/index.jsx': 'Baz/index.jsx',
+      'Bar\\Baz\\index.js': 'Baz/index.js',
+      'Bar\\Baz\\index.jsx': 'Baz/index.jsx',
+      '/Bar/Baz/index.js': 'Baz/index.js',
+      '/Bar/Baz/index.jsx': 'Baz/index.jsx',
+      '\\Bar\\Baz\\index.js': 'Baz/index.js',
+      '\\Bar\\Baz\\index.jsx': 'Baz/index.jsx',
+      'C:\\funny long (path)/index.js': 'funny long (path)/index.js',
+      'C:\\funny long (path)/index.jsx': 'funny long (path)/index.jsx',
+    };
+    Object.keys(fileNames).forEach((fileName, i) => {
+      ReactDOM.render(
+        <Component __source={{fileName, lineNumber: i}} />,
+        container,
+      );
+    });
+    if (__DEV__) {
+      let i = 0;
+      expect(console.error.calls.count()).toBe(Object.keys(fileNames).length);
+      for (let fileName in fileNames) {
+        if (!fileNames.hasOwnProperty(fileName)) {
+          continue;
+        }
+        const args = console.error.calls.argsFor(i);
+        const componentStack = args[args.length - 1];
+        const parsed = parseErrorInfo({componentStack});
+        expect(parsed).toEqual({
+          componentStack: [
+            {
+              name: 'Component',
+              owner: null,
+              source: {fileName: fileNames[fileName], lineNumber: i},
+            },
+          ],
+        });
+        i++;
+      }
+    }
+  });
+
+  it('should parse owner names when source is missing', () => {
+    let parsedErrorInfo;
+    class Owner extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <Component __source={undefined} />;
+      }
+    }
+
+    class Component extends React.Component {
+      componentDidMount() {
+        throw new Error();
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<Owner __source={undefined} />, container);
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Component',
+          owner: __DEV__ ? {name: 'Owner'} : null,
+          source: null,
+        },
+        {
+          name: 'Owner',
+          owner: null,
+          source: null,
+        },
+      ],
+    });
+  });
+
+  it('should work with anonymous components', () => {
+    let parsedErrorInfo;
+
+    class ErrorBoundary extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <>{this.props.children}</>;
+      }
+    }
+
+    const AnonymousComponent = (() =>
+      function() {
+        React.useLayoutEffect(() => {
+          throw new Error();
+        }, []);
+
+        return <div />;
+      })();
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <AnonymousComponent />
+      </ErrorBoundary>,
+      container,
+    );
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Unknown',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+        {
+          name: 'ErrorBoundary',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+      ],
+    });
+  });
+
+  it('should parse source info', () => {
+    let parsedErrorInfo;
+
+    class ErrorBoundary extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <>{this.props.children}</>;
+      }
+    }
+
+    class Component extends React.Component {
+      componentDidMount() {
+        throw new Error();
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <Component />
+      </ErrorBoundary>,
+      container,
+    );
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Component',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+        {
+          name: 'ErrorBoundary',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+      ],
+    });
+  });
+});

--- a/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
@@ -98,7 +98,7 @@ describe('Component stack trace parsing', () => {
     if (__DEV__) {
       let i = 0;
       expect(console.error.calls.count()).toBe(Object.keys(fileNames).length);
-      for (let fileName in fileNames) {
+      for (const fileName in fileNames) {
         if (!fileNames.hasOwnProperty(fileName)) {
           continue;
         }

--- a/packages/react-devtools-shared/src/backend/describeComponentFrame.js
+++ b/packages/react-devtools-shared/src/backend/describeComponentFrame.js
@@ -35,7 +35,7 @@ export default function describeComponentFrame(
             // Note the below string contains a zero width space after the "/" character.
             // This is to prevent browsers like Chrome from formatting the file name as a link.
             // (Since this is a source link, it would not work to open the source file anyway.)
-            fileName = folderName + '/​' + fileName;
+            fileName = folderName + '/\u200B' + fileName;
           }
         }
       }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Adds a parser for component stack strings, acting roughly as the inverse of [`getStackByFiberInDevAndProd`](https://github.com/facebook/react/blob/dd8205cef9a3176ef29dd5904f1352561f7ef43a/packages/react-reconciler/src/ReactCurrentFiber.js#L49-L57). It's exposed only via `react-debug-tools` and there is no plan to make it an officially supported public API.

This API is intended to allow privileged consumers (React Native etc) to process the information in component stacks without [rolling their own parsers](https://github.com/facebook/react-native/blob/f3d37325cbeb25db2aae2f5aa7b37de7b8a06f82/Libraries/LogBox/Data/parseLogBoxLog.js#L126-L146) (and without requiring direct access to React's internal data structures). Additionally, this will allow React to change the format of component stacks as needed without breaking these consumers.

This specific design is informed by a previous discussion between @sebmarkbage, @gaearon, @rickhanlonii and myself. The implementation is the best I could come up with naively but I'm sure there are wrinkles to be ironed out.

## Context for this change

We want to make it possible to decode component stacks using a source map, as a sustainable alternative to adding `displayName` properties to components in minified builds. Thanks to [function maps in Metro](https://github.com/facebook/metro/commit/64fc81e676ea781234dfe20c2bfaabdb1bef6b9e) and the Hermes [`getFunctionLocation`](https://github.com/facebook/hermes/commit/7364f96f19f87ea9317ca65541a8f154e2e839ff) API, this will first be possible for React Native apps using Hermes, but can translate to other environments given the required support from build tooling and VMs.

The plan is for React to feature-detect `getFunctionLocation`, call it on each component and encode the result in the component stack string, as well as expose it in the output of this parser.

## Test Plan

Tests, Flow