### PR TITLE
[DevTools] Added resize support for Components panel.

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -43,7 +43,7 @@
   }
 
   .SelectedElementWrapper {
-    flex: 0 0 50%;
+    flex: 1 1 50%;
   }
 
   .ResizeBar {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -1,5 +1,5 @@
 .TreeWrapper {
-  flex: 0 0 65%;
+  flex: 0 0 var(--horizontal-resize-percentage);
   overflow: auto;
 }
 
@@ -24,7 +24,7 @@
 
 @media screen and (max-width: 600px) {
   .TreeWrapper {
-    flex: 0 0 50%;
+    flex: 0 0 var(--vertical-resize-percentage);
   }
 
   .SelectedElementWrapper {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -1,14 +1,3 @@
-.ComponentsWrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: row;
-  background-color: var(--color-background);
-  color: var(--color-text);
-  font-family: var(--font-family-sans);
-}
-
 .TreeWrapper {
   flex: 0 0 65%;
   overflow: auto;
@@ -34,10 +23,6 @@
 }
 
 @media screen and (max-width: 600px) {
-  .ComponentsWrapper {
-    flex-direction: column;
-  }
-
   .TreeWrapper {
     flex: 0 0 50%;
   }

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -1,4 +1,4 @@
-.Components {
+.ComponentsWrapper {
   position: relative;
   width: 100%;
   height: 100%;
@@ -15,13 +15,26 @@
 }
 
 .SelectedElementWrapper {
-  flex: 0 0 35%;
+  flex: 1 1 35%;
   overflow-x: hidden;
   overflow-y: auto;
 }
 
+.ResizeBarWrapper {
+  flex: 0 0 0px;
+  position: relative;
+}
+
+.ResizeBar {
+  position: absolute;
+  left: -2px;
+  width: 5px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
 @media screen and (max-width: 600px) {
-  .Components {
+  .ComponentsWrapper {
     flex-direction: column;
   }
 
@@ -31,6 +44,14 @@
 
   .SelectedElementWrapper {
     flex: 0 0 50%;
+  }
+
+  .ResizeBar {
+    top: -2px;
+    left: 0;
+    width: 100%;
+    height: 5px;
+    cursor: ns-resize;
   }
 }
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Suspense, Fragment, useRef, useEffect, useReducer} from 'react';
+import * as React from 'react';
+import {Suspense, Fragment, useRef, useEffect, useReducer} from 'react';
 import Tree from './Tree';
 import SelectedElement from './SelectedElement';
 import {InspectedElementContextController} from './InspectedElementContext';

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -111,73 +111,64 @@ function ComponentResizer({children}): {|children: Function|} {
       : RESIZE_DIRECTIONS.VERTICAL;
   }, [componentsWrapperRef]);
 
-  const onResizeStart = useCallback(() => {
-    setIsResizing(true);
-  }, [setIsResizing]);
+  const onResizeStart = () => setIsResizing(true);
+  const onResizeEnd = () => setIsResizing(false);
+  const onResize = e => {
+    if (
+      !isResizing ||
+      componentsWrapperRef.current === null ||
+      resizeElementRef.current === null
+    ) {
+      return;
+    }
 
-  const onResizeEnd = useCallback(() => {
-    setIsResizing(false);
-  }, [setIsResizing]);
+    e.preventDefault();
 
-  const onResize = useCallback(
-    e => {
-      if (
-        !isResizing ||
-        componentsWrapperRef.current === null ||
-        resizeElementRef.current === null
-      ) {
-        return;
-      }
-
-      e.preventDefault();
-
-      const {
-        height,
-        width,
-        left,
-        top,
-      } = componentsWrapperRef.current.getBoundingClientRect();
-      const resizeDirection = getResizeDirection();
-      const currentMousePosition: number =
+    const {
+      height,
+      width,
+      left,
+      top,
+    } = componentsWrapperRef.current.getBoundingClientRect();
+    const resizeDirection = getResizeDirection();
+    const currentMousePosition: number =
+      resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
+        ? e.clientX - left
+        : e.clientY - top;
+    const BOUNDARY_PADDING: number = 40;
+    const boundary: {|
+      min: number,
+      max: number,
+    |} = {
+      min: BOUNDARY_PADDING,
+      max:
         resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-          ? e.clientX - left
-          : e.clientY - top;
-      const BOUNDARY_PADDING: number = 40;
-      const boundary: {|
-        min: number,
-        max: number,
-      |} = {
-        min: BOUNDARY_PADDING,
-        max:
-          resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-            ? width - BOUNDARY_PADDING
-            : height - BOUNDARY_PADDING,
-      };
-      const isMousePositionInBounds: boolean =
-        currentMousePosition > boundary.min &&
-        currentMousePosition < boundary.max;
+          ? width - BOUNDARY_PADDING
+          : height - BOUNDARY_PADDING,
+    };
+    const isMousePositionInBounds: boolean =
+      currentMousePosition > boundary.min &&
+      currentMousePosition < boundary.max;
 
-      if (isMousePositionInBounds) {
-        const resizedElementDimension: number =
-          resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL ? width : height;
-        const updatedFlexBasisValue: number =
-          (currentMousePosition / resizedElementDimension) * 100;
+    if (isMousePositionInBounds) {
+      const resizedElementDimension: number =
+        resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL ? width : height;
+      const updatedFlexBasisValue: number =
+        (currentMousePosition / resizedElementDimension) * 100;
 
-        resizeElementRef.current.style.flexBasis = `${updatedFlexBasisValue}%`;
+      resizeElementRef.current.style.flexBasis = `${updatedFlexBasisValue}%`;
 
-        clearTimeout(updateLocalStorageTimeoutId.current);
+      clearTimeout(updateLocalStorageTimeoutId.current);
 
-        updateLocalStorageTimeoutId.current = setTimeout(() => {
-          if (resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL) {
-            setHorizontalPercentage(updatedFlexBasisValue);
-          } else {
-            setVerticalPercentage(updatedFlexBasisValue);
-          }
-        }, 500);
-      }
-    },
-    [componentsWrapperRef, resizeElementRef, isResizing],
-  );
+      updateLocalStorageTimeoutId.current = setTimeout(() => {
+        if (resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL) {
+          setHorizontalPercentage(updatedFlexBasisValue);
+        } else {
+          setVerticalPercentage(updatedFlexBasisValue);
+        }
+      }, 500);
+    }
+  };
 
   useLayoutEffect(() => {
     if (componentsWrapperRef.current !== null) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -7,16 +7,13 @@
  * @flow
  */
 
-import * as React from 'react';
-import {
+import React, {
   Suspense,
   Fragment,
   useRef,
   useState,
   useMemo,
   useCallback,
-  useDebugValue,
-  useEffect
 } from 'react';
 import Tree from './Tree';
 import SelectedElement from './SelectedElement';
@@ -27,46 +24,48 @@ import portaledContent from '../portaledContent';
 import {ModalDialog} from '../ModalDialog';
 import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/SettingsModal';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
-import {useLocalStorage} from "../hooks";
+import {useLocalStorage} from '../hooks';
 
 import styles from './Components.css';
 
 function Components(_: {||}) {
-  return <SettingsModalContextController>
-    <OwnersListContextController>
-      <InspectedElementContextController>
-        <ComponentResizer>
-          {({resizeElementRef, onResizeStart, resizeElementStyles}) =>
-            <Fragment>
-              <div
-                ref={resizeElementRef}
-                className={styles.TreeWrapper}
-                style={{
-                  ...resizeElementStyles
-                }}
-              >
-                <Tree/>
-              </div>
-              <div className={styles.ResizeBarWrapper}>
+  return (
+    <SettingsModalContextController>
+      <OwnersListContextController>
+        <InspectedElementContextController>
+          <ComponentResizer>
+            {({resizeElementRef, onResizeStart, resizeElementStyles}) => (
+              <Fragment>
                 <div
-                  onMouseDown={onResizeStart}
-                  className={styles.ResizeBar}
-                />
-              </div>
-              <div className={styles.SelectedElementWrapper}>
-                <NativeStyleContextController>
-                  <Suspense fallback={<Loading/>}>
-                    <SelectedElement/>
-                  </Suspense>
-                </NativeStyleContextController>
-              </div>
-              <ModalDialog/>
-              <SettingsModal/>
-            </Fragment>}
-        </ComponentResizer>
-      </InspectedElementContextController>
-    </OwnersListContextController>
-  </SettingsModalContextController>;
+                  ref={resizeElementRef}
+                  className={styles.TreeWrapper}
+                  style={{
+                    ...resizeElementStyles,
+                  }}>
+                  <Tree />
+                </div>
+                <div className={styles.ResizeBarWrapper}>
+                  <div
+                    onMouseDown={onResizeStart}
+                    className={styles.ResizeBar}
+                  />
+                </div>
+                <div className={styles.SelectedElementWrapper}>
+                  <NativeStyleContextController>
+                    <Suspense fallback={<Loading />}>
+                      <SelectedElement />
+                    </Suspense>
+                  </NativeStyleContextController>
+                </div>
+                <ModalDialog />
+                <SettingsModal />
+              </Fragment>
+            )}
+          </ComponentResizer>
+        </InspectedElementContextController>
+      </OwnersListContextController>
+    </SettingsModalContextController>
+  );
 }
 
 const resizeDirections = {
@@ -74,10 +73,12 @@ const resizeDirections = {
   VERTICAL: 'VERTICAL',
 };
 
-
-function ComponentResizer({ children }: {| children: React$Node |}) {
+function ComponentResizer({children}): {|children: Function|} {
   const [isResizing, setIsResizing] = useState(false);
-  const [horizontalPercentage, setHorizontalPercentage] = useLocalStorage<number>(
+  const [
+    horizontalPercentage,
+    setHorizontalPercentage,
+  ] = useLocalStorage<number>(
     `React::DevTools::resizedElementPercentage::${resizeDirections.HORIZONTAL}`,
     65,
   );
@@ -89,9 +90,15 @@ function ComponentResizer({ children }: {| children: React$Node |}) {
   const componentsWrapperRef = useRef(null);
   const resizeElementRef = useRef(null);
 
-  const resizeElementStyles = useMemo(() => ({
-    flexBasis: `${window.innerWidth > 600 ? horizontalPercentage : verticalPercentage}%`,
-  }), [horizontalPercentage, verticalPercentage]);
+
+  const resizeElementStyles = useMemo(
+    () => ({
+      flexBasis: `${
+        window.innerWidth > 600 ? horizontalPercentage : verticalPercentage
+      }%`,
+    }),
+    [horizontalPercentage, verticalPercentage],
+  );
 
   const onResizeStart = useCallback(() => {
     setIsResizing(true);
@@ -101,51 +108,77 @@ function ComponentResizer({ children }: {| children: React$Node |}) {
     setIsResizing(false);
   }, [setIsResizing]);
 
-  const onResize = useCallback((e) => {
-    if (!isResizing || (componentsWrapperRef.current === null || resizeElementRef.current === null)) {
-      return;
-    }
+  const onResize = useCallback(
+    e => {
+      if (
+        !isResizing ||
+        componentsWrapperRef.current === null ||
+          resizeElementRef.current === null
+      ) {
+        return;
+      }
 
-    e.preventDefault();
+      e.preventDefault();
 
-    const {height, width, left, top} = componentsWrapperRef.current.getBoundingClientRect();
-    const resizeDirection = width > 600 ? resizeDirections.HORIZONTAL : resizeDirections.VERTICAL;
-    const currentMousePosition = resizeDirection === resizeDirections.HORIZONTAL ? (e.clientX - left) : (e.clientY - top);
-    const boundary = {
-      min: 40,
-      max: (resizeDirection === resizeDirections.HORIZONTAL ? width - 40 : height - 40),
-    };
-    const mousePositionInBounds = currentMousePosition > boundary.min && currentMousePosition < boundary.max;
+      const {
+        height,
+        width,
+        left,
+        top,
+      } = componentsWrapperRef.current.getBoundingClientRect();
+      const resizeDirection =
+        width > 600 ? resizeDirections.HORIZONTAL : resizeDirections.VERTICAL;
+      const currentMousePosition =
+        resizeDirection === resizeDirections.HORIZONTAL
+          ? e.clientX - left
+          : e.clientY - top;
+      const boundary = {
+        min: 40,
+        max:
+          resizeDirection === resizeDirections.HORIZONTAL
+            ? width - 40
+            : height - 40,
+      };
+      const mousePositionInBounds =
+        currentMousePosition > boundary.min &&
+        currentMousePosition < boundary.max;
 
-    if (mousePositionInBounds) {
-      const updatedFlexBasisValue = (currentMousePosition / (resizeDirection === resizeDirections.HORIZONTAL ? width : height)) * 100;
+      if (mousePositionInBounds) {
+        const updatedFlexBasisValue =
+          (currentMousePosition /
+            (resizeDirection === resizeDirections.HORIZONTAL
+              ? width
+              : height)) *
+          100;
 
-      resizeElementRef.current.style.flexBasis = `${updatedFlexBasisValue}%`;
+        resizeElementRef.current.style.flexBasis = `${updatedFlexBasisValue}%`;
 
-      clearTimeout(updateLocalStorageTimeoutId.current);
-      updateLocalStorageTimeoutId.current = setTimeout(() => {
-        resizeDirection === resizeDirections.HORIZONTAL ? setHorizontalPercentage(updatedFlexBasisValue) : setVerticalPercentage(updatedFlexBasisValue);
-      }, 500);
-    }
-  }, [componentsWrapperRef, resizeElementRef, isResizing]);
+        clearTimeout(updateLocalStorageTimeoutId.current);
+
+        updateLocalStorageTimeoutId.current = setTimeout(() => {
+          if (resizeDirection === resizeDirections.HORIZONTAL) {
+            setHorizontalPercentage(updatedFlexBasisValue);
+          } else {
+            setVerticalPercentage(updatedFlexBasisValue);
+          }
+        }, 500);
+      }
+    },
+    [componentsWrapperRef, resizeElementRef, isResizing],
+  );
 
   return (
     <div
       ref={componentsWrapperRef}
       className={styles.ComponentsWrapper}
-      {
-        ...(
-          isResizing && {
-            onMouseMove: onResize,
-            onMouseLeave: onResizeEnd,
-            onMouseUp: onResizeEnd,
-          }
-        )
-      }
-    >
+      {...(isResizing && {
+        onMouseMove: onResize,
+        onMouseLeave: onResizeEnd,
+        onMouseUp: onResizeEnd,
+      })}>
       {children({resizeElementRef, onResizeStart, resizeElementStyles})}
     </div>
-  )
+  );
 }
 
 function Loading() {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -103,9 +103,10 @@ function ComponentResizer({children}): {|children: Function|} {
     if (componentsWrapperRef.current === null) {
       return RESIZE_DIRECTIONS.HORIZONTAL;
     }
+    const VERTICAL_MODE_MAX_WIDTH: number = 600;
     const {width} = componentsWrapperRef.current.getBoundingClientRect();
 
-    return width > 600
+    return width > VERTICAL_MODE_MAX_WIDTH
       ? RESIZE_DIRECTIONS.HORIZONTAL
       : RESIZE_DIRECTIONS.VERTICAL;
   }, [componentsWrapperRef]);
@@ -141,27 +142,26 @@ function ComponentResizer({children}): {|children: Function|} {
         resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
           ? e.clientX - left
           : e.clientY - top;
+      const BOUNDARY_PADDING: number = 40;
       const boundary: {|
         min: number,
         max: number,
       |} = {
-        min: 40,
+        min: BOUNDARY_PADDING,
         max:
           resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-            ? width - 40
-            : height - 40,
+            ? width - BOUNDARY_PADDING
+            : height - BOUNDARY_PADDING,
       };
-      const mousePositionInBounds: boolean =
+      const isMousePositionInBounds: boolean =
         currentMousePosition > boundary.min &&
         currentMousePosition < boundary.max;
 
-      if (mousePositionInBounds) {
+      if (isMousePositionInBounds) {
+        const resizedElementDimension: number =
+          resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL ? width : height;
         const updatedFlexBasisValue: number =
-          (currentMousePosition /
-            (resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-              ? width
-              : height)) *
-          100;
+          (currentMousePosition / resizedElementDimension) * 100;
 
         resizeElementRef.current.style.flexBasis = `${updatedFlexBasisValue}%`;
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -68,10 +68,17 @@ function Components(_: {||}) {
   );
 }
 
-const RESIZE_DIRECTIONS = {
+type HorizontalResizeDirection = 'HORIZONTAL';
+type VerticalResizeDirection = 'VERTICAL';
+
+const RESIZE_DIRECTIONS: {|
+  HORIZONTAL: HorizontalResizeDirection,
+  VERTICAL: VerticalResizeDirection,
+|} = {
   HORIZONTAL: 'HORIZONTAL',
   VERTICAL: 'VERTICAL',
 };
+
 const LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_HORIZONTAL_KEY = `React::DevTools::resizedElementPercentage::${RESIZE_DIRECTIONS.HORIZONTAL}`;
 const LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_VERTICAL_KEY = `React::DevTools::resizedElementPercentage::${RESIZE_DIRECTIONS.VERTICAL}`;
 
@@ -92,6 +99,16 @@ function ComponentResizer({children}): {|children: Function|} {
   const componentsWrapperRef = useRef<HTMLDivElement>(null);
   const resizeElementRef = useRef<HTMLElement>(null);
   const [resizeElementStyles, setResizeElementStyles] = useState<Object>({});
+  const getResizeDirection: Function = useCallback(() => {
+    if (componentsWrapperRef.current === null) {
+      return RESIZE_DIRECTIONS.HORIZONTAL;
+    }
+    const {width} = componentsWrapperRef.current.getBoundingClientRect();
+
+    return width > 600
+      ? RESIZE_DIRECTIONS.HORIZONTAL
+      : RESIZE_DIRECTIONS.VERTICAL;
+  }, [componentsWrapperRef]);
 
   const onResizeStart = useCallback(() => {
     setIsResizing(true);
@@ -119,8 +136,7 @@ function ComponentResizer({children}): {|children: Function|} {
         left,
         top,
       } = componentsWrapperRef.current.getBoundingClientRect();
-      const resizeDirection =
-        width > 600 ? RESIZE_DIRECTIONS.HORIZONTAL : RESIZE_DIRECTIONS.VERTICAL;
+      const resizeDirection = getResizeDirection();
       const currentMousePosition: number =
         resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
           ? e.clientX - left
@@ -165,7 +181,7 @@ function ComponentResizer({children}): {|children: Function|} {
 
   useLayoutEffect(() => {
     if (componentsWrapperRef.current !== null) {
-      if (componentsWrapperRef.current.getBoundingClientRect().width > 600) {
+      if (getResizeDirection() === RESIZE_DIRECTIONS.HORIZONTAL) {
         setResizeElementStyles({
           flexBasis: `${horizontalPercentage}%`,
         });

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -90,7 +90,9 @@ function ComponentResizer({children}): {|children: Function|} {
   const componentsWrapperRef = useRef(null);
   const resizeElementRef = useRef(null);
 
-
+  // TODO: We might be saving the localStorage values,
+  // TODO: but window.innerWidth might be bellow 600 so that why it's broken.
+  // TODO: OR we can't access the property when building the extension. :(
   const resizeElementStyles = useMemo(
     () => ({
       flexBasis: `${

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -170,7 +170,9 @@ function createResizeReducer(wrapperRef) {
 function ComponentResizer({children}): {|children: Function|} {
   const componentsWrapperRef = useRef<HTMLDivElement>(null);
   const resizeElementRef = useRef<HTMLElement>(null);
-  const [state, dispatch, ACTION_TYPES] = createResizeReducer(componentsWrapperRef);
+  const [state, dispatch, ACTION_TYPES] = createResizeReducer(
+    componentsWrapperRef,
+  );
 
   const onResizeStart = () =>
     dispatch({type: ACTION_TYPES.SET_IS_RESIZING, payload: true});

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {Suspense, Fragment } from 'react';
+import {Suspense, Fragment} from 'react';
 import Tree from './Tree';
 import SelectedElement from './SelectedElement';
 import {InspectedElementContextController} from './InspectedElementContext';
@@ -30,10 +30,7 @@ function Components(_: {||}) {
           <ComponentsResizer>
             {({resizeElementRef, onResizeStart}) => (
               <Fragment>
-                <div
-                  ref={resizeElementRef}
-                  className={styles.TreeWrapper}
-                >
+                <div ref={resizeElementRef} className={styles.TreeWrapper}>
                   <Tree />
                 </div>
                 <div className={styles.ResizeBarWrapper}>

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -8,17 +8,17 @@
  */
 
 import * as React from 'react';
-import {Suspense, Fragment, useRef, useEffect, useReducer} from 'react';
+import {Suspense, Fragment } from 'react';
 import Tree from './Tree';
 import SelectedElement from './SelectedElement';
 import {InspectedElementContextController} from './InspectedElementContext';
 import {NativeStyleContextController} from './NativeStyleEditor/context';
 import {OwnersListContextController} from './OwnersListContext';
+import ComponentsResizer from './ComponentsResizer';
 import portaledContent from '../portaledContent';
 import {ModalDialog} from '../ModalDialog';
 import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/SettingsModal';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
-import {useLocalStorage} from '../hooks';
 
 import styles from './Components.css';
 
@@ -27,15 +27,13 @@ function Components(_: {||}) {
     <SettingsModalContextController>
       <OwnersListContextController>
         <InspectedElementContextController>
-          <ComponentResizer>
-            {({resizeElementRef, onResizeStart, resizeElementStyles}) => (
+          <ComponentsResizer>
+            {({resizeElementRef, onResizeStart}) => (
               <Fragment>
                 <div
                   ref={resizeElementRef}
                   className={styles.TreeWrapper}
-                  style={{
-                    ...resizeElementStyles,
-                  }}>
+                >
                   <Tree />
                 </div>
                 <div className={styles.ResizeBarWrapper}>
@@ -55,201 +53,10 @@ function Components(_: {||}) {
                 <SettingsModal />
               </Fragment>
             )}
-          </ComponentResizer>
+          </ComponentsResizer>
         </InspectedElementContextController>
       </OwnersListContextController>
     </SettingsModalContextController>
-  );
-}
-
-type HorizontalResizeDirection = 'HORIZONTAL';
-type VerticalResizeDirection = 'VERTICAL';
-
-const RESIZE_DIRECTIONS: {|
-  HORIZONTAL: HorizontalResizeDirection,
-  VERTICAL: VerticalResizeDirection,
-|} = {
-  HORIZONTAL: 'HORIZONTAL',
-  VERTICAL: 'VERTICAL',
-};
-
-function createResizeReducer(wrapperRef) {
-  const LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_HORIZONTAL_KEY = `React::DevTools::resizedElementPercentage::${RESIZE_DIRECTIONS.HORIZONTAL}`;
-  const LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_VERTICAL_KEY = `React::DevTools::resizedElementPercentage::${RESIZE_DIRECTIONS.VERTICAL}`;
-  const [
-    horizontalPercentage,
-    setHorizontalPercentage,
-  ] = useLocalStorage<string>(
-    LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_HORIZONTAL_KEY,
-    '65%',
-  );
-  const [verticalPercentage, setVerticalPercentage] = useLocalStorage<string>(
-    LOCAL_STORAGE_RESIZE_ELEMENT_PERCENTAGE_VERTICAL_KEY,
-    '50%',
-  );
-  const resizeTimeout = useRef(null);
-
-  const getResizeDirection: Function = ref => () => {
-    if (ref.current != null) {
-      const VERTICAL_MODE_MAX_WIDTH: number = 600;
-      const {width} = ref.current.getBoundingClientRect();
-
-      return width > VERTICAL_MODE_MAX_WIDTH
-        ? RESIZE_DIRECTIONS.HORIZONTAL
-        : RESIZE_DIRECTIONS.VERTICAL;
-    }
-
-    return RESIZE_DIRECTIONS.HORIZONTAL;
-  };
-
-  // We need to watch/set for changes to this ref in order to get the correct resize direction.
-  useEffect(() => {
-    if (wrapperRef.current != null) {
-      dispatch({type: 'setWrapperRef', payload: wrapperRef});
-    }
-  }, [wrapperRef]);
-
-  const initialState = {
-    wrapperRef: wrapperRef,
-    isResizing: false,
-    horizontalPercentage,
-    verticalPercentage,
-    getResizeDirection: getResizeDirection(wrapperRef),
-  };
-
-  const ACTION_TYPES = {
-    SET_IS_RESIZING: 'setIsResizing',
-    SET_WRAPPER_REF: 'setWrapperRef',
-    SET_HORIZONTAL_PERCENTAGE: 'setHorizontalPercentage',
-    SET_VERTICAL_PERCENTAGE: 'setVerticalPercentage',
-  };
-
-  // eslint-disable-next-line no-shadow
-  const [state, dispatch] = useReducer((state, action) => {
-    switch (action.type) {
-      case ACTION_TYPES.SET_IS_RESIZING:
-        return {
-          ...state,
-          isResizing: action.payload,
-        };
-      case ACTION_TYPES.SET_WRAPPER_REF:
-        return {
-          ...state,
-          wrapperRef: action.payload,
-          getResizeDirection: getResizeDirection(action.payload),
-        };
-      case ACTION_TYPES.SET_HORIZONTAL_PERCENTAGE:
-      case ACTION_TYPES.SET_VERTICAL_PERCENTAGE:
-        const percentageState = {
-          [action.type === ACTION_TYPES.SET_HORIZONTAL_PERCENTAGE
-            ? 'horizontalPercentage'
-            : 'verticalPercentage']: action.payload,
-        };
-
-        clearTimeout(resizeTimeout.current);
-        resizeTimeout.current = setTimeout(() => {
-          if (action.type === ACTION_TYPES.SET_HORIZONTAL_PERCENTAGE) {
-            setHorizontalPercentage(action.payload);
-          } else {
-            setVerticalPercentage(action.payload);
-          }
-        }, 400);
-
-        return {
-          ...state,
-          ...percentageState,
-        };
-      default:
-        return state;
-    }
-  }, initialState);
-
-  return [state, dispatch, ACTION_TYPES];
-}
-
-function ComponentResizer({children}): {|children: Function|} {
-  const componentsWrapperRef = useRef<HTMLDivElement>(null);
-  const resizeElementRef = useRef<HTMLElement>(null);
-  const [state, dispatch, ACTION_TYPES] = createResizeReducer(
-    componentsWrapperRef,
-  );
-
-  const onResizeStart = () =>
-    dispatch({type: ACTION_TYPES.SET_IS_RESIZING, payload: true});
-  const onResizeEnd = () =>
-    dispatch({type: ACTION_TYPES.SET_IS_RESIZING, payload: false});
-  const onResize = e => {
-    if (
-      !state.isResizing ||
-      state.wrapperRef.current === null ||
-      resizeElementRef.current === null
-    ) {
-      return;
-    }
-
-    e.preventDefault();
-
-    const {
-      height,
-      width,
-      left,
-      top,
-    } = state.wrapperRef.current.getBoundingClientRect();
-    const resizeDirection = state.getResizeDirection();
-
-    const currentMousePosition: number =
-      resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-        ? e.clientX - left
-        : e.clientY - top;
-    const BOUNDARY_PADDING: number = 42;
-    const boundary: {|
-      min: number,
-      max: number,
-    |} = {
-      min: BOUNDARY_PADDING,
-      max:
-        resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-          ? width - BOUNDARY_PADDING
-          : height - BOUNDARY_PADDING,
-    };
-    const isMousePositionInBounds: boolean =
-      currentMousePosition > boundary.min &&
-      currentMousePosition < boundary.max;
-
-    if (isMousePositionInBounds) {
-      const resizedElementDimension: number =
-        resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL ? width : height;
-      const updatedFlexBasisValue: string = `${(currentMousePosition /
-        resizedElementDimension) *
-        100}%`;
-      const SET_PERCENTAGE_ACTION =
-        resizeDirection === RESIZE_DIRECTIONS.HORIZONTAL
-          ? ACTION_TYPES.SET_HORIZONTAL_PERCENTAGE
-          : ACTION_TYPES.SET_VERTICAL_PERCENTAGE;
-
-      resizeElementRef.current.style.flexBasis = updatedFlexBasisValue;
-      dispatch({type: SET_PERCENTAGE_ACTION, payload: updatedFlexBasisValue});
-    }
-  };
-
-  const resizeElementStyles = {
-    flexBasis:
-      state.getResizeDirection() === RESIZE_DIRECTIONS.HORIZONTAL
-        ? state.horizontalPercentage
-        : state.verticalPercentage,
-  };
-
-  return (
-    <div
-      ref={componentsWrapperRef}
-      className={styles.ComponentsWrapper}
-      {...(state.isResizing && {
-        onMouseMove: onResize,
-        onMouseLeave: onResizeEnd,
-        onMouseUp: onResizeEnd,
-      })}>
-      {children({resizeElementRef, onResizeStart, resizeElementStyles})}
-    </div>
   );
 }
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.css
@@ -1,0 +1,16 @@
+.ComponentsWrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-family-sans);
+}
+
+@media screen and (max-width: 600px) {
+  .ComponentsWrapper {
+    flex-direction: column;
+  }
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
@@ -1,0 +1,207 @@
+import type {ElementRef} from 'react';
+
+import * as React from 'react';
+import {useEffect, useLayoutEffect, useReducer, useRef} from 'react';
+import {
+  localStorageGetItem,
+  localStorageSetItem,
+} from 'react-devtools-shared/src/storage';
+import styles from './ComponentsResizer.css';
+
+const LOCAL_STORAGE_KEY = 'React::DevTools::createResizeReducer';
+const VERTICAL_MODE_MAX_WIDTH = 600;
+const MINIMUM_SIZE = 50;
+
+type Props = {|
+  children: ({
+    resizeElementRef: ElementRef<HTMLElement>,
+    onResizeStart: () => void,
+  }) => React$Node,
+|};
+
+export default function ComponentsResizer({children}: Props) {
+  const wrapperElementRef = useRef<HTMLDivElement>(null);
+  const resizeElementRef = useRef<HTMLElement>(null);
+  const [state, dispatch] = createResizeReducer(
+    wrapperElementRef,
+    resizeElementRef,
+  );
+
+  const {isResizing} = state;
+
+  const onResizeStart = () =>
+    dispatch({type: 'ACTION_SET_IS_RESIZING', payload: true});
+  const onResizeEnd = () =>
+    dispatch({type: 'ACTION_SET_IS_RESIZING', payload: false});
+
+  const onResize = event => {
+    const resizeElement = resizeElementRef.current;
+    const wrapperElement = wrapperElementRef.current;
+
+    if (!isResizing || wrapperElement === null || resizeElement === null) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const orientation = getOrientation(wrapperElementRef);
+
+    const {height, width, left, top} = wrapperElement.getBoundingClientRect();
+
+    const currentMousePosition =
+      orientation === 'horizontal' ? event.clientX - left : event.clientY - top;
+
+    const boundaryMin = MINIMUM_SIZE;
+    const boundaryMax =
+      orientation === 'horizontal'
+        ? width - MINIMUM_SIZE
+        : height - MINIMUM_SIZE;
+
+    const isMousePositionInBounds =
+      currentMousePosition > boundaryMin && currentMousePosition < boundaryMax;
+
+    if (isMousePositionInBounds) {
+      const resizedElementDimension =
+        orientation === 'horizontal' ? width : height;
+      const actionType =
+        orientation === 'horizontal'
+          ? 'ACTION_SET_HORIZONTAL_PERCENTAGE'
+          : 'ACTION_SET_VERTICAL_PERCENTAGE';
+
+      resizeElement.style.flexBasis = `${(currentMousePosition /
+        resizedElementDimension) *
+      100}%`;
+
+      dispatch({
+        type: actionType,
+        payload: currentMousePosition / resizedElementDimension,
+      });
+    }
+  };
+
+  return (
+    <div
+      ref={wrapperElementRef}
+      className={styles.ComponentsWrapper}
+      {...(isResizing && {
+        onMouseMove: onResize,
+        onMouseLeave: onResizeEnd,
+        onMouseUp: onResizeEnd,
+      })}>
+      {children({resizeElementRef, onResizeStart})}
+    </div>
+  );
+}
+
+type Orientation = 'horizontal' | 'vertical';
+
+type ResizeActionType =
+  | 'ACTION_SET_DID_MOUNT'
+  | 'ACTION_SET_IS_RESIZING'
+  | 'ACTION_SET_HORIZONTAL_PERCENTAGE'
+  | 'ACTION_SET_VERTICAL_PERCENTAGE';
+
+type ResizeAction = {|
+  type: ResizeActionType,
+  payload: any,
+|};
+
+type ResizeState = {|
+  horizontalPercentage: number,
+  isResizing: boolean,
+  verticalPercentage: number,
+|};
+
+function initResizeState(): ResizeState {
+  let horizontalPercentage = 0.65;
+  let verticalPercentage = 0.5;
+
+  try {
+    let data = localStorageGetItem(LOCAL_STORAGE_KEY);
+    if (data != null) {
+      data = JSON.parse(data);
+      horizontalPercentage = data.horizontalPercentage;
+      verticalPercentage = data.verticalPercentage;
+    }
+  } catch (error) {}
+
+  return {
+    horizontalPercentage,
+    isResizing: false,
+    verticalPercentage,
+  };
+}
+
+function resizeReducer(state: ResizeState, action: ResizeAction): ResizeState {
+  switch (action.type) {
+    case 'ACTION_SET_IS_RESIZING':
+      return {
+        ...state,
+        isResizing: action.payload,
+      };
+    case 'ACTION_SET_HORIZONTAL_PERCENTAGE':
+      return {
+        ...state,
+        horizontalPercentage: action.payload,
+      };
+    case 'ACTION_SET_VERTICAL_PERCENTAGE':
+      return {
+        ...state,
+        verticalPercentage: action.payload,
+      };
+    default:
+      return state;
+  }
+}
+
+function getOrientation(
+  wrapperElementRef: ElementRef<HTMLElement>,
+): null | Orientation {
+  const wrapperElement = wrapperElementRef.current;
+  if (wrapperElement != null) {
+    const {width} = wrapperElement.getBoundingClientRect();
+    return width > VERTICAL_MODE_MAX_WIDTH ? 'horizontal' : 'vertical';
+  }
+  return null;
+}
+
+function createResizeReducer(wrapperElementRef, resizeElementRef) {
+  const [state, dispatch] = useReducer<ResizeState, ResizeAction>(
+    resizeReducer,
+    null,
+    initResizeState,
+  );
+  const {horizontalPercentage, verticalPercentage} = state;
+  const orientationRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const orientation = getOrientation(wrapperElementRef);
+
+    if (orientation !== orientationRef.current) {
+      orientationRef.current = orientation;
+
+      const percentage =
+        orientation === 'horizontal'
+          ? horizontalPercentage
+          : verticalPercentage;
+      const resizeElement = resizeElementRef.current;
+      resizeElement.style.flexBasis = `${percentage * 100}%`;
+    }
+  });
+
+  useEffect(() => {
+    const timeoutID = setTimeout(() => {
+      localStorageSetItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify({
+          horizontalPercentage,
+          verticalPercentage,
+        }),
+      );
+    }, 500);
+
+    return () => clearTimeout(timeoutID);
+  }, [horizontalPercentage, verticalPercentage]);
+
+  return [state, dispatch];
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
@@ -20,8 +20,8 @@ type Props = {|
 |};
 
 export default function ComponentsResizer({children}: Props) {
-  const wrapperElementRef = useRef<HTMLDivElement>(null);
-  const resizeElementRef = useRef<HTMLElement>(null);
+  const wrapperElementRef = useRef(null);
+  const resizeElementRef = useRef(null);
   const [state, dispatch] = createResizeReducer(
     wrapperElementRef,
     resizeElementRef,
@@ -67,10 +67,12 @@ export default function ComponentsResizer({children}: Props) {
         orientation === 'horizontal'
           ? 'ACTION_SET_HORIZONTAL_PERCENTAGE'
           : 'ACTION_SET_VERTICAL_PERCENTAGE';
+      const percentage = (currentMousePosition / resizedElementDimension) * 100;
 
-      resizeElement.style.flexBasis = `${(currentMousePosition /
-        resizedElementDimension) *
-      100}%`;
+      resizeElement.style.setProperty(
+        `--${orientation}-resize-percentage`,
+        `${percentage}%`,
+      );
 
       dispatch({
         type: actionType,
@@ -166,11 +168,7 @@ function getOrientation(
 }
 
 function createResizeReducer(wrapperElementRef, resizeElementRef) {
-  const [state, dispatch] = useReducer<ResizeState, ResizeAction>(
-    resizeReducer,
-    null,
-    initResizeState,
-  );
+  const [state, dispatch] = useReducer(resizeReducer, null, initResizeState);
   const {horizontalPercentage, verticalPercentage} = state;
   const orientationRef = useRef(null);
 
@@ -185,7 +183,11 @@ function createResizeReducer(wrapperElementRef, resizeElementRef) {
           ? horizontalPercentage
           : verticalPercentage;
       const resizeElement = resizeElementRef.current;
-      resizeElement.style.flexBasis = `${percentage * 100}%`;
+
+      resizeElement.style.setProperty(
+        `--${orientation}-resize-percentage`,
+        `${percentage * 100}%`,
+      );
     }
   });
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import type {ElementRef} from 'react';
 
 import * as React from 'react';
@@ -20,8 +29,8 @@ type Props = {|
 |};
 
 export default function ComponentsResizer({children}: Props) {
-  const wrapperElementRef = useRef(null);
-  const resizeElementRef = useRef(null);
+  const wrapperElementRef = useRef<HTMLDivElement>(null);
+  const resizeElementRef = useRef<HTMLElement>(null);
   const [state, dispatch] = createResizeReducer(
     wrapperElementRef,
     resizeElementRef,
@@ -168,7 +177,7 @@ function getOrientation(
 }
 
 function createResizeReducer(wrapperElementRef, resizeElementRef) {
-  const [state, dispatch] = useReducer(resizeReducer, null, initResizeState);
+  const [state, dispatch] = useReducer<ResizeState, ResizeAction>(resizeReducer, null, initResizeState);
   const {horizontalPercentage, verticalPercentage} = state;
   const orientationRef = useRef(null);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
@@ -214,19 +214,17 @@ function createResizeReducer(wrapperElementRef, resizeElementRef) {
   }, []);
 
   useLayoutEffect(() => {
-    const orientation = getOrientation(wrapperElementRef);
-
-    if (orientation !== orientationRef.current) {
-      orientationRef.current = orientation;
-
-      const percentage =
-        orientation === 'horizontal'
-          ? horizontalPercentage
-          : verticalPercentage;
-
-      setResizeCSSVariable(resizeElementRef, orientation, percentage * 100);
-    }
-  });
+    setResizeCSSVariable(
+      resizeElementRef,
+      'horizontal',
+      horizontalPercentage * 100,
+    );
+    setResizeCSSVariable(
+      resizeElementRef,
+      'vertical',
+      verticalPercentage * 100,
+    );
+  }, []);
 
   useEffect(() => {
     const timeoutID = setTimeout(() => {

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentsResizer.js
@@ -195,7 +195,6 @@ function createResizeReducer(wrapperElementRef, resizeElementRef) {
     initResizeState,
   );
   const {horizontalPercentage, verticalPercentage} = state;
-  const orientationRef = useRef(null);
 
   // Initial set up for the resize percentage CSS variables.
   useLayoutEffect(() => {


### PR DESCRIPTION
**Summary**

Adding support for resizing the components panel.

Changes are remembered when the user refreshes.

**Solves**: #17389 

**Demo**:

Horizontal Resize:
![74515268-89e76080-4f0e-11ea-8b1b-4c2e2cf90322](https://user-images.githubusercontent.com/23095052/74603147-ca7edf80-50b0-11ea-887f-db7ada855c50.gif)

Vertical Resize:
![74515373-bac79580-4f0e-11ea-96d5-fcfa2c7ffff4](https://user-images.githubusercontent.com/23095052/74603149-d074c080-50b0-11ea-820f-63db30b4c285.gif)

**PS**:
I saw something weird happening. I'm seeing vertical scroll bars in the components / inspected component areas.
This is happening as well in `master` so I am pretty sure that these changes aren't causing the issue. (Chrome / Firefox extension)

<img width="855" alt="Screenshot 2020-02-16 at 11 16 29" src="https://user-images.githubusercontent.com/23095052/74603176-0f0a7b00-50b1-11ea-8571-8174f8daf364.png">

Can you check if it's happening for you as well @bvaughn ?
⚠️  **Update**: Now I'm not seeing the above issue. 🤷‍♂ Still it would be good if someone also checked. ⚠️ 