### PR TITLE
Add component location to component stacks under Hermes

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugTools.js
+++ b/packages/react-debug-tools/src/ReactDebugTools.js
@@ -8,5 +8,6 @@
  */
 
 import {inspectHooks, inspectHooksOfFiber} from './ReactDebugHooks';
+import {parseErrorInfo} from './ReactErrorInfoParser';
 
-export {inspectHooks, inspectHooksOfFiber};
+export {inspectHooks, inspectHooksOfFiber, parseErrorInfo};

--- a/packages/react-debug-tools/src/ReactErrorInfoParser.js
+++ b/packages/react-debug-tools/src/ReactErrorInfoParser.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const FRAME_RE = /\n {4}in (.+?)(?: \(created by (.+?)\)| \(at (.*)\:([0-9]+?)\))?$/gm;
+
+type DescribedFiber = {
+  +name: string,
+  +source: ?{+fileName: string, +lineNumber: number, ...},
+  +owner: ?{+name: string, ...},
+  ...
+};
+
+type ParsedErrorInfo = {
+  +componentStack: $ReadOnlyArray<DescribedFiber>,
+  ...
+};
+
+export function parseErrorInfo({
+  componentStack,
+}: {
+  +componentStack: string,
+  ...
+}): ParsedErrorInfo {
+  const result = {componentStack: []};
+  let match;
+  while ((match = FRAME_RE.exec(componentStack))) {
+    const [, name, ownerName, sourceFileName, sourceLineNumber] = match;
+    result.componentStack.push({
+      name,
+      owner: ownerName != null ? {name: ownerName} : null,
+      source:
+        sourceFileName != null
+          ? {
+              fileName: normalizeFileName(sourceFileName),
+              lineNumber: Number.parseInt(sourceLineNumber, 10),
+            }
+          : null,
+    });
+  }
+  return result;
+}
+
+function normalizeFileName(fileName: string): string {
+  // DevTools injects zero-width spaces to control formatting in the console.
+  return fileName.replace(/\u200B/g, '');
+}

--- a/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let parseErrorInfo;
+
+describe('Component stack trace parsing', () => {
+  beforeEach(() => {
+    React = require('react');
+    ReactDOM = require('react-dom');
+    parseErrorInfo = require('react-debug-tools').parseErrorInfo;
+  });
+
+  it('should parse filenames and line numbers', () => {
+    class Component extends React.Component {
+      render() {
+        return [<span>a</span>, <span>b</span>];
+      }
+    }
+
+    spyOnDev(console, 'error');
+    const container = document.createElement('div');
+    const fileNames = {
+      '': '',
+      '/': '',
+      '\\': '',
+      Foo: 'Foo',
+      'Bar/Foo': 'Foo',
+      'Bar\\Foo': 'Foo',
+      'Baz/Bar/Foo': 'Foo',
+      'Baz\\Bar\\Foo': 'Foo',
+
+      'Foo.js': 'Foo.js',
+      'Foo.jsx': 'Foo.jsx',
+      '/Foo.js': 'Foo.js',
+      '/Foo.jsx': 'Foo.jsx',
+      '\\Foo.js': 'Foo.js',
+      '\\Foo.jsx': 'Foo.jsx',
+      'Bar/Foo.js': 'Foo.js',
+      'Bar/Foo.jsx': 'Foo.jsx',
+      'Bar\\Foo.js': 'Foo.js',
+      'Bar\\Foo.jsx': 'Foo.jsx',
+      '/Bar/Foo.js': 'Foo.js',
+      '/Bar/Foo.jsx': 'Foo.jsx',
+      '\\Bar\\Foo.js': 'Foo.js',
+      '\\Bar\\Foo.jsx': 'Foo.jsx',
+      'Bar/Baz/Foo.js': 'Foo.js',
+      'Bar/Baz/Foo.jsx': 'Foo.jsx',
+      'Bar\\Baz\\Foo.js': 'Foo.js',
+      'Bar\\Baz\\Foo.jsx': 'Foo.jsx',
+      '/Bar/Baz/Foo.js': 'Foo.js',
+      '/Bar/Baz/Foo.jsx': 'Foo.jsx',
+      '\\Bar\\Baz\\Foo.js': 'Foo.js',
+      '\\Bar\\Baz\\Foo.jsx': 'Foo.jsx',
+      'C:\\funny long (path)/Foo.js': 'Foo.js',
+      'C:\\funny long (path)/Foo.jsx': 'Foo.jsx',
+
+      'index.js': 'index.js',
+      'index.jsx': 'index.jsx',
+      '/index.js': 'index.js',
+      '/index.jsx': 'index.jsx',
+      '\\index.js': 'index.js',
+      '\\index.jsx': 'index.jsx',
+      'Bar/index.js': 'Bar/index.js',
+      'Bar/index.jsx': 'Bar/index.jsx',
+      'Bar\\index.js': 'Bar/index.js',
+      'Bar\\index.jsx': 'Bar/index.jsx',
+      '/Bar/index.js': 'Bar/index.js',
+      '/Bar/index.jsx': 'Bar/index.jsx',
+      '\\Bar\\index.js': 'Bar/index.js',
+      '\\Bar\\index.jsx': 'Bar/index.jsx',
+      'Bar/Baz/index.js': 'Baz/index.js',
+      'Bar/Baz/index.jsx': 'Baz/index.jsx',
+      'Bar\\Baz\\index.js': 'Baz/index.js',
+      'Bar\\Baz\\index.jsx': 'Baz/index.jsx',
+      '/Bar/Baz/index.js': 'Baz/index.js',
+      '/Bar/Baz/index.jsx': 'Baz/index.jsx',
+      '\\Bar\\Baz\\index.js': 'Baz/index.js',
+      '\\Bar\\Baz\\index.jsx': 'Baz/index.jsx',
+      'C:\\funny long (path)/index.js': 'funny long (path)/index.js',
+      'C:\\funny long (path)/index.jsx': 'funny long (path)/index.jsx',
+    };
+    Object.keys(fileNames).forEach((fileName, i) => {
+      ReactDOM.render(
+        <Component __source={{fileName, lineNumber: i}} />,
+        container,
+      );
+    });
+    if (__DEV__) {
+      let i = 0;
+      expect(console.error.calls.count()).toBe(Object.keys(fileNames).length);
+      for (let fileName in fileNames) {
+        if (!fileNames.hasOwnProperty(fileName)) {
+          continue;
+        }
+        const args = console.error.calls.argsFor(i);
+        const componentStack = args[args.length - 1];
+        const parsed = parseErrorInfo({componentStack});
+        expect(parsed).toEqual({
+          componentStack: [
+            {
+              name: 'Component',
+              owner: null,
+              source: {fileName: fileNames[fileName], lineNumber: i},
+            },
+          ],
+        });
+        i++;
+      }
+    }
+  });
+
+  it('should parse owner names when source is missing', () => {
+    let parsedErrorInfo;
+    class Owner extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <Component __source={undefined} />;
+      }
+    }
+
+    class Component extends React.Component {
+      componentDidMount() {
+        throw new Error();
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<Owner __source={undefined} />, container);
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Component',
+          owner: __DEV__ ? {name: 'Owner'} : null,
+          source: null,
+        },
+        {
+          name: 'Owner',
+          owner: null,
+          source: null,
+        },
+      ],
+    });
+  });
+
+  it('should work with anonymous components', () => {
+    let parsedErrorInfo;
+
+    class ErrorBoundary extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <>{this.props.children}</>;
+      }
+    }
+
+    const AnonymousComponent = (() =>
+      function() {
+        React.useLayoutEffect(() => {
+          throw new Error();
+        }, []);
+
+        return <div />;
+      })();
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <AnonymousComponent />
+      </ErrorBoundary>,
+      container,
+    );
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Unknown',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+        {
+          name: 'ErrorBoundary',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+      ],
+    });
+  });
+
+  it('should parse source info', () => {
+    let parsedErrorInfo;
+
+    class ErrorBoundary extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        parsedErrorInfo = parseErrorInfo(errorInfo);
+      }
+
+      render() {
+        return <>{this.props.children}</>;
+      }
+    }
+
+    class Component extends React.Component {
+      componentDidMount() {
+        throw new Error();
+      }
+
+      render() {
+        return <div />;
+      }
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <ErrorBoundary>
+        <Component />
+      </ErrorBoundary>,
+      container,
+    );
+
+    expect(parsedErrorInfo).toEqual({
+      componentStack: [
+        {
+          name: 'Component',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+        {
+          name: 'ErrorBoundary',
+          owner: null,
+          source: __DEV__
+            ? {
+                fileName: 'ReactErrorInfoParser-test.js',
+                lineNumber: expect.any(Number),
+              }
+            : null,
+        },
+      ],
+    });
+  });
+});

--- a/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactErrorInfoParser-test.js
@@ -98,7 +98,7 @@ describe('Component stack trace parsing', () => {
     if (__DEV__) {
       let i = 0;
       expect(console.error.calls.count()).toBe(Object.keys(fileNames).length);
-      for (let fileName in fileNames) {
+      for (const fileName in fileNames) {
         if (!fileNames.hasOwnProperty(fileName)) {
           continue;
         }

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -376,6 +376,7 @@ describe('console', () => {
             lineNumber: 42,
           },
           owner: null,
+          location: null,
         },
         {
           name: 'Parent',
@@ -384,8 +385,75 @@ describe('console', () => {
             lineNumber: expect.any(Number),
           },
           owner: null,
+          location: null,
         },
       ],
+    });
+  });
+
+  describe('Hermes-specific behavior', () => {
+    let origHermesInternal;
+    const FAKE_FUNCTION_LOCATION = Object.freeze({
+      fileName: 'foo',
+      lineNumber: 42,
+      columnNumber: 1,
+      isNative: false,
+    });
+    beforeEach(() => {
+      origHermesInternal = global.HermesInternal;
+      global.HermesInternal = {
+        getFunctionLocation: () => FAKE_FUNCTION_LOCATION,
+      };
+    });
+    afterEach(() => {
+      global.HermesInternal = origHermesInternal;
+    });
+
+    it('should include component location alongside element source', () => {
+      const Intermediate = ({children}) => children;
+      const Parent = () => (
+        <Intermediate>
+          <Child
+            __source={{fileName: 'path/to/child/index.js', lineNumber: 42}}
+          />
+        </Intermediate>
+      );
+      const Child = () => {
+        fakeConsole.error('error');
+        return null;
+      };
+
+      act(() => ReactDOM.render(<Parent />, document.createElement('div')));
+
+      expect(mockError).toHaveBeenCalledTimes(1);
+      expect(mockError.mock.calls[0]).toHaveLength(2);
+      expect(mockError.mock.calls[0][0]).toBe('error');
+      expect(
+        parseErrorInfo({
+          componentStack: mockError.mock.calls[0][1],
+        }),
+      ).toEqual({
+        componentStack: [
+          {
+            name: 'Child',
+            source: {
+              fileName: 'child/index.js',
+              lineNumber: 42,
+            },
+            owner: null,
+            location: {hermes: FAKE_FUNCTION_LOCATION},
+          },
+          {
+            name: 'Parent',
+            source: {
+              fileName: 'console-test.js',
+              lineNumber: expect.any(Number),
+            },
+            owner: null,
+            location: {hermes: FAKE_FUNCTION_LOCATION},
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -117,6 +117,7 @@ export function patch(): void {
                   name,
                   current._debugSource,
                   ownerName,
+                  current.type,
                 );
 
                 current = owner;

--- a/packages/react-devtools-shared/src/backend/describeComponentFrame.js
+++ b/packages/react-devtools-shared/src/backend/describeComponentFrame.js
@@ -35,7 +35,7 @@ export default function describeComponentFrame(
             // Note the below string contains a zero width space after the "/" character.
             // This is to prevent browsers like Chrome from formatting the file name as a link.
             // (Since this is a source link, it would not work to open the source file anyway.)
-            fileName = folderName + '/​' + fileName;
+            fileName = folderName + '/\u200B' + fileName;
           }
         }
       }

--- a/packages/react-devtools-shared/src/backend/describeComponentFrame.js
+++ b/packages/react-devtools-shared/src/backend/describeComponentFrame.js
@@ -12,12 +12,16 @@
 //
 // It has been modified slightly to add a zero width space as commented below.
 
+// FIXME: This import doesn't work.
+import getComponentLocation from 'shared/getComponentLocation';
+
 const BEFORE_SLASH_RE = /^(.*)[\\/]/;
 
 export default function describeComponentFrame(
   name: null | string,
   source: any,
   ownerName: null | string,
+  type: Function,
 ) {
   let sourceInfo = '';
   if (source) {
@@ -44,5 +48,10 @@ export default function describeComponentFrame(
   } else if (ownerName) {
     sourceInfo = ' (created by ' + ownerName + ')';
   }
-  return '\n    in ' + (name || 'Unknown') + sourceInfo;
+  let extraData = '';
+  const componentLocation = getComponentLocation(type);
+  if (componentLocation) {
+    extraData = ' ' + JSON.stringify({location: componentLocation});
+  }
+  return '\n    in ' + (name || 'Unknown') + extraData + sourceInfo;
 }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -116,7 +116,7 @@ if (__DEV__) {
     const type = element.type;
     const name = getComponentName(type);
     const ownerName = null;
-    return describeComponentFrame(name, source, ownerName);
+    return describeComponentFrame(name, source, ownerName, type);
   };
 
   pushCurrentDebugStack = function(stack: Array<Frame>) {

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -40,7 +40,7 @@ function describeFiber(fiber: Fiber): string {
       if (owner) {
         ownerName = getComponentName(owner.type);
       }
-      return describeComponentFrame(name, source, ownerName);
+      return describeComponentFrame(name, source, ownerName, fiber.type);
   }
 }
 

--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -44,6 +44,7 @@ if (__DEV__) {
         name,
         currentlyValidatingElement._source,
         owner && getComponentName(owner.type),
+        currentlyValidatingElement.type,
       );
     }
 

--- a/packages/shared/describeComponentFrame.js
+++ b/packages/shared/describeComponentFrame.js
@@ -7,12 +7,15 @@
  * @flow
  */
 
+import getComponentLocation from 'shared/getComponentLocation';
+
 const BEFORE_SLASH_RE = /^(.*)[\\\/]/;
 
-export default function(
+export default function describeComponentFrame(
   name: null | string,
   source: any,
   ownerName: null | string,
+  type: Function,
 ) {
   let sourceInfo = '';
   if (source) {
@@ -36,5 +39,10 @@ export default function(
   } else if (ownerName) {
     sourceInfo = ' (created by ' + ownerName + ')';
   }
-  return '\n    in ' + (name || 'Unknown') + sourceInfo;
+  let extraData = '';
+  const componentLocation = getComponentLocation(type);
+  if (componentLocation) {
+    extraData = ' ' + JSON.stringify({location: componentLocation});
+  }
+  return '\n    in ' + (name || 'Unknown') + extraData + sourceInfo;
 }

--- a/packages/shared/getComponentLocation.js
+++ b/packages/shared/getComponentLocation.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {LazyComponent} from 'react/src/ReactLazy';
+
+import {
+  REACT_CONTEXT_TYPE,
+  REACT_FORWARD_REF_TYPE,
+  REACT_FRAGMENT_TYPE,
+  REACT_PORTAL_TYPE,
+  REACT_MEMO_TYPE,
+  REACT_PROFILER_TYPE,
+  REACT_PROVIDER_TYPE,
+  REACT_STRICT_MODE_TYPE,
+  REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
+  REACT_LAZY_TYPE,
+  REACT_BLOCK_TYPE,
+} from 'shared/ReactSymbols';
+
+type HermesSourceLocation = {
+  +fileName: ?string,
+  +lineNumber?: ?number,
+  +columnNumber?: ?number,
+  +cjsModuleOffset?: ?number,
+  +virtualOffset?: ?number,
+  +isNative: ?boolean,
+  ...
+};
+
+export type RuntimeSourceLocation = {
+  +hermes?: HermesSourceLocation,
+};
+
+function getFunctionLocation(type: Function): RuntimeSourceLocation | null {
+  if (
+    typeof global.HermesInternal === 'object' &&
+    global.HermesInternal &&
+    typeof global.HermesInternal.getFunctionLocation === 'function'
+  ) {
+    return {hermes: global.HermesInternal.getFunctionLocation(type)};
+  }
+  return null;
+}
+
+function getComponentLocation(type: mixed): RuntimeSourceLocation | null {
+  if (type == null) {
+    // Host root, text node or just invalid type.
+    return null;
+  }
+  if (__DEV__) {
+    if (typeof (type: any).tag === 'number') {
+      console.error(
+        'Received an unexpected object in getComponentLocation(). ' +
+          'This is likely a bug in React. Please file an issue.',
+      );
+    }
+  }
+  if (typeof type === 'function') {
+    // TODO: User-defined HOCs?
+    return getFunctionLocation((type: any));
+  }
+  if (typeof type === 'string') {
+    return null;
+  }
+  switch (type) {
+    case REACT_FRAGMENT_TYPE:
+      return null;
+    case REACT_PORTAL_TYPE:
+      return null;
+    case REACT_PROFILER_TYPE:
+      return null;
+    case REACT_STRICT_MODE_TYPE:
+      return null;
+    case REACT_SUSPENSE_TYPE:
+      return null;
+    case REACT_SUSPENSE_LIST_TYPE:
+      return null;
+  }
+  if (typeof type === 'object') {
+    switch (type.$$typeof) {
+      case REACT_CONTEXT_TYPE:
+        return null;
+      case REACT_PROVIDER_TYPE:
+        return null;
+      case REACT_FORWARD_REF_TYPE:
+        return getComponentLocation(type.render);
+      case REACT_MEMO_TYPE:
+        return getComponentLocation(type.type);
+      case REACT_BLOCK_TYPE:
+        return getComponentLocation(type._render);
+      case REACT_LAZY_TYPE: {
+        const lazyComponent: LazyComponent<any, any> = (type: any);
+        const payload = lazyComponent._payload;
+        const init = lazyComponent._init;
+        try {
+          return getComponentLocation(init(payload));
+        } catch (x) {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export default getComponentLocation;

--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -43,6 +43,9 @@ packages.forEach(name => {
   ] = `<rootDir>/build/node_modules/${name}/$1`;
 });
 
+// Shared isn't a built package; it's a special case.
+moduleNameMapper['^shared/([^/]+)$'] = '<rootDir>/packages/shared/$1';
+
 module.exports = Object.assign({}, baseConfig, {
   // Redirect imports to the compiled bundles
   moduleNameMapper,


### PR DESCRIPTION
NOTE: This is based on https://github.com/facebook/react/pull/18043 ([compare](https://github.com/motiz88/react/compare/error-info-parser...motiz88:error-info-with-source-location)).

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Prints the source location of each component in component stack traces. This is the location where the component is _defined_ (as opposed to _used_). It's obtained from a Hermes-specific API since there is no standard JS API to retrieve the location of an arbitrary function. With this, apps targeting Hermes will log component stacks that can be decoded using a source map.

## ~TODO~ Discussion topics

- [ ] Agree on serialisation format; currently it's an optional JSON object embedded in each individual stack trace line.
- [ ] Normalise terminology and update parameter/property names etc: `source` (element source location) vs `location` (component source location) is confusing.
- [x] Update as needed to match changes in https://github.com/facebook/react/pull/18043 (e.g. import the parser from `react-debug-tools` rather than from `ReactSharedInternals`).
- [ ] Decide whether we need to implement special support for drilling through user-defined HOCs (_probably_ not).
- [x] Complete the implementation in DevTools console wrapper.

## Test Plan

Added tests