### PR TITLE
[react-interactions] Ensure onBeforeBlur fires for hideInstance

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -598,7 +598,7 @@ function instanceContainsElem(instance: Instance, element: HTMLElement) {
 
 export function hideInstance(instance: Instance): void {
   // Ensure we trigger `onBeforeBlur` if the active focused elment
-  // is ether the instance of a child of the instance. We need
+  // is ether the instance of a child or the instance. We need
   // to traverse the Fiber tree here rather than use node.contains()
   // as the child node might be inside a Portal.
   if (enableDeprecatedFlareAPI && selectionInformation) {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -58,6 +58,17 @@ import {
 } from '../events/DeprecatedDOMEventResponderSystem';
 import {retryIfBlockedOn} from '../events/ReactDOMEventReplaying';
 
+import {
+  enableSuspenseServerRenderer,
+  enableDeprecatedFlareAPI,
+  enableFundamentalAPI,
+} from 'shared/ReactFeatureFlags';
+import {HostComponent} from 'shared/ReactWorkTags';
+import {
+  RESPONDER_EVENT_SYSTEM,
+  IS_PASSIVE,
+} from 'legacy-events/EventSystemFlags';
+
 export type Type = string;
 export type Props = {
   autoFocus?: boolean,
@@ -111,16 +122,6 @@ type SelectionInformation = {|
   focusedElem: null | HTMLElement,
   selectionRange: mixed,
 |};
-
-import {
-  enableSuspenseServerRenderer,
-  enableDeprecatedFlareAPI,
-  enableFundamentalAPI,
-} from 'shared/ReactFeatureFlags';
-import {
-  RESPONDER_EVENT_SYSTEM,
-  IS_PASSIVE,
-} from 'legacy-events/EventSystemFlags';
 
 let SUPPRESS_HYDRATION_WARNING;
 if (__DEV__) {
@@ -584,7 +585,28 @@ export function clearSuspenseBoundaryFromContainer(
   retryIfBlockedOn(container);
 }
 
+function instanceContainsElem(instance: Instance, element: HTMLElement) {
+  let fiber = getClosestInstanceFromNode(element);
+  while (fiber !== null) {
+    if (fiber.tag === HostComponent && fiber.stateNode === element) {
+      return true;
+    }
+    fiber = fiber.return;
+  }
+  return false;
+}
+
 export function hideInstance(instance: Instance): void {
+  // Ensure we trigger `onBeforeBlur` if the active focused elment
+  // is ether the instance of a child of the instance. We need
+  // to traverse the Fiber tree here rather than use node.contains()
+  // as the child node might be inside a Portal.
+  if (enableDeprecatedFlareAPI && selectionInformation) {
+    const focusedElem = selectionInformation.focusedElem;
+    if (focusedElem !== null && instanceContainsElem(instance, focusedElem)) {
+      dispatchBeforeDetachedBlur(((focusedElem: any): HTMLElement));
+    }
+  }
   // TODO: Does this work for all element types? What about MathML? Should we
   // pass host context to this method?
   instance = ((instance: any): HTMLElement);


### PR DESCRIPTION
As part of the React Flare system, we have the notion of a React specific event called `onBeforeBlur`. This is meant to triggered just before a managed node of React gets removed or hidden from the UI. We already support the case where this fires before we removed the node, but we didn't have a codepath or support for when this can occur during Suspense. During Suspense, we `display: none` the content when showing the fallback, which means that the React Flare focus systems fail to know of the fact that `blur` is about to be triggered, which is required to properly handle focus management logic. This PR adds that code path in, so `onBeforeBlur` correctly fires during Suspense too.

On a separate node, we should move this logic and other existing `onBeforeBlur` logic out of the Flare flag sometime and make it its own core feature at some point.