### PR TITLE
Add container to event listener signature

### DIFF
--- a/packages/legacy-events/ReactGenericBatching.js
+++ b/packages/legacy-events/ReactGenericBatching.js
@@ -23,8 +23,8 @@ import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 let batchedUpdatesImpl = function(fn, bookkeeping) {
   return fn(bookkeeping);
 };
-let discreteUpdatesImpl = function(fn, a, b, c) {
-  return fn(a, b, c);
+let discreteUpdatesImpl = function(fn, a, b, c, d) {
+  return fn(a, b, c, d);
 };
 let flushDiscreteUpdatesImpl = function() {};
 let batchedEventUpdatesImpl = batchedUpdatesImpl;
@@ -89,11 +89,11 @@ export function executeUserEventHandler(fn: any => void, value: any): void {
   }
 }
 
-export function discreteUpdates(fn, a, b, c) {
+export function discreteUpdates(fn, a, b, c, d) {
   const prevIsInsideEventHandler = isInsideEventHandler;
   isInsideEventHandler = true;
   try {
-    return discreteUpdatesImpl(fn, a, b, c);
+    return discreteUpdatesImpl(fn, a, b, c, d);
   } finally {
     isInsideEventHandler = prevIsInsideEventHandler;
     if (!isInsideEventHandler) {

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -124,6 +124,7 @@ type QueuedReplayableEvent = {|
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
+  container: Document | Element | Node,
 |};
 
 let hasScheduledReplayAttempt = false;
@@ -252,12 +253,14 @@ function createQueuedReplayableEvent(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
+  container: Document | Element | Node,
 ): QueuedReplayableEvent {
   return {
     blockedOn,
     topLevelType,
     eventSystemFlags: eventSystemFlags | IS_REPLAYED,
     nativeEvent,
+    container,
   };
 }
 
@@ -266,12 +269,14 @@ export function queueDiscreteEvent(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
+  container: Document | Element | Node,
 ): void {
   const queuedEvent = createQueuedReplayableEvent(
     blockedOn,
     topLevelType,
     eventSystemFlags,
     nativeEvent,
+    container,
   );
   queuedDiscreteEvents.push(queuedEvent);
   if (enableSelectiveHydration) {
@@ -339,6 +344,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
+  container: Document | Element | Node,
 ): QueuedReplayableEvent {
   if (
     existingQueuedEvent === null ||
@@ -349,6 +355,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
       topLevelType,
       eventSystemFlags,
       nativeEvent,
+      container,
     );
     if (blockedOn !== null) {
       let fiber = getInstanceFromNode(blockedOn);
@@ -372,6 +379,7 @@ export function queueIfContinuousEvent(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
+  container: Document | Element | Node,
 ): boolean {
   // These set relatedTarget to null because the replayed event will be treated as if we
   // moved from outside the window (no target) onto the target once it hydrates.
@@ -385,6 +393,7 @@ export function queueIfContinuousEvent(
         topLevelType,
         eventSystemFlags,
         focusEvent,
+        container,
       );
       return true;
     }
@@ -396,6 +405,7 @@ export function queueIfContinuousEvent(
         topLevelType,
         eventSystemFlags,
         dragEvent,
+        container,
       );
       return true;
     }
@@ -407,6 +417,7 @@ export function queueIfContinuousEvent(
         topLevelType,
         eventSystemFlags,
         mouseEvent,
+        container,
       );
       return true;
     }
@@ -421,6 +432,7 @@ export function queueIfContinuousEvent(
           topLevelType,
           eventSystemFlags,
           pointerEvent,
+          container,
         ),
       );
       return true;
@@ -436,6 +448,7 @@ export function queueIfContinuousEvent(
           topLevelType,
           eventSystemFlags,
           pointerEvent,
+          container,
         ),
       );
       return true;
@@ -512,6 +525,7 @@ function attemptReplayContinuousQueuedEvent(
     queuedEvent.topLevelType,
     queuedEvent.eventSystemFlags,
     queuedEvent.nativeEvent,
+    queuedEvent.container,
   );
   if (nextBlockedOn !== null) {
     // We're still blocked. Try again later.
@@ -554,6 +568,7 @@ function replayUnblockedEvents() {
       nextDiscreteEvent.topLevelType,
       nextDiscreteEvent.eventSystemFlags,
       nextDiscreteEvent.nativeEvent,
+      nextDiscreteEvent.container,
     );
     if (nextBlockedOn !== null) {
       // We're still blocked. Try again later.

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -62,7 +62,7 @@ let hasWarnedAboutDeprecatedMockComponent = false;
  */
 function simulateNativeEventOnNode(topLevelType, node, fakeNativeEvent) {
   fakeNativeEvent.target = node;
-  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, fakeNativeEvent);
+  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, document, fakeNativeEvent);
 }
 
 /**

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1160,17 +1160,18 @@ export function batchedEventUpdates<A, R>(fn: A => R, a: A): R {
   }
 }
 
-export function discreteUpdates<A, B, C, R>(
+export function discreteUpdates<A, B, C, D, R>(
   fn: (A, B, C) => R,
   a: A,
   b: B,
   c: C,
+  d: D,
 ): R {
   const prevExecutionContext = executionContext;
   executionContext |= DiscreteEventContext;
   try {
     // Should this
-    return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c));
+    return runWithPriority(UserBlockingPriority, fn.bind(null, a, b, c, d));
   } finally {
     executionContext = prevExecutionContext;
     if (executionContext === NoContext) {


### PR DESCRIPTION
Note: This PR is a pre-requisite for the modern root event system.

For the new event system that uses root containers to register nodes. For this to work, we need a sane way of knowing what the container is, so we can properly find ancestors.

We could use `nativeEvent.currentTarget` but that seems fragile, as the `currentTarget` can change when the event bubbles, or might not be there if we bypass native events entirely (if we ever decided to add `onBeforeBlur` to the plugin event system).

Instead, we can bind the `container` to the dispatch function, as we do with other arguments. This then allows us to know the container correctly in all cases. Furthermore, we pass this to the event replaying logic so it can properly replay the event with the correct `container`.