### PR TITLE
add no-restricted-globals to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,8 @@ const {
   esNextPaths,
 } = require('./scripts/shared/pathsByLanguageVersion');
 
+const restrictedGlobals = require('confusing-browser-globals');
+
 const OFF = 0;
 const ERROR = 2;
 
@@ -45,6 +47,7 @@ module.exports = {
     'no-bitwise': OFF,
     'no-inner-declarations': [ERROR, 'functions'],
     'no-multi-spaces': ERROR,
+    'no-restricted-globals': [ERROR].concat(restrictedGlobals),
     'no-restricted-syntax': [ERROR, 'WithStatement'],
     'no-shadow': ERROR,
     'no-unused-expressions': ERROR,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chalk": "^3.0.0",
     "cli-table": "^0.3.1",
     "coffee-script": "^1.12.7",
+    "confusing-browser-globals": "^1.0.9",
     "core-js": "^3.6.4",
     "coveralls": "^3.0.9",
     "create-react-class": "^15.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3871,6 +3871,11 @@ configstore@^4.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
+confusing-browser-globals@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
+  integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
+
 connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"


### PR DESCRIPTION
Our current lint config assumes a browser environment, which means it won't warn you if you use a variable like `name` without declaring it earlier. This PR imports the same one used by create-react-app, and enables it against our codebase.
