### PR TITLE
Add guard around FocusWithin responder root events

### DIFF
--- a/packages/react-interactions/events/src/dom/Focus.js
+++ b/packages/react-interactions/events/src/dom/Focus.js
@@ -36,7 +36,7 @@ type FocusState = {
   isFocused: boolean,
   isFocusVisible: boolean,
   pointerType: PointerType,
-  ...
+  addedRootEvents?: boolean,
 };
 
 type FocusProps = {
@@ -416,6 +416,7 @@ const focusResponderImpl = {
       isFocused: false,
       isFocusVisible: false,
       pointerType: '',
+      addedRootEvents: false,
     };
   },
   onMount() {
@@ -622,7 +623,10 @@ const focusWithinResponderImpl = {
             onBeforeBlurWithin,
             DiscreteEvent,
           );
-          context.addRootEventTypes(rootEventTypes);
+          if (!state.addedRootEvents) {
+            state.addedRootEvents = true;
+            context.addRootEventTypes(rootEventTypes);
+          }
         } else {
           // We want to propagate to next focusWithin responder
           // if this responder doesn't handle beforeblur
@@ -660,7 +664,10 @@ const focusWithinResponderImpl = {
       if (detachedTarget !== null && detachedTarget === event.target) {
         dispatchBlurWithinEvents(context, event, props, state);
         state.detachedTarget = null;
-        context.removeRootEventTypes(rootEventTypes);
+        if (state.addedRootEvents) {
+          state.addedRootEvents = false;
+          context.removeRootEventTypes(rootEventTypes);
+        }
       }
     }
   },


### PR DESCRIPTION
We've run into an interesting problem internally that is likely due to a strange set of events from the recent `onBeforeBlur` change, causing `addRootEventTypes` to try and add the same event before removing it. This change should guard the change to prevent the invariant from occuring in these cases.

I'll try and make a repro test tomorrow and see if there's an alternative way to fix this.