### PR TITLE
Further pre-requisite changes to plugin event system

### DIFF
--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -29,7 +29,7 @@ export type PluginModule<NativeEvent> = {
     nativeTarget: NativeEvent,
     nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
+    container?: Document | Element | Node,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
-  ...
 };

--- a/packages/legacy-events/ReactSyntheticEventType.js
+++ b/packages/legacy-events/ReactSyntheticEventType.js
@@ -31,4 +31,4 @@ export type ReactSyntheticEvent = {|
     nativeEventTarget: EventTarget,
   ) => ReactSyntheticEvent,
   isPersistent: () => boolean,
-|} & SyntheticEvent<>;
+|};

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -123,7 +123,7 @@ function createRootImpl(
       container.nodeType === DOCUMENT_NODE
         ? container
         : container.ownerDocument;
-    eagerlyTrapReplayableEvents(doc);
+    eagerlyTrapReplayableEvents(container, doc);
   }
   return root;
 }

--- a/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
+++ b/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
@@ -264,7 +264,7 @@ function handleTopLevel(bookKeeping: BookKeepingInstance) {
   }
 }
 
-export function dispatchEventForPluginEventSystem(
+export function dispatchEventForLegacyPluginEventSystem(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
@@ -311,16 +311,16 @@ export function legacyListenToEvent(
   registrationName: string,
   mountAt: Document | Element | Node,
 ): void {
-  const listeningSet = getListenerMapForElement(mountAt);
+  const listenerMap = getListenerMapForElement(mountAt);
   const dependencies = registrationNameDependencies[registrationName];
 
   for (let i = 0; i < dependencies.length; i++) {
     const dependency = dependencies[i];
-    listenToTopLevelEvent(dependency, mountAt, listeningSet);
+    legacyListenToTopLevelEvent(dependency, mountAt, listenerMap);
   }
 }
 
-export function listenToTopLevelEvent(
+export function legacyListenToTopLevelEvent(
   topLevelType: DOMTopLevelEventType,
   mountAt: Document | Element | Node,
   listenerMap: Map<DOMTopLevelEventType | string, null | (any => void)>,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -60,7 +60,7 @@ import {
   DiscreteEvent,
 } from 'shared/ReactTypes';
 import {getEventPriorityForPluginSystem} from './DOMEventProperties';
-import {dispatchEventForPluginEventSystem} from './DOMLegacyEventPluginSystem';
+import {dispatchEventForLegacyPluginEventSystem} from './DOMLegacyEventPluginSystem';
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,
@@ -242,8 +242,8 @@ export function dispatchEvent(
       null, // Flags that we're not actually blocked on anything as far as we know.
       topLevelType,
       eventSystemFlags,
-      nativeEvent,
       container,
+      nativeEvent,
     );
     return;
   }
@@ -251,8 +251,8 @@ export function dispatchEvent(
   const blockedOn = attemptToDispatchEvent(
     topLevelType,
     eventSystemFlags,
-    nativeEvent,
     container,
+    nativeEvent,
   );
 
   if (blockedOn === null) {
@@ -267,8 +267,8 @@ export function dispatchEvent(
       blockedOn,
       topLevelType,
       eventSystemFlags,
-      nativeEvent,
       container,
+      nativeEvent,
     );
     return;
   }
@@ -278,8 +278,8 @@ export function dispatchEvent(
       blockedOn,
       topLevelType,
       eventSystemFlags,
-      nativeEvent,
       container,
+      nativeEvent,
     )
   ) {
     return;
@@ -293,7 +293,7 @@ export function dispatchEvent(
   // in case the event system needs to trace it.
   if (enableDeprecatedFlareAPI) {
     if (eventSystemFlags & PLUGIN_EVENT_SYSTEM) {
-      dispatchEventForPluginEventSystem(
+      dispatchEventForLegacyPluginEventSystem(
         topLevelType,
         eventSystemFlags,
         nativeEvent,
@@ -311,7 +311,7 @@ export function dispatchEvent(
       );
     }
   } else {
-    dispatchEventForPluginEventSystem(
+    dispatchEventForLegacyPluginEventSystem(
       topLevelType,
       eventSystemFlags,
       nativeEvent,
@@ -324,8 +324,8 @@ export function dispatchEvent(
 export function attemptToDispatchEvent(
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  nativeEvent: AnyNativeEvent,
   container: Document | Element | Node,
+  nativeEvent: AnyNativeEvent,
 ): null | Container | SuspenseInstance {
   // TODO: Warn if _enabled is false.
 
@@ -372,7 +372,7 @@ export function attemptToDispatchEvent(
 
   if (enableDeprecatedFlareAPI) {
     if (eventSystemFlags & PLUGIN_EVENT_SYSTEM) {
-      dispatchEventForPluginEventSystem(
+      dispatchEventForLegacyPluginEventSystem(
         topLevelType,
         eventSystemFlags,
         nativeEvent,
@@ -390,7 +390,7 @@ export function attemptToDispatchEvent(
       );
     }
   } else {
-    dispatchEventForPluginEventSystem(
+    dispatchEventForLegacyPluginEventSystem(
       topLevelType,
       eventSystemFlags,
       nativeEvent,

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -166,11 +166,16 @@ const SelectEventPlugin = {
     nativeEvent,
     nativeEventTarget,
     eventSystemFlags,
+    container,
   ) {
-    const doc = getEventTargetDocument(nativeEventTarget);
+    const containerOrDoc =
+      container || getEventTargetDocument(nativeEventTarget);
     // Track whether all listeners exists for this plugin. If none exist, we do
     // not extract events. See #3639.
-    if (!doc || !isListeningToAllDependencies('onSelect', doc)) {
+    if (
+      !containerOrDoc ||
+      !isListeningToAllDependencies('onSelect', containerOrDoc)
+    ) {
       return null;
     }
 


### PR DESCRIPTION
This PR contains the following changes:

- Adds some changes requested in comments from follow ups in https://github.com/facebook/react/pull/18075, specifcally repositioning the argument `container`.
- Adds support for `SelectEventPlugin.js` to take an eventual container
- Rename `dispatchEventForPluginEventSystem` to `dispatchEventForLegacyPluginEventSystem`
- Tweaked `SyntheticEvent` types
- Refactored some logic in event replaying to allow for both container and document to be passed through, enabling further code paths for the modern event system