### PR TITLE
[WIP] Move Everything to ES Modules in Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "rimraf": "^3.0.0",
     "rollup": "^1.19.4",
     "rollup-plugin-babel": "^4.0.1",
-    "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^2.1.1",
     "rollup-plugin-prettier": "^0.6.0",
     "rollup-plugin-replace": "^2.2.0",

--- a/packages/eslint-plugin-react-hooks/index.js
+++ b/packages/eslint-plugin-react-hooks/index.js
@@ -7,4 +7,6 @@
 
 'use strict';
 
-module.exports = require('./src/index');
+import {rules} from './src/index';
+
+export default {rules};

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "homepage": "https://reactjs.org/",
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  },
   "peerDependencies": {
     "jest": "^23.0.1 || ^24.0.0 || ^25.1.0",
     "react": "^16.0.0",

--- a/packages/react-art/Circle.js
+++ b/packages/react-art/Circle.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Circle = require('./npm/Circle');
-
-module.exports = Circle;
+export {default} from './npm/Circle';

--- a/packages/react-art/Rectangle.js
+++ b/packages/react-art/Rectangle.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Rectangle = require('./npm/Rectangle');
-
-module.exports = Rectangle;
+export {default} from './npm/Rectangle';

--- a/packages/react-art/Wedge.js
+++ b/packages/react-art/Wedge.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Wedge = require('./npm/Wedge');
-
-module.exports = Wedge;
+export {default} from './npm/Wedge';

--- a/packages/react-art/index.js
+++ b/packages/react-art/index.js
@@ -9,6 +9,28 @@
 
 'use strict';
 
-const ReactART = require('./src/ReactART');
+import {
+  ClippingRectangle,
+  Group,
+  Shape,
+  Path,
+  LinearGradient,
+  Pattern,
+  RadialGradient,
+  Surface,
+  Text,
+  Transform,
+} from './src/ReactART';
 
-module.exports = ReactART;
+export default {
+  ClippingRectangle,
+  Group,
+  Shape,
+  Path,
+  LinearGradient,
+  Pattern,
+  RadialGradient,
+  Surface,
+  Text,
+  Transform,
+};

--- a/packages/react-debug-tools/index.js
+++ b/packages/react-debug-tools/index.js
@@ -7,7 +7,4 @@
 
 'use strict';
 
-const ReactDebugTools = require('./src/ReactDebugTools');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactDebugTools.default || ReactDebugTools;
+export {default} from './src/ReactDebugTools';

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -29,6 +29,7 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "error-stack-parser": "^2.0.2"
+    "error-stack-parser": "^2.0.2",
+    "object-assign": "^4.1.1"
   }
 }

--- a/packages/react-debug-tools/src/ReactDebugTools.js
+++ b/packages/react-debug-tools/src/ReactDebugTools.js
@@ -9,4 +9,4 @@
 
 import {inspectHooks, inspectHooksOfFiber} from './ReactDebugHooks';
 
-export {inspectHooks, inspectHooksOfFiber};
+export default {inspectHooks, inspectHooksOfFiber};

--- a/packages/react-dom/index.fb.js
+++ b/packages/react-dom/index.fb.js
@@ -7,8 +7,4 @@
 
 'use strict';
 
-const ReactDOMFB = require('./src/client/ReactDOMFB');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactDOMFB.default || ReactDOMFB;
+export {default} from './src/client/ReactDOM';

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOM = require('./src/client/ReactDOM');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactDOM.default || ReactDOM;
+export {default} from './src/client/ReactDOM';

--- a/packages/react-dom/server.browser.js
+++ b/packages/react-dom/server.browser.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOMServer = require('./src/server/ReactDOMServerBrowser');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactDOMServer.default || ReactDOMServer;
+export {default} from './src/server/ReactDOMServerBrowser';

--- a/packages/react-dom/server.js
+++ b/packages/react-dom/server.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./server.node');
+export {default} from './server.node';

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOMServer = require('./src/server/ReactDOMServerNode');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactDOMServer.default || ReactDOMServer;
+export {default} from './src/server/ReactDOMServerNode';

--- a/packages/react-dom/test-utils.js
+++ b/packages/react-dom/test-utils.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactTestUtils = require('./src/test-utils/ReactTestUtils');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactTestUtils.default || ReactTestUtils;
+export {default} from './src/test-utils/ReactTestUtils';

--- a/packages/react-dom/testing.js
+++ b/packages/react-dom/testing.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOM = require('./src/client/ReactDOM');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactDOM.default || ReactDOM;
+export {default} from './src/client/ReactDOM';

--- a/packages/react-dom/unstable-fizz.browser.js
+++ b/packages/react-dom/unstable-fizz.browser.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOMFizzServerBrowser = require('./src/server/ReactDOMFizzServerBrowser');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactDOMFizzServerBrowser.default || ReactDOMFizzServerBrowser;
+export {default} from './src/server/ReactDOMFizzServerBrowser';

--- a/packages/react-dom/unstable-fizz.js
+++ b/packages/react-dom/unstable-fizz.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./unstable-fizz.node');
+export {default} from './unstable-fizz.node';

--- a/packages/react-dom/unstable-fizz.node.js
+++ b/packages/react-dom/unstable-fizz.node.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactDOMFizzServerNode = require('./src/server/ReactDOMFizzServerNode');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactDOMFizzServerNode.default || ReactDOMFizzServerNode;
+export {default} from './src/server/ReactDOMFizzServerNode';

--- a/packages/react-flight-dom-webpack/index.js
+++ b/packages/react-flight-dom-webpack/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactFlightDOMClient = require('./src/ReactFlightDOMClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactFlightDOMClient.default || ReactFlightDOMClient;
+export {default} from './src/ReactFlightDOMClient';

--- a/packages/react-flight-dom-webpack/server.browser.js
+++ b/packages/react-flight-dom-webpack/server.browser.js
@@ -9,9 +9,4 @@
 
 'use strict';
 
-const ReactFlightDOMServerBrowser = require('./src/ReactFlightDOMServerBrowser');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports =
-  ReactFlightDOMServerBrowser.default || ReactFlightDOMServerBrowser;
+export {default} from './src/ReactFlightDOMServerBrowser';

--- a/packages/react-flight-dom-webpack/server.js
+++ b/packages/react-flight-dom-webpack/server.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./server.node');
+export {default} from './server.node';

--- a/packages/react-flight-dom-webpack/server.node.js
+++ b/packages/react-flight-dom-webpack/server.node.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactFlightDOMServerNode = require('./src/ReactFlightDOMServerNode');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactFlightDOMServerNode.default || ReactFlightDOMServerNode;
+export {default} from './src/ReactFlightDOMServerNode';

--- a/packages/react-flight/index.js
+++ b/packages/react-flight/index.js
@@ -19,4 +19,4 @@
 
 'use strict';
 
-export {default} from './src/ReactFlightClient';
+export * from './src/ReactFlightClient';

--- a/packages/react-flight/index.js
+++ b/packages/react-flight/index.js
@@ -19,8 +19,4 @@
 
 'use strict';
 
-const ReactFlightClient = require('./src/ReactFlightClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFlightClient.default || ReactFlightClient;
+export {default} from './src/ReactFlightClient';

--- a/packages/react-interactions/events/context-menu.js
+++ b/packages/react-interactions/events/context-menu.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/ContextMenu');
+export * from './src/dom/ContextMenu';

--- a/packages/react-interactions/events/focus.js
+++ b/packages/react-interactions/events/focus.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Focus');
+export * from './src/dom/Focus';

--- a/packages/react-interactions/events/hover.js
+++ b/packages/react-interactions/events/hover.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Hover');
+export * from './src/dom/Hover';

--- a/packages/react-interactions/events/input.js
+++ b/packages/react-interactions/events/input.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Input');
+export * from './src/dom/Input';

--- a/packages/react-interactions/events/keyboard.js
+++ b/packages/react-interactions/events/keyboard.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Keyboard');
+export * from './src/dom/Keyboard';

--- a/packages/react-interactions/events/press-legacy.js
+++ b/packages/react-interactions/events/press-legacy.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/PressLegacy');
+export * from './src/dom/PressLegacy';

--- a/packages/react-interactions/events/press.js
+++ b/packages/react-interactions/events/press.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Press');
+export * from './src/dom/Press';

--- a/packages/react-interactions/events/tap.js
+++ b/packages/react-interactions/events/tap.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Tap');
+export * from './src/dom/Tap';

--- a/packages/react-native-renderer/fabric.js
+++ b/packages/react-native-renderer/fabric.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactFabric = require('./src/ReactFabric');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFabric.default || ReactFabric;
+export {default} from './src/ReactFabric';

--- a/packages/react-native-renderer/index.js
+++ b/packages/react-native-renderer/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNativeRenderer = require('./src/ReactNativeRenderer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNativeRenderer.default || ReactNativeRenderer;
+export {default} from './src/ReactNativeRenderer';

--- a/packages/react-noop-renderer/flight-client.js
+++ b/packages/react-noop-renderer/flight-client.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNoopFlightClient = require('./src/ReactNoopFlightClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopFlightClient.default || ReactNoopFlightClient;
+export {default} from './src/ReactNoopFlightClient';

--- a/packages/react-noop-renderer/flight-server.js
+++ b/packages/react-noop-renderer/flight-server.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNoopFlightServer = require('./src/ReactNoopFlightServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopFlightServer.default || ReactNoopFlightServer;
+export {default} from './src/ReactNoopFlightServer';

--- a/packages/react-noop-renderer/index.js
+++ b/packages/react-noop-renderer/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNoop = require('./src/ReactNoop');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoop.default || ReactNoop;
+export {default} from './src/ReactNoop';

--- a/packages/react-noop-renderer/persistent.js
+++ b/packages/react-noop-renderer/persistent.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNoopPersistent = require('./src/ReactNoopPersistent');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopPersistent.default || ReactNoopPersistent;
+export {default} from './src/ReactNoopPersistent';

--- a/packages/react-noop-renderer/server.js
+++ b/packages/react-noop-renderer/server.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactNoopServer = require('./src/ReactNoopServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopServer.default || ReactNoopServer;
+export {default} from './src/ReactNoopServer';

--- a/packages/react-reconciler/index.js
+++ b/packages/react-reconciler/index.js
@@ -19,4 +19,4 @@
 
 'use strict';
 
-export {default} from './src/ReactFiberReconciler';
+export * from './src/ReactFiberReconciler';

--- a/packages/react-reconciler/index.js
+++ b/packages/react-reconciler/index.js
@@ -19,8 +19,4 @@
 
 'use strict';
 
-const ReactFiberReconciler = require('./src/ReactFiberReconciler');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFiberReconciler.default || ReactFiberReconciler;
+export {default} from './src/ReactFiberReconciler';

--- a/packages/react-reconciler/persistent.js
+++ b/packages/react-reconciler/persistent.js
@@ -9,4 +9,4 @@
 
 // This is the same export as in index.js,
 // with persistent reconciler flags turned on.
-export {default} from './src/ReactFiberReconciler';
+export * from './src/ReactFiberReconciler';

--- a/packages/react-reconciler/persistent.js
+++ b/packages/react-reconciler/persistent.js
@@ -9,8 +9,4 @@
 
 // This is the same export as in index.js,
 // with persistent reconciler flags turned on.
-const ReactFiberReconciler = require('./src/ReactFiberReconciler');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFiberReconciler.default || ReactFiberReconciler;
+export {default} from './src/ReactFiberReconciler';

--- a/packages/react-refresh/babel.js
+++ b/packages/react-refresh/babel.js
@@ -7,7 +7,4 @@
 
 'use strict';
 
-const ReactFreshBabelPlugin = require('./src/ReactFreshBabelPlugin');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFreshBabelPlugin.default || ReactFreshBabelPlugin;
+export {default} from './src/ReactFreshBabelPlugin';

--- a/packages/react-refresh/runtime.js
+++ b/packages/react-refresh/runtime.js
@@ -7,7 +7,4 @@
 
 'use strict';
 
-const ReactFreshRuntime = require('./src/ReactFreshRuntime');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFreshRuntime.default || ReactFreshRuntime;
+export {default} from './src/ReactFreshRuntime';

--- a/packages/react-refresh/runtime.js
+++ b/packages/react-refresh/runtime.js
@@ -7,4 +7,4 @@
 
 'use strict';
 
-export {default} from './src/ReactFreshRuntime';
+export * from './src/ReactFreshRuntime';

--- a/packages/react-server/flight.js
+++ b/packages/react-server/flight.js
@@ -19,4 +19,4 @@
 
 'use strict';
 
-export {default} from './src/ReactFlightServer';
+export * from './src/ReactFlightServer';

--- a/packages/react-server/flight.js
+++ b/packages/react-server/flight.js
@@ -19,8 +19,4 @@
 
 'use strict';
 
-const ReactFlightServer = require('./src/ReactFlightServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFlightServer.default || ReactFlightServer;
+export {default} from './src/ReactFlightServer';

--- a/packages/react-server/index.js
+++ b/packages/react-server/index.js
@@ -19,8 +19,4 @@
 
 'use strict';
 
-const ReactFizzStreamer = require('./src/ReactFizzStreamer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFizzStreamer.default || ReactFizzStreamer;
+export {default} from './src/ReactFizzStreamer';

--- a/packages/react-server/index.js
+++ b/packages/react-server/index.js
@@ -19,4 +19,4 @@
 
 'use strict';
 
-export {default} from './src/ReactFizzStreamer';
+export * from './src/ReactFizzStreamer';

--- a/packages/react-test-renderer/index.js
+++ b/packages/react-test-renderer/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactTestRenderer = require('./src/ReactTestRenderer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactTestRenderer.default || ReactTestRenderer;
+export {default} from './src/ReactTestRenderer';

--- a/packages/react-test-renderer/shallow.js
+++ b/packages/react-test-renderer/shallow.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const ReactShallowRenderer = require('./src/ReactShallowRenderer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactShallowRenderer.default || ReactShallowRenderer;
+export {default} from './src/ReactShallowRenderer';

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const React = require('./src/React');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = React.default || React;
+export {default} from './src/React';

--- a/packages/react/testing.js
+++ b/packages/react/testing.js
@@ -9,8 +9,4 @@
 
 'use strict';
 
-const React = require('./src/React');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = React.default || React;
+export {default} from './src/React';

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -8,4 +8,4 @@
 'use strict';
 
 // TODO: this is special because it gets imported during build.
-module.exports = '16.12.0';
+export default '16.12.0';

--- a/packages/shared/forks/object-assign.inline-umd.js
+++ b/packages/shared/forks/object-assign.inline-umd.js
@@ -1,0 +1,97 @@
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
+/* eslint-disable */
+
+'use strict';
+
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+
+function toObject(val) {
+  if (val === null || val === undefined) {
+    throw new TypeError(
+      'Object.assign cannot be called with null or undefined',
+    );
+  }
+
+  return Object(val);
+}
+
+function shouldUseNative() {
+  try {
+    if (!Object.assign) {
+      return false;
+    }
+
+    // Detect buggy property enumeration order in older V8 versions.
+
+    // https://bugs.chromium.org/p/v8/issues/detail?id=4118
+    var test1 = new String('abc'); // eslint-disable-line no-new-wrappers
+    test1[5] = 'de';
+    if (Object.getOwnPropertyNames(test1)[0] === '5') {
+      return false;
+    }
+
+    // https://bugs.chromium.org/p/v8/issues/detail?id=3056
+    var test2 = {};
+    for (var i = 0; i < 10; i++) {
+      test2['_' + String.fromCharCode(i)] = i;
+    }
+    var order2 = Object.getOwnPropertyNames(test2).map(function(n) {
+      return test2[n];
+    });
+    if (order2.join('') !== '0123456789') {
+      return false;
+    }
+
+    // https://bugs.chromium.org/p/v8/issues/detail?id=3056
+    var test3 = {};
+    'abcdefghijklmnopqrst'.split('').forEach(function(letter) {
+      test3[letter] = letter;
+    });
+    if (
+      Object.keys(Object.assign({}, test3)).join('') !== 'abcdefghijklmnopqrst'
+    ) {
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    // We don't expect any of the above to throw, but better to be safe.
+    return false;
+  }
+}
+
+export default shouldUseNative()
+  ? Object.assign
+  : function(target, source) {
+      var from;
+      var to = toObject(target);
+      var symbols;
+
+      for (var s = 1; s < arguments.length; s++) {
+        from = Object(arguments[s]);
+
+        for (var key in from) {
+          if (hasOwnProperty.call(from, key)) {
+            to[key] = from[key];
+          }
+        }
+
+        if (getOwnPropertySymbols) {
+          symbols = getOwnPropertySymbols(from);
+          for (var i = 0; i < symbols.length; i++) {
+            if (propIsEnumerable.call(from, symbols[i])) {
+              to[symbols[i]] = from[symbols[i]];
+            }
+          }
+        }
+      }
+
+      return to;
+    };

--- a/packages/shared/forks/prop-types-checkPropTypes.inline-umd.js
+++ b/packages/shared/forks/prop-types-checkPropTypes.inline-umd.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+var printWarning = function() {};
+
+if (process.env.NODE_ENV !== 'production') {
+  var loggedTypeFailures = {};
+  var has = Function.call.bind(Object.prototype.hasOwnProperty);
+
+  printWarning = function(text) {
+    var message = 'Warning: ' + text;
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      throw new Error(message);
+    } catch (x) {}
+  };
+}
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?Function} getStack Returns the component stack.
+ * @private
+ */
+function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
+  if (process.env.NODE_ENV !== 'production') {
+    for (var typeSpecName in typeSpecs) {
+      if (has(typeSpecs, typeSpecName)) {
+        var error;
+        // Prop type validation may throw. In case they do, we don't want to
+        // fail the render phase where it didn't fail before. So we log it.
+        // After these have been cleaned up, we'll let them throw.
+        try {
+          // This is intentionally an invariant that gets caught. It's the same
+          // behavior as without this statement except with a better message.
+          if (typeof typeSpecs[typeSpecName] !== 'function') {
+            var err = Error(
+              (componentName || 'React class') +
+                ': ' +
+                location +
+                ' type `' +
+                typeSpecName +
+                '` is invalid; ' +
+                'it must be a function, usually from the `prop-types` package, but received `' +
+                typeof typeSpecs[typeSpecName] +
+                '`.',
+            );
+            err.name = 'Invariant Violation';
+            throw err;
+          }
+          error = typeSpecs[typeSpecName](
+            values,
+            typeSpecName,
+            componentName,
+            location,
+            null,
+            'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED',
+          );
+        } catch (ex) {
+          error = ex;
+        }
+        if (error && !(error instanceof Error)) {
+          printWarning(
+            (componentName || 'React class') +
+              ': type specification of ' +
+              location +
+              ' `' +
+              typeSpecName +
+              '` is invalid; the type checker ' +
+              'function must return `null` or an `Error` but returned a ' +
+              typeof error +
+              '. ' +
+              'You may have forgotten to pass an argument to the type checker ' +
+              'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' +
+              'shape all require an argument).',
+          );
+        }
+        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
+          // Only monitor this failure once because there tends to be a lot of the
+          // same error.
+          loggedTypeFailures[error.message] = true;
+
+          var stack = getStack ? getStack() : '';
+
+          printWarning(
+            'Failed ' +
+              location +
+              ' type: ' +
+              error.message +
+              (stack != null ? stack : ''),
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Resets warning cache when testing.
+ *
+ * @private
+ */
+checkPropTypes.resetWarningCache = function() {
+  if (process.env.NODE_ENV !== 'production') {
+    loggedTypeFailures = {};
+  }
+};
+
+export default checkPropTypes;

--- a/scripts/release/publish-commands/update-stable-version-numbers.js
+++ b/scripts/release/publish-commands/update-stable-version-numbers.js
@@ -44,7 +44,7 @@ const run = async ({cwd, packages, skipPackages, tags}) => {
     const sourceReactVersion = readFileSync(
       sourceReactVersionPath,
       'utf8'
-    ).replace(/module\.exports = '[^']+';/, `module.exports = '${version}';`);
+    ).replace(/export default '[^']+';/, `export default '${version}';`);
     writeFileSync(sourceReactVersionPath, sourceReactVersion);
   }
 };

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -209,10 +209,7 @@ const updateVersionsForNext = async (cwd, reactVersion, version) => {
   const sourceReactVersion = readFileSync(
     sourceReactVersionPath,
     'utf8'
-  ).replace(
-    /module\.exports = '[^']+';/,
-    `module.exports = '${reactVersion}';`
-  );
+  ).replace(/export default '[^']+';/, `export default '${reactVersion}';`);
   writeFileSync(sourceReactVersionPath, sourceReactVersion);
 
   // Update the root package.json.

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -3,7 +3,6 @@
 const rollup = require('rollup');
 const babel = require('rollup-plugin-babel');
 const closure = require('./plugins/closure-plugin');
-const commonjs = require('rollup-plugin-commonjs');
 const prettier = require('rollup-plugin-prettier');
 const replace = require('rollup-plugin-replace');
 const stripBanner = require('rollup-plugin-strip-banner');
@@ -394,8 +393,6 @@ function getPlugins(
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
       __EXPERIMENTAL__,
     }),
-    // We still need CommonJS for external deps like object-assign.
-    commonjs(),
     // Apply dead code elimination and/or minification.
     isProduction &&
       closure(

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -22,8 +22,8 @@ const {RENDERER, RECONCILER} = moduleTypes;
 // If you need to replace a file with another file for a specific environment,
 // add it to this list with the logic for choosing the right replacement.
 const forks = Object.freeze({
-  // Optimization: for UMDs, use object-assign polyfill that is already a part
-  // of the React package instead of bundling it again.
+  // Optimization: for UMDs, use a version that we can inline into the React bundle.
+  // Use that from all other bundles.
   'object-assign': (bundleType, entry, dependencies) => {
     if (
       bundleType !== UMD_DEV &&
@@ -34,12 +34,16 @@ const forks = Object.freeze({
       // happens. Other bundles just require('object-assign') anyway.
       return null;
     }
+    if (entry === 'react') {
+      // Use the forked version that uses ES modules instead of CommonJS.
+      return 'shared/forks/object-assign.inline-umd.js';
+    }
     if (dependencies.indexOf('react') === -1) {
       // We can only apply the optimizations to bundle that depend on React
       // because we read assign() from an object exposed on React internals.
       return null;
     }
-    // We can use the fork!
+    // We can use the fork that reads the secret export!
     return 'shared/forks/object-assign.umd.js';
   },
 

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -47,6 +47,20 @@ const forks = Object.freeze({
     return 'shared/forks/object-assign.umd.js';
   },
 
+  // Fork the propTypes check for UMD bundles to use ES modules instead of CommonJS.
+  'prop-types/checkPropTypes': (bundleType, entry, dependencies) => {
+    if (
+      bundleType !== UMD_DEV &&
+      bundleType !== UMD_PROD &&
+      bundleType !== UMD_PROFILING
+    ) {
+      // It's only relevant for UMD bundles since that's where the duplication
+      // happens. Other bundles just require('prop-types/checkPropTypes') anyway.
+      return null;
+    }
+    return 'shared/forks/prop-types-checkPropTypes.inline-umd.js';
+  },
+
   // Without this fork, importing `shared/ReactSharedInternals` inside
   // the `react` package itself would not work due to a cyclical dependency.
   'shared/ReactSharedInternals': (bundleType, entry, dependencies) => {

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -279,10 +279,9 @@ ${license}
 
 if (process.env.NODE_ENV !== "production") {
   module.exports = function $$$reconciler($$$hostConfig) {
+    var exports = {};
 ${source}
-    var $$$renderer = module.exports;
-    module.exports = $$$reconciler;
-    return $$$renderer;
+    return exports;
   };
 }`;
   },
@@ -295,10 +294,9 @@ ${source}
 ${license}
  */
 module.exports = function $$$reconciler($$$hostConfig) {
+    var exports = {};
 ${source}
-    var $$$renderer = module.exports;
-    module.exports = $$$reconciler;
-    return $$$renderer;
+    return exports;
 };`;
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5366,7 +5366,7 @@ estree-walker@^0.3.0:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
   integrity sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=
 
-estree-walker@^0.6.0, estree-walker@^0.6.1:
+estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
@@ -11444,16 +11444,6 @@ rollup-plugin-babel@^4.0.1:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
-
-rollup-plugin-commonjs@^9.3.4:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
-  integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
-  dependencies:
-    estree-walker "^0.6.0"
-    magic-string "^0.25.2"
-    resolve "^1.10.0"
-    rollup-pluginutils "^2.6.0"
 
 rollup-plugin-node-resolve@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
It turns out that our loose reliance on CommonJS isn't really letting Rollup do its best work. It's also covering up a bunch of quirks that cause other issues and this ends up leaking. We really only intended it to be used to suck in requires into UMD builds. Unfortunately it also means that we're actually inlining in a bunch of builds accidentally too.

The usage of CommonJS at the export level also covers up a bunch of issues by converting it first into an intermediate layer of CommonJS and then back again.

I want to get to a point where we can remove the CommonJS plugin from Rollup. I was hoping we could just fork the object-assign and prop-types ones because 1) both of these are kind of frozen and we should ideally get rid of the dep in the next version 2) umds are likely to get dropped soon too anyway. Unfortunately react-art also supports UMD, for some reason, and it's harder to fork all of art. I might end up keeping the CommonJS plugin but only for ART for this reason until we can kill those UMD bundles.

We should also start preparing for actually exporting ES modules. Right now we're not very rigid with how we export things. We should be always exporting a default for now since that gives us the best CommonJS output. We can't start exporting the esModule flag since that would start breaking things. 
(Although I settled on just doing that for react-interactions because it was easier and it's FB only.)

However, this means that importing named imports etc. don't work. Including in our own code. Like DevTools. So we'll need to fix that up too.

There's a bunch to do here and I'm really just getting started.