### PR TITLE
Codemod to import * as React from "react";

### DIFF
--- a/packages/create-subscription/src/createSubscription.js
+++ b/packages/create-subscription/src/createSubscription.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 
 type Unsubscribe = () => void;

--- a/packages/react-art/src/ReactART.js
+++ b/packages/react-art/src/ReactART.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 import ReactVersion from 'shared/ReactVersion';
 import {LegacyRoot} from 'shared/ReactRootTags';
 import {

--- a/packages/react-cache/src/ReactCache.js
+++ b/packages/react-cache/src/ReactCache.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import {createLRU} from './LRU';
 

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -1,6 +1,7 @@
 /** @flow */
 
-import React, {forwardRef} from 'react';
+import * as React from 'react';
+import {forwardRef} from 'react';
 import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenu.js
@@ -7,13 +7,8 @@
  * @flow
  */
 
-import React, {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import * as React from 'react';
+import {useContext, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {RegistryContext} from './Contexts';
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/ContextMenuItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenuItem.css';

--- a/packages/react-devtools-shared/src/devtools/cache.js
+++ b/packages/react-devtools-shared/src/devtools/cache.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {createContext} from 'react';
+import * as React from 'react';
+import {createContext} from 'react';
 
 // Cache implementation was forked from the React repo:
 // https://github.com/facebook/react/blob/master/packages/react-cache/src/ReactCache.js

--- a/packages/react-devtools-shared/src/devtools/views/Button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Button.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import Tooltip from '@reach/tooltip';
 
 import styles from './Button.css';

--- a/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
+++ b/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import styles from './ButtonIcon.css';
 
 export type IconType =

--- a/packages/react-devtools-shared/src/devtools/views/Components/Badge.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Badge.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment} from 'react';
+import * as React from 'react';
+import {Fragment} from 'react';
 import {
   ElementTypeMemo,
   ElementTypeForwardRef,

--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Suspense} from 'react';
+import * as React from 'react';
+import {Suspense} from 'react';
 import Tree from './Tree';
 import SelectedElement from './SelectedElement';
 import {InspectedElementContextController} from './InspectedElementContext';

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableName.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableName.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useState} from 'react';
 import AutoSizeInput from './NativeStyleEditor/AutoSizeInput';
 import styles from './EditableName.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useRef} from 'react';
+import * as React from 'react';
+import {Fragment, useRef} from 'react';
 import styles from './EditableValue.css';
 import {useEditableValue} from '../hooks';
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext, useMemo, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useContext, useMemo, useState} from 'react';
 import Store from 'react-devtools-shared/src/devtools/store';
 import Badge from './Badge';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Components/ExpandCollapseToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ExpandCollapseToggle.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/HocBadges.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HocBadges.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import {
   ElementTypeForwardRef,
   ElementTypeMemo,

--- a/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
@@ -8,7 +8,8 @@
  */
 
 import {copy} from 'clipboard-js';
-import React, {useCallback, useContext, useRef, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useRef, useState} from 'react';
 import {BridgeContext, StoreContext} from '../context';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectHostNodesToggle.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useEffect, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useEffect, useState} from 'react';
 import {BridgeContext} from '../context';
 import Toggle from '../Toggle';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   useCallback,
   useContext,

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -8,7 +8,8 @@
  */
 
 import {copy} from 'clipboard-js';
-import React, {useCallback, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useState} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import KeyValue from './KeyValue';

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useEffect, useRef, useState} from 'react';
+import * as React from 'react';
+import {useEffect, useRef, useState} from 'react';
 import EditableValue from './EditableValue';
 import ExpandCollapseToggle from './ExpandCollapseToggle';
 import {alphaSortEntries, getMetaValueLabel} from '../utils';

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useLayoutEffect, useRef} from 'react';
+import * as React from 'react';
+import {Fragment, useLayoutEffect, useRef} from 'react';
 import styles from './AutoSizeInput.css';
 
 type Props = {

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/LayoutViewer.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/LayoutViewer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import styles from './LayoutViewer.css';
 
 import type {Layout} from './types';

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/StyleEditor.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/StyleEditor.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext, useMemo, useRef, useState} from 'react';
+import * as React from 'react';
+import {useContext, useMemo, useRef, useState} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 import {copy} from 'clipboard-js';
 import {

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   useCallback,
   useContext,

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/index.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext, useMemo} from 'react';
+import * as React from 'react';
+import {Fragment, useContext, useMemo} from 'react';
 import {StoreContext} from 'react-devtools-shared/src/devtools/views/context';
 import {useSubscription} from 'react-devtools-shared/src/devtools/views/hooks';
 import {NativeStyleContext} from './context';

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {createContext, useCallback, useContext, useEffect} from 'react';
+import * as React from 'react';
+import {createContext, useCallback, useContext, useEffect} from 'react';
 import {createResource} from '../../cache';
 import {BridgeContext, StoreContext} from '../context';
 import {TreeStateContext} from './TreeContext';

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.js
@@ -6,7 +6,8 @@
  *
  * @flow
  */
-import React, {
+import * as React from 'react';
+import {
   Fragment,
   useCallback,
   useContext,

--- a/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useEffect, useRef} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useEffect, useRef} from 'react';
 import {TreeDispatcherContext, TreeStateContext} from './TreeContext';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -8,7 +8,8 @@
  */
 
 import {copy} from 'clipboard-js';
-import React, {Fragment, useCallback, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useContext} from 'react';
 import {TreeDispatcherContext, TreeStateContext} from './TreeContext';
 import {BridgeContext, ContextMenuContext, StoreContext} from '../context';
 import ContextMenu from '../../ContextMenu/ContextMenu';

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext, useMemo} from 'react';
+import * as React from 'react';
+import {useContext, useMemo} from 'react';
 import {TreeStateContext} from './TreeContext';
 import {SettingsContext} from '../Settings/SettingsContext';
 import TreeFocusedContext from './TreeFocusedContext';

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   Fragment,
   Suspense,
   useCallback,

--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -24,7 +24,8 @@
 // For this reason, changes to the tree context are processed in sequence: tree -> search -> owners
 // This enables each section to potentially override (or mask) previous values.
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   useCallback,
   useContext,

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -12,7 +12,8 @@
 import '@reach/menu-button/styles.css';
 import '@reach/tooltip/styles.css';
 
-import React, {useEffect, useMemo, useState} from 'react';
+import * as React from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import Store from '../store';
 import {BridgeContext, ContextMenuContext, StoreContext} from './context';
 import Components from './Components/Components';

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Component} from 'react';
+import * as React from 'react';
+import {Component} from 'react';
 import styles from './ErrorBoundary.css';
 
 type Props = {|

--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import styles from './Icon.css';
 
 export type IconType =

--- a/packages/react-devtools-shared/src/devtools/views/ModalDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/ModalDialog.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   useCallback,
   useContext,

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ChartNode.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ChartNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import styles from './ChartNode.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ClearProfilingDataButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ClearProfilingDataButton.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext} from 'react';
+import * as React from 'react';
+import {useCallback, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
@@ -7,13 +7,8 @@
  * @flow
  */
 
-import React, {
-  forwardRef,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import * as React from 'react';
+import {forwardRef, useCallback, useContext, useMemo, useState} from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {FixedSizeList} from 'react-window';
 import {ProfilerContext} from './ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraphListItem.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraphListItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, memo, useCallback, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, memo, useCallback, useContext} from 'react';
 import {areEqual} from 'react-window';
 import {barWidthThreshold} from './constants';
 import {getGradientColor} from './utils';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useMemo, useState} from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {FixedSizeList} from 'react-window';
 import {ProfilerContext} from './ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRankedListItem.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRankedListItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {memo, useCallback, useContext} from 'react';
+import * as React from 'react';
+import {memo, useCallback, useContext} from 'react';
 import {areEqual} from 'react-window';
 import {minBarWidth} from './constants';
 import {getGradientColor} from './utils';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 import {formatDuration, formatTime} from './utils';
 import WhatChanged from './WhatChanged';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/InteractionListItem.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/InteractionListItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {memo, useCallback} from 'react';
+import * as React from 'react';
+import {memo, useCallback} from 'react';
 import {areEqual} from 'react-window';
 import {getGradientColor} from './utils';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Interactions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Interactions.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useMemo} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useMemo} from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {FixedSizeList} from 'react-window';
 import {ProfilerContext} from './ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/NoCommitData.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/NoCommitData.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import styles from './NoCommitData.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/NoInteractions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/NoInteractions.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import styles from './NoInteractions.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useContext} from 'react';
 import {ModalDialog} from '../ModalDialog';
 import {ProfilerContext} from './ProfilerContext';
 import TabBar from '../TabBar';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
@@ -7,13 +7,8 @@
  * @flow
  */
 
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import * as React from 'react';
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 import {useLocalStorage, useSubscription} from '../hooks';
 import {

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilingImportExportButtons.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext, useCallback, useRef} from 'react';
+import * as React from 'react';
+import {Fragment, useContext, useCallback, useRef} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 import {ModalDialogContext} from '../ModalDialog';
 import Button from '../Button';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/RecordToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/RecordToggle.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {ProfilerContext} from './ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ReloadAndProfileButton.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ReloadAndProfileButton.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useMemo} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useMemo} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {BridgeContext, StoreContext} from '../context';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/RootSelector.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/RootSelector.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 
 import styles from './RootSelector.css';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarCommitInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarCommitInfo.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 import {formatDuration, formatTime} from './utils';
 import {StoreContext} from '../context';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarInteractions.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarInteractions.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
 import {formatDuration, formatTime} from './utils';
 import {StoreContext} from '../context';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext} from 'react';
+import * as React from 'react';
+import {Fragment, useContext} from 'react';
 import WhatChanged from './WhatChanged';
 import {ProfilerContext} from './ProfilerContext';
 import {formatDuration, formatTime} from './utils';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import * as React from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {FixedSizeList} from 'react-window';
 import SnapshotCommitListItem from './SnapshotCommitListItem';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitListItem.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitListItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {memo, useCallback} from 'react';
+import * as React from 'react';
+import {memo, useCallback} from 'react';
 import {areEqual} from 'react-window';
 import {getGradientColor, formatDuration, formatTime} from './utils';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotSelector.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotSelector.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useContext, useMemo} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useContext, useMemo} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {ProfilerContext} from './ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Tooltip.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Tooltip.js
@@ -1,6 +1,7 @@
 /** @flow */
 
-import React, {useRef} from 'react';
+import * as React from 'react';
+import {useRef} from 'react';
 
 import styles from './Tooltip.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/WhatChanged.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/WhatChanged.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 import {ProfilerContext} from '../Profiler/ProfilerContext';
 import {StoreContext} from '../context';
 

--- a/packages/react-devtools-shared/src/devtools/views/ReactLogo.js
+++ b/packages/react-devtools-shared/src/devtools/views/ReactLogo.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 import styles from './ReactLogo.css';
 

--- a/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ComponentsSettings.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   useCallback,
   useContext,
   useEffect,

--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useContext} from 'react';
+import * as React from 'react';
+import {useContext} from 'react';
 import {SettingsContext} from './SettingsContext';
 import {StoreContext} from '../context';
 import {CHANGE_LOG_URL} from 'react-devtools-shared/src/constants';

--- a/packages/react-devtools-shared/src/devtools/views/Settings/ProfilerSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/ProfilerSettings.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useMemo, useRef} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useMemo, useRef} from 'react';
 import {useSubscription} from '../hooks';
 import {StoreContext} from '../context';
 import {ProfilerContext} from 'react-devtools-shared/src/devtools/views/Profiler/ProfilerContext';

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   useContext,
   useEffect,

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.js
@@ -7,13 +7,8 @@
  * @flow
  */
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useEffect, useMemo, useRef} from 'react';
 import {SettingsModalContext} from './SettingsModalContext';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModalContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModalContext.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {createContext, useMemo, useState} from 'react';
+import * as React from 'react';
+import {createContext, useMemo, useState} from 'react';
 
 export type DisplayDensity = 'comfortable' | 'compact';
 export type Theme = 'auto' | 'light' | 'dark';

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback, useContext, useMemo} from 'react';
+import * as React from 'react';
+import {useCallback, useContext, useMemo} from 'react';
 import {SettingsModalContext} from './SettingsModalContext';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';

--- a/packages/react-devtools-shared/src/devtools/views/TabBar.js
+++ b/packages/react-devtools-shared/src/devtools/views/TabBar.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback} from 'react';
 import Tooltip from '@reach/tooltip';
 import Icon from './Icon';
 

--- a/packages/react-devtools-shared/src/devtools/views/Toggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Toggle.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {useCallback} from 'react';
+import * as React from 'react';
+import {useCallback} from 'react';
 import Tooltip from '@reach/tooltip';
 
 import styles from './Toggle.css';

--- a/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext, useEffect, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useContext, useEffect, useState} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 import {ModalDialogContext} from './ModalDialog';
 import {StoreContext} from './context';

--- a/packages/react-devtools-shared/src/devtools/views/WarnIfLegacyBackendDetected.js
+++ b/packages/react-devtools-shared/src/devtools/views/WarnIfLegacyBackendDetected.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useContext, useEffect} from 'react';
+import * as React from 'react';
+import {Fragment, useContext, useEffect} from 'react';
 import {BridgeContext} from './context';
 import {ModalDialogContext} from './ModalDialog';
 

--- a/packages/react-devtools-shared/src/devtools/views/portaledContent.js
+++ b/packages/react-devtools-shared/src/devtools/views/portaledContent.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import {createPortal} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary';
 

--- a/packages/react-devtools-shell/src/app/DeeplyNestedComponents/index.js
+++ b/packages/react-devtools-shell/src/app/DeeplyNestedComponents/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment} from 'react';
+import * as React from 'react';
+import {Fragment} from 'react';
 
 function wrapWithHoc(Component, index) {
   function HOC() {

--- a/packages/react-devtools-shell/src/app/EditableProps/index.js
+++ b/packages/react-devtools-shell/src/app/EditableProps/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   Component,
   forwardRef,

--- a/packages/react-devtools-shell/src/app/ElementTypes/index.js
+++ b/packages/react-devtools-shell/src/app/ElementTypes/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   createContext,
   forwardRef,
   lazy,

--- a/packages/react-devtools-shell/src/app/Hydration/index.js
+++ b/packages/react-devtools-shell/src/app/Hydration/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useDebugValue, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useDebugValue, useState} from 'react';
 
 const div = document.createElement('div');
 const exmapleFunction = () => {};

--- a/packages/react-devtools-shell/src/app/Iframe/index.js
+++ b/packages/react-devtools-shell/src/app/Iframe/index.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import {Fragment} from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 
 export default function Iframe() {
   return (

--- a/packages/react-devtools-shell/src/app/Iframe/index.js
+++ b/packages/react-devtools-shell/src/app/Iframe/index.js
@@ -1,6 +1,7 @@
 /** @flow */
 
-import React, {Fragment} from 'react';
+import * as React from 'react';
+import {Fragment} from 'react';
 import ReactDOM from 'react-dom';
 
 export default function Iframe() {

--- a/packages/react-devtools-shell/src/app/InspectableElements/CircularReferences.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CircularReferences.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const arrayOne = [];
 const arrayTwo = [];

--- a/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {createContext, Component, Fragment, useContext} from 'react';
+import * as React from 'react';
+import {createContext, Component, Fragment, useContext} from 'react';
 import PropTypes from 'prop-types';
 
 function someNamedFunction() {}

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {
+import * as React from 'react';
+import {
   forwardRef,
   Fragment,
   memo,

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomObject.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomObject.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 class Custom {
   _number = 42;

--- a/packages/react-devtools-shell/src/app/InspectableElements/EdgeCaseObjects.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/EdgeCaseObjects.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const objectWithModifiedHasOwnProperty = {
   foo: 'abc',

--- a/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment} from 'react';
+import * as React from 'react';
+import {Fragment} from 'react';
 import UnserializableProps from './UnserializableProps';
 import CircularReferences from './CircularReferences';
 import Contexts from './Contexts';

--- a/packages/react-devtools-shell/src/app/InspectableElements/NestedProps.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/NestedProps.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const object = {
   string: 'abc',

--- a/packages/react-devtools-shell/src/app/InspectableElements/SimpleValues.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/SimpleValues.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Component} from 'react';
+import * as React from 'react';
+import {Component} from 'react';
 
 function noop() {}
 

--- a/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/UnserializableProps.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import Immutable from 'immutable';
 
 const set = new Set(['abc', 123]);

--- a/packages/react-devtools-shell/src/app/InteractionTracing/index.js
+++ b/packages/react-devtools-shell/src/app/InteractionTracing/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useEffect, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 import {
   unstable_trace as trace,

--- a/packages/react-devtools-shell/src/app/PriorityLevels/index.js
+++ b/packages/react-devtools-shell/src/app/PriorityLevels/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import {
   unstable_IdlePriority as IdlePriority,
   unstable_LowPriority as LowPriority,

--- a/packages/react-devtools-shell/src/app/ReactNativeWeb/index.js
+++ b/packages/react-devtools-shell/src/app/ReactNativeWeb/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useState} from 'react';
 // $FlowFixMe
 import {Button, Text, View} from 'react-native-web';
 

--- a/packages/react-devtools-shell/src/app/SuspenseTree/index.js
+++ b/packages/react-devtools-shell/src/app/SuspenseTree/index.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, Suspense, SuspenseList, useState} from 'react';
+import * as React from 'react';
+import {Fragment, Suspense, SuspenseList, useState} from 'react';
 
 function SuspenseTree() {
   return (

--- a/packages/react-devtools-shell/src/app/ToDoList/List.js
+++ b/packages/react-devtools-shell/src/app/ToDoList/List.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {Fragment, useCallback, useState} from 'react';
+import * as React from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import ListItem from './ListItem';
 import styles from './List.css';
 

--- a/packages/react-devtools-shell/src/app/ToDoList/ListItem.js
+++ b/packages/react-devtools-shell/src/app/ToDoList/ListItem.js
@@ -7,7 +7,8 @@
  * @flow
  */
 
-import React, {memo, useCallback} from 'react';
+import * as React from 'react';
+import {memo, useCallback} from 'react';
 import styles from './ListItem.css';
 
 import type {Item} from './List';

--- a/packages/react-devtools-shell/src/app/Toggle/index.js
+++ b/packages/react-devtools-shell/src/app/Toggle/index.js
@@ -1,4 +1,5 @@
-import React, {useState} from 'react';
+import * as React from 'react';
+import {useState} from 'react';
 
 export default function Toggle() {
   const [show, setShow] = useState(false);

--- a/packages/react-dom/src/client/ReactDOMOption.js
+++ b/packages/react-dom/src/client/ReactDOMOption.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import {getToStringValue, toString} from './ToStringValue';
 
 let didWarnSelectedSetOnOption = false;

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -12,7 +12,7 @@ import type {ReactElement} from 'shared/ReactElementType';
 import type {LazyComponent} from 'shared/ReactLazyComponent';
 import type {ReactProvider, ReactContext} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
 import describeComponentFrame from 'shared/describeComponentFrame';

--- a/packages/react-dom/src/shared/checkReact.js
+++ b/packages/react-dom/src/shared/checkReact.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import invariant from 'shared/invariant';
 
 invariant(

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
 import {get as getInstance} from 'shared/ReactInstanceMap';

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -6,7 +6,7 @@
  */
 
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import {findCurrentFiberUsingSlowPath} from 'react-reconciler/reflection';
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import {

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -9,7 +9,7 @@
 
 import type {Thenable} from 'react-reconciler/src/ReactFiberWorkLoop';
 
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import enqueueTask from 'shared/enqueueTask';
 import * as Scheduler from 'scheduler';

--- a/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
+++ b/packages/react-dom/src/unstable-native-dependencies/ReactDOMUnstableNativeDependencies.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ReactDOM from 'react-dom';
+import * as ReactDOM from 'react-dom';
 import {setComponentTree} from 'legacy-events/EventPluginUtils';
 import ResponderEventPlugin from 'legacy-events/ResponderEventPlugin';
 import ResponderTouchHistoryStore from 'legacy-events/ResponderTouchHistoryStore';

--- a/packages/react-interactions/events/src/dom/ContextMenu.js
+++ b/packages/react-interactions/events/src/dom/ContextMenu.js
@@ -14,7 +14,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {DiscreteEvent} from 'shared/ReactTypes';
 
 type ContextMenuProps = {|

--- a/packages/react-interactions/events/src/dom/Focus.js
+++ b/packages/react-interactions/events/src/dom/Focus.js
@@ -14,7 +14,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {DiscreteEvent} from 'shared/ReactTypes';
 
 /**

--- a/packages/react-interactions/events/src/dom/Hover.js
+++ b/packages/react-interactions/events/src/dom/Hover.js
@@ -14,7 +14,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {UserBlockingEvent} from 'shared/ReactTypes';
 
 type HoverProps = {

--- a/packages/react-interactions/events/src/dom/Input.js
+++ b/packages/react-interactions/events/src/dom/Input.js
@@ -12,7 +12,7 @@ import type {
   ReactDOMResponderContext,
 } from 'shared/ReactDOMTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {DiscreteEvent} from 'shared/ReactTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 

--- a/packages/react-interactions/events/src/dom/Keyboard.js
+++ b/packages/react-interactions/events/src/dom/Keyboard.js
@@ -13,7 +13,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {DiscreteEvent} from 'shared/ReactTypes';
 import {isVirtualClick} from './shared';
 

--- a/packages/react-interactions/events/src/dom/Press.js
+++ b/packages/react-interactions/events/src/dom/Press.js
@@ -9,7 +9,7 @@
 
 import type {PointerType} from 'shared/ReactDOMTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {useTap} from 'react-interactions/events/tap';
 import {useKeyboard} from 'react-interactions/events/keyboard';
 

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -17,7 +17,7 @@ import type {
   ReactEventResponderListener,
 } from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {DiscreteEvent, UserBlockingEvent} from 'shared/ReactTypes';
 
 type PressProps = {|

--- a/packages/react-interactions/events/src/dom/Tap.js
+++ b/packages/react-interactions/events/src/dom/Tap.js
@@ -14,7 +14,7 @@ import type {
 } from 'shared/ReactDOMTypes';
 import type {ReactEventResponderListener} from 'shared/ReactTypes';
 
-import React from 'react';
+import * as React from 'react';
 import {
   buttonsEnum,
   dispatchDiscreteEvent,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -11,7 +11,7 @@ import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 import type {UpdateQueue} from './ReactUpdateQueue';
 
-import React from 'react';
+import * as React from 'react';
 import {Update, Snapshot} from 'shared/ReactSideEffectTags';
 import {
   debugRenderPhaseSideEffectsForStrictMode,

--- a/packages/react-test-renderer/src/ReactShallowRenderer.js
+++ b/packages/react-test-renderer/src/ReactShallowRenderer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 import {isForwardRef, isMemo, ForwardRef} from 'react-is';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import getComponentName from 'shared/getComponentName';

--- a/packages/shared/ReactSharedInternals.js
+++ b/packages/shared/ReactSharedInternals.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;

--- a/packages/shared/forks/Scheduler.umd.js
+++ b/packages/shared/forks/Scheduler.umd.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/packages/shared/forks/SchedulerTracing.umd.js
+++ b/packages/shared/forks/SchedulerTracing.umd.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/packages/shared/forks/object-assign.umd.js
+++ b/packages/shared/forks/object-assign.umd.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import React from 'react';
+import * as React from 'react';
 
 const ReactInternals = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 


### PR DESCRIPTION
This is the correct way to import React from an ES module since the ES module will not have a default export. Only named exports.

I'm doing some changes to named exports and this will stop working. For open source ES modules we'll probably publish some default object that warns as an upgrade path but we can't use that in our own code.