### PR TITLE
Code mod import * as React from 'react' in react-window

### DIFF
--- a/packages/react-devtools-shared/src/node_modules/react-window/src/createGridComponent.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/createGridComponent.js
@@ -1,7 +1,8 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
-import React, { createElement, PureComponent } from 'react';
+import * as React from 'react';
+import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/createListComponent.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/createListComponent.js
@@ -1,7 +1,8 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
-import React, { createElement, PureComponent } from 'react';
+import * as React from 'react';
+import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getRTLOffsetType } from './domHelpers';
 


### PR DESCRIPTION
I missed this in https://github.com/facebook/react/pull/18102 because it's in a node_modules folder that I filtered.

I guess this is a checked in version? Probably need to fix this upstream too.