### PR TITLE
Add @nolint to FB bundle headers

### DIFF
--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -133,6 +133,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * @preserve-invariant-messages
  */
@@ -152,6 +153,7 @@ ${source}
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * @preserve-invariant-messages
  */
@@ -165,6 +167,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * @preserve-invariant-messages
  */
@@ -178,6 +181,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @providesModule ${globalName}-dev
  * @preventMunge
  * ${'@gen' + 'erated'}
@@ -198,6 +202,7 @@ ${source}
 ${license}
  *
  * @noflow
+ * @nolint
  * @providesModule ${globalName}-prod
  * @preventMunge
  * ${'@gen' + 'erated'}
@@ -212,6 +217,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @providesModule ${globalName}-profiling
  * @preventMunge
  * ${'@gen' + 'erated'}
@@ -226,6 +232,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * ${'@gen' + 'erated'}
  */
@@ -245,6 +252,7 @@ ${source}
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * ${'@gen' + 'erated'}
  */
@@ -258,6 +266,7 @@ ${source}`;
 ${license}
  *
  * @noflow
+ * @nolint
  * @preventMunge
  * ${'@gen' + 'erated'}
  */


### PR DESCRIPTION
Let's add the @nolint header to the FB/RN bundles so that we don't run eslint on the bundles.