### PR TITLE
Remove react-dom OSS testing builds

### DIFF
--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -8,15 +8,11 @@
  */
 
 let React;
-let ReactDOM;
+let DOMAct;
 let TestRenderer;
+let TestAct;
 
 global.__DEV__ = process.env.NODE_ENV !== 'production';
-
-jest.mock('react-dom', () =>
-  require.requireActual('react-dom/cjs/react-dom-testing.development.js')
-);
-// we'll replace the above with react/testing and react-dom/testing right before the next minor
 
 expect.extend(require('../toWarnDev'));
 
@@ -24,8 +20,9 @@ describe('unmocked scheduler', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    ReactDOM = require('react-dom');
+    DOMAct = require('react-dom/test-utils').act;
     TestRenderer = require('react-test-renderer');
+    TestAct = TestRenderer.act;
   });
 
   it('flushes work only outside the outermost act() corresponding to its own renderer', () => {
@@ -37,8 +34,8 @@ describe('unmocked scheduler', () => {
       return null;
     }
     // in legacy mode, this tests whether an act only flushes its own effects
-    TestRenderer.act(() => {
-      ReactDOM.act(() => {
+    TestAct(() => {
+      DOMAct(() => {
         TestRenderer.create(<Effecty />);
       });
       expect(log).toEqual([]);
@@ -47,8 +44,8 @@ describe('unmocked scheduler', () => {
 
     log = [];
     // for doublechecking, we flip it inside out, and assert on the outermost
-    ReactDOM.act(() => {
-      TestRenderer.act(() => {
+    DOMAct(() => {
+      TestAct(() => {
         TestRenderer.create(<Effecty />);
       });
       expect(log).toEqual(['called']);
@@ -64,8 +61,9 @@ describe('mocked scheduler', () => {
       require.requireActual('scheduler/unstable_mock')
     );
     React = require('react');
-    ReactDOM = require('react-dom');
+    DOMAct = require('react-dom/test-utils').act;
     TestRenderer = require('react-test-renderer');
+    TestAct = TestRenderer.act;
   });
 
   afterEach(() => {
@@ -81,8 +79,8 @@ describe('mocked scheduler', () => {
       return null;
     }
     // with a mocked scheduler, this tests whether it flushes all work only on the outermost act
-    TestRenderer.act(() => {
-      ReactDOM.act(() => {
+    TestAct(() => {
+      DOMAct(() => {
         TestRenderer.create(<Effecty />);
       });
       expect(log).toEqual([]);
@@ -91,8 +89,8 @@ describe('mocked scheduler', () => {
 
     log = [];
     // for doublechecking, we flip it inside out, and assert on the outermost
-    ReactDOM.act(() => {
-      TestRenderer.act(() => {
+    DOMAct(() => {
+      TestAct(() => {
         TestRenderer.create(<Effecty />);
       });
       expect(log).toEqual([]);

--- a/fixtures/dom/src/__tests__/wrong-act-test.js
+++ b/fixtures/dom/src/__tests__/wrong-act-test.js
@@ -10,6 +10,7 @@
 let React;
 let ReactDOM;
 let ReactART;
+let TestUtils;
 let ARTSVGMode;
 let ARTCurrentMode;
 let TestRenderer;
@@ -17,11 +18,6 @@ let ARTTest;
 
 global.__DEV__ = process.env.NODE_ENV !== 'production';
 global.__EXPERIMENTAL__ = process.env.RELEASE_CHANNEL === 'experimental';
-
-jest.mock('react-dom', () =>
-  require.requireActual('react-dom/cjs/react-dom-testing.development.js')
-);
-// we'll replace the above with react/testing and react-dom/testing right before the next minor
 
 expect.extend(require('../toWarnDev'));
 
@@ -33,6 +29,7 @@ beforeEach(() => {
   jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
+  TestUtils = require('react-dom/test-utils');
   ReactART = require('react-art');
   ARTSVGMode = require('art/modes/svg');
   ARTCurrentMode = require('art/modes/current');
@@ -73,7 +70,7 @@ beforeEach(() => {
 });
 
 it("doesn't warn when you use the right act + renderer: dom", () => {
-  ReactDOM.act(() => {
+  TestUtils.act(() => {
     ReactDOM.render(<App />, document.createElement('div'));
   });
 });
@@ -89,7 +86,7 @@ it('resets correctly across renderers', () => {
     React.useEffect(() => {}, []);
     return null;
   }
-  ReactDOM.act(() => {
+  TestUtils.act(() => {
     TestRenderer.act(() => {});
     expect(() => {
       TestRenderer.create(<Effecty />);
@@ -126,7 +123,7 @@ it('warns when using the wrong act version - test + dom: updates', () => {
 
 it('warns when using the wrong act version - dom + test: .create()', () => {
   expect(() => {
-    ReactDOM.act(() => {
+    TestUtils.act(() => {
       TestRenderer.create(<App />);
     });
   }).toWarnDev(["It looks like you're using the wrong act()"], {
@@ -137,7 +134,7 @@ it('warns when using the wrong act version - dom + test: .create()', () => {
 it('warns when using the wrong act version - dom + test: .update()', () => {
   const root = TestRenderer.create(<App key="one" />);
   expect(() => {
-    ReactDOM.act(() => {
+    TestUtils.act(() => {
       root.update(<App key="two" />);
     });
   }).toWarnDev(["It looks like you're using the wrong act()"], {
@@ -154,14 +151,14 @@ it('warns when using the wrong act version - dom + test: updates', () => {
   }
   TestRenderer.create(<Counter />);
   expect(() => {
-    ReactDOM.act(() => {
+    TestUtils.act(() => {
       setCtr(1);
     });
   }).toWarnDev(["It looks like you're using the wrong act()"]);
 });
 
 it('does not warn when nesting react-act inside react-dom', () => {
-  ReactDOM.act(() => {
+  TestUtils.act(() => {
     ReactDOM.render(<ARTTest />, document.createElement('div'));
   });
 });
@@ -174,7 +171,7 @@ it('does not warn when nesting react-act inside react-test-renderer', () => {
 
 it("doesn't warn if you use nested acts from different renderers", () => {
   TestRenderer.act(() => {
-    ReactDOM.act(() => {
+    TestUtils.act(() => {
       TestRenderer.create(<App />);
     });
   });

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -104,22 +104,6 @@ const bundles = [
     externals: ['react', 'react-dom'],
   },
 
-  /******* React DOM - Testing *******/
-  {
-    moduleType: RENDERER,
-    bundleTypes: [
-      UMD_DEV,
-      UMD_PROD,
-      UMD_PROFILING,
-      NODE_DEV,
-      NODE_PROD,
-      NODE_PROFILING,
-    ],
-    entry: 'react-dom/testing',
-    global: 'ReactDOM',
-    externals: ['react'],
-  },
-
   /******* React DOM - www - Testing *******/
   {
     moduleType: RENDERER,

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -46,7 +46,7 @@ const forks = Object.freeze({
   // Without this fork, importing `shared/ReactSharedInternals` inside
   // the `react` package itself would not work due to a cyclical dependency.
   'shared/ReactSharedInternals': (bundleType, entry, dependencies) => {
-    if (entry === 'react' || entry === 'react/testing') {
+    if (entry === 'react') {
       return 'react/src/ReactSharedInternals';
     }
     if (dependencies.indexOf('react') === -1) {
@@ -107,7 +107,6 @@ const forks = Object.freeze({
         }
         return 'shared/forks/ReactFeatureFlags.test-renderer.js';
       case 'react-dom/testing':
-      case 'react/testing':
         switch (bundleType) {
           case FB_WWW_DEV:
           case FB_WWW_PROD:


### PR DESCRIPTION
The testing build versions of react-dom are included in the OSS builds right now, but we're not ready to share them yet. This PR removes them for now (back soon for the next release).

Do your magic, CI. 
