### PR TITLE
Refactor Portal Fiber parts for event system changes

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -505,6 +505,7 @@ export function setInitialProperties(
   tag: string,
   rawProps: Object,
   rootContainerElement: Element | Document,
+  internalRootInstanceHandle: Object,
 ): void {
   const isCustomComponentTag = isCustomComponent(tag, rawProps);
   if (__DEV__) {
@@ -637,6 +638,7 @@ export function diffProperties(
   lastRawProps: Object,
   nextRawProps: Object,
   rootContainerElement: Element | Document,
+  internalRootInstanceHandle: Object,
 ): null | Array<mixed> {
   if (__DEV__) {
     validatePropertiesInDevelopment(tag, nextRawProps);
@@ -898,6 +900,7 @@ export function diffHydratedProperties(
   rawProps: Object,
   parentNamespace: string,
   rootContainerElement: Element | Document,
+  internalRootInstanceHandle: Object,
 ): null | Array<mixed> {
   let isCustomComponentTag;
   let extraAttributeNames: Set<string>;

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -280,8 +280,15 @@ export function finalizeInitialChildren(
   props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): boolean {
-  setInitialProperties(domElement, type, props, rootContainerInstance);
+  setInitialProperties(
+    domElement,
+    type,
+    props,
+    rootContainerInstance,
+    internalRootInstanceHandle,
+  );
   return shouldAutoFocusHostComponent(type, props);
 }
 
@@ -292,6 +299,7 @@ export function prepareUpdate(
   newProps: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): null | Array<mixed> {
   if (__DEV__) {
     const hostContextDev = ((hostContext: any): HostContextDev);
@@ -314,6 +322,7 @@ export function prepareUpdate(
     oldProps,
     newProps,
     rootContainerInstance,
+    internalRootInstanceHandle,
   );
 }
 
@@ -745,6 +754,7 @@ export function hydrateInstance(
   rootContainerInstance: Container,
   hostContext: HostContext,
   internalInstanceHandle: Object,
+  internalRootInstanceHandle: Object,
 ): null | Array<mixed> {
   precacheFiberNode(internalInstanceHandle, instance);
   // TODO: Possibly defer this until the commit phase where all the events
@@ -763,6 +773,7 @@ export function hydrateInstance(
     props,
     parentNamespace,
     rootContainerInstance,
+    internalRootInstanceHandle,
   );
 }
 

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -124,7 +124,7 @@ type QueuedReplayableEvent = {|
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
-  container: Document | Element | Node,
+  rootInst: Object,
 |};
 
 let hasScheduledReplayAttempt = false;
@@ -255,7 +255,7 @@ function createQueuedReplayableEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: Document | Element | Node,
+  internalRootInstanceHandle: Object | null,
   nativeEvent: AnyNativeEvent,
 ): QueuedReplayableEvent {
   return {
@@ -263,7 +263,7 @@ function createQueuedReplayableEvent(
     topLevelType,
     eventSystemFlags: eventSystemFlags | IS_REPLAYED,
     nativeEvent,
-    container,
+    rootInst: internalRootInstanceHandle,
   };
 }
 
@@ -271,14 +271,14 @@ export function queueDiscreteEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: Document | Element | Node,
+  internalRootInstanceHandle: Object | null,
   nativeEvent: AnyNativeEvent,
 ): void {
   const queuedEvent = createQueuedReplayableEvent(
     blockedOn,
     topLevelType,
     eventSystemFlags,
-    container,
+    internalRootInstanceHandle,
     nativeEvent,
   );
   queuedDiscreteEvents.push(queuedEvent);
@@ -346,7 +346,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: Document | Element | Node,
+  internalRootInstanceHandle: Object | null,
   nativeEvent: AnyNativeEvent,
 ): QueuedReplayableEvent {
   if (
@@ -357,7 +357,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
       blockedOn,
       topLevelType,
       eventSystemFlags,
-      container,
+      internalRootInstanceHandle,
       nativeEvent,
     );
     if (blockedOn !== null) {
@@ -381,7 +381,7 @@ export function queueIfContinuousEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: Document | Element | Node,
+  internalRootInstanceHandle: Object | null,
   nativeEvent: AnyNativeEvent,
 ): boolean {
   // These set relatedTarget to null because the replayed event will be treated as if we
@@ -395,7 +395,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        internalRootInstanceHandle,
         focusEvent,
       );
       return true;
@@ -407,7 +407,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        internalRootInstanceHandle,
         dragEvent,
       );
       return true;
@@ -419,7 +419,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        internalRootInstanceHandle,
         mouseEvent,
       );
       return true;
@@ -434,7 +434,7 @@ export function queueIfContinuousEvent(
           blockedOn,
           topLevelType,
           eventSystemFlags,
-          container,
+          internalRootInstanceHandle,
           pointerEvent,
         ),
       );
@@ -450,7 +450,7 @@ export function queueIfContinuousEvent(
           blockedOn,
           topLevelType,
           eventSystemFlags,
-          container,
+          internalRootInstanceHandle,
           pointerEvent,
         ),
       );
@@ -527,7 +527,7 @@ function attemptReplayContinuousQueuedEvent(
   let nextBlockedOn = attemptToDispatchEvent(
     queuedEvent.topLevelType,
     queuedEvent.eventSystemFlags,
-    queuedEvent.container,
+    queuedEvent.rootInst,
     queuedEvent.nativeEvent,
   );
   if (nextBlockedOn !== null) {
@@ -570,7 +570,7 @@ function replayUnblockedEvents() {
     let nextBlockedOn = attemptToDispatchEvent(
       nextDiscreteEvent.topLevelType,
       nextDiscreteEvent.eventSystemFlags,
-      nextDiscreteEvent.container,
+      nextDiscreteEvent.rootInst,
       nextDiscreteEvent.nativeEvent,
     );
     if (nextBlockedOn !== null) {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -62,7 +62,7 @@ let hasWarnedAboutDeprecatedMockComponent = false;
  */
 function simulateNativeEventOnNode(topLevelType, node, fakeNativeEvent) {
   fakeNativeEvent.target = node;
-  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, document, fakeNativeEvent);
+  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, null, fakeNativeEvent);
 }
 
 /**

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -253,6 +253,7 @@ export function finalizeInitialChildren(
   props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): boolean {
   return false;
 }
@@ -298,6 +299,7 @@ export function prepareUpdate(
   newProps: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): null | Object {
   const viewConfig = instance.canonical.viewConfig;
   const updatePayload = diff(oldProps, newProps, viewConfig.validAttributes);

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -149,6 +149,7 @@ export function finalizeInitialChildren(
   props: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): boolean {
   // Don't send a no-op message over the bridge.
   if (parentInstance._children.length === 0) {
@@ -212,6 +213,7 @@ export function prepareUpdate(
   newProps: Props,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  internalRootInstanceHandle: Object,
 ): null | Object {
   return UPDATE_SIGNAL;
 }

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -26,6 +26,7 @@ import type {UpdateQueue} from './ReactUpdateQueue';
 import type {ContextDependency} from './ReactFiberNewContext';
 import type {HookType} from './ReactFiberHooks';
 import type {SuspenseInstance} from './ReactFiberHostConfig';
+import type {FiberPortal} from './ReactFiberRoot';
 
 import invariant from 'shared/invariant';
 import {
@@ -902,11 +903,13 @@ export function createFiberFromPortal(
   const pendingProps = portal.children !== null ? portal.children : [];
   const fiber = createFiber(HostPortal, pendingProps, portal.key, mode);
   fiber.expirationTime = expirationTime;
-  fiber.stateNode = {
+  const portalContainer: FiberPortal = {
     containerInfo: portal.containerInfo,
+    current: fiber,
     pendingChildren: null, // Used by persistent updates
     implementation: portal.implementation,
   };
+  fiber.stateNode = portalContainer;
   return fiber;
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -117,7 +117,7 @@ import {
 } from './ReactFiberHostConfig';
 import type {SuspenseInstance} from './ReactFiberHostConfig';
 import {shouldSuspend} from './ReactFiberReconciler';
-import {pushHostContext, pushHostContainer} from './ReactFiberHostContext';
+import {pushHostContext, pushRootOrPortal} from './ReactFiberHostContext';
 import {
   suspenseStackCursor,
   pushSuspenseContext,
@@ -983,7 +983,7 @@ function pushHostRootContext(workInProgress) {
     // Should always be set
     pushTopLevelContextObject(workInProgress, root.context, false);
   }
-  pushHostContainer(workInProgress, root.containerInfo);
+  pushRootOrPortal(workInProgress, root);
 }
 
 function updateHostRoot(current, workInProgress, renderExpirationTime) {
@@ -2594,7 +2594,7 @@ function updatePortalComponent(
   workInProgress: Fiber,
   renderExpirationTime: ExpirationTime,
 ) {
-  pushHostContainer(workInProgress, workInProgress.stateNode.containerInfo);
+  pushRootOrPortal(workInProgress, workInProgress.stateNode);
   const nextChildren = workInProgress.pendingProps;
   if (current === null) {
     // Portals are special because we don't append the children during mount
@@ -2954,10 +2954,7 @@ function beginWork(
           break;
         }
         case HostPortal:
-          pushHostContainer(
-            workInProgress,
-            workInProgress.stateNode.containerInfo,
-          );
+          pushRootOrPortal(workInProgress, workInProgress.stateNode);
           break;
         case ContextProvider: {
           const newValue = workInProgress.memoizedProps.value;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -986,13 +986,16 @@ function commitContainer(finishedWork: Fiber) {
     }
     case HostRoot:
     case HostPortal: {
+      const portalContainer = finishedWork.stateNode;
       const portalOrRoot: {
         containerInfo: Container,
         pendingChildren: ChildSet,
         ...
-      } = finishedWork.stateNode;
+      } = portalContainer;
       const {containerInfo, pendingChildren} = portalOrRoot;
       replaceContainerChildren(containerInfo, pendingChildren);
+      // Update the fiber on the portal container
+      portalContainer.current = finishedWork;
       return;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -13,7 +13,7 @@ import type {
   ReactFundamentalComponentInstance,
   ReactScopeInstance,
 } from 'shared/ReactTypes';
-import type {FiberRoot} from './ReactFiberRoot';
+import type {FiberRoot, RootOrPortal} from './ReactFiberRoot';
 import type {
   Instance,
   Type,
@@ -83,7 +83,7 @@ import {
   shouldUpdateFundamentalComponent,
 } from './ReactFiberHostConfig';
 import {
-  getRootHostContainer,
+  getRootOrPortal,
   popHostContext,
   getHostContext,
   popHostContainer,
@@ -195,6 +195,7 @@ if (supportsMutation) {
     workInProgress: Fiber,
     type: Type,
     newProps: Props,
+    rootOrPortal: RootOrPortal,
     rootContainerInstance: Container,
   ) {
     // If we have an alternate, that means this is an update and we need to
@@ -222,6 +223,7 @@ if (supportsMutation) {
       newProps,
       rootContainerInstance,
       currentHostContext,
+      rootOrPortal,
     );
     // TODO: Type this specific to this type of component.
     workInProgress.updateQueue = (updatePayload: any);
@@ -456,6 +458,7 @@ if (supportsMutation) {
     workInProgress: Fiber,
     type: Type,
     newProps: Props,
+    rootOrPortal: RootOrPortal,
     rootContainerInstance: Container,
   ) {
     const currentInstance = current.stateNode;
@@ -480,6 +483,7 @@ if (supportsMutation) {
         newProps,
         rootContainerInstance,
         currentHostContext,
+        rootOrPortal,
       );
     }
     if (childrenUnchanged && updatePayload === null) {
@@ -505,6 +509,7 @@ if (supportsMutation) {
         newProps,
         rootContainerInstance,
         currentHostContext,
+        rootOrPortal,
       )
     ) {
       markUpdate(workInProgress);
@@ -528,7 +533,8 @@ if (supportsMutation) {
   ) {
     if (oldText !== newText) {
       // If the text content differs, we'll create a new text instance for it.
-      const rootContainerInstance = getRootHostContainer();
+      const rootOrPortal = getRootOrPortal();
+      const rootContainerInstance = rootOrPortal.containerInfo;
       const currentHostContext = getHostContext();
       workInProgress.stateNode = createTextInstance(
         newText,
@@ -553,6 +559,7 @@ if (supportsMutation) {
     workInProgress: Fiber,
     type: Type,
     newProps: Props,
+    rootOrPortal: RootOrPortal,
     rootContainerInstance: Container,
   ) {
     // Noop
@@ -682,7 +689,8 @@ function completeWork(
     }
     case HostComponent: {
       popHostContext(workInProgress);
-      const rootContainerInstance = getRootHostContainer();
+      const rootOrPortal = getRootOrPortal();
+      const rootContainerInstance = rootOrPortal.containerInfo;
       const type = workInProgress.type;
       if (current !== null && workInProgress.stateNode != null) {
         updateHostComponent(
@@ -690,6 +698,7 @@ function completeWork(
           workInProgress,
           type,
           newProps,
+          rootOrPortal,
           rootContainerInstance,
         );
 
@@ -729,6 +738,7 @@ function completeWork(
               workInProgress,
               rootContainerInstance,
               currentHostContext,
+              rootOrPortal,
             )
           ) {
             // If changes to the hydrated node need to be applied at the
@@ -780,6 +790,7 @@ function completeWork(
               newProps,
               rootContainerInstance,
               currentHostContext,
+              rootOrPortal,
             )
           ) {
             markUpdate(workInProgress);
@@ -809,7 +820,8 @@ function completeWork(
           );
           // This can happen when we abort work.
         }
-        const rootContainerInstance = getRootHostContainer();
+        const rootOrPortal = getRootOrPortal();
+        const rootContainerInstance = rootOrPortal.containerInfo;
         const currentHostContext = getHostContext();
         let wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
@@ -1259,7 +1271,8 @@ function completeWork(
           if (enableDeprecatedFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
-              const rootContainerInstance = getRootHostContainer();
+              const rootOrPortal = getRootOrPortal();
+              const rootContainerInstance = rootOrPortal.containerInfo;
               updateDeprecatedEventListeners(
                 listeners,
                 workInProgress,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -16,6 +16,7 @@ import type {
   Container,
   HostContext,
 } from './ReactFiberHostConfig';
+import type {RootOrPortal} from './ReactFiberRoot';
 import type {SuspenseState} from './ReactFiberSuspenseComponent';
 
 import {
@@ -295,6 +296,7 @@ function prepareToHydrateHostInstance(
   fiber: Fiber,
   rootContainerInstance: Container,
   hostContext: HostContext,
+  rootOrPortal: RootOrPortal,
 ): boolean {
   if (!supportsHydration) {
     invariant(
@@ -312,6 +314,7 @@ function prepareToHydrateHostInstance(
     rootContainerInstance,
     hostContext,
     fiber,
+    rootOrPortal,
   );
   // TODO: Type this specific to this type of component.
   fiber.updateQueue = (updatePayload: any);

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -15,6 +15,7 @@ import type {Thenable} from './ReactFiberWorkLoop';
 import type {Interaction} from 'scheduler/src/Tracing';
 import type {SuspenseHydrationCallbacks} from './ReactFiberSuspenseComponent';
 import type {ReactPriorityLevel} from './SchedulerWithReactIntegration';
+import type {Container, ChildSet} from './ReactFiberHostConfig';
 
 import {noTimeout} from './ReactFiberHostConfig';
 import {createHostRootFiber} from './ReactFiber';
@@ -102,6 +103,15 @@ export type FiberRoot = {
   ...SuspenseCallbackOnlyFiberRootProperties,
   ...
 };
+
+export type FiberPortal = {
+  containerInfo: Container,
+  current: Fiber,
+  implementation: any,
+  pendingChildren: null | ChildSet,
+};
+
+export type RootOrPortal = FiberRoot | FiberPortal;
 
 function FiberRootNode(containerInfo, tag, hydrate) {
   this.tag = tag;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -184,6 +184,7 @@ export function finalizeInitialChildren(
   props: Props,
   rootContainerInstance: Container,
   hostContext: Object,
+  internalRootInstanceHandle: Object,
 ): boolean {
   return false;
 }
@@ -195,6 +196,7 @@ export function prepareUpdate(
   newProps: Props,
   rootContainerInstance: Container,
   hostContext: Object,
+  internalRootInstanceHandle: Object,
 ): null | {...} {
   return UPDATE_SIGNAL;
 }


### PR DESCRIPTION
This PR makes some changes to how we store the root container instance in context, and instead makes it so we store the root fiber instead. I've also added a Flow node for portal containers and also made it so that portal contains also have a `current` field, like root fiber containers do (this is needed for later changes that make the new event system possible). Lastly, we no longer pass around a `container` DOM node through the event dispatch system and instead expect the root/portal fiber instance passed to the host config.

The reason for making these changes, is that the previous assumption in passing around the "root container" element to the event system falls down in a bunch of places. Notably, where we might use the same container DOM element for multiple roots (`ReactDOM.createPortal(..., document.body)` comes to mind here). So instead of passing around the DOM node, we can instead pass around the boxed container for either the root or portal fiber – allowing the event system to traverse the correct tree and apply the correct semantics for when we encounter multiple roots during event propagation.

Lastly, the changes to the host context stack are so that we can get the root/portal fiber directly. This was far less code and probably more performant that maintaining another stack just for root/portal fibers. We can easily get the container element from the root/portal fibers after, so there should be no difference in output compared to master.