### PR TITLE
[Fabric] Fix targetAsInstance dispatchEvent "cannot read property of null"

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -88,6 +88,7 @@ export function dispatchEvent(
   if (enableNativeTargetAsInstance) {
     if (targetFiber != null) {
       const stateNode = targetFiber.stateNode;
+      // Guard against Fiber being unmounted
       if (stateNode != null) {
         eventTarget = stateNode.canonical;
       }

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -86,7 +86,7 @@ export function dispatchEvent(
 
   let eventTarget = null;
   if (enableNativeTargetAsInstance) {
-    if (targetFiber != null) {
+    if (targetFiber?.stateNode != null) {
       eventTarget = targetFiber.stateNode.canonical;
     }
   } else {

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -86,8 +86,11 @@ export function dispatchEvent(
 
   let eventTarget = null;
   if (enableNativeTargetAsInstance) {
-    if (targetFiber?.stateNode != null) {
-      eventTarget = targetFiber.stateNode.canonical;
+    if (targetFiber != null) {
+      const stateNode = targetFiber.stateNode;
+      if (stateNode != null) {
+        eventTarget = stateNode.canonical;
+      }
     }
   } else {
     eventTarget = nativeEvent.target;


### PR DESCRIPTION
## Summary

In some cases in prod testing, the `targetFiber` here in `dispatchEvent` does not have a stateNode. If we try to get `canonical` directly from stateNode, it will crash. We already check that `targetFiber` is non-null before continuing, I think it makes sense to check stateNode as well.

It's unclear to me why this is happening in the first place, though (why we'd have a targetFiber but not a stateNode). We may want to investigate and fix that in addition to/instead of this.

## Test Plan

`yarn test`
`yarn test-prod`
`yarn flow fabric`

I have an FB-internal prod test as well.