### PR TITLE
Move remaining things to named exports

### DIFF
--- a/packages/eslint-plugin-react-hooks/index.js
+++ b/packages/eslint-plugin-react-hooks/index.js
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
-module.exports = require('./src/index');
+export * from './src/index';

--- a/packages/react-art/Circle.js
+++ b/packages/react-art/Circle.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Circle = require('./npm/Circle');
-
-module.exports = Circle;
+export {default} from './npm/Circle';

--- a/packages/react-art/Rectangle.js
+++ b/packages/react-art/Rectangle.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Rectangle = require('./npm/Rectangle');
-
-module.exports = Rectangle;
+export {default} from './npm/Rectangle';

--- a/packages/react-art/Wedge.js
+++ b/packages/react-art/Wedge.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const Wedge = require('./npm/Wedge');
-
-module.exports = Wedge;
+export {default} from './npm/Wedge';

--- a/packages/react-art/index.js
+++ b/packages/react-art/index.js
@@ -7,8 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactART = require('./src/ReactART');
-
-module.exports = ReactART;
+export * from './src/ReactART';

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -11,22 +11,25 @@
 
 'use strict';
 
-const React = require('react');
+import * as React from 'react';
+
+import * as ReactART from 'react-art';
+import ARTSVGMode from 'art/modes/svg';
+import ARTCurrentMode from 'art/modes/current';
+// Since these are default exports, we need to import them using ESM.
+// Since they must be on top, we need to import this before ReactDOM.
+import Circle from 'react-art/Circle';
+import Rectangle from 'react-art/Rectangle';
+import Wedge from 'react-art/Wedge';
+
+// Isolate DOM renderer.
+jest.resetModules();
 const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-dom/test-utils');
 
 // Isolate test renderer.
 jest.resetModules();
 const ReactTestRenderer = require('react-test-renderer');
-
-// Isolate ART renderer.
-jest.resetModules();
-const ReactART = require('react-art');
-const ARTSVGMode = require('art/modes/svg');
-const ARTCurrentMode = require('art/modes/current');
-const Circle = require('react-art/Circle');
-const Rectangle = require('react-art/Rectangle');
-const Wedge = require('react-art/Wedge');
 
 // Isolate the noop renderer
 jest.resetModules();

--- a/packages/react-debug-tools/index.js
+++ b/packages/react-debug-tools/index.js
@@ -5,9 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
-const ReactDebugTools = require('./src/ReactDebugTools');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactDebugTools.default || ReactDebugTools;
+export * from './src/ReactDebugTools';

--- a/packages/react-flight-dom-webpack/index.js
+++ b/packages/react-flight-dom-webpack/index.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactFlightDOMClient = require('./src/ReactFlightDOMClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactFlightDOMClient.default || ReactFlightDOMClient;
+export * from './src/ReactFlightDOMClient';

--- a/packages/react-flight-dom-webpack/server.browser.js
+++ b/packages/react-flight-dom-webpack/server.browser.js
@@ -7,11 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactFlightDOMServerBrowser = require('./src/ReactFlightDOMServerBrowser');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports =
-  ReactFlightDOMServerBrowser.default || ReactFlightDOMServerBrowser;
+export * from './src/ReactFlightDOMServerBrowser';

--- a/packages/react-flight-dom-webpack/server.js
+++ b/packages/react-flight-dom-webpack/server.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./server.node');
+export * from './server.node';

--- a/packages/react-flight-dom-webpack/server.node.js
+++ b/packages/react-flight-dom-webpack/server.node.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactFlightDOMServerNode = require('./src/ReactFlightDOMServerNode');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest
-module.exports = ReactFlightDOMServerNode.default || ReactFlightDOMServerNode;
+export * from './src/ReactFlightDOMServerNode';

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
@@ -79,8 +79,4 @@ function readFromXHR<T>(request: XMLHttpRequest): ReactModelRoot<T> {
   return getModelRoot(response);
 }
 
-export default {
-  readFromXHR,
-  readFromFetch,
-  readFromReadableStream,
-};
+export {readFromXHR, readFromFetch, readFromReadableStream};

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -29,6 +29,4 @@ function renderToReadableStream(model: ReactModel): ReadableStream {
   });
 }
 
-export default {
-  renderToReadableStream,
-};
+export {renderToReadableStream};

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -26,6 +26,4 @@ function pipeToNodeWritable(model: ReactModel, destination: Writable): void {
   startWork(request);
 }
 
-export default {
-  pipeToNodeWritable,
-};
+export {pipeToNodeWritable};

--- a/packages/react-flight/index.js
+++ b/packages/react-flight/index.js
@@ -17,10 +17,4 @@
 // `react-server/inline-typed` (which *is*) for the current renderer.
 // On CI, we run Flow checks for each renderer separately.
 
-'use strict';
-
-const ReactFlightClient = require('./src/ReactFlightClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFlightClient.default || ReactFlightClient;
+export * from './src/ReactFlightClient';

--- a/packages/react-interactions/events/context-menu.js
+++ b/packages/react-interactions/events/context-menu.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/ContextMenu');
+export * from './src/dom/ContextMenu';

--- a/packages/react-interactions/events/focus.js
+++ b/packages/react-interactions/events/focus.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Focus');
+export * from './src/dom/Focus';

--- a/packages/react-interactions/events/hover.js
+++ b/packages/react-interactions/events/hover.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Hover');
+export * from './src/dom/Hover';

--- a/packages/react-interactions/events/input.js
+++ b/packages/react-interactions/events/input.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Input');
+export * from './src/dom/Input';

--- a/packages/react-interactions/events/keyboard.js
+++ b/packages/react-interactions/events/keyboard.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Keyboard');
+export * from './src/dom/Keyboard';

--- a/packages/react-interactions/events/press-legacy.js
+++ b/packages/react-interactions/events/press-legacy.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/PressLegacy');
+export * from './src/dom/PressLegacy';

--- a/packages/react-interactions/events/press.js
+++ b/packages/react-interactions/events/press.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Press');
+export * from './src/dom/Press';

--- a/packages/react-interactions/events/tap.js
+++ b/packages/react-interactions/events/tap.js
@@ -7,6 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-module.exports = require('./src/dom/Tap');
+export * from './src/dom/Tap';

--- a/packages/react-noop-renderer/flight-client.js
+++ b/packages/react-noop-renderer/flight-client.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactNoopFlightClient = require('./src/ReactNoopFlightClient');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopFlightClient.default || ReactNoopFlightClient;
+export * from './src/ReactNoopFlightClient';

--- a/packages/react-noop-renderer/flight-server.js
+++ b/packages/react-noop-renderer/flight-server.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactNoopFlightServer = require('./src/ReactNoopFlightServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopFlightServer.default || ReactNoopFlightServer;
+export * from './src/ReactNoopFlightServer';

--- a/packages/react-noop-renderer/index.js
+++ b/packages/react-noop-renderer/index.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactNoop = require('./src/ReactNoop');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoop.default || ReactNoop;
+export * from './src/ReactNoop';

--- a/packages/react-noop-renderer/persistent.js
+++ b/packages/react-noop-renderer/persistent.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactNoopPersistent = require('./src/ReactNoopPersistent');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopPersistent.default || ReactNoopPersistent;
+export * from './src/ReactNoopPersistent';

--- a/packages/react-noop-renderer/server.js
+++ b/packages/react-noop-renderer/server.js
@@ -7,10 +7,4 @@
  * @flow
  */
 
-'use strict';
-
-const ReactNoopServer = require('./src/ReactNoopServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactNoopServer.default || ReactNoopServer;
+export * from './src/ReactNoopServer';

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -17,9 +17,36 @@
 import ReactFiberReconciler from 'react-reconciler';
 import createReactNoop from './createReactNoop';
 
-const ReactNoop = createReactNoop(
+export const {
+  _Scheduler,
+  getChildren,
+  getPendingChildren,
+  getOrCreateRootContainer,
+  createRoot,
+  createBlockingRoot,
+  getChildrenAsJSX,
+  getPendingChildrenAsJSX,
+  createPortal,
+  render,
+  renderLegacySyncRoot,
+  renderToRootWithID,
+  unmountRootWithID,
+  findInstance,
+  flushNextYield,
+  flushWithHostCounters,
+  expire,
+  flushExpired,
+  batchedUpdates,
+  deferredUpdates,
+  unbatchedUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
+  flushSync,
+  flushPassiveEffects,
+  act,
+  dumpTree,
+  getRoot,
+} = createReactNoop(
   ReactFiberReconciler, // reconciler
   true, // useMutation
 );
-
-export default ReactNoop;

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -38,6 +38,4 @@ function read<T>(source: Source): ReactModelRoot<T> {
   return getModelRoot(response);
 }
 
-export default {
-  read,
-};
+export {read};

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -52,6 +52,4 @@ function render(model: ReactModel): Destination {
   return destination;
 }
 
-export default {
-  render,
-};
+export {render};

--- a/packages/react-noop-renderer/src/ReactNoopPersistent.js
+++ b/packages/react-noop-renderer/src/ReactNoopPersistent.js
@@ -17,9 +17,36 @@
 import ReactFiberPersistentReconciler from 'react-reconciler/persistent';
 import createReactNoop from './createReactNoop';
 
-const ReactNoopPersistent = createReactNoop(
+export const {
+  _Scheduler,
+  getChildren,
+  getPendingChildren,
+  getOrCreateRootContainer,
+  createRoot,
+  createBlockingRoot,
+  getChildrenAsJSX,
+  getPendingChildrenAsJSX,
+  createPortal,
+  render,
+  renderLegacySyncRoot,
+  renderToRootWithID,
+  unmountRootWithID,
+  findInstance,
+  flushNextYield,
+  flushWithHostCounters,
+  expire,
+  flushExpired,
+  batchedUpdates,
+  deferredUpdates,
+  unbatchedUpdates,
+  discreteUpdates,
+  flushDiscreteUpdates,
+  flushSync,
+  flushPassiveEffects,
+  act,
+  dumpTree,
+  getRoot,
+} = createReactNoop(
   ReactFiberPersistentReconciler, // reconciler
   false, // useMutation
 );
-
-export default ReactNoopPersistent;

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -47,6 +47,4 @@ function render(children: React$Element<any>): Destination {
   return destination;
 }
 
-export default {
-  render,
-};
+export {render};

--- a/packages/react-reconciler/index.js
+++ b/packages/react-reconciler/index.js
@@ -17,10 +17,4 @@
 // `react-reconciler/inline-typed` (which *is*) for the current renderer.
 // On CI, we run Flow checks for each renderer separately.
 
-'use strict';
-
-const ReactFiberReconciler = require('./src/ReactFiberReconciler');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFiberReconciler.default || ReactFiberReconciler;
+export * from './src/ReactFiberReconciler';

--- a/packages/react-reconciler/persistent.js
+++ b/packages/react-reconciler/persistent.js
@@ -9,8 +9,4 @@
 
 // This is the same export as in index.js,
 // with persistent reconciler flags turned on.
-const ReactFiberReconciler = require('./src/ReactFiberReconciler');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFiberReconciler.default || ReactFiberReconciler;
+export * from './src/ReactFiberReconciler';

--- a/packages/react-refresh/babel.js
+++ b/packages/react-refresh/babel.js
@@ -5,9 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
-const ReactFreshBabelPlugin = require('./src/ReactFreshBabelPlugin');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFreshBabelPlugin.default || ReactFreshBabelPlugin;
+export {default} from './src/ReactFreshBabelPlugin';

--- a/packages/react-refresh/runtime.js
+++ b/packages/react-refresh/runtime.js
@@ -5,9 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
-const ReactFreshRuntime = require('./src/ReactFreshRuntime');
-
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFreshRuntime.default || ReactFreshRuntime;
+export * from './src/ReactFreshRuntime';

--- a/packages/react-server/flight.js
+++ b/packages/react-server/flight.js
@@ -17,10 +17,4 @@
 // `react-server/flight.inline-typed` (which *is*) for the current renderer.
 // On CI, we run Flow checks for each renderer separately.
 
-'use strict';
-
-const ReactFlightServer = require('./src/ReactFlightServer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFlightServer.default || ReactFlightServer;
+export * from './src/ReactFlightServer';

--- a/packages/react-server/index.js
+++ b/packages/react-server/index.js
@@ -17,10 +17,4 @@
 // `react-server/inline-typed` (which *is*) for the current renderer.
 // On CI, we run Flow checks for each renderer separately.
 
-'use strict';
-
-const ReactFizzStreamer = require('./src/ReactFizzStreamer');
-
-// TODO: decide on the top-level export form.
-// This is hacky but makes it work with both Rollup and Jest.
-module.exports = ReactFizzStreamer.default || ReactFizzStreamer;
+export * from './src/ReactFizzStreamer';

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -288,10 +288,9 @@ ${license}
 
 if (process.env.NODE_ENV !== "production") {
   module.exports = function $$$reconciler($$$hostConfig) {
+    var exports = {};
 ${source}
-    var $$$renderer = module.exports;
-    module.exports = $$$reconciler;
-    return $$$renderer;
+    return exports;
   };
 }`;
   },
@@ -304,10 +303,9 @@ ${source}
 ${license}
  */
 module.exports = function $$$reconciler($$$hostConfig) {
+    var exports = {};
 ${source}
-    var $$$renderer = module.exports;
-    module.exports = $$$reconciler;
-    return $$$renderer;
+    return exports;
 };`;
   },
 };


### PR DESCRIPTION
The interesting case here is the noop renderers. The wrappers around the reconciler now changed to use a local export that gets mutated.

ReactNoop and ReactNoopPersistent now have to destructure the object to list out the names it's going to export. We should probably refactor ReactNoop away from createReactNoop. Especially since it's also not Flow typed.
