### PR TITLE
More event system cleanup and scaffolding

### DIFF
--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -29,7 +29,7 @@ export type PluginModule<NativeEvent> = {
     nativeTarget: NativeEvent,
     nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
-    container?: Document | Element | Node,
+    container?: Document | Element,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
 };

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -10,6 +10,7 @@
 import {registrationNameModules} from 'legacy-events/EventPluginRegistry';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import endsWith from 'shared/endsWith';
+import invariant from 'shared/invariant';
 import {setListenToResponderEventTypes} from '../events/DeprecatedDOMEventResponderSystem';
 
 import {
@@ -59,7 +60,6 @@ import {getListenerMapForElement} from '../events/DOMEventListenerMap';
 import {
   addResponderEventSystemEvent,
   removeActiveResponderEventSystemEvent,
-  trapBubbledEvent,
 } from '../events/ReactDOMEventListener.js';
 import {mediaEventTypes} from '../events/DOMTopLevelEventTypes';
 import {
@@ -74,7 +74,12 @@ import {
   shouldRemoveAttribute,
 } from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
-import {DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE} from '../shared/HTMLNodeType';
+import {
+  DOCUMENT_NODE,
+  DOCUMENT_FRAGMENT_NODE,
+  ELEMENT_NODE,
+  COMMENT_NODE,
+} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
 import possibleStandardNames from '../shared/possibleStandardNames';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
@@ -84,8 +89,13 @@ import {validateProperties as validateUnknownProperties} from '../shared/ReactDO
 import {
   enableDeprecatedFlareAPI,
   enableTrustedTypesIntegration,
+  enableModernEventSystem,
 } from 'shared/ReactFeatureFlags';
-import {legacyListenToEvent} from '../events/DOMLegacyEventPluginSystem';
+import {
+  legacyListenToEvent,
+  legacyTrapBubbledEvent,
+} from '../events/DOMLegacyEventPluginSystem';
+import {listenToEvent} from '../events/DOMModernPluginEventSystem';
 
 let didWarnInvalidHydration = false;
 let didWarnScriptTags = false;
@@ -260,16 +270,36 @@ if (__DEV__) {
 }
 
 function ensureListeningTo(
-  rootContainerElement: Element | Node,
+  rootContainerInstance: Element | Node,
   registrationName: string,
 ): void {
-  const isDocumentOrFragment =
-    rootContainerElement.nodeType === DOCUMENT_NODE ||
-    rootContainerElement.nodeType === DOCUMENT_FRAGMENT_NODE;
-  const doc = isDocumentOrFragment
-    ? rootContainerElement
-    : rootContainerElement.ownerDocument;
-  legacyListenToEvent(registrationName, doc);
+  if (enableModernEventSystem) {
+    // If we have a comment node, then use the parent node,
+    // which should be an element.
+    const rootContainerElement =
+      rootContainerInstance.nodeType === COMMENT_NODE
+        ? rootContainerInstance.parentNode
+        : rootContainerInstance;
+    // Containers can only ever be element nodes. We do not
+    // want to register events to document fragments or documents
+    // with the modern plugin event system.
+    invariant(
+      rootContainerElement != null &&
+        rootContainerElement.nodeType === ELEMENT_NODE,
+      'ensureListeningTo(): received a container that was not an element node. ' +
+        'This is likely a bug in React.',
+    );
+    listenToEvent(registrationName, ((rootContainerElement: any): Element));
+  } else {
+    // Legacy plugin event system path
+    const isDocumentOrFragment =
+      rootContainerInstance.nodeType === DOCUMENT_NODE ||
+      rootContainerInstance.nodeType === DOCUMENT_FRAGMENT_NODE;
+    const doc = isDocumentOrFragment
+      ? rootContainerInstance
+      : rootContainerInstance.ownerDocument;
+    legacyListenToEvent(registrationName, ((doc: any): Document));
+  }
 }
 
 function getOwnerDocumentFromRootContainer(
@@ -514,41 +544,55 @@ export function setInitialProperties(
     case 'iframe':
     case 'object':
     case 'embed':
-      trapBubbledEvent(TOP_LOAD, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_LOAD, domElement);
+      }
       props = rawProps;
       break;
     case 'video':
     case 'audio':
-      // Create listener for each media event
-      for (let i = 0; i < mediaEventTypes.length; i++) {
-        trapBubbledEvent(mediaEventTypes[i], domElement);
+      if (!enableModernEventSystem) {
+        // Create listener for each media event
+        for (let i = 0; i < mediaEventTypes.length; i++) {
+          legacyTrapBubbledEvent(mediaEventTypes[i], domElement);
+        }
       }
       props = rawProps;
       break;
     case 'source':
-      trapBubbledEvent(TOP_ERROR, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_ERROR, domElement);
+      }
       props = rawProps;
       break;
     case 'img':
     case 'image':
     case 'link':
-      trapBubbledEvent(TOP_ERROR, domElement);
-      trapBubbledEvent(TOP_LOAD, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_ERROR, domElement);
+        legacyTrapBubbledEvent(TOP_LOAD, domElement);
+      }
       props = rawProps;
       break;
     case 'form':
-      trapBubbledEvent(TOP_RESET, domElement);
-      trapBubbledEvent(TOP_SUBMIT, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_RESET, domElement);
+        legacyTrapBubbledEvent(TOP_SUBMIT, domElement);
+      }
       props = rawProps;
       break;
     case 'details':
-      trapBubbledEvent(TOP_TOGGLE, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_TOGGLE, domElement);
+      }
       props = rawProps;
       break;
     case 'input':
       ReactDOMInputInitWrapperState(domElement, rawProps);
       props = ReactDOMInputGetHostProps(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');
@@ -560,7 +604,9 @@ export function setInitialProperties(
     case 'select':
       ReactDOMSelectInitWrapperState(domElement, rawProps);
       props = ReactDOMSelectGetHostProps(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');
@@ -568,7 +614,9 @@ export function setInitialProperties(
     case 'textarea':
       ReactDOMTextareaInitWrapperState(domElement, rawProps);
       props = ReactDOMTextareaGetHostProps(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');
@@ -898,34 +946,48 @@ export function diffHydratedProperties(
     case 'iframe':
     case 'object':
     case 'embed':
-      trapBubbledEvent(TOP_LOAD, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_LOAD, domElement);
+      }
       break;
     case 'video':
     case 'audio':
-      // Create listener for each media event
-      for (let i = 0; i < mediaEventTypes.length; i++) {
-        trapBubbledEvent(mediaEventTypes[i], domElement);
+      if (!enableModernEventSystem) {
+        // Create listener for each media event
+        for (let i = 0; i < mediaEventTypes.length; i++) {
+          legacyTrapBubbledEvent(mediaEventTypes[i], domElement);
+        }
       }
       break;
     case 'source':
-      trapBubbledEvent(TOP_ERROR, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_ERROR, domElement);
+      }
       break;
     case 'img':
     case 'image':
     case 'link':
-      trapBubbledEvent(TOP_ERROR, domElement);
-      trapBubbledEvent(TOP_LOAD, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_ERROR, domElement);
+        legacyTrapBubbledEvent(TOP_LOAD, domElement);
+      }
       break;
     case 'form':
-      trapBubbledEvent(TOP_RESET, domElement);
-      trapBubbledEvent(TOP_SUBMIT, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_RESET, domElement);
+        legacyTrapBubbledEvent(TOP_SUBMIT, domElement);
+      }
       break;
     case 'details':
-      trapBubbledEvent(TOP_TOGGLE, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_TOGGLE, domElement);
+      }
       break;
     case 'input':
       ReactDOMInputInitWrapperState(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');
@@ -935,14 +997,18 @@ export function diffHydratedProperties(
       break;
     case 'select':
       ReactDOMSelectInitWrapperState(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');
       break;
     case 'textarea':
       ReactDOMTextareaInitWrapperState(domElement, rawProps);
-      trapBubbledEvent(TOP_INVALID, domElement);
+      if (!enableModernEventSystem) {
+        legacyTrapBubbledEvent(TOP_INVALID, domElement);
+      }
       // For controlled components we always need to ensure we're listening
       // to onChange. Even if there is no listener.
       ensureListeningTo(rootContainerElement, 'onChange');

--- a/packages/react-dom/src/events/DOMEventListenerMap.js
+++ b/packages/react-dom/src/events/DOMEventListenerMap.js
@@ -9,6 +9,8 @@
 
 import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 
+import {registrationNameDependencies} from 'legacy-events/EventPluginRegistry';
+
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 // prettier-ignore
 const elementListenerMap:
@@ -28,4 +30,20 @@ export function getListenerMapForElement(
     elementListenerMap.set(element, listenerMap);
   }
   return listenerMap;
+}
+
+export function isListeningToAllDependencies(
+  registrationName: string,
+  mountAt: Document | Element,
+): boolean {
+  const listenerMap = getListenerMapForElement(mountAt);
+  const dependencies = registrationNameDependencies[registrationName];
+
+  for (let i = 0; i < dependencies.length; i++) {
+    const dependency = dependencies[i];
+    if (!listenerMap.has(dependency)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
+import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
+import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
+
+import {registrationNameDependencies} from 'legacy-events/EventPluginRegistry';
+
+import {trapEventForPluginEventSystem} from './ReactDOMEventListener';
+import {getListenerMapForElement} from './DOMEventListenerMap';
+import {
+  TOP_FOCUS,
+  TOP_LOAD,
+  TOP_ABORT,
+  TOP_CANCEL,
+  TOP_INVALID,
+  TOP_BLUR,
+  TOP_SCROLL,
+  TOP_CLOSE,
+  TOP_RESET,
+  TOP_SUBMIT,
+  TOP_CAN_PLAY,
+  TOP_CAN_PLAY_THROUGH,
+  TOP_DURATION_CHANGE,
+  TOP_EMPTIED,
+  TOP_ENCRYPTED,
+  TOP_ENDED,
+  TOP_ERROR,
+  TOP_WAITING,
+  TOP_VOLUME_CHANGE,
+  TOP_TIME_UPDATE,
+  TOP_SUSPEND,
+  TOP_STALLED,
+  TOP_SEEKING,
+  TOP_SEEKED,
+  TOP_PLAY,
+  TOP_PAUSE,
+  TOP_LOAD_START,
+  TOP_LOADED_DATA,
+  TOP_LOADED_METADATA,
+  TOP_RATE_CHANGE,
+  TOP_PROGRESS,
+  TOP_PLAYING,
+} from './DOMTopLevelEventTypes';
+
+const capturePhaseEvents = new Set([
+  TOP_FOCUS,
+  TOP_BLUR,
+  TOP_SCROLL,
+  TOP_LOAD,
+  TOP_ABORT,
+  TOP_CANCEL,
+  TOP_CLOSE,
+  TOP_INVALID,
+  TOP_RESET,
+  TOP_SUBMIT,
+  TOP_ABORT,
+  TOP_CAN_PLAY,
+  TOP_CAN_PLAY_THROUGH,
+  TOP_DURATION_CHANGE,
+  TOP_EMPTIED,
+  TOP_ENCRYPTED,
+  TOP_ENDED,
+  TOP_ERROR,
+  TOP_LOADED_DATA,
+  TOP_LOADED_METADATA,
+  TOP_LOAD_START,
+  TOP_PAUSE,
+  TOP_PLAY,
+  TOP_PLAYING,
+  TOP_PROGRESS,
+  TOP_RATE_CHANGE,
+  TOP_SEEKED,
+  TOP_SEEKING,
+  TOP_STALLED,
+  TOP_SUSPEND,
+  TOP_TIME_UPDATE,
+  TOP_VOLUME_CHANGE,
+  TOP_WAITING,
+]);
+
+export function listenToTopLevelEvent(
+  topLevelType: DOMTopLevelEventType,
+  rootContainerElement: Element,
+  listenerMap: Map<DOMTopLevelEventType | string, null | (any => void)>,
+): void {
+  if (!listenerMap.has(topLevelType)) {
+    const isCapturePhase = capturePhaseEvents.has(topLevelType);
+    trapEventForPluginEventSystem(
+      rootContainerElement,
+      topLevelType,
+      isCapturePhase,
+    );
+    listenerMap.set(topLevelType, null);
+  }
+}
+
+export function listenToEvent(
+  registrationName: string,
+  rootContainerElement: Element,
+): void {
+  const listenerMap = getListenerMapForElement(rootContainerElement);
+  const dependencies = registrationNameDependencies[registrationName];
+
+  for (let i = 0; i < dependencies.length; i++) {
+    const dependency = dependencies[i];
+    listenToTopLevelEvent(dependency, rootContainerElement, listenerMap);
+  }
+}
+
+export function dispatchEventForPluginEventSystem(
+  topLevelType: DOMTopLevelEventType,
+  eventSystemFlags: EventSystemFlags,
+  nativeEvent: AnyNativeEvent,
+  targetInst: null | Fiber,
+  rootContainer: Document | Element,
+): void {
+  // TODO
+}

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -26,7 +26,7 @@ import getActiveElement from '../client/getActiveElement';
 import {getNodeFromInstance} from '../client/ReactDOMComponentTree';
 import {hasSelectionCapabilities} from '../client/ReactInputSelection';
 import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
-import {isListeningToAllDependencies} from './DOMLegacyEventPluginSystem';
+import {isListeningToAllDependencies} from './DOMEventListenerMap';
 
 const skipSelectionChangeEvent =
   canUseDOM && 'documentMode' in document && document.documentMode <= 11;

--- a/packages/react-dom/src/events/forks/EventListener-www.js
+++ b/packages/react-dom/src/events/forks/EventListener-www.js
@@ -16,16 +16,16 @@ export function addEventBubbleListener(
   element: Element,
   eventType: string,
   listener: Function,
-): void {
-  EventListenerWWW.listen(element, eventType, listener);
+) {
+  return EventListenerWWW.listen(element, eventType, listener);
 }
 
 export function addEventCaptureListener(
   element: Element,
   eventType: string,
   listener: Function,
-): void {
-  EventListenerWWW.capture(element, eventType, listener);
+) {
+  return EventListenerWWW.capture(element, eventType, listener);
 }
 
 export function addEventCaptureListenerWithPassiveFlag(
@@ -33,8 +33,8 @@ export function addEventCaptureListenerWithPassiveFlag(
   eventType: string,
   listener: Function,
   passive: boolean,
-): void {
-  EventListenerWWW.captureWithPassiveFlag(
+) {
+  return EventListenerWWW.captureWithPassiveFlag(
     element,
     eventType,
     listener,

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -345,5 +345,6 @@
   "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
   "345": "Root did not complete. This is a bug in React.",
   "346": "An event responder context was used outside of an event cycle.",
-  "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead."
+  "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
+  "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React."
 }


### PR DESCRIPTION
This PR is another step towards adding a forked modern event system that uses roots. Before we get to that stage, we need to do some cleanup and add some parts of the scaffolding. 

Specifically, this PR does the following:
- fork `ensureListeningTo` to accept modern/legacy events
- wrap `legacyTrapBubbledEvent` calls in a flag, as we won't do these in the modern event system (we use the capture phase instead).
- add `dispatchEventForLegacyPluginEventSystem` calls at `DOMEventListener` behind the flag, as the entrance point for dispatching modern event system events.
- add `listenToTopLevelEvent` calls at `ReactDOMEventReplaying` behind the flag, as the entrance point for replaying modern event system events.
- add `DOMModernPluginEventSystem` module. This doesn't do much for now, the rest of the code and tests will come in a follow up PR. It does register events accordingly however.
- various small changes to Flow types and cleanup of DOMEventListener

Note: there should be no functional changes to the existing legacy event system.