### PR TITLE
Change ReactVersion from CJS to ES module

### DIFF
--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -5,7 +5,5 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 // TODO: this is special because it gets imported during build.
-module.exports = '16.13.0';
+export default '16.13.0';

--- a/scripts/release/publish-commands/update-stable-version-numbers.js
+++ b/scripts/release/publish-commands/update-stable-version-numbers.js
@@ -44,7 +44,7 @@ const run = async ({cwd, packages, skipPackages, tags}) => {
     const sourceReactVersion = readFileSync(
       sourceReactVersionPath,
       'utf8'
-    ).replace(/module\.exports = '[^']+';/, `module.exports = '${version}';`);
+    ).replace(/export default '[^']+';/, `export default '${version}';`);
     writeFileSync(sourceReactVersionPath, sourceReactVersion);
   }
 };

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -209,10 +209,7 @@ const updateVersionsForNext = async (cwd, reactVersion, version) => {
   const sourceReactVersion = readFileSync(
     sourceReactVersionPath,
     'utf8'
-  ).replace(
-    /module\.exports = '[^']+';/,
-    `module.exports = '${reactVersion}';`
-  );
+  ).replace(/export default '[^']+';/, `export default '${reactVersion}';`);
   writeFileSync(sourceReactVersionPath, sourceReactVersion);
 
   // Update the root package.json.

--- a/scripts/tasks/version-check.js
+++ b/scripts/tasks/version-check.js
@@ -7,7 +7,12 @@
 
 'use strict';
 
-const reactVersion = require('../../package.json').version;
+const fs = require('fs');
+const ReactVersionSrc = fs.readFileSync(
+  require.resolve('../../packages/shared/ReactVersion')
+);
+const reactVersion = /export default '([^']+)';/.exec(ReactVersionSrc)[1];
+
 const versions = {
   'packages/react/package.json': require('../../packages/react/package.json')
     .version,
@@ -15,7 +20,7 @@ const versions = {
     .version,
   'packages/react-test-renderer/package.json': require('../../packages/react-test-renderer/package.json')
     .version,
-  'packages/shared/ReactVersion.js': require('../../packages/shared/ReactVersion'),
+  'packages/shared/ReactVersion.js': reactVersion,
 };
 
 let allVersionsMatch = true;


### PR DESCRIPTION
We need this to get rid of CJS in the build tool chain.