### PR TITLE
Only use Rollup's CommonJS plugin for "react-art"

### DIFF
--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -23,6 +23,9 @@
     "react": "^16.0.0",
     "react-test-renderer": "^16.0.0"
   },
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -29,6 +29,7 @@
     "react": "^16.0.0"
   },
   "dependencies": {
-    "error-stack-parser": "^2.0.2"
+    "error-stack-parser": "^2.0.2",
+    "object-assign": "^4.1.1"
   }
 }

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -392,8 +392,10 @@ function getPlugins(
       'process.env.NODE_ENV': isProduction ? "'production'" : "'development'",
       __EXPERIMENTAL__,
     }),
-    // We still need CommonJS for external deps like object-assign.
-    commonjs(),
+    // The CommonJS plugin *only* exists to pull "art" into "react-art".
+    // I'm going to port "art" to ES modules to avoid this problem.
+    // Please don't enable this for anything else!
+    isUMDBundle && entry === 'react-art' && commonjs(),
     // Apply dead code elimination and/or minification.
     isProduction &&
       closure(


### PR DESCRIPTION
This upgrades the shallow renderer dep, and properly make react-debug-tools and jest-react depend on object-assign as an external dependency instead of compiling it in.

This means that "art" is our only CJS dependency that needs to be compiled with Rollup. So we can now disable the CJS plugin for everything else. That ensures we don't reintroduce new CJS dependencies.

I'm hoping to port "art" to ESM or we can just drop the UMD build. Then we can get rid of the plugin completely.