### PR TITLE
Bump react-shallow-renderer to 16.13.1

### DIFF
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "react-is": "^16.8.6",
-    "react-shallow-renderer": "^16.13.0",
+    "react-shallow-renderer": "^16.13.1",
     "scheduler": "^0.19.0"
   },
   "peerDependencies": {

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -47,6 +47,11 @@ const forks = Object.freeze({
     return 'shared/forks/object-assign.umd.js';
   },
 
+  'react-shallow-renderer': () => {
+    // Use ESM build of `react-shallow-renderer`.
+    return 'react-shallow-renderer/esm/index.js';
+  },
+
   // Without this fork, importing `shared/ReactSharedInternals` inside
   // the `react` package itself would not work due to a cyclical dependency.
   'shared/ReactSharedInternals': (bundleType, entry, dependencies) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10856,10 +10856,10 @@ react-native-web@^0.11.5:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-shallow-renderer@^16.13.0:
-  version "16.13.0"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.13.0.tgz#18defe59ac922a9623fcbb8bed8db0da7c728fd4"
-  integrity sha512-qdFKyjjHSp5t4+Fs4479JqYDQnBdHi/IZEnGEmZZKZqoiwxjG4DKJPYd7YTaTmalUAqZlZR+K9ayz1+8tEctSg==
+react-shallow-renderer@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.13.1.tgz#4cfd6dc0f05a8d4d261ff7a80e9b88f15491a00a"
+  integrity sha512-hLmExm5/ZnjodLgm/4oxYw4i7fL6LLPhbO9mF/4tmaZUurtLrp2aSeDHZmRk0SVCHXPz0VaEbb3Dqi5J7odz7Q==
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0"


### PR DESCRIPTION
See https://github.com/webpack/webpack/issues/7973

### Most recent edit

I've now removed the `module` field from `react-shallow-renderer` to avoid ESM/CJS interop issues and published v16.13.1 of the package (see related PR https://github.com/NMinhNguyen/react-shallow-renderer/pull/34).

### Edit

Just came across https://github.com/webpack/webpack/issues/6584 as well

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This change fixes a plausible CJS <-> ESM interop issue in webpack that I mentioned in https://github.com/facebook/react/pull/18186#issuecomment-592794066 (see https://github.com/webpack/webpack/issues/7973 for details).

I was actually able to reproduce this issue by tweaking `node_modules` (to use `react-shallow-renderer`) and running `yarn test:karma` in Material-UI's repo - https://github.com/mui-org/material-ui/blob/aa0963253bd682d0c08f21114037749e3e9f0817/package.json#L36

Although it does pick up the ESM version of `react-shallow-renderer`, Enzyme uses `_interopRequireDefault` (https://unpkg.com/browse/enzyme-adapter-react-16@1.15.2/build/ReactSixteenAdapter.js) when `require()`-ing it so things don't actually break. But imagine a proper CJS setup (with webpack) where users are doing `require('react-test-renderer/shallow')`, they could get this `.default` key.

I'm not so concerned about direct imports of `react-shallow-renderer` (as in, not transitively via `react-test-renderer/shallow`) because it's a new package, so I don't think dropping the ESM build is worth it.

Note: this issue doesn't affect Jest (and as a result, CRA).

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I modified `react-test-renderer/shallow` like so in Material-UI's `node_modules`:

```js
const ReactShallowRenderer = require('react-shallow-renderer')

console.log('Resolved path:', require.resolve('react-shallow-renderer'))
console.log({__esModule: ReactShallowRenderer.__esModule, ReactShallowRenderer})

module.exports = ReactShallowRenderer;
```

And got the following output:

> HeadlessChrome 80.0.3987 (Mac OS X 10.15.1) LOG: 'Resolved path: ./node_modules/react-shallow-renderer/esm/index.js'
> HeadlessChrome 80.0.3987 (Mac OS X 10.15.1) LOG: Object{__esModule: true, ReactShallowRenderer: Object{default: function ReactShallowRenderer() { ... }}}


