### PR TITLE
Do not warn when a controlled input has `onInput` handler.

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -115,6 +115,10 @@ describe('ReactDOMInput', () => {
     ReactDOM.render(<input type="checkbox" checked={undefined} />, container);
   });
 
+  it('should not warn with value and onInput handler', () => {
+    ReactDOM.render(<input value="..." onInput={() => {}} />, container);
+  });
+
   it('should properly control a value even if no event listener exists', () => {
     let node;
 

--- a/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
+++ b/packages/react-dom/src/shared/ReactControlledValuePropTypes.js
@@ -33,6 +33,7 @@ if (__DEV__) {
       if (
         hasReadOnlyValue[props.type] ||
         props.onChange ||
+        props.onInput ||
         props.readOnly ||
         props.disabled ||
         props[propName] == null ||


### PR DESCRIPTION
## Summary

`onInput` behaves the same as `onChange` for controlled inputs as far as I know, so React should not print the following warning when `onInput` is present.

> Failed prop type: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.

## Test Plan

This code prints the warning above before this commit, but it shouldn't because `onInput` = `onChange` for controlled inputs.

    ReactDOM.render(<input value="..." onInput={() => {}} />, container);

I have added tests for this and they pass.