### PR TITLE
Refine PressLegacy blur logic to account for IE11 issue.

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -886,16 +886,9 @@ const pressResponderImpl = {
         break;
       }
       case 'blur': {
-        // If we encounter a blur event that moves focus to
-        // the window, then the relatedTarget will be null.
-        // In this case, we should cancel the active press.
-        // Alternatively, if the blur target matches the
-        // current pressed target, we should also cancel
-        // the active press.
-        if (
-          isPressed &&
-          (nativeEvent.relatedTarget === null || target === state.pressTarget)
-        ) {
+        // If we encounter a blur that happens on the pressed target
+        // then disengage the blur.
+        if (isPressed && target === state.pressTarget) {
           dispatchCancel(event, context, props, state);
         }
       }

--- a/packages/react-interactions/events/src/dom/Tap.js
+++ b/packages/react-interactions/events/src/dom/Tap.js
@@ -103,6 +103,7 @@ const rootEventTypes = hasPointerEvents
       'pointermove',
       'pointercancel',
       'scroll',
+      'blur',
     ]
   : [
       'click_active',
@@ -114,6 +115,7 @@ const rootEventTypes = hasPointerEvents
       'touchmove',
       'touchcancel',
       'scroll',
+      'blur',
     ];
 
 /**
@@ -696,6 +698,13 @@ const responderImpl = {
         }
         removeRootEventTypes(context, state);
         break;
+      }
+      case 'blur': {
+        // If we encounter a blur that happens on the pressed target
+        // then disengage the blur.
+        if (state.isActive && nativeEvent.target === state.responderTarget) {
+          dispatchCancel(context, props, state);
+        }
       }
     }
   },

--- a/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/Press-test.internal.js
@@ -700,4 +700,25 @@ describeWithPointerEvent('Press responder', hasPointerEvents => {
     target.pointerup();
     target.pointerdown();
   });
+
+  it('when blur occurs on a pressed target, we should disengage press', () => {
+    const onPress = jest.fn();
+    const onPressStart = jest.fn();
+    const onPressEnd = jest.fn();
+    const buttonRef = React.createRef();
+
+    const Component = () => {
+      const listener = usePress({onPress, onPressStart, onPressEnd});
+      return <button ref={buttonRef} DEPRECATED_flareListeners={listener} />;
+    };
+    ReactDOM.render(<Component />, container);
+
+    const target = createEventTarget(buttonRef.current);
+    target.pointerdown();
+    expect(onPressStart).toBeCalled();
+    target.blur();
+    expect(onPressEnd).toBeCalled();
+    target.pointerup();
+    expect(onPress).not.toBeCalled();
+  });
 });

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -1173,10 +1173,10 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
     expect(onPressEnd).toBeCalled();
   });
 
-  it('focus moving to the window should stop the press', () => {
-    const onPress = jest.fn(e => e.preventDefault());
-    const onPressStart = jest.fn(e => e.preventDefault());
-    const onPressEnd = jest.fn(e => e.preventDefault());
+  it('when blur occurs on a pressed target, we should disengage press', () => {
+    const onPress = jest.fn();
+    const onPressStart = jest.fn();
+    const onPressEnd = jest.fn();
     const buttonRef = React.createRef();
 
     const Component = () => {
@@ -1187,10 +1187,8 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
 
     const target = createEventTarget(buttonRef.current);
     target.pointerdown();
-    const secondTarget = createEventTarget(document);
-    // relatedTarget is null when moving focus to window
     expect(onPressStart).toBeCalled();
-    secondTarget.blur({relatedTarget: null});
+    target.blur();
     expect(onPressEnd).toBeCalled();
     target.pointerup();
     expect(onPress).not.toBeCalled();


### PR DESCRIPTION
This PR fixes an issues that was created in https://github.com/facebook/react/pull/18125. Notbaly, the issue was that IE11 fires `blur` events with a `null` `relatedTarget` when you click a focusable node.

Really, we never really needed the `relatedTarget`. Instead we can use the other part of the logic that checks if the actively pressed target is blurred instead. Given that all our Pressable nodes internally are always focusable, this should provide consistent characteristics across all browsers.

I've also ported the changes/fix to the `Tap` and `Press` event modules.