### PR TITLE
Modern Event System: add plugin handling and forked paths

### DIFF
--- a/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactBrowserEventEmitter-test.internal.js
@@ -17,6 +17,7 @@ let ReactDOMComponentTree;
 let listenToEvent;
 let ReactDOMEventListener;
 let ReactTestUtils;
+let ReactFeatureFlags;
 
 let idCallOrder;
 const recordID = function(id) {
@@ -60,13 +61,20 @@ describe('ReactBrowserEventEmitter', () => {
     jest.resetModules();
     LISTENER.mockClear();
 
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
     EventPluginGetListener = require('legacy-events/getListener').default;
     EventPluginRegistry = require('legacy-events/EventPluginRegistry');
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMComponentTree = require('../client/ReactDOMComponentTree');
-    listenToEvent = require('../events/DOMLegacyEventPluginSystem')
-      .legacyListenToEvent;
+    if (ReactFeatureFlags.enableModernEventSystem) {
+      listenToEvent = require('../events/DOMModernPluginEventSystem')
+        .listenToEvent;
+    } else {
+      listenToEvent = require('../events/DOMLegacyEventPluginSystem')
+        .legacyListenToEvent;
+    }
+
     ReactDOMEventListener = require('../events/ReactDOMEventListener');
     ReactTestUtils = require('react-dom/test-utils');
 

--- a/packages/react-dom/src/__tests__/ReactTreeTraversal-test.js
+++ b/packages/react-dom/src/__tests__/ReactTreeTraversal-test.js
@@ -11,6 +11,7 @@
 
 let React;
 let ReactDOM;
+let ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 const ChildComponent = ({id, eventHandler}) => (
   <div
@@ -203,41 +204,89 @@ describe('ReactTreeTraversal', () => {
       expect(mockFn.mock.calls).toEqual(expectedCalls);
     });
 
-    it('should enter from the window', () => {
-      const enterNode = document.getElementById('P_P1_C1__DIV');
+    // This will not work with the modern event system that
+    // attaches event listeners to roots as the event below
+    // is being triggered on a node that React does not listen
+    // to any more. Instead we should fire mouseover.
+    if (ReactFeatureFlags.enableModernEventSystem) {
+      it('should enter from the window', () => {
+        const enterNode = document.getElementById('P_P1_C1__DIV');
 
-      const expectedCalls = [
-        ['P', 'mouseenter'],
-        ['P_P1', 'mouseenter'],
-        ['P_P1_C1__DIV', 'mouseenter'],
-      ];
+        const expectedCalls = [
+          ['P', 'mouseenter'],
+          ['P_P1', 'mouseenter'],
+          ['P_P1_C1__DIV', 'mouseenter'],
+        ];
 
-      outerNode1.dispatchEvent(
-        new MouseEvent('mouseout', {
-          bubbles: true,
-          cancelable: true,
-          relatedTarget: enterNode,
-        }),
-      );
+        enterNode.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: outerNode1,
+          }),
+        );
 
-      expect(mockFn.mock.calls).toEqual(expectedCalls);
-    });
+        expect(mockFn.mock.calls).toEqual(expectedCalls);
+      });
+    } else {
+      it('should enter from the window', () => {
+        const enterNode = document.getElementById('P_P1_C1__DIV');
 
-    it('should enter from the window to the shallowest', () => {
-      const enterNode = document.getElementById('P');
+        const expectedCalls = [
+          ['P', 'mouseenter'],
+          ['P_P1', 'mouseenter'],
+          ['P_P1_C1__DIV', 'mouseenter'],
+        ];
 
-      const expectedCalls = [['P', 'mouseenter']];
+        outerNode1.dispatchEvent(
+          new MouseEvent('mouseout', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: enterNode,
+          }),
+        );
 
-      outerNode1.dispatchEvent(
-        new MouseEvent('mouseout', {
-          bubbles: true,
-          cancelable: true,
-          relatedTarget: enterNode,
-        }),
-      );
+        expect(mockFn.mock.calls).toEqual(expectedCalls);
+      });
+    }
 
-      expect(mockFn.mock.calls).toEqual(expectedCalls);
-    });
+    // This will not work with the modern event system that
+    // attaches event listeners to roots as the event below
+    // is being triggered on a node that React does not listen
+    // to any more. Instead we should fire mouseover.
+    if (ReactFeatureFlags.enableModernEventSystem) {
+      it('should enter from the window to the shallowest', () => {
+        const enterNode = document.getElementById('P');
+
+        const expectedCalls = [['P', 'mouseenter']];
+
+        enterNode.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: outerNode1,
+          }),
+        );
+
+        expect(mockFn.mock.calls).toEqual(expectedCalls);
+      });
+    } else {
+      it('should enter from the window to the shallowest', () => {
+        const enterNode = document.getElementById('P');
+
+        const expectedCalls = [['P', 'mouseenter']];
+
+        outerNode1.dispatchEvent(
+          new MouseEvent('mouseout', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: enterNode,
+          }),
+        );
+
+        expect(mockFn.mock.calls).toEqual(expectedCalls);
+      });
+    }
 
     it('should leave to the window', () => {
       const leaveNode = document.getElementById('P_P1_C1__DIV');

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -11,10 +11,15 @@ import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
 import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
+import type {PluginModule} from 'legacy-events/PluginModuleType';
 
 import {registrationNameDependencies} from 'legacy-events/EventPluginRegistry';
+import {batchedEventUpdates} from 'legacy-events/ReactGenericBatching';
+import {executeDispatchesInOrder} from 'legacy-events/EventPluginUtils';
+import {plugins} from 'legacy-events/EventPluginRegistry';
 
 import {trapEventForPluginEventSystem} from './ReactDOMEventListener';
+import getEventTarget from './getEventTarget';
 import {getListenerMapForElement} from './DOMEventListenerMap';
 import {
   TOP_FOCUS,
@@ -87,6 +92,48 @@ const capturePhaseEvents = new Set([
   TOP_WAITING,
 ]);
 
+const isArray = Array.isArray;
+
+function dispatchEventsForPlugins(
+  topLevelType: DOMTopLevelEventType,
+  eventSystemFlags: EventSystemFlags,
+  nativeEvent: AnyNativeEvent,
+  targetInst: null | Fiber,
+  rootContainer: Element | Document,
+): void {
+  const nativeEventTarget = getEventTarget(nativeEvent);
+  const syntheticEvents = [];
+
+  for (let i = 0; i < plugins.length; i++) {
+    const possiblePlugin: PluginModule<AnyNativeEvent> = plugins[i];
+    if (possiblePlugin) {
+      const extractedEvents = possiblePlugin.extractEvents(
+        topLevelType,
+        targetInst,
+        nativeEvent,
+        nativeEventTarget,
+        eventSystemFlags,
+        rootContainer,
+      );
+      if (extractedEvents) {
+        if (isArray(extractedEvents)) {
+          syntheticEvents.push(...(extractedEvents: any));
+        } else {
+          syntheticEvents.push(extractedEvents);
+        }
+      }
+    }
+  }
+  for (let i = 0; i < syntheticEvents.length; i++) {
+    const syntheticEvent = syntheticEvents[i];
+    executeDispatchesInOrder(syntheticEvent);
+    // Release the event from the pool if needed
+    if (!syntheticEvent.isPersistent()) {
+      syntheticEvent.constructor.release(syntheticEvent);
+    }
+  }
+}
+
 export function listenToTopLevelEvent(
   topLevelType: DOMTopLevelEventType,
   rootContainerElement: Element,
@@ -123,5 +170,15 @@ export function dispatchEventForPluginEventSystem(
   targetInst: null | Fiber,
   rootContainer: Document | Element,
 ): void {
-  // TODO
+  let ancestorInst = targetInst;
+
+  batchedEventUpdates(() =>
+    dispatchEventsForPlugins(
+      topLevelType,
+      eventSystemFlags,
+      nativeEvent,
+      ancestorInst,
+      rootContainer,
+    ),
+  );
 }

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -13,14 +13,10 @@ let React;
 let ReactFeatureFlags;
 let ReactDOM;
 
-function dispatchEvent(element, type) {
-  const event = document.createEvent('Event');
-  event.initEvent(type, true, true);
-  element.dispatchEvent(event);
-}
-
 function dispatchClickEvent(element) {
-  dispatchEvent(element, 'click');
+  const event = document.createEvent('Event');
+  event.initEvent('click', true, true);
+  element.dispatchEvent(event);
 }
 
 describe('DOMModernPluginEventSystem', () => {

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+
+function dispatchEvent(element, type) {
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  element.dispatchEvent(event);
+}
+
+function dispatchClickEvent(element) {
+  dispatchEvent(element, 'click');
+}
+
+describe('DOMModernPluginEventSystem', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableModernEventSystem = true;
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('handle propagation of click events', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    const log = [];
+    const onClick = jest.fn(e => log.push(['bubble', e.currentTarget]));
+    const onClickCapture = jest.fn(e => log.push(['capture', e.currentTarget]));
+
+    function Test() {
+      return (
+        <button
+          ref={buttonRef}
+          onClick={onClick}
+          onClickCapture={onClickCapture}>
+          <div ref={divRef} onClick={onClick} onClickCapture={onClickCapture}>
+            Click me!
+          </div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    dispatchClickEvent(buttonElement);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClickCapture).toHaveBeenCalledTimes(1);
+    expect(log[0]).toEqual(['capture', buttonElement]);
+    expect(log[1]).toEqual(['bubble', buttonElement]);
+
+    let divElement = divRef.current;
+    dispatchClickEvent(divElement);
+    expect(onClick).toHaveBeenCalledTimes(3);
+    expect(onClickCapture).toHaveBeenCalledTimes(3);
+    expect(log[2]).toEqual(['capture', buttonElement]);
+    expect(log[3]).toEqual(['capture', divElement]);
+    expect(log[4]).toEqual(['bubble', divElement]);
+    expect(log[5]).toEqual(['bubble', buttonElement]);
+  });
+
+  it('handle propagation of focus events', () => {
+    const buttonRef = React.createRef();
+    const divRef = React.createRef();
+    const log = [];
+    const onFocus = jest.fn(e => log.push(['bubble', e.currentTarget]));
+    const onFocusCapture = jest.fn(e => log.push(['capture', e.currentTarget]));
+
+    function Test() {
+      return (
+        <button
+          ref={buttonRef}
+          onFocus={onFocus}
+          onFocusCapture={onFocusCapture}>
+          <div
+            ref={divRef}
+            onFocus={onFocus}
+            onFocusCapture={onFocusCapture}
+            tabIndex={0}>
+            Click me!
+          </div>
+        </button>
+      );
+    }
+
+    ReactDOM.render(<Test />, container);
+
+    let buttonElement = buttonRef.current;
+    buttonElement.focus();
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onFocusCapture).toHaveBeenCalledTimes(1);
+    expect(log[0]).toEqual(['capture', buttonElement]);
+    expect(log[1]).toEqual(['bubble', buttonElement]);
+
+    let divElement = divRef.current;
+    divElement.focus();
+    expect(onFocus).toHaveBeenCalledTimes(3);
+    expect(onFocusCapture).toHaveBeenCalledTimes(3);
+    expect(log[2]).toEqual(['capture', buttonElement]);
+    expect(log[3]).toEqual(['capture', divElement]);
+    expect(log[4]).toEqual(['bubble', divElement]);
+    expect(log[5]).toEqual(['bubble', buttonElement]);
+  });
+});


### PR DESCRIPTION
This PR adds more of the modern event system logic, enough that based single root/non-portal logic now works and removing the flag should result in most tests passing. Note: this PR does not affect the existing legacy event system, and the only real changes are to the new modern event system (which is behind a flag anyway). This PR consists of:

- `DOMModernPluginEventSystem.js` adds event plugin handling, which is basically the exact same code from the legacy event system (except refactored to use basic for loops)
- `DOMModernPluginEventSystem-test.internal.js` that showes basic capture/bubble events working correctly with the new system (on a single root/non-portal example)
- `ReactBrowserEventEmitter-test.internal.js` uses the correct existing depending on the modern event system flag
- `ReactDOMEventListener-test.js ` disables or alters the expected outcome when using the new system
- `ReactTreeTraversal-test.js` disables or alters the expected outcome when using the new system
- `EnterLeaveEventPlugin.js` alters the logic to account for the new event system having roots rather than a single document listener, plus disables the first ancestor logic for the modern event system.