### PR TITLE
Use accumulateTwoPhaseDispatchesSingle directly

### DIFF
--- a/packages/legacy-events/EventPropagators.js
+++ b/packages/legacy-events/EventPropagators.js
@@ -66,7 +66,7 @@ function accumulateDirectionalDispatches(inst, phase, event) {
  * single traversal for the entire collection of events because each event may
  * have a different target.
  */
-function accumulateTwoPhaseDispatchesSingle(event) {
+export function accumulateTwoPhaseDispatchesSingle(event) {
   if (event && event.dispatchConfig.phasedRegistrationNames) {
     traverseTwoPhase(event._targetInst, accumulateDirectionalDispatches, event);
   }

--- a/packages/react-dom/src/events/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/BeforeInputEventPlugin.js
@@ -7,7 +7,7 @@
 
 import type {TopLevelType} from 'legacy-events/TopLevelEventTypes';
 
-import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
+import {accumulateTwoPhaseDispatchesSingle} from 'legacy-events/EventPropagators';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 
 import {
@@ -276,7 +276,7 @@ function extractCompositionEvent(
     }
   }
 
-  accumulateTwoPhaseDispatches(event);
+  accumulateTwoPhaseDispatchesSingle(event);
   return event;
 }
 
@@ -437,7 +437,7 @@ function extractBeforeInputEvent(
   );
 
   event.data = chars;
-  accumulateTwoPhaseDispatches(event);
+  accumulateTwoPhaseDispatchesSingle(event);
   return event;
 }
 

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -6,7 +6,7 @@
  */
 
 import {runEventsInBatch} from 'legacy-events/EventBatching';
-import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
+import {accumulateTwoPhaseDispatchesSingle} from 'legacy-events/EventPropagators';
 import {enqueueStateRestore} from 'legacy-events/ReactControlledComponent';
 import {batchedUpdates} from 'legacy-events/ReactGenericBatching';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
@@ -59,7 +59,7 @@ function createAndAccumulateChangeEvent(inst, nativeEvent, target) {
   event.type = 'change';
   // Flag this event loop as needing state restore.
   enqueueStateRestore(target);
-  accumulateTwoPhaseDispatches(event);
+  accumulateTwoPhaseDispatchesSingle(event);
   return event;
 }
 /**

--- a/packages/react-dom/src/events/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/SelectEventPlugin.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
+import {accumulateTwoPhaseDispatchesSingle} from 'legacy-events/EventPropagators';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
 import isTextInputElement from 'shared/isTextInputElement';
@@ -135,7 +135,7 @@ function constructSelectEvent(nativeEvent, nativeEventTarget) {
     syntheticEvent.type = 'select';
     syntheticEvent.target = activeElement;
 
-    accumulateTwoPhaseDispatches(syntheticEvent);
+    accumulateTwoPhaseDispatchesSingle(syntheticEvent);
 
     return syntheticEvent;
   }

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -16,7 +16,7 @@ import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {PluginModule} from 'legacy-events/PluginModuleType';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
-import {accumulateTwoPhaseDispatches} from 'legacy-events/EventPropagators';
+import {accumulateTwoPhaseDispatchesSingle} from 'legacy-events/EventPropagators';
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
@@ -191,7 +191,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> = {
       nativeEvent,
       nativeEventTarget,
     );
-    accumulateTwoPhaseDispatches(event);
+    accumulateTwoPhaseDispatchesSingle(event);
     return event;
   },
 };


### PR DESCRIPTION
I noticed this when working on the modern event system, so thought I'd add the improvement separately.

We only accumulate two phase dispatches on a single event. So passing it to `accumulateTwoPhaseDispatches` is unecessary in a bunch of places and is just overhead and runtime indirection.

Furthermore, with the modern event system we may want to add an additonal argument to `accumulateTwoPhaseDispatchesSingle` during event plugin phase, so this makes that far simpler to do.