### PR TITLE
react-devtools: move electron to optionalDependencies

### DIFF
--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -23,11 +23,13 @@
     "start": "node bin.js"
   },
   "dependencies": {
-    "cross-spawn": "^5.0.1",
-    "electron": "^5.0.0",
+    "cross-spawn": "^5.0.1",    
     "ip": "^1.1.4",
     "minimist": "^1.2.0",
     "react-devtools-core": "4.5.0",
     "update-notifier": "^2.1.0"
+  },
+  "optionalDependencies": {
+    "electron": "^5.0.0"
   }
 }


### PR DESCRIPTION
When we yarn/ci, we download electron only because it's listed in react-devtools as a dependency. We don't seem to use it for any tests or bundles though, so it's non-essential for the build. Further the electron download point is flaky, leading to ci failures like this https://circleci.com/gh/facebook/react/95743 This PR simply moves electron to optionalDependencies, so the build doesn't fail even if the download fails.