### PR TITLE
Fix instanceContainsElem bug

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -591,7 +591,7 @@ export function clearSuspenseBoundaryFromContainer(
 function instanceContainsElem(instance: Instance, element: HTMLElement) {
   let fiber = getClosestInstanceFromNode(element);
   while (fiber !== null) {
-    if (fiber.tag === HostComponent && fiber.stateNode === element) {
+    if (fiber.tag === HostComponent && fiber.stateNode === instance) {
       return true;
     }
     fiber = fiber.return;


### PR DESCRIPTION
This was an obvious bug on reflection, and most definitely a typo. The function is designed to find if an element is contained within another element in the fiber tree, except the original function mistakenly used `element` instead of `instance`, so we just early return everytime.