### PR TITLE
Remove _ctor field from Lazy components

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -9,7 +9,7 @@
 
 import type {ThreadID} from './ReactThreadIDAllocator';
 import type {ReactElement} from 'shared/ReactElementType';
-import type {LazyComponent} from 'shared/ReactLazyComponent';
+import type {LazyComponent} from 'react/src/ReactLazy';
 import type {ReactProvider, ReactContext} from 'shared/ReactTypes';
 
 import * as React from 'react';
@@ -17,12 +17,8 @@ import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {
-  Resolved,
-  Rejected,
-  Pending,
-  initializeLazyComponentType,
-} from 'shared/ReactLazyComponent';
+import {initializeLazyComponentType} from 'shared/ReactLazyComponent';
+import {Resolved, Rejected, Pending} from 'react/src/ReactLazy';
 import {
   warnAboutDeprecatedLifecycles,
   disableLegacyContext,

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -18,7 +18,7 @@ import getComponentName from 'shared/getComponentName';
 import describeComponentFrame from 'shared/describeComponentFrame';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {initializeLazyComponentType} from 'shared/ReactLazyComponent';
-import {Resolved, Rejected, Pending} from 'react/src/ReactLazy';
+import {Resolved, Rejected, Pending} from 'shared/ReactLazyStatusTags';
 import {
   warnAboutDeprecatedLifecycles,
   disableLegacyContext,

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -9,7 +9,7 @@
 
 import type {LazyComponent} from 'react/src/ReactLazy';
 
-import {Resolved} from 'react/src/ReactLazy';
+import {Resolved} from 'shared/ReactLazyStatusTags';
 import {initializeLazyComponentType} from 'shared/ReactLazyComponent';
 
 export function resolveDefaultProps(Component: any, baseProps: Object): Object {

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -7,9 +7,10 @@
  * @flow
  */
 
-import type {LazyComponent} from 'shared/ReactLazyComponent';
+import type {LazyComponent} from 'react/src/ReactLazy';
 
-import {Resolved, initializeLazyComponentType} from 'shared/ReactLazyComponent';
+import {Resolved} from 'react/src/ReactLazy';
+import {initializeLazyComponentType} from 'shared/ReactLazyComponent';
 
 export function resolveDefaultProps(Component: any, baseProps: Object): Object {
   if (Component && Component.defaultProps) {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -43,18 +43,13 @@ export type LazyComponent<T> =
   | ResolvedLazyComponent<T>
   | RejectedLazyComponent;
 
-export const Uninitialized = -1;
-export const Pending = 0;
-export const Resolved = 1;
-export const Rejected = 2;
-
 export function lazy<T>(
   ctor: () => Thenable<{default: T, ...} | T, mixed>,
 ): LazyComponent<T> {
   let lazyType: LazyComponent<T> = {
     $$typeof: REACT_LAZY_TYPE,
     // React uses these fields to store the result.
-    _status: Uninitialized,
+    _status: -1,
     _result: ctor,
   };
 

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -7,9 +7,46 @@
  * @flow
  */
 
-import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
-
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
+
+type Thenable<T, R> = {
+  then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
+};
+
+export type UninitializedLazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _status: -1,
+  _result: () => Thenable<{default: T, ...} | T, mixed>,
+};
+
+export type PendingLazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _status: 0,
+  _result: Thenable<{default: T, ...} | T, mixed>,
+};
+
+export type ResolvedLazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _status: 1,
+  _result: T,
+};
+
+export type RejectedLazyComponent = {
+  $$typeof: Symbol | number,
+  _status: 2,
+  _result: mixed,
+};
+
+export type LazyComponent<T> =
+  | UninitializedLazyComponent<T>
+  | PendingLazyComponent<T>
+  | ResolvedLazyComponent<T>
+  | RejectedLazyComponent;
+
+export const Uninitialized = -1;
+export const Pending = 0;
+export const Resolved = 1;
+export const Rejected = 2;
 
 export function lazy<T>(
   ctor: () => Thenable<{default: T, ...} | T, mixed>,
@@ -17,7 +54,7 @@ export function lazy<T>(
   let lazyType: LazyComponent<T> = {
     $$typeof: REACT_LAZY_TYPE,
     // React uses these fields to store the result.
-    _status: -1,
+    _status: Uninitialized,
     _result: ctor,
   };
 

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -3,14 +3,18 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import type {LazyComponent, Thenable} from 'shared/ReactLazyComponent';
 
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 
-export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
-  let lazyType = {
+export function lazy<T>(
+  ctor: () => Thenable<{default: T, ...} | T, mixed>,
+): LazyComponent<T> {
+  let lazyType: LazyComponent<T> = {
     $$typeof: REACT_LAZY_TYPE,
     _ctor: ctor,
     // React uses these fields to store the result.
@@ -22,6 +26,7 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
     // In production, this would just set it on the object.
     let defaultProps;
     let propTypes;
+    // $FlowFixMe
     Object.defineProperties(lazyType, {
       defaultProps: {
         configurable: true,
@@ -36,6 +41,7 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           );
           defaultProps = newDefaultProps;
           // Match production behavior more closely:
+          // $FlowFixMe
           Object.defineProperty(lazyType, 'defaultProps', {
             enumerable: true,
           });
@@ -54,6 +60,7 @@ export function lazy<T, R>(ctor: () => Thenable<T, R>): LazyComponent<T> {
           );
           propTypes = newPropTypes;
           // Match production behavior more closely:
+          // $FlowFixMe
           Object.defineProperty(lazyType, 'propTypes', {
             enumerable: true,
           });

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -16,10 +16,9 @@ export function lazy<T>(
 ): LazyComponent<T> {
   let lazyType: LazyComponent<T> = {
     $$typeof: REACT_LAZY_TYPE,
-    _ctor: ctor,
     // React uses these fields to store the result.
     _status: -1,
-    _result: null,
+    _result: ctor,
   };
 
   if (__DEV__) {

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -7,44 +7,14 @@
  * @flow
  */
 
-export type Thenable<T, R> = {
-  then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
-};
+import type {
+  PendingLazyComponent,
+  ResolvedLazyComponent,
+  RejectedLazyComponent,
+  LazyComponent,
+} from 'react/src/ReactLazy';
 
-type UninitializedLazyComponent<T> = {
-  $$typeof: Symbol | number,
-  _status: -1,
-  _result: () => Thenable<{default: T, ...} | T, mixed>,
-};
-
-type PendingLazyComponent<T> = {
-  $$typeof: Symbol | number,
-  _status: 0,
-  _result: Thenable<{default: T, ...} | T, mixed>,
-};
-
-type ResolvedLazyComponent<T> = {
-  $$typeof: Symbol | number,
-  _status: 1,
-  _result: T,
-};
-
-type RejectedLazyComponent = {
-  $$typeof: Symbol | number,
-  _status: 2,
-  _result: mixed,
-};
-
-export type LazyComponent<T> =
-  | UninitializedLazyComponent<T>
-  | PendingLazyComponent<T>
-  | ResolvedLazyComponent<T>
-  | RejectedLazyComponent;
-
-export const Uninitialized = -1;
-export const Pending = 0;
-export const Resolved = 1;
-export const Rejected = 2;
+import {Uninitialized, Pending, Resolved, Rejected} from 'react/src/ReactLazy';
 
 export function refineResolvedLazyComponent<T>(
   lazyComponent: LazyComponent<T>,
@@ -59,10 +29,7 @@ export function initializeLazyComponentType(
     let ctor = lazyComponent._result;
     if (!ctor) {
       // TODO: Remove this later. THis only exists in case you use an older "react" package.
-      ctor = ((lazyComponent: any)._ctor: () => Thenable<
-        {default: any, ...} | any,
-        mixed,
-      >);
+      ctor = ((lazyComponent: any)._ctor: typeof ctor);
     }
     const thenable = ctor();
     // Transition to the next state.

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -20,14 +20,6 @@ export type LazyComponent<T> = {
   ...
 };
 
-type ResolvedLazyComponent<T> = {
-  $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...}, mixed>,
-  _status: 1,
-  _result: any,
-  ...
-};
-
 export const Uninitialized = -1;
 export const Pending = 0;
 export const Resolved = 1;
@@ -35,7 +27,7 @@ export const Rejected = 2;
 
 export function refineResolvedLazyComponent<T>(
   lazyComponent: LazyComponent<T>,
-): ResolvedLazyComponent<T> | null {
+): T | null {
   return lazyComponent._status === Resolved ? lazyComponent._result : null;
 }
 

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -14,7 +14,12 @@ import type {
   LazyComponent,
 } from 'react/src/ReactLazy';
 
-import {Uninitialized, Pending, Resolved, Rejected} from 'react/src/ReactLazy';
+import {
+  Uninitialized,
+  Pending,
+  Resolved,
+  Rejected,
+} from './ReactLazyStatusTags';
 
 export function refineResolvedLazyComponent<T>(
   lazyComponent: LazyComponent<T>,

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -9,16 +9,41 @@
 
 export type Thenable<T, R> = {
   then(resolve: (T) => mixed, reject: (mixed) => mixed): R,
-  ...
 };
 
-export type LazyComponent<T> = {
+type UninitializedLazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...}, mixed>,
-  _status: 0 | 1 | 2,
-  _result: any,
-  ...
+  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
+  _status: -1,
+  _result: null,
 };
+
+type PendingLazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
+  _status: 0,
+  _result: Thenable<{default: T, ...} | T, mixed>,
+};
+
+type ResolvedLazyComponent<T> = {
+  $$typeof: Symbol | number,
+  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
+  _status: 1,
+  _result: T,
+};
+
+type RejectedLazyComponent = {
+  $$typeof: Symbol | number,
+  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
+  _status: 2,
+  _result: mixed,
+};
+
+export type LazyComponent<T> =
+  | UninitializedLazyComponent<T>
+  | PendingLazyComponent<T>
+  | ResolvedLazyComponent<T>
+  | RejectedLazyComponent;
 
 export const Uninitialized = -1;
 export const Pending = 0;
@@ -35,10 +60,12 @@ export function initializeLazyComponentType(
   lazyComponent: LazyComponent<any>,
 ): void {
   if (lazyComponent._status === Uninitialized) {
-    lazyComponent._status = Pending;
     const ctor = lazyComponent._ctor;
     const thenable = ctor();
-    lazyComponent._result = thenable;
+    // Transition to the next state.
+    const pending: PendingLazyComponent<any> = (lazyComponent: any);
+    pending._status = Pending;
+    pending._result = thenable;
     thenable.then(
       moduleObject => {
         if (lazyComponent._status === Pending) {
@@ -53,14 +80,18 @@ export function initializeLazyComponentType(
               );
             }
           }
-          lazyComponent._status = Resolved;
-          lazyComponent._result = defaultExport;
+          // Transition to the next state.
+          const resolved: ResolvedLazyComponent<any> = (lazyComponent: any);
+          resolved._status = Resolved;
+          resolved._result = defaultExport;
         }
       },
       error => {
         if (lazyComponent._status === Pending) {
-          lazyComponent._status = Rejected;
-          lazyComponent._result = error;
+          // Transition to the next state.
+          const rejected: RejectedLazyComponent = (lazyComponent: any);
+          rejected._status = Rejected;
+          rejected._result = error;
         }
       },
     );

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -13,28 +13,24 @@ export type Thenable<T, R> = {
 
 type UninitializedLazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
   _status: -1,
-  _result: null,
+  _result: () => Thenable<{default: T, ...} | T, mixed>,
 };
 
 type PendingLazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
   _status: 0,
   _result: Thenable<{default: T, ...} | T, mixed>,
 };
 
 type ResolvedLazyComponent<T> = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
   _status: 1,
   _result: T,
 };
 
 type RejectedLazyComponent = {
   $$typeof: Symbol | number,
-  _ctor: () => Thenable<{default: T, ...} | T, mixed>,
   _status: 2,
   _result: mixed,
 };
@@ -60,7 +56,7 @@ export function initializeLazyComponentType(
   lazyComponent: LazyComponent<any>,
 ): void {
   if (lazyComponent._status === Uninitialized) {
-    const ctor = lazyComponent._ctor;
+    const ctor = lazyComponent._result;
     const thenable = ctor();
     // Transition to the next state.
     const pending: PendingLazyComponent<any> = (lazyComponent: any);

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -56,7 +56,14 @@ export function initializeLazyComponentType(
   lazyComponent: LazyComponent<any>,
 ): void {
   if (lazyComponent._status === Uninitialized) {
-    const ctor = lazyComponent._result;
+    let ctor = lazyComponent._result;
+    if (!ctor) {
+      // TODO: Remove this later. THis only exists in case you use an older "react" package.
+      ctor = ((lazyComponent: any)._ctor: () => Thenable<
+        {default: any, ...} | any,
+        mixed,
+      >);
+    }
     const thenable = ctor();
     // Transition to the next state.
     const pending: PendingLazyComponent<any> = (lazyComponent: any);

--- a/packages/shared/ReactLazyStatusTags.js
+++ b/packages/shared/ReactLazyStatusTags.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// TODO: Move this to "react" once we can import from externals.
+export const Uninitialized = -1;
+export const Pending = 0;
+export const Resolved = 1;
+export const Rejected = 2;

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {LazyComponent} from 'shared/ReactLazyComponent';
+import type {LazyComponent} from 'react/src/ReactLazy';
 
 import {
   REACT_CONTEXT_TYPE,


### PR DESCRIPTION
This field is not needed because it's only used before we've initialized, and we don't have anything else to store before we've initialized.

This isn't an important perf optimization by itself but this refactor is motivated by lining it up with the same work on Blocks.