### PR TITLE
[Blocks] Make it possible to have lazy initialized and lazy loaded Blocks

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -9,6 +9,7 @@
 
 import type {ReactElement} from 'shared/ReactElementType';
 import type {ReactPortal} from 'shared/ReactTypes';
+import type {BlockComponent} from 'react/src/block';
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
 
@@ -420,18 +421,24 @@ function ChildReconciler(shouldTrackSideEffects) {
       } else if (
         enableBlocksAPI &&
         current.tag === Block &&
-        element.type.$$typeof === REACT_BLOCK_TYPE &&
-        element.type.render === current.type.render
+        element.type.$$typeof === REACT_BLOCK_TYPE
       ) {
-        // Same as above but also update the .type field.
-        const existing = useFiber(current, element.props);
-        existing.return = returnFiber;
-        existing.type = element.type;
-        if (__DEV__) {
-          existing._debugSource = element._source;
-          existing._debugOwner = element._owner;
+        // TODO: If this block is not initialized we need to initialize it first,
+        // since it might synchronously resolve to something we can reconcile.
+        if (
+          (element.type: BlockComponent<any, any, any>)._fn ===
+          (current.type: BlockComponent<any, any, any>)._fn
+        ) {
+          // Same as above but also update the .type field.
+          const existing = useFiber(current, element.props);
+          existing.return = returnFiber;
+          existing.type = element.type;
+          if (__DEV__) {
+            existing._debugSource = element._source;
+            existing._debugOwner = element._owner;
+          }
+          return existing;
         }
-        return existing;
       }
     }
     // Insert
@@ -1179,19 +1186,23 @@ function ChildReconciler(shouldTrackSideEffects) {
           }
           case Block:
             if (enableBlocksAPI) {
-              if (
-                element.type.$$typeof === REACT_BLOCK_TYPE &&
-                element.type.render === child.type.render
-              ) {
-                deleteRemainingChildren(returnFiber, child.sibling);
-                const existing = useFiber(child, element.props);
-                existing.type = element.type;
-                existing.return = returnFiber;
-                if (__DEV__) {
-                  existing._debugSource = element._source;
-                  existing._debugOwner = element._owner;
+              if (element.type.$$typeof === REACT_BLOCK_TYPE) {
+                // TODO: If this block is not initialized we need to initialize it first,
+                // since it might synchronously resolve to something we can reconcile.
+                if (
+                  (element.type: BlockComponent<any, any, any>)._fn ===
+                  (child.type: BlockComponent<any, any, any>)._fn
+                ) {
+                  deleteRemainingChildren(returnFiber, child.sibling);
+                  const existing = useFiber(child, element.props);
+                  existing.type = element.type;
+                  existing.return = returnFiber;
+                  if (__DEV__) {
+                    existing._debugSource = element._source;
+                    existing._debugOwner = element._owner;
+                  }
+                  return existing;
                 }
-                return existing;
               }
             }
           // We intentionally fallthrough here if enableBlocksAPI is not on.

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -48,6 +48,7 @@ import {
 } from './ReactCurrentFiber';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading';
 import {StrictMode} from './ReactTypeOfMode';
+import {initializeBlockComponentType} from 'shared/ReactLazyComponent';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -423,8 +424,9 @@ function ChildReconciler(shouldTrackSideEffects) {
         current.tag === Block &&
         element.type.$$typeof === REACT_BLOCK_TYPE
       ) {
-        // TODO: If this block is not initialized we need to initialize it first,
-        // since it might synchronously resolve to something we can reconcile.
+        // The new Block might not be initialized yet. We need to initialize
+        // it in case initializing it turns out it would match.
+        initializeBlockComponentType(element.type);
         if (
           (element.type: BlockComponent<any, any, any>)._fn ===
           (current.type: BlockComponent<any, any, any>)._fn
@@ -1187,8 +1189,9 @@ function ChildReconciler(shouldTrackSideEffects) {
           case Block:
             if (enableBlocksAPI) {
               if (element.type.$$typeof === REACT_BLOCK_TYPE) {
-                // TODO: If this block is not initialized we need to initialize it first,
-                // since it might synchronously resolve to something we can reconcile.
+                // The new Block might not be initialized yet. We need to initialize
+                // it in case initializing it turns out it would match.
+                initializeBlockComponentType(element.type);
                 if (
                   (element.type: BlockComponent<any, any, any>)._fn ===
                   (child.type: BlockComponent<any, any, any>)._fn

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -18,7 +18,6 @@ import type {
   SuspenseListTailMode,
 } from './ReactFiberSuspenseComponent';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
-import type {} from 'react/src/block';
 
 import checkPropTypes from 'shared/checkPropTypes';
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
+import type {BlockComponent} from 'react/src/block';
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
@@ -17,6 +18,7 @@ import type {
   SuspenseListTailMode,
 } from './ReactFiberSuspenseComponent';
 import type {SuspenseContext} from './ReactFiberSuspenseContext';
+import type {} from 'react/src/block';
 
 import checkPropTypes from 'shared/checkPropTypes';
 
@@ -166,6 +168,7 @@ import {
   readLazyComponentType,
   resolveDefaultProps,
 } from './ReactFiberLazyComponent';
+import {initializeBlockComponentType} from 'shared/ReactLazyComponent';
 import {
   resolveLazyComponentTag,
   createFiberFromTypeAndProps,
@@ -181,6 +184,7 @@ import {
   renderDidSuspendDelayIfPossible,
   markUnprocessedUpdateTime,
 } from './ReactFiberWorkLoop';
+import {Resolved} from 'shared/ReactLazyStatusTags';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -693,10 +697,10 @@ function updateFunctionComponent(
   return workInProgress.child;
 }
 
-function updateBlock(
+function updateBlock<Props, Payload, Data>(
   current: Fiber | null,
   workInProgress: Fiber,
-  block: any,
+  block: BlockComponent<Props, Payload, Data>,
   nextProps: any,
   renderExpirationTime: ExpirationTime,
 ) {
@@ -704,8 +708,13 @@ function updateBlock(
   // hasn't yet mounted. This happens after the first render suspends.
   // We'll need to figure out if this is fine or can cause issues.
 
-  const render = block.render;
-  const data = block.query();
+  initializeBlockComponentType(block);
+  if (block._status !== Resolved) {
+    throw block._data;
+  }
+
+  const render = block._fn;
+  const data = block._data;
 
   // The rest is a fork of updateFunctionComponent
   let nextChildren;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -343,12 +343,12 @@ function areHookInputsEqual(
   return true;
 }
 
-export function renderWithHooks(
+export function renderWithHooks<Props, SecondArg>(
   current: Fiber | null,
   workInProgress: Fiber,
-  Component: any,
-  props: any,
-  secondArg: any,
+  Component: (p: Props, arg: SecondArg) => any,
+  props: Props,
+  secondArg: SecondArg,
   nextRenderExpirationTime: ExpirationTime,
 ): any {
   renderExpirationTime = nextRenderExpirationTime;

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -14,6 +14,13 @@ import type {
   LazyComponent,
 } from 'react/src/ReactLazy';
 
+import type {
+  PendingBlockComponent,
+  ResolvedBlockComponent,
+  RejectedBlockComponent,
+  BlockComponent,
+} from 'react/src/block';
+
 import {
   Uninitialized,
   Pending,
@@ -67,6 +74,53 @@ export function initializeLazyComponentType(
           const rejected: RejectedLazyComponent = (lazyComponent: any);
           rejected._status = Rejected;
           rejected._result = error;
+        }
+      },
+    );
+  }
+}
+
+export function initializeBlockComponentType<Props, Payload, Data>(
+  blockComponent: BlockComponent<Props, Payload, Data>,
+): void {
+  if (blockComponent._status === Uninitialized) {
+    const thenableOrTuple = blockComponent._fn(blockComponent._data);
+    if (typeof thenableOrTuple.then !== 'function') {
+      let tuple: [any, any] = (thenableOrTuple: any);
+      const resolved: ResolvedBlockComponent<
+        Props,
+        Data,
+      > = (blockComponent: any);
+      resolved._status = Resolved;
+      resolved._data = tuple[0];
+      resolved._fn = tuple[1];
+      return;
+    }
+    const thenable = (thenableOrTuple: any);
+    // Transition to the next state.
+    const pending: PendingBlockComponent<Props, Data> = (blockComponent: any);
+    pending._status = Pending;
+    pending._data = thenable;
+    pending._fn = null;
+    thenable.then(
+      (tuple: [any, any]) => {
+        if (blockComponent._status === Pending) {
+          // Transition to the next state.
+          const resolved: ResolvedBlockComponent<
+            Props,
+            Data,
+          > = (blockComponent: any);
+          resolved._status = Resolved;
+          resolved._data = tuple[0];
+          resolved._fn = tuple[1];
+        }
+      },
+      error => {
+        if (blockComponent._status === Pending) {
+          // Transition to the next state.
+          const rejected: RejectedBlockComponent = (blockComponent: any);
+          rejected._status = Rejected;
+          rejected._data = error;
         }
       },
     );


### PR DESCRIPTION
This builds on a similar design as Lazy in https://github.com/facebook/react/pull/18217

The goal here is to make evaluating the query lazy but still allow render functions from different sources to reconcile against each other - even if they're lazy. In my first approach I hid the lazy loading into the "render" function wrapper which is not going to work since it doesn't reconcile against the same thing anymore then.