### PR TITLE
Modern Event System: export internal FB flag for testing

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -20,6 +20,7 @@ export const {
   warnAboutShorthandPropertyCollision,
   disableSchedulerTimeoutBasedOnReactExpirationTime,
   warnAboutSpreadingKeyToJSX,
+  enableModernEventSystem,
 } = require('ReactFeatureFlags');
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -94,8 +95,6 @@ export const disableTextareaChildren = __EXPERIMENTAL__;
 export const disableMapsAsChildren = __EXPERIMENTAL__;
 
 export const warnUnstableRenderSubtreeIntoContainer = false;
-
-export const enableModernEventSystem = false;
 
 export const enableLegacyFBPrimerSupport = !__EXPERIMENTAL__;
 


### PR DESCRIPTION
This re-exports the `enableModernEventSystem` flag so we can test this internally at FB.