### PR TITLE
Revert "feat: honor displayName of context types"

### DIFF
--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -120,11 +120,6 @@ export function createContext<T>(
           return context.Consumer;
         },
       },
-      displayName: {
-        get() {
-          return context.displayName;
-        },
-      },
     });
     // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
     context.Consumer = Consumer;

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -18,7 +18,6 @@
 let PropTypes;
 let React;
 let ReactDOM;
-let ReactDOMServer;
 let ReactTestUtils;
 
 describe('ReactContextValidator', () => {
@@ -28,7 +27,6 @@ describe('ReactContextValidator', () => {
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');
-    ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -671,28 +669,6 @@ describe('ReactContextValidator', () => {
 
     expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toErrorDev(
       'Warning: ComponentB: Function components do not support contextType.',
-    );
-  });
-
-  it('should honor a displayName if set on the context type', () => {
-    const Context = React.createContext(null);
-    Context.displayName = 'MyContextType';
-    function Validator() {
-      return null;
-    }
-    Validator.propTypes = {dontPassToSeeErrorStack: PropTypes.bool.isRequired};
-
-    expect(() => {
-      ReactDOMServer.renderToStaticMarkup(
-        <Context.Provider>
-          <Context.Consumer>{() => <Validator />}</Context.Consumer>
-        </Context.Provider>,
-      );
-    }).toErrorDev(
-      'Warning: Failed prop type: The prop `dontPassToSeeErrorStack` is marked as required in `Validator`, but its value is `undefined`.\n' +
-        '    in Validator (at **)\n' +
-        '    in MyContextType.Consumer (at **)\n' +
-        '    in MyContextType.Provider (at **)',
     );
   });
 });

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -24,7 +24,6 @@ import {
   REACT_BLOCK_TYPE,
 } from 'shared/ReactSymbols';
 import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
-import type {ReactContext, ReactProviderType} from 'shared/ReactTypes';
 
 function getWrappedName(
   outerType: mixed,
@@ -36,10 +35,6 @@ function getWrappedName(
     (outerType: any).displayName ||
     (functionName !== '' ? `${wrapperName}(${functionName})` : wrapperName)
   );
-}
-
-function getContextName(type: ReactContext<any>) {
-  return type.displayName || 'Context';
 }
 
 function getComponentName(type: mixed): string | null {
@@ -78,11 +73,9 @@ function getComponentName(type: mixed): string | null {
   if (typeof type === 'object') {
     switch (type.$$typeof) {
       case REACT_CONTEXT_TYPE:
-        const context: ReactContext<any> = (type: any);
-        return getContextName(context) + '.Consumer';
+        return 'Context.Consumer';
       case REACT_PROVIDER_TYPE:
-        const provider: ReactProviderType<any> = (type: any);
-        return getContextName(provider._context) + '.Provider';
+        return 'Context.Provider';
       case REACT_FORWARD_REF_TYPE:
         return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_MEMO_TYPE:


### PR DESCRIPTION
Reverts facebook/react#18035. This breaks an internal FB test where we try and set the `displayName` on the context type. Otherwise we get this runtime exception:

`TypeError: Cannot set property displayName of #<Object> which has only a getter`