### PR TITLE
feat: honor displayName of context types

### DIFF
--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -120,6 +120,11 @@ export function createContext<T>(
           return context.Consumer;
         },
       },
+      displayName: {
+        get() {
+          return context.displayName;
+        },
+      },
     });
     // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty
     context.Consumer = Consumer;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -124,6 +124,12 @@ export function createContext<T>(
         get() {
           return context.displayName;
         },
+        set() {
+          console.warn(
+            'Setting `displayName` on Context.Consumer has no effect. ' +
+              "You should set it directly on the context with Context.displayName = 'NamedContext'.",
+          );
+        },
       },
     });
     // $FlowFixMe: Flow complains about missing properties because it doesn't understand defineProperty

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -57,6 +57,7 @@ export function createContext<T>(
 
   let hasWarnedAboutUsingNestedContextConsumers = false;
   let hasWarnedAboutUsingConsumerProvider = false;
+  let hasWarnedAboutDisplayNameOnConsumer = false;
 
   if (__DEV__) {
     // A separate object, but proxies back to the original context object for
@@ -125,10 +126,13 @@ export function createContext<T>(
           return context.displayName;
         },
         set() {
-          console.warn(
-            'Setting `displayName` on Context.Consumer has no effect. ' +
-              "You should set it directly on the context with Context.displayName = 'NamedContext'.",
-          );
+          if (!hasWarnedAboutDisplayNameOnConsumer) {
+            console.warn(
+              'Setting `displayName` on Context.Consumer has no effect. ' +
+                "You should set it directly on the context with Context.displayName = 'NamedContext'.",
+            );
+            hasWarnedAboutDisplayNameOnConsumer = true;
+          }
         },
       },
     });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -18,6 +18,7 @@
 let PropTypes;
 let React;
 let ReactDOM;
+let ReactDOMServer;
 let ReactTestUtils;
 
 describe('ReactContextValidator', () => {
@@ -27,6 +28,7 @@ describe('ReactContextValidator', () => {
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');
+    ReactDOMServer = require('react-dom/server');
     ReactTestUtils = require('react-dom/test-utils');
   });
 
@@ -669,6 +671,28 @@ describe('ReactContextValidator', () => {
 
     expect(() => ReactTestUtils.renderIntoDocument(<ComponentB />)).toErrorDev(
       'Warning: ComponentB: Function components do not support contextType.',
+    );
+  });
+
+  it('should honor a displayName if set on the context type', () => {
+    const Context = React.createContext(null);
+    Context.displayName = 'MyContextType';
+    function Validator() {
+      return null;
+    }
+    Validator.propTypes = {dontPassToSeeErrorStack: PropTypes.bool.isRequired};
+
+    expect(() => {
+      ReactDOMServer.renderToStaticMarkup(
+        <Context.Provider>
+          <Context.Consumer>{() => <Validator />}</Context.Consumer>
+        </Context.Provider>,
+      );
+    }).toErrorDev(
+      'Warning: Failed prop type: The prop `dontPassToSeeErrorStack` is marked as required in `Validator`, but its value is `undefined`.\n' +
+        '    in Validator (at **)\n' +
+        '    in MyContextType.Consumer (at **)\n' +
+        '    in MyContextType.Provider (at **)',
     );
   });
 });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -706,5 +706,8 @@ describe('ReactContextValidator', () => {
         "You should set it directly on the context with Context.displayName = 'NamedContext'.",
       {withoutStack: true},
     );
+
+    // warning is deduped so subsequent setting is fine
+    Context.Consumer.displayName = 'ignored';
   });
 });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -695,4 +695,16 @@ describe('ReactContextValidator', () => {
         '    in MyContextType.Provider (at **)',
     );
   });
+
+  it('warns if displayName is set on the consumer type', () => {
+    const Context = React.createContext(null);
+
+    expect(() => {
+      Context.Consumer.displayName = 'ignored';
+    }).toWarnDev(
+      'Warning: Setting `displayName` on Context.Consumer has no effect. ' +
+        "You should set it directly on the context with Context.displayName = 'NamedContext'.",
+      {withoutStack: true},
+    );
+  });
 });

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -24,6 +24,7 @@ import {
   REACT_BLOCK_TYPE,
 } from 'shared/ReactSymbols';
 import {refineResolvedLazyComponent} from 'shared/ReactLazyComponent';
+import type {ReactContext, ReactProviderType} from 'shared/ReactTypes';
 
 function getWrappedName(
   outerType: mixed,
@@ -35,6 +36,10 @@ function getWrappedName(
     (outerType: any).displayName ||
     (functionName !== '' ? `${wrapperName}(${functionName})` : wrapperName)
   );
+}
+
+function getContextName(type: ReactContext<any>) {
+  return type.displayName || 'Context';
 }
 
 function getComponentName(type: mixed): string | null {
@@ -73,9 +78,11 @@ function getComponentName(type: mixed): string | null {
   if (typeof type === 'object') {
     switch (type.$$typeof) {
       case REACT_CONTEXT_TYPE:
-        return 'Context.Consumer';
+        const context: ReactContext<any> = (type: any);
+        return getContextName(context) + '.Consumer';
       case REACT_PROVIDER_TYPE:
-        return 'Context.Provider';
+        const provider: ReactProviderType<any> = (type: any);
+        return getContextName(provider._context) + '.Provider';
       case REACT_FORWARD_REF_TYPE:
         return getWrappedName(type, type.render, 'ForwardRef');
       case REACT_MEMO_TYPE:


### PR DESCRIPTION
## Summary

New iteration of #18035 which had to be reverted (#18223) since setting `Context.Consumer.displayName` would throw. 

Setting `Context.Consumer.displayName` ignores the given value but emits warning. As far as I can tell this doesn't do anything on `master`: https://codesandbox.io/s/priceless-hooks-lm0ky

## Test Plan

@trueadm should sign this off since this affects internal tests. If a warning is still too loud we could put it behind a flag that we turn off for the fb builds.
