### PR TITLE
Enable enableProfilerCommitHooks flag for FB

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,7 +35,7 @@ export const {
 export let enableUserTimingAPI = __DEV__ && !__EXPERIMENTAL__;
 
 export const enableProfilerTimer = __PROFILE__;
-export const enableProfilerCommitHooks = false;
+export const enableProfilerCommitHooks = __PROFILE__;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSchedulerDebugging = true;
 


### PR DESCRIPTION
Alternately, I could hook this up to a GK, but it seems like it would be nice if the flag were static.