### PR TITLE
Fix yarn warning on running 'yarn build-for-devtools'

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "scripts": {
     "build": "node ./scripts/rollup/build.js",
-    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build -- react/index,react-dom,react-is,react-debug-tools,scheduler,react-test-renderer --type=NODE",
+    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react-dom,react-is,react-debug-tools,scheduler,react-test-renderer --type=NODE",
     "linc": "node ./scripts/tasks/linc.js",
     "lint": "node ./scripts/tasks/eslint.js",
     "lint-build": "node ./scripts/rollup/validate/index.js",


### PR DESCRIPTION
fixes #18231

## Summary

Remove the "--" in `yarn build-for-devtools` script

