### PR TITLE
[React Native] Add getInspectorDataForViewAtPoint

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -34,7 +34,7 @@ import ReactVersion from 'shared/ReactVersion';
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 import {getClosestInstanceFromNode} from './ReactFabricComponentTree';
-import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
+import {getInspectorDataForViewAtPoint, getInspectorDataForViewTag} from './ReactNativeFiberInspector';
 
 import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -233,7 +233,8 @@ export {
 injectIntoDevTools({
   findFiberByHostInstance: getClosestInstanceFromNode,
   getInspectorDataForViewTag: getInspectorDataForViewTag,
-  bundleType: __DEV__ ? 1 : 0,
+  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(null, findNodeHandle),
+  bundleType: __DEV__ ? 1 : 0, 
   version: ReactVersion,
   rendererPackageName: 'react-native-renderer',
 });

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -34,7 +34,10 @@ import ReactVersion from 'shared/ReactVersion';
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 import {getClosestInstanceFromNode} from './ReactFabricComponentTree';
-import {getInspectorDataForViewAtPoint, getInspectorDataForViewTag} from './ReactNativeFiberInspector';
+import {
+  getInspectorDataForViewAtPoint,
+  getInspectorDataForViewTag,
+} from './ReactNativeFiberInspector';
 
 import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -233,8 +236,11 @@ export {
 injectIntoDevTools({
   findFiberByHostInstance: getClosestInstanceFromNode,
   getInspectorDataForViewTag: getInspectorDataForViewTag,
-  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(null, findNodeHandle),
-  bundleType: __DEV__ ? 1 : 0, 
+  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(
+    null,
+    findNodeHandle,
+  ),
+  bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-native-renderer',
 });

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -34,11 +34,17 @@ class ReactNativeFiberHostComponent {
   _children: Array<Instance | number>;
   _nativeTag: number;
   viewConfig: ReactNativeBaseComponentViewConfig<>;
+  _internalFiberInstanceHandle: Object;
 
-  constructor(tag: number, viewConfig: ReactNativeBaseComponentViewConfig<>) {
+  constructor(
+    tag: number,
+    viewConfig: ReactNativeBaseComponentViewConfig<>,
+    internalInstanceHandle: Object,
+  ) {
     this._nativeTag = tag;
     this._children = [];
     this.viewConfig = viewConfig;
+    this._internalFiberInstanceHandle = internalInstanceHandle;
   }
 
   blur() {

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -188,8 +188,8 @@ if (__DEV__) {
         inspectedView._internalInstanceHandle.stateNode.node,
         locationX,
         locationY,
-        shadowNode => {
-          if (shadowNode == null) {
+        internalInstanceHandle => {
+          if (internalInstanceHandle == null) {
             callback({
               pointerY: locationY,
               frame: {left: 0, top: 0, width: 0, height: 0},
@@ -198,9 +198,9 @@ if (__DEV__) {
           }
 
           closestInstance =
-            shadowNode.stateNode.canonical._internalInstanceHandle;
+            internalInstanceHandle.stateNode.canonical._internalInstanceHandle;
           nativeFabricUIManager.measure(
-            shadowNode.stateNode.node,
+            internalInstanceHandle.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
               callback({
                 pointerY: locationY,

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -253,7 +253,7 @@ if (__DEV__) {
   ): void => {
     invariant(
       false,
-      'getInspectorDataForViewAtPoint() is not available in production',
+      'getInspectorDataForViewAtPoint() is not available in production.',
     );
   };
 }

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -202,7 +202,7 @@ if (__DEV__) {
           callback({
             ...inspectorData,
             frame: {left, top, width, height},
-            touchedViewTag: nativeViewTag
+            touchedViewTag: nativeViewTag,
           });
         },
       );

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -8,7 +8,7 @@
  */
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import type {TouchedViewDataAtPoint} from './ReactNativeTypes';
+import type {TouchedViewDataAtPoint, InspectorData} from './ReactNativeTypes';
 
 import {
   findCurrentHostFiber,
@@ -91,7 +91,7 @@ if (__DEV__) {
     }));
   };
 
-  const getInspectorDataForInstance = function(closestInstance, frame): Object {
+  const getInspectorDataForInstance = function(closestInstance): InspectorData {
     // Handle case where user clicks outside of ReactNative
     if (!closestInstance) {
       return {
@@ -112,7 +112,6 @@ if (__DEV__) {
 
     return {
       hierarchy,
-      frame,
       props,
       selection,
       source,
@@ -156,12 +155,6 @@ if (__DEV__) {
     callback: (viewData: TouchedViewDataAtPoint) => mixed,
   ): void {
     let closestInstance = null;
-    let frame = {
-      left: 0,
-      top: 0,
-      width: 0,
-      height: 0,
-    };
 
     if (inspectedView._internalInstanceHandle != null) {
       // For Fabric we can look up the instance handle directly and measure it.
@@ -171,7 +164,11 @@ if (__DEV__) {
         locationY,
         shadowNode => {
           if (shadowNode == null) {
-            callback(getInspectorDataForInstance(closestInstance, frame));
+            callback({
+              pointerY: locationY,
+              frame: {left: 0, top: 0, width: 0, height: 0},
+              ...getInspectorDataForInstance(closestInstance),
+            });
           }
 
           closestInstance =
@@ -179,12 +176,10 @@ if (__DEV__) {
           nativeFabricUIManager.measure(
             shadowNode.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
-              const inspectorData = getInspectorDataForInstance(
-                closestInstance,
-              );
               callback({
-                ...inspectorData,
+                pointerY: locationY,
                 frame: {left: pageX, top: pageY, width, height},
+                ...getInspectorDataForInstance(closestInstance),
               });
             },
           );
@@ -201,6 +196,7 @@ if (__DEV__) {
           );
           callback({
             ...inspectorData,
+            pointerY: locationY,
             frame: {left, top, width, height},
             touchedViewTag: nativeViewTag,
           });

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -8,7 +8,10 @@
  */
 
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
-import type {ReactFabricType, HostComponent as ReactNativeHostComponent} from './ReactNativeTypes';
+import type {
+  ReactFabricType,
+  HostComponent as ReactNativeHostComponent,
+} from './ReactNativeTypes';
 
 import {
   findCurrentHostFiber,
@@ -117,7 +120,7 @@ if (__DEV__) {
       selection,
       source,
     };
-  }
+  };
 
   getInspectorDataForViewTag = function(viewTag: number): Object {
     const closestInstance = getClosestInstanceFromNode(viewTag);
@@ -161,10 +164,10 @@ if (__DEV__) {
       top: 0,
       width: 0,
       height: 0,
-    }
+    };
 
     if (inspectedView._internalInstanceHandle != null) {
-      // fabric
+      // For Fabric we can look up the instance handle directly and measure it.
       nativeFabricUIManager.findNodeAtPoint(
         inspectedView._internalInstanceHandle.stateNode.node,
         x,
@@ -174,7 +177,8 @@ if (__DEV__) {
             callback(getInspectorDataForInstance(closestInstance, frame));
           }
 
-          closestInstance = shadowNode.stateNode.canonical._internalInstanceHandle;
+          closestInstance =
+            shadowNode.stateNode.canonical._internalInstanceHandle;
           nativeFabricUIManager.measure(
             shadowNode.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
@@ -183,7 +187,7 @@ if (__DEV__) {
                 top: pageY,
                 width,
                 height,
-              }
+              };
 
               callback(getInspectorDataForInstance(closestInstance, frame));
             },
@@ -191,18 +195,21 @@ if (__DEV__) {
         },
       );
     } else if (inspectedView._internalFiberInstanceHandle != null) {
+      // For Paper we fall back to the old strategy using the React tag.
       UIManager.findSubviewIn(
         findNodeHandle(inspectedView),
         [x, y],
         (nativeViewTag, left, top, width, height) => {
           frame = {
-                left,
-                top,
-                width,
-                height,
-              };
-          var closestInstance = getClosestInstanceFromNode(nativeViewTag); // Handle case where user clicks outside of ReactNative
-          const inspectorData = getInspectorDataForInstance(closestInstance, frame);
+            left,
+            top,
+            width,
+            height,
+          };
+          const inspectorData = getInspectorDataForInstance(
+            getClosestInstanceFromNode(nativeViewTag),
+            frame,
+          );
           callback({...inspectorData, nativeViewTag});
         },
       );

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -108,7 +108,11 @@ export function createInstance(
     updatePayload, // props
   );
 
-  const component = new ReactNativeFiberHostComponent(tag, viewConfig);
+  const component = new ReactNativeFiberHostComponent(
+    tag,
+    viewConfig,
+    internalInstanceHandle,
+  );
 
   precacheFiberNode(internalInstanceHandle, tag);
   updateFiberProps(tag, props);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -36,7 +36,7 @@ import ReactVersion from 'shared/ReactVersion';
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 import {getClosestInstanceFromNode} from './ReactNativeComponentTree';
-import {getInspectorDataForViewTag} from './ReactNativeFiberInspector';
+import {getInspectorDataForViewTag, getInspectorDataForViewAtPoint} from './ReactNativeFiberInspector';
 
 import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -247,6 +247,7 @@ export {
 injectIntoDevTools({
   findFiberByHostInstance: getClosestInstanceFromNode,
   getInspectorDataForViewTag: getInspectorDataForViewTag,
+  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(null, findNodeHandle),
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-native-renderer',

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -36,7 +36,10 @@ import ReactVersion from 'shared/ReactVersion';
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 import {getClosestInstanceFromNode} from './ReactNativeComponentTree';
-import {getInspectorDataForViewTag, getInspectorDataForViewAtPoint} from './ReactNativeFiberInspector';
+import {
+  getInspectorDataForViewTag,
+  getInspectorDataForViewAtPoint,
+} from './ReactNativeFiberInspector';
 
 import {LegacyRoot} from 'shared/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -247,7 +250,10 @@ export {
 injectIntoDevTools({
   findFiberByHostInstance: getClosestInstanceFromNode,
   getInspectorDataForViewTag: getInspectorDataForViewTag,
-  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(null, findNodeHandle),
+  getInspectorDataForViewAtPoint: getInspectorDataForViewAtPoint.bind(
+    null,
+    findNodeHandle,
+  ),
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,
   rendererPackageName: 'react-native-renderer',

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -118,7 +118,7 @@ type InspectorDataGetter = (
   source: InspectorDataSource,
 |}>;
 
-export type InspectorData = $ReadOnly<{
+export type InspectorData = $ReadOnly<{|
   hierarchy: Array<{|
     name: ?string,
     getInspectorData: InspectorDataGetter,
@@ -126,9 +126,9 @@ export type InspectorData = $ReadOnly<{
   selection: ?number,
   props: InspectorDataProps,
   source: ?InspectorDataSource,
-}>;
+|}>;
 
-export type TouchedViewDataAtPoint = $ReadOnly<{
+export type TouchedViewDataAtPoint = $ReadOnly<{|
   pointerY: number,
   touchedViewTag?: number,
   frame: $ReadOnly<{|
@@ -138,7 +138,7 @@ export type TouchedViewDataAtPoint = $ReadOnly<{
     height: number,
   |}>,
   ...InspectorData,
-}>;
+|}>;
 
 /**
  * Flat ReactNative renderer bundles are too big for Flow to parse efficiently.

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -100,22 +100,44 @@ type SecretInternalsType = {
   ...
 };
 
-export type TouchedViewDataAtPoint = $ReadOnly<{
-  hierarchy?: ?Array<{|name: string|}>,
-  pointerY: number,
-  touchedViewTag?: ?number,
-  props: $ReadOnly<{[propName: string]: string, ...}>,
-  selection: number,
-  source: $ReadOnly<{|
-    fileName?: string,
-    lineNumber?: number,
+type InspectorDataProps = $ReadOnly<{
+  [propName: string]: string,
+  ...,
+}>;
+
+type InspectorDataSource = $ReadOnly<{|
+  fileName?: string,
+  lineNumber?: number,
+|}>;
+
+type InspectorDataGetter = (
+  (componentOrHandle: any) => ?number,
+) => $ReadOnly<{|
+  measure: Function,
+  props: InspectorDataProps,
+  source: ?InspectorDataSource,
+|}>;
+
+export type InspectorData = $ReadOnly<{
+  hierarchy?: ?Array<{|
+    name: ?string,
+    getInspectorData: InspectorDataGetter,
   |}>,
+  selection: ?number,
+  props: InspectorDataProps,
+  source: ?InspectorDataSource,
+}>;
+
+export type TouchedViewDataAtPoint = $ReadOnly<{
+  pointerY: ?number,
+  touchedViewTag?: ?number,
   frame?: ?$ReadOnly<{|
     top?: ?number,
     left?: ?number,
     width?: ?number,
     height: ?number,
   |}>,
+  ...InspectorData,
 }>;
 
 /**

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -115,11 +115,11 @@ type InspectorDataGetter = (
 ) => $ReadOnly<{|
   measure: Function,
   props: InspectorDataProps,
-  source: ?InspectorDataSource,
+  source: InspectorDataSource,
 |}>;
 
 export type InspectorData = $ReadOnly<{
-  hierarchy?: ?Array<{|
+  hierarchy: Array<{|
     name: ?string,
     getInspectorData: InspectorDataGetter,
   |}>,
@@ -129,13 +129,13 @@ export type InspectorData = $ReadOnly<{
 }>;
 
 export type TouchedViewDataAtPoint = $ReadOnly<{
-  pointerY: ?number,
-  touchedViewTag?: ?number,
-  frame?: ?$ReadOnly<{|
-    top?: ?number,
-    left?: ?number,
-    width?: ?number,
-    height: ?number,
+  pointerY: number,
+  touchedViewTag?: number,
+  frame: $ReadOnly<{|
+    top: number,
+    left: number,
+    width: number,
+    height: number,
   |}>,
   ...InspectorData,
 }>;

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -100,6 +100,24 @@ type SecretInternalsType = {
   ...
 };
 
+export type TouchedViewDataAtPoint = $ReadOnly<{
+  hierarchy?: ?Array<{|name: string|}>,
+  pointerY: number,
+  touchedViewTag?: ?number,
+  props: $ReadOnly<{[propName: string]: string, ...}>,
+  selection: number,
+  source: $ReadOnly<{|
+    fileName?: string,
+    lineNumber?: number,
+  |}>,
+  frame?: ?$ReadOnly<{|
+    top?: ?number,
+    left?: ?number,
+    width?: ?number,
+    height: ?number,
+  |}>,
+}>;
+
 /**
  * Flat ReactNative renderer bundles are too big for Flow to parse efficiently.
  * Provide minimal Flow typing for the high-level RN API and call it a day.

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -10,6 +10,7 @@
 import type {Fiber} from './ReactFiber';
 import type {FiberRoot} from './ReactFiberRoot';
 import type {RootTag} from 'shared/ReactRootTags';
+import type {TouchedViewDataAtPoint} from 'react-native-renderer/src/ReactNativeTypes';
 import type {
   Instance,
   TextInstance,
@@ -109,6 +110,12 @@ type DevToolsConfig = {|
   // This API is unfortunately RN-specific.
   // TODO: Change it to accept Fiber instead and type it properly.
   getInspectorDataForViewTag?: (tag: number) => Object,
+  // Used by RN in-app inspector.
+  getInspectorDataForViewAtPoint?: (
+    inspectedView: Object,
+    locationX: number,
+    locationY: number,
+    callback: (viewData: TouchedViewDataAtPoint) => mixed) => void,
 |};
 
 let didWarnAboutNestedUpdates;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -115,7 +115,8 @@ type DevToolsConfig = {|
     inspectedView: Object,
     locationX: number,
     locationY: number,
-    callback: (viewData: TouchedViewDataAtPoint) => mixed) => void,
+    callback: (viewData: TouchedViewDataAtPoint) => mixed,
+  ) => void,
 |};
 
 let didWarnAboutNestedUpdates;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -346,5 +346,6 @@
   "345": "Root did not complete. This is a bug in React.",
   "346": "An event responder context was used outside of an event cycle.",
   "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
-  "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React."
+  "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React.",
+  "349": "getInspectorDataForViewAtPoint() is not available in production"
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -347,5 +347,5 @@
   "346": "An event responder context was used outside of an event cycle.",
   "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
   "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React.",
-  "349": "getInspectorDataForViewAtPoint() is not available in production"
+  "349": "getInspectorDataForViewAtPoint() is not available in production."
 }

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -18,6 +18,7 @@ import type {
 } from 'react-native-renderer/src/ReactNativeTypes';
 import type {RNTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 import type {CapturedError} from 'react-reconciler/src/ReactCapturedValue';
+import type {Fiber} from 'react-reconciler/src/ReactFiber';
 
 type DeepDifferOptions = {|+unsafelyIgnoreFunctions?: boolean|};
 
@@ -96,6 +97,17 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
     ) => Promise<any>,
     setJSResponder: (reactTag: number, blockNativeResponder: boolean) => void,
     clearJSResponder: () => void,
+    findSubviewIn: (
+      reactTag: ?number,
+      point: Array<number>,
+      callback: (
+        nativeViewTag: number,
+        left: number,
+        top: number,
+        width: number,
+        height: number,
+      ) => void,
+    ) => void,
     ...
   };
   declare export var BatchedBridge: {
@@ -155,6 +167,12 @@ declare var nativeFabricUIManager: {
     relativeNode: Node,
     onFail: () => void,
     onSuccess: MeasureLayoutOnSuccessCallback,
+  ) => void,
+  findNodeAtPoint: (
+    node: Node,
+    locationX: number,
+    locationY: number,
+    callback: (Fiber) => void,
   ) => void,
   ...
 };


### PR DESCRIPTION
## Summary
This diff adds `getInspectorDataForViewAtPoint`, accessible through the DevTools hook, which provides an interface to return inspector data about the view touched at a given point. This allows the React Native inspector to ask React for information about a view at an x,y touch point without any knowledge of how each renderer gets the information.

## Implementation

**Paper**
For Paper we've just moved the logic from the [InspectorOverlay](https://github.com/facebook/react-native/blob/c3d072955024824d7ff6113fc9f642d25c462f16/Libraries/Inspector/InspectorOverlay.js#L40-L50) into React Core. This will allow us to delete `getInspectorDataForViewTag` called [here](https://github.com/facebook/react-native/blob/c3d072955024824d7ff6113fc9f642d25c462f16/Libraries/Inspector/Inspector.js#L61) which is necessary since Fabric does not support React tags.

**Fabric**
For Fabric we add a new strategy which queries native for a node using `findNodeAtPoint`, passes the shadow node to `measure`, and then asks React for the fiber information.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Manually tested in Fabric and Paper for React Native.