### PR TITLE
Hard-code disableModulePatternComponents in tests

### DIFF
--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -18,6 +18,8 @@ jest.mock('shared/ReactFeatureFlags', () => {
   wwwFlags.enableUserTimingAPI = defaultFlags.enableUserTimingAPI;
   wwwFlags.disableJavaScriptURLs = defaultFlags.disableJavaScriptURLs;
   wwwFlags.enableDeprecatedFlareAPI = defaultFlags.enableDeprecatedFlareAPI;
+  wwwFlags.disableModulePatternComponents =
+    defaultFlags.disableModulePatternComponents;
 
   return wwwFlags;
 });


### PR DESCRIPTION
Hard-coding this until tests are fixed, to unblock master.