### PR TITLE
Eager bailouts only for use state

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -112,7 +112,6 @@ type Update<S, A> = {|
 type UpdateQueue<S, A> = {|
   pending: Update<S, A> | null,
   dispatch: (A => mixed) | null,
-  lastRenderedReducer: ((S, A) => S) | null,
   lastRenderedState: S | null,
 |};
 
@@ -641,7 +640,6 @@ function mountReducer<S, I, A>(
   const queue = (hook.queue = {
     pending: null,
     dispatch: null,
-    lastRenderedReducer: reducer,
     lastRenderedState: (initialState: any),
   });
   const dispatch: Dispatch<A> = (queue.dispatch = (dispatchAction.bind(
@@ -663,8 +661,6 @@ function updateReducer<S, I, A>(
     queue !== null,
     'Should have a queue. This is likely a bug in React. Please file an issue.',
   );
-
-  queue.lastRenderedReducer = reducer;
 
   const current: Hook = (currentHook: any);
 
@@ -788,8 +784,6 @@ function rerenderReducer<S, I, A>(
     'Should have a queue. This is likely a bug in React. Please file an issue.',
   );
 
-  queue.lastRenderedReducer = reducer;
-
   // This is a re-render. Apply the new render phase updates to the previous
   // work-in-progress hook.
   const dispatch: Dispatch<A> = (queue.dispatch: any);
@@ -842,7 +836,6 @@ function mountState<S>(
   const queue = (hook.queue = {
     pending: null,
     dispatch: null,
-    lastRenderedReducer: basicStateReducer,
     lastRenderedState: (initialState: any),
   });
   const dispatch: Dispatch<
@@ -1554,7 +1547,6 @@ function setState<S>(
       // The queue is currently empty, which means we can eagerly compute the
       // next state before entering the render phase. If the new state is the
       // same as the current state, we may be able to bail out entirely.
-      const lastRenderedReducer = queue.lastRenderedReducer;
       let prevDispatcher;
       if (__DEV__) {
         prevDispatcher = ReactCurrentDispatcher.current;
@@ -1562,7 +1554,7 @@ function setState<S>(
       }
       try {
         const currentState: S = (queue.lastRenderedState: any);
-        const eagerState = lastRenderedReducer(currentState, action);
+        const eagerState = basicStateReducer(currentState, action);
         // Stash the eagerly computed state, and the reducer used to compute
         // it, on the update object. If the reducer hasn't changed by the
         // time we enter the render phase, then the eager state can be used

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -103,7 +103,7 @@ type Update<S, A> = {|
   expirationTime: ExpirationTime,
   suspenseConfig: null | SuspenseConfig,
   action: A,
-  eagerlyComputed: false,
+  eagerlyComputed: boolean,
   eagerState: S | null,
   next: Update<S, A>,
   priority?: ReactPriorityLevel,
@@ -1330,7 +1330,7 @@ function dispatchAction<S, A>(
 
 function setState<S>(
   fiber: Fiber,
-  queue: UpdateQueue<S>,
+  queue: UpdateQueue<S, BasicStateAction<S>>,
   action: BasicStateAction<S>
 ) {
  if (__DEV__) {
@@ -1351,7 +1351,7 @@ function setState<S>(
     suspenseConfig,
   );
 
-  const update: Update<S, A> = {
+  const update: Update<S, BasicStateAction<S>> = {
     expirationTime,
     suspenseConfig,
     action,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1394,15 +1394,10 @@ function setState<S>(
         const eagerState = basicStateReducer(currentState, action);
         if (is(eagerState, currentState)) {
           // Fast path. We can bail out without scheduling React to re-render.
-          // It's still possible that we'll need to rebase this update later,
-          // if the component re-renders for a different reason and by that
-          // time the reducer has changed.
           return;
         }
-        // Stash the eagerly computed state, and the reducer used to compute
-        // it, on the update object. If the reducer hasn't changed by the
-        // time we enter the render phase, then the eager state can be used
-        // without calling the reducer again.
+        // Stash the eagerly computed state on the update object.
+        // It will be reused without without calling basicStateReducer again.
         update.eagerlyComputed = true;
         update.eagerState = eagerState;
       } catch (error) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1488,45 +1488,6 @@ function dispatchAction<S, A>(
     update.expirationTime = renderExpirationTime;
     currentlyRenderingFiber.expirationTime = renderExpirationTime;
   } else {
-    if (
-      fiber.expirationTime === NoWork &&
-      (alternate === null || alternate.expirationTime === NoWork)
-    ) {
-      // The queue is currently empty, which means we can eagerly compute the
-      // next state before entering the render phase. If the new state is the
-      // same as the current state, we may be able to bail out entirely.
-      const lastRenderedReducer = queue.lastRenderedReducer;
-      if (lastRenderedReducer !== null) {
-        let prevDispatcher;
-        if (__DEV__) {
-          prevDispatcher = ReactCurrentDispatcher.current;
-          ReactCurrentDispatcher.current = InvalidNestedHooksDispatcherOnUpdateInDEV;
-        }
-        try {
-          const currentState: S = (queue.lastRenderedState: any);
-          const eagerState = lastRenderedReducer(currentState, action);
-          // Stash the eagerly computed state, and the reducer used to compute
-          // it, on the update object. If the reducer hasn't changed by the
-          // time we enter the render phase, then the eager state can be used
-          // without calling the reducer again.
-          update.eagerReducer = lastRenderedReducer;
-          update.eagerState = eagerState;
-          if (is(eagerState, currentState)) {
-            // Fast path. We can bail out without scheduling React to re-render.
-            // It's still possible that we'll need to rebase this update later,
-            // if the component re-renders for a different reason and by that
-            // time the reducer has changed.
-            return;
-          }
-        } catch (error) {
-          // Suppress the error. It will throw again in the render phase.
-        } finally {
-          if (__DEV__) {
-            ReactCurrentDispatcher.current = prevDispatcher;
-          }
-        }
-      }
-    }
     if (__DEV__) {
       // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
       if ('undefined' !== typeof jest) {

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -1252,10 +1252,7 @@ function rerenderTransition(
   return [start, isPending];
 }
 
-function appendUpdate<S, A>(
-  queue: UpdateQueue<S, A>,
-  update: Update<S, A>,
-) {
+function appendUpdate<S, A>(queue: UpdateQueue<S, A>, update: Update<S, A>) {
   const pending = queue.pending;
   if (pending === null) {
     // This is the first update. Create a circular list.
@@ -1331,9 +1328,9 @@ function dispatchAction<S, A>(
 function setState<S>(
   fiber: Fiber,
   queue: UpdateQueue<S, BasicStateAction<S>>,
-  action: BasicStateAction<S>
+  action: BasicStateAction<S>,
 ) {
- if (__DEV__) {
+  if (__DEV__) {
     if (typeof arguments[3] === 'function') {
       console.error(
         "State updates from the useState() Hook don't support the " +
@@ -1416,7 +1413,7 @@ function setState<S>(
       }
     }
 
-    appendUpdate(queue, update)
+    appendUpdate(queue, update);
     scheduleWork(fiber, expirationTime);
   }
 }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -270,7 +270,7 @@ describe('ReactHooks', () => {
         }),
       );
     }).toErrorDev(
-      'State updates from the useState() and useReducer() Hooks ' +
+      'State updates from the useState() Hook ' +
         "don't support the second callback argument. " +
         'To execute a side effect after rendering, ' +
         'declare it in the component body with useEffect().',
@@ -304,7 +304,7 @@ describe('ReactHooks', () => {
         }),
       );
     }).toErrorDev(
-      'State updates from the useState() and useReducer() Hooks ' +
+      'State updates from the useReducer() Hook ' +
         "don't support the second callback argument. " +
         'To execute a side effect after rendering, ' +
         'declare it in the component body with useEffect().',

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -3030,56 +3030,6 @@ function loadModules({
         });
       });
 
-      it('eager bailout optimization should always compare to latest rendered reducer', () => {
-        // Edge case based on a bug report
-        let setCounter;
-        function App() {
-          const [counter, _setCounter] = useState(1);
-          setCounter = _setCounter;
-          return <Component count={counter} />;
-        }
-
-        function Component({count}) {
-          const [state, dispatch] = useReducer(() => {
-            // This reducer closes over a value from props. If the reducer is not
-            // properly updated, the eager reducer will compare to an old value
-            // and bail out incorrectly.
-            Scheduler.unstable_yieldValue('Reducer: ' + count);
-            return count;
-          }, -1);
-          useEffect(() => {
-            Scheduler.unstable_yieldValue('Effect: ' + count);
-            dispatch();
-          }, [count]);
-          Scheduler.unstable_yieldValue('Render: ' + state);
-          return count;
-        }
-
-        act(() => {
-          ReactNoop.render(<App />);
-          expect(Scheduler).toFlushAndYield([
-            'Render: -1',
-            'Effect: 1',
-            'Reducer: 1',
-            'Reducer: 1',
-            'Render: 1',
-          ]);
-          expect(ReactNoop).toMatchRenderedOutput('1');
-        });
-
-        act(() => {
-          setCounter(2);
-        });
-        expect(Scheduler).toHaveYielded([
-          'Render: 1',
-          'Effect: 2',
-          'Reducer: 2',
-          'Reducer: 2',
-          'Render: 2',
-        ]);
-        expect(ReactNoop).toMatchRenderedOutput('2');
-      });
-
       // Regression test. Covers a case where an internal state variable
       // (`didReceiveUpdate`) is not reset properly.
       it('state bail out edge case (#16359)', async () => {
@@ -3213,7 +3163,7 @@ function loadModules({
           increment();
           increment();
         });
-        expect(Scheduler).toHaveYielded([]);
+        expect(Scheduler).toHaveYielded(['Render count: 0']);
         expect(ReactNoop).toMatchRenderedOutput('0');
 
         act(() => {


### PR DESCRIPTION
## Summary

fixes #15088 closes #15198

I've stumbled upon an edge case where bailed out actions were kept in the update queue and could be applied using the newly rendered reducer during future rerender. This can be observed here - https://codesandbox.io/s/silly-paper-22org . Just click the disable button, click the increment button multiple times and click the disable button once again. The counter will jump to the number of times you have clicked on the incrementing button while it really should still show 0.

@sebmarkbage has suggested ditching the eager bailout optimization for the useReducer case altogether [here](https://github.com/facebook/react/pull/15198#issuecomment-561364762) and @gaearon has [recently encouraged me](https://github.com/facebook/react/pull/15198#issuecomment-593970984) to just follow this suggestion.

@sebmarkbage has also suggested that "We should also forbid suspending in a setState reducer.", but I'm not sure what that means exactly and how it should be approached so any tips regarding that would be highly appreciated.

As to the implementation - I've managed to remove the need to store "lastRenderedReducer" at all and also I've decided to only append updates to the queue if the rerender is scheduled. In the current implementation on the master branch, the queue was slightly prone to a minor memory leak because theoretically, it was possible to append bailed out updates until the next rerender and that, theoretically, could never happen. This is not a real-life scenario, but it still seems better to avoid appending to the queue unnecessarily to avoid going through those updates during the next render.

## Test Plan

I've run tests, lint & flow dom tasks before sending this as PR.