### PR TITLE
 feat(devtools): Allow editing of context value in Consumer

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2730,11 +2730,6 @@ export function attach(
   }
 
   function setInContext(id: number, path: Array<string | number>, value: any) {
-    // To simplify hydration and display of primative context values (e.g. number, string)
-    // the inspectElement() method wraps context in a {value: ...} object.
-    // We need to remove the first part of the path (the "value") before continuing.
-    path = path.slice(1);
-
     const fiber = findCurrentFiberUsingSlowPathById(id);
     if (fiber !== null) {
       const typeSymbol = getTypeSymbol(fiber.type);
@@ -2749,10 +2744,14 @@ export function attach(
         // if the edited context value was the default value of the context
         // there is no Context.Provider above the consumer fiber
         if (providerFiber !== null && typeof overrideProps === 'function') {
-          const providerPath = ['value', ...path];
-          overrideProps(providerFiber, providerPath, value);
+          overrideProps(providerFiber, path, value);
         }
       } else {
+        // To simplify hydration and display of primative context values (e.g. number, string)
+        // the inspectElement() method wraps context in a {value: ...} object.
+        // We need to remove the first part of the path (the "value") before continuing.
+        path = path.slice(1);
+
         const instance = fiber.stateNode;
         if (path.length === 0) {
           // Simple context value

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -33,6 +33,7 @@ import {
   ElementTypeFunction,
   ElementTypeMemo,
   ElementTypeSuspense,
+  ElementTypeContext,
 } from 'react-devtools-shared/src/types';
 
 import styles from './SelectedElement.css';
@@ -360,6 +361,13 @@ function InspectedElementView({
           rendererID,
           forceFallback: value,
         });
+      }
+    };
+  } else if (type === ElementTypeContext) {
+    overrideContextFn = (path: Array<string | number>, value: any) => {
+      const rendererID = store.getRendererIDForElement(id);
+      if (rendererID !== null) {
+        bridge.send('overrideContext', {id, path, rendererID, value});
       }
     };
   }

--- a/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/Contexts.js
@@ -104,7 +104,23 @@ export default function Contexts() {
         <LegacyContextConsumer />
       </LegacyContextProvider>
       <ModernContext.Provider value={contextData}>
-        <ModernContext.Consumer>{value => null}</ModernContext.Consumer>
+        <ModernContext.Consumer>
+          {value => {
+            return (
+              <React.Fragment>
+                <pre>{JSON.stringify(value, null, 2)}</pre>
+                <ModernContext.Provider
+                  value={{nested: true, array: ['a', 'b', 'c']}}>
+                  <ModernContext.Consumer>
+                    {nestedValue => (
+                      <pre>{JSON.stringify(nestedValue, null, 2)}</pre>
+                    )}
+                  </ModernContext.Consumer>
+                </ModernContext.Provider>
+              </React.Fragment>
+            );
+          }}
+        </ModernContext.Consumer>
         <ModernContextType />
       </ModernContext.Provider>
       <FunctionalContextConsumer />


### PR DESCRIPTION
Review on per-commit basis advised

## Summary

Allow editing of the context value from a consumer if the value comes from a Provider component.

## Test Plan

Verified locally by using react-devtools-shell:

`master`:
![devools-context-consumer-master](https://user-images.githubusercontent.com/12292047/76244932-519c1f00-623b-11ea-9b05-f4e2260913a4.gif)

`pr`:
![devools-context-consumer-pr](https://user-images.githubusercontent.com/12292047/76244935-52cd4c00-623b-11ea-8e80-9d37f35e2b09.gif)

