### PR TITLE
[Flight] Split Streaming from Relay Implemenation

### DIFF
--- a/packages/react-client/flight.js
+++ b/packages/react-client/flight.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './src/ReactFlightClient';
+export * from './src/ReactFlightClientStream';

--- a/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-export type Source = Promise<Response> | ReadableStream | XMLHttpRequest;
-
 export type StringDecoder = TextDecoder;
 
 export const supportsBinaryStreams = true;

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Response as ResponseBase, JSONValue} from './ReactFlightClient';
+
+import type {StringDecoder} from './ReactFlightClientHostConfig';
+
+import {
+  createResponse as createResponseImpl,
+  resolveModelChunk,
+  resolveErrorChunk,
+  parseModelFromJSON,
+} from './ReactFlightClient';
+
+import {
+  supportsBinaryStreams,
+  createStringDecoder,
+  readPartialStringChunk,
+  readFinalStringChunk,
+} from './ReactFlightClientHostConfig';
+
+export type ReactModelRoot<T> = {|
+  model: T,
+|};
+
+type Response = ResponseBase & {
+  fromJSON: (key: string, value: JSONValue) => any,
+  stringDecoder: StringDecoder,
+};
+
+export function createResponse(): Response {
+  let response: Response = (createResponseImpl(): any);
+  response.fromJSON = function(key: string, value: JSONValue) {
+    return parseModelFromJSON(response, this, key, value);
+  };
+  if (supportsBinaryStreams) {
+    response.stringDecoder = createStringDecoder();
+  }
+  return response;
+}
+
+function processFullRow(response: Response, row: string): void {
+  if (row === '') {
+    return;
+  }
+  let tag = row[0];
+  switch (tag) {
+    case 'J': {
+      let colon = row.indexOf(':', 1);
+      let id = parseInt(row.substring(1, colon), 16);
+      let json = row.substring(colon + 1);
+      let model = JSON.parse(json, response.fromJSON);
+      resolveModelChunk(response, id, model);
+      return;
+    }
+    case 'E': {
+      let colon = row.indexOf(':', 1);
+      let id = parseInt(row.substring(1, colon), 16);
+      let json = row.substring(colon + 1);
+      let errorInfo = JSON.parse(json);
+      resolveErrorChunk(response, id, errorInfo.message, errorInfo.stack);
+      return;
+    }
+    default: {
+      // Assume this is the root model.
+      let model = JSON.parse(row, response.fromJSON);
+      resolveModelChunk(response, 0, model);
+      return;
+    }
+  }
+}
+
+export function processStringChunk(
+  response: Response,
+  chunk: string,
+  offset: number,
+): void {
+  let linebreak = chunk.indexOf('\n', offset);
+  while (linebreak > -1) {
+    let fullrow = response.partialRow + chunk.substring(offset, linebreak);
+    processFullRow(response, fullrow);
+    response.partialRow = '';
+    offset = linebreak + 1;
+    linebreak = chunk.indexOf('\n', offset);
+  }
+  response.partialRow += chunk.substring(offset);
+}
+
+export function processBinaryChunk(
+  response: Response,
+  chunk: Uint8Array,
+): void {
+  if (!supportsBinaryStreams) {
+    throw new Error("This environment don't support binary chunks.");
+  }
+  let stringDecoder = response.stringDecoder;
+  let linebreak = chunk.indexOf(10); // newline
+  while (linebreak > -1) {
+    let fullrow =
+      response.partialRow +
+      readFinalStringChunk(stringDecoder, chunk.subarray(0, linebreak));
+    processFullRow(response, fullrow);
+    response.partialRow = '';
+    chunk = chunk.subarray(linebreak + 1);
+    linebreak = chunk.indexOf(10); // newline
+  }
+  response.partialRow += readPartialStringChunk(stringDecoder, chunk);
+}
+
+export {reportGlobalError, close, getModelRoot} from './ReactFlightClient';

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -7,9 +7,7 @@
  * @flow
  */
 
-import type {ReactModelRoot} from 'react-client/src/ReactFlightClient';
-
-import type {Chunk} from './ReactFlightDOMRelayClientHostConfig';
+import type {Response, JSONValue} from 'react-client/src/ReactFlightClient';
 
 import {
   createResponse,
@@ -19,8 +17,6 @@ import {
   resolveErrorChunk,
   close,
 } from 'react-client/src/ReactFlightClient';
-
-type EncodedData = Array<Chunk>;
 
 function parseModel(response, targetObj, key, value) {
   if (typeof value === 'object' && value !== null) {
@@ -42,27 +38,17 @@ function parseModel(response, targetObj, key, value) {
   return parseModelFromJSON(response, targetObj, key, value);
 }
 
-function read<T>(data: EncodedData): ReactModelRoot<T> {
-  let response = createResponse();
-  for (let i = 0; i < data.length; i++) {
-    let chunk = data[i];
-    if (chunk.type === 'json') {
-      resolveModelChunk(
-        response,
-        chunk.id,
-        parseModel(response, {}, '', chunk.json),
-      );
-    } else {
-      resolveErrorChunk(
-        response,
-        chunk.id,
-        chunk.json.message,
-        chunk.json.stack,
-      );
-    }
-  }
-  close(response);
-  return getModelRoot(response);
+export {createResponse, getModelRoot, close};
+
+export function resolveModel(response: Response, id: number, json: JSONValue) {
+  resolveModelChunk(response, id, parseModel(response, {}, '', json));
 }
 
-export {read};
+export function resolveError(
+  response: Response,
+  id: number,
+  message: string,
+  stack: string,
+) {
+  resolveErrorChunk(response, id, message, stack);
+}

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -7,7 +7,29 @@
  * @flow
  */
 
-export type Source = Array<string>;
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | {[key: string]: JSONValue}
+  | Array<JSONValue>;
+
+export type Chunk =
+  | {
+      type: 'json',
+      id: number,
+      json: JSONValue,
+    }
+  | {
+      type: 'error',
+      id: number,
+      json: {
+        message: string,
+        stack: string,
+        ...
+      },
+    };
 
 export type StringDecoder = void;
 

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -7,30 +7,6 @@
  * @flow
  */
 
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | {[key: string]: JSONValue}
-  | Array<JSONValue>;
-
-export type Chunk =
-  | {
-      type: 'json',
-      id: number,
-      json: JSONValue,
-    }
-  | {
-      type: 'error',
-      id: number,
-      json: {
-        message: string,
-        stack: string,
-        ...
-      },
-    };
-
 export type StringDecoder = void;
 
 export const supportsBinaryStreams = false;

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -8,10 +8,11 @@
  */
 
 import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {Chunk} from './ReactFlightDOMRelayServerHostConfig';
 
 import {createRequest, startWork} from 'react-server/src/ReactFlightServer';
 
-type EncodedData = Array<string>;
+type EncodedData = Array<Chunk>;
 
 function render(model: ReactModel): EncodedData {
   let data: EncodedData = [];

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -8,17 +8,13 @@
  */
 
 import type {ReactModel} from 'react-server/src/ReactFlightServer';
-import type {Chunk} from './ReactFlightDOMRelayServerHostConfig';
+import type {Destination} from './ReactFlightDOMRelayServerHostConfig';
 
 import {createRequest, startWork} from 'react-server/src/ReactFlightServer';
 
-type EncodedData = Array<Chunk>;
-
-function render(model: ReactModel): EncodedData {
-  let data: EncodedData = [];
-  let request = createRequest(model, data);
+function render(model: ReactModel, destination: Destination): void {
+  let request = createRequest(model, destination);
   startWork(request);
-  return data;
 }
 
 export {render};

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -7,7 +7,84 @@
  * @flow
  */
 
-export type Destination = Array<string>;
+import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+
+import {resolveModelToJSON} from 'react-server/src/ReactFlightServer';
+
+export type Destination = Array<Chunk>;
+
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | {[key: string]: JSONValue}
+  | Array<JSONValue>;
+
+export type Chunk =
+  | {
+      type: 'json',
+      id: number,
+      json: JSONValue,
+    }
+  | {
+      type: 'error',
+      id: number,
+      json: {
+        message: string,
+        stack: string,
+        ...
+      },
+    };
+
+export function processErrorChunk(
+  request: Request,
+  id: number,
+  message: string,
+  stack: string,
+): Chunk {
+  return {
+    type: 'error',
+    id: id,
+    json: {
+      message,
+      stack,
+    },
+  };
+}
+
+function convertModelToJSON(request: Request, model: ReactModel): JSONValue {
+  let json = resolveModelToJSON(request, model);
+  if (typeof json === 'object' && json !== null) {
+    if (Array.isArray(json)) {
+      let jsonArray: Array<JSONValue> = [];
+      for (let i = 0; i < json.length; i++) {
+        jsonArray[i] = convertModelToJSON(request, json[i]);
+      }
+      return jsonArray;
+    } else {
+      let jsonObj: {[key: string]: JSONValue} = {};
+      for (let key in json) {
+        jsonObj[key] = convertModelToJSON(request, json[key]);
+      }
+      return jsonObj;
+    }
+  }
+  return json;
+}
+
+export function processModelChunk(
+  request: Request,
+  id: number,
+  model: ReactModel,
+): Chunk {
+  let json = convertModelToJSON(request, model);
+  return {
+    type: 'json',
+    id: id,
+    json: json,
+  };
+}
 
 export function scheduleWork(callback: () => void) {
   callback();
@@ -17,18 +94,11 @@ export function flushBuffered(destination: Destination) {}
 
 export function beginWriting(destination: Destination) {}
 
-export function writeChunk(
-  destination: Destination,
-  buffer: Uint8Array,
-): boolean {
-  destination.push(Buffer.from((buffer: any)).toString('utf8'));
+export function writeChunk(destination: Destination, chunk: Chunk): boolean {
+  destination.push(chunk);
   return true;
 }
 
 export function completeWriting(destination: Destination) {}
 
 export function close(destination: Destination) {}
-
-export function convertStringToBuffer(content: string): Uint8Array {
-  return Buffer.from(content, 'utf8');
-}

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -9,9 +9,13 @@
 
 import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
 
+import type {Destination} from 'ReactFlightDOMRelayServerIntegration';
+
 import {resolveModelToJSON} from 'react-server/src/ReactFlightServer';
 
-export type Destination = Array<Chunk>;
+import {emitModel, emitError} from 'ReactFlightDOMRelayServerIntegration';
+
+export type {Destination} from 'ReactFlightDOMRelayServerIntegration';
 
 type JSONValue =
   | string
@@ -95,10 +99,14 @@ export function flushBuffered(destination: Destination) {}
 export function beginWriting(destination: Destination) {}
 
 export function writeChunk(destination: Destination, chunk: Chunk): boolean {
-  destination.push(chunk);
+  if (chunk.type === 'json') {
+    emitModel(destination, chunk.id, chunk.json);
+  } else {
+    emitError(destination, chunk.id, chunk.json.message, chunk.json.stack);
+  }
   return true;
 }
 
 export function completeWriting(destination: Destination) {}
 
-export function close(destination: Destination) {}
+export {close} from 'ReactFlightDOMRelayServerIntegration';

--- a/packages/react-flight-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
+++ b/packages/react-flight-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const ReactFlightDOMRelayServerIntegration = {
+  emitModel(destination, id, json) {
+    destination.push({
+      type: 'json',
+      id: id,
+      json: json,
+    });
+  },
+  emitError(destination, id, message, stack) {
+    destination.push({
+      type: 'error',
+      id: id,
+      json: {message, stack},
+    });
+  },
+  close(destination) {},
+};
+
+module.exports = ReactFlightDOMRelayServerIntegration;

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -24,7 +24,7 @@ const {
   createResponse,
   getModelRoot,
   processStringChunk,
-  complete,
+  close,
 } = ReactFlightClient({
   supportsBinaryStreams: false,
 });
@@ -34,7 +34,7 @@ function read<T>(source: Source): ReactModelRoot<T> {
   for (let i = 0; i < source.length; i++) {
     processStringChunk(response, source[i], 0);
   }
-  complete(response);
+  close(response);
   return getModelRoot(response);
 }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Destination} from './ReactServerStreamConfig';
+import type {Destination} from './ReactFlightServerConfig';
 
 import {
   scheduleWork,
@@ -17,64 +17,9 @@ import {
   flushBuffered,
   close,
   convertStringToBuffer,
-} from './ReactServerStreamConfig';
+} from './ReactFlightServerConfig';
 import {renderHostChildrenToString} from './ReactServerFormatConfig';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
-
-/*
-
-FLIGHT PROTOCOL GRAMMAR
-
-Response
-- JSONData RowSequence
-- JSONData
-
-RowSequence
-- Row RowSequence
-- Row
-
-Row
-- "J" RowID JSONData
-- "H" RowID HTMLData
-- "B" RowID BlobData
-- "U" RowID URLData
-- "E" RowID ErrorData
-
-RowID
-- HexDigits ":"
-
-HexDigits
-- HexDigit HexDigits
-- HexDigit
-
-HexDigit
-- 0-F
-
-URLData
-- (UTF8 encoded URL) "\n"
-
-ErrorData
-- (UTF8 encoded JSON: {message: "...", stack: "..."}) "\n"
-
-JSONData
-- (UTF8 encoded JSON) "\n"
-  - String values that begin with $ are escaped with a "$" prefix.
-  - References to other rows are encoding as JSONReference strings.
-
-JSONReference
-- "$" HexDigits
-
-HTMLData
-- ByteSize (UTF8 encoded HTML)
-
-BlobData
-- ByteSize (Binary Data)
-
-ByteSize
-- (unsigned 32-bit integer)
-*/
-
-// TODO: Implement HTMLData, BlobData and URLData.
 
 const stringify = JSON.stringify;
 
@@ -95,13 +40,12 @@ type ReactJSONValue =
   | Array<ReactModel>
   | ReactModelObject;
 
-type ReactModelObject = {+[key: string]: ReactModel, ...};
+type ReactModelObject = {+[key: string]: ReactModel};
 
 type Segment = {
   id: number,
   model: ReactModel,
   ping: () => void,
-  ...
 };
 
 type OpaqueRequest = {
@@ -113,7 +57,6 @@ type OpaqueRequest = {
   completedErrorChunks: Array<Uint8Array>,
   flowing: boolean,
   toJSON: (key: string, value: ReactModel) => ReactJSONValue,
-  ...
 };
 
 export function createRequest(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Destination} from './ReactFlightServerConfig';
+import type {Destination, Chunk} from './ReactFlightServerConfig';
 
 import {
   scheduleWork,
@@ -16,12 +16,19 @@ import {
   completeWriting,
   flushBuffered,
   close,
-  convertStringToBuffer,
+  processModelChunk,
+  processErrorChunk,
 } from './ReactFlightServerConfig';
 import {renderHostChildrenToString} from './ReactServerFormatConfig';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
-const stringify = JSON.stringify;
+type ReactJSONValue =
+  | string
+  | boolean
+  | number
+  | null
+  | Array<ReactModel>
+  | ReactModelObject;
 
 export type ReactModel =
   | React$Element<any>
@@ -32,14 +39,6 @@ export type ReactModel =
   | Iterable<ReactModel>
   | ReactModelObject;
 
-type ReactJSONValue =
-  | string
-  | boolean
-  | number
-  | null
-  | Array<ReactModel>
-  | ReactModelObject;
-
 type ReactModelObject = {+[key: string]: ReactModel};
 
 type Segment = {
@@ -48,13 +47,13 @@ type Segment = {
   ping: () => void,
 };
 
-type OpaqueRequest = {
+export type Request = {
   destination: Destination,
   nextChunkId: number,
   pendingChunks: number,
   pingedSegments: Array<Segment>,
-  completedJSONChunks: Array<Uint8Array>,
-  completedErrorChunks: Array<Uint8Array>,
+  completedJSONChunks: Array<Chunk>,
+  completedErrorChunks: Array<Chunk>,
   flowing: boolean,
   toJSON: (key: string, value: ReactModel) => ReactJSONValue,
 };
@@ -62,7 +61,7 @@ type OpaqueRequest = {
 export function createRequest(
   model: ReactModel,
   destination: Destination,
-): OpaqueRequest {
+): Request {
   let pingedSegments = [];
   let request = {
     destination,
@@ -95,7 +94,7 @@ function attemptResolveModelComponent(element: React$Element<any>): ReactModel {
   }
 }
 
-function pingSegment(request: OpaqueRequest, segment: Segment): void {
+function pingSegment(request: Request, segment: Segment): void {
   let pingedSegments = request.pingedSegments;
   pingedSegments.push(segment);
   if (pingedSegments.length === 1) {
@@ -103,7 +102,7 @@ function pingSegment(request: OpaqueRequest, segment: Segment): void {
   }
 }
 
-function createSegment(request: OpaqueRequest, model: ReactModel): Segment {
+function createSegment(request: Request, model: ReactModel): Segment {
   let id = request.nextChunkId++;
   let segment = {
     id,
@@ -117,10 +116,6 @@ function serializeIDRef(id: number): string {
   return '$' + id.toString(16);
 }
 
-function serializeRowHeader(tag: string, id: number) {
-  return tag + id.toString(16) + ':';
-}
-
 function escapeStringValue(value: string): string {
   if (value[0] === '$') {
     // We need to escape $ prefixed strings since we use that to encode
@@ -131,8 +126,8 @@ function escapeStringValue(value: string): string {
   }
 }
 
-function resolveModelToJSON(
-  request: OpaqueRequest,
+export function resolveModelToJSON(
+  request: Request,
   value: ReactModel,
 ): ReactJSONValue {
   if (typeof value === 'string') {
@@ -167,11 +162,7 @@ function resolveModelToJSON(
   return value;
 }
 
-function emitErrorChunk(
-  request: OpaqueRequest,
-  id: number,
-  error: mixed,
-): void {
+function emitErrorChunk(request: Request, id: number, error: mixed): void {
   // TODO: We should not leak error messages to the client in prod.
   // Give this an error code instead and log on the server.
   // We can serialize the error in DEV as a convenience.
@@ -187,12 +178,12 @@ function emitErrorChunk(
   } catch (x) {
     message = 'An error occurred but serializing the error message failed.';
   }
-  let errorInfo = {message, stack};
-  let row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
-  request.completedErrorChunks.push(convertStringToBuffer(row));
+
+  let processedChunk = processErrorChunk(request, id, message, stack);
+  request.completedErrorChunks.push(processedChunk);
 }
 
-function retrySegment(request: OpaqueRequest, segment: Segment): void {
+function retrySegment(request: Request, segment: Segment): void {
   let value = segment.model;
   try {
     while (
@@ -206,15 +197,8 @@ function retrySegment(request: OpaqueRequest, segment: Segment): void {
       segment.model = element;
       value = attemptResolveModelComponent(element);
     }
-    let json = stringify(value, request.toJSON);
-    let row;
-    let id = segment.id;
-    if (id === 0) {
-      row = json + '\n';
-    } else {
-      row = serializeRowHeader('J', id) + json + '\n';
-    }
-    request.completedJSONChunks.push(convertStringToBuffer(row));
+    let processedChunk = processModelChunk(request, segment.id, value);
+    request.completedJSONChunks.push(processedChunk);
   } catch (x) {
     if (typeof x === 'object' && x !== null && typeof x.then === 'function') {
       // Something suspended again, let's pick it back up later.
@@ -228,7 +212,7 @@ function retrySegment(request: OpaqueRequest, segment: Segment): void {
   }
 }
 
-function performWork(request: OpaqueRequest): void {
+function performWork(request: Request): void {
   let pingedSegments = request.pingedSegments;
   request.pingedSegments = [];
   for (let i = 0; i < pingedSegments.length; i++) {
@@ -241,7 +225,7 @@ function performWork(request: OpaqueRequest): void {
 }
 
 let reentrant = false;
-function flushCompletedChunks(request: OpaqueRequest): void {
+function flushCompletedChunks(request: Request): void {
   if (reentrant) {
     return;
   }
@@ -284,12 +268,12 @@ function flushCompletedChunks(request: OpaqueRequest): void {
   }
 }
 
-export function startWork(request: OpaqueRequest): void {
+export function startWork(request: Request): void {
   request.flowing = true;
   scheduleWork(() => performWork(request));
 }
 
-export function startFlowing(request: OpaqueRequest): void {
+export function startFlowing(request: Request): void {
   request.flowing = true;
   flushCompletedChunks(request);
 }

--- a/packages/react-server/src/ReactFlightServerConfig.js
+++ b/packages/react-server/src/ReactFlightServerConfig.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable react-internal/invariant-args */
+
+import invariant from 'shared/invariant';
+
+// We expect that our Rollup, Jest, and Flow configurations
+// always shim this module with the corresponding host config
+// (either provided by a renderer, or a generic shim for npm).
+//
+// We should never resolve to this file, but it exists to make
+// sure that if we *do* accidentally break the configuration,
+// the failure isn't silent.
+
+invariant(false, 'This module must be shimmed by a specific renderer.');

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// This file is an intermediate layer to translate between Flight
+// calls to stream output.
+
+import type {Destination as DestinationT} from './ReactServerStreamConfig';
+
+export type Destination = DestinationT;
+
+export {
+  scheduleWork,
+  flushBuffered,
+  beginWriting,
+  writeChunk,
+  completeWriting,
+  close,
+  convertStringToBuffer,
+} from './ReactServerStreamConfig';

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -8,7 +8,61 @@
  */
 
 // This file is an intermediate layer to translate between Flight
-// calls to stream output.
+// calls to stream output over a binary stream.
+
+/*
+FLIGHT PROTOCOL GRAMMAR
+
+Response
+- JSONData RowSequence
+- JSONData
+
+RowSequence
+- Row RowSequence
+- Row
+
+Row
+- "J" RowID JSONData
+- "H" RowID HTMLData
+- "B" RowID BlobData
+- "U" RowID URLData
+- "E" RowID ErrorData
+
+RowID
+- HexDigits ":"
+
+HexDigits
+- HexDigit HexDigits
+- HexDigit
+
+HexDigit
+- 0-F
+
+URLData
+- (UTF8 encoded URL) "\n"
+
+ErrorData
+- (UTF8 encoded JSON: {message: "...", stack: "..."}) "\n"
+
+JSONData
+- (UTF8 encoded JSON) "\n"
+  - String values that begin with $ are escaped with a "$" prefix.
+  - References to other rows are encoding as JSONReference strings.
+
+JSONReference
+- "$" HexDigits
+
+HTMLData
+- ByteSize (UTF8 encoded HTML)
+
+BlobData
+- ByteSize (Binary Data)
+
+ByteSize
+- (unsigned 32-bit integer)
+*/
+
+// TODO: Implement HTMLData, BlobData and URLData.
 
 import type {Destination as DestinationT} from './ReactServerStreamConfig';
 

--- a/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// This is a host config that's used for the `react-server` package on npm.
+// It is only used by third-party renderers.
+//
+// Its API lets you pass the host config as an argument.
+// However, inside the `react-server` we treat host config as a module.
+// This file is a shim between two worlds.
+//
+// It works because the `react-server` bundle is wrapped in something like:
+//
+// module.exports = function ($$$config) {
+//   /* renderer code */
+// }
+//
+// So `$$$config` looks like a global variable, but it's
+// really an argument to a top-level wrapping function.
+
+declare var $$$hostConfig: any;
+export opaque type Destination = mixed; // eslint-disable-line no-undef
+
+export const scheduleWork = $$$hostConfig.scheduleWork;
+export const beginWriting = $$$hostConfig.beginWriting;
+export const writeChunk = $$$hostConfig.writeChunk;
+export const completeWriting = $$$hostConfig.completeWriting;
+export const flushBuffered = $$$hostConfig.flushBuffered;
+export const close = $$$hostConfig.close;
+export const convertStringToBuffer = $$$hostConfig.convertStringToBuffer;

--- a/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.custom.js
@@ -7,29 +7,4 @@
  * @flow
  */
 
-// This is a host config that's used for the `react-server` package on npm.
-// It is only used by third-party renderers.
-//
-// Its API lets you pass the host config as an argument.
-// However, inside the `react-server` we treat host config as a module.
-// This file is a shim between two worlds.
-//
-// It works because the `react-server` bundle is wrapped in something like:
-//
-// module.exports = function ($$$config) {
-//   /* renderer code */
-// }
-//
-// So `$$$config` looks like a global variable, but it's
-// really an argument to a top-level wrapping function.
-
-declare var $$$hostConfig: any;
-export opaque type Destination = mixed; // eslint-disable-line no-undef
-
-export const scheduleWork = $$$hostConfig.scheduleWork;
-export const beginWriting = $$$hostConfig.beginWriting;
-export const writeChunk = $$$hostConfig.writeChunk;
-export const completeWriting = $$$hostConfig.completeWriting;
-export const flushBuffered = $$$hostConfig.flushBuffered;
-export const close = $$$hostConfig.close;
-export const convertStringToBuffer = $$$hostConfig.convertStringToBuffer;
+export * from '../ReactFlightServerConfigStream';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-browser.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from '../ReactFlightServerConfigStream';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-relay.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-relay.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig';

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from '../ReactFlightServerConfigStream';

--- a/packages/react-server/src/forks/ReactServerStreamConfig.dom-relay.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.dom-relay.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from 'react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig';
+export * from '../ReactServerStreamConfigNode';

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -29,6 +29,7 @@
 ../environment.js
 ../react-devtools.js
 ../react-native-host-hooks.js
+../react-relay-hooks.js
 
 [lints]
 untyped-type-import=error

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -51,6 +51,7 @@ function writeConfig(renderer, rendererInfo, isServerSupported) {
 module.name_mapper='ReactFiberHostConfig$$' -> 'forks/ReactFiberHostConfig.${renderer}'
 module.name_mapper='ReactServerStreamConfig$$' -> 'forks/ReactServerStreamConfig.${serverRenderer}'
 module.name_mapper='ReactServerFormatConfig$$' -> 'forks/ReactServerFormatConfig.${serverRenderer}'
+module.name_mapper='ReactFlightServerConfig$$' -> 'forks/ReactFlightServerConfig.${serverRenderer}'
 module.name_mapper='ReactFlightClientHostConfig$$' -> 'forks/ReactFlightClientHostConfig.${serverRenderer}'
     `.trim(),
     )

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | {[key: string]: JSONValue}
+  | Array<JSONValue>;
+
+declare module 'ReactFlightDOMRelayServerIntegration' {
+  declare export opaque type Destination;
+  declare export function emitModel(
+    destination: Destination,
+    id: number,
+    json: JSONValue,
+  ): void;
+  declare export function emitError(
+    destination: Destination,
+    id: number,
+    message: string,
+    stack: string,
+  ): void;
+  declare export function close(destination: Destination): void;
+}

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -13,6 +13,7 @@ jest.mock('react-reconciler', () => {
 });
 const shimServerStreamConfigPath = 'react-server/src/ReactServerStreamConfig';
 const shimServerFormatConfigPath = 'react-server/src/ReactServerFormatConfig';
+const shimFlightServerConfigPath = 'react-server/src/ReactFlightServerConfig';
 jest.mock('react-server', () => {
   return config => {
     jest.mock(shimServerStreamConfigPath, () => config);
@@ -24,6 +25,7 @@ jest.mock('react-server/flight', () => {
   return config => {
     jest.mock(shimServerStreamConfigPath, () => config);
     jest.mock(shimServerFormatConfigPath, () => config);
+    jest.mock(shimFlightServerConfigPath, () => config);
     return require.requireActual('react-server/flight');
   };
 });
@@ -41,6 +43,7 @@ const configPaths = [
   'react-client/src/ReactFlightClientHostConfig',
   'react-server/src/ReactServerStreamConfig',
   'react-server/src/ReactServerFormatConfig',
+  'react-server/src/ReactFlightServerConfig',
 ];
 
 function mockAllConfigs(rendererInfo) {

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -25,7 +25,11 @@ jest.mock('react-server/flight', () => {
   return config => {
     jest.mock(shimServerStreamConfigPath, () => config);
     jest.mock(shimServerFormatConfigPath, () => config);
-    jest.mock(shimFlightServerConfigPath, () => config);
+    jest.mock(shimFlightServerConfigPath, () =>
+      require.requireActual(
+        'react-server/src/forks/ReactFlightServerConfig.custom'
+      )
+    );
     return require.requireActual('react-server/flight');
   };
 });

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -203,7 +203,11 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-flight-dom-relay/server',
     global: 'ReactFlightDOMRelayServer',
-    externals: ['react', 'react-dom/server'],
+    externals: [
+      'react',
+      'react-dom/server',
+      'ReactFlightDOMRelayServerIntegration',
+    ],
   },
 
   /******* React DOM Flight Client Relay *******/

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -354,6 +354,34 @@ const forks = Object.freeze({
     );
   },
 
+  'react-server/src/ReactFlightServerConfig': (
+    bundleType,
+    entry,
+    dependencies,
+    moduleType
+  ) => {
+    if (dependencies.indexOf('react-server') !== -1) {
+      return null;
+    }
+    if (moduleType !== RENDERER && moduleType !== RECONCILER) {
+      return null;
+    }
+    // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+    for (let rendererInfo of inlinedHostConfigs) {
+      if (rendererInfo.entryPoints.indexOf(entry) !== -1) {
+        if (!rendererInfo.isServerSupported) {
+          return null;
+        }
+        return `react-server/src/forks/ReactFlightServerConfig.${rendererInfo.shortName}.js`;
+      }
+    }
+    throw new Error(
+      'Expected ReactFlightServerConfig to always be replaced with a shim, but ' +
+        `found no mention of "${entry}" entry point in ./scripts/shared/inlinedHostConfigs.js. ` +
+        'Did you mean to add it there to associate it with a specific renderer?'
+    );
+  },
+
   'react-client/src/ReactFlightClientHostConfig': (
     bundleType,
     entry,


### PR DESCRIPTION
This splits the Flight implementation into a general JSON chunk part and a streaming part. The default implementation goes to a binary/string stream API which varies between Node and W3C streams. The Relay implementation by-passes the serialization and instead gets passed JSON-serializable object chunks.

The server configs are layered like this:

- ReactFlightServer
  - ReactFlightServerConfig
    - ReactFlightServerConfigStream
      - ReactServerStreamConfig
        - ReactServerStreamConfigNode
        - ReactServerStreamConfigBrowser
    - ReactFlightDOMRelayServerHostConfig

The client is a bit simpler. The implementation just imports ReactFlightClient (used by Relay) or ReactFlightClientStream (used by Streams).

## Flight Relay Server Bindings

The API for the server is: 

```
function render(model: ReactModel, destination: Destination): void;
```

The first argument is something that can be returned from a Block. I.e. the root model. Something JSONable. This will change to require a Block. The second argument is whatever Relay wants to the target to be.

This also depends on an external file that we'll have to add to www: `ReactFlightDOMRelayServerIntegration.js`. This will needs to implement the following API:

```
 opaque type Destination;
 function emitModel(
    destination: Destination,
    id: number,
    json: JSONValue,
  ): void;
 function emitError(
    destination: Destination,
    id: number,
    message: string,
    stack: string,
  ): void;
function close(destination: Destination): void;
```

This will be called asynchronously as ReactFlight completes part of the model. Once there's no more to render, it'll call `close()` on the destination. Relay can then serialize these rows as it wants.

## Flight Relay Client Bindings

The client API is:

```
function createResponse(): Response;
function getModelRoot<T>(response: Response): {model: T};
function resolveModel(
  response: Response,
  id: number,
  json: JSONValue,
): void;
function resolveError(
  response: Response,
  id: number,
  message: string,
  stack: string,
): void;
function close(response: Response): void;
```

To use this, you first have to create a "response". You can get a model out of the response which will just have placeholders in it. This particular API will change as I get rid of "proxies". It’ll return a Block instead. The principle is that it can return something even before any data has loaded so you immediately get something that can suspend.

The resolveModel and resolveError are called as new rows stream in. `close` should be called when there's no more rows or the connection dies (even if it dies early).