### PR TITLE
Fix Flow type for AnyNativeEvent

### DIFF
--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -17,7 +17,7 @@ import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
 export type EventTypes = {[key: string]: DispatchConfig, ...};
 
-export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | Touch;
+export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 


### PR DESCRIPTION
I noticed this a while back and came across it today again. This refines `AnyNativeEvent` which incorrectly used `Touch` rather than `TouchEvent` (they are different things entirely). 