### PR TITLE
Don't warn about unmounted state updates from a passive destroy function

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -199,13 +199,14 @@ const {
 
 type ExecutionContext = number;
 
-const NoContext = /*                    */ 0b000000;
-const BatchedContext = /*               */ 0b000001;
-const EventContext = /*                 */ 0b000010;
-const DiscreteEventContext = /*         */ 0b000100;
-const LegacyUnbatchedContext = /*       */ 0b001000;
-const RenderContext = /*                */ 0b010000;
-const CommitContext = /*                */ 0b100000;
+const NoContext = /*                    */ 0b0000000;
+const BatchedContext = /*               */ 0b0000001;
+const EventContext = /*                 */ 0b0000010;
+const DiscreteEventContext = /*         */ 0b0000100;
+const LegacyUnbatchedContext = /*       */ 0b0001000;
+const RenderContext = /*                */ 0b0010000;
+const CommitContext = /*                */ 0b0100000;
+const PassiveEffectContext = /*         */ 0b1000000;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5;
 const RootIncomplete = 0;
@@ -2280,6 +2281,7 @@ function flushPassiveEffectsImpl() {
   );
   const prevExecutionContext = executionContext;
   executionContext |= CommitContext;
+  executionContext |= PassiveEffectContext;
   const prevInteractions = pushInteractions(root);
 
   if (runAllPassiveEffectDestroysBeforeCreates) {
@@ -2796,6 +2798,11 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
       if (pendingPassiveHookEffectsUnmount.indexOf(fiber) >= 0) {
         return;
       }
+    }
+
+    // If we are currently flushing passive effects, skip this warning.
+    if ((executionContext & PassiveEffectContext) !== NoContext) {
+      return;
     }
 
     // We show the whole stack but dedupe on the top component's name because

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1289,7 +1289,7 @@ function loadModules({
             });
           });
 
-          it('still warns about state updates from within passive unmount function', () => {
+          it('does not warn about state updates from within passive unmount function', () => {
             function Component() {
               Scheduler.unstable_yieldValue('Component');
               const [didLoad, setDidLoad] = React.useState(false);
@@ -1315,11 +1315,7 @@ function loadModules({
 
               // Unmount but don't process pending passive destroy function
               ReactNoop.unmountRootWithID('root');
-              expect(() => {
-                expect(Scheduler).toFlushAndYield(['passive destroy']);
-              }).toErrorDev(
-                "Warning: Can't perform a React state update on an unmounted component.",
-              );
+              expect(Scheduler).toFlushAndYield(['passive destroy']);
             });
           });
         }


### PR DESCRIPTION
Suppress new warning introduced by PRs #17925 and #17947.