### PR TITLE
[Flight] Encode server rendered host components as array tuples

### DIFF
--- a/fixtures/flight-browser/index.html
+++ b/fixtures/flight-browser/index.html
@@ -57,9 +57,7 @@
 
       let model = {
         title: <Title />,
-        content: {
-          __html: <HTML />,
-        }
+        content: <HTML />,
       };
 
       let stream = ReactFlightDOMServer.renderToReadableStream(model);
@@ -90,7 +88,7 @@
           <Suspense fallback="...">
             <h1>{model.title}</h1>
           </Suspense>
-          <div dangerouslySetInnerHTML={model.content} />
+          {model.content}
         </div>;
       }
 

--- a/fixtures/flight/server/handler.js
+++ b/fixtures/flight/server/handler.js
@@ -20,9 +20,7 @@ function HTML() {
 module.exports = function(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   let model = {
-    content: {
-      __html: <HTML />,
-    },
+    content: <HTML />,
   };
   ReactFlightDOMServer.pipeToNodeWritable(model, res);
 };

--- a/fixtures/flight/src/App.js
+++ b/fixtures/flight/src/App.js
@@ -1,7 +1,7 @@
 import React, {Suspense} from 'react';
 
 function Content({data}) {
-  return <p dangerouslySetInnerHTML={data.model.content} />;
+  return data.model.content;
 }
 
 function App({data}) {

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -22,11 +22,11 @@ function parseModel(response, targetObj, key, value) {
   if (typeof value === 'object' && value !== null) {
     if (Array.isArray(value)) {
       for (let i = 0; i < value.length; i++) {
-        value[i] = parseModel(response, value, '' + i, value[i]);
+        (value: any)[i] = parseModel(response, value, '' + i, value[i]);
       }
     } else {
       for (let innerKey in value) {
-        value[innerKey] = parseModel(
+        (value: any)[innerKey] = parseModel(
           response,
           value,
           innerKey,

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -65,7 +65,12 @@ describe('ReactFlightDOMBrowser', () => {
     let result = ReactFlightDOMClient.readFromReadableStream(stream);
     await waitForSuspense(() => {
       expect(result.model).toEqual({
-        html: '<div><span>hello</span><span>world</span></div>',
+        html: (
+          <div>
+            <span>hello</span>
+            <span>world</span>
+          </div>
+        ),
       });
     });
   });

--- a/packages/react-server/src/ReactDOMServerFormatConfig.js
+++ b/packages/react-server/src/ReactDOMServerFormatConfig.js
@@ -9,8 +9,6 @@
 
 import {convertStringToBuffer} from 'react-server/src/ReactServerStreamConfig';
 
-import {renderToStaticMarkup} from 'react-dom/server';
-
 export function formatChunkAsString(type: string, props: Object): string {
   let str = '<' + type + '>';
   if (typeof props.children === 'string') {
@@ -22,14 +20,4 @@ export function formatChunkAsString(type: string, props: Object): string {
 
 export function formatChunk(type: string, props: Object): Uint8Array {
   return convertStringToBuffer(formatChunkAsString(type, props));
-}
-
-export function renderHostChildrenToString(
-  children: React$Element<any>,
-): string {
-  // TODO: This file is used to actually implement a server renderer
-  // so we can't actually reference the renderer here. Instead, we
-  // should replace this method with a reference to Fizz which
-  // then uses this file to implement the server renderer.
-  return renderToStaticMarkup(children);
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -19,7 +19,7 @@ import {
   processModelChunk,
   processErrorChunk,
 } from './ReactFlightServerConfig';
-import {renderHostChildrenToString} from './ReactServerFormatConfig';
+
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 type ReactJSONValue =
@@ -88,7 +88,7 @@ function attemptResolveModelComponent(element: React$Element<any>): ReactModel {
     return type(props);
   } else if (typeof type === 'string') {
     // This is a host element. E.g. HTML.
-    return renderHostChildrenToString(element);
+    return [REACT_ELEMENT_TYPE, type, element.key, element.props];
   } else {
     throw new Error('Unsupported type.');
   }
@@ -119,7 +119,7 @@ function serializeIDRef(id: number): string {
 function escapeStringValue(value: string): string {
   if (value[0] === '$') {
     // We need to escape $ prefixed strings since we use that to encode
-    // references to IDs.
+    // references to IDs and as a special symbol value.
     return '$' + value;
   } else {
     return value;
@@ -132,6 +132,10 @@ export function resolveModelToJSON(
 ): ReactJSONValue {
   if (typeof value === 'string') {
     return escapeStringValue(value);
+  }
+
+  if (value === REACT_ELEMENT_TYPE) {
+    return '$';
   }
 
   while (

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -28,5 +28,3 @@ export opaque type Destination = mixed; // eslint-disable-line no-undef
 
 export const formatChunkAsString = $$$hostConfig.formatChunkAsString;
 export const formatChunk = $$$hostConfig.formatChunk;
-export const renderHostChildrenToString =
-  $$$hostConfig.renderHostChildrenToString;


### PR DESCRIPTION
This replaces the HTML renderer with instead resolving host elements into arrays tagged with the `react.element` symbol. These turn into proper React Elements on the client.

The symbol is encoded as the magical value `"$"`. This has security implications so this special value needs to remain escaped for other strings.

We could just encode the element as `{$$typeof: "$", type: type, key: key props: props}` but that's a lot more bytes. So instead I encode it as `["$", type, key, props]` and then convert it back on the client.

In a follow up I intend to encode Block Pairs ("thunks") as `["@", render, data]`.

It would be nicer if React's reconciler could just accept these tuples directly. We should consider that as part of the deprecation work around elements.