### PR TITLE
Don't use Spread in DevTools Injection

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -511,7 +511,10 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {ReactCurrentDispatcher} = ReactSharedInternals;
 
   return injectInternals({
-    ...devToolsConfig,
+    bundleType: devToolsConfig.bundleType,
+    version: devToolsConfig.version,
+    rendererPackageName: devToolsConfig.rendererPackageName,
+    getInspectorDataForViewTag: devToolsConfig.getInspectorDataForViewTag,
     overrideHookState,
     overrideProps,
     setSuspenseHandler,


### PR DESCRIPTION
Related to this https://github.com/facebook/react/pull/18233/files#r391135037

We could encourage new arbitrary things to be added to this object through spread but that shares a namespace with our own things which risks us colliding and causing weird behavior. The Flow type defines that this is exact so to enforce that it is indeed exact, we can instead enumerate the values.

We really should be doing that everywhere in our internals, like we do with fiber cloning for example, and ideally avoid Object.assign as much as possible even in user facing APIs.

In DEV behavior I'm not as strict but this ships in PROD.