### PR TITLE
Don't use closures in DevTools injection

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.js
@@ -21,6 +21,7 @@ import {DidCapture} from './ReactSideEffectTags';
 declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: Object | void;
 
 let onScheduleFiberRoot = null;
+let rendererID = null;
 let onCommitFiberRoot = null;
 let onCommitFiberUnmount = null;
 let hasLoggedError = false;
@@ -52,66 +53,16 @@ export function injectInternals(internals: Object): boolean {
     return true;
   }
   try {
-    const rendererID = hook.inject(internals);
+    rendererID = hook.inject(internals);
     // We have successfully injected, so now it is safe to set up hooks.
     if (__DEV__) {
       // Only used by Fast Refresh
       if (typeof hook.onScheduleFiberRoot === 'function') {
-        onScheduleFiberRoot = (root, children) => {
-          try {
-            hook.onScheduleFiberRoot(rendererID, root, children);
-          } catch (err) {
-            if (__DEV__ && !hasLoggedError) {
-              hasLoggedError = true;
-              console.error(
-                'React instrumentation encountered an error: %s',
-                err,
-              );
-            }
-          }
-        };
+        onScheduleFiberRoot = hook.onScheduleFiberRoot;
       }
     }
-    onCommitFiberRoot = (root, expirationTime) => {
-      try {
-        const didError = (root.current.effectTag & DidCapture) === DidCapture;
-        if (enableProfilerTimer) {
-          const currentTime = getCurrentTime();
-          const priorityLevel = inferPriorityFromExpirationTime(
-            currentTime,
-            expirationTime,
-          );
-          hook.onCommitFiberRoot(rendererID, root, priorityLevel, didError);
-        } else {
-          hook.onCommitFiberRoot(rendererID, root, undefined, didError);
-        }
-      } catch (err) {
-        if (__DEV__) {
-          if (!hasLoggedError) {
-            hasLoggedError = true;
-            console.error(
-              'React instrumentation encountered an error: %s',
-              err,
-            );
-          }
-        }
-      }
-    };
-    onCommitFiberUnmount = fiber => {
-      try {
-        hook.onCommitFiberUnmount(rendererID, fiber);
-      } catch (err) {
-        if (__DEV__) {
-          if (!hasLoggedError) {
-            hasLoggedError = true;
-            console.error(
-              'React instrumentation encountered an error: %s',
-              err,
-            );
-          }
-        }
-      }
-    };
+    onCommitFiberRoot = hook.onCommitFiberRoot;
+    onCommitFiberUnmount = hook.onCommitFiberUnmount;
   } catch (err) {
     // Catch all errors because it is unsafe to throw during initialization.
     if (__DEV__) {
@@ -123,19 +74,56 @@ export function injectInternals(internals: Object): boolean {
 }
 
 export function onScheduleRoot(root: FiberRoot, children: ReactNodeList) {
-  if (typeof onScheduleFiberRoot === 'function') {
-    onScheduleFiberRoot(root, children);
+  if (__DEV__) {
+    if (typeof onScheduleFiberRoot === 'function') {
+      try {
+        onScheduleFiberRoot(rendererID, root, children);
+      } catch (err) {
+        if (__DEV__ && !hasLoggedError) {
+          hasLoggedError = true;
+          console.error('React instrumentation encountered an error: %s', err);
+        }
+      }
+    }
   }
 }
 
 export function onCommitRoot(root: FiberRoot, expirationTime: ExpirationTime) {
   if (typeof onCommitFiberRoot === 'function') {
-    onCommitFiberRoot(root, expirationTime);
+    try {
+      const didError = (root.current.effectTag & DidCapture) === DidCapture;
+      if (enableProfilerTimer) {
+        const currentTime = getCurrentTime();
+        const priorityLevel = inferPriorityFromExpirationTime(
+          currentTime,
+          expirationTime,
+        );
+        onCommitFiberRoot(rendererID, root, priorityLevel, didError);
+      } else {
+        onCommitFiberRoot(rendererID, root, undefined, didError);
+      }
+    } catch (err) {
+      if (__DEV__) {
+        if (!hasLoggedError) {
+          hasLoggedError = true;
+          console.error('React instrumentation encountered an error: %s', err);
+        }
+      }
+    }
   }
 }
 
 export function onCommitUnmount(fiber: Fiber) {
   if (typeof onCommitFiberUnmount === 'function') {
-    onCommitFiberUnmount(fiber);
+    try {
+      onCommitFiberUnmount(rendererID, fiber);
+    } catch (err) {
+      if (__DEV__) {
+        if (!hasLoggedError) {
+          hasLoggedError = true;
+          console.error('React instrumentation encountered an error: %s', err);
+        }
+      }
+    }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -506,6 +506,24 @@ if (__DEV__) {
   };
 }
 
+function findHostInstanceByFiber(fiber: Fiber): Instance | TextInstance | null {
+  const hostFiber = findCurrentHostFiber(fiber);
+  if (hostFiber === null) {
+    return null;
+  }
+  return hostFiber.stateNode;
+}
+
+function emptyFindFiberByHostInstance(
+  instance: Instance | TextInstance,
+): Fiber | null {
+  return null;
+}
+
+function getCurrentFiberForDevTools() {
+  return ReactCurrentFiberCurrent;
+}
+
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {findFiberByHostInstance} = devToolsConfig;
   const {ReactCurrentDispatcher} = ReactSharedInternals;
@@ -520,27 +538,16 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     setSuspenseHandler,
     scheduleUpdate,
     currentDispatcherRef: ReactCurrentDispatcher,
-    findHostInstanceByFiber(fiber: Fiber): Instance | TextInstance | null {
-      const hostFiber = findCurrentHostFiber(fiber);
-      if (hostFiber === null) {
-        return null;
-      }
-      return hostFiber.stateNode;
-    },
-    findFiberByHostInstance(instance: Instance | TextInstance): Fiber | null {
-      if (!findFiberByHostInstance) {
-        // Might not be implemented by the renderer.
-        return null;
-      }
-      return findFiberByHostInstance(instance);
-    },
+    findHostInstanceByFiber,
+    findFiberByHostInstance:
+      findFiberByHostInstance || emptyFindFiberByHostInstance,
     // React Refresh
     findHostInstancesForRefresh: __DEV__ ? findHostInstancesForRefresh : null,
     scheduleRefresh: __DEV__ ? scheduleRefresh : null,
     scheduleRoot: __DEV__ ? scheduleRoot : null,
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
     // Enables DevTools to append owner stacks to error messages in DEV mode.
-    getCurrentFiber: __DEV__ ? () => ReactCurrentFiberCurrent : null,
+    getCurrentFiber: __DEV__ ? getCurrentFiberForDevTools : null,
   });
 }
 


### PR DESCRIPTION
Nested closures are tricky. They're not super efficient and when they share scope between multiple closures they're hard for a compiler to optimize. It's also unclear how many versions will be created.

By hoisting things out an just make it simple calls the compiler can do a much better job.

## Before 

```js
"function" === typeof ik && ik(c.stateNode, d);
```
```js
"function" === typeof Qi && Qi(b);
```
```js
var ik = null,
  Qi = null;
function nk(a) {
  if ("undefined" === typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) return !1;
  var b = __REACT_DEVTOOLS_GLOBAL_HOOK__;
  if (b.isDisabled || !b.supportsFiber) return !0;
  try {
    var c = b.inject(a);
    ik = function(a) {
      try {
        b.onCommitFiberRoot(c, a, void 0, 64 === (a.current.effectTag & 64));
      } catch (e) {}
    };
    Qi = function(a) {
      try {
        b.onCommitFiberUnmount(c, a);
      } catch (e) {}
    };
  } catch (d) {}
  return !0;
}
(function(a) {
  var b = a.findFiberByHostInstance;
  return nk(
    n({}, a, {
      overrideHookState: null,
      overrideProps: null,
      setSuspenseHandler: null,
      scheduleUpdate: null,
      currentDispatcherRef: Wa.ReactCurrentDispatcher,
      findHostInstanceByFiber: function(a) {
        a = ic(a);
        return null === a ? null : a.stateNode;
      },
      findFiberByHostInstance: function(a) {
        return b ? b(a) : null;
      },
      findHostInstancesForRefresh: null,
      scheduleRefresh: null,
      scheduleRoot: null,
      setRefreshHandler: null,
      getCurrentFiber: null
    })
  );
})({
  findFiberByHostInstance: uc,
  bundleType: 0,
  version: "16.13.0",
  rendererPackageName: "react-dom"
});
```

## After

```js
  if ("function" === typeof ik)
    try {
      ik(Qi, c, void 0, 64 === (c.current.effectTag & 64));
    } catch (ya) {}
```
```js
  if ("function" === typeof Pi)
    try {
      Pi(Qi, b);
    } catch (e) {}
```
```js
var Dk = {
    findFiberByHostInstance: tc,
    bundleType: 0,
    version: "16.13.0",
    rendererPackageName: "react-dom"
  };
var Ek = {
  bundleType: Dk.bundleType,
  version: Dk.version,
  rendererPackageName: Dk.rendererPackageName,
  getInspectorDataForViewTag: Dk.getInspectorDataForViewTag,
  overrideHookState: null,
  overrideProps: null,
  setSuspenseHandler: null,
  scheduleUpdate: null,
  currentDispatcherRef: Ya.ReactCurrentDispatcher,
  findHostInstanceByFiber: function(a) {
    a = hc(a);
    return null === a ? null : a.stateNode;
  },
  findFiberByHostInstance: Dk.findFiberByHostInstance || tk,
  findHostInstancesForRefresh: null,
  scheduleRefresh: null,
  scheduleRoot: null,
  setRefreshHandler: null,
  getCurrentFiber: null
};
if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
  var Fk = __REACT_DEVTOOLS_GLOBAL_HOOK__;
  if (!Fk.isDisabled && Fk.supportsFiber)
    try {
      (Qi = Fk.inject(Ek)),
        (ik = Fk.onCommitFiberRoot),
        (Pi = Fk.onCommitFiberUnmount);
    } catch (a) {}
}
```

Note that it's still sub-optimal because the config object gets created even though it should be able to be inlined by Closure Compiler. We should really switch this per-renderer config object to be a HostConfig the whole thing instead to avoid that.

The injected object is also created outside the condition so it's always created even if no devtools is present.