### PR TITLE
Wrap Components and Profiler tabs with box-size style too

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Components.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Components.css
@@ -9,6 +9,11 @@
   font-family: var(--font-family-sans);
 }
 
+.Components, .Components * {
+  box-sizing: border-box;
+  -webkit-font-smoothing: var(--font-smoothing);
+}
+
 .TreeWrapper {
   flex: 0 0 var(--horizontal-resize-percentage);
   overflow: auto;

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.css
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.css
@@ -56,6 +56,5 @@
 
 .DevTools, .DevTools * {
   box-sizing: border-box;
-
   -webkit-font-smoothing: var(--font-smoothing);
 }

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
@@ -11,6 +11,11 @@
   color: var(--color-text);
 }
 
+.Profiler, .Profiler * {
+  box-sizing: border-box;
+  -webkit-font-smoothing: var(--font-smoothing);
+}
+
 .LeftColumn {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
For the browser extension, these views get rendered into portals and so they don't inherit the box-sizing style from the `.DevTools` wrapper element. This causes views like the Profiler commit selector to subtly break.

This regressed with 9cc094a.

Resolves #18284

<img width="369" alt="Screen Shot 2020-03-11 at 6 35 52 PM" src="https://user-images.githubusercontent.com/29597/76479008-a076bf80-63c7-11ea-9e2f-4e878d781d32.png">
