### PR TITLE
Remove manual feature flag overrides

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -33,3177 +33,3038 @@ let useDeferredValue;
 let forwardRef;
 let memo;
 let act;
+let deferPassiveEffectCleanupDuringUnmount;
+let runAllPassiveEffectDestroysBeforeCreates;
 
-function loadModules({
-  deferPassiveEffectCleanupDuringUnmount,
-  runAllPassiveEffectDestroysBeforeCreates,
-}) {
-  ReactFeatureFlags = require('shared/ReactFeatureFlags');
-  ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
-  ReactFeatureFlags.enableSchedulerTracing = true;
-  ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
-  ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount = deferPassiveEffectCleanupDuringUnmount;
-  ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates = runAllPassiveEffectDestroysBeforeCreates;
-  ReactFeatureFlags.enableProfilerTimer = true;
-  React = require('react');
-  ReactNoop = require('react-noop-renderer');
-  Scheduler = require('scheduler');
-  SchedulerTracing = require('scheduler/tracing');
-  ReactCache = require('react-cache');
-  useState = React.useState;
-  useReducer = React.useReducer;
-  useEffect = React.useEffect;
-  useLayoutEffect = React.useLayoutEffect;
-  useCallback = React.useCallback;
-  useMemo = React.useMemo;
-  useRef = React.useRef;
-  useImperativeHandle = React.useImperativeHandle;
-  forwardRef = React.forwardRef;
-  memo = React.memo;
-  useTransition = React.useTransition;
-  useDeferredValue = React.useDeferredValue;
-  Suspense = React.Suspense;
-  act = ReactNoop.act;
-}
+describe('ReactHooksWithNoopRenderer', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
 
-[true, false].forEach(deferPassiveEffectCleanupDuringUnmount => {
-  [true, false].forEach(runAllPassiveEffectDestroysBeforeCreates => {
-    describe(`ReactHooksWithNoopRenderer deferPassiveEffectCleanupDuringUnmount:${deferPassiveEffectCleanupDuringUnmount} runAllPassiveEffectDestroysBeforeCreates:${runAllPassiveEffectDestroysBeforeCreates}`, () => {
-      beforeEach(() => {
-        jest.resetModules();
-        jest.useFakeTimers();
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.enableSchedulerTracing = true;
+    ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
+    ReactFeatureFlags.enableProfilerTimer = true;
+    deferPassiveEffectCleanupDuringUnmount =
+      ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount;
+    runAllPassiveEffectDestroysBeforeCreates =
+      ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates;
 
-        loadModules({
-          deferPassiveEffectCleanupDuringUnmount,
-          runAllPassiveEffectDestroysBeforeCreates,
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    SchedulerTracing = require('scheduler/tracing');
+    ReactCache = require('react-cache');
+    useState = React.useState;
+    useReducer = React.useReducer;
+    useEffect = React.useEffect;
+    useLayoutEffect = React.useLayoutEffect;
+    useCallback = React.useCallback;
+    useMemo = React.useMemo;
+    useRef = React.useRef;
+    useImperativeHandle = React.useImperativeHandle;
+    forwardRef = React.forwardRef;
+    memo = React.memo;
+    useTransition = React.useTransition;
+    useDeferredValue = React.useDeferredValue;
+    Suspense = React.Suspense;
+    act = ReactNoop.act;
+
+    TextResource = ReactCache.unstable_createResource(
+      ([text, ms = 0]) => {
+        return new Promise((resolve, reject) =>
+          setTimeout(() => {
+            Scheduler.unstable_yieldValue(`Promise resolved [${text}]`);
+            resolve(text);
+          }, ms),
+        );
+      },
+      ([text, ms]) => text,
+    );
+  });
+
+  function span(prop) {
+    return {type: 'span', hidden: false, children: [], prop};
+  }
+
+  function hiddenSpan(prop) {
+    return {type: 'span', children: [], prop, hidden: true};
+  }
+
+  function Text(props) {
+    Scheduler.unstable_yieldValue(props.text);
+    return <span prop={props.text} />;
+  }
+
+  function AsyncText(props) {
+    const text = props.text;
+    try {
+      TextResource.read([props.text, props.ms]);
+      Scheduler.unstable_yieldValue(text);
+      return <span prop={text} />;
+    } catch (promise) {
+      if (typeof promise.then === 'function') {
+        Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
+      } else {
+        Scheduler.unstable_yieldValue(`Error! [${text}]`);
+      }
+      throw promise;
+    }
+  }
+
+  function advanceTimers(ms) {
+    // Note: This advances Jest's virtual time but not React's. Use
+    // ReactNoop.expire for that.
+    if (typeof ms !== 'number') {
+      throw new Error('Must specify ms');
+    }
+    jest.advanceTimersByTime(ms);
+    // Wait until the end of the current tick
+    // We cannot use a timer since we're faking them
+    return Promise.resolve().then(() => {});
+  }
+
+  it('resumes after an interruption', () => {
+    function Counter(props, ref) {
+      const [count, updateCount] = useState(0);
+      useImperativeHandle(ref, () => ({updateCount}));
+      return <Text text={props.label + ': ' + count} />;
+    }
+    Counter = forwardRef(Counter);
+
+    // Initial mount
+    const counter = React.createRef(null);
+    ReactNoop.render(<Counter label="Count" ref={counter} />);
+    expect(Scheduler).toFlushAndYield(['Count: 0']);
+    expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+    // Schedule some updates
+    ReactNoop.batchedUpdates(() => {
+      counter.current.updateCount(1);
+      counter.current.updateCount(count => count + 10);
+    });
+
+    // Partially flush without committing
+    expect(Scheduler).toFlushAndYieldThrough(['Count: 11']);
+    expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+    // Interrupt with a high priority update
+    ReactNoop.flushSync(() => {
+      ReactNoop.render(<Counter label="Total" />);
+    });
+    expect(Scheduler).toHaveYielded(['Total: 0']);
+
+    // Resume rendering
+    expect(Scheduler).toFlushAndYield(['Total: 11']);
+    expect(ReactNoop.getChildren()).toEqual([span('Total: 11')]);
+  });
+
+  it('throws inside class components', () => {
+    class BadCounter extends React.Component {
+      render() {
+        const [count] = useState(0);
+        return <Text text={this.props.label + ': ' + count} />;
+      }
+    }
+    ReactNoop.render(<BadCounter />);
+
+    expect(Scheduler).toFlushAndThrow(
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+    );
+
+    // Confirm that a subsequent hook works properly.
+    function GoodCounter(props, ref) {
+      const [count] = useState(props.initialCount);
+      return <Text text={count} />;
+    }
+    ReactNoop.render(<GoodCounter initialCount={10} />);
+    expect(Scheduler).toFlushAndYield([10]);
+  });
+
+  it('throws inside module-style components', () => {
+    function Counter() {
+      return {
+        render() {
+          const [count] = useState(0);
+          return <Text text={this.props.label + ': ' + count} />;
+        },
+      };
+    }
+    ReactNoop.render(<Counter />);
+    expect(() =>
+      expect(Scheduler).toFlushAndThrow(
+        'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen ' +
+          'for one of the following reasons:\n' +
+          '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+          '2. You might be breaking the Rules of Hooks\n' +
+          '3. You might have more than one copy of React in the same app\n' +
+          'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+      ),
+    ).toErrorDev(
+      'Warning: The <Counter /> component appears to be a function component that returns a class instance. ' +
+        'Change Counter to a class that extends React.Component instead. ' +
+        "If you can't use a class try assigning the prototype on the function as a workaround. " +
+        '`Counter.prototype = React.Component.prototype`. ' +
+        "Don't use an arrow function since it cannot be called with `new` by React.",
+    );
+
+    // Confirm that a subsequent hook works properly.
+    function GoodCounter(props) {
+      const [count] = useState(props.initialCount);
+      return <Text text={count} />;
+    }
+    ReactNoop.render(<GoodCounter initialCount={10} />);
+    expect(Scheduler).toFlushAndYield([10]);
+  });
+
+  it('throws when called outside the render phase', () => {
+    expect(() => useState(0)).toThrow(
+      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+        ' one of the following reasons:\n' +
+        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+        '2. You might be breaking the Rules of Hooks\n' +
+        '3. You might have more than one copy of React in the same app\n' +
+        'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+    );
+  });
+
+  describe('useState', () => {
+    it('simple mount and update', () => {
+      function Counter(props, ref) {
+        const [count, updateCount] = useState(0);
+        useImperativeHandle(ref, () => ({updateCount}));
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => counter.current.updateCount(1));
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+
+      act(() => counter.current.updateCount(count => count + 10));
+      expect(Scheduler).toHaveYielded(['Count: 11']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
+    });
+
+    it('lazy state initializer', () => {
+      function Counter(props, ref) {
+        const [count, updateCount] = useState(() => {
+          Scheduler.unstable_yieldValue('getInitialState');
+          return props.initialState;
         });
+        useImperativeHandle(ref, () => ({updateCount}));
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter initialState={42} ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['getInitialState', 'Count: 42']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 42')]);
 
-        TextResource = ReactCache.unstable_createResource(
-          ([text, ms = 0]) => {
-            return new Promise((resolve, reject) =>
-              setTimeout(() => {
-                Scheduler.unstable_yieldValue(`Promise resolved [${text}]`);
-                resolve(text);
-              }, ms),
-            );
-          },
-          ([text, ms]) => text,
+      act(() => counter.current.updateCount(7));
+      expect(Scheduler).toHaveYielded(['Count: 7']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 7')]);
+    });
+
+    it('multiple states', () => {
+      function Counter(props, ref) {
+        const [count, updateCount] = useState(0);
+        const [label, updateLabel] = useState('Count');
+        useImperativeHandle(ref, () => ({updateCount, updateLabel}));
+        return <Text text={label + ': ' + count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => counter.current.updateCount(7));
+      expect(Scheduler).toHaveYielded(['Count: 7']);
+
+      act(() => counter.current.updateLabel('Total'));
+      expect(Scheduler).toHaveYielded(['Total: 7']);
+    });
+
+    it('returns the same updater function every time', () => {
+      let updaters = [];
+      function Counter() {
+        const [count, updateCount] = useState(0);
+        updaters.push(updateCount);
+        return <Text text={'Count: ' + count} />;
+      }
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => updaters[0](1));
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+
+      act(() => updaters[0](count => count + 10));
+      expect(Scheduler).toHaveYielded(['Count: 11']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
+
+      expect(updaters).toEqual([updaters[0], updaters[0], updaters[0]]);
+    });
+
+    it('warns on set after unmount', () => {
+      let _updateCount;
+      function Counter(props, ref) {
+        const [, updateCount] = useState(0);
+        _updateCount = updateCount;
+        return null;
+      }
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushWithoutYielding();
+      ReactNoop.render(null);
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(() => act(() => _updateCount(1))).toErrorDev(
+        "Warning: Can't perform a React state update on an unmounted " +
+          'component. This is a no-op, but it indicates a memory leak in your ' +
+          'application. To fix, cancel all subscriptions and asynchronous ' +
+          'tasks in a useEffect cleanup function.\n' +
+          '    in Counter (at **)',
+      );
+    });
+
+    it('works with memo', () => {
+      let _updateCount;
+      function Counter(props) {
+        const [count, updateCount] = useState(0);
+        _updateCount = updateCount;
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = memo(Counter);
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => _updateCount(1));
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+    });
+  });
+
+  describe('updates during the render phase', () => {
+    it('restarts the render function and applies the new updates on top', () => {
+      function ScrollView({row: newRow}) {
+        let [isScrollingDown, setIsScrollingDown] = useState(false);
+        let [row, setRow] = useState(null);
+
+        if (row !== newRow) {
+          // Row changed since last render. Update isScrollingDown.
+          setIsScrollingDown(row !== null && newRow > row);
+          setRow(newRow);
+        }
+
+        return <Text text={`Scrolling down: ${isScrollingDown}`} />;
+      }
+
+      ReactNoop.render(<ScrollView row={1} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
+
+      ReactNoop.render(<ScrollView row={5} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
+
+      ReactNoop.render(<ScrollView row={5} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
+
+      ReactNoop.render(<ScrollView row={10} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: true')]);
+
+      ReactNoop.render(<ScrollView row={2} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
+
+      ReactNoop.render(<ScrollView row={2} />);
+      expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
+      expect(ReactNoop.getChildren()).toEqual([span('Scrolling down: false')]);
+    });
+
+    it('warns about render phase update on a different component', async () => {
+      let setStep;
+      function Foo() {
+        const [step, _setStep] = useState(0);
+        setStep = _setStep;
+        return <Text text={`Foo [${step}]`} />;
+      }
+
+      function Bar({triggerUpdate}) {
+        if (triggerUpdate) {
+          setStep(1);
+        }
+        return <Text text="Bar" />;
+      }
+
+      const root = ReactNoop.createRoot();
+
+      await ReactNoop.act(async () => {
+        root.render(
+          <>
+            <Foo />
+            <Bar />
+          </>,
         );
       });
+      expect(Scheduler).toHaveYielded(['Foo [0]', 'Bar']);
 
-      function span(prop) {
-        return {type: 'span', hidden: false, children: [], prop};
-      }
-
-      function hiddenSpan(prop) {
-        return {type: 'span', children: [], prop, hidden: true};
-      }
-
-      function Text(props) {
-        Scheduler.unstable_yieldValue(props.text);
-        return <span prop={props.text} />;
-      }
-
-      function AsyncText(props) {
-        const text = props.text;
-        try {
-          TextResource.read([props.text, props.ms]);
-          Scheduler.unstable_yieldValue(text);
-          return <span prop={text} />;
-        } catch (promise) {
-          if (typeof promise.then === 'function') {
-            Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
-          } else {
-            Scheduler.unstable_yieldValue(`Error! [${text}]`);
-          }
-          throw promise;
-        }
-      }
-
-      function advanceTimers(ms) {
-        // Note: This advances Jest's virtual time but not React's. Use
-        // ReactNoop.expire for that.
-        if (typeof ms !== 'number') {
-          throw new Error('Must specify ms');
-        }
-        jest.advanceTimersByTime(ms);
-        // Wait until the end of the current tick
-        // We cannot use a timer since we're faking them
-        return Promise.resolve().then(() => {});
-      }
-
-      it('resumes after an interruption', () => {
-        function Counter(props, ref) {
-          const [count, updateCount] = useState(0);
-          useImperativeHandle(ref, () => ({updateCount}));
-          return <Text text={props.label + ': ' + count} />;
-        }
-        Counter = forwardRef(Counter);
-
-        // Initial mount
-        const counter = React.createRef(null);
-        ReactNoop.render(<Counter label="Count" ref={counter} />);
-        expect(Scheduler).toFlushAndYield(['Count: 0']);
-        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-        // Schedule some updates
-        ReactNoop.batchedUpdates(() => {
-          counter.current.updateCount(1);
-          counter.current.updateCount(count => count + 10);
-        });
-
-        // Partially flush without committing
-        expect(Scheduler).toFlushAndYieldThrough(['Count: 11']);
-        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-        // Interrupt with a high priority update
-        ReactNoop.flushSync(() => {
-          ReactNoop.render(<Counter label="Total" />);
-        });
-        expect(Scheduler).toHaveYielded(['Total: 0']);
-
-        // Resume rendering
-        expect(Scheduler).toFlushAndYield(['Total: 11']);
-        expect(ReactNoop.getChildren()).toEqual([span('Total: 11')]);
-      });
-
-      it('throws inside class components', () => {
-        class BadCounter extends React.Component {
-          render() {
-            const [count] = useState(0);
-            return <Text text={this.props.label + ': ' + count} />;
-          }
-        }
-        ReactNoop.render(<BadCounter />);
-
-        expect(Scheduler).toFlushAndThrow(
-          'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-            ' one of the following reasons:\n' +
-            '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-            '2. You might be breaking the Rules of Hooks\n' +
-            '3. You might have more than one copy of React in the same app\n' +
-            'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+      // Bar will update Foo during its render phase. React should warn.
+      await ReactNoop.act(async () => {
+        root.render(
+          <>
+            <Foo />
+            <Bar triggerUpdate={true} />
+          </>,
         );
-
-        // Confirm that a subsequent hook works properly.
-        function GoodCounter(props, ref) {
-          const [count] = useState(props.initialCount);
-          return <Text text={count} />;
-        }
-        ReactNoop.render(<GoodCounter initialCount={10} />);
-        expect(Scheduler).toFlushAndYield([10]);
-      });
-
-      it('throws inside module-style components', () => {
-        function Counter() {
-          return {
-            render() {
-              const [count] = useState(0);
-              return <Text text={this.props.label + ': ' + count} />;
-            },
-          };
-        }
-        ReactNoop.render(<Counter />);
         expect(() =>
-          expect(Scheduler).toFlushAndThrow(
-            'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen ' +
-              'for one of the following reasons:\n' +
-              '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-              '2. You might be breaking the Rules of Hooks\n' +
-              '3. You might have more than one copy of React in the same app\n' +
-              'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
-          ),
-        ).toErrorDev(
-          'Warning: The <Counter /> component appears to be a function component that returns a class instance. ' +
-            'Change Counter to a class that extends React.Component instead. ' +
-            "If you can't use a class try assigning the prototype on the function as a workaround. " +
-            '`Counter.prototype = React.Component.prototype`. ' +
-            "Don't use an arrow function since it cannot be called with `new` by React.",
-        );
+          expect(Scheduler).toFlushAndYield(['Foo [0]', 'Bar', 'Foo [1]']),
+        ).toErrorDev([
+          'Cannot update a component from inside the function body of a ' +
+            'different component.',
+        ]);
+      });
+    });
 
-        // Confirm that a subsequent hook works properly.
-        function GoodCounter(props) {
-          const [count] = useState(props.initialCount);
-          return <Text text={count} />;
+    it('keeps restarting until there are no more new updates', () => {
+      function Counter({row: newRow}) {
+        let [count, setCount] = useState(0);
+        if (count < 3) {
+          setCount(count + 1);
         }
-        ReactNoop.render(<GoodCounter initialCount={10} />);
-        expect(Scheduler).toFlushAndYield([10]);
-      });
+        Scheduler.unstable_yieldValue('Render: ' + count);
+        return <Text text={count} />;
+      }
 
-      it('throws when called outside the render phase', () => {
-        expect(() => useState(0)).toThrow(
-          'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-            ' one of the following reasons:\n' +
-            '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-            '2. You might be breaking the Rules of Hooks\n' +
-            '3. You might have more than one copy of React in the same app\n' +
-            'See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.',
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield([
+        'Render: 0',
+        'Render: 1',
+        'Render: 2',
+        'Render: 3',
+        3,
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(3)]);
+    });
+
+    it('updates multiple times within same render function', () => {
+      function Counter({row: newRow}) {
+        let [count, setCount] = useState(0);
+        if (count < 12) {
+          setCount(c => c + 1);
+          setCount(c => c + 1);
+          setCount(c => c + 1);
+        }
+        Scheduler.unstable_yieldValue('Render: ' + count);
+        return <Text text={count} />;
+      }
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield([
+        // Should increase by three each time
+        'Render: 0',
+        'Render: 3',
+        'Render: 6',
+        'Render: 9',
+        'Render: 12',
+        12,
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(12)]);
+    });
+
+    it('throws after too many iterations', () => {
+      function Counter({row: newRow}) {
+        let [count, setCount] = useState(0);
+        setCount(count + 1);
+        Scheduler.unstable_yieldValue('Render: ' + count);
+        return <Text text={count} />;
+      }
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndThrow(
+        'Too many re-renders. React limits the number of renders to prevent ' +
+          'an infinite loop.',
+      );
+    });
+
+    it('works with useReducer', () => {
+      function reducer(state, action) {
+        return action === 'increment' ? state + 1 : state;
+      }
+      function Counter({row: newRow}) {
+        let [count, dispatch] = useReducer(reducer, 0);
+        if (count < 3) {
+          dispatch('increment');
+        }
+        Scheduler.unstable_yieldValue('Render: ' + count);
+        return <Text text={count} />;
+      }
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield([
+        'Render: 0',
+        'Render: 1',
+        'Render: 2',
+        'Render: 3',
+        3,
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(3)]);
+    });
+
+    it('uses reducer passed at time of render, not time of dispatch', () => {
+      // This test is a bit contrived but it demonstrates a subtle edge case.
+
+      // Reducer A increments by 1. Reducer B increments by 10.
+      function reducerA(state, action) {
+        switch (action) {
+          case 'increment':
+            return state + 1;
+          case 'reset':
+            return 0;
+        }
+      }
+      function reducerB(state, action) {
+        switch (action) {
+          case 'increment':
+            return state + 10;
+          case 'reset':
+            return 0;
+        }
+      }
+
+      function Counter({row: newRow}, ref) {
+        let [reducer, setReducer] = useState(() => reducerA);
+        let [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(ref, () => ({dispatch}));
+        if (count < 20) {
+          dispatch('increment');
+          // Swap reducers each time we increment
+          if (reducer === reducerA) {
+            setReducer(() => reducerB);
+          } else {
+            setReducer(() => reducerA);
+          }
+        }
+        Scheduler.unstable_yieldValue('Render: ' + count);
+        return <Text text={count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield([
+        // The count should increase by alternating amounts of 10 and 1
+        // until we reach 21.
+        'Render: 0',
+        'Render: 10',
+        'Render: 11',
+        'Render: 21',
+        21,
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(21)]);
+
+      // Test that it works on update, too. This time the log is a bit different
+      // because we started with reducerB instead of reducerA.
+      ReactNoop.act(() => {
+        counter.current.dispatch('reset');
+      });
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toHaveYielded([
+        'Render: 0',
+        'Render: 1',
+        'Render: 11',
+        'Render: 12',
+        'Render: 22',
+        22,
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(22)]);
+    });
+
+    it('discards render phase updates if something suspends', () => {
+      const thenable = {then() {}};
+      function Foo({signal}) {
+        return (
+          <Suspense fallback="Loading...">
+            <Bar signal={signal} />
+          </Suspense>
         );
+      }
+
+      function Bar({signal: newSignal}) {
+        let [counter, setCounter] = useState(0);
+        let [signal, setSignal] = useState(true);
+
+        // Increment a counter every time the signal changes
+        if (signal !== newSignal) {
+          setCounter(c => c + 1);
+          setSignal(newSignal);
+          if (counter === 0) {
+            // We're suspending during a render that includes render phase
+            // updates. Those updates should not persist to the next render.
+            Scheduler.unstable_yieldValue('Suspend!');
+            throw thenable;
+          }
+        }
+
+        return <Text text={counter} />;
+      }
+
+      const root = ReactNoop.createRoot();
+      root.render(<Foo signal={true} />);
+
+      expect(Scheduler).toFlushAndYield([0]);
+      expect(root).toMatchRenderedOutput(<span prop={0} />);
+
+      root.render(<Foo signal={false} />);
+      expect(Scheduler).toFlushAndYield(['Suspend!']);
+      expect(root).toMatchRenderedOutput(<span prop={0} />);
+
+      // Rendering again should suspend again.
+      root.render(<Foo signal={false} />);
+      expect(Scheduler).toFlushAndYield(['Suspend!']);
+    });
+
+    it('discards render phase updates if something suspends, but not other updates in the same component', async () => {
+      const thenable = {then() {}};
+      function Foo({signal}) {
+        return (
+          <Suspense fallback="Loading...">
+            <Bar signal={signal} />
+          </Suspense>
+        );
+      }
+
+      let setLabel;
+      function Bar({signal: newSignal}) {
+        let [counter, setCounter] = useState(0);
+
+        if (counter === 1) {
+          // We're suspending during a render that includes render phase
+          // updates. Those updates should not persist to the next render.
+          Scheduler.unstable_yieldValue('Suspend!');
+          throw thenable;
+        }
+
+        let [signal, setSignal] = useState(true);
+
+        // Increment a counter every time the signal changes
+        if (signal !== newSignal) {
+          setCounter(c => c + 1);
+          setSignal(newSignal);
+        }
+
+        let [label, _setLabel] = useState('A');
+        setLabel = _setLabel;
+
+        return <Text text={`${label}:${counter}`} />;
+      }
+
+      const root = ReactNoop.createRoot();
+      root.render(<Foo signal={true} />);
+
+      expect(Scheduler).toFlushAndYield(['A:0']);
+      expect(root).toMatchRenderedOutput(<span prop="A:0" />);
+
+      await ReactNoop.act(async () => {
+        root.render(<Foo signal={false} />);
+        setLabel('B');
+      });
+      expect(Scheduler).toHaveYielded(['Suspend!']);
+      expect(root).toMatchRenderedOutput(<span prop="A:0" />);
+
+      // Rendering again should suspend again.
+      root.render(<Foo signal={false} />);
+      expect(Scheduler).toFlushAndYield(['Suspend!']);
+
+      // Flip the signal back to "cancel" the update. However, the update to
+      // label should still proceed. It shouldn't have been dropped.
+      root.render(<Foo signal={true} />);
+      expect(Scheduler).toFlushAndYield(['B:0']);
+      expect(root).toMatchRenderedOutput(<span prop="B:0" />);
+    });
+
+    // TODO: This should probably warn
+    it.experimental('calling startTransition inside render phase', async () => {
+      let startTransition;
+      function App() {
+        let [counter, setCounter] = useState(0);
+        let [_startTransition] = useTransition();
+        startTransition = _startTransition;
+
+        if (counter === 0) {
+          startTransition(() => {
+            setCounter(c => c + 1);
+          });
+        }
+
+        return <Text text={counter} />;
+      }
+
+      const root = ReactNoop.createRoot();
+      root.render(<App />);
+      expect(Scheduler).toFlushAndYield([1]);
+      expect(root).toMatchRenderedOutput(<span prop={1} />);
+    });
+  });
+
+  describe('useReducer', () => {
+    it('simple mount and update', () => {
+      const INCREMENT = 'INCREMENT';
+      const DECREMENT = 'DECREMENT';
+
+      function reducer(state, action) {
+        switch (action) {
+          case 'INCREMENT':
+            return state + 1;
+          case 'DECREMENT':
+            return state - 1;
+          default:
+            return state;
+        }
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(ref, () => ({dispatch}));
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => counter.current.dispatch(INCREMENT));
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      act(() => {
+        counter.current.dispatch(DECREMENT);
+        counter.current.dispatch(DECREMENT);
+        counter.current.dispatch(DECREMENT);
       });
 
-      describe('useState', () => {
-        it('simple mount and update', () => {
-          function Counter(props, ref) {
-            const [count, updateCount] = useState(0);
-            useImperativeHandle(ref, () => ({updateCount}));
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      expect(Scheduler).toHaveYielded(['Count: -2']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: -2')]);
+    });
 
-          act(() => counter.current.updateCount(1));
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+    it('lazy init', () => {
+      const INCREMENT = 'INCREMENT';
+      const DECREMENT = 'DECREMENT';
 
-          act(() => counter.current.updateCount(count => count + 10));
-          expect(Scheduler).toHaveYielded(['Count: 11']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
+      function reducer(state, action) {
+        switch (action) {
+          case 'INCREMENT':
+            return state + 1;
+          case 'DECREMENT':
+            return state - 1;
+          default:
+            return state;
+        }
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, props, p => {
+          Scheduler.unstable_yieldValue('Init');
+          return p.initialCount;
         });
+        useImperativeHandle(ref, () => ({dispatch}));
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter initialCount={10} ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Init', 'Count: 10']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 10')]);
 
-        it('lazy state initializer', () => {
-          function Counter(props, ref) {
-            const [count, updateCount] = useState(() => {
-              Scheduler.unstable_yieldValue('getInitialState');
-              return props.initialState;
-            });
-            useImperativeHandle(ref, () => ({updateCount}));
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter initialState={42} ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['getInitialState', 'Count: 42']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 42')]);
+      act(() => counter.current.dispatch(INCREMENT));
+      expect(Scheduler).toHaveYielded(['Count: 11']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
 
-          act(() => counter.current.updateCount(7));
-          expect(Scheduler).toHaveYielded(['Count: 7']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 7')]);
+      act(() => {
+        counter.current.dispatch(DECREMENT);
+        counter.current.dispatch(DECREMENT);
+        counter.current.dispatch(DECREMENT);
+      });
+
+      expect(Scheduler).toHaveYielded(['Count: 8']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 8')]);
+    });
+
+    // Regression test for https://github.com/facebook/react/issues/14360
+    it('handles dispatches with mixed priorities', () => {
+      const INCREMENT = 'INCREMENT';
+
+      function reducer(state, action) {
+        return action === INCREMENT ? state + 1 : state;
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(ref, () => ({dispatch}));
+        return <Text text={'Count: ' + count} />;
+      }
+
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      ReactNoop.batchedUpdates(() => {
+        counter.current.dispatch(INCREMENT);
+        counter.current.dispatch(INCREMENT);
+        counter.current.dispatch(INCREMENT);
+      });
+
+      ReactNoop.flushSync(() => {
+        counter.current.dispatch(INCREMENT);
+      });
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+
+      expect(Scheduler).toFlushAndYield(['Count: 4']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 4')]);
+    });
+  });
+
+  describe('useEffect', () => {
+    it('simple mount and update', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Passive effect [${props.count}]`);
         });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        // Effects are deferred until after the commit
+        expect(Scheduler).toFlushAndYield(['Passive effect [0]']);
+      });
 
-        it('multiple states', () => {
-          function Counter(props, ref) {
-            const [count, updateCount] = useState(0);
-            const [label, updateLabel] = useState('Count');
-            useImperativeHandle(ref, () => ({updateCount, updateLabel}));
-            return <Text text={label + ': ' + count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+        // Effects are deferred until after the commit
+        expect(Scheduler).toFlushAndYield(['Passive effect [1]']);
+      });
+    });
 
-          act(() => counter.current.updateCount(7));
-          expect(Scheduler).toHaveYielded(['Count: 7']);
-
-          act(() => counter.current.updateLabel('Total'));
-          expect(Scheduler).toHaveYielded(['Total: 7']);
+    it('flushes passive effects even with sibling deletions', () => {
+      function LayoutEffect(props) {
+        useLayoutEffect(() => {
+          Scheduler.unstable_yieldValue(`Layout effect`);
         });
+        return <Text text="Layout" />;
+      }
+      function PassiveEffect(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Passive effect`);
+        }, []);
+        return <Text text="Passive" />;
+      }
+      let passive = <PassiveEffect key="p" />;
+      act(() => {
+        ReactNoop.render([<LayoutEffect key="l" />, passive]);
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Layout',
+          'Passive',
+          'Layout effect',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Layout'),
+          span('Passive'),
+        ]);
+        // Destroying the first child shouldn't prevent the passive effect from
+        // being executed
+        ReactNoop.render([passive]);
+        expect(Scheduler).toFlushAndYield(['Passive effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Passive')]);
+      });
+      // exiting act calls flushPassiveEffects(), but there are none left to flush.
+      expect(Scheduler).toHaveYielded([]);
+    });
 
-        it('returns the same updater function every time', () => {
-          let updaters = [];
-          function Counter() {
-            const [count, updateCount] = useState(0);
-            updaters.push(updateCount);
-            return <Text text={'Count: ' + count} />;
-          }
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          act(() => updaters[0](1));
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-
-          act(() => updaters[0](count => count + 10));
-          expect(Scheduler).toHaveYielded(['Count: 11']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
-
-          expect(updaters).toEqual([updaters[0], updaters[0], updaters[0]]);
+    it('flushes passive effects even if siblings schedule an update', () => {
+      function PassiveEffect(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue('Passive effect');
         });
+        return <Text text="Passive" />;
+      }
+      function LayoutEffect(props) {
+        let [count, setCount] = useState(0);
+        useLayoutEffect(() => {
+          // Scheduling work shouldn't interfere with the queued passive effect
+          if (count === 0) {
+            setCount(1);
+          }
+          Scheduler.unstable_yieldValue('Layout effect ' + count);
+        });
+        return <Text text="Layout" />;
+      }
 
-        it('warns on set after unmount', () => {
-          let _updateCount;
-          function Counter(props, ref) {
-            const [, updateCount] = useState(0);
-            _updateCount = updateCount;
+      ReactNoop.render([<PassiveEffect key="p" />, <LayoutEffect key="l" />]);
+
+      act(() => {
+        expect(Scheduler).toFlushAndYield([
+          'Passive',
+          'Layout',
+          'Layout effect 0',
+          'Passive effect',
+          'Layout',
+          'Layout effect 1',
+        ]);
+      });
+
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Passive'),
+        span('Layout'),
+      ]);
+    });
+
+    it('flushes passive effects even if siblings schedule a new root', () => {
+      function PassiveEffect(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue('Passive effect');
+        }, []);
+        return <Text text="Passive" />;
+      }
+      function LayoutEffect(props) {
+        useLayoutEffect(() => {
+          Scheduler.unstable_yieldValue('Layout effect');
+          // Scheduling work shouldn't interfere with the queued passive effect
+          ReactNoop.renderToRootWithID(<Text text="New Root" />, 'root2');
+        });
+        return <Text text="Layout" />;
+      }
+      act(() => {
+        ReactNoop.render([<PassiveEffect key="p" />, <LayoutEffect key="l" />]);
+        expect(Scheduler).toFlushAndYield([
+          'Passive',
+          'Layout',
+          'Layout effect',
+          'Passive effect',
+          'New Root',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Passive'),
+          span('Layout'),
+        ]);
+      });
+    });
+
+    it(
+      'flushes effects serially by flushing old effects before flushing ' +
+        "new ones, if they haven't already fired",
+      () => {
+        function getCommittedText() {
+          const children = ReactNoop.getChildren();
+          if (children === null) {
             return null;
           }
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushWithoutYielding();
-          ReactNoop.render(null);
-          expect(Scheduler).toFlushWithoutYielding();
-          expect(() => act(() => _updateCount(1))).toErrorDev(
-            "Warning: Can't perform a React state update on an unmounted " +
-              'component. This is a no-op, but it indicates a memory leak in your ' +
-              'application. To fix, cancel all subscriptions and asynchronous ' +
-              'tasks in a useEffect cleanup function.\n' +
-              '    in Counter (at **)',
-          );
-        });
-
-        it('works with memo', () => {
-          let _updateCount;
-          function Counter(props) {
-            const [count, updateCount] = useState(0);
-            _updateCount = updateCount;
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = memo(Counter);
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield([]);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          act(() => _updateCount(1));
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-        });
-      });
-
-      describe('updates during the render phase', () => {
-        it('restarts the render function and applies the new updates on top', () => {
-          function ScrollView({row: newRow}) {
-            let [isScrollingDown, setIsScrollingDown] = useState(false);
-            let [row, setRow] = useState(null);
-
-            if (row !== newRow) {
-              // Row changed since last render. Update isScrollingDown.
-              setIsScrollingDown(row !== null && newRow > row);
-              setRow(newRow);
-            }
-
-            return <Text text={`Scrolling down: ${isScrollingDown}`} />;
-          }
-
-          ReactNoop.render(<ScrollView row={1} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: false'),
-          ]);
-
-          ReactNoop.render(<ScrollView row={5} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: true'),
-          ]);
-
-          ReactNoop.render(<ScrollView row={5} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: true'),
-          ]);
-
-          ReactNoop.render(<ScrollView row={10} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: true']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: true'),
-          ]);
-
-          ReactNoop.render(<ScrollView row={2} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: false'),
-          ]);
-
-          ReactNoop.render(<ScrollView row={2} />);
-          expect(Scheduler).toFlushAndYield(['Scrolling down: false']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Scrolling down: false'),
-          ]);
-        });
-
-        it('warns about render phase update on a different component', async () => {
-          let setStep;
-          function Foo() {
-            const [step, _setStep] = useState(0);
-            setStep = _setStep;
-            return <Text text={`Foo [${step}]`} />;
-          }
-
-          function Bar({triggerUpdate}) {
-            if (triggerUpdate) {
-              setStep(1);
-            }
-            return <Text text="Bar" />;
-          }
-
-          const root = ReactNoop.createRoot();
-
-          await ReactNoop.act(async () => {
-            root.render(
-              <>
-                <Foo />
-                <Bar />
-              </>,
-            );
-          });
-          expect(Scheduler).toHaveYielded(['Foo [0]', 'Bar']);
-
-          // Bar will update Foo during its render phase. React should warn.
-          await ReactNoop.act(async () => {
-            root.render(
-              <>
-                <Foo />
-                <Bar triggerUpdate={true} />
-              </>,
-            );
-            expect(() =>
-              expect(Scheduler).toFlushAndYield(['Foo [0]', 'Bar', 'Foo [1]']),
-            ).toErrorDev([
-              'Cannot update a component from inside the function body of a ' +
-                'different component.',
-            ]);
-          });
-        });
-
-        it('keeps restarting until there are no more new updates', () => {
-          function Counter({row: newRow}) {
-            let [count, setCount] = useState(0);
-            if (count < 3) {
-              setCount(count + 1);
-            }
-            Scheduler.unstable_yieldValue('Render: ' + count);
-            return <Text text={count} />;
-          }
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield([
-            'Render: 0',
-            'Render: 1',
-            'Render: 2',
-            'Render: 3',
-            3,
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(3)]);
-        });
-
-        it('updates multiple times within same render function', () => {
-          function Counter({row: newRow}) {
-            let [count, setCount] = useState(0);
-            if (count < 12) {
-              setCount(c => c + 1);
-              setCount(c => c + 1);
-              setCount(c => c + 1);
-            }
-            Scheduler.unstable_yieldValue('Render: ' + count);
-            return <Text text={count} />;
-          }
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield([
-            // Should increase by three each time
-            'Render: 0',
-            'Render: 3',
-            'Render: 6',
-            'Render: 9',
-            'Render: 12',
-            12,
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(12)]);
-        });
-
-        it('throws after too many iterations', () => {
-          function Counter({row: newRow}) {
-            let [count, setCount] = useState(0);
-            setCount(count + 1);
-            Scheduler.unstable_yieldValue('Render: ' + count);
-            return <Text text={count} />;
-          }
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndThrow(
-            'Too many re-renders. React limits the number of renders to prevent ' +
-              'an infinite loop.',
-          );
-        });
-
-        it('works with useReducer', () => {
-          function reducer(state, action) {
-            return action === 'increment' ? state + 1 : state;
-          }
-          function Counter({row: newRow}) {
-            let [count, dispatch] = useReducer(reducer, 0);
-            if (count < 3) {
-              dispatch('increment');
-            }
-            Scheduler.unstable_yieldValue('Render: ' + count);
-            return <Text text={count} />;
-          }
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield([
-            'Render: 0',
-            'Render: 1',
-            'Render: 2',
-            'Render: 3',
-            3,
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(3)]);
-        });
-
-        it('uses reducer passed at time of render, not time of dispatch', () => {
-          // This test is a bit contrived but it demonstrates a subtle edge case.
-
-          // Reducer A increments by 1. Reducer B increments by 10.
-          function reducerA(state, action) {
-            switch (action) {
-              case 'increment':
-                return state + 1;
-              case 'reset':
-                return 0;
-            }
-          }
-          function reducerB(state, action) {
-            switch (action) {
-              case 'increment':
-                return state + 10;
-              case 'reset':
-                return 0;
-            }
-          }
-
-          function Counter({row: newRow}, ref) {
-            let [reducer, setReducer] = useState(() => reducerA);
-            let [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(ref, () => ({dispatch}));
-            if (count < 20) {
-              dispatch('increment');
-              // Swap reducers each time we increment
-              if (reducer === reducerA) {
-                setReducer(() => reducerB);
-              } else {
-                setReducer(() => reducerA);
-              }
-            }
-            Scheduler.unstable_yieldValue('Render: ' + count);
-            return <Text text={count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield([
-            // The count should increase by alternating amounts of 10 and 1
-            // until we reach 21.
-            'Render: 0',
-            'Render: 10',
-            'Render: 11',
-            'Render: 21',
-            21,
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(21)]);
-
-          // Test that it works on update, too. This time the log is a bit different
-          // because we started with reducerB instead of reducerA.
-          ReactNoop.act(() => {
-            counter.current.dispatch('reset');
-          });
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toHaveYielded([
-            'Render: 0',
-            'Render: 1',
-            'Render: 11',
-            'Render: 12',
-            'Render: 22',
-            22,
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(22)]);
-        });
-
-        it('discards render phase updates if something suspends', () => {
-          const thenable = {then() {}};
-          function Foo({signal}) {
-            return (
-              <Suspense fallback="Loading...">
-                <Bar signal={signal} />
-              </Suspense>
-            );
-          }
-
-          function Bar({signal: newSignal}) {
-            let [counter, setCounter] = useState(0);
-            let [signal, setSignal] = useState(true);
-
-            // Increment a counter every time the signal changes
-            if (signal !== newSignal) {
-              setCounter(c => c + 1);
-              setSignal(newSignal);
-              if (counter === 0) {
-                // We're suspending during a render that includes render phase
-                // updates. Those updates should not persist to the next render.
-                Scheduler.unstable_yieldValue('Suspend!');
-                throw thenable;
-              }
-            }
-
-            return <Text text={counter} />;
-          }
-
-          const root = ReactNoop.createRoot();
-          root.render(<Foo signal={true} />);
-
-          expect(Scheduler).toFlushAndYield([0]);
-          expect(root).toMatchRenderedOutput(<span prop={0} />);
-
-          root.render(<Foo signal={false} />);
-          expect(Scheduler).toFlushAndYield(['Suspend!']);
-          expect(root).toMatchRenderedOutput(<span prop={0} />);
-
-          // Rendering again should suspend again.
-          root.render(<Foo signal={false} />);
-          expect(Scheduler).toFlushAndYield(['Suspend!']);
-        });
-
-        it('discards render phase updates if something suspends, but not other updates in the same component', async () => {
-          const thenable = {then() {}};
-          function Foo({signal}) {
-            return (
-              <Suspense fallback="Loading...">
-                <Bar signal={signal} />
-              </Suspense>
-            );
-          }
-
-          let setLabel;
-          function Bar({signal: newSignal}) {
-            let [counter, setCounter] = useState(0);
-
-            if (counter === 1) {
-              // We're suspending during a render that includes render phase
-              // updates. Those updates should not persist to the next render.
-              Scheduler.unstable_yieldValue('Suspend!');
-              throw thenable;
-            }
-
-            let [signal, setSignal] = useState(true);
-
-            // Increment a counter every time the signal changes
-            if (signal !== newSignal) {
-              setCounter(c => c + 1);
-              setSignal(newSignal);
-            }
-
-            let [label, _setLabel] = useState('A');
-            setLabel = _setLabel;
-
-            return <Text text={`${label}:${counter}`} />;
-          }
-
-          const root = ReactNoop.createRoot();
-          root.render(<Foo signal={true} />);
-
-          expect(Scheduler).toFlushAndYield(['A:0']);
-          expect(root).toMatchRenderedOutput(<span prop="A:0" />);
-
-          await ReactNoop.act(async () => {
-            root.render(<Foo signal={false} />);
-            setLabel('B');
-          });
-          expect(Scheduler).toHaveYielded(['Suspend!']);
-          expect(root).toMatchRenderedOutput(<span prop="A:0" />);
-
-          // Rendering again should suspend again.
-          root.render(<Foo signal={false} />);
-          expect(Scheduler).toFlushAndYield(['Suspend!']);
-
-          // Flip the signal back to "cancel" the update. However, the update to
-          // label should still proceed. It shouldn't have been dropped.
-          root.render(<Foo signal={true} />);
-          expect(Scheduler).toFlushAndYield(['B:0']);
-          expect(root).toMatchRenderedOutput(<span prop="B:0" />);
-        });
-
-        // TODO: This should probably warn
-        it.experimental(
-          'calling startTransition inside render phase',
-          async () => {
-            let startTransition;
-            function App() {
-              let [counter, setCounter] = useState(0);
-              let [_startTransition] = useTransition();
-              startTransition = _startTransition;
-
-              if (counter === 0) {
-                startTransition(() => {
-                  setCounter(c => c + 1);
-                });
-              }
-
-              return <Text text={counter} />;
-            }
-
-            const root = ReactNoop.createRoot();
-            root.render(<App />);
-            expect(Scheduler).toFlushAndYield([1]);
-            expect(root).toMatchRenderedOutput(<span prop={1} />);
-          },
-        );
-      });
-
-      describe('useReducer', () => {
-        it('simple mount and update', () => {
-          const INCREMENT = 'INCREMENT';
-          const DECREMENT = 'DECREMENT';
-
-          function reducer(state, action) {
-            switch (action) {
-              case 'INCREMENT':
-                return state + 1;
-              case 'DECREMENT':
-                return state - 1;
-              default:
-                return state;
-            }
-          }
-
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(ref, () => ({dispatch}));
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          act(() => counter.current.dispatch(INCREMENT));
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          act(() => {
-            counter.current.dispatch(DECREMENT);
-            counter.current.dispatch(DECREMENT);
-            counter.current.dispatch(DECREMENT);
-          });
-
-          expect(Scheduler).toHaveYielded(['Count: -2']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: -2')]);
-        });
-
-        it('lazy init', () => {
-          const INCREMENT = 'INCREMENT';
-          const DECREMENT = 'DECREMENT';
-
-          function reducer(state, action) {
-            switch (action) {
-              case 'INCREMENT':
-                return state + 1;
-              case 'DECREMENT':
-                return state - 1;
-              default:
-                return state;
-            }
-          }
-
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, props, p => {
-              Scheduler.unstable_yieldValue('Init');
-              return p.initialCount;
-            });
-            useImperativeHandle(ref, () => ({dispatch}));
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter initialCount={10} ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Init', 'Count: 10']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 10')]);
-
-          act(() => counter.current.dispatch(INCREMENT));
-          expect(Scheduler).toHaveYielded(['Count: 11']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 11')]);
-
-          act(() => {
-            counter.current.dispatch(DECREMENT);
-            counter.current.dispatch(DECREMENT);
-            counter.current.dispatch(DECREMENT);
-          });
-
-          expect(Scheduler).toHaveYielded(['Count: 8']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 8')]);
-        });
-
-        // Regression test for https://github.com/facebook/react/issues/14360
-        it('handles dispatches with mixed priorities', () => {
-          const INCREMENT = 'INCREMENT';
-
-          function reducer(state, action) {
-            return action === INCREMENT ? state + 1 : state;
-          }
-
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(ref, () => ({dispatch}));
-            return <Text text={'Count: ' + count} />;
-          }
-
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          ReactNoop.batchedUpdates(() => {
-            counter.current.dispatch(INCREMENT);
-            counter.current.dispatch(INCREMENT);
-            counter.current.dispatch(INCREMENT);
-          });
-
-          ReactNoop.flushSync(() => {
-            counter.current.dispatch(INCREMENT);
-          });
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-
-          expect(Scheduler).toFlushAndYield(['Count: 4']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 4')]);
-        });
-      });
-
-      describe('useEffect', () => {
-        it('simple mount and update', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Passive effect [${props.count}]`);
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            // Effects are deferred until after the commit
-            expect(Scheduler).toFlushAndYield(['Passive effect [0]']);
-          });
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-            // Effects are deferred until after the commit
-            expect(Scheduler).toFlushAndYield(['Passive effect [1]']);
-          });
-        });
-
-        it('flushes passive effects even with sibling deletions', () => {
-          function LayoutEffect(props) {
-            useLayoutEffect(() => {
-              Scheduler.unstable_yieldValue(`Layout effect`);
-            });
-            return <Text text="Layout" />;
-          }
-          function PassiveEffect(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Passive effect`);
-            }, []);
-            return <Text text="Passive" />;
-          }
-          let passive = <PassiveEffect key="p" />;
-          act(() => {
-            ReactNoop.render([<LayoutEffect key="l" />, passive]);
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Layout',
-              'Passive',
-              'Layout effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Layout'),
-              span('Passive'),
-            ]);
-            // Destroying the first child shouldn't prevent the passive effect from
-            // being executed
-            ReactNoop.render([passive]);
-            expect(Scheduler).toFlushAndYield(['Passive effect']);
-            expect(ReactNoop.getChildren()).toEqual([span('Passive')]);
-          });
-          // exiting act calls flushPassiveEffects(), but there are none left to flush.
-          expect(Scheduler).toHaveYielded([]);
-        });
-
-        it('flushes passive effects even if siblings schedule an update', () => {
-          function PassiveEffect(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue('Passive effect');
-            });
-            return <Text text="Passive" />;
-          }
-          function LayoutEffect(props) {
-            let [count, setCount] = useState(0);
-            useLayoutEffect(() => {
-              // Scheduling work shouldn't interfere with the queued passive effect
-              if (count === 0) {
-                setCount(1);
-              }
-              Scheduler.unstable_yieldValue('Layout effect ' + count);
-            });
-            return <Text text="Layout" />;
-          }
-
-          ReactNoop.render([
-            <PassiveEffect key="p" />,
-            <LayoutEffect key="l" />,
-          ]);
-
-          act(() => {
-            expect(Scheduler).toFlushAndYield([
-              'Passive',
-              'Layout',
-              'Layout effect 0',
-              'Passive effect',
-              'Layout',
-              'Layout effect 1',
-            ]);
-          });
-
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Passive'),
-            span('Layout'),
-          ]);
-        });
-
-        it('flushes passive effects even if siblings schedule a new root', () => {
-          function PassiveEffect(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue('Passive effect');
-            }, []);
-            return <Text text="Passive" />;
-          }
-          function LayoutEffect(props) {
-            useLayoutEffect(() => {
-              Scheduler.unstable_yieldValue('Layout effect');
-              // Scheduling work shouldn't interfere with the queued passive effect
-              ReactNoop.renderToRootWithID(<Text text="New Root" />, 'root2');
-            });
-            return <Text text="Layout" />;
-          }
-          act(() => {
-            ReactNoop.render([
-              <PassiveEffect key="p" />,
-              <LayoutEffect key="l" />,
-            ]);
-            expect(Scheduler).toFlushAndYield([
-              'Passive',
-              'Layout',
-              'Layout effect',
-              'Passive effect',
-              'New Root',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Passive'),
-              span('Layout'),
-            ]);
-          });
-        });
-
-        it(
-          'flushes effects serially by flushing old effects before flushing ' +
-            "new ones, if they haven't already fired",
-          () => {
-            function getCommittedText() {
-              const children = ReactNoop.getChildren();
-              if (children === null) {
-                return null;
-              }
-              return children[0].prop;
-            }
-
-            function Counter(props) {
-              useEffect(() => {
-                Scheduler.unstable_yieldValue(
-                  `Committed state when effect was fired: ${getCommittedText()}`,
-                );
-              });
-              return <Text text={props.count} />;
-            }
-            act(() => {
-              ReactNoop.render(<Counter count={0} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([0, 'Sync effect']);
-              expect(ReactNoop.getChildren()).toEqual([span(0)]);
-              // Before the effects have a chance to flush, schedule another update
-              ReactNoop.render(<Counter count={1} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                // The previous effect flushes before the reconciliation
-                'Committed state when effect was fired: 0',
-                1,
-                'Sync effect',
-              ]);
-              expect(ReactNoop.getChildren()).toEqual([span(1)]);
-            });
-
-            expect(Scheduler).toHaveYielded([
-              'Committed state when effect was fired: 1',
-            ]);
-          },
-        );
-
-        if (
-          deferPassiveEffectCleanupDuringUnmount &&
-          runAllPassiveEffectDestroysBeforeCreates
-        ) {
-          it('defers passive effect destroy functions during unmount', () => {
-            function Child({bar, foo}) {
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('passive bar create');
-                return () => {
-                  Scheduler.unstable_yieldValue('passive bar destroy');
-                };
-              }, [bar]);
-              React.useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue('layout bar create');
-                return () => {
-                  Scheduler.unstable_yieldValue('layout bar destroy');
-                };
-              }, [bar]);
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('passive foo create');
-                return () => {
-                  Scheduler.unstable_yieldValue('passive foo destroy');
-                };
-              }, [foo]);
-              React.useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue('layout foo create');
-                return () => {
-                  Scheduler.unstable_yieldValue('layout foo destroy');
-                };
-              }, [foo]);
-              Scheduler.unstable_yieldValue('render');
-              return null;
-            }
-
-            act(() => {
-              ReactNoop.render(<Child bar={1} foo={1} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'render',
-                'layout bar create',
-                'layout foo create',
-                'Sync effect',
-              ]);
-              // Effects are deferred until after the commit
-              expect(Scheduler).toFlushAndYield([
-                'passive bar create',
-                'passive foo create',
-              ]);
-            });
-
-            // This update is exists to test an internal implementation detail:
-            // Effects without updating dependencies lose their layout/passive tag during an update.
-            act(() => {
-              ReactNoop.render(<Child bar={1} foo={2} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'render',
-                'layout foo destroy',
-                'layout foo create',
-                'Sync effect',
-              ]);
-              // Effects are deferred until after the commit
-              expect(Scheduler).toFlushAndYield([
-                'passive foo destroy',
-                'passive foo create',
-              ]);
-            });
-
-            // Unmount the component and verify that passive destroy functions are deferred until post-commit.
-            act(() => {
-              ReactNoop.render(null, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'layout bar destroy',
-                'layout foo destroy',
-                'Sync effect',
-              ]);
-              // Effects are deferred until after the commit
-              expect(Scheduler).toFlushAndYield([
-                'passive bar destroy',
-                'passive foo destroy',
-              ]);
-            });
-          });
-
-          it('does not warn about state updates for unmounted components with pending passive unmounts', () => {
-            let completePendingRequest = null;
-            function Component() {
-              Scheduler.unstable_yieldValue('Component');
-              const [didLoad, setDidLoad] = React.useState(false);
-              React.useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue('layout create');
-                return () => {
-                  Scheduler.unstable_yieldValue('layout destroy');
-                };
-              }, []);
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('passive create');
-                // Mimic an XHR request with a complete handler that updates state.
-                completePendingRequest = () => setDidLoad(true);
-                return () => {
-                  Scheduler.unstable_yieldValue('passive destroy');
-                };
-              }, []);
-              return didLoad;
-            }
-
-            act(() => {
-              ReactNoop.renderToRootWithID(<Component />, 'root', () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'Component',
-                'layout create',
-                'Sync effect',
-              ]);
-              ReactNoop.flushPassiveEffects();
-              expect(Scheduler).toHaveYielded(['passive create']);
-
-              // Unmount but don't process pending passive destroy function
-              ReactNoop.unmountRootWithID('root');
-              expect(Scheduler).toFlushAndYieldThrough(['layout destroy']);
-
-              // Simulate an XHR completing, which will cause a state update-
-              // but should not log a warning.
-              completePendingRequest();
-
-              ReactNoop.flushPassiveEffects();
-              expect(Scheduler).toHaveYielded(['passive destroy']);
-            });
-          });
-
-          it('still warns about state updates for unmounted components with no pending passive unmounts', () => {
-            let completePendingRequest = null;
-            function Component() {
-              Scheduler.unstable_yieldValue('Component');
-              const [didLoad, setDidLoad] = React.useState(false);
-              React.useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue('layout create');
-                // Mimic an XHR request with a complete handler that updates state.
-                completePendingRequest = () => setDidLoad(true);
-                return () => {
-                  Scheduler.unstable_yieldValue('layout destroy');
-                };
-              }, []);
-              return didLoad;
-            }
-
-            act(() => {
-              ReactNoop.renderToRootWithID(<Component />, 'root', () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'Component',
-                'layout create',
-                'Sync effect',
-              ]);
-
-              // Unmount but don't process pending passive destroy function
-              ReactNoop.unmountRootWithID('root');
-              expect(Scheduler).toFlushAndYieldThrough(['layout destroy']);
-
-              // Simulate an XHR completing.
-              expect(completePendingRequest).toErrorDev(
-                "Warning: Can't perform a React state update on an unmounted component.",
-              );
-            });
-          });
-
-          it('still warns if there are pending passive unmount effects but not for the current fiber', () => {
-            let completePendingRequest = null;
-            function ComponentWithXHR() {
-              Scheduler.unstable_yieldValue('Component');
-              const [didLoad, setDidLoad] = React.useState(false);
-              React.useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue('a:layout create');
-                return () => {
-                  Scheduler.unstable_yieldValue('a:layout destroy');
-                };
-              }, []);
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('a:passive create');
-                // Mimic an XHR request with a complete handler that updates state.
-                completePendingRequest = () => setDidLoad(true);
-              }, []);
-              return didLoad;
-            }
-
-            function ComponentWithPendingPassiveUnmount() {
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('b:passive create');
-                return () => {
-                  Scheduler.unstable_yieldValue('b:passive destroy');
-                };
-              }, []);
-              return null;
-            }
-
-            act(() => {
-              ReactNoop.renderToRootWithID(
-                <>
-                  <ComponentWithXHR />
-                  <ComponentWithPendingPassiveUnmount />
-                </>,
-                'root',
-                () => Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'Component',
-                'a:layout create',
-                'Sync effect',
-              ]);
-              ReactNoop.flushPassiveEffects();
-              expect(Scheduler).toHaveYielded([
-                'a:passive create',
-                'b:passive create',
-              ]);
-
-              // Unmount but don't process pending passive destroy function
-              ReactNoop.unmountRootWithID('root');
-              expect(Scheduler).toFlushAndYieldThrough(['a:layout destroy']);
-
-              // Simulate an XHR completing in the component without a pending passive effect..
-              expect(completePendingRequest).toErrorDev(
-                "Warning: Can't perform a React state update on an unmounted component.",
-              );
-            });
-          });
-
-          it('still warns about state updates from within passive unmount function', () => {
-            function Component() {
-              Scheduler.unstable_yieldValue('Component');
-              const [didLoad, setDidLoad] = React.useState(false);
-              React.useEffect(() => {
-                Scheduler.unstable_yieldValue('passive create');
-                return () => {
-                  setDidLoad(true);
-                  Scheduler.unstable_yieldValue('passive destroy');
-                };
-              }, []);
-              return didLoad;
-            }
-
-            act(() => {
-              ReactNoop.renderToRootWithID(<Component />, 'root', () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'Component',
-                'Sync effect',
-                'passive create',
-              ]);
-
-              // Unmount but don't process pending passive destroy function
-              ReactNoop.unmountRootWithID('root');
-              expect(() => {
-                expect(Scheduler).toFlushAndYield(['passive destroy']);
-              }).toErrorDev(
-                "Warning: Can't perform a React state update on an unmounted component.",
-              );
-            });
-          });
+          return children[0].prop;
         }
 
-        it('updates have async priority', () => {
-          function Counter(props) {
-            const [count, updateCount] = useState('(empty)');
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
-              updateCount(props.count);
-            }, [props.count]);
-            return <Text text={'Count: ' + count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
+        function Counter(props) {
+          useEffect(() => {
+            Scheduler.unstable_yieldValue(
+              `Committed state when effect was fired: ${getCommittedText()}`,
             );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: (empty)',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
-            ReactNoop.flushPassiveEffects();
-            expect(Scheduler).toHaveYielded(['Schedule update [0]']);
-            expect(Scheduler).toFlushAndYield(['Count: 0']);
           });
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            ReactNoop.flushPassiveEffects();
-            expect(Scheduler).toHaveYielded(['Schedule update [1]']);
-            expect(Scheduler).toFlushAndYield(['Count: 1']);
-          });
+          return <Text text={props.count} />;
+        }
+        act(() => {
+          ReactNoop.render(<Counter count={0} />, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([0, 'Sync effect']);
+          expect(ReactNoop.getChildren()).toEqual([span(0)]);
+          // Before the effects have a chance to flush, schedule another update
+          ReactNoop.render(<Counter count={1} />, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            // The previous effect flushes before the reconciliation
+            'Committed state when effect was fired: 0',
+            1,
+            'Sync effect',
+          ]);
+          expect(ReactNoop.getChildren()).toEqual([span(1)]);
         });
 
-        it('updates have async priority even if effects are flushed early', () => {
-          function Counter(props) {
-            const [count, updateCount] = useState('(empty)');
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
-              updateCount(props.count);
-            }, [props.count]);
-            return <Text text={'Count: ' + count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: (empty)',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+        expect(Scheduler).toHaveYielded([
+          'Committed state when effect was fired: 1',
+        ]);
+      },
+    );
 
-            // Rendering again should flush the previous commit's effects
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Schedule update [0]',
-              'Count: 0',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+    if (
+      deferPassiveEffectCleanupDuringUnmount &&
+      runAllPassiveEffectDestroysBeforeCreates
+    ) {
+      it('defers passive effect destroy functions during unmount', () => {
+        function Child({bar, foo}) {
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('passive bar create');
+            return () => {
+              Scheduler.unstable_yieldValue('passive bar destroy');
+            };
+          }, [bar]);
+          React.useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue('layout bar create');
+            return () => {
+              Scheduler.unstable_yieldValue('layout bar destroy');
+            };
+          }, [bar]);
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('passive foo create');
+            return () => {
+              Scheduler.unstable_yieldValue('passive foo destroy');
+            };
+          }, [foo]);
+          React.useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue('layout foo create');
+            return () => {
+              Scheduler.unstable_yieldValue('layout foo destroy');
+            };
+          }, [foo]);
+          Scheduler.unstable_yieldValue('render');
+          return null;
+        }
 
-            expect(Scheduler).toFlushAndYieldThrough(['Sync effect']);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            ReactNoop.flushPassiveEffects();
-            expect(Scheduler).toHaveYielded(['Schedule update [1]']);
-            expect(Scheduler).toFlushAndYield(['Count: 1']);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
+        act(() => {
+          ReactNoop.render(<Child bar={1} foo={1} />, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'render',
+            'layout bar create',
+            'layout foo create',
+            'Sync effect',
+          ]);
+          // Effects are deferred until after the commit
+          expect(Scheduler).toFlushAndYield([
+            'passive bar create',
+            'passive foo create',
+          ]);
         });
 
-        it('flushes passive effects when flushing discrete updates', () => {
-          let _updateCount;
-          function Counter(props) {
-            const [count, updateCount] = useState(0);
-            _updateCount = updateCount;
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Will set count to 1`);
-              updateCount(1);
-            }, []);
-            return <Text text={'Count: ' + count} />;
-          }
+        // This update is exists to test an internal implementation detail:
+        // Effects without updating dependencies lose their layout/passive tag during an update.
+        act(() => {
+          ReactNoop.render(<Child bar={1} foo={2} />, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'render',
+            'layout foo destroy',
+            'layout foo create',
+            'Sync effect',
+          ]);
+          // Effects are deferred until after the commit
+          expect(Scheduler).toFlushAndYield([
+            'passive foo destroy',
+            'passive foo create',
+          ]);
+        });
 
-          // we explicitly wait for missing act() warnings here since
-          // it's a lot harder to simulate this condition inside an act scope
-          expect(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          }).toErrorDev(['An update to Counter ran an effect']);
+        // Unmount the component and verify that passive destroy functions are deferred until post-commit.
+        act(() => {
+          ReactNoop.render(null, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'layout bar destroy',
+            'layout foo destroy',
+            'Sync effect',
+          ]);
+          // Effects are deferred until after the commit
+          expect(Scheduler).toFlushAndYield([
+            'passive bar destroy',
+            'passive foo destroy',
+          ]);
+        });
+      });
 
-          // A discrete event forces the passive effect to be flushed --
-          // updateCount(1) happens first, so 2 wins.
-          ReactNoop.flushDiscreteUpdates();
-          ReactNoop.discreteUpdates(() => {
-            // (use batchedUpdates to silence the act() warning)
-            ReactNoop.batchedUpdates(() => {
-              _updateCount(2);
-            });
-          });
-          expect(Scheduler).toHaveYielded(['Will set count to 1']);
-          expect(() => {
-            expect(Scheduler).toFlushAndYield(['Count: 2']);
-          }).toErrorDev([
-            'An update to Counter ran an effect',
-            'An update to Counter ran an effect',
+      it('does not warn about state updates for unmounted components with pending passive unmounts', () => {
+        let completePendingRequest = null;
+        function Component() {
+          Scheduler.unstable_yieldValue('Component');
+          const [didLoad, setDidLoad] = React.useState(false);
+          React.useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue('layout create');
+            return () => {
+              Scheduler.unstable_yieldValue('layout destroy');
+            };
+          }, []);
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('passive create');
+            // Mimic an XHR request with a complete handler that updates state.
+            completePendingRequest = () => setDidLoad(true);
+            return () => {
+              Scheduler.unstable_yieldValue('passive destroy');
+            };
+          }, []);
+          return didLoad;
+        }
+
+        act(() => {
+          ReactNoop.renderToRootWithID(<Component />, 'root', () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'Component',
+            'layout create',
+            'Sync effect',
+          ]);
+          ReactNoop.flushPassiveEffects();
+          expect(Scheduler).toHaveYielded(['passive create']);
+
+          // Unmount but don't process pending passive destroy function
+          ReactNoop.unmountRootWithID('root');
+          expect(Scheduler).toFlushAndYieldThrough(['layout destroy']);
+
+          // Simulate an XHR completing, which will cause a state update-
+          // but should not log a warning.
+          completePendingRequest();
+
+          ReactNoop.flushPassiveEffects();
+          expect(Scheduler).toHaveYielded(['passive destroy']);
+        });
+      });
+
+      it('still warns about state updates for unmounted components with no pending passive unmounts', () => {
+        let completePendingRequest = null;
+        function Component() {
+          Scheduler.unstable_yieldValue('Component');
+          const [didLoad, setDidLoad] = React.useState(false);
+          React.useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue('layout create');
+            // Mimic an XHR request with a complete handler that updates state.
+            completePendingRequest = () => setDidLoad(true);
+            return () => {
+              Scheduler.unstable_yieldValue('layout destroy');
+            };
+          }, []);
+          return didLoad;
+        }
+
+        act(() => {
+          ReactNoop.renderToRootWithID(<Component />, 'root', () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'Component',
+            'layout create',
+            'Sync effect',
           ]);
 
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
+          // Unmount but don't process pending passive destroy function
+          ReactNoop.unmountRootWithID('root');
+          expect(Scheduler).toFlushAndYieldThrough(['layout destroy']);
+
+          // Simulate an XHR completing.
+          expect(completePendingRequest).toErrorDev(
+            "Warning: Can't perform a React state update on an unmounted component.",
+          );
         });
+      });
 
-        it('flushes passive effects when flushing discrete updates (with tracing)', () => {
-          const onInteractionScheduledWorkCompleted = jest.fn();
-          const onWorkCanceled = jest.fn();
-          SchedulerTracing.unstable_subscribe({
-            onInteractionScheduledWorkCompleted,
-            onInteractionTraced: jest.fn(),
-            onWorkCanceled,
-            onWorkScheduled: jest.fn(),
-            onWorkStarted: jest.fn(),
-            onWorkStopped: jest.fn(),
-          });
+      it('still warns if there are pending passive unmount effects but not for the current fiber', () => {
+        let completePendingRequest = null;
+        function ComponentWithXHR() {
+          Scheduler.unstable_yieldValue('Component');
+          const [didLoad, setDidLoad] = React.useState(false);
+          React.useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue('a:layout create');
+            return () => {
+              Scheduler.unstable_yieldValue('a:layout destroy');
+            };
+          }, []);
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('a:passive create');
+            // Mimic an XHR request with a complete handler that updates state.
+            completePendingRequest = () => setDidLoad(true);
+          }, []);
+          return didLoad;
+        }
 
-          let _updateCount;
-          function Counter(props) {
-            const [count, updateCount] = useState(0);
-            _updateCount = updateCount;
-            useEffect(() => {
-              expect(
-                SchedulerTracing.unstable_getCurrent(),
-              ).toMatchInteractions([tracingEvent]);
-              Scheduler.unstable_yieldValue(`Will set count to 1`);
-              updateCount(1);
-            }, []);
-            return <Text text={'Count: ' + count} />;
-          }
+        function ComponentWithPendingPassiveUnmount() {
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('b:passive create');
+            return () => {
+              Scheduler.unstable_yieldValue('b:passive destroy');
+            };
+          }, []);
+          return null;
+        }
 
-          const tracingEvent = {id: 0, name: 'hello', timestamp: 0};
-          // we explicitly wait for missing act() warnings here since
-          // it's a lot harder to simulate this condition inside an act scope
-          expect(() => {
-            SchedulerTracing.unstable_trace(
-              tracingEvent.name,
-              tracingEvent.timestamp,
-              () => {
-                ReactNoop.render(<Counter count={0} />, () =>
-                  Scheduler.unstable_yieldValue('Sync effect'),
-                );
-              },
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          }).toErrorDev(['An update to Counter ran an effect']);
-
-          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
-
-          // A discrete event forces the passive effect to be flushed --
-          // updateCount(1) happens first, so 2 wins.
-          ReactNoop.flushDiscreteUpdates();
-          ReactNoop.discreteUpdates(() => {
-            // (use batchedUpdates to silence the act() warning)
-            ReactNoop.batchedUpdates(() => {
-              _updateCount(2);
-            });
-          });
-          expect(Scheduler).toHaveYielded(['Will set count to 1']);
-          expect(() => {
-            expect(Scheduler).toFlushAndYield(['Count: 2']);
-          }).toErrorDev([
-            'An update to Counter ran an effect',
-            'An update to Counter ran an effect',
+        act(() => {
+          ReactNoop.renderToRootWithID(
+            <>
+              <ComponentWithXHR />
+              <ComponentWithPendingPassiveUnmount />
+            </>,
+            'root',
+            () => Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'Component',
+            'a:layout create',
+            'Sync effect',
+          ]);
+          ReactNoop.flushPassiveEffects();
+          expect(Scheduler).toHaveYielded([
+            'a:passive create',
+            'b:passive create',
           ]);
 
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
+          // Unmount but don't process pending passive destroy function
+          ReactNoop.unmountRootWithID('root');
+          expect(Scheduler).toFlushAndYieldThrough(['a:layout destroy']);
 
-          expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
-          expect(onWorkCanceled).toHaveBeenCalledTimes(0);
+          // Simulate an XHR completing in the component without a pending passive effect..
+          expect(completePendingRequest).toErrorDev(
+            "Warning: Can't perform a React state update on an unmounted component.",
+          );
         });
+      });
 
-        it(
-          'in legacy mode, useEffect is deferred and updates finish synchronously ' +
-            '(in a single batch)',
+      it('still warns about state updates from within passive unmount function', () => {
+        function Component() {
+          Scheduler.unstable_yieldValue('Component');
+          const [didLoad, setDidLoad] = React.useState(false);
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('passive create');
+            return () => {
+              setDidLoad(true);
+              Scheduler.unstable_yieldValue('passive destroy');
+            };
+          }, []);
+          return didLoad;
+        }
+
+        act(() => {
+          ReactNoop.renderToRootWithID(<Component />, 'root', () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'Component',
+            'Sync effect',
+            'passive create',
+          ]);
+
+          // Unmount but don't process pending passive destroy function
+          ReactNoop.unmountRootWithID('root');
+          expect(() => {
+            expect(Scheduler).toFlushAndYield(['passive destroy']);
+          }).toErrorDev(
+            "Warning: Can't perform a React state update on an unmounted component.",
+          );
+        });
+      });
+    }
+
+    it('updates have async priority', () => {
+      function Counter(props) {
+        const [count, updateCount] = useState('(empty)');
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
+          updateCount(props.count);
+        }, [props.count]);
+        return <Text text={'Count: ' + count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Count: (empty)',
+          'Sync effect',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+        ReactNoop.flushPassiveEffects();
+        expect(Scheduler).toHaveYielded(['Schedule update [0]']);
+        expect(Scheduler).toFlushAndYield(['Count: 0']);
+      });
+
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        ReactNoop.flushPassiveEffects();
+        expect(Scheduler).toHaveYielded(['Schedule update [1]']);
+        expect(Scheduler).toFlushAndYield(['Count: 1']);
+      });
+    });
+
+    it('updates have async priority even if effects are flushed early', () => {
+      function Counter(props) {
+        const [count, updateCount] = useState('(empty)');
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
+          updateCount(props.count);
+        }, [props.count]);
+        return <Text text={'Count: ' + count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Count: (empty)',
+          'Sync effect',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+
+        // Rendering again should flush the previous commit's effects
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Schedule update [0]',
+          'Count: 0',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+
+        expect(Scheduler).toFlushAndYieldThrough(['Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        ReactNoop.flushPassiveEffects();
+        expect(Scheduler).toHaveYielded(['Schedule update [1]']);
+        expect(Scheduler).toFlushAndYield(['Count: 1']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+    });
+
+    it('flushes passive effects when flushing discrete updates', () => {
+      let _updateCount;
+      function Counter(props) {
+        const [count, updateCount] = useState(0);
+        _updateCount = updateCount;
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Will set count to 1`);
+          updateCount(1);
+        }, []);
+        return <Text text={'Count: ' + count} />;
+      }
+
+      // we explicitly wait for missing act() warnings here since
+      // it's a lot harder to simulate this condition inside an act scope
+      expect(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      }).toErrorDev(['An update to Counter ran an effect']);
+
+      // A discrete event forces the passive effect to be flushed --
+      // updateCount(1) happens first, so 2 wins.
+      ReactNoop.flushDiscreteUpdates();
+      ReactNoop.discreteUpdates(() => {
+        // (use batchedUpdates to silence the act() warning)
+        ReactNoop.batchedUpdates(() => {
+          _updateCount(2);
+        });
+      });
+      expect(Scheduler).toHaveYielded(['Will set count to 1']);
+      expect(() => {
+        expect(Scheduler).toFlushAndYield(['Count: 2']);
+      }).toErrorDev([
+        'An update to Counter ran an effect',
+        'An update to Counter ran an effect',
+      ]);
+
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
+    });
+
+    it('flushes passive effects when flushing discrete updates (with tracing)', () => {
+      const onInteractionScheduledWorkCompleted = jest.fn();
+      const onWorkCanceled = jest.fn();
+      SchedulerTracing.unstable_subscribe({
+        onInteractionScheduledWorkCompleted,
+        onInteractionTraced: jest.fn(),
+        onWorkCanceled,
+        onWorkScheduled: jest.fn(),
+        onWorkStarted: jest.fn(),
+        onWorkStopped: jest.fn(),
+      });
+
+      let _updateCount;
+      function Counter(props) {
+        const [count, updateCount] = useState(0);
+        _updateCount = updateCount;
+        useEffect(() => {
+          expect(SchedulerTracing.unstable_getCurrent()).toMatchInteractions([
+            tracingEvent,
+          ]);
+          Scheduler.unstable_yieldValue(`Will set count to 1`);
+          updateCount(1);
+        }, []);
+        return <Text text={'Count: ' + count} />;
+      }
+
+      const tracingEvent = {id: 0, name: 'hello', timestamp: 0};
+      // we explicitly wait for missing act() warnings here since
+      // it's a lot harder to simulate this condition inside an act scope
+      expect(() => {
+        SchedulerTracing.unstable_trace(
+          tracingEvent.name,
+          tracingEvent.timestamp,
           () => {
-            function Counter(props) {
-              const [count, updateCount] = useState('(empty)');
-              useEffect(() => {
-                // Update multiple times. These should all be batched together in
-                // a single render.
-                updateCount(props.count);
-                updateCount(props.count);
-                updateCount(props.count);
-                updateCount(props.count);
-                updateCount(props.count);
-                updateCount(props.count);
-              }, [props.count]);
-              return <Text text={'Count: ' + count} />;
-            }
-            act(() => {
-              ReactNoop.renderLegacySyncRoot(<Counter count={0} />);
-              // Even in legacy mode, effects are deferred until after paint
-              expect(Scheduler).toFlushAndYieldThrough(['Count: (empty)']);
-              expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
-            });
-
-            // effects get fored on exiting act()
-            // There were multiple updates, but there should only be a
-            // single render
-            expect(Scheduler).toHaveYielded(['Count: 0']);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+            ReactNoop.render(<Counter count={0} />, () =>
+              Scheduler.unstable_yieldValue('Sync effect'),
+            );
           },
         );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      }).toErrorDev(['An update to Counter ran an effect']);
 
-        it('flushSync is not allowed', () => {
-          function Counter(props) {
-            const [count, updateCount] = useState('(empty)');
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
-              ReactNoop.flushSync(() => {
-                updateCount(props.count);
-              });
-            }, [props.count]);
-            return <Text text={'Count: ' + count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: (empty)',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
-            expect(() => {
-              ReactNoop.flushPassiveEffects();
-            }).toThrow('flushSync was called from inside a lifecycle method');
-          });
+      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(0);
+
+      // A discrete event forces the passive effect to be flushed --
+      // updateCount(1) happens first, so 2 wins.
+      ReactNoop.flushDiscreteUpdates();
+      ReactNoop.discreteUpdates(() => {
+        // (use batchedUpdates to silence the act() warning)
+        ReactNoop.batchedUpdates(() => {
+          _updateCount(2);
+        });
+      });
+      expect(Scheduler).toHaveYielded(['Will set count to 1']);
+      expect(() => {
+        expect(Scheduler).toFlushAndYield(['Count: 2']);
+      }).toErrorDev([
+        'An update to Counter ran an effect',
+        'An update to Counter ran an effect',
+      ]);
+
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 2')]);
+
+      expect(onInteractionScheduledWorkCompleted).toHaveBeenCalledTimes(1);
+      expect(onWorkCanceled).toHaveBeenCalledTimes(0);
+    });
+
+    it(
+      'in legacy mode, useEffect is deferred and updates finish synchronously ' +
+        '(in a single batch)',
+      () => {
+        function Counter(props) {
+          const [count, updateCount] = useState('(empty)');
+          useEffect(() => {
+            // Update multiple times. These should all be batched together in
+            // a single render.
+            updateCount(props.count);
+            updateCount(props.count);
+            updateCount(props.count);
+            updateCount(props.count);
+            updateCount(props.count);
+            updateCount(props.count);
+          }, [props.count]);
+          return <Text text={'Count: ' + count} />;
+        }
+        act(() => {
+          ReactNoop.renderLegacySyncRoot(<Counter count={0} />);
+          // Even in legacy mode, effects are deferred until after paint
+          expect(Scheduler).toFlushAndYieldThrough(['Count: (empty)']);
+          expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
         });
 
-        it('unmounts previous effect', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        // effects get fored on exiting act()
+        // There were multiple updates, but there should only be a
+        // single render
+        expect(Scheduler).toHaveYielded(['Count: 0']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      },
+    );
+
+    it('flushSync is not allowed', () => {
+      function Counter(props) {
+        const [count, updateCount] = useState('(empty)');
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Schedule update [${props.count}]`);
+          ReactNoop.flushSync(() => {
+            updateCount(props.count);
           });
+        }, [props.count]);
+        return <Text text={'Count: ' + count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Count: (empty)',
+          'Sync effect',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: (empty)')]);
+        expect(() => {
+          ReactNoop.flushPassiveEffects();
+        }).toThrow('flushSync was called from inside a lifecycle method');
+      });
+    });
 
-          expect(Scheduler).toHaveYielded(['Did create [0]']);
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
-
-          expect(Scheduler).toHaveYielded([
-            'Did destroy [0]',
-            'Did create [1]',
-          ]);
+    it('unmounts previous effect', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
+          };
         });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
 
-        it('unmounts on deletion', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          });
+      expect(Scheduler).toHaveYielded(['Did create [0]']);
 
-          expect(Scheduler).toHaveYielded(['Did create [0]']);
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
 
-          ReactNoop.render(null);
-          expect(Scheduler).toFlushAndYield(['Did destroy [0]']);
-          expect(ReactNoop.getChildren()).toEqual([]);
+      expect(Scheduler).toHaveYielded(['Did destroy [0]', 'Did create [1]']);
+    });
+
+    it('unmounts on deletion', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
+          };
         });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
 
-        it('unmounts on deletion after skipped effect', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
-              };
-            }, []);
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          });
+      expect(Scheduler).toHaveYielded(['Did create [0]']);
 
-          expect(Scheduler).toHaveYielded(['Did create [0]']);
+      ReactNoop.render(null);
+      expect(Scheduler).toFlushAndYield(['Did destroy [0]']);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
 
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
+    it('unmounts on deletion after skipped effect', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did create [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Did destroy [${props.count}]`);
+          };
+        }, []);
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
 
-          expect(Scheduler).toHaveYielded([]);
+      expect(Scheduler).toHaveYielded(['Did create [0]']);
 
-          ReactNoop.render(null);
-          expect(Scheduler).toFlushAndYield(['Did destroy [0]']);
-          expect(ReactNoop.getChildren()).toEqual([]);
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+
+      expect(Scheduler).toHaveYielded([]);
+
+      ReactNoop.render(null);
+      expect(Scheduler).toFlushAndYield(['Did destroy [0]']);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
+
+    it('always fires effects if no dependencies are provided', () => {
+      function effect() {
+        Scheduler.unstable_yieldValue(`Did create`);
+        return () => {
+          Scheduler.unstable_yieldValue(`Did destroy`);
+        };
+      }
+      function Counter(props) {
+        useEffect(effect);
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
+
+      expect(Scheduler).toHaveYielded(['Did create']);
+
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+
+      expect(Scheduler).toHaveYielded(['Did destroy', 'Did create']);
+
+      ReactNoop.render(null);
+      expect(Scheduler).toFlushAndYield(['Did destroy']);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
+
+    it('skips effect if inputs have not changed', () => {
+      function Counter(props) {
+        const text = `${props.label}: ${props.count}`;
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did create [${text}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Did destroy [${text}]`);
+          };
+        }, [props.label, props.count]);
+        return <Text text={text} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter label="Count" count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+      });
+
+      expect(Scheduler).toHaveYielded(['Did create [Count: 0]']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      act(() => {
+        ReactNoop.render(<Counter label="Count" count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        // Count changed
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+
+      expect(Scheduler).toHaveYielded([
+        'Did destroy [Count: 0]',
+        'Did create [Count: 1]',
+      ]);
+
+      act(() => {
+        ReactNoop.render(<Counter label="Count" count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        // Nothing changed, so no effect should have fired
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+      });
+
+      expect(Scheduler).toHaveYielded([]);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+
+      act(() => {
+        ReactNoop.render(<Counter label="Total" count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        // Label changed
+        expect(Scheduler).toFlushAndYieldThrough(['Total: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Total: 1')]);
+      });
+
+      expect(Scheduler).toHaveYielded([
+        'Did destroy [Count: 1]',
+        'Did create [Total: 1]',
+      ]);
+    });
+
+    it('multiple effects', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did commit 1 [${props.count}]`);
         });
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Did commit 2 [${props.count}]`);
+        });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
 
-        it('always fires effects if no dependencies are provided', () => {
-          function effect() {
-            Scheduler.unstable_yieldValue(`Did create`);
+      expect(Scheduler).toHaveYielded(['Did commit 1 [0]', 'Did commit 2 [0]']);
+
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+      expect(Scheduler).toHaveYielded(['Did commit 1 [1]', 'Did commit 2 [1]']);
+    });
+
+    it('unmounts all previous effects before creating any new ones', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
+          };
+        });
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
+          };
+        });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      });
+
+      expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
+
+      act(() => {
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      });
+      expect(Scheduler).toHaveYielded([
+        'Unmount A [0]',
+        'Unmount B [0]',
+        'Mount A [1]',
+        'Mount B [1]',
+      ]);
+    });
+
+    if (runAllPassiveEffectDestroysBeforeCreates) {
+      it('unmounts all previous effects between siblings before creating any new ones', () => {
+        function Counter({count, label}) {
+          useEffect(() => {
+            Scheduler.unstable_yieldValue(`Mount ${label} [${count}]`);
             return () => {
-              Scheduler.unstable_yieldValue(`Did destroy`);
+              Scheduler.unstable_yieldValue(`Unmount ${label} [${count}]`);
             };
-          }
-          function Counter(props) {
-            useEffect(effect);
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
           });
-
-          expect(Scheduler).toHaveYielded(['Did create']);
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
-
-          expect(Scheduler).toHaveYielded(['Did destroy', 'Did create']);
-
-          ReactNoop.render(null);
-          expect(Scheduler).toFlushAndYield(['Did destroy']);
-          expect(ReactNoop.getChildren()).toEqual([]);
+          return <Text text={`${label} ${count}`} />;
+        }
+        act(() => {
+          ReactNoop.render(
+            <>
+              <Counter label="A" count={0} />
+              <Counter label="B" count={0} />
+            </>,
+            () => Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'A 0',
+            'B 0',
+            'Sync effect',
+          ]);
+          expect(ReactNoop.getChildren()).toEqual([span('A 0'), span('B 0')]);
         });
 
-        it('skips effect if inputs have not changed', () => {
-          function Counter(props) {
-            const text = `${props.label}: ${props.count}`;
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did create [${text}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Did destroy [${text}]`);
-              };
-            }, [props.label, props.count]);
-            return <Text text={text} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter label="Count" count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-          });
+        expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
 
-          expect(Scheduler).toHaveYielded(['Did create [Count: 0]']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
-          act(() => {
-            ReactNoop.render(<Counter label="Count" count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            // Count changed
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
-
-          expect(Scheduler).toHaveYielded([
-            'Did destroy [Count: 0]',
-            'Did create [Count: 1]',
+        act(() => {
+          ReactNoop.render(
+            <>
+              <Counter label="A" count={1} />
+              <Counter label="B" count={1} />
+            </>,
+            () => Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'A 1',
+            'B 1',
+            'Sync effect',
           ]);
+          expect(ReactNoop.getChildren()).toEqual([span('A 1'), span('B 1')]);
+        });
+        expect(Scheduler).toHaveYielded([
+          'Unmount A [0]',
+          'Unmount B [0]',
+          'Mount A [1]',
+          'Mount B [1]',
+        ]);
 
-          act(() => {
-            ReactNoop.render(<Counter label="Count" count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            // Nothing changed, so no effect should have fired
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-          });
+        act(() => {
+          ReactNoop.render(
+            <>
+              <Counter label="B" count={2} />
+              <Counter label="C" count={0} />
+            </>,
+            () => Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough([
+            'B 2',
+            'C 0',
+            'Sync effect',
+          ]);
+          expect(ReactNoop.getChildren()).toEqual([span('B 2'), span('C 0')]);
+        });
+        expect(Scheduler).toHaveYielded([
+          'Unmount A [1]',
+          'Unmount B [1]',
+          'Mount B [2]',
+          'Mount C [0]',
+        ]);
+      });
+    }
 
-          expect(Scheduler).toHaveYielded([]);
+    it('handles errors in create on mount', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
+          };
+        });
+        useEffect(() => {
+          Scheduler.unstable_yieldValue('Oops!');
+          throw new Error('Oops!');
+          // eslint-disable-next-line no-unreachable
+          Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
+          };
+        });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
+      });
+
+      expect(Scheduler).toHaveYielded([
+        'Mount A [0]',
+        'Oops!',
+        // Clean up effect A. There's no effect B to clean-up, because it
+        // never mounted.
+        'Unmount A [0]',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
+
+    it('handles errors in create on update', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
+          };
+        });
+        useEffect(() => {
+          if (props.count === 1) {
+            Scheduler.unstable_yieldValue('Oops!');
+            throw new Error('Oops!');
+          }
+          Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
+          };
+        });
+        return <Text text={'Count: ' + props.count} />;
+      }
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        ReactNoop.flushPassiveEffects();
+        expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
+      });
+
+      act(() => {
+        // This update will trigger an error
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+        expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
+        expect(Scheduler).toHaveYielded(
+          deferPassiveEffectCleanupDuringUnmount &&
+            runAllPassiveEffectDestroysBeforeCreates
+            ? ['Unmount A [0]', 'Unmount B [0]', 'Mount A [1]', 'Oops!']
+            : [
+                'Unmount A [0]',
+                'Unmount B [0]',
+                'Mount A [1]',
+                'Oops!',
+                'Unmount A [1]',
+              ],
+        );
+        expect(ReactNoop.getChildren()).toEqual([]);
+      });
+      if (
+        deferPassiveEffectCleanupDuringUnmount &&
+        runAllPassiveEffectDestroysBeforeCreates
+      ) {
+        expect(Scheduler).toHaveYielded([
+          // Clean up effect A runs passively on unmount.
+          // There's no effect B to clean-up, because it never mounted.
+          'Unmount A [1]',
+        ]);
+      }
+    });
+
+    it('handles errors in destroy on update', () => {
+      function Counter(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue('Oops!');
+            if (props.count === 0) {
+              throw new Error('Oops!');
+            }
+          };
+        });
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
+          return () => {
+            Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
+          };
+        });
+        return <Text text={'Count: ' + props.count} />;
+      }
+
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+        ReactNoop.flushPassiveEffects();
+        expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
+      });
+
+      if (
+        deferPassiveEffectCleanupDuringUnmount &&
+        runAllPassiveEffectDestroysBeforeCreates
+      ) {
+        act(() => {
+          // This update will trigger an error during passive effect unmount
+          ReactNoop.render(<Counter count={1} />, () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+          expect(Scheduler).toFlushAndYieldThrough(['Count: 1', 'Sync effect']);
           expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+          expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
 
-          act(() => {
-            ReactNoop.render(<Counter label="Total" count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            // Label changed
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Total: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Total: 1')]);
-          });
-
+          // This branch enables a feature flag that flushes all passive destroys in a
+          // separate pass before flushing any passive creates.
+          // A result of this two-pass flush is that an error thrown from unmount does
+          // not block the subsequent create functions from being run.
           expect(Scheduler).toHaveYielded([
-            'Did destroy [Count: 1]',
-            'Did create [Total: 1]',
-          ]);
-        });
-
-        it('multiple effects', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did commit 1 [${props.count}]`);
-            });
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Did commit 2 [${props.count}]`);
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          });
-
-          expect(Scheduler).toHaveYielded([
-            'Did commit 1 [0]',
-            'Did commit 2 [0]',
-          ]);
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
-          expect(Scheduler).toHaveYielded([
-            'Did commit 1 [1]',
-            'Did commit 2 [1]',
-          ]);
-        });
-
-        it('unmounts all previous effects before creating any new ones', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
-              };
-            });
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          });
-
-          expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
-
-          act(() => {
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          });
-          expect(Scheduler).toHaveYielded([
-            'Unmount A [0]',
+            'Oops!',
             'Unmount B [0]',
             'Mount A [1]',
             'Mount B [1]',
           ]);
         });
 
-        if (runAllPassiveEffectDestroysBeforeCreates) {
-          it('unmounts all previous effects between siblings before creating any new ones', () => {
-            function Counter({count, label}) {
-              useEffect(() => {
-                Scheduler.unstable_yieldValue(`Mount ${label} [${count}]`);
-                return () => {
-                  Scheduler.unstable_yieldValue(`Unmount ${label} [${count}]`);
-                };
-              });
-              return <Text text={`${label} ${count}`} />;
-            }
-            act(() => {
-              ReactNoop.render(
-                <>
-                  <Counter label="A" count={0} />
-                  <Counter label="B" count={0} />
-                </>,
-                () => Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'A 0',
-                'B 0',
-                'Sync effect',
-              ]);
-              expect(ReactNoop.getChildren()).toEqual([
-                span('A 0'),
-                span('B 0'),
-              ]);
-            });
-
-            expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
-
-            act(() => {
-              ReactNoop.render(
-                <>
-                  <Counter label="A" count={1} />
-                  <Counter label="B" count={1} />
-                </>,
-                () => Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'A 1',
-                'B 1',
-                'Sync effect',
-              ]);
-              expect(ReactNoop.getChildren()).toEqual([
-                span('A 1'),
-                span('B 1'),
-              ]);
-            });
-            expect(Scheduler).toHaveYielded([
-              'Unmount A [0]',
-              'Unmount B [0]',
-              'Mount A [1]',
-              'Mount B [1]',
-            ]);
-
-            act(() => {
-              ReactNoop.render(
-                <>
-                  <Counter label="B" count={2} />
-                  <Counter label="C" count={0} />
-                </>,
-                () => Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'B 2',
-                'C 0',
-                'Sync effect',
-              ]);
-              expect(ReactNoop.getChildren()).toEqual([
-                span('B 2'),
-                span('C 0'),
-              ]);
-            });
-            expect(Scheduler).toHaveYielded([
-              'Unmount A [1]',
-              'Unmount B [1]',
-              'Mount B [2]',
-              'Mount C [0]',
-            ]);
-          });
-        }
-
-        it('handles errors in create on mount', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
-              };
-            });
-            useEffect(() => {
-              Scheduler.unstable_yieldValue('Oops!');
-              throw new Error('Oops!');
-              // eslint-disable-next-line no-unreachable
-              Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-          });
-
-          expect(Scheduler).toHaveYielded([
-            'Mount A [0]',
-            'Oops!',
-            // Clean up effect A. There's no effect B to clean-up, because it
-            // never mounted.
-            'Unmount A [0]',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([]);
-        });
-
-        it('handles errors in create on update', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount A [${props.count}]`);
-              };
-            });
-            useEffect(() => {
-              if (props.count === 1) {
-                Scheduler.unstable_yieldValue('Oops!');
-                throw new Error('Oops!');
-              }
-              Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            ReactNoop.flushPassiveEffects();
-            expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
-          });
-
-          act(() => {
-            // This update will trigger an error
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 1',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-            expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-            expect(Scheduler).toHaveYielded(
-              deferPassiveEffectCleanupDuringUnmount &&
-                runAllPassiveEffectDestroysBeforeCreates
-                ? ['Unmount A [0]', 'Unmount B [0]', 'Mount A [1]', 'Oops!']
-                : [
-                    'Unmount A [0]',
-                    'Unmount B [0]',
-                    'Mount A [1]',
-                    'Oops!',
-                    'Unmount A [1]',
-                  ],
-            );
-            expect(ReactNoop.getChildren()).toEqual([]);
-          });
-          if (
-            deferPassiveEffectCleanupDuringUnmount &&
-            runAllPassiveEffectDestroysBeforeCreates
-          ) {
-            expect(Scheduler).toHaveYielded([
-              // Clean up effect A runs passively on unmount.
-              // There's no effect B to clean-up, because it never mounted.
-              'Unmount A [1]',
-            ]);
-          }
-        });
-
-        it('handles errors in destroy on update', () => {
-          function Counter(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount A [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue('Oops!');
-                if (props.count === 0) {
-                  throw new Error('Oops!');
-                }
-              };
-            });
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(`Mount B [${props.count}]`);
-              return () => {
-                Scheduler.unstable_yieldValue(`Unmount B [${props.count}]`);
-              };
-            });
-            return <Text text={'Count: ' + props.count} />;
-          }
-
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Count: 0',
-              'Sync effect',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-            ReactNoop.flushPassiveEffects();
-            expect(Scheduler).toHaveYielded(['Mount A [0]', 'Mount B [0]']);
-          });
-
-          if (
-            deferPassiveEffectCleanupDuringUnmount &&
-            runAllPassiveEffectDestroysBeforeCreates
-          ) {
-            act(() => {
-              // This update will trigger an error during passive effect unmount
-              ReactNoop.render(<Counter count={1} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(Scheduler).toFlushAndYieldThrough([
-                'Count: 1',
-                'Sync effect',
-              ]);
-              expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-              expect(() => ReactNoop.flushPassiveEffects()).toThrow('Oops');
-
-              // This branch enables a feature flag that flushes all passive destroys in a
-              // separate pass before flushing any passive creates.
-              // A result of this two-pass flush is that an error thrown from unmount does
-              // not block the subsequent create functions from being run.
-              expect(Scheduler).toHaveYielded([
-                'Oops!',
-                'Unmount B [0]',
-                'Mount A [1]',
-                'Mount B [1]',
-              ]);
-            });
-
-            // <Counter> gets unmounted because an error is thrown above.
-            // The remaining destroy functions are run later on unmount, since they're passive.
-            // In this case, one of them throws again (because of how the test is written).
-            expect(Scheduler).toHaveYielded(['Oops!', 'Unmount B [1]']);
-            expect(ReactNoop.getChildren()).toEqual([]);
-          } else {
-            act(() => {
-              // This update will trigger an error during passive effect unmount
-              ReactNoop.render(<Counter count={1} />, () =>
-                Scheduler.unstable_yieldValue('Sync effect'),
-              );
-              expect(() => {
-                expect(Scheduler).toFlushAndYield(['Count: 1', 'Sync effect']);
-              }).toThrow('Oops!');
-              expect(ReactNoop.getChildren()).toEqual([]);
-              ReactNoop.flushPassiveEffects();
-            });
-          }
-        });
-
-        it('works with memo', () => {
-          function Counter({count}) {
-            useLayoutEffect(() => {
-              Scheduler.unstable_yieldValue('Mount: ' + count);
-              return () => Scheduler.unstable_yieldValue('Unmount: ' + count);
-            });
-            return <Text text={'Count: ' + count} />;
-          }
-          Counter = memo(Counter);
-
-          ReactNoop.render(<Counter count={0} />, () =>
-            Scheduler.unstable_yieldValue('Sync effect'),
-          );
-          expect(Scheduler).toFlushAndYieldThrough([
-            'Count: 0',
-            'Mount: 0',
-            'Sync effect',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-
+        // <Counter> gets unmounted because an error is thrown above.
+        // The remaining destroy functions are run later on unmount, since they're passive.
+        // In this case, one of them throws again (because of how the test is written).
+        expect(Scheduler).toHaveYielded(['Oops!', 'Unmount B [1]']);
+        expect(ReactNoop.getChildren()).toEqual([]);
+      } else {
+        act(() => {
+          // This update will trigger an error during passive effect unmount
           ReactNoop.render(<Counter count={1} />, () =>
             Scheduler.unstable_yieldValue('Sync effect'),
           );
-          expect(Scheduler).toFlushAndYieldThrough([
-            'Count: 1',
-            'Unmount: 0',
-            'Mount: 1',
-            'Sync effect',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-
-          ReactNoop.render(null);
-          expect(Scheduler).toFlushAndYieldThrough(['Unmount: 1']);
-          expect(ReactNoop.getChildren()).toEqual([]);
-        });
-      });
-
-      describe('useLayoutEffect', () => {
-        it('fires layout effects after the host has been mutated', () => {
-          function getCommittedText() {
-            const yields = Scheduler.unstable_clearYields();
-            const children = ReactNoop.getChildren();
-            Scheduler.unstable_yieldValue(yields);
-            if (children === null) {
-              return null;
-            }
-            return children[0].prop;
-          }
-
-          function Counter(props) {
-            useLayoutEffect(() => {
-              Scheduler.unstable_yieldValue(`Current: ${getCommittedText()}`);
-            });
-            return <Text text={props.count} />;
-          }
-
-          ReactNoop.render(<Counter count={0} />, () =>
-            Scheduler.unstable_yieldValue('Sync effect'),
-          );
-          expect(Scheduler).toFlushAndYieldThrough([
-            [0],
-            'Current: 0',
-            'Sync effect',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(0)]);
-
-          ReactNoop.render(<Counter count={1} />, () =>
-            Scheduler.unstable_yieldValue('Sync effect'),
-          );
-          expect(Scheduler).toFlushAndYieldThrough([
-            [1],
-            'Current: 1',
-            'Sync effect',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span(1)]);
-        });
-
-        it('force flushes passive effects before firing new layout effects', () => {
-          let committedText = '(empty)';
-
-          function Counter(props) {
-            useLayoutEffect(() => {
-              // Normally this would go in a mutation effect, but this test
-              // intentionally omits a mutation effect.
-              committedText = props.count + '';
-
-              Scheduler.unstable_yieldValue(
-                `Mount layout [current: ${committedText}]`,
-              );
-              return () => {
-                Scheduler.unstable_yieldValue(
-                  `Unmount layout [current: ${committedText}]`,
-                );
-              };
-            });
-            useEffect(() => {
-              Scheduler.unstable_yieldValue(
-                `Mount normal [current: ${committedText}]`,
-              );
-              return () => {
-                Scheduler.unstable_yieldValue(
-                  `Unmount normal [current: ${committedText}]`,
-                );
-              };
-            });
-            return null;
-          }
-
-          act(() => {
-            ReactNoop.render(<Counter count={0} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Mount layout [current: 0]',
-              'Sync effect',
-            ]);
-            expect(committedText).toEqual('0');
-            ReactNoop.render(<Counter count={1} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough([
-              'Mount normal [current: 0]',
-              'Unmount layout [current: 0]',
-              'Mount layout [current: 1]',
-              'Sync effect',
-            ]);
-            expect(committedText).toEqual('1');
-          });
-
-          expect(Scheduler).toHaveYielded([
-            'Unmount normal [current: 1]',
-            'Mount normal [current: 1]',
-          ]);
-        });
-      });
-
-      describe('useCallback', () => {
-        it('memoizes callback by comparing inputs', () => {
-          class IncrementButton extends React.PureComponent {
-            increment = () => {
-              this.props.increment();
-            };
-            render() {
-              return <Text text="Increment" />;
-            }
-          }
-
-          function Counter({incrementBy}) {
-            const [count, updateCount] = useState(0);
-            const increment = useCallback(
-              () => updateCount(c => c + incrementBy),
-              [incrementBy],
-            );
-            return (
-              <>
-                <IncrementButton increment={increment} ref={button} />
-                <Text text={'Count: ' + count} />
-              </>
-            );
-          }
-
-          const button = React.createRef(null);
-          ReactNoop.render(<Counter incrementBy={1} />);
-          expect(Scheduler).toFlushAndYield(['Increment', 'Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Increment'),
-            span('Count: 0'),
-          ]);
-
-          act(button.current.increment);
-          expect(Scheduler).toHaveYielded([
-            // Button should not re-render, because its props haven't changed
-            // 'Increment',
-            'Count: 1',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Increment'),
-            span('Count: 1'),
-          ]);
-
-          // Increase the increment amount
-          ReactNoop.render(<Counter incrementBy={10} />);
-          expect(Scheduler).toFlushAndYield([
-            // Inputs did change this time
-            'Increment',
-            'Count: 1',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Increment'),
-            span('Count: 1'),
-          ]);
-
-          // Callback should have updated
-          act(button.current.increment);
-          expect(Scheduler).toHaveYielded(['Count: 11']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('Increment'),
-            span('Count: 11'),
-          ]);
-        });
-      });
-
-      describe('useMemo', () => {
-        it('memoizes value by comparing to previous inputs', () => {
-          function CapitalizedText(props) {
-            const text = props.text;
-            const capitalizedText = useMemo(() => {
-              Scheduler.unstable_yieldValue(`Capitalize '${text}'`);
-              return text.toUpperCase();
-            }, [text]);
-            return <Text text={capitalizedText} />;
-          }
-
-          ReactNoop.render(<CapitalizedText text="hello" />);
-          expect(Scheduler).toFlushAndYield(["Capitalize 'hello'", 'HELLO']);
-          expect(ReactNoop.getChildren()).toEqual([span('HELLO')]);
-
-          ReactNoop.render(<CapitalizedText text="hi" />);
-          expect(Scheduler).toFlushAndYield(["Capitalize 'hi'", 'HI']);
-          expect(ReactNoop.getChildren()).toEqual([span('HI')]);
-
-          ReactNoop.render(<CapitalizedText text="hi" />);
-          expect(Scheduler).toFlushAndYield(['HI']);
-          expect(ReactNoop.getChildren()).toEqual([span('HI')]);
-
-          ReactNoop.render(<CapitalizedText text="goodbye" />);
-          expect(Scheduler).toFlushAndYield([
-            "Capitalize 'goodbye'",
-            'GOODBYE',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('GOODBYE')]);
-        });
-
-        it('always re-computes if no inputs are provided', () => {
-          function LazyCompute(props) {
-            const computed = useMemo(props.compute);
-            return <Text text={computed} />;
-          }
-
-          function computeA() {
-            Scheduler.unstable_yieldValue('compute A');
-            return 'A';
-          }
-
-          function computeB() {
-            Scheduler.unstable_yieldValue('compute B');
-            return 'B';
-          }
-
-          ReactNoop.render(<LazyCompute compute={computeA} />);
-          expect(Scheduler).toFlushAndYield(['compute A', 'A']);
-
-          ReactNoop.render(<LazyCompute compute={computeA} />);
-          expect(Scheduler).toFlushAndYield(['compute A', 'A']);
-
-          ReactNoop.render(<LazyCompute compute={computeA} />);
-          expect(Scheduler).toFlushAndYield(['compute A', 'A']);
-
-          ReactNoop.render(<LazyCompute compute={computeB} />);
-          expect(Scheduler).toFlushAndYield(['compute B', 'B']);
-        });
-
-        it('should not invoke memoized function during re-renders unless inputs change', () => {
-          function LazyCompute(props) {
-            const computed = useMemo(() => props.compute(props.input), [
-              props.input,
-            ]);
-            const [count, setCount] = useState(0);
-            if (count < 3) {
-              setCount(count + 1);
-            }
-            return <Text text={computed} />;
-          }
-
-          function compute(val) {
-            Scheduler.unstable_yieldValue('compute ' + val);
-            return val;
-          }
-
-          ReactNoop.render(<LazyCompute compute={compute} input="A" />);
-          expect(Scheduler).toFlushAndYield(['compute A', 'A']);
-
-          ReactNoop.render(<LazyCompute compute={compute} input="A" />);
-          expect(Scheduler).toFlushAndYield(['A']);
-
-          ReactNoop.render(<LazyCompute compute={compute} input="B" />);
-          expect(Scheduler).toFlushAndYield(['compute B', 'B']);
-        });
-      });
-
-      describe('useRef', () => {
-        it('creates a ref object initialized with the provided value', () => {
-          jest.useFakeTimers();
-
-          function useDebouncedCallback(callback, ms, inputs) {
-            const timeoutID = useRef(-1);
-            useEffect(() => {
-              return function unmount() {
-                clearTimeout(timeoutID.current);
-              };
-            }, []);
-            const debouncedCallback = useCallback(
-              (...args) => {
-                clearTimeout(timeoutID.current);
-                timeoutID.current = setTimeout(callback, ms, ...args);
-              },
-              [callback, ms],
-            );
-            return useCallback(debouncedCallback, inputs);
-          }
-
-          let ping;
-          function App() {
-            ping = useDebouncedCallback(
-              value => {
-                Scheduler.unstable_yieldValue('ping: ' + value);
-              },
-              100,
-              [],
-            );
-            return null;
-          }
-
-          act(() => {
-            ReactNoop.render(<App />);
-          });
-          expect(Scheduler).toHaveYielded([]);
-
-          ping(1);
-          ping(2);
-          ping(3);
-
-          expect(Scheduler).toHaveYielded([]);
-
-          jest.advanceTimersByTime(100);
-
-          expect(Scheduler).toHaveYielded(['ping: 3']);
-
-          ping(4);
-          jest.advanceTimersByTime(20);
-          ping(5);
-          ping(6);
-          jest.advanceTimersByTime(80);
-
-          expect(Scheduler).toHaveYielded([]);
-
-          jest.advanceTimersByTime(20);
-          expect(Scheduler).toHaveYielded(['ping: 6']);
-        });
-
-        it('should return the same ref during re-renders', () => {
-          function Counter() {
-            const ref = useRef('val');
-            const [count, setCount] = useState(0);
-            const [firstRef] = useState(ref);
-
-            if (firstRef !== ref) {
-              throw new Error('should never change');
-            }
-
-            if (count < 3) {
-              setCount(count + 1);
-            }
-
-            return <Text text={ref.current} />;
-          }
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield(['val']);
-
-          ReactNoop.render(<Counter />);
-          expect(Scheduler).toFlushAndYield(['val']);
-        });
-      });
-
-      describe('useImperativeHandle', () => {
-        it('does not update when deps are the same', () => {
-          const INCREMENT = 'INCREMENT';
-
-          function reducer(state, action) {
-            return action === INCREMENT ? state + 1 : state;
-          }
-
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(ref, () => ({count, dispatch}), []);
-            return <Text text={'Count: ' + count} />;
-          }
-
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          expect(counter.current.count).toBe(0);
-
-          act(() => {
-            counter.current.dispatch(INCREMENT);
-          });
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          // Intentionally not updated because of [] deps:
-          expect(counter.current.count).toBe(0);
-        });
-
-        // Regression test for https://github.com/facebook/react/issues/14782
-        it('automatically updates when deps are not specified', () => {
-          const INCREMENT = 'INCREMENT';
-
-          function reducer(state, action) {
-            return action === INCREMENT ? state + 1 : state;
-          }
-
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(ref, () => ({count, dispatch}));
-            return <Text text={'Count: ' + count} />;
-          }
-
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          expect(counter.current.count).toBe(0);
-
-          act(() => {
-            counter.current.dispatch(INCREMENT);
-          });
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          expect(counter.current.count).toBe(1);
-        });
-
-        it('updates when deps are different', () => {
-          const INCREMENT = 'INCREMENT';
-
-          function reducer(state, action) {
-            return action === INCREMENT ? state + 1 : state;
-          }
-
-          let totalRefUpdates = 0;
-          function Counter(props, ref) {
-            const [count, dispatch] = useReducer(reducer, 0);
-            useImperativeHandle(
-              ref,
-              () => {
-                totalRefUpdates++;
-                return {count, dispatch};
-              },
-              [count],
-            );
-            return <Text text={'Count: ' + count} />;
-          }
-
-          Counter = forwardRef(Counter);
-          const counter = React.createRef(null);
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-          expect(counter.current.count).toBe(0);
-          expect(totalRefUpdates).toBe(1);
-
-          act(() => {
-            counter.current.dispatch(INCREMENT);
-          });
-          expect(Scheduler).toHaveYielded(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          expect(counter.current.count).toBe(1);
-          expect(totalRefUpdates).toBe(2);
-
-          // Update that doesn't change the ref dependencies
-          ReactNoop.render(<Counter ref={counter} />);
-          expect(Scheduler).toFlushAndYield(['Count: 1']);
-          expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
-          expect(counter.current.count).toBe(1);
-          expect(totalRefUpdates).toBe(2); // Should not increase since last time
-        });
-      });
-      describe('useTransition', () => {
-        it.experimental(
-          'delays showing loading state until after timeout',
-          async () => {
-            let transition;
-            function App() {
-              const [show, setShow] = useState(false);
-              const [startTransition, isPending] = useTransition({
-                timeoutMs: 1000,
-              });
-              transition = () => {
-                startTransition(() => {
-                  setShow(true);
-                });
-              };
-              return (
-                <Suspense
-                  fallback={<Text text={`Loading... Pending: ${isPending}`} />}>
-                  {show ? (
-                    <AsyncText
-                      ms={2000}
-                      text={`After... Pending: ${isPending}`}
-                    />
-                  ) : (
-                    <Text text={`Before... Pending: ${isPending}`} />
-                  )}
-                </Suspense>
-              );
-            }
-            ReactNoop.render(<App />);
-            expect(Scheduler).toFlushAndYield(['Before... Pending: false']);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: false'),
-            ]);
-
-            act(() => {
-              Scheduler.unstable_runWithPriority(
-                Scheduler.unstable_UserBlockingPriority,
-                transition,
-              );
-            });
-            Scheduler.unstable_advanceTime(500);
-            await advanceTimers(500);
-            expect(Scheduler).toHaveYielded([
-              'Before... Pending: true',
-              'Suspend! [After... Pending: false]',
-              'Loading... Pending: false',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: true'),
-            ]);
-
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            expect(ReactNoop.getChildren()).toEqual([
-              hiddenSpan('Before... Pending: true'),
-              span('Loading... Pending: false'),
-            ]);
-
-            Scheduler.unstable_advanceTime(500);
-            await advanceTimers(500);
-            expect(Scheduler).toHaveYielded([
-              'Promise resolved [After... Pending: false]',
-            ]);
-            expect(Scheduler).toFlushAndYield(['After... Pending: false']);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('After... Pending: false'),
-            ]);
-          },
-        );
-        it.experimental(
-          'delays showing loading state until after busyDelayMs + busyMinDurationMs',
-          async () => {
-            let transition;
-            function App() {
-              const [show, setShow] = useState(false);
-              const [startTransition, isPending] = useTransition({
-                busyDelayMs: 1000,
-                busyMinDurationMs: 2000,
-              });
-              transition = () => {
-                startTransition(() => {
-                  setShow(true);
-                });
-              };
-              return (
-                <Suspense
-                  fallback={<Text text={`Loading... Pending: ${isPending}`} />}>
-                  {show ? (
-                    <AsyncText
-                      ms={2000}
-                      text={`After... Pending: ${isPending}`}
-                    />
-                  ) : (
-                    <Text text={`Before... Pending: ${isPending}`} />
-                  )}
-                </Suspense>
-              );
-            }
-            ReactNoop.render(<App />);
-            expect(Scheduler).toFlushAndYield(['Before... Pending: false']);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: false'),
-            ]);
-
-            act(() => {
-              Scheduler.unstable_runWithPriority(
-                Scheduler.unstable_UserBlockingPriority,
-                transition,
-              );
-            });
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            expect(Scheduler).toHaveYielded([
-              'Before... Pending: true',
-              'Suspend! [After... Pending: false]',
-              'Loading... Pending: false',
-            ]);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: true'),
-            ]);
-
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            expect(Scheduler).toHaveYielded([
-              'Promise resolved [After... Pending: false]',
-            ]);
-            expect(Scheduler).toFlushAndYield(['After... Pending: false']);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: true'),
-            ]);
-
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('Before... Pending: true'),
-            ]);
-            Scheduler.unstable_advanceTime(250);
-            await advanceTimers(250);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('After... Pending: false'),
-            ]);
-          },
-        );
-      });
-      describe('useDeferredValue', () => {
-        it.experimental(
-          'defers text value until specified timeout',
-          async () => {
-            function TextBox({text}) {
-              return <AsyncText ms={1000} text={text} />;
-            }
-
-            let _setText;
-            function App() {
-              const [text, setText] = useState('A');
-              const deferredText = useDeferredValue(text, {
-                timeoutMs: 500,
-              });
-              _setText = setText;
-              return (
-                <>
-                  <Text text={text} />
-                  <Suspense fallback={<Text text={'Loading'} />}>
-                    <TextBox text={deferredText} />
-                  </Suspense>
-                </>
-              );
-            }
-
-            act(() => {
-              ReactNoop.render(<App />);
-            });
-
-            expect(Scheduler).toHaveYielded(['A', 'Suspend! [A]', 'Loading']);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('A'),
-              span('Loading'),
-            ]);
-
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-            expect(Scheduler).toFlushAndYield(['A']);
-            expect(ReactNoop.getChildren()).toEqual([span('A'), span('A')]);
-
-            act(() => {
-              _setText('B');
-            });
-            expect(Scheduler).toHaveYielded([
-              'B',
-              'A',
-              'B',
-              'Suspend! [B]',
-              'Loading',
-            ]);
-            expect(Scheduler).toFlushAndYield([]);
-            expect(ReactNoop.getChildren()).toEqual([span('B'), span('A')]);
-
-            Scheduler.unstable_advanceTime(250);
-            await advanceTimers(250);
-            expect(Scheduler).toFlushAndYield([]);
-            expect(ReactNoop.getChildren()).toEqual([span('B'), span('A')]);
-
-            Scheduler.unstable_advanceTime(500);
-            await advanceTimers(500);
-            expect(ReactNoop.getChildren()).toEqual([
-              span('B'),
-              hiddenSpan('A'),
-              span('Loading'),
-            ]);
-
-            Scheduler.unstable_advanceTime(250);
-            await advanceTimers(250);
-            expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-
-            act(() => {
-              expect(Scheduler).toFlushAndYield(['B']);
-            });
-            expect(ReactNoop.getChildren()).toEqual([span('B'), span('B')]);
-          },
-        );
-      });
-
-      describe('progressive enhancement (not supported)', () => {
-        it('mount additional state', () => {
-          let updateA;
-          let updateB;
-          // let updateC;
-
-          function App(props) {
-            const [A, _updateA] = useState(0);
-            const [B, _updateB] = useState(0);
-            updateA = _updateA;
-            updateB = _updateB;
-
-            let C;
-            if (props.loadC) {
-              useState(0);
-            } else {
-              C = '[not loaded]';
-            }
-
-            return <Text text={`A: ${A}, B: ${B}, C: ${C}`} />;
-          }
-
-          ReactNoop.render(<App loadC={false} />);
-          expect(Scheduler).toFlushAndYield(['A: 0, B: 0, C: [not loaded]']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('A: 0, B: 0, C: [not loaded]'),
-          ]);
-
-          act(() => {
-            updateA(2);
-            updateB(3);
-          });
-
-          expect(Scheduler).toHaveYielded(['A: 2, B: 3, C: [not loaded]']);
-          expect(ReactNoop.getChildren()).toEqual([
-            span('A: 2, B: 3, C: [not loaded]'),
-          ]);
-
-          ReactNoop.render(<App loadC={true} />);
           expect(() => {
-            expect(() => {
-              expect(Scheduler).toFlushAndYield(['A: 2, B: 3, C: 0']);
-            }).toThrow('Rendered more hooks than during the previous render');
-          }).toErrorDev([
-            'Warning: React has detected a change in the order of Hooks called by App. ' +
-              'This will lead to bugs and errors if not fixed. For more information, ' +
-              'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
-              '   Previous render            Next render\n' +
-              '   ------------------------------------------------------\n' +
-              '1. useState                   useState\n' +
-              '2. useState                   useState\n' +
-              '3. undefined                  useState\n' +
-              '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n',
-          ]);
-
-          // Uncomment if/when we support this again
-          // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 0')]);
-
-          // updateC(4);
-          // expect(Scheduler).toFlushAndYield(['A: 2, B: 3, C: 4']);
-          // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
+            expect(Scheduler).toFlushAndYield(['Count: 1', 'Sync effect']);
+          }).toThrow('Oops!');
+          expect(ReactNoop.getChildren()).toEqual([]);
+          ReactNoop.flushPassiveEffects();
         });
-
-        it('unmount state', () => {
-          let updateA;
-          let updateB;
-          let updateC;
-
-          function App(props) {
-            const [A, _updateA] = useState(0);
-            const [B, _updateB] = useState(0);
-            updateA = _updateA;
-            updateB = _updateB;
-
-            let C;
-            if (props.loadC) {
-              const [_C, _updateC] = useState(0);
-              C = _C;
-              updateC = _updateC;
-            } else {
-              C = '[not loaded]';
-            }
-
-            return <Text text={`A: ${A}, B: ${B}, C: ${C}`} />;
-          }
-
-          ReactNoop.render(<App loadC={true} />);
-          expect(Scheduler).toFlushAndYield(['A: 0, B: 0, C: 0']);
-          expect(ReactNoop.getChildren()).toEqual([span('A: 0, B: 0, C: 0')]);
-          act(() => {
-            updateA(2);
-            updateB(3);
-            updateC(4);
-          });
-          expect(Scheduler).toHaveYielded(['A: 2, B: 3, C: 4']);
-          expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
-          ReactNoop.render(<App loadC={false} />);
-          expect(Scheduler).toFlushAndThrow(
-            'Rendered fewer hooks than expected. This may be caused by an ' +
-              'accidental early return statement.',
-          );
-        });
-
-        it('unmount effects', () => {
-          function App(props) {
-            useEffect(() => {
-              Scheduler.unstable_yieldValue('Mount A');
-              return () => {
-                Scheduler.unstable_yieldValue('Unmount A');
-              };
-            }, []);
-
-            if (props.showMore) {
-              useEffect(() => {
-                Scheduler.unstable_yieldValue('Mount B');
-                return () => {
-                  Scheduler.unstable_yieldValue('Unmount B');
-                };
-              }, []);
-            }
-
-            return null;
-          }
-
-          act(() => {
-            ReactNoop.render(<App showMore={false} />, () =>
-              Scheduler.unstable_yieldValue('Sync effect'),
-            );
-            expect(Scheduler).toFlushAndYieldThrough(['Sync effect']);
-          });
-
-          expect(Scheduler).toHaveYielded(['Mount A']);
-
-          act(() => {
-            ReactNoop.render(<App showMore={true} />);
-            expect(() => {
-              expect(() => {
-                expect(Scheduler).toFlushAndYield([]);
-              }).toThrow('Rendered more hooks than during the previous render');
-            }).toErrorDev([
-              'Warning: React has detected a change in the order of Hooks called by App. ' +
-                'This will lead to bugs and errors if not fixed. For more information, ' +
-                'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
-                '   Previous render            Next render\n' +
-                '   ------------------------------------------------------\n' +
-                '1. useEffect                  useEffect\n' +
-                '2. undefined                  useEffect\n' +
-                '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n',
-            ]);
-          });
-
-          // Uncomment if/when we support this again
-          // ReactNoop.flushPassiveEffects();
-          // expect(Scheduler).toHaveYielded(['Mount B']);
-
-          // ReactNoop.render(<App showMore={false} />);
-          // expect(Scheduler).toFlushAndThrow(
-          //   'Rendered fewer hooks than expected. This may be caused by an ' +
-          //     'accidental early return statement.',
-          // );
-        });
-      });
-
-      it('eager bailout optimization should always compare to latest rendered reducer', () => {
-        // Edge case based on a bug report
-        let setCounter;
-        function App() {
-          const [counter, _setCounter] = useState(1);
-          setCounter = _setCounter;
-          return <Component count={counter} />;
-        }
-
-        function Component({count}) {
-          const [state, dispatch] = useReducer(() => {
-            // This reducer closes over a value from props. If the reducer is not
-            // properly updated, the eager reducer will compare to an old value
-            // and bail out incorrectly.
-            Scheduler.unstable_yieldValue('Reducer: ' + count);
-            return count;
-          }, -1);
-          useEffect(() => {
-            Scheduler.unstable_yieldValue('Effect: ' + count);
-            dispatch();
-          }, [count]);
-          Scheduler.unstable_yieldValue('Render: ' + state);
-          return count;
-        }
-
-        act(() => {
-          ReactNoop.render(<App />);
-          expect(Scheduler).toFlushAndYield([
-            'Render: -1',
-            'Effect: 1',
-            'Reducer: 1',
-            'Reducer: 1',
-            'Render: 1',
-          ]);
-          expect(ReactNoop).toMatchRenderedOutput('1');
-        });
-
-        act(() => {
-          setCounter(2);
-        });
-        expect(Scheduler).toHaveYielded([
-          'Render: 1',
-          'Effect: 2',
-          'Reducer: 2',
-          'Reducer: 2',
-          'Render: 2',
-        ]);
-        expect(ReactNoop).toMatchRenderedOutput('2');
-      });
-
-      // Regression test. Covers a case where an internal state variable
-      // (`didReceiveUpdate`) is not reset properly.
-      it('state bail out edge case (#16359)', async () => {
-        let setCounterA;
-        let setCounterB;
-
-        function CounterA() {
-          const [counter, setCounter] = useState(0);
-          setCounterA = setCounter;
-          Scheduler.unstable_yieldValue('Render A: ' + counter);
-          useEffect(() => {
-            Scheduler.unstable_yieldValue('Commit A: ' + counter);
-          });
-          return counter;
-        }
-
-        function CounterB() {
-          const [counter, setCounter] = useState(0);
-          setCounterB = setCounter;
-          Scheduler.unstable_yieldValue('Render B: ' + counter);
-          useEffect(() => {
-            Scheduler.unstable_yieldValue('Commit B: ' + counter);
-          });
-          return counter;
-        }
-
-        const root = ReactNoop.createRoot(null);
-        await ReactNoop.act(async () => {
-          root.render(
-            <>
-              <CounterA />
-              <CounterB />
-            </>,
-          );
-        });
-        expect(Scheduler).toHaveYielded([
-          'Render A: 0',
-          'Render B: 0',
-          'Commit A: 0',
-          'Commit B: 0',
-        ]);
-
-        await ReactNoop.act(async () => {
-          setCounterA(1);
-
-          // In the same batch, update B twice. To trigger the condition we're
-          // testing, the first update is necessary to bypass the early
-          // bailout optimization.
-          setCounterB(1);
-          setCounterB(0);
-        });
-        expect(Scheduler).toHaveYielded([
-          'Render A: 1',
-          'Render B: 0',
-          'Commit A: 1',
-          // B should not fire an effect because the update bailed out
-          // 'Commit B: 0',
-        ]);
-      });
-
-      it('should update latest rendered reducer when a preceding state receives a render phase update', () => {
-        // Similar to previous test, except using a preceding render phase update
-        // instead of new props.
-        let dispatch;
-        function App() {
-          const [step, setStep] = useState(0);
-          const [shadow, _dispatch] = useReducer(() => step, step);
-          dispatch = _dispatch;
-
-          if (step < 5) {
-            setStep(step + 1);
-          }
-
-          Scheduler.unstable_yieldValue(`Step: ${step}, Shadow: ${shadow}`);
-          return shadow;
-        }
-
-        ReactNoop.render(<App />);
-        expect(Scheduler).toFlushAndYield([
-          'Step: 0, Shadow: 0',
-          'Step: 1, Shadow: 0',
-          'Step: 2, Shadow: 0',
-          'Step: 3, Shadow: 0',
-          'Step: 4, Shadow: 0',
-          'Step: 5, Shadow: 0',
-        ]);
-        expect(ReactNoop).toMatchRenderedOutput('0');
-
-        act(() => dispatch());
-        expect(Scheduler).toHaveYielded(['Step: 5, Shadow: 5']);
-        expect(ReactNoop).toMatchRenderedOutput('5');
-      });
-
-      it('should process the rest pending updates after a render phase update', () => {
-        // Similar to previous test, except using a preceding render phase update
-        // instead of new props.
-        let updateA;
-        let updateC;
-        function App() {
-          const [a, setA] = useState(false);
-          const [b, setB] = useState(false);
-          if (a !== b) {
-            setB(a);
-          }
-          // Even though we called setB above,
-          // we should still apply the changes to C,
-          // during this render pass.
-          const [c, setC] = useState(false);
-          updateA = setA;
-          updateC = setC;
-          return `${a ? 'A' : 'a'}${b ? 'B' : 'b'}${c ? 'C' : 'c'}`;
-        }
-
-        act(() => ReactNoop.render(<App />));
-        expect(ReactNoop).toMatchRenderedOutput('abc');
-
-        act(() => {
-          updateA(true);
-          // This update should not get dropped.
-          updateC(true);
-        });
-        expect(ReactNoop).toMatchRenderedOutput('ABC');
-      });
+      }
     });
+
+    it('works with memo', () => {
+      function Counter({count}) {
+        useLayoutEffect(() => {
+          Scheduler.unstable_yieldValue('Mount: ' + count);
+          return () => Scheduler.unstable_yieldValue('Unmount: ' + count);
+        });
+        return <Text text={'Count: ' + count} />;
+      }
+      Counter = memo(Counter);
+
+      ReactNoop.render(<Counter count={0} />, () =>
+        Scheduler.unstable_yieldValue('Sync effect'),
+      );
+      expect(Scheduler).toFlushAndYieldThrough([
+        'Count: 0',
+        'Mount: 0',
+        'Sync effect',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+
+      ReactNoop.render(<Counter count={1} />, () =>
+        Scheduler.unstable_yieldValue('Sync effect'),
+      );
+      expect(Scheduler).toFlushAndYieldThrough([
+        'Count: 1',
+        'Unmount: 0',
+        'Mount: 1',
+        'Sync effect',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+
+      ReactNoop.render(null);
+      expect(Scheduler).toFlushAndYieldThrough(['Unmount: 1']);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    });
+  });
+
+  describe('useLayoutEffect', () => {
+    it('fires layout effects after the host has been mutated', () => {
+      function getCommittedText() {
+        const yields = Scheduler.unstable_clearYields();
+        const children = ReactNoop.getChildren();
+        Scheduler.unstable_yieldValue(yields);
+        if (children === null) {
+          return null;
+        }
+        return children[0].prop;
+      }
+
+      function Counter(props) {
+        useLayoutEffect(() => {
+          Scheduler.unstable_yieldValue(`Current: ${getCommittedText()}`);
+        });
+        return <Text text={props.count} />;
+      }
+
+      ReactNoop.render(<Counter count={0} />, () =>
+        Scheduler.unstable_yieldValue('Sync effect'),
+      );
+      expect(Scheduler).toFlushAndYieldThrough([
+        [0],
+        'Current: 0',
+        'Sync effect',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(0)]);
+
+      ReactNoop.render(<Counter count={1} />, () =>
+        Scheduler.unstable_yieldValue('Sync effect'),
+      );
+      expect(Scheduler).toFlushAndYieldThrough([
+        [1],
+        'Current: 1',
+        'Sync effect',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span(1)]);
+    });
+
+    it('force flushes passive effects before firing new layout effects', () => {
+      let committedText = '(empty)';
+
+      function Counter(props) {
+        useLayoutEffect(() => {
+          // Normally this would go in a mutation effect, but this test
+          // intentionally omits a mutation effect.
+          committedText = props.count + '';
+
+          Scheduler.unstable_yieldValue(
+            `Mount layout [current: ${committedText}]`,
+          );
+          return () => {
+            Scheduler.unstable_yieldValue(
+              `Unmount layout [current: ${committedText}]`,
+            );
+          };
+        });
+        useEffect(() => {
+          Scheduler.unstable_yieldValue(
+            `Mount normal [current: ${committedText}]`,
+          );
+          return () => {
+            Scheduler.unstable_yieldValue(
+              `Unmount normal [current: ${committedText}]`,
+            );
+          };
+        });
+        return null;
+      }
+
+      act(() => {
+        ReactNoop.render(<Counter count={0} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Mount layout [current: 0]',
+          'Sync effect',
+        ]);
+        expect(committedText).toEqual('0');
+        ReactNoop.render(<Counter count={1} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough([
+          'Mount normal [current: 0]',
+          'Unmount layout [current: 0]',
+          'Mount layout [current: 1]',
+          'Sync effect',
+        ]);
+        expect(committedText).toEqual('1');
+      });
+
+      expect(Scheduler).toHaveYielded([
+        'Unmount normal [current: 1]',
+        'Mount normal [current: 1]',
+      ]);
+    });
+  });
+
+  describe('useCallback', () => {
+    it('memoizes callback by comparing inputs', () => {
+      class IncrementButton extends React.PureComponent {
+        increment = () => {
+          this.props.increment();
+        };
+        render() {
+          return <Text text="Increment" />;
+        }
+      }
+
+      function Counter({incrementBy}) {
+        const [count, updateCount] = useState(0);
+        const increment = useCallback(() => updateCount(c => c + incrementBy), [
+          incrementBy,
+        ]);
+        return (
+          <>
+            <IncrementButton increment={increment} ref={button} />
+            <Text text={'Count: ' + count} />
+          </>
+        );
+      }
+
+      const button = React.createRef(null);
+      ReactNoop.render(<Counter incrementBy={1} />);
+      expect(Scheduler).toFlushAndYield(['Increment', 'Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Increment'),
+        span('Count: 0'),
+      ]);
+
+      act(button.current.increment);
+      expect(Scheduler).toHaveYielded([
+        // Button should not re-render, because its props haven't changed
+        // 'Increment',
+        'Count: 1',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Increment'),
+        span('Count: 1'),
+      ]);
+
+      // Increase the increment amount
+      ReactNoop.render(<Counter incrementBy={10} />);
+      expect(Scheduler).toFlushAndYield([
+        // Inputs did change this time
+        'Increment',
+        'Count: 1',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Increment'),
+        span('Count: 1'),
+      ]);
+
+      // Callback should have updated
+      act(button.current.increment);
+      expect(Scheduler).toHaveYielded(['Count: 11']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('Increment'),
+        span('Count: 11'),
+      ]);
+    });
+  });
+
+  describe('useMemo', () => {
+    it('memoizes value by comparing to previous inputs', () => {
+      function CapitalizedText(props) {
+        const text = props.text;
+        const capitalizedText = useMemo(() => {
+          Scheduler.unstable_yieldValue(`Capitalize '${text}'`);
+          return text.toUpperCase();
+        }, [text]);
+        return <Text text={capitalizedText} />;
+      }
+
+      ReactNoop.render(<CapitalizedText text="hello" />);
+      expect(Scheduler).toFlushAndYield(["Capitalize 'hello'", 'HELLO']);
+      expect(ReactNoop.getChildren()).toEqual([span('HELLO')]);
+
+      ReactNoop.render(<CapitalizedText text="hi" />);
+      expect(Scheduler).toFlushAndYield(["Capitalize 'hi'", 'HI']);
+      expect(ReactNoop.getChildren()).toEqual([span('HI')]);
+
+      ReactNoop.render(<CapitalizedText text="hi" />);
+      expect(Scheduler).toFlushAndYield(['HI']);
+      expect(ReactNoop.getChildren()).toEqual([span('HI')]);
+
+      ReactNoop.render(<CapitalizedText text="goodbye" />);
+      expect(Scheduler).toFlushAndYield(["Capitalize 'goodbye'", 'GOODBYE']);
+      expect(ReactNoop.getChildren()).toEqual([span('GOODBYE')]);
+    });
+
+    it('always re-computes if no inputs are provided', () => {
+      function LazyCompute(props) {
+        const computed = useMemo(props.compute);
+        return <Text text={computed} />;
+      }
+
+      function computeA() {
+        Scheduler.unstable_yieldValue('compute A');
+        return 'A';
+      }
+
+      function computeB() {
+        Scheduler.unstable_yieldValue('compute B');
+        return 'B';
+      }
+
+      ReactNoop.render(<LazyCompute compute={computeA} />);
+      expect(Scheduler).toFlushAndYield(['compute A', 'A']);
+
+      ReactNoop.render(<LazyCompute compute={computeA} />);
+      expect(Scheduler).toFlushAndYield(['compute A', 'A']);
+
+      ReactNoop.render(<LazyCompute compute={computeA} />);
+      expect(Scheduler).toFlushAndYield(['compute A', 'A']);
+
+      ReactNoop.render(<LazyCompute compute={computeB} />);
+      expect(Scheduler).toFlushAndYield(['compute B', 'B']);
+    });
+
+    it('should not invoke memoized function during re-renders unless inputs change', () => {
+      function LazyCompute(props) {
+        const computed = useMemo(() => props.compute(props.input), [
+          props.input,
+        ]);
+        const [count, setCount] = useState(0);
+        if (count < 3) {
+          setCount(count + 1);
+        }
+        return <Text text={computed} />;
+      }
+
+      function compute(val) {
+        Scheduler.unstable_yieldValue('compute ' + val);
+        return val;
+      }
+
+      ReactNoop.render(<LazyCompute compute={compute} input="A" />);
+      expect(Scheduler).toFlushAndYield(['compute A', 'A']);
+
+      ReactNoop.render(<LazyCompute compute={compute} input="A" />);
+      expect(Scheduler).toFlushAndYield(['A']);
+
+      ReactNoop.render(<LazyCompute compute={compute} input="B" />);
+      expect(Scheduler).toFlushAndYield(['compute B', 'B']);
+    });
+  });
+
+  describe('useRef', () => {
+    it('creates a ref object initialized with the provided value', () => {
+      jest.useFakeTimers();
+
+      function useDebouncedCallback(callback, ms, inputs) {
+        const timeoutID = useRef(-1);
+        useEffect(() => {
+          return function unmount() {
+            clearTimeout(timeoutID.current);
+          };
+        }, []);
+        const debouncedCallback = useCallback(
+          (...args) => {
+            clearTimeout(timeoutID.current);
+            timeoutID.current = setTimeout(callback, ms, ...args);
+          },
+          [callback, ms],
+        );
+        return useCallback(debouncedCallback, inputs);
+      }
+
+      let ping;
+      function App() {
+        ping = useDebouncedCallback(
+          value => {
+            Scheduler.unstable_yieldValue('ping: ' + value);
+          },
+          100,
+          [],
+        );
+        return null;
+      }
+
+      act(() => {
+        ReactNoop.render(<App />);
+      });
+      expect(Scheduler).toHaveYielded([]);
+
+      ping(1);
+      ping(2);
+      ping(3);
+
+      expect(Scheduler).toHaveYielded([]);
+
+      jest.advanceTimersByTime(100);
+
+      expect(Scheduler).toHaveYielded(['ping: 3']);
+
+      ping(4);
+      jest.advanceTimersByTime(20);
+      ping(5);
+      ping(6);
+      jest.advanceTimersByTime(80);
+
+      expect(Scheduler).toHaveYielded([]);
+
+      jest.advanceTimersByTime(20);
+      expect(Scheduler).toHaveYielded(['ping: 6']);
+    });
+
+    it('should return the same ref during re-renders', () => {
+      function Counter() {
+        const ref = useRef('val');
+        const [count, setCount] = useState(0);
+        const [firstRef] = useState(ref);
+
+        if (firstRef !== ref) {
+          throw new Error('should never change');
+        }
+
+        if (count < 3) {
+          setCount(count + 1);
+        }
+
+        return <Text text={ref.current} />;
+      }
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield(['val']);
+
+      ReactNoop.render(<Counter />);
+      expect(Scheduler).toFlushAndYield(['val']);
+    });
+  });
+
+  describe('useImperativeHandle', () => {
+    it('does not update when deps are the same', () => {
+      const INCREMENT = 'INCREMENT';
+
+      function reducer(state, action) {
+        return action === INCREMENT ? state + 1 : state;
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(ref, () => ({count, dispatch}), []);
+        return <Text text={'Count: ' + count} />;
+      }
+
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      expect(counter.current.count).toBe(0);
+
+      act(() => {
+        counter.current.dispatch(INCREMENT);
+      });
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      // Intentionally not updated because of [] deps:
+      expect(counter.current.count).toBe(0);
+    });
+
+    // Regression test for https://github.com/facebook/react/issues/14782
+    it('automatically updates when deps are not specified', () => {
+      const INCREMENT = 'INCREMENT';
+
+      function reducer(state, action) {
+        return action === INCREMENT ? state + 1 : state;
+      }
+
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(ref, () => ({count, dispatch}));
+        return <Text text={'Count: ' + count} />;
+      }
+
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      expect(counter.current.count).toBe(0);
+
+      act(() => {
+        counter.current.dispatch(INCREMENT);
+      });
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      expect(counter.current.count).toBe(1);
+    });
+
+    it('updates when deps are different', () => {
+      const INCREMENT = 'INCREMENT';
+
+      function reducer(state, action) {
+        return action === INCREMENT ? state + 1 : state;
+      }
+
+      let totalRefUpdates = 0;
+      function Counter(props, ref) {
+        const [count, dispatch] = useReducer(reducer, 0);
+        useImperativeHandle(
+          ref,
+          () => {
+            totalRefUpdates++;
+            return {count, dispatch};
+          },
+          [count],
+        );
+        return <Text text={'Count: ' + count} />;
+      }
+
+      Counter = forwardRef(Counter);
+      const counter = React.createRef(null);
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
+      expect(counter.current.count).toBe(0);
+      expect(totalRefUpdates).toBe(1);
+
+      act(() => {
+        counter.current.dispatch(INCREMENT);
+      });
+      expect(Scheduler).toHaveYielded(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      expect(counter.current.count).toBe(1);
+      expect(totalRefUpdates).toBe(2);
+
+      // Update that doesn't change the ref dependencies
+      ReactNoop.render(<Counter ref={counter} />);
+      expect(Scheduler).toFlushAndYield(['Count: 1']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 1')]);
+      expect(counter.current.count).toBe(1);
+      expect(totalRefUpdates).toBe(2); // Should not increase since last time
+    });
+  });
+  describe('useTransition', () => {
+    it.experimental(
+      'delays showing loading state until after timeout',
+      async () => {
+        let transition;
+        function App() {
+          const [show, setShow] = useState(false);
+          const [startTransition, isPending] = useTransition({
+            timeoutMs: 1000,
+          });
+          transition = () => {
+            startTransition(() => {
+              setShow(true);
+            });
+          };
+          return (
+            <Suspense
+              fallback={<Text text={`Loading... Pending: ${isPending}`} />}>
+              {show ? (
+                <AsyncText ms={2000} text={`After... Pending: ${isPending}`} />
+              ) : (
+                <Text text={`Before... Pending: ${isPending}`} />
+              )}
+            </Suspense>
+          );
+        }
+        ReactNoop.render(<App />);
+        expect(Scheduler).toFlushAndYield(['Before... Pending: false']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: false'),
+        ]);
+
+        act(() => {
+          Scheduler.unstable_runWithPriority(
+            Scheduler.unstable_UserBlockingPriority,
+            transition,
+          );
+        });
+        Scheduler.unstable_advanceTime(500);
+        await advanceTimers(500);
+        expect(Scheduler).toHaveYielded([
+          'Before... Pending: true',
+          'Suspend! [After... Pending: false]',
+          'Loading... Pending: false',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: true'),
+        ]);
+
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
+        expect(ReactNoop.getChildren()).toEqual([
+          hiddenSpan('Before... Pending: true'),
+          span('Loading... Pending: false'),
+        ]);
+
+        Scheduler.unstable_advanceTime(500);
+        await advanceTimers(500);
+        expect(Scheduler).toHaveYielded([
+          'Promise resolved [After... Pending: false]',
+        ]);
+        expect(Scheduler).toFlushAndYield(['After... Pending: false']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('After... Pending: false'),
+        ]);
+      },
+    );
+    it.experimental(
+      'delays showing loading state until after busyDelayMs + busyMinDurationMs',
+      async () => {
+        let transition;
+        function App() {
+          const [show, setShow] = useState(false);
+          const [startTransition, isPending] = useTransition({
+            busyDelayMs: 1000,
+            busyMinDurationMs: 2000,
+          });
+          transition = () => {
+            startTransition(() => {
+              setShow(true);
+            });
+          };
+          return (
+            <Suspense
+              fallback={<Text text={`Loading... Pending: ${isPending}`} />}>
+              {show ? (
+                <AsyncText ms={2000} text={`After... Pending: ${isPending}`} />
+              ) : (
+                <Text text={`Before... Pending: ${isPending}`} />
+              )}
+            </Suspense>
+          );
+        }
+        ReactNoop.render(<App />);
+        expect(Scheduler).toFlushAndYield(['Before... Pending: false']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: false'),
+        ]);
+
+        act(() => {
+          Scheduler.unstable_runWithPriority(
+            Scheduler.unstable_UserBlockingPriority,
+            transition,
+          );
+        });
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
+        expect(Scheduler).toHaveYielded([
+          'Before... Pending: true',
+          'Suspend! [After... Pending: false]',
+          'Loading... Pending: false',
+        ]);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: true'),
+        ]);
+
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
+        expect(Scheduler).toHaveYielded([
+          'Promise resolved [After... Pending: false]',
+        ]);
+        expect(Scheduler).toFlushAndYield(['After... Pending: false']);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: true'),
+        ]);
+
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('Before... Pending: true'),
+        ]);
+        Scheduler.unstable_advanceTime(250);
+        await advanceTimers(250);
+        expect(ReactNoop.getChildren()).toEqual([
+          span('After... Pending: false'),
+        ]);
+      },
+    );
+  });
+  describe('useDeferredValue', () => {
+    it.experimental('defers text value until specified timeout', async () => {
+      function TextBox({text}) {
+        return <AsyncText ms={1000} text={text} />;
+      }
+
+      let _setText;
+      function App() {
+        const [text, setText] = useState('A');
+        const deferredText = useDeferredValue(text, {
+          timeoutMs: 500,
+        });
+        _setText = setText;
+        return (
+          <>
+            <Text text={text} />
+            <Suspense fallback={<Text text={'Loading'} />}>
+              <TextBox text={deferredText} />
+            </Suspense>
+          </>
+        );
+      }
+
+      act(() => {
+        ReactNoop.render(<App />);
+      });
+
+      expect(Scheduler).toHaveYielded(['A', 'Suspend! [A]', 'Loading']);
+      expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading')]);
+
+      Scheduler.unstable_advanceTime(1000);
+      await advanceTimers(1000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['A']);
+      expect(ReactNoop.getChildren()).toEqual([span('A'), span('A')]);
+
+      act(() => {
+        _setText('B');
+      });
+      expect(Scheduler).toHaveYielded([
+        'B',
+        'A',
+        'B',
+        'Suspend! [B]',
+        'Loading',
+      ]);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(ReactNoop.getChildren()).toEqual([span('B'), span('A')]);
+
+      Scheduler.unstable_advanceTime(250);
+      await advanceTimers(250);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(ReactNoop.getChildren()).toEqual([span('B'), span('A')]);
+
+      Scheduler.unstable_advanceTime(500);
+      await advanceTimers(500);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('B'),
+        hiddenSpan('A'),
+        span('Loading'),
+      ]);
+
+      Scheduler.unstable_advanceTime(250);
+      await advanceTimers(250);
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+
+      act(() => {
+        expect(Scheduler).toFlushAndYield(['B']);
+      });
+      expect(ReactNoop.getChildren()).toEqual([span('B'), span('B')]);
+    });
+  });
+
+  describe('progressive enhancement (not supported)', () => {
+    it('mount additional state', () => {
+      let updateA;
+      let updateB;
+      // let updateC;
+
+      function App(props) {
+        const [A, _updateA] = useState(0);
+        const [B, _updateB] = useState(0);
+        updateA = _updateA;
+        updateB = _updateB;
+
+        let C;
+        if (props.loadC) {
+          useState(0);
+        } else {
+          C = '[not loaded]';
+        }
+
+        return <Text text={`A: ${A}, B: ${B}, C: ${C}`} />;
+      }
+
+      ReactNoop.render(<App loadC={false} />);
+      expect(Scheduler).toFlushAndYield(['A: 0, B: 0, C: [not loaded]']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('A: 0, B: 0, C: [not loaded]'),
+      ]);
+
+      act(() => {
+        updateA(2);
+        updateB(3);
+      });
+
+      expect(Scheduler).toHaveYielded(['A: 2, B: 3, C: [not loaded]']);
+      expect(ReactNoop.getChildren()).toEqual([
+        span('A: 2, B: 3, C: [not loaded]'),
+      ]);
+
+      ReactNoop.render(<App loadC={true} />);
+      expect(() => {
+        expect(() => {
+          expect(Scheduler).toFlushAndYield(['A: 2, B: 3, C: 0']);
+        }).toThrow('Rendered more hooks than during the previous render');
+      }).toErrorDev([
+        'Warning: React has detected a change in the order of Hooks called by App. ' +
+          'This will lead to bugs and errors if not fixed. For more information, ' +
+          'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
+          '   Previous render            Next render\n' +
+          '   ------------------------------------------------------\n' +
+          '1. useState                   useState\n' +
+          '2. useState                   useState\n' +
+          '3. undefined                  useState\n' +
+          '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n',
+      ]);
+
+      // Uncomment if/when we support this again
+      // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 0')]);
+
+      // updateC(4);
+      // expect(Scheduler).toFlushAndYield(['A: 2, B: 3, C: 4']);
+      // expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
+    });
+
+    it('unmount state', () => {
+      let updateA;
+      let updateB;
+      let updateC;
+
+      function App(props) {
+        const [A, _updateA] = useState(0);
+        const [B, _updateB] = useState(0);
+        updateA = _updateA;
+        updateB = _updateB;
+
+        let C;
+        if (props.loadC) {
+          const [_C, _updateC] = useState(0);
+          C = _C;
+          updateC = _updateC;
+        } else {
+          C = '[not loaded]';
+        }
+
+        return <Text text={`A: ${A}, B: ${B}, C: ${C}`} />;
+      }
+
+      ReactNoop.render(<App loadC={true} />);
+      expect(Scheduler).toFlushAndYield(['A: 0, B: 0, C: 0']);
+      expect(ReactNoop.getChildren()).toEqual([span('A: 0, B: 0, C: 0')]);
+      act(() => {
+        updateA(2);
+        updateB(3);
+        updateC(4);
+      });
+      expect(Scheduler).toHaveYielded(['A: 2, B: 3, C: 4']);
+      expect(ReactNoop.getChildren()).toEqual([span('A: 2, B: 3, C: 4')]);
+      ReactNoop.render(<App loadC={false} />);
+      expect(Scheduler).toFlushAndThrow(
+        'Rendered fewer hooks than expected. This may be caused by an ' +
+          'accidental early return statement.',
+      );
+    });
+
+    it('unmount effects', () => {
+      function App(props) {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue('Mount A');
+          return () => {
+            Scheduler.unstable_yieldValue('Unmount A');
+          };
+        }, []);
+
+        if (props.showMore) {
+          useEffect(() => {
+            Scheduler.unstable_yieldValue('Mount B');
+            return () => {
+              Scheduler.unstable_yieldValue('Unmount B');
+            };
+          }, []);
+        }
+
+        return null;
+      }
+
+      act(() => {
+        ReactNoop.render(<App showMore={false} />, () =>
+          Scheduler.unstable_yieldValue('Sync effect'),
+        );
+        expect(Scheduler).toFlushAndYieldThrough(['Sync effect']);
+      });
+
+      expect(Scheduler).toHaveYielded(['Mount A']);
+
+      act(() => {
+        ReactNoop.render(<App showMore={true} />);
+        expect(() => {
+          expect(() => {
+            expect(Scheduler).toFlushAndYield([]);
+          }).toThrow('Rendered more hooks than during the previous render');
+        }).toErrorDev([
+          'Warning: React has detected a change in the order of Hooks called by App. ' +
+            'This will lead to bugs and errors if not fixed. For more information, ' +
+            'read the Rules of Hooks: https://fb.me/rules-of-hooks\n\n' +
+            '   Previous render            Next render\n' +
+            '   ------------------------------------------------------\n' +
+            '1. useEffect                  useEffect\n' +
+            '2. undefined                  useEffect\n' +
+            '   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n',
+        ]);
+      });
+
+      // Uncomment if/when we support this again
+      // ReactNoop.flushPassiveEffects();
+      // expect(Scheduler).toHaveYielded(['Mount B']);
+
+      // ReactNoop.render(<App showMore={false} />);
+      // expect(Scheduler).toFlushAndThrow(
+      //   'Rendered fewer hooks than expected. This may be caused by an ' +
+      //     'accidental early return statement.',
+      // );
+    });
+  });
+
+  it('eager bailout optimization should always compare to latest rendered reducer', () => {
+    // Edge case based on a bug report
+    let setCounter;
+    function App() {
+      const [counter, _setCounter] = useState(1);
+      setCounter = _setCounter;
+      return <Component count={counter} />;
+    }
+
+    function Component({count}) {
+      const [state, dispatch] = useReducer(() => {
+        // This reducer closes over a value from props. If the reducer is not
+        // properly updated, the eager reducer will compare to an old value
+        // and bail out incorrectly.
+        Scheduler.unstable_yieldValue('Reducer: ' + count);
+        return count;
+      }, -1);
+      useEffect(() => {
+        Scheduler.unstable_yieldValue('Effect: ' + count);
+        dispatch();
+      }, [count]);
+      Scheduler.unstable_yieldValue('Render: ' + state);
+      return count;
+    }
+
+    act(() => {
+      ReactNoop.render(<App />);
+      expect(Scheduler).toFlushAndYield([
+        'Render: -1',
+        'Effect: 1',
+        'Reducer: 1',
+        'Reducer: 1',
+        'Render: 1',
+      ]);
+      expect(ReactNoop).toMatchRenderedOutput('1');
+    });
+
+    act(() => {
+      setCounter(2);
+    });
+    expect(Scheduler).toHaveYielded([
+      'Render: 1',
+      'Effect: 2',
+      'Reducer: 2',
+      'Reducer: 2',
+      'Render: 2',
+    ]);
+    expect(ReactNoop).toMatchRenderedOutput('2');
+  });
+
+  // Regression test. Covers a case where an internal state variable
+  // (`didReceiveUpdate`) is not reset properly.
+  it('state bail out edge case (#16359)', async () => {
+    let setCounterA;
+    let setCounterB;
+
+    function CounterA() {
+      const [counter, setCounter] = useState(0);
+      setCounterA = setCounter;
+      Scheduler.unstable_yieldValue('Render A: ' + counter);
+      useEffect(() => {
+        Scheduler.unstable_yieldValue('Commit A: ' + counter);
+      });
+      return counter;
+    }
+
+    function CounterB() {
+      const [counter, setCounter] = useState(0);
+      setCounterB = setCounter;
+      Scheduler.unstable_yieldValue('Render B: ' + counter);
+      useEffect(() => {
+        Scheduler.unstable_yieldValue('Commit B: ' + counter);
+      });
+      return counter;
+    }
+
+    const root = ReactNoop.createRoot(null);
+    await ReactNoop.act(async () => {
+      root.render(
+        <>
+          <CounterA />
+          <CounterB />
+        </>,
+      );
+    });
+    expect(Scheduler).toHaveYielded([
+      'Render A: 0',
+      'Render B: 0',
+      'Commit A: 0',
+      'Commit B: 0',
+    ]);
+
+    await ReactNoop.act(async () => {
+      setCounterA(1);
+
+      // In the same batch, update B twice. To trigger the condition we're
+      // testing, the first update is necessary to bypass the early
+      // bailout optimization.
+      setCounterB(1);
+      setCounterB(0);
+    });
+    expect(Scheduler).toHaveYielded([
+      'Render A: 1',
+      'Render B: 0',
+      'Commit A: 1',
+      // B should not fire an effect because the update bailed out
+      // 'Commit B: 0',
+    ]);
+  });
+
+  it('should update latest rendered reducer when a preceding state receives a render phase update', () => {
+    // Similar to previous test, except using a preceding render phase update
+    // instead of new props.
+    let dispatch;
+    function App() {
+      const [step, setStep] = useState(0);
+      const [shadow, _dispatch] = useReducer(() => step, step);
+      dispatch = _dispatch;
+
+      if (step < 5) {
+        setStep(step + 1);
+      }
+
+      Scheduler.unstable_yieldValue(`Step: ${step}, Shadow: ${shadow}`);
+      return shadow;
+    }
+
+    ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield([
+      'Step: 0, Shadow: 0',
+      'Step: 1, Shadow: 0',
+      'Step: 2, Shadow: 0',
+      'Step: 3, Shadow: 0',
+      'Step: 4, Shadow: 0',
+      'Step: 5, Shadow: 0',
+    ]);
+    expect(ReactNoop).toMatchRenderedOutput('0');
+
+    act(() => dispatch());
+    expect(Scheduler).toHaveYielded(['Step: 5, Shadow: 5']);
+    expect(ReactNoop).toMatchRenderedOutput('5');
+  });
+
+  it('should process the rest pending updates after a render phase update', () => {
+    // Similar to previous test, except using a preceding render phase update
+    // instead of new props.
+    let updateA;
+    let updateC;
+    function App() {
+      const [a, setA] = useState(false);
+      const [b, setB] = useState(false);
+      if (a !== b) {
+        setB(a);
+      }
+      // Even though we called setB above,
+      // we should still apply the changes to C,
+      // during this render pass.
+      const [c, setC] = useState(false);
+      updateA = setA;
+      updateC = setC;
+      return `${a ? 'A' : 'a'}${b ? 'B' : 'b'}${c ? 'C' : 'c'}`;
+    }
+
+    act(() => ReactNoop.render(<App />));
+    expect(ReactNoop).toMatchRenderedOutput('abc');
+
+    act(() => {
+      updateA(true);
+      // This update should not get dropped.
+      updateC(true);
+    });
+    expect(ReactNoop).toMatchRenderedOutput('ABC');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -9,95 +9,1495 @@ let Suspense;
 let TextResource;
 let textResourceShouldFail;
 
-function loadModules({
-  deferPassiveEffectCleanupDuringUnmount,
-  runAllPassiveEffectDestroysBeforeCreates,
-}) {
-  ReactFeatureFlags = require('shared/ReactFeatureFlags');
-  ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
-  ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
-  ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
-  ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount = deferPassiveEffectCleanupDuringUnmount;
-  ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates = runAllPassiveEffectDestroysBeforeCreates;
-  React = require('react');
-  Fragment = React.Fragment;
-  ReactNoop = require('react-noop-renderer');
-  Scheduler = require('scheduler');
-  ReactCache = require('react-cache');
-  Suspense = React.Suspense;
+describe('ReactSuspenseWithNoopRenderer', () => {
+  if (!__EXPERIMENTAL__) {
+    it("empty test so Jest doesn't complain", () => {});
+    return;
+  }
 
-  TextResource = ReactCache.unstable_createResource(
-    ([text, ms = 0]) => {
-      return new Promise((resolve, reject) =>
-        setTimeout(() => {
-          if (textResourceShouldFail) {
-            Scheduler.unstable_yieldValue(`Promise rejected [${text}]`);
-            reject(new Error('Failed to load: ' + text));
-          } else {
-            Scheduler.unstable_yieldValue(`Promise resolved [${text}]`);
-            resolve(text);
-          }
-        }, ms),
+  beforeEach(() => {
+    jest.resetModules();
+
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
+    ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+    ReactFeatureFlags.flushSuspenseFallbacksInTests = false;
+    React = require('react');
+    Fragment = React.Fragment;
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    ReactCache = require('react-cache');
+    Suspense = React.Suspense;
+
+    TextResource = ReactCache.unstable_createResource(
+      ([text, ms = 0]) => {
+        return new Promise((resolve, reject) =>
+          setTimeout(() => {
+            if (textResourceShouldFail) {
+              Scheduler.unstable_yieldValue(`Promise rejected [${text}]`);
+              reject(new Error('Failed to load: ' + text));
+            } else {
+              Scheduler.unstable_yieldValue(`Promise resolved [${text}]`);
+              resolve(text);
+            }
+          }, ms),
+        );
+      },
+      ([text, ms]) => text,
+    );
+    textResourceShouldFail = false;
+  });
+
+  // function div(...children) {
+  //   children = children.map(
+  //     c => (typeof c === 'string' ? {text: c, hidden: false} : c),
+  //   );
+  //   return {type: 'div', children, prop: undefined, hidden: false};
+  // }
+
+  function span(prop) {
+    return {type: 'span', children: [], prop, hidden: false};
+  }
+
+  function hiddenSpan(prop) {
+    return {type: 'span', children: [], prop, hidden: true};
+  }
+
+  function advanceTimers(ms) {
+    // Note: This advances Jest's virtual time but not React's. Use
+    // ReactNoop.expire for that.
+    if (typeof ms !== 'number') {
+      throw new Error('Must specify ms');
+    }
+    jest.advanceTimersByTime(ms);
+    // Wait until the end of the current tick
+    // We cannot use a timer since we're faking them
+    return Promise.resolve().then(() => {});
+  }
+
+  function Text(props) {
+    Scheduler.unstable_yieldValue(props.text);
+    return <span prop={props.text} ref={props.hostRef} />;
+  }
+
+  function AsyncText(props) {
+    const text = props.text;
+    try {
+      TextResource.read([props.text, props.ms]);
+      Scheduler.unstable_yieldValue(text);
+      return <span prop={text} />;
+    } catch (promise) {
+      if (typeof promise.then === 'function') {
+        Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
+      } else {
+        Scheduler.unstable_yieldValue(`Error! [${text}]`);
+      }
+      throw promise;
+    }
+  }
+
+  it('does not restart rendering for initial render', async () => {
+    function Bar(props) {
+      Scheduler.unstable_yieldValue('Bar');
+      return props.children;
+    }
+
+    function Foo() {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <>
+          <Suspense fallback={<Text text="Loading..." />}>
+            <Bar>
+              <AsyncText text="A" ms={100} />
+              <Text text="B" />
+            </Bar>
+          </Suspense>
+          <Text text="C" />
+          <Text text="D" />
+        </>
       );
-    },
-    ([text, ms]) => text,
-  );
-  textResourceShouldFail = false;
-}
+    }
 
-[true, false].forEach(deferPassiveEffectCleanupDuringUnmount => {
-  [true, false].forEach(runAllPassiveEffectDestroysBeforeCreates => {
-    describe(`ReactSuspenseWithNoopRenderer deferPassiveEffectCleanupDuringUnmount:${deferPassiveEffectCleanupDuringUnmount} runAllPassiveEffectDestroysBeforeCreates:${runAllPassiveEffectDestroysBeforeCreates}`, () => {
-      if (!__EXPERIMENTAL__) {
-        it("empty test so Jest doesn't complain", () => {});
-        return;
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYieldThrough([
+      'Foo',
+      'Bar',
+      // A suspends
+      'Suspend! [A]',
+      // But we keep rendering the siblings
+      'B',
+      'Loading...',
+      'C',
+      // We leave D incomplete.
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush the promise completely
+    Scheduler.unstable_advanceTime(100);
+    await advanceTimers(100);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+
+    // Even though the promise has resolved, we should now flush
+    // and commit the in progress render instead of restarting.
+    expect(Scheduler).toFlushAndYield(['D']);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Loading...'),
+      span('C'),
+      span('D'),
+    ]);
+
+    // Await one micro task to attach the retry listeners.
+    await null;
+
+    // Next, we'll flush the complete content.
+    expect(Scheduler).toFlushAndYield(['Bar', 'A', 'B']);
+
+    expect(ReactNoop.getChildren()).toEqual([
+      span('A'),
+      span('B'),
+      span('C'),
+      span('D'),
+    ]);
+  });
+
+  it('suspends rendering and continues later', async () => {
+    function Bar(props) {
+      Scheduler.unstable_yieldValue('Bar');
+      return props.children;
+    }
+
+    function Foo({renderBar}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {renderBar ? (
+            <Bar>
+              <AsyncText text="A" ms={100} />
+              <Text text="B" />
+            </Bar>
+          ) : null}
+        </Suspense>
+      );
+    }
+
+    // Render empty shell.
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    // The update will suspend.
+    ReactNoop.render(<Foo renderBar={true} />);
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      'Bar',
+      // A suspends
+      'Suspend! [A]',
+      // But we keep rendering the siblings
+      'B',
+      'Loading...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush some of the time
+    await advanceTimers(50);
+    // Still nothing...
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush the promise completely
+    await advanceTimers(50);
+    // Renders successfully
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('suspends siblings and later recovers each independently', async () => {
+    // Render two sibling Suspense components
+    ReactNoop.render(
+      <Fragment>
+        <Suspense fallback={<Text text="Loading A..." />}>
+          <AsyncText text="A" ms={5000} />
+        </Suspense>
+        <Suspense fallback={<Text text="Loading B..." />}>
+          <AsyncText text="B" ms={6000} />
+        </Suspense>
+      </Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([
+      'Suspend! [A]',
+      'Loading A...',
+      'Suspend! [B]',
+      'Loading B...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Loading A...'),
+      span('Loading B...'),
+    ]);
+
+    // Advance time by enough that the first Suspense's promise resolves and
+    // switches back to the normal view. The second Suspense should still
+    // show the placeholder
+    ReactNoop.expire(5000);
+    await advanceTimers(5000);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading B...')]);
+
+    // Advance time by enough that the second Suspense's promise resolves
+    // and switches back to the normal view
+    ReactNoop.expire(1000);
+    await advanceTimers(1000);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(Scheduler).toFlushAndYield(['B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('continues rendering siblings after suspending', async () => {
+    // A shell is needed. The update cause it to suspend.
+    ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
+    expect(Scheduler).toFlushAndYield([]);
+    // B suspends. Continue rendering the remaining siblings.
+    ReactNoop.render(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <Text text="A" />
+        <AsyncText text="B" />
+        <Text text="C" />
+        <Text text="D" />
+      </Suspense>,
+    );
+    // B suspends. Continue rendering the remaining siblings.
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      'Suspend! [B]',
+      'C',
+      'D',
+      'Loading...',
+    ]);
+    // Did not commit yet.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Wait for data to resolve
+    await advanceTimers(100);
+    // Renders successfully
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(Scheduler).toFlushAndYield(['A', 'B', 'C', 'D']);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('A'),
+      span('B'),
+      span('C'),
+      span('D'),
+    ]);
+  });
+
+  it('retries on error', async () => {
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
       }
-
-      beforeEach(() => {
-        jest.resetModules();
-
-        loadModules({
-          deferPassiveEffectCleanupDuringUnmount,
-          runAllPassiveEffectDestroysBeforeCreates,
-        });
-      });
-
-      // function div(...children) {
-      //   children = children.map(
-      //     c => (typeof c === 'string' ? {text: c, hidden: false} : c),
-      //   );
-      //   return {type: 'div', children, prop: undefined, hidden: false};
-      // }
-
-      function span(prop) {
-        return {type: 'span', children: [], prop, hidden: false};
+      reset() {
+        this.setState({error: null});
       }
-
-      function hiddenSpan(prop) {
-        return {type: 'span', children: [], prop, hidden: true};
-      }
-
-      function advanceTimers(ms) {
-        // Note: This advances Jest's virtual time but not React's. Use
-        // ReactNoop.expire for that.
-        if (typeof ms !== 'number') {
-          throw new Error('Must specify ms');
+      render() {
+        if (this.state.error !== null) {
+          return <Text text={'Caught error: ' + this.state.error.message} />;
         }
-        jest.advanceTimersByTime(ms);
-        // Wait until the end of the current tick
-        // We cannot use a timer since we're faking them
-        return Promise.resolve().then(() => {});
+        return this.props.children;
+      }
+    }
+
+    const errorBoundary = React.createRef();
+    function App({renderContent}) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {renderContent ? (
+            <ErrorBoundary ref={errorBoundary}>
+              <AsyncText text="Result" ms={1000} />
+            </ErrorBoundary>
+          ) : null}
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.render(<App renderContent={true} />);
+    expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    textResourceShouldFail = true;
+    ReactNoop.expire(1000);
+    await advanceTimers(1000);
+    textResourceShouldFail = false;
+
+    expect(Scheduler).toHaveYielded(['Promise rejected [Result]']);
+
+    expect(Scheduler).toFlushAndYield([
+      'Error! [Result]',
+
+      // React retries one more time
+      'Error! [Result]',
+
+      // Errored again on retry. Now handle it.
+      'Caught error: Failed to load: Result',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Caught error: Failed to load: Result'),
+    ]);
+  });
+
+  it('retries on error after falling back to a placeholder', async () => {
+    class ErrorBoundary extends React.Component {
+      state = {error: null};
+      componentDidCatch(error) {
+        this.setState({error});
+      }
+      reset() {
+        this.setState({error: null});
+      }
+      render() {
+        if (this.state.error !== null) {
+          return <Text text={'Caught error: ' + this.state.error.message} />;
+        }
+        return this.props.children;
+      }
+    }
+
+    const errorBoundary = React.createRef();
+    function App() {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <ErrorBoundary ref={errorBoundary}>
+            <AsyncText text="Result" ms={3000} />
+          </ErrorBoundary>
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    textResourceShouldFail = true;
+    ReactNoop.expire(3000);
+    await advanceTimers(3000);
+    textResourceShouldFail = false;
+
+    expect(Scheduler).toHaveYielded(['Promise rejected [Result]']);
+    expect(Scheduler).toFlushAndYield([
+      'Error! [Result]',
+
+      // React retries one more time
+      'Error! [Result]',
+
+      // Errored again on retry. Now handle it.
+
+      'Caught error: Failed to load: Result',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Caught error: Failed to load: Result'),
+    ]);
+  });
+
+  it('can update at a higher priority while in a suspended state', async () => {
+    function App(props) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Text text={props.highPri} />
+          <AsyncText text={props.lowPri} />
+        </Suspense>
+      );
+    }
+
+    // Initial mount
+    ReactNoop.render(<App highPri="A" lowPri="1" />);
+    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [1]', 'Loading...']);
+    await advanceTimers(0);
+    expect(Scheduler).toHaveYielded(['Promise resolved [1]']);
+    expect(Scheduler).toFlushAndYield(['A', '1']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('1')]);
+
+    // Update the low-pri text
+    ReactNoop.render(<App highPri="A" lowPri="2" />);
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      // Suspends
+      'Suspend! [2]',
+      'Loading...',
+    ]);
+
+    // While we're still waiting for the low-pri update to complete, update the
+    // high-pri text at high priority.
+    ReactNoop.flushSync(() => {
+      ReactNoop.render(<App highPri="B" lowPri="1" />);
+    });
+    expect(Scheduler).toHaveYielded(['B', '1']);
+    expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
+
+    // Unblock the low-pri text and finish
+    await advanceTimers(0);
+    expect(Scheduler).toHaveYielded(['Promise resolved [2]']);
+    expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
+  });
+
+  it('keeps working on lower priority work after being pinged', async () => {
+    // Advance the virtual time so that we're close to the edge of a bucket.
+    ReactNoop.expire(149);
+
+    function App(props) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {props.showA && <AsyncText text="A" />}
+          {props.showB && <Text text="B" />}
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<App showA={false} showB={false} />);
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    ReactNoop.render(<App showA={true} showB={false} />);
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance React's virtual time by enough to fall into a new async bucket,
+    // but not enough to expire the suspense timeout.
+    ReactNoop.expire(120);
+    ReactNoop.render(<App showA={true} showB={true} />);
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'B', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    await advanceTimers(0);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('tries rendering a lower priority pending update even if a higher priority one suspends', async () => {
+    function App(props) {
+      if (props.hide) {
+        return <Text text="(empty)" />;
+      }
+      return (
+        <Suspense fallback="Loading...">
+          <AsyncText ms={2000} text="Async" />
+        </Suspense>
+      );
+    }
+
+    // Schedule a high pri update and a low pri update, without rendering in
+    // between.
+    ReactNoop.discreteUpdates(() => {
+      // High pri
+      ReactNoop.render(<App />);
+    });
+    // Low pri
+    ReactNoop.render(<App hide={true} />);
+
+    expect(Scheduler).toFlushAndYield([
+      // The first update suspends
+      'Suspend! [Async]',
+      // but we have another pending update that we can work on
+      '(empty)',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('(empty)')]);
+  });
+
+  it('tries each subsequent level after suspending', async () => {
+    const root = ReactNoop.createRoot();
+
+    function App({step, shouldSuspend}) {
+      return (
+        <Suspense fallback="Loading...">
+          <Text text="Sibling" />
+          {shouldSuspend ? (
+            <AsyncText ms={10000} text={'Step ' + step} />
+          ) : (
+            <Text text={'Step ' + step} />
+          )}
+        </Suspense>
+      );
+    }
+
+    function interrupt() {
+      // React has a heuristic to batch all updates that occur within the same
+      // event. This is a trick to circumvent that heuristic.
+      ReactNoop.flushSync(() => {
+        ReactNoop.renderToRootWithID(null, 'other-root');
+      });
+    }
+
+    // Mount the Suspense boundary without suspending, so that the subsequent
+    // updates suspend with a delay.
+    await ReactNoop.act(async () => {
+      root.render(<App step={0} shouldSuspend={false} />);
+    });
+    await advanceTimers(1000);
+    expect(Scheduler).toHaveYielded(['Sibling', 'Step 0']);
+
+    // Schedule an update at several distinct expiration times
+    await ReactNoop.act(async () => {
+      root.render(<App step={1} shouldSuspend={true} />);
+      Scheduler.unstable_advanceTime(1000);
+      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      interrupt();
+
+      root.render(<App step={2} shouldSuspend={true} />);
+      Scheduler.unstable_advanceTime(1000);
+      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      interrupt();
+
+      root.render(<App step={3} shouldSuspend={true} />);
+      Scheduler.unstable_advanceTime(1000);
+      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      interrupt();
+
+      root.render(<App step={4} shouldSuspend={false} />);
+    });
+
+    // Should suspend at each distinct level
+    expect(Scheduler).toHaveYielded([
+      'Sibling',
+      'Suspend! [Step 1]',
+      'Sibling',
+      'Suspend! [Step 2]',
+      'Sibling',
+      'Suspend! [Step 3]',
+      'Sibling',
+      'Step 4',
+    ]);
+  });
+
+  it('forces an expiration after an update times out', async () => {
+    ReactNoop.render(
+      <Fragment>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(
+      <Fragment>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={20000} />
+        </Suspense>
+        <Text text="Sync" />
+      </Fragment>,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      // The async child suspends
+      'Suspend! [Async]',
+      // Render the placeholder
+      'Loading...',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The update hasn't expired yet, so we commit nothing.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance both React's virtual time and Jest's timers by enough to expire
+    // the update, but not by enough to flush the suspending promise.
+    ReactNoop.expire(10000);
+    await advanceTimers(10000);
+    // No additional rendering work is required, since we already prepared
+    // the placeholder.
+    expect(Scheduler).toHaveYielded([]);
+    // Should have committed the placeholder.
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(10000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
+    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('switches to an inner fallback after suspending for a while', async () => {
+    // Advance the virtual time so that we're closer to the edge of a bucket.
+    ReactNoop.expire(200);
+
+    ReactNoop.render(
+      <Fragment>
+        <Text text="Sync" />
+        <Suspense fallback={<Text text="Loading outer..." />}>
+          <AsyncText text="Outer content" ms={300} />
+          <Suspense fallback={<Text text="Loading inner..." />}>
+            <AsyncText text="Inner content" ms={1000} />
+          </Suspense>
+        </Suspense>
+      </Fragment>,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      'Sync',
+      // The async content suspends
+      'Suspend! [Outer content]',
+      'Suspend! [Inner content]',
+      'Loading inner...',
+      'Loading outer...',
+    ]);
+    // The outer loading state finishes immediately.
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Sync'),
+      span('Loading outer...'),
+    ]);
+
+    // Resolve the outer promise.
+    ReactNoop.expire(300);
+    await advanceTimers(300);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Outer content]']);
+    expect(Scheduler).toFlushAndYield([
+      'Outer content',
+      'Suspend! [Inner content]',
+      'Loading inner...',
+    ]);
+    // Don't commit the inner placeholder yet.
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Sync'),
+      span('Loading outer...'),
+    ]);
+
+    // Expire the inner timeout.
+    ReactNoop.expire(500);
+    await advanceTimers(500);
+    // Now that 750ms have elapsed since the outer placeholder timed out,
+    // we can timeout the inner placeholder.
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Sync'),
+      span('Outer content'),
+      span('Loading inner...'),
+    ]);
+
+    // Finally, flush the inner promise. We should see the complete screen.
+    ReactNoop.expire(1000);
+    await advanceTimers(1000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Inner content]']);
+    expect(Scheduler).toFlushAndYield(['Inner content']);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Sync'),
+      span('Outer content'),
+      span('Inner content'),
+    ]);
+  });
+
+  it('renders an expiration boundary synchronously', async () => {
+    spyOnDev(console, 'error');
+    // Synchronously render a tree that suspends
+    ReactNoop.flushSync(() =>
+      ReactNoop.render(
+        <Fragment>
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText text="Async" />
+          </Suspense>
+          <Text text="Sync" />
+        </Fragment>,
+      ),
+    );
+    expect(Scheduler).toHaveYielded([
+      // The async child suspends
+      'Suspend! [Async]',
+      // We immediately render the fallback UI
+      'Loading...',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The tree commits synchronously
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(0);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
+    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('suspending inside an expired expiration boundary will bubble to the next one', async () => {
+    ReactNoop.flushSync(() =>
+      ReactNoop.render(
+        <Fragment>
+          <Suspense fallback={<Text text="Loading (outer)..." />}>
+            <Suspense fallback={<AsyncText text="Loading (inner)..." />}>
+              <AsyncText text="Async" />
+            </Suspense>
+            <Text text="Sync" />
+          </Suspense>
+        </Fragment>,
+      ),
+    );
+    expect(Scheduler).toHaveYielded([
+      'Suspend! [Async]',
+      'Suspend! [Loading (inner)...]',
+      'Sync',
+      'Loading (outer)...',
+    ]);
+    // The tree commits synchronously
+    expect(ReactNoop.getChildren()).toEqual([span('Loading (outer)...')]);
+  });
+
+  it('expires early by default', async () => {
+    ReactNoop.render(
+      <Fragment>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </Fragment>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(
+      <Fragment>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={3000} />
+        </Suspense>
+        <Text text="Sync" />
+      </Fragment>,
+    );
+
+    expect(Scheduler).toFlushAndYield([
+      // The async child suspends
+      'Suspend! [Async]',
+      'Loading...',
+      // Continue on the sibling
+      'Sync',
+    ]);
+    // The update hasn't expired yet, so we commit nothing.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance both React's virtual time and Jest's timers by enough to trigger
+    // the timeout, but not by enough to flush the promise or reach the true
+    // expiration time.
+    ReactNoop.expire(2000);
+    await advanceTimers(2000);
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...'), span('Sync')]);
+
+    // Once the promise resolves, we render the suspended view
+    await advanceTimers(1000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
+    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
+  });
+
+  it('resolves successfully even if fallback render is pending', async () => {
+    ReactNoop.render(
+      <>
+        <Suspense fallback={<Text text="Loading..." />} />
+      </>,
+    );
+    expect(Scheduler).toFlushAndYield([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+    ReactNoop.render(
+      <>
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="Async" ms={3000} />
+        </Suspense>
+      </>,
+    );
+    expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Async]']);
+    await advanceTimers(1500);
+    expect(Scheduler).toHaveYielded([]);
+    expect(ReactNoop.getChildren()).toEqual([]);
+    // Before we have a chance to flush, the promise resolves.
+    await advanceTimers(2000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
+    expect(Scheduler).toFlushAndYield([
+      // We've now pinged the boundary but we don't know if we should restart yet,
+      // because we haven't completed the suspense boundary.
+      'Loading...',
+      // Once we've completed the boundary we restarted.
+      'Async',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Async')]);
+  });
+
+  it('throws a helpful error when an update is suspends without a placeholder', () => {
+    ReactNoop.render(<AsyncText ms={1000} text="Async" />);
+    expect(Scheduler).toFlushAndThrow(
+      'AsyncText suspended while rendering, but no fallback UI was specified.',
+    );
+  });
+
+  it('a Suspense component correctly handles more than one suspended child', async () => {
+    ReactNoop.render(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <AsyncText text="A" ms={100} />
+        <AsyncText text="B" ms={100} />
+      </Suspense>,
+    );
+    Scheduler.unstable_advanceTime(10000);
+    expect(Scheduler).toFlushExpired([
+      'Suspend! [A]',
+      'Suspend! [B]',
+      'Loading...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    await advanceTimers(100);
+
+    expect(Scheduler).toHaveYielded([
+      'Promise resolved [A]',
+      'Promise resolved [B]',
+    ]);
+    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('can resume rendering earlier than a timeout', async () => {
+    ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
+    expect(Scheduler).toFlushAndYield([]);
+
+    ReactNoop.render(
+      <Suspense fallback={<Text text="Loading..." />}>
+        <AsyncText text="Async" ms={100} />
+      </Suspense>,
+    );
+    expect(Scheduler).toFlushAndYield(['Suspend! [Async]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Advance time by an amount slightly smaller than what's necessary to
+    // resolve the promise
+    await advanceTimers(99);
+
+    // Nothing has rendered yet
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Resolve the promise
+    await advanceTimers(1);
+    // We can now resume rendering
+    expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
+    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async')]);
+  });
+
+  it('starts working on an update even if its priority falls between two suspended levels', async () => {
+    function App(props) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {props.text === 'C' || props.text === 'S' ? (
+            <Text text={props.text} />
+          ) : (
+            <AsyncText text={props.text} ms={10000} />
+          )}
+        </Suspense>
+      );
+    }
+
+    // First mount without suspending. This ensures we already have content
+    // showing so that subsequent updates will suspend.
+    ReactNoop.render(<App text="S" />);
+    expect(Scheduler).toFlushAndYield(['S']);
+
+    // Schedule an update, and suspend for up to 5 seconds.
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App text="A" />),
+      {
+        timeoutMs: 5000,
+      },
+    );
+    // The update should suspend.
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([span('S')]);
+
+    // Advance time until right before it expires.
+    await advanceTimers(4999);
+    ReactNoop.expire(4999);
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([span('S')]);
+
+    // Schedule another low priority update.
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App text="B" />),
+      {
+        timeoutMs: 10000,
+      },
+    );
+    // This update should also suspend.
+    expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+    expect(ReactNoop.getChildren()).toEqual([span('S')]);
+
+    // Schedule a regular update. Its expiration time will fall between
+    // the expiration times of the previous two updates.
+    ReactNoop.render(<App text="C" />);
+    expect(Scheduler).toFlushAndYield(['C']);
+    expect(ReactNoop.getChildren()).toEqual([span('C')]);
+
+    await advanceTimers(10000);
+    // Flush the remaining work.
+    expect(Scheduler).toHaveYielded([
+      'Promise resolved [A]',
+      'Promise resolved [B]',
+    ]);
+    // Nothing else to render.
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([span('C')]);
+  });
+
+  it('flushes all expired updates in a single batch', async () => {
+    class Foo extends React.Component {
+      componentDidUpdate() {
+        Scheduler.unstable_yieldValue('Commit: ' + this.props.text);
+      }
+      componentDidMount() {
+        Scheduler.unstable_yieldValue('Commit: ' + this.props.text);
+      }
+      render() {
+        return (
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText ms={20000} text={this.props.text} />
+          </Suspense>
+        );
+      }
+    }
+
+    ReactNoop.render(<Foo text="" />);
+    ReactNoop.expire(1000);
+    jest.advanceTimersByTime(1000);
+    ReactNoop.render(<Foo text="go" />);
+    ReactNoop.expire(1000);
+    jest.advanceTimersByTime(1000);
+    ReactNoop.render(<Foo text="good" />);
+    ReactNoop.expire(1000);
+    jest.advanceTimersByTime(1000);
+    ReactNoop.render(<Foo text="goodbye" />);
+
+    Scheduler.unstable_advanceTime(10000);
+    jest.advanceTimersByTime(10000);
+
+    expect(Scheduler).toFlushExpired([
+      'Suspend! [goodbye]',
+      'Loading...',
+      'Commit: goodbye',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    Scheduler.unstable_advanceTime(20000);
+    await advanceTimers(20000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [goodbye]']);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    expect(Scheduler).toFlushAndYield(['goodbye']);
+    expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
+  });
+
+  it('a suspended update that expires', async () => {
+    // Regression test. This test used to fall into an infinite loop.
+    function ExpensiveText({text}) {
+      // This causes the update to expire.
+      Scheduler.unstable_advanceTime(10000);
+      // Then something suspends.
+      return <AsyncText text={text} ms={200000} />;
+    }
+
+    function App() {
+      return (
+        <Suspense fallback="Loading...">
+          <ExpensiveText text="A" />
+          <ExpensiveText text="B" />
+          <ExpensiveText text="C" />
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield([
+      'Suspend! [A]',
+      'Suspend! [B]',
+      'Suspend! [C]',
+    ]);
+    expect(ReactNoop).toMatchRenderedOutput('Loading...');
+
+    await advanceTimers(200000);
+    expect(Scheduler).toHaveYielded([
+      'Promise resolved [A]',
+      'Promise resolved [B]',
+      'Promise resolved [C]',
+    ]);
+
+    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <span prop="A" />
+        <span prop="B" />
+        <span prop="C" />
+      </>,
+    );
+  });
+
+  describe('legacy mode mode', () => {
+    it('times out immediately', async () => {
+      function App() {
+        return (
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText ms={100} text="Result" />
+          </Suspense>
+        );
       }
 
-      function Text(props) {
-        Scheduler.unstable_yieldValue(props.text);
-        return <span prop={props.text} ref={props.hostRef} />;
+      // Times out immediately, ignoring the specified threshold.
+      ReactNoop.renderLegacySyncRoot(<App />);
+      expect(Scheduler).toHaveYielded(['Suspend! [Result]', 'Loading...']);
+      expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+      ReactNoop.expire(100);
+      await advanceTimers(100);
+
+      expect(Scheduler).toHaveYielded(['Promise resolved [Result]']);
+      expect(Scheduler).toFlushExpired(['Result']);
+      expect(ReactNoop.getChildren()).toEqual([span('Result')]);
+    });
+
+    it('times out immediately when Suspense is in legacy mode', async () => {
+      class UpdatingText extends React.Component {
+        state = {step: 1};
+        render() {
+          return <AsyncText ms={100} text={`Step: ${this.state.step}`} />;
+        }
       }
 
-      function AsyncText(props) {
-        const text = props.text;
+      function Spinner() {
+        return (
+          <Fragment>
+            <Text text="Loading (1)" />
+            <Text text="Loading (2)" />
+            <Text text="Loading (3)" />
+          </Fragment>
+        );
+      }
+
+      const text = React.createRef(null);
+      function App() {
+        return (
+          <Suspense fallback={<Spinner />}>
+            <UpdatingText ref={text} />
+            <Text text="Sibling" />
+          </Suspense>
+        );
+      }
+
+      // Initial mount.
+      ReactNoop.renderLegacySyncRoot(<App />);
+      await advanceTimers(100);
+      expect(Scheduler).toHaveYielded([
+        'Suspend! [Step: 1]',
+        'Sibling',
+        'Loading (1)',
+        'Loading (2)',
+        'Loading (3)',
+        'Promise resolved [Step: 1]',
+      ]);
+      expect(Scheduler).toFlushExpired(['Step: 1']);
+      expect(ReactNoop).toMatchRenderedOutput(
+        <>
+          <span prop="Step: 1" />
+          <span prop="Sibling" />
+        </>,
+      );
+
+      // Update.
+      text.current.setState({step: 2}, () =>
+        Scheduler.unstable_yieldValue('Update did commit'),
+      );
+
+      expect(ReactNoop.flushNextYield()).toEqual([
+        'Suspend! [Step: 2]',
+        'Loading (1)',
+        'Loading (2)',
+        'Loading (3)',
+        'Update did commit',
+      ]);
+      expect(ReactNoop).toMatchRenderedOutput(
+        <>
+          <span hidden={true} prop="Step: 1" />
+          <span hidden={true} prop="Sibling" />
+          <span prop="Loading (1)" />
+          <span prop="Loading (2)" />
+          <span prop="Loading (3)" />
+        </>,
+      );
+
+      await advanceTimers(100);
+      expect(Scheduler).toHaveYielded(['Promise resolved [Step: 2]']);
+      expect(Scheduler).toFlushExpired(['Step: 2']);
+      expect(ReactNoop).toMatchRenderedOutput(
+        <>
+          <span prop="Step: 2" />
+          <span prop="Sibling" />
+        </>,
+      );
+    });
+
+    it('does not re-render siblings in loose mode', async () => {
+      class TextWithLifecycle extends React.Component {
+        componentDidMount() {
+          Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
+        }
+        componentDidUpdate() {
+          Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
+        }
+        render() {
+          return <Text {...this.props} />;
+        }
+      }
+
+      class AsyncTextWithLifecycle extends React.Component {
+        componentDidMount() {
+          Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
+        }
+        componentDidUpdate() {
+          Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
+        }
+        render() {
+          return <AsyncText {...this.props} />;
+        }
+      }
+
+      function App() {
+        return (
+          <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
+            <TextWithLifecycle text="A" />
+            <AsyncTextWithLifecycle ms={100} text="B" />
+            <TextWithLifecycle text="C" />
+          </Suspense>
+        );
+      }
+
+      ReactNoop.renderLegacySyncRoot(<App />, () =>
+        Scheduler.unstable_yieldValue('Commit root'),
+      );
+      expect(Scheduler).toHaveYielded([
+        'A',
+        'Suspend! [B]',
+        'C',
+
+        'Loading...',
+        'Mount [A]',
+        'Mount [B]',
+        'Mount [C]',
+        // This should be a mount, not an update.
+        'Mount [Loading...]',
+        'Commit root',
+      ]);
+      expect(ReactNoop).toMatchRenderedOutput(
+        <>
+          <span hidden={true} prop="A" />
+          <span hidden={true} prop="C" />
+
+          <span prop="Loading..." />
+        </>,
+      );
+
+      ReactNoop.expire(1000);
+      await advanceTimers(1000);
+
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+      expect(Scheduler).toFlushExpired(['B']);
+      expect(ReactNoop).toMatchRenderedOutput(
+        <>
+          <span prop="A" />
+          <span prop="B" />
+          <span prop="C" />
+        </>,
+      );
+    });
+
+    it('suspends inside constructor', async () => {
+      class AsyncTextInConstructor extends React.Component {
+        constructor(props) {
+          super(props);
+          const text = props.text;
+          Scheduler.unstable_yieldValue('constructor');
+          try {
+            TextResource.read([props.text, props.ms]);
+            this.state = {text};
+          } catch (promise) {
+            if (typeof promise.then === 'function') {
+              Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
+            } else {
+              Scheduler.unstable_yieldValue(`Error! [${text}]`);
+            }
+            throw promise;
+          }
+        }
+        componentDidMount() {
+          Scheduler.unstable_yieldValue('componentDidMount');
+        }
+        render() {
+          Scheduler.unstable_yieldValue(this.state.text);
+          return <span prop={this.state.text} />;
+        }
+      }
+
+      ReactNoop.renderLegacySyncRoot(
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncTextInConstructor ms={100} text="Hi" />
+        </Suspense>,
+      );
+
+      expect(Scheduler).toHaveYielded([
+        'constructor',
+        'Suspend! [Hi]',
+        'Loading...',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+      await advanceTimers(1000);
+
+      expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
+      expect(Scheduler).toFlushExpired([
+        'constructor',
+        'Hi',
+        'componentDidMount',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
+    });
+
+    it('does not infinite loop if fallback contains lifecycle method', async () => {
+      class Fallback extends React.Component {
+        state = {
+          name: 'foo',
+        };
+        componentDidMount() {
+          this.setState({
+            name: 'bar',
+          });
+        }
+        render() {
+          return <Text text="Loading..." />;
+        }
+      }
+
+      class Demo extends React.Component {
+        render() {
+          return (
+            <Suspense fallback={<Fallback />}>
+              <AsyncText text="Hi" ms={100} />
+            </Suspense>
+          );
+        }
+      }
+
+      ReactNoop.renderLegacySyncRoot(<Demo />);
+
+      expect(Scheduler).toHaveYielded([
+        'Suspend! [Hi]',
+        'Loading...',
+        // Re-render due to lifecycle update
+        'Loading...',
+      ]);
+      expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+      await advanceTimers(100);
+      expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
+      expect(Scheduler).toFlushExpired(['Hi']);
+      expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
+    });
+
+    if (global.__PERSISTENT__) {
+      it('hides/unhides suspended children before layout effects fire (persistent)', async () => {
+        const {useRef, useLayoutEffect} = React;
+
+        function Parent() {
+          const child = useRef(null);
+
+          useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue(ReactNoop.getPendingChildrenAsJSX());
+          });
+
+          return (
+            <span ref={child} hidden={false}>
+              <AsyncText ms={1000} text="Hi" />
+            </span>
+          );
+        }
+
+        function App(props) {
+          return (
+            <Suspense fallback={<Text text="Loading..." />}>
+              <Parent />
+            </Suspense>
+          );
+        }
+
+        ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
+
+        expect(Scheduler).toHaveYielded([
+          'Suspend! [Hi]',
+          'Loading...',
+          // The child should have already been hidden
+          <>
+            <span hidden={true} />
+            <span prop="Loading..." />
+          </>,
+        ]);
+
+        await advanceTimers(1000);
+
+        expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
+        expect(Scheduler).toFlushExpired(['Hi']);
+      });
+    } else {
+      it('hides/unhides suspended children before layout effects fire (mutation)', async () => {
+        const {useRef, useLayoutEffect} = React;
+
+        function Parent() {
+          const child = useRef(null);
+
+          useLayoutEffect(() => {
+            Scheduler.unstable_yieldValue(
+              'Child is hidden: ' + child.current.hidden,
+            );
+          });
+
+          return (
+            <span ref={child} hidden={false}>
+              <AsyncText ms={1000} text="Hi" />
+            </span>
+          );
+        }
+
+        function App(props) {
+          return (
+            <Suspense fallback={<Text text="Loading..." />}>
+              <Parent />
+            </Suspense>
+          );
+        }
+
+        ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
+
+        expect(Scheduler).toHaveYielded([
+          'Suspend! [Hi]',
+          'Loading...',
+          // The child should have already been hidden
+          'Child is hidden: true',
+        ]);
+
+        await advanceTimers(1000);
+
+        expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
+        expect(Scheduler).toFlushExpired(['Hi']);
+      });
+    }
+
+    it('handles errors in the return path of a component that suspends', async () => {
+      // Covers an edge case where an error is thrown inside the complete phase
+      // of a component that is in the return path of a component that suspends.
+      // The second error should also be handled (i.e. able to be captured by
+      // an error boundary.
+      class ErrorBoundary extends React.Component {
+        state = {error: null};
+        static getDerivedStateFromError(error, errorInfo) {
+          return {error};
+        }
+        render() {
+          if (this.state.error) {
+            return `Caught an error: ${this.state.error.message}`;
+          }
+          return this.props.children;
+        }
+      }
+
+      ReactNoop.renderLegacySyncRoot(
+        <ErrorBoundary>
+          <Suspense fallback="Loading...">
+            <errorInCompletePhase>
+              <AsyncText ms={1000} text="Async" />
+            </errorInCompletePhase>
+          </Suspense>
+        </ErrorBoundary>,
+      );
+
+      expect(Scheduler).toHaveYielded(['Suspend! [Async]']);
+      expect(ReactNoop).toMatchRenderedOutput(
+        'Caught an error: Error in host config.',
+      );
+    });
+
+    it('does not drop mounted effects', async () => {
+      let never = {then() {}};
+
+      let setShouldSuspend;
+      function App() {
+        const [shouldSuspend, _setShouldSuspend] = React.useState(0);
+        setShouldSuspend = _setShouldSuspend;
+        return (
+          <Suspense fallback="Loading...">
+            <Child shouldSuspend={shouldSuspend} />
+          </Suspense>
+        );
+      }
+
+      function Child({shouldSuspend}) {
+        if (shouldSuspend) {
+          throw never;
+        }
+
+        React.useEffect(() => {
+          Scheduler.unstable_yieldValue('Mount');
+          return () => {
+            Scheduler.unstable_yieldValue('Unmount');
+          };
+        }, []);
+
+        return 'Child';
+      }
+
+      const root = ReactNoop.createLegacyRoot(null);
+      await ReactNoop.act(async () => {
+        root.render(<App />);
+      });
+      expect(Scheduler).toHaveYielded(['Mount']);
+      expect(root).toMatchRenderedOutput('Child');
+
+      // Suspend the child. This puts it into an inconsistent state.
+      await ReactNoop.act(async () => {
+        setShouldSuspend(true);
+      });
+      expect(root).toMatchRenderedOutput('Loading...');
+
+      // Unmount everying
+      await ReactNoop.act(async () => {
+        root.render(null);
+      });
+      expect(Scheduler).toHaveYielded(['Unmount']);
+    });
+  });
+
+  it('does not call lifecycles of a suspended component', async () => {
+    class TextWithLifecycle extends React.Component {
+      componentDidMount() {
+        Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
+      }
+      componentDidUpdate() {
+        Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
+      }
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue(`Unmount [${this.props.text}]`);
+      }
+      render() {
+        return <Text {...this.props} />;
+      }
+    }
+
+    class AsyncTextWithLifecycle extends React.Component {
+      componentDidMount() {
+        Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
+      }
+      componentDidUpdate() {
+        Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
+      }
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue(`Unmount [${this.props.text}]`);
+      }
+      render() {
+        const text = this.props.text;
+        const ms = this.props.ms;
         try {
-          TextResource.read([props.text, props.ms]);
+          TextResource.read([text, ms]);
           Scheduler.unstable_yieldValue(text);
           return <span prop={text} />;
         } catch (promise) {
@@ -109,2896 +1509,1439 @@ function loadModules({
           throw promise;
         }
       }
-
-      it('does not restart rendering for initial render', async () => {
-        function Bar(props) {
-          Scheduler.unstable_yieldValue('Bar');
-          return props.children;
-        }
-
-        function Foo() {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <>
-              <Suspense fallback={<Text text="Loading..." />}>
-                <Bar>
-                  <AsyncText text="A" ms={100} />
-                  <Text text="B" />
-                </Bar>
-              </Suspense>
-              <Text text="C" />
-              <Text text="D" />
-            </>
-          );
-        }
-
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYieldThrough([
-          'Foo',
-          'Bar',
-          // A suspends
-          'Suspend! [A]',
-          // But we keep rendering the siblings
-          'B',
-          'Loading...',
-          'C',
-          // We leave D incomplete.
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Flush the promise completely
-        Scheduler.unstable_advanceTime(100);
-        await advanceTimers(100);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-
-        // Even though the promise has resolved, we should now flush
-        // and commit the in progress render instead of restarting.
-        expect(Scheduler).toFlushAndYield(['D']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Loading...'),
-          span('C'),
-          span('D'),
-        ]);
-
-        // Await one micro task to attach the retry listeners.
-        await null;
-
-        // Next, we'll flush the complete content.
-        expect(Scheduler).toFlushAndYield(['Bar', 'A', 'B']);
-
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('B'),
-          span('C'),
-          span('D'),
-        ]);
-      });
-
-      it('suspends rendering and continues later', async () => {
-        function Bar(props) {
-          Scheduler.unstable_yieldValue('Bar');
-          return props.children;
-        }
-
-        function Foo({renderBar}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {renderBar ? (
-                <Bar>
-                  <AsyncText text="A" ms={100} />
-                  <Text text="B" />
-                </Bar>
-              ) : null}
-            </Suspense>
-          );
-        }
-
-        // Render empty shell.
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield(['Foo']);
-
-        // The update will suspend.
-        ReactNoop.render(<Foo renderBar={true} />);
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          'Bar',
-          // A suspends
-          'Suspend! [A]',
-          // But we keep rendering the siblings
-          'B',
-          'Loading...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Flush some of the time
-        await advanceTimers(50);
-        // Still nothing...
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Flush the promise completely
-        await advanceTimers(50);
-        // Renders successfully
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('suspends siblings and later recovers each independently', async () => {
-        // Render two sibling Suspense components
-        ReactNoop.render(
-          <Fragment>
-            <Suspense fallback={<Text text="Loading A..." />}>
-              <AsyncText text="A" ms={5000} />
-            </Suspense>
-            <Suspense fallback={<Text text="Loading B..." />}>
-              <AsyncText text="B" ms={6000} />
-            </Suspense>
-          </Fragment>,
-        );
-        expect(Scheduler).toFlushAndYield([
-          'Suspend! [A]',
-          'Loading A...',
-          'Suspend! [B]',
-          'Loading B...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Loading A...'),
-          span('Loading B...'),
-        ]);
-
-        // Advance time by enough that the first Suspense's promise resolves and
-        // switches back to the normal view. The second Suspense should still
-        // show the placeholder
-        ReactNoop.expire(5000);
-        await advanceTimers(5000);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['A']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('Loading B...'),
-        ]);
-
-        // Advance time by enough that the second Suspense's promise resolves
-        // and switches back to the normal view
-        ReactNoop.expire(1000);
-        await advanceTimers(1000);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(Scheduler).toFlushAndYield(['B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('continues rendering siblings after suspending', async () => {
-        // A shell is needed. The update cause it to suspend.
-        ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
-        expect(Scheduler).toFlushAndYield([]);
-        // B suspends. Continue rendering the remaining siblings.
-        ReactNoop.render(
-          <Suspense fallback={<Text text="Loading..." />}>
-            <Text text="A" />
-            <AsyncText text="B" />
-            <Text text="C" />
-            <Text text="D" />
-          </Suspense>,
-        );
-        // B suspends. Continue rendering the remaining siblings.
-        expect(Scheduler).toFlushAndYield([
-          'A',
-          'Suspend! [B]',
-          'C',
-          'D',
-          'Loading...',
-        ]);
-        // Did not commit yet.
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Wait for data to resolve
-        await advanceTimers(100);
-        // Renders successfully
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(Scheduler).toFlushAndYield(['A', 'B', 'C', 'D']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('B'),
-          span('C'),
-          span('D'),
-        ]);
-      });
-
-      it('retries on error', async () => {
-        class ErrorBoundary extends React.Component {
-          state = {error: null};
-          componentDidCatch(error) {
-            this.setState({error});
-          }
-          reset() {
-            this.setState({error: null});
-          }
-          render() {
-            if (this.state.error !== null) {
-              return (
-                <Text text={'Caught error: ' + this.state.error.message} />
-              );
-            }
-            return this.props.children;
-          }
-        }
-
-        const errorBoundary = React.createRef();
-        function App({renderContent}) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {renderContent ? (
-                <ErrorBoundary ref={errorBoundary}>
-                  <AsyncText text="Result" ms={1000} />
-                </ErrorBoundary>
-              ) : null}
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<App />);
-        expect(Scheduler).toFlushAndYield([]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        ReactNoop.render(<App renderContent={true} />);
-        expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        textResourceShouldFail = true;
-        ReactNoop.expire(1000);
-        await advanceTimers(1000);
-        textResourceShouldFail = false;
-
-        expect(Scheduler).toHaveYielded(['Promise rejected [Result]']);
-
-        expect(Scheduler).toFlushAndYield([
-          'Error! [Result]',
-
-          // React retries one more time
-          'Error! [Result]',
-
-          // Errored again on retry. Now handle it.
-          'Caught error: Failed to load: Result',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Caught error: Failed to load: Result'),
-        ]);
-      });
-
-      it('retries on error after falling back to a placeholder', async () => {
-        class ErrorBoundary extends React.Component {
-          state = {error: null};
-          componentDidCatch(error) {
-            this.setState({error});
-          }
-          reset() {
-            this.setState({error: null});
-          }
-          render() {
-            if (this.state.error !== null) {
-              return (
-                <Text text={'Caught error: ' + this.state.error.message} />
-              );
-            }
-            return this.props.children;
-          }
-        }
-
-        const errorBoundary = React.createRef();
-        function App() {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <ErrorBoundary ref={errorBoundary}>
-                <AsyncText text="Result" ms={3000} />
-              </ErrorBoundary>
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<App />);
-        expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        textResourceShouldFail = true;
-        ReactNoop.expire(3000);
-        await advanceTimers(3000);
-        textResourceShouldFail = false;
-
-        expect(Scheduler).toHaveYielded(['Promise rejected [Result]']);
-        expect(Scheduler).toFlushAndYield([
-          'Error! [Result]',
-
-          // React retries one more time
-          'Error! [Result]',
-
-          // Errored again on retry. Now handle it.
-
-          'Caught error: Failed to load: Result',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Caught error: Failed to load: Result'),
-        ]);
-      });
-
-      it('can update at a higher priority while in a suspended state', async () => {
-        function App(props) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <Text text={props.highPri} />
-              <AsyncText text={props.lowPri} />
-            </Suspense>
-          );
-        }
-
-        // Initial mount
-        ReactNoop.render(<App highPri="A" lowPri="1" />);
-        expect(Scheduler).toFlushAndYield(['A', 'Suspend! [1]', 'Loading...']);
-        await advanceTimers(0);
-        expect(Scheduler).toHaveYielded(['Promise resolved [1]']);
-        expect(Scheduler).toFlushAndYield(['A', '1']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('1')]);
-
-        // Update the low-pri text
-        ReactNoop.render(<App highPri="A" lowPri="2" />);
-        expect(Scheduler).toFlushAndYield([
-          'A',
-          // Suspends
-          'Suspend! [2]',
-          'Loading...',
-        ]);
-
-        // While we're still waiting for the low-pri update to complete, update the
-        // high-pri text at high priority.
-        ReactNoop.flushSync(() => {
-          ReactNoop.render(<App highPri="B" lowPri="1" />);
-        });
-        expect(Scheduler).toHaveYielded(['B', '1']);
-        expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
-
-        // Unblock the low-pri text and finish
-        await advanceTimers(0);
-        expect(Scheduler).toHaveYielded(['Promise resolved [2]']);
-        expect(ReactNoop.getChildren()).toEqual([span('B'), span('1')]);
-      });
-
-      it('keeps working on lower priority work after being pinged', async () => {
-        // Advance the virtual time so that we're close to the edge of a bucket.
-        ReactNoop.expire(149);
-
-        function App(props) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {props.showA && <AsyncText text="A" />}
-              {props.showB && <Text text="B" />}
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<App showA={false} showB={false} />);
-        expect(Scheduler).toFlushAndYield([]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        ReactNoop.render(<App showA={true} showB={false} />);
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Advance React's virtual time by enough to fall into a new async bucket,
-        // but not enough to expire the suspense timeout.
-        ReactNoop.expire(120);
-        ReactNoop.render(<App showA={true} showB={true} />);
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'B', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        await advanceTimers(0);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['A', 'B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('tries rendering a lower priority pending update even if a higher priority one suspends', async () => {
-        function App(props) {
-          if (props.hide) {
-            return <Text text="(empty)" />;
-          }
-          return (
-            <Suspense fallback="Loading...">
-              <AsyncText ms={2000} text="Async" />
-            </Suspense>
-          );
-        }
-
-        // Schedule a high pri update and a low pri update, without rendering in
-        // between.
-        ReactNoop.discreteUpdates(() => {
-          // High pri
-          ReactNoop.render(<App />);
-        });
-        // Low pri
-        ReactNoop.render(<App hide={true} />);
-
-        expect(Scheduler).toFlushAndYield([
-          // The first update suspends
-          'Suspend! [Async]',
-          // but we have another pending update that we can work on
-          '(empty)',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('(empty)')]);
-      });
-
-      it('tries each subsequent level after suspending', async () => {
-        const root = ReactNoop.createRoot();
-
-        function App({step, shouldSuspend}) {
-          return (
-            <Suspense fallback="Loading...">
-              <Text text="Sibling" />
-              {shouldSuspend ? (
-                <AsyncText ms={10000} text={'Step ' + step} />
-              ) : (
-                <Text text={'Step ' + step} />
-              )}
-            </Suspense>
-          );
-        }
-
-        function interrupt() {
-          // React has a heuristic to batch all updates that occur within the same
-          // event. This is a trick to circumvent that heuristic.
-          ReactNoop.flushSync(() => {
-            ReactNoop.renderToRootWithID(null, 'other-root');
-          });
-        }
-
-        // Mount the Suspense boundary without suspending, so that the subsequent
-        // updates suspend with a delay.
-        await ReactNoop.act(async () => {
-          root.render(<App step={0} shouldSuspend={false} />);
-        });
-        await advanceTimers(1000);
-        expect(Scheduler).toHaveYielded(['Sibling', 'Step 0']);
-
-        // Schedule an update at several distinct expiration times
-        await ReactNoop.act(async () => {
-          root.render(<App step={1} shouldSuspend={true} />);
-          Scheduler.unstable_advanceTime(1000);
-          expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
-          interrupt();
-
-          root.render(<App step={2} shouldSuspend={true} />);
-          Scheduler.unstable_advanceTime(1000);
-          expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
-          interrupt();
-
-          root.render(<App step={3} shouldSuspend={true} />);
-          Scheduler.unstable_advanceTime(1000);
-          expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
-          interrupt();
-
-          root.render(<App step={4} shouldSuspend={false} />);
-        });
-
-        // Should suspend at each distinct level
-        expect(Scheduler).toHaveYielded([
-          'Sibling',
-          'Suspend! [Step 1]',
-          'Sibling',
-          'Suspend! [Step 2]',
-          'Sibling',
-          'Suspend! [Step 3]',
-          'Sibling',
-          'Step 4',
-        ]);
-      });
-
-      it('forces an expiration after an update times out', async () => {
-        ReactNoop.render(
-          <Fragment>
-            <Suspense fallback={<Text text="Loading..." />} />
-          </Fragment>,
-        );
-        expect(Scheduler).toFlushAndYield([]);
-
-        ReactNoop.render(
-          <Fragment>
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text="Async" ms={20000} />
-            </Suspense>
-            <Text text="Sync" />
-          </Fragment>,
-        );
-
-        expect(Scheduler).toFlushAndYield([
-          // The async child suspends
-          'Suspend! [Async]',
-          // Render the placeholder
-          'Loading...',
-          // Continue on the sibling
-          'Sync',
-        ]);
-        // The update hasn't expired yet, so we commit nothing.
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Advance both React's virtual time and Jest's timers by enough to expire
-        // the update, but not by enough to flush the suspending promise.
-        ReactNoop.expire(10000);
-        await advanceTimers(10000);
-        // No additional rendering work is required, since we already prepared
-        // the placeholder.
-        expect(Scheduler).toHaveYielded([]);
-        // Should have committed the placeholder.
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Loading...'),
-          span('Sync'),
-        ]);
-
-        // Once the promise resolves, we render the suspended view
-        await advanceTimers(10000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-        expect(Scheduler).toFlushAndYield(['Async']);
-        expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
-      });
-
-      it('switches to an inner fallback after suspending for a while', async () => {
-        // Advance the virtual time so that we're closer to the edge of a bucket.
-        ReactNoop.expire(200);
-
-        ReactNoop.render(
-          <Fragment>
-            <Text text="Sync" />
-            <Suspense fallback={<Text text="Loading outer..." />}>
-              <AsyncText text="Outer content" ms={300} />
-              <Suspense fallback={<Text text="Loading inner..." />}>
-                <AsyncText text="Inner content" ms={1000} />
-              </Suspense>
-            </Suspense>
-          </Fragment>,
-        );
-
-        expect(Scheduler).toFlushAndYield([
-          'Sync',
-          // The async content suspends
-          'Suspend! [Outer content]',
-          'Suspend! [Inner content]',
-          'Loading inner...',
-          'Loading outer...',
-        ]);
-        // The outer loading state finishes immediately.
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Sync'),
-          span('Loading outer...'),
-        ]);
-
-        // Resolve the outer promise.
-        ReactNoop.expire(300);
-        await advanceTimers(300);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Outer content]']);
-        expect(Scheduler).toFlushAndYield([
-          'Outer content',
-          'Suspend! [Inner content]',
-          'Loading inner...',
-        ]);
-        // Don't commit the inner placeholder yet.
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Sync'),
-          span('Loading outer...'),
-        ]);
-
-        // Expire the inner timeout.
-        ReactNoop.expire(500);
-        await advanceTimers(500);
-        // Now that 750ms have elapsed since the outer placeholder timed out,
-        // we can timeout the inner placeholder.
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Sync'),
-          span('Outer content'),
-          span('Loading inner...'),
-        ]);
-
-        // Finally, flush the inner promise. We should see the complete screen.
-        ReactNoop.expire(1000);
-        await advanceTimers(1000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Inner content]']);
-        expect(Scheduler).toFlushAndYield(['Inner content']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Sync'),
-          span('Outer content'),
-          span('Inner content'),
-        ]);
-      });
-
-      it('renders an expiration boundary synchronously', async () => {
-        spyOnDev(console, 'error');
-        // Synchronously render a tree that suspends
-        ReactNoop.flushSync(() =>
-          ReactNoop.render(
-            <Fragment>
-              <Suspense fallback={<Text text="Loading..." />}>
-                <AsyncText text="Async" />
-              </Suspense>
-              <Text text="Sync" />
-            </Fragment>,
-          ),
-        );
-        expect(Scheduler).toHaveYielded([
-          // The async child suspends
-          'Suspend! [Async]',
-          // We immediately render the fallback UI
-          'Loading...',
-          // Continue on the sibling
-          'Sync',
-        ]);
-        // The tree commits synchronously
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Loading...'),
-          span('Sync'),
-        ]);
-
-        // Once the promise resolves, we render the suspended view
-        await advanceTimers(0);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-        expect(Scheduler).toFlushAndYield(['Async']);
-        expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
-      });
-
-      it('suspending inside an expired expiration boundary will bubble to the next one', async () => {
-        ReactNoop.flushSync(() =>
-          ReactNoop.render(
-            <Fragment>
-              <Suspense fallback={<Text text="Loading (outer)..." />}>
-                <Suspense fallback={<AsyncText text="Loading (inner)..." />}>
-                  <AsyncText text="Async" />
-                </Suspense>
-                <Text text="Sync" />
-              </Suspense>
-            </Fragment>,
-          ),
-        );
-        expect(Scheduler).toHaveYielded([
-          'Suspend! [Async]',
-          'Suspend! [Loading (inner)...]',
-          'Sync',
-          'Loading (outer)...',
-        ]);
-        // The tree commits synchronously
-        expect(ReactNoop.getChildren()).toEqual([span('Loading (outer)...')]);
-      });
-
-      it('expires early by default', async () => {
-        ReactNoop.render(
-          <Fragment>
-            <Suspense fallback={<Text text="Loading..." />} />
-          </Fragment>,
-        );
-        expect(Scheduler).toFlushAndYield([]);
-
-        ReactNoop.render(
-          <Fragment>
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text="Async" ms={3000} />
-            </Suspense>
-            <Text text="Sync" />
-          </Fragment>,
-        );
-
-        expect(Scheduler).toFlushAndYield([
-          // The async child suspends
-          'Suspend! [Async]',
-          'Loading...',
-          // Continue on the sibling
-          'Sync',
-        ]);
-        // The update hasn't expired yet, so we commit nothing.
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Advance both React's virtual time and Jest's timers by enough to trigger
-        // the timeout, but not by enough to flush the promise or reach the true
-        // expiration time.
-        ReactNoop.expire(2000);
-        await advanceTimers(2000);
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Loading...'),
-          span('Sync'),
-        ]);
-
-        // Once the promise resolves, we render the suspended view
-        await advanceTimers(1000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-        expect(Scheduler).toFlushAndYield(['Async']);
-        expect(ReactNoop.getChildren()).toEqual([span('Async'), span('Sync')]);
-      });
-
-      it('resolves successfully even if fallback render is pending', async () => {
-        ReactNoop.render(
-          <>
-            <Suspense fallback={<Text text="Loading..." />} />
-          </>,
-        );
-        expect(Scheduler).toFlushAndYield([]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-        ReactNoop.render(
-          <>
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text="Async" ms={3000} />
-            </Suspense>
-          </>,
-        );
-        expect(ReactNoop.flushNextYield()).toEqual(['Suspend! [Async]']);
-        await advanceTimers(1500);
-        expect(Scheduler).toHaveYielded([]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-        // Before we have a chance to flush, the promise resolves.
-        await advanceTimers(2000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-        expect(Scheduler).toFlushAndYield([
-          // We've now pinged the boundary but we don't know if we should restart yet,
-          // because we haven't completed the suspense boundary.
-          'Loading...',
-          // Once we've completed the boundary we restarted.
-          'Async',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Async')]);
-      });
-
-      it('throws a helpful error when an update is suspends without a placeholder', () => {
-        ReactNoop.render(<AsyncText ms={1000} text="Async" />);
-        expect(Scheduler).toFlushAndThrow(
-          'AsyncText suspended while rendering, but no fallback UI was specified.',
-        );
-      });
-
-      it('a Suspense component correctly handles more than one suspended child', async () => {
-        ReactNoop.render(
-          <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncText text="A" ms={100} />
-            <AsyncText text="B" ms={100} />
-          </Suspense>,
-        );
-        Scheduler.unstable_advanceTime(10000);
-        expect(Scheduler).toFlushExpired([
-          'Suspend! [A]',
-          'Suspend! [B]',
-          'Loading...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        await advanceTimers(100);
-
-        expect(Scheduler).toHaveYielded([
-          'Promise resolved [A]',
-          'Promise resolved [B]',
-        ]);
-        expect(Scheduler).toFlushAndYield(['A', 'B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('can resume rendering earlier than a timeout', async () => {
-        ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
-        expect(Scheduler).toFlushAndYield([]);
-
-        ReactNoop.render(
-          <Suspense fallback={<Text text="Loading..." />}>
-            <AsyncText text="Async" ms={100} />
-          </Suspense>,
-        );
-        expect(Scheduler).toFlushAndYield(['Suspend! [Async]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Advance time by an amount slightly smaller than what's necessary to
-        // resolve the promise
-        await advanceTimers(99);
-
-        // Nothing has rendered yet
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Resolve the promise
-        await advanceTimers(1);
-        // We can now resume rendering
-        expect(Scheduler).toHaveYielded(['Promise resolved [Async]']);
-        expect(Scheduler).toFlushAndYield(['Async']);
-        expect(ReactNoop.getChildren()).toEqual([span('Async')]);
-      });
-
-      it('starts working on an update even if its priority falls between two suspended levels', async () => {
-        function App(props) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {props.text === 'C' || props.text === 'S' ? (
-                <Text text={props.text} />
-              ) : (
-                <AsyncText text={props.text} ms={10000} />
-              )}
-            </Suspense>
-          );
-        }
-
-        // First mount without suspending. This ensures we already have content
-        // showing so that subsequent updates will suspend.
-        ReactNoop.render(<App text="S" />);
-        expect(Scheduler).toFlushAndYield(['S']);
-
-        // Schedule an update, and suspend for up to 5 seconds.
-        React.unstable_withSuspenseConfig(
-          () => ReactNoop.render(<App text="A" />),
-          {
-            timeoutMs: 5000,
-          },
-        );
-        // The update should suspend.
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([span('S')]);
-
-        // Advance time until right before it expires.
-        await advanceTimers(4999);
-        ReactNoop.expire(4999);
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([span('S')]);
-
-        // Schedule another low priority update.
-        React.unstable_withSuspenseConfig(
-          () => ReactNoop.render(<App text="B" />),
-          {
-            timeoutMs: 10000,
-          },
-        );
-        // This update should also suspend.
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
-        expect(ReactNoop.getChildren()).toEqual([span('S')]);
-
-        // Schedule a regular update. Its expiration time will fall between
-        // the expiration times of the previous two updates.
-        ReactNoop.render(<App text="C" />);
-        expect(Scheduler).toFlushAndYield(['C']);
-        expect(ReactNoop.getChildren()).toEqual([span('C')]);
-
-        await advanceTimers(10000);
-        // Flush the remaining work.
-        expect(Scheduler).toHaveYielded([
-          'Promise resolved [A]',
-          'Promise resolved [B]',
-        ]);
-        // Nothing else to render.
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([span('C')]);
-      });
-
-      it('flushes all expired updates in a single batch', async () => {
-        class Foo extends React.Component {
-          componentDidUpdate() {
-            Scheduler.unstable_yieldValue('Commit: ' + this.props.text);
-          }
-          componentDidMount() {
-            Scheduler.unstable_yieldValue('Commit: ' + this.props.text);
-          }
-          render() {
-            return (
-              <Suspense fallback={<Text text="Loading..." />}>
-                <AsyncText ms={20000} text={this.props.text} />
-              </Suspense>
-            );
-          }
-        }
-
-        ReactNoop.render(<Foo text="" />);
-        ReactNoop.expire(1000);
-        jest.advanceTimersByTime(1000);
-        ReactNoop.render(<Foo text="go" />);
-        ReactNoop.expire(1000);
-        jest.advanceTimersByTime(1000);
-        ReactNoop.render(<Foo text="good" />);
-        ReactNoop.expire(1000);
-        jest.advanceTimersByTime(1000);
-        ReactNoop.render(<Foo text="goodbye" />);
-
-        Scheduler.unstable_advanceTime(10000);
-        jest.advanceTimersByTime(10000);
-
-        expect(Scheduler).toFlushExpired([
-          'Suspend! [goodbye]',
-          'Loading...',
-          'Commit: goodbye',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        Scheduler.unstable_advanceTime(20000);
-        await advanceTimers(20000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [goodbye]']);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        expect(Scheduler).toFlushAndYield(['goodbye']);
-        expect(ReactNoop.getChildren()).toEqual([span('goodbye')]);
-      });
-
-      it('a suspended update that expires', async () => {
-        // Regression test. This test used to fall into an infinite loop.
-        function ExpensiveText({text}) {
-          // This causes the update to expire.
-          Scheduler.unstable_advanceTime(10000);
-          // Then something suspends.
-          return <AsyncText text={text} ms={200000} />;
-        }
-
-        function App() {
-          return (
-            <Suspense fallback="Loading...">
-              <ExpensiveText text="A" />
-              <ExpensiveText text="B" />
-              <ExpensiveText text="C" />
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<App />);
-        expect(Scheduler).toFlushAndYield([
-          'Suspend! [A]',
-          'Suspend! [B]',
-          'Suspend! [C]',
-        ]);
-        expect(ReactNoop).toMatchRenderedOutput('Loading...');
-
-        await advanceTimers(200000);
-        expect(Scheduler).toHaveYielded([
-          'Promise resolved [A]',
-          'Promise resolved [B]',
-          'Promise resolved [C]',
-        ]);
-
-        expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <span prop="A" />
-            <span prop="B" />
-            <span prop="C" />
-          </>,
-        );
-      });
-
-      describe('legacy mode mode', () => {
-        it('times out immediately', async () => {
-          function App() {
-            return (
-              <Suspense fallback={<Text text="Loading..." />}>
-                <AsyncText ms={100} text="Result" />
-              </Suspense>
-            );
-          }
-
-          // Times out immediately, ignoring the specified threshold.
-          ReactNoop.renderLegacySyncRoot(<App />);
-          expect(Scheduler).toHaveYielded(['Suspend! [Result]', 'Loading...']);
-          expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-          ReactNoop.expire(100);
-          await advanceTimers(100);
-
-          expect(Scheduler).toHaveYielded(['Promise resolved [Result]']);
-          expect(Scheduler).toFlushExpired(['Result']);
-          expect(ReactNoop.getChildren()).toEqual([span('Result')]);
-        });
-
-        it('times out immediately when Suspense is in legacy mode', async () => {
-          class UpdatingText extends React.Component {
-            state = {step: 1};
-            render() {
-              return <AsyncText ms={100} text={`Step: ${this.state.step}`} />;
-            }
-          }
-
-          function Spinner() {
-            return (
-              <Fragment>
-                <Text text="Loading (1)" />
-                <Text text="Loading (2)" />
-                <Text text="Loading (3)" />
-              </Fragment>
-            );
-          }
-
-          const text = React.createRef(null);
-          function App() {
-            return (
-              <Suspense fallback={<Spinner />}>
-                <UpdatingText ref={text} />
-                <Text text="Sibling" />
-              </Suspense>
-            );
-          }
-
-          // Initial mount.
-          ReactNoop.renderLegacySyncRoot(<App />);
-          await advanceTimers(100);
-          expect(Scheduler).toHaveYielded([
-            'Suspend! [Step: 1]',
-            'Sibling',
-            'Loading (1)',
-            'Loading (2)',
-            'Loading (3)',
-            'Promise resolved [Step: 1]',
-          ]);
-          expect(Scheduler).toFlushExpired(['Step: 1']);
-          expect(ReactNoop).toMatchRenderedOutput(
-            <>
-              <span prop="Step: 1" />
-              <span prop="Sibling" />
-            </>,
-          );
-
-          // Update.
-          text.current.setState({step: 2}, () =>
-            Scheduler.unstable_yieldValue('Update did commit'),
-          );
-
-          expect(ReactNoop.flushNextYield()).toEqual([
-            'Suspend! [Step: 2]',
-            'Loading (1)',
-            'Loading (2)',
-            'Loading (3)',
-            'Update did commit',
-          ]);
-          expect(ReactNoop).toMatchRenderedOutput(
-            <>
-              <span hidden={true} prop="Step: 1" />
-              <span hidden={true} prop="Sibling" />
-              <span prop="Loading (1)" />
-              <span prop="Loading (2)" />
-              <span prop="Loading (3)" />
-            </>,
-          );
-
-          await advanceTimers(100);
-          expect(Scheduler).toHaveYielded(['Promise resolved [Step: 2]']);
-          expect(Scheduler).toFlushExpired(['Step: 2']);
-          expect(ReactNoop).toMatchRenderedOutput(
-            <>
-              <span prop="Step: 2" />
-              <span prop="Sibling" />
-            </>,
-          );
-        });
-
-        it('does not re-render siblings in loose mode', async () => {
-          class TextWithLifecycle extends React.Component {
-            componentDidMount() {
-              Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
-            }
-            componentDidUpdate() {
-              Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
-            }
-            render() {
-              return <Text {...this.props} />;
-            }
-          }
-
-          class AsyncTextWithLifecycle extends React.Component {
-            componentDidMount() {
-              Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
-            }
-            componentDidUpdate() {
-              Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
-            }
-            render() {
-              return <AsyncText {...this.props} />;
-            }
-          }
-
-          function App() {
-            return (
-              <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
-                <TextWithLifecycle text="A" />
-                <AsyncTextWithLifecycle ms={100} text="B" />
-                <TextWithLifecycle text="C" />
-              </Suspense>
-            );
-          }
-
-          ReactNoop.renderLegacySyncRoot(<App />, () =>
-            Scheduler.unstable_yieldValue('Commit root'),
-          );
-          expect(Scheduler).toHaveYielded([
-            'A',
-            'Suspend! [B]',
-            'C',
-
-            'Loading...',
-            'Mount [A]',
-            'Mount [B]',
-            'Mount [C]',
-            // This should be a mount, not an update.
-            'Mount [Loading...]',
-            'Commit root',
-          ]);
-          expect(ReactNoop).toMatchRenderedOutput(
-            <>
-              <span hidden={true} prop="A" />
-              <span hidden={true} prop="C" />
-
-              <span prop="Loading..." />
-            </>,
-          );
-
-          ReactNoop.expire(1000);
-          await advanceTimers(1000);
-
-          expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-          expect(Scheduler).toFlushExpired(['B']);
-          expect(ReactNoop).toMatchRenderedOutput(
-            <>
-              <span prop="A" />
-              <span prop="B" />
-              <span prop="C" />
-            </>,
-          );
-        });
-
-        it('suspends inside constructor', async () => {
-          class AsyncTextInConstructor extends React.Component {
-            constructor(props) {
-              super(props);
-              const text = props.text;
-              Scheduler.unstable_yieldValue('constructor');
-              try {
-                TextResource.read([props.text, props.ms]);
-                this.state = {text};
-              } catch (promise) {
-                if (typeof promise.then === 'function') {
-                  Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
-                } else {
-                  Scheduler.unstable_yieldValue(`Error! [${text}]`);
-                }
-                throw promise;
-              }
-            }
-            componentDidMount() {
-              Scheduler.unstable_yieldValue('componentDidMount');
-            }
-            render() {
-              Scheduler.unstable_yieldValue(this.state.text);
-              return <span prop={this.state.text} />;
-            }
-          }
-
-          ReactNoop.renderLegacySyncRoot(
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncTextInConstructor ms={100} text="Hi" />
-            </Suspense>,
-          );
-
-          expect(Scheduler).toHaveYielded([
-            'constructor',
-            'Suspend! [Hi]',
-            'Loading...',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-          await advanceTimers(1000);
-
-          expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-          expect(Scheduler).toFlushExpired([
-            'constructor',
-            'Hi',
-            'componentDidMount',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
-        });
-
-        it('does not infinite loop if fallback contains lifecycle method', async () => {
-          class Fallback extends React.Component {
-            state = {
-              name: 'foo',
-            };
-            componentDidMount() {
-              this.setState({
-                name: 'bar',
-              });
-            }
-            render() {
-              return <Text text="Loading..." />;
-            }
-          }
-
-          class Demo extends React.Component {
-            render() {
-              return (
-                <Suspense fallback={<Fallback />}>
-                  <AsyncText text="Hi" ms={100} />
-                </Suspense>
-              );
-            }
-          }
-
-          ReactNoop.renderLegacySyncRoot(<Demo />);
-
-          expect(Scheduler).toHaveYielded([
-            'Suspend! [Hi]',
-            'Loading...',
-            // Re-render due to lifecycle update
-            'Loading...',
-          ]);
-          expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-          await advanceTimers(100);
-          expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-          expect(Scheduler).toFlushExpired(['Hi']);
-          expect(ReactNoop.getChildren()).toEqual([span('Hi')]);
-        });
-
-        if (global.__PERSISTENT__) {
-          it('hides/unhides suspended children before layout effects fire (persistent)', async () => {
-            const {useRef, useLayoutEffect} = React;
-
-            function Parent() {
-              const child = useRef(null);
-
-              useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue(
-                  ReactNoop.getPendingChildrenAsJSX(),
-                );
-              });
-
-              return (
-                <span ref={child} hidden={false}>
-                  <AsyncText ms={1000} text="Hi" />
-                </span>
-              );
-            }
-
-            function App(props) {
-              return (
-                <Suspense fallback={<Text text="Loading..." />}>
-                  <Parent />
-                </Suspense>
-              );
-            }
-
-            ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
-
-            expect(Scheduler).toHaveYielded([
-              'Suspend! [Hi]',
-              'Loading...',
-              // The child should have already been hidden
-              <>
-                <span hidden={true} />
-                <span prop="Loading..." />
-              </>,
-            ]);
-
-            await advanceTimers(1000);
-
-            expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-            expect(Scheduler).toFlushExpired(['Hi']);
-          });
-        } else {
-          it('hides/unhides suspended children before layout effects fire (mutation)', async () => {
-            const {useRef, useLayoutEffect} = React;
-
-            function Parent() {
-              const child = useRef(null);
-
-              useLayoutEffect(() => {
-                Scheduler.unstable_yieldValue(
-                  'Child is hidden: ' + child.current.hidden,
-                );
-              });
-
-              return (
-                <span ref={child} hidden={false}>
-                  <AsyncText ms={1000} text="Hi" />
-                </span>
-              );
-            }
-
-            function App(props) {
-              return (
-                <Suspense fallback={<Text text="Loading..." />}>
-                  <Parent />
-                </Suspense>
-              );
-            }
-
-            ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
-
-            expect(Scheduler).toHaveYielded([
-              'Suspend! [Hi]',
-              'Loading...',
-              // The child should have already been hidden
-              'Child is hidden: true',
-            ]);
-
-            await advanceTimers(1000);
-
-            expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-            expect(Scheduler).toFlushExpired(['Hi']);
-          });
-        }
-
-        it('handles errors in the return path of a component that suspends', async () => {
-          // Covers an edge case where an error is thrown inside the complete phase
-          // of a component that is in the return path of a component that suspends.
-          // The second error should also be handled (i.e. able to be captured by
-          // an error boundary.
-          class ErrorBoundary extends React.Component {
-            state = {error: null};
-            static getDerivedStateFromError(error, errorInfo) {
-              return {error};
-            }
-            render() {
-              if (this.state.error) {
-                return `Caught an error: ${this.state.error.message}`;
-              }
-              return this.props.children;
-            }
-          }
-
-          ReactNoop.renderLegacySyncRoot(
-            <ErrorBoundary>
-              <Suspense fallback="Loading...">
-                <errorInCompletePhase>
-                  <AsyncText ms={1000} text="Async" />
-                </errorInCompletePhase>
-              </Suspense>
-            </ErrorBoundary>,
-          );
-
-          expect(Scheduler).toHaveYielded(['Suspend! [Async]']);
-          expect(ReactNoop).toMatchRenderedOutput(
-            'Caught an error: Error in host config.',
-          );
-        });
-
-        it('does not drop mounted effects', async () => {
-          let never = {then() {}};
-
-          let setShouldSuspend;
-          function App() {
-            const [shouldSuspend, _setShouldSuspend] = React.useState(0);
-            setShouldSuspend = _setShouldSuspend;
-            return (
-              <Suspense fallback="Loading...">
-                <Child shouldSuspend={shouldSuspend} />
-              </Suspense>
-            );
-          }
-
-          function Child({shouldSuspend}) {
-            if (shouldSuspend) {
-              throw never;
-            }
-
-            React.useEffect(() => {
-              Scheduler.unstable_yieldValue('Mount');
-              return () => {
-                Scheduler.unstable_yieldValue('Unmount');
-              };
-            }, []);
-
-            return 'Child';
-          }
-
-          const root = ReactNoop.createLegacyRoot(null);
-          await ReactNoop.act(async () => {
-            root.render(<App />);
-          });
-          expect(Scheduler).toHaveYielded(['Mount']);
-          expect(root).toMatchRenderedOutput('Child');
-
-          // Suspend the child. This puts it into an inconsistent state.
-          await ReactNoop.act(async () => {
-            setShouldSuspend(true);
-          });
-          expect(root).toMatchRenderedOutput('Loading...');
-
-          // Unmount everying
-          await ReactNoop.act(async () => {
-            root.render(null);
-          });
-          expect(Scheduler).toHaveYielded(['Unmount']);
-        });
-      });
-
-      it('does not call lifecycles of a suspended component', async () => {
-        class TextWithLifecycle extends React.Component {
-          componentDidMount() {
-            Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
-          }
-          componentDidUpdate() {
-            Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
-          }
-          componentWillUnmount() {
-            Scheduler.unstable_yieldValue(`Unmount [${this.props.text}]`);
-          }
-          render() {
-            return <Text {...this.props} />;
-          }
-        }
-
-        class AsyncTextWithLifecycle extends React.Component {
-          componentDidMount() {
-            Scheduler.unstable_yieldValue(`Mount [${this.props.text}]`);
-          }
-          componentDidUpdate() {
-            Scheduler.unstable_yieldValue(`Update [${this.props.text}]`);
-          }
-          componentWillUnmount() {
-            Scheduler.unstable_yieldValue(`Unmount [${this.props.text}]`);
-          }
-          render() {
-            const text = this.props.text;
-            const ms = this.props.ms;
-            try {
-              TextResource.read([text, ms]);
-              Scheduler.unstable_yieldValue(text);
-              return <span prop={text} />;
-            } catch (promise) {
-              if (typeof promise.then === 'function') {
-                Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
-              } else {
-                Scheduler.unstable_yieldValue(`Error! [${text}]`);
-              }
-              throw promise;
-            }
-          }
-        }
-
-        function App() {
-          return (
-            <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
-              <TextWithLifecycle text="A" />
-              <AsyncTextWithLifecycle ms={100} text="B" />
-              <TextWithLifecycle text="C" />
-            </Suspense>
-          );
-        }
-
-        ReactNoop.renderLegacySyncRoot(<App />, () =>
-          Scheduler.unstable_yieldValue('Commit root'),
-        );
-        expect(Scheduler).toHaveYielded([
-          'A',
-          'Suspend! [B]',
-          'C',
-          'Loading...',
-
-          'Mount [A]',
-          // B's lifecycle should not fire because it suspended
-          // 'Mount [B]',
-          'Mount [C]',
-          'Mount [Loading...]',
-          'Commit root',
-        ]);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <span hidden={true} prop="A" />
-            <span hidden={true} prop="C" />
-            <span prop="Loading..." />
-          </>,
-        );
-      });
-
-      it('does not call lifecycles of a suspended component (hooks)', async () => {
-        function TextWithLifecycle(props) {
-          React.useLayoutEffect(() => {
-            Scheduler.unstable_yieldValue(`Layout Effect [${props.text}]`);
-            return () => {
-              Scheduler.unstable_yieldValue(
-                `Destroy Layout Effect [${props.text}]`,
-              );
-            };
-          }, [props.text]);
-          React.useEffect(() => {
-            Scheduler.unstable_yieldValue(`Effect [${props.text}]`);
-            return () => {
-              Scheduler.unstable_yieldValue(`Destroy Effect [${props.text}]`);
-            };
-          }, [props.text]);
-          return <Text {...props} />;
-        }
-
-        function AsyncTextWithLifecycle(props) {
-          React.useLayoutEffect(() => {
-            Scheduler.unstable_yieldValue(`Layout Effect [${props.text}]`);
-            return () => {
-              Scheduler.unstable_yieldValue(
-                `Destroy Layout Effect [${props.text}]`,
-              );
-            };
-          }, [props.text]);
-          React.useEffect(() => {
-            Scheduler.unstable_yieldValue(`Effect [${props.text}]`);
-            return () => {
-              Scheduler.unstable_yieldValue(`Destroy Effect [${props.text}]`);
-            };
-          }, [props.text]);
-          const text = props.text;
-          const ms = props.ms;
-          try {
-            TextResource.read([text, ms]);
-            Scheduler.unstable_yieldValue(text);
-            return <span prop={text} />;
-          } catch (promise) {
-            if (typeof promise.then === 'function') {
-              Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
-            } else {
-              Scheduler.unstable_yieldValue(`Error! [${text}]`);
-            }
-            throw promise;
-          }
-        }
-
-        function App({text}) {
-          return (
-            <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
-              <TextWithLifecycle text="A" />
-              <AsyncTextWithLifecycle ms={100} text={text} />
-              <TextWithLifecycle text="C" />
-            </Suspense>
-          );
-        }
-
-        ReactNoop.renderLegacySyncRoot(<App text="B" />, () =>
-          Scheduler.unstable_yieldValue('Commit root'),
-        );
-        expect(Scheduler).toHaveYielded([
-          'A',
-          'Suspend! [B]',
-          'C',
-          'Loading...',
-
-          'Layout Effect [A]',
-          // B's effect should not fire because it suspended
-          // 'Layout Effect [B]',
-          'Layout Effect [C]',
-          'Layout Effect [Loading...]',
-          'Commit root',
-        ]);
-
-        // Flush passive effects.
-        expect(Scheduler).toFlushAndYield([
-          'Effect [A]',
-          // B's effect should not fire because it suspended
-          // 'Effect [B]',
-          'Effect [C]',
-          'Effect [Loading...]',
-        ]);
-
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <span hidden={true} prop="A" />
-            <span hidden={true} prop="C" />
-            <span prop="Loading..." />
-          </>,
-        );
-
-        Scheduler.unstable_advanceTime(500);
-        await advanceTimers(500);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-
-        if (
-          ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount &&
-          ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates
-        ) {
-          expect(Scheduler).toFlushAndYield([
-            'B',
-            'Destroy Layout Effect [Loading...]',
-            'Layout Effect [B]',
-            'Destroy Effect [Loading...]',
-            'Effect [B]',
-          ]);
-        } else {
-          expect(Scheduler).toFlushAndYield([
-            'B',
-            'Destroy Layout Effect [Loading...]',
-            'Destroy Effect [Loading...]',
-            'Layout Effect [B]',
-            'Effect [B]',
-          ]);
-        }
-
-        // Update
-        ReactNoop.renderLegacySyncRoot(<App text="B2" />, () =>
-          Scheduler.unstable_yieldValue('Commit root'),
-        );
-
-        expect(Scheduler).toHaveYielded([
-          'A',
-          'Suspend! [B2]',
-          'C',
-          'Loading...',
-
-          // B2's effect should not fire because it suspended
-          // 'Layout Effect [B2]',
-          'Layout Effect [Loading...]',
-          'Commit root',
-        ]);
-
-        // Flush passive effects.
-        expect(Scheduler).toFlushAndYield([
-          // B2's effect should not fire because it suspended
-          // 'Effect [B2]',
-          'Effect [Loading...]',
-        ]);
-
-        Scheduler.unstable_advanceTime(500);
-        await advanceTimers(500);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
-
-        if (
-          ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount &&
-          ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates
-        ) {
-          expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [Loading...]',
-            'Destroy Layout Effect [B]',
-            'Layout Effect [B2]',
-            'Destroy Effect [Loading...]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ]);
-        } else {
-          expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [Loading...]',
-            'Destroy Effect [Loading...]',
-            'Destroy Layout Effect [B]',
-            'Layout Effect [B2]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ]);
-        }
-      });
-
-      it('suspends for longer if something took a long (CPU bound) time to render', async () => {
-        function Foo({renderContent}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {renderContent ? <AsyncText text="A" ms={5000} /> : null}
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield(['Foo']);
-
-        ReactNoop.render(<Foo renderContent={true} />);
-        Scheduler.unstable_advanceTime(100);
-        await advanceTimers(100);
-        // Start rendering
-        expect(Scheduler).toFlushAndYieldThrough(['Foo']);
-        // For some reason it took a long time to render Foo.
-        Scheduler.unstable_advanceTime(1250);
-        await advanceTimers(1250);
-        expect(Scheduler).toFlushAndYield([
-          // A suspends
-          'Suspend! [A]',
-          'Loading...',
-        ]);
-        // We're now suspended and we haven't shown anything yet.
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Flush some of the time
-        Scheduler.unstable_advanceTime(450);
-        await advanceTimers(450);
-        // Because we've already been waiting for so long we can
-        // wait a bit longer. Still nothing...
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Eventually we'll show the fallback.
-        Scheduler.unstable_advanceTime(500);
-        await advanceTimers(500);
-        // No need to rerender.
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        // Flush the promise completely
-        Scheduler.unstable_advanceTime(4500);
-        await advanceTimers(4500);
-        // Renders successfully
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['A']);
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
-      });
-
-      it('does not suspends if a fallback has been shown for a long time', async () => {
-        function Foo() {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text="A" ms={5000} />
-              <Suspense fallback={<Text text="Loading more..." />}>
-                <AsyncText text="B" ms={10000} />
-              </Suspense>
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<Foo />);
-        // Start rendering
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          // A suspends
-          'Suspend! [A]',
-          // B suspends
-          'Suspend! [B]',
-          'Loading more...',
-          'Loading...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        // Wait a long time.
-        Scheduler.unstable_advanceTime(5000);
-        await advanceTimers(5000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-
-        // Retry with the new content.
-        expect(Scheduler).toFlushAndYield([
-          'A',
-          // B still suspends
-          'Suspend! [B]',
-          'Loading more...',
-        ]);
-        // Because we've already been waiting for so long we've exceeded
-        // our threshold and we show the next level immediately.
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('Loading more...'),
-        ]);
-
-        // Flush the last promise completely
-        Scheduler.unstable_advanceTime(5000);
-        await advanceTimers(5000);
-        // Renders successfully
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(Scheduler).toFlushAndYield(['B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('does suspend if a fallback has been shown for a short time', async () => {
-        function Foo() {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text="A" ms={200} />
-              <Suspense fallback={<Text text="Loading more..." />}>
-                <AsyncText text="B" ms={450} />
-              </Suspense>
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<Foo />);
-        // Start rendering
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          // A suspends
-          'Suspend! [A]',
-          // B suspends
-          'Suspend! [B]',
-          'Loading more...',
-          'Loading...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        // Wait a short time.
-        Scheduler.unstable_advanceTime(250);
-        await advanceTimers(250);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-
-        // Retry with the new content.
-        expect(Scheduler).toFlushAndYield([
-          'A',
-          // B still suspends
-          'Suspend! [B]',
-          'Loading more...',
-        ]);
-        // Because we've already been waiting for so long we can
-        // wait a bit longer. Still nothing...
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-        Scheduler.unstable_advanceTime(200);
-        await advanceTimers(200);
-
-        // Before we commit another Promise resolves.
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        // We're still showing the first loading state.
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-        // Restart and render the complete content.
-        expect(Scheduler).toFlushAndYield(['A', 'B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
-      });
-
-      it('does not suspend for very long after a higher priority update', async () => {
-        function Foo({renderContent}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              {renderContent ? <AsyncText text="A" ms={5000} /> : null}
-            </Suspense>
-          );
-        }
-
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield(['Foo']);
-
-        ReactNoop.discreteUpdates(() =>
-          ReactNoop.render(<Foo renderContent={true} />),
-        );
-        expect(Scheduler).toFlushAndYieldThrough(['Foo']);
-
-        // Advance some time.
-        Scheduler.unstable_advanceTime(100);
-        await advanceTimers(100);
-
-        expect(Scheduler).toFlushAndYield([
-          // A suspends
-          'Suspend! [A]',
-          'Loading...',
-        ]);
-
-        // We're now suspended and we haven't shown anything yet.
-        expect(ReactNoop.getChildren()).toEqual([]);
-
-        // Flush some of the time
-        Scheduler.unstable_advanceTime(500);
-        jest.advanceTimersByTime(500);
-
-        // We should have already shown the fallback.
-        // When we wrote this test, we inferred the start time of high priority
-        // updates as way earlier in the past. This test ensures that we don't
-        // use this assumption to add a very long JND.
-        expect(Scheduler).toFlushWithoutYielding();
-        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-      });
-
-      // TODO: flip to "warns" when this is implemented again.
-      it('does not warn when a low priority update suspends inside a high priority update for functional components', async () => {
-        let _setShow;
-        function App() {
-          let [show, setShow] = React.useState(false);
-          _setShow = setShow;
-          return (
-            <Suspense fallback="Loading...">
-              {show && <AsyncText text="A" />}
-            </Suspense>
-          );
-        }
-
-        await ReactNoop.act(async () => {
-          ReactNoop.render(<App />);
-        });
-
-        // TODO: assert toErrorDev() when the warning is implemented again.
-        ReactNoop.act(() => {
-          Scheduler.unstable_runWithPriority(
-            Scheduler.unstable_UserBlockingPriority,
-            () => _setShow(true),
-          );
-        });
-      });
-
-      // TODO: flip to "warns" when this is implemented again.
-      it('does not warn when a low priority update suspends inside a high priority update for class components', async () => {
-        let show;
-        class App extends React.Component {
-          state = {show: false};
-
-          render() {
-            show = () => this.setState({show: true});
-            return (
-              <Suspense fallback="Loading...">
-                {this.state.show && <AsyncText text="A" />}
-              </Suspense>
-            );
-          }
-        }
-
-        await ReactNoop.act(async () => {
-          ReactNoop.render(<App />);
-        });
-
-        // TODO: assert toErrorDev() when the warning is implemented again.
-        ReactNoop.act(() => {
-          Scheduler.unstable_runWithPriority(
-            Scheduler.unstable_UserBlockingPriority,
-            () => show(),
-          );
-        });
-      });
-
-      it('does not warn about wrong Suspense priority if no new fallbacks are shown', async () => {
-        let showB;
-        class App extends React.Component {
-          state = {showB: false};
-
-          render() {
-            showB = () => this.setState({showB: true});
-            return (
-              <Suspense fallback="Loading...">
-                {<AsyncText text="A" />}
-                {this.state.showB && <AsyncText text="B" />}
-              </Suspense>
-            );
-          }
-        }
-
-        await ReactNoop.act(async () => {
-          ReactNoop.render(<App />);
-        });
-
-        expect(Scheduler).toHaveYielded(['Suspend! [A]']);
-        expect(ReactNoop).toMatchRenderedOutput('Loading...');
-
-        ReactNoop.act(() => {
-          Scheduler.unstable_runWithPriority(
-            Scheduler.unstable_UserBlockingPriority,
-            () => showB(),
-          );
-        });
-
-        expect(Scheduler).toHaveYielded(['Suspend! [A]', 'Suspend! [B]']);
-      });
-
-      // TODO: flip to "warns" when this is implemented again.
-      it(
-        'does not warn when component that triggered user-blocking update is between Suspense boundary ' +
-          'and component that suspended',
-        async () => {
-          let _setShow;
-          function A() {
-            const [show, setShow] = React.useState(false);
-            _setShow = setShow;
-            return show && <AsyncText text="A" />;
-          }
-          function App() {
-            return (
-              <Suspense fallback="Loading...">
-                <A />
-              </Suspense>
-            );
-          }
-          await ReactNoop.act(async () => {
-            ReactNoop.render(<App />);
-          });
-
-          // TODO: assert toErrorDev() when the warning is implemented again.
-          ReactNoop.act(() => {
-            Scheduler.unstable_runWithPriority(
-              Scheduler.unstable_UserBlockingPriority,
-              () => _setShow(true),
-            );
-          });
-        },
+    }
+
+    function App() {
+      return (
+        <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
+          <TextWithLifecycle text="A" />
+          <AsyncTextWithLifecycle ms={100} text="B" />
+          <TextWithLifecycle text="C" />
+        </Suspense>
       );
+    }
 
-      it('normal priority updates suspending do not warn for class components', async () => {
-        let show;
-        class App extends React.Component {
-          state = {show: false};
+    ReactNoop.renderLegacySyncRoot(<App />, () =>
+      Scheduler.unstable_yieldValue('Commit root'),
+    );
+    expect(Scheduler).toHaveYielded([
+      'A',
+      'Suspend! [B]',
+      'C',
+      'Loading...',
 
-          render() {
-            show = () => this.setState({show: true});
-            return (
-              <Suspense fallback="Loading...">
-                {this.state.show && <AsyncText text="A" />}
-              </Suspense>
-            );
-          }
-        }
+      'Mount [A]',
+      // B's lifecycle should not fire because it suspended
+      // 'Mount [B]',
+      'Mount [C]',
+      'Mount [Loading...]',
+      'Commit root',
+    ]);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <span hidden={true} prop="A" />
+        <span hidden={true} prop="C" />
+        <span prop="Loading..." />
+      </>,
+    );
+  });
 
-        await ReactNoop.act(async () => {
-          ReactNoop.render(<App />);
-        });
-
-        // also make sure lowpriority is okay
-        await ReactNoop.act(async () => show(true));
-
-        expect(Scheduler).toHaveYielded(['Suspend! [A]']);
-        Scheduler.unstable_advanceTime(100);
-        await advanceTimers(100);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-      });
-
-      it('normal priority updates suspending do not warn for functional components', async () => {
-        let _setShow;
-        function App() {
-          let [show, setShow] = React.useState(false);
-          _setShow = setShow;
-          return (
-            <Suspense fallback="Loading...">
-              {show && <AsyncText text="A" />}
-            </Suspense>
+  it('does not call lifecycles of a suspended component (hooks)', async () => {
+    function TextWithLifecycle(props) {
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue(`Layout Effect [${props.text}]`);
+        return () => {
+          Scheduler.unstable_yieldValue(
+            `Destroy Layout Effect [${props.text}]`,
           );
-        }
+        };
+      }, [props.text]);
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue(`Effect [${props.text}]`);
+        return () => {
+          Scheduler.unstable_yieldValue(`Destroy Effect [${props.text}]`);
+        };
+      }, [props.text]);
+      return <Text {...props} />;
+    }
 
-        await ReactNoop.act(async () => {
-          ReactNoop.render(<App />);
-        });
-
-        // also make sure lowpriority is okay
-        await ReactNoop.act(async () => _setShow(true));
-
-        expect(Scheduler).toHaveYielded(['Suspend! [A]']);
-        Scheduler.unstable_advanceTime(100);
-        await advanceTimers(100);
-
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-      });
-
-      it('shows the parent fallback if the inner fallback should be avoided', async () => {
-        function Foo({showC}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Initial load..." />}>
-              <Suspense
-                unstable_avoidThisFallback={true}
-                fallback={<Text text="Updating..." />}>
-                <AsyncText text="A" ms={5000} />
-                {showC ? <AsyncText text="C" ms={5000} /> : null}
-              </Suspense>
-              <Text text="B" />
-            </Suspense>
+    function AsyncTextWithLifecycle(props) {
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue(`Layout Effect [${props.text}]`);
+        return () => {
+          Scheduler.unstable_yieldValue(
+            `Destroy Layout Effect [${props.text}]`,
           );
+        };
+      }, [props.text]);
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue(`Effect [${props.text}]`);
+        return () => {
+          Scheduler.unstable_yieldValue(`Destroy Effect [${props.text}]`);
+        };
+      }, [props.text]);
+      const text = props.text;
+      const ms = props.ms;
+      try {
+        TextResource.read([text, ms]);
+        Scheduler.unstable_yieldValue(text);
+        return <span prop={text} />;
+      } catch (promise) {
+        if (typeof promise.then === 'function') {
+          Scheduler.unstable_yieldValue(`Suspend! [${text}]`);
+        } else {
+          Scheduler.unstable_yieldValue(`Error! [${text}]`);
         }
+        throw promise;
+      }
+    }
 
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          'Suspend! [A]',
-          'B',
-          'Initial load...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('Initial load...')]);
+    function App({text}) {
+      return (
+        <Suspense fallback={<TextWithLifecycle text="Loading..." />}>
+          <TextWithLifecycle text="A" />
+          <AsyncTextWithLifecycle ms={100} text={text} />
+          <TextWithLifecycle text="C" />
+        </Suspense>
+      );
+    }
 
-        // Eventually we resolve and show the data.
-        Scheduler.unstable_advanceTime(5000);
-        await advanceTimers(5000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['A', 'B']);
-        expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+    ReactNoop.renderLegacySyncRoot(<App text="B" />, () =>
+      Scheduler.unstable_yieldValue('Commit root'),
+    );
+    expect(Scheduler).toHaveYielded([
+      'A',
+      'Suspend! [B]',
+      'C',
+      'Loading...',
 
-        // Update to show C
-        ReactNoop.render(<Foo showC={true} />);
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          'A',
-          'Suspend! [C]',
-          'Updating...',
-          'B',
-        ]);
-        // Flush to skip suspended time.
-        Scheduler.unstable_advanceTime(600);
-        await advanceTimers(600);
-        // Since the optional suspense boundary is already showing its content,
-        // we have to use the inner fallback instead.
-        expect(ReactNoop.getChildren()).toEqual([
-          hiddenSpan('A'),
-          span('Updating...'),
-          span('B'),
-        ]);
+      'Layout Effect [A]',
+      // B's effect should not fire because it suspended
+      // 'Layout Effect [B]',
+      'Layout Effect [C]',
+      'Layout Effect [Loading...]',
+      'Commit root',
+    ]);
 
-        // Later we load the data.
-        Scheduler.unstable_advanceTime(5000);
-        await advanceTimers(5000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [C]']);
-        expect(Scheduler).toFlushAndYield(['A', 'C']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('C'),
-          span('B'),
-        ]);
+    // Flush passive effects.
+    expect(Scheduler).toFlushAndYield([
+      'Effect [A]',
+      // B's effect should not fire because it suspended
+      // 'Effect [B]',
+      'Effect [C]',
+      'Effect [Loading...]',
+    ]);
+
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <span hidden={true} prop="A" />
+        <span hidden={true} prop="C" />
+        <span prop="Loading..." />
+      </>,
+    );
+
+    Scheduler.unstable_advanceTime(500);
+    await advanceTimers(500);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+
+    if (
+      ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount &&
+      ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates
+    ) {
+      expect(Scheduler).toFlushAndYield([
+        'B',
+        'Destroy Layout Effect [Loading...]',
+        'Layout Effect [B]',
+        'Destroy Effect [Loading...]',
+        'Effect [B]',
+      ]);
+    } else {
+      expect(Scheduler).toFlushAndYield([
+        'B',
+        'Destroy Layout Effect [Loading...]',
+        'Destroy Effect [Loading...]',
+        'Layout Effect [B]',
+        'Effect [B]',
+      ]);
+    }
+
+    // Update
+    ReactNoop.renderLegacySyncRoot(<App text="B2" />, () =>
+      Scheduler.unstable_yieldValue('Commit root'),
+    );
+
+    expect(Scheduler).toHaveYielded([
+      'A',
+      'Suspend! [B2]',
+      'C',
+      'Loading...',
+
+      // B2's effect should not fire because it suspended
+      // 'Layout Effect [B2]',
+      'Layout Effect [Loading...]',
+      'Commit root',
+    ]);
+
+    // Flush passive effects.
+    expect(Scheduler).toFlushAndYield([
+      // B2's effect should not fire because it suspended
+      // 'Effect [B2]',
+      'Effect [Loading...]',
+    ]);
+
+    Scheduler.unstable_advanceTime(500);
+    await advanceTimers(500);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
+
+    if (
+      ReactFeatureFlags.deferPassiveEffectCleanupDuringUnmount &&
+      ReactFeatureFlags.runAllPassiveEffectDestroysBeforeCreates
+    ) {
+      expect(Scheduler).toFlushAndYield([
+        'B2',
+        'Destroy Layout Effect [Loading...]',
+        'Destroy Layout Effect [B]',
+        'Layout Effect [B2]',
+        'Destroy Effect [Loading...]',
+        'Destroy Effect [B]',
+        'Effect [B2]',
+      ]);
+    } else {
+      expect(Scheduler).toFlushAndYield([
+        'B2',
+        'Destroy Layout Effect [Loading...]',
+        'Destroy Effect [Loading...]',
+        'Destroy Layout Effect [B]',
+        'Layout Effect [B2]',
+        'Destroy Effect [B]',
+        'Effect [B2]',
+      ]);
+    }
+  });
+
+  it('suspends for longer if something took a long (CPU bound) time to render', async () => {
+    function Foo({renderContent}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {renderContent ? <AsyncText text="A" ms={5000} /> : null}
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    ReactNoop.render(<Foo renderContent={true} />);
+    Scheduler.unstable_advanceTime(100);
+    await advanceTimers(100);
+    // Start rendering
+    expect(Scheduler).toFlushAndYieldThrough(['Foo']);
+    // For some reason it took a long time to render Foo.
+    Scheduler.unstable_advanceTime(1250);
+    await advanceTimers(1250);
+    expect(Scheduler).toFlushAndYield([
+      // A suspends
+      'Suspend! [A]',
+      'Loading...',
+    ]);
+    // We're now suspended and we haven't shown anything yet.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush some of the time
+    Scheduler.unstable_advanceTime(450);
+    await advanceTimers(450);
+    // Because we've already been waiting for so long we can
+    // wait a bit longer. Still nothing...
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Eventually we'll show the fallback.
+    Scheduler.unstable_advanceTime(500);
+    await advanceTimers(500);
+    // No need to rerender.
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    // Flush the promise completely
+    Scheduler.unstable_advanceTime(4500);
+    await advanceTimers(4500);
+    // Renders successfully
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+  });
+
+  it('does not suspends if a fallback has been shown for a long time', async () => {
+    function Foo() {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="A" ms={5000} />
+          <Suspense fallback={<Text text="Loading more..." />}>
+            <AsyncText text="B" ms={10000} />
+          </Suspense>
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    // Start rendering
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      // A suspends
+      'Suspend! [A]',
+      // B suspends
+      'Suspend! [B]',
+      'Loading more...',
+      'Loading...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    // Wait a long time.
+    Scheduler.unstable_advanceTime(5000);
+    await advanceTimers(5000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+
+    // Retry with the new content.
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      // B still suspends
+      'Suspend! [B]',
+      'Loading more...',
+    ]);
+    // Because we've already been waiting for so long we've exceeded
+    // our threshold and we show the next level immediately.
+    expect(ReactNoop.getChildren()).toEqual([
+      span('A'),
+      span('Loading more...'),
+    ]);
+
+    // Flush the last promise completely
+    Scheduler.unstable_advanceTime(5000);
+    await advanceTimers(5000);
+    // Renders successfully
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(Scheduler).toFlushAndYield(['B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('does suspend if a fallback has been shown for a short time', async () => {
+    function Foo() {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text="A" ms={200} />
+          <Suspense fallback={<Text text="Loading more..." />}>
+            <AsyncText text="B" ms={450} />
+          </Suspense>
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    // Start rendering
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      // A suspends
+      'Suspend! [A]',
+      // B suspends
+      'Suspend! [B]',
+      'Loading more...',
+      'Loading...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    // Wait a short time.
+    Scheduler.unstable_advanceTime(250);
+    await advanceTimers(250);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+
+    // Retry with the new content.
+    expect(Scheduler).toFlushAndYield([
+      'A',
+      // B still suspends
+      'Suspend! [B]',
+      'Loading more...',
+    ]);
+    // Because we've already been waiting for so long we can
+    // wait a bit longer. Still nothing...
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+
+    Scheduler.unstable_advanceTime(200);
+    await advanceTimers(200);
+
+    // Before we commit another Promise resolves.
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    // We're still showing the first loading state.
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+    // Restart and render the complete content.
+    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+  });
+
+  it('does not suspend for very long after a higher priority update', async () => {
+    function Foo({renderContent}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          {renderContent ? <AsyncText text="A" ms={5000} /> : null}
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo']);
+
+    ReactNoop.discreteUpdates(() =>
+      ReactNoop.render(<Foo renderContent={true} />),
+    );
+    expect(Scheduler).toFlushAndYieldThrough(['Foo']);
+
+    // Advance some time.
+    Scheduler.unstable_advanceTime(100);
+    await advanceTimers(100);
+
+    expect(Scheduler).toFlushAndYield([
+      // A suspends
+      'Suspend! [A]',
+      'Loading...',
+    ]);
+
+    // We're now suspended and we haven't shown anything yet.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush some of the time
+    Scheduler.unstable_advanceTime(500);
+    jest.advanceTimersByTime(500);
+
+    // We should have already shown the fallback.
+    // When we wrote this test, we inferred the start time of high priority
+    // updates as way earlier in the past. This test ensures that we don't
+    // use this assumption to add a very long JND.
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+  });
+
+  // TODO: flip to "warns" when this is implemented again.
+  it('does not warn when a low priority update suspends inside a high priority update for functional components', async () => {
+    let _setShow;
+    function App() {
+      let [show, setShow] = React.useState(false);
+      _setShow = setShow;
+      return (
+        <Suspense fallback="Loading...">
+          {show && <AsyncText text="A" />}
+        </Suspense>
+      );
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App />);
+    });
+
+    // TODO: assert toErrorDev() when the warning is implemented again.
+    ReactNoop.act(() => {
+      Scheduler.unstable_runWithPriority(
+        Scheduler.unstable_UserBlockingPriority,
+        () => _setShow(true),
+      );
+    });
+  });
+
+  // TODO: flip to "warns" when this is implemented again.
+  it('does not warn when a low priority update suspends inside a high priority update for class components', async () => {
+    let show;
+    class App extends React.Component {
+      state = {show: false};
+
+      render() {
+        show = () => this.setState({show: true});
+        return (
+          <Suspense fallback="Loading...">
+            {this.state.show && <AsyncText text="A" />}
+          </Suspense>
+        );
+      }
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App />);
+    });
+
+    // TODO: assert toErrorDev() when the warning is implemented again.
+    ReactNoop.act(() => {
+      Scheduler.unstable_runWithPriority(
+        Scheduler.unstable_UserBlockingPriority,
+        () => show(),
+      );
+    });
+  });
+
+  it('does not warn about wrong Suspense priority if no new fallbacks are shown', async () => {
+    let showB;
+    class App extends React.Component {
+      state = {showB: false};
+
+      render() {
+        showB = () => this.setState({showB: true});
+        return (
+          <Suspense fallback="Loading...">
+            {<AsyncText text="A" />}
+            {this.state.showB && <AsyncText text="B" />}
+          </Suspense>
+        );
+      }
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App />);
+    });
+
+    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    expect(ReactNoop).toMatchRenderedOutput('Loading...');
+
+    ReactNoop.act(() => {
+      Scheduler.unstable_runWithPriority(
+        Scheduler.unstable_UserBlockingPriority,
+        () => showB(),
+      );
+    });
+
+    expect(Scheduler).toHaveYielded(['Suspend! [A]', 'Suspend! [B]']);
+  });
+
+  // TODO: flip to "warns" when this is implemented again.
+  it(
+    'does not warn when component that triggered user-blocking update is between Suspense boundary ' +
+      'and component that suspended',
+    async () => {
+      let _setShow;
+      function A() {
+        const [show, setShow] = React.useState(false);
+        _setShow = setShow;
+        return show && <AsyncText text="A" />;
+      }
+      function App() {
+        return (
+          <Suspense fallback="Loading...">
+            <A />
+          </Suspense>
+        );
+      }
+      await ReactNoop.act(async () => {
+        ReactNoop.render(<App />);
       });
 
-      it('favors showing the inner fallback for nested top level avoided fallback', async () => {
-        function Foo({showB}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense
-              unstable_avoidThisFallback={true}
-              fallback={<Text text="Loading A..." />}>
-              <Text text="A" />
+      // TODO: assert toErrorDev() when the warning is implemented again.
+      ReactNoop.act(() => {
+        Scheduler.unstable_runWithPriority(
+          Scheduler.unstable_UserBlockingPriority,
+          () => _setShow(true),
+        );
+      });
+    },
+  );
+
+  it('normal priority updates suspending do not warn for class components', async () => {
+    let show;
+    class App extends React.Component {
+      state = {show: false};
+
+      render() {
+        show = () => this.setState({show: true});
+        return (
+          <Suspense fallback="Loading...">
+            {this.state.show && <AsyncText text="A" />}
+          </Suspense>
+        );
+      }
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App />);
+    });
+
+    // also make sure lowpriority is okay
+    await ReactNoop.act(async () => show(true));
+
+    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    Scheduler.unstable_advanceTime(100);
+    await advanceTimers(100);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+  });
+
+  it('normal priority updates suspending do not warn for functional components', async () => {
+    let _setShow;
+    function App() {
+      let [show, setShow] = React.useState(false);
+      _setShow = setShow;
+      return (
+        <Suspense fallback="Loading...">
+          {show && <AsyncText text="A" />}
+        </Suspense>
+      );
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App />);
+    });
+
+    // also make sure lowpriority is okay
+    await ReactNoop.act(async () => _setShow(true));
+
+    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    Scheduler.unstable_advanceTime(100);
+    await advanceTimers(100);
+
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+  });
+
+  it('shows the parent fallback if the inner fallback should be avoided', async () => {
+    function Foo({showC}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Initial load..." />}>
+          <Suspense
+            unstable_avoidThisFallback={true}
+            fallback={<Text text="Updating..." />}>
+            <AsyncText text="A" ms={5000} />
+            {showC ? <AsyncText text="C" ms={5000} /> : null}
+          </Suspense>
+          <Text text="B" />
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      'Suspend! [A]',
+      'B',
+      'Initial load...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('Initial load...')]);
+
+    // Eventually we resolve and show the data.
+    Scheduler.unstable_advanceTime(5000);
+    await advanceTimers(5000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('B')]);
+
+    // Update to show C
+    ReactNoop.render(<Foo showC={true} />);
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      'A',
+      'Suspend! [C]',
+      'Updating...',
+      'B',
+    ]);
+    // Flush to skip suspended time.
+    Scheduler.unstable_advanceTime(600);
+    await advanceTimers(600);
+    // Since the optional suspense boundary is already showing its content,
+    // we have to use the inner fallback instead.
+    expect(ReactNoop.getChildren()).toEqual([
+      hiddenSpan('A'),
+      span('Updating...'),
+      span('B'),
+    ]);
+
+    // Later we load the data.
+    Scheduler.unstable_advanceTime(5000);
+    await advanceTimers(5000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [C]']);
+    expect(Scheduler).toFlushAndYield(['A', 'C']);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('C'), span('B')]);
+  });
+
+  it('favors showing the inner fallback for nested top level avoided fallback', async () => {
+    function Foo({showB}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense
+          unstable_avoidThisFallback={true}
+          fallback={<Text text="Loading A..." />}>
+          <Text text="A" />
+          <Suspense
+            unstable_avoidThisFallback={true}
+            fallback={<Text text="Loading B..." />}>
+            <AsyncText text="B" ms={5000} />
+          </Suspense>
+        </Suspense>
+      );
+    }
+
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      'A',
+      'Suspend! [B]',
+      'Loading B...',
+    ]);
+    // Flush to skip suspended time.
+    Scheduler.unstable_advanceTime(600);
+    await advanceTimers(600);
+
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading B...')]);
+  });
+
+  it('keeps showing an avoided parent fallback if it is already showing', async () => {
+    function Foo({showB}) {
+      Scheduler.unstable_yieldValue('Foo');
+      return (
+        <Suspense fallback={<Text text="Initial load..." />}>
+          <Suspense
+            unstable_avoidThisFallback={true}
+            fallback={<Text text="Loading A..." />}>
+            <Text text="A" />
+            {showB ? (
               <Suspense
                 unstable_avoidThisFallback={true}
                 fallback={<Text text="Loading B..." />}>
                 <AsyncText text="B" ms={5000} />
               </Suspense>
-            </Suspense>
-          );
-        }
+            ) : null}
+          </Suspense>
+        </Suspense>
+      );
+    }
 
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          'A',
-          'Suspend! [B]',
-          'Loading B...',
-        ]);
-        // Flush to skip suspended time.
-        Scheduler.unstable_advanceTime(600);
-        await advanceTimers(600);
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield(['Foo', 'A']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
 
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('Loading B...'),
-        ]);
-      });
+    ReactNoop.render(<Foo showB={true} />);
 
-      it('keeps showing an avoided parent fallback if it is already showing', async () => {
-        function Foo({showB}) {
-          Scheduler.unstable_yieldValue('Foo');
-          return (
-            <Suspense fallback={<Text text="Initial load..." />}>
-              <Suspense
-                unstable_avoidThisFallback={true}
-                fallback={<Text text="Loading A..." />}>
-                <Text text="A" />
-                {showB ? (
-                  <Suspense
-                    unstable_avoidThisFallback={true}
-                    fallback={<Text text="Loading B..." />}>
-                    <AsyncText text="B" ms={5000} />
-                  </Suspense>
-                ) : null}
-              </Suspense>
-            </Suspense>
-          );
-        }
+    expect(Scheduler).toFlushAndYield([
+      'Foo',
+      'A',
+      'Suspend! [B]',
+      'Loading B...',
+    ]);
+    // Still suspended.
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
 
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield(['Foo', 'A']);
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
+    // Flush to skip suspended time.
+    Scheduler.unstable_advanceTime(600);
+    await advanceTimers(600);
 
-        ReactNoop.render(<Foo showB={true} />);
+    expect(ReactNoop.getChildren()).toEqual([span('A'), span('Loading B...')]);
+  });
 
-        expect(Scheduler).toFlushAndYield([
-          'Foo',
-          'A',
-          'Suspend! [B]',
-          'Loading B...',
-        ]);
-        // Still suspended.
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
+  it('commits a suspended idle pri render within a reasonable time', async () => {
+    function Foo({renderContent}) {
+      return (
+        <Fragment>
+          <Suspense fallback={<Text text="Loading A..." />}>
+            {renderContent ? <AsyncText text="A" ms={10000} /> : null}
+          </Suspense>
+        </Fragment>
+      );
+    }
 
-        // Flush to skip suspended time.
-        Scheduler.unstable_advanceTime(600);
-        await advanceTimers(600);
+    ReactNoop.render(<Foo />);
+    expect(Scheduler).toFlushAndYield([]);
 
-        expect(ReactNoop.getChildren()).toEqual([
-          span('A'),
-          span('Loading B...'),
-        ]);
-      });
+    ReactNoop.render(<Foo renderContent={1} />);
 
-      it('commits a suspended idle pri render within a reasonable time', async () => {
-        function Foo({renderContent}) {
-          return (
-            <Fragment>
-              <Suspense fallback={<Text text="Loading A..." />}>
-                {renderContent ? <AsyncText text="A" ms={10000} /> : null}
-              </Suspense>
-            </Fragment>
-          );
-        }
+    // Took a long time to render. This is to ensure we get a long suspense time.
+    // Could also use something like withSuspenseConfig to simulate this.
+    Scheduler.unstable_advanceTime(1500);
+    await advanceTimers(1500);
 
-        ReactNoop.render(<Foo />);
-        expect(Scheduler).toFlushAndYield([]);
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A...']);
+    // We're still suspended.
+    expect(ReactNoop.getChildren()).toEqual([]);
 
-        ReactNoop.render(<Foo renderContent={1} />);
+    // Schedule an update at idle pri.
+    Scheduler.unstable_runWithPriority(Scheduler.unstable_IdlePriority, () =>
+      ReactNoop.render(<Foo renderContent={2} />),
+    );
+    // We won't even work on Idle priority.
+    expect(Scheduler).toFlushAndYield([]);
 
-        // Took a long time to render. This is to ensure we get a long suspense time.
-        // Could also use something like withSuspenseConfig to simulate this.
-        Scheduler.unstable_advanceTime(1500);
-        await advanceTimers(1500);
+    // We're still suspended.
+    expect(ReactNoop.getChildren()).toEqual([]);
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A...']);
-        // We're still suspended.
-        expect(ReactNoop.getChildren()).toEqual([]);
+    // Advance time a little bit.
+    Scheduler.unstable_advanceTime(150);
+    await advanceTimers(150);
 
-        // Schedule an update at idle pri.
-        Scheduler.unstable_runWithPriority(
-          Scheduler.unstable_IdlePriority,
-          () => ReactNoop.render(<Foo renderContent={2} />),
+    // We should not have committed yet because we had a long suspense time.
+    expect(ReactNoop.getChildren()).toEqual([]);
+
+    // Flush to skip suspended time.
+    Scheduler.unstable_advanceTime(600);
+    await advanceTimers(600);
+
+    expect(ReactNoop.getChildren()).toEqual([span('Loading A...')]);
+  });
+
+  describe('delays transitions when there a suspense config is supplied', () => {
+    const SUSPENSE_CONFIG = {
+      timeoutMs: 2000,
+    };
+
+    it('top level render', async () => {
+      function App({page}) {
+        return (
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText text={page} ms={5000} />
+          </Suspense>
         );
-        // We won't even work on Idle priority.
-        expect(Scheduler).toFlushAndYield([]);
+      }
 
-        // We're still suspended.
-        expect(ReactNoop.getChildren()).toEqual([]);
+      // Initial render.
+      React.unstable_withSuspenseConfig(
+        () => ReactNoop.render(<App page="A" />),
+        SUSPENSE_CONFIG,
+      );
 
-        // Advance time a little bit.
-        Scheduler.unstable_advanceTime(150);
-        await advanceTimers(150);
+      expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+      // Only a short time is needed to unsuspend the initial loading state.
+      Scheduler.unstable_advanceTime(400);
+      await advanceTimers(400);
+      expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
 
-        // We should not have committed yet because we had a long suspense time.
-        expect(ReactNoop.getChildren()).toEqual([]);
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(5000);
+      await advanceTimers(5000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['A']);
+      expect(ReactNoop.getChildren()).toEqual([span('A')]);
 
-        // Flush to skip suspended time.
-        Scheduler.unstable_advanceTime(600);
-        await advanceTimers(600);
+      // Start transition.
+      React.unstable_withSuspenseConfig(
+        () => ReactNoop.render(<App page="B" />),
+        SUSPENSE_CONFIG,
+      );
 
-        expect(ReactNoop.getChildren()).toEqual([span('Loading A...')]);
-      });
+      expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+      Scheduler.unstable_advanceTime(1000);
+      await advanceTimers(1000);
+      // Even after a second, we have still not yet flushed the loading state.
+      expect(ReactNoop.getChildren()).toEqual([span('A')]);
+      Scheduler.unstable_advanceTime(1100);
+      await advanceTimers(1100);
+      // After the timeout, we do show the loading state.
+      expect(ReactNoop.getChildren()).toEqual([
+        hiddenSpan('A'),
+        span('Loading...'),
+      ]);
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(3000);
+      await advanceTimers(3000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+      expect(Scheduler).toFlushAndYield(['B']);
+      expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    });
 
-      describe('delays transitions when there a suspense config is supplied', () => {
-        const SUSPENSE_CONFIG = {
-          timeoutMs: 2000,
-        };
-
-        it('top level render', async () => {
-          function App({page}) {
-            return (
-              <Suspense fallback={<Text text="Loading..." />}>
-                <AsyncText text={page} ms={5000} />
-              </Suspense>
-            );
-          }
-
-          // Initial render.
-          React.unstable_withSuspenseConfig(
-            () => ReactNoop.render(<App page="A" />),
-            SUSPENSE_CONFIG,
-          );
-
-          expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-          // Only a short time is needed to unsuspend the initial loading state.
-          Scheduler.unstable_advanceTime(400);
-          await advanceTimers(400);
-          expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(5000);
-          await advanceTimers(5000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-          expect(Scheduler).toFlushAndYield(['A']);
-          expect(ReactNoop.getChildren()).toEqual([span('A')]);
-
-          // Start transition.
-          React.unstable_withSuspenseConfig(
-            () => ReactNoop.render(<App page="B" />),
-            SUSPENSE_CONFIG,
-          );
-
-          expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
-          Scheduler.unstable_advanceTime(1000);
-          await advanceTimers(1000);
-          // Even after a second, we have still not yet flushed the loading state.
-          expect(ReactNoop.getChildren()).toEqual([span('A')]);
-          Scheduler.unstable_advanceTime(1100);
-          await advanceTimers(1100);
-          // After the timeout, we do show the loading state.
-          expect(ReactNoop.getChildren()).toEqual([
-            hiddenSpan('A'),
-            span('Loading...'),
-          ]);
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(3000);
-          await advanceTimers(3000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-          expect(Scheduler).toFlushAndYield(['B']);
-          expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        });
-
-        it('hooks', async () => {
-          let transitionToPage;
-          function App() {
-            let [page, setPage] = React.useState('none');
-            transitionToPage = setPage;
-            if (page === 'none') {
-              return null;
-            }
-            return (
-              <Suspense fallback={<Text text="Loading..." />}>
-                <AsyncText text={page} ms={5000} />
-              </Suspense>
-            );
-          }
-
-          ReactNoop.render(<App />);
-          expect(Scheduler).toFlushAndYield([]);
-
-          // Initial render.
-          await ReactNoop.act(async () => {
-            React.unstable_withSuspenseConfig(
-              () => transitionToPage('A'),
-              SUSPENSE_CONFIG,
-            );
-
-            expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-            // Only a short time is needed to unsuspend the initial loading state.
-            Scheduler.unstable_advanceTime(400);
-            await advanceTimers(400);
-            expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-          });
-
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(5000);
-          await advanceTimers(5000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-          expect(Scheduler).toFlushAndYield(['A']);
-          expect(ReactNoop.getChildren()).toEqual([span('A')]);
-
-          // Start transition.
-          await ReactNoop.act(async () => {
-            React.unstable_withSuspenseConfig(
-              () => transitionToPage('B'),
-              SUSPENSE_CONFIG,
-            );
-
-            expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            // Even after a second, we have still not yet flushed the loading state.
-            expect(ReactNoop.getChildren()).toEqual([span('A')]);
-            Scheduler.unstable_advanceTime(1100);
-            await advanceTimers(1100);
-            // After the timeout, we do show the loading state.
-            expect(ReactNoop.getChildren()).toEqual([
-              hiddenSpan('A'),
-              span('Loading...'),
-            ]);
-          });
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(3000);
-          await advanceTimers(3000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-          expect(Scheduler).toFlushAndYield(['B']);
-          expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        });
-
-        it('classes', async () => {
-          let transitionToPage;
-          class App extends React.Component {
-            state = {page: 'none'};
-            render() {
-              transitionToPage = page => this.setState({page});
-              let page = this.state.page;
-              if (page === 'none') {
-                return null;
-              }
-              return (
-                <Suspense fallback={<Text text="Loading..." />}>
-                  <AsyncText text={page} ms={5000} />
-                </Suspense>
-              );
-            }
-          }
-
-          ReactNoop.render(<App />);
-          expect(Scheduler).toFlushAndYield([]);
-
-          // Initial render.
-          await ReactNoop.act(async () => {
-            React.unstable_withSuspenseConfig(
-              () => transitionToPage('A'),
-              SUSPENSE_CONFIG,
-            );
-
-            expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-            // Only a short time is needed to unsuspend the initial loading state.
-            Scheduler.unstable_advanceTime(400);
-            await advanceTimers(400);
-            expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
-          });
-
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(5000);
-          await advanceTimers(5000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-          expect(Scheduler).toFlushAndYield(['A']);
-          expect(ReactNoop.getChildren()).toEqual([span('A')]);
-
-          // Start transition.
-          await ReactNoop.act(async () => {
-            React.unstable_withSuspenseConfig(
-              () => transitionToPage('B'),
-              SUSPENSE_CONFIG,
-            );
-
-            expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
-            Scheduler.unstable_advanceTime(1000);
-            await advanceTimers(1000);
-            // Even after a second, we have still not yet flushed the loading state.
-            expect(ReactNoop.getChildren()).toEqual([span('A')]);
-            Scheduler.unstable_advanceTime(1100);
-            await advanceTimers(1100);
-            // After the timeout, we do show the loading state.
-            expect(ReactNoop.getChildren()).toEqual([
-              hiddenSpan('A'),
-              span('Loading...'),
-            ]);
-          });
-          // Later we load the data.
-          Scheduler.unstable_advanceTime(3000);
-          await advanceTimers(3000);
-          expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-          expect(Scheduler).toFlushAndYield(['B']);
-          expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        });
-      });
-
-      it('disables suspense config when nothing is passed to withSuspenseConfig', async () => {
-        function App({page}) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <AsyncText text={page} ms={2000} />
-            </Suspense>
-          );
+    it('hooks', async () => {
+      let transitionToPage;
+      function App() {
+        let [page, setPage] = React.useState('none');
+        transitionToPage = setPage;
+        if (page === 'none') {
+          return null;
         }
+        return (
+          <Suspense fallback={<Text text="Loading..." />}>
+            <AsyncText text={page} ms={5000} />
+          </Suspense>
+        );
+      }
 
-        // Initial render.
-        ReactNoop.render(<App page="A" />);
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-        Scheduler.unstable_advanceTime(2000);
-        await advanceTimers(2000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['A']);
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
+      ReactNoop.render(<App />);
+      expect(Scheduler).toFlushAndYield([]);
 
-        // Start transition.
+      // Initial render.
+      await ReactNoop.act(async () => {
         React.unstable_withSuspenseConfig(
-          () => {
-            // When we schedule an inner transition without a suspense config
-            // so it should only suspend for a short time.
-            React.unstable_withSuspenseConfig(() =>
-              ReactNoop.render(<App page="B" />),
-            );
-          },
-          {timeoutMs: 2000},
+          () => transitionToPage('A'),
+          SUSPENSE_CONFIG,
+        );
+
+        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        // Only a short time is needed to unsuspend the initial loading state.
+        Scheduler.unstable_advanceTime(400);
+        await advanceTimers(400);
+        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+      });
+
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(5000);
+      await advanceTimers(5000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['A']);
+      expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+      // Start transition.
+      await ReactNoop.act(async () => {
+        React.unstable_withSuspenseConfig(
+          () => transitionToPage('B'),
+          SUSPENSE_CONFIG,
         );
 
         expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
-        // Suspended
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
-        Scheduler.unstable_advanceTime(500);
-        await advanceTimers(500);
-        // Committed loading state.
-        expect(ReactNoop.getChildren()).toEqual([
-          hiddenSpan('A'),
-          span('Loading...'),
-        ]);
-
-        Scheduler.unstable_advanceTime(2000);
-        await advanceTimers(2000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(Scheduler).toFlushAndYield(['B']);
-        expect(ReactNoop.getChildren()).toEqual([span('B')]);
-
-        React.unstable_withSuspenseConfig(
-          () => {
-            // First we schedule an inner unrelated update.
-            React.unstable_withSuspenseConfig(() =>
-              ReactNoop.render(<App page="B" unrelated={true} />),
-            );
-            // Then we schedule another transition to a slow page,
-            // but at this scope we should suspend for longer.
-            Scheduler.unstable_next(() => ReactNoop.render(<App page="C" />));
-          },
-          {timeoutMs: 2000},
-        );
-        expect(Scheduler).toFlushAndYield([
-          'Suspend! [C]',
-          'Loading...',
-          'Suspend! [C]',
-          'Loading...',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        Scheduler.unstable_advanceTime(1200);
-        await advanceTimers(1200);
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
         // Even after a second, we have still not yet flushed the loading state.
-        expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        Scheduler.unstable_advanceTime(1200);
-        await advanceTimers(1200);
-        // After the two second timeout we show the loading state.
+        expect(ReactNoop.getChildren()).toEqual([span('A')]);
+        Scheduler.unstable_advanceTime(1100);
+        await advanceTimers(1100);
+        // After the timeout, we do show the loading state.
         expect(ReactNoop.getChildren()).toEqual([
-          hiddenSpan('B'),
+          hiddenSpan('A'),
           span('Loading...'),
         ]);
       });
-
-      it('withSuspenseConfig timeout applies when we use an updated avoided boundary', async () => {
-        function App({page}) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <Text text="Hi!" />
-              <Suspense
-                fallback={<Text text={'Loading ' + page + '...'} />}
-                unstable_avoidThisFallback={true}>
-                <AsyncText text={page} ms={3000} />
-              </Suspense>
-            </Suspense>
-          );
-        }
-
-        // Initial render.
-        ReactNoop.render(<App page="A" />);
-        expect(Scheduler).toFlushAndYield([
-          'Hi!',
-          'Suspend! [A]',
-          'Loading...',
-        ]);
-        Scheduler.unstable_advanceTime(3000);
-        await advanceTimers(3000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-
-        // Start transition.
-        React.unstable_withSuspenseConfig(
-          () => ReactNoop.render(<App page="B" />),
-          {timeoutMs: 2000},
-        );
-
-        expect(Scheduler).toFlushAndYield([
-          'Hi!',
-          'Suspend! [B]',
-          'Loading B...',
-        ]);
-
-        // Suspended
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-        Scheduler.unstable_advanceTime(1800);
-        await advanceTimers(1800);
-        expect(Scheduler).toFlushAndYield([]);
-        // We should still be suspended here because this loading state should be avoided.
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-        Scheduler.unstable_advanceTime(1500);
-        await advanceTimers(1500);
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Hi!'),
-          hiddenSpan('A'),
-          span('Loading B...'),
-        ]);
-      });
-
-      it('withSuspenseConfig timeout applies when we use a newly created avoided boundary', async () => {
-        function App({page}) {
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <Text text="Hi!" />
-              {page === 'A' ? (
-                <Text text="A" />
-              ) : (
-                <Suspense
-                  fallback={<Text text={'Loading ' + page + '...'} />}
-                  unstable_avoidThisFallback={true}>
-                  <AsyncText text={page} ms={3000} />
-                </Suspense>
-              )}
-            </Suspense>
-          );
-        }
-
-        // Initial render.
-        ReactNoop.render(<App page="A" />);
-        expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-
-        // Start transition.
-        React.unstable_withSuspenseConfig(
-          () => ReactNoop.render(<App page="B" />),
-          {timeoutMs: 2000},
-        );
-
-        expect(Scheduler).toFlushAndYield([
-          'Hi!',
-          'Suspend! [B]',
-          'Loading B...',
-        ]);
-
-        // Suspended
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-        Scheduler.unstable_advanceTime(1800);
-        await advanceTimers(1800);
-        expect(Scheduler).toFlushAndYield([]);
-        // We should still be suspended here because this loading state should be avoided.
-        expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
-        Scheduler.unstable_advanceTime(1500);
-        await advanceTimers(1500);
-        expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Hi!'),
-          span('Loading B...'),
-        ]);
-      });
-
-      it('supports delaying a busy spinner from disappearing', async () => {
-        function useLoadingIndicator(config) {
-          let [isLoading, setLoading] = React.useState(false);
-          let start = React.useCallback(
-            cb => {
-              setLoading(true);
-              Scheduler.unstable_next(() =>
-                React.unstable_withSuspenseConfig(() => {
-                  setLoading(false);
-                  cb();
-                }, config),
-              );
-            },
-            [setLoading, config],
-          );
-          return [isLoading, start];
-        }
-
-        const SUSPENSE_CONFIG = {
-          timeoutMs: 10000,
-          busyDelayMs: 500,
-          busyMinDurationMs: 400,
-        };
-
-        let transitionToPage;
-
-        function App() {
-          let [page, setPage] = React.useState('A');
-          let [isLoading, startLoading] = useLoadingIndicator(SUSPENSE_CONFIG);
-          transitionToPage = nextPage => startLoading(() => setPage(nextPage));
-          return (
-            <Fragment>
-              <Text text={page} />
-              {isLoading ? <Text text="L" /> : null}
-            </Fragment>
-          );
-        }
-
-        // Initial render.
-        ReactNoop.render(<App />);
-        expect(Scheduler).toFlushAndYield(['A']);
-        expect(ReactNoop.getChildren()).toEqual([span('A')]);
-
-        await ReactNoop.act(async () => {
-          transitionToPage('B');
-          // Rendering B is quick and we didn't have enough
-          // time to show the loading indicator.
-          Scheduler.unstable_advanceTime(200);
-          await advanceTimers(200);
-          expect(Scheduler).toFlushAndYield(['A', 'L', 'B']);
-          expect(ReactNoop.getChildren()).toEqual([span('B')]);
-        });
-
-        await ReactNoop.act(async () => {
-          transitionToPage('C');
-          // Rendering C is a bit slower so we've already showed
-          // the loading indicator.
-          Scheduler.unstable_advanceTime(600);
-          await advanceTimers(600);
-          expect(Scheduler).toFlushAndYield(['B', 'L', 'C']);
-          // We're technically done now but we haven't shown the
-          // loading indicator for long enough yet so we'll suspend
-          // while we keep it on the screen a bit longer.
-          expect(ReactNoop.getChildren()).toEqual([span('B'), span('L')]);
-          Scheduler.unstable_advanceTime(400);
-          await advanceTimers(400);
-          expect(ReactNoop.getChildren()).toEqual([span('C')]);
-        });
-
-        await ReactNoop.act(async () => {
-          transitionToPage('D');
-          // Rendering D is very slow so we've already showed
-          // the loading indicator.
-          Scheduler.unstable_advanceTime(1000);
-          await advanceTimers(1000);
-          expect(Scheduler).toFlushAndYield(['C', 'L', 'D']);
-          // However, since we exceeded the minimum time to show
-          // the loading indicator, we commit immediately.
-          expect(ReactNoop.getChildren()).toEqual([span('D')]);
-        });
-      });
-
-      it("suspended commit remains suspended even if there's another update at same expiration", async () => {
-        // Regression test
-        function App({text}) {
-          return (
-            <Suspense fallback="Loading...">
-              <AsyncText ms={2000} text={text} />
-            </Suspense>
-          );
-        }
-
-        const root = ReactNoop.createRoot();
-        await ReactNoop.act(async () => {
-          root.render(<App text="Initial" />);
-        });
-
-        // Resolve initial render
-        await ReactNoop.act(async () => {
-          Scheduler.unstable_advanceTime(2000);
-          await advanceTimers(2000);
-        });
-        expect(Scheduler).toHaveYielded([
-          'Suspend! [Initial]',
-          'Promise resolved [Initial]',
-          'Initial',
-        ]);
-        expect(root).toMatchRenderedOutput(<span prop="Initial" />);
-
-        // Update. Since showing a fallback would hide content that's already
-        // visible, it should suspend for a bit without committing.
-        await ReactNoop.act(async () => {
-          root.render(<App text="First update" />);
-
-          expect(Scheduler).toFlushAndYield(['Suspend! [First update]']);
-          // Should not display a fallback
-          expect(root).toMatchRenderedOutput(<span prop="Initial" />);
-        });
-
-        // Update again. This should also suspend for a bit.
-        await ReactNoop.act(async () => {
-          root.render(<App text="Second update" />);
-
-          expect(Scheduler).toFlushAndYield(['Suspend! [Second update]']);
-          // Should not display a fallback
-          expect(root).toMatchRenderedOutput(<span prop="Initial" />);
-        });
-      });
-
-      it('regression test: resets current "debug phase" after suspending', async () => {
-        function App() {
-          return (
-            <Suspense fallback="Loading...">
-              <Foo suspend={false} />
-            </Suspense>
-          );
-        }
-
-        const thenable = {then() {}};
-
-        let foo;
-        class Foo extends React.Component {
-          state = {suspend: false};
-          render() {
-            foo = this;
-
-            if (this.state.suspend) {
-              Scheduler.unstable_yieldValue('Suspend!');
-              throw thenable;
-            }
-
-            return <Text text="Foo" />;
-          }
-        }
-
-        const root = ReactNoop.createRoot();
-        await ReactNoop.act(async () => {
-          root.render(<App />);
-        });
-
-        expect(Scheduler).toHaveYielded(['Foo']);
-
-        await ReactNoop.act(async () => {
-          foo.setState({suspend: true});
-
-          // In the regression that this covers, we would neglect to reset the
-          // current debug phase after suspending (in the catch block), so React
-          // thinks we're still inside the render phase.
-          expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
-
-          // Then when this setState happens, React would incorrectly fire a warning
-          // about updates that happen the render phase (only fired by classes).
-          foo.setState({suspend: false});
-        });
-
-        expect(root).toMatchRenderedOutput(<span prop="Foo" />);
-      });
-
-      it('should not render hidden content while suspended on higher pri', async () => {
-        function Offscreen() {
-          Scheduler.unstable_yieldValue('Offscreen');
-          return 'Offscreen';
-        }
-        function App({showContent}) {
-          React.useLayoutEffect(() => {
-            Scheduler.unstable_yieldValue('Commit');
-          });
-          return (
-            <>
-              <div hidden={true}>
-                <Offscreen />
-              </div>
-              <Suspense fallback={<Text text="Loading..." />}>
-                {showContent ? <AsyncText text="A" ms={2000} /> : null}
-              </Suspense>
-            </>
-          );
-        }
-
-        // Initial render.
-        ReactNoop.render(<App showContent={false} />);
-        expect(Scheduler).toFlushAndYieldThrough(['Commit']);
-        expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
-
-        // Start transition.
-        React.unstable_withSuspenseConfig(
-          () => {
-            ReactNoop.render(<App showContent={true} />);
-          },
-          {timeoutMs: 2000},
-        );
-
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-        Scheduler.unstable_advanceTime(2000);
-        await advanceTimers(2000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <div hidden={true} />
-            <span prop="A" />
-          </>,
-        );
-        expect(Scheduler).toFlushAndYield(['Offscreen']);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <div hidden={true}>Offscreen</div>
-            <span prop="A" />
-          </>,
-        );
-      });
-
-      it('should be able to unblock higher pri content before suspended hidden', async () => {
-        function Offscreen() {
-          Scheduler.unstable_yieldValue('Offscreen');
-          return 'Offscreen';
-        }
-        function App({showContent}) {
-          React.useLayoutEffect(() => {
-            Scheduler.unstable_yieldValue('Commit');
-          });
-          return (
-            <Suspense fallback={<Text text="Loading..." />}>
-              <div hidden={true}>
-                <AsyncText text="A" ms={2000} />
-                <Offscreen />
-              </div>
-              {showContent ? <AsyncText text="A" ms={2000} /> : null}
-            </Suspense>
-          );
-        }
-
-        // Initial render.
-        ReactNoop.render(<App showContent={false} />);
-        expect(Scheduler).toFlushAndYieldThrough(['Commit']);
-        expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
-
-        // Partially render through the hidden content.
-        expect(Scheduler).toFlushAndYieldThrough(['Suspend! [A]']);
-
-        // Start transition.
-        React.unstable_withSuspenseConfig(
-          () => {
-            ReactNoop.render(<App showContent={true} />);
-          },
-          {timeoutMs: 5000},
-        );
-
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
-        Scheduler.unstable_advanceTime(2000);
-        await advanceTimers(2000);
-        expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
-        expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <div hidden={true} />
-            <span prop="A" />
-          </>,
-        );
-        expect(Scheduler).toFlushAndYield(['A', 'Offscreen']);
-        expect(ReactNoop).toMatchRenderedOutput(
-          <>
-            <div hidden={true}>
-              <span prop="A" />
-              Offscreen
-            </div>
-            <span prop="A" />
-          </>,
-        );
-      });
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(3000);
+      await advanceTimers(3000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+      expect(Scheduler).toFlushAndYield(['B']);
+      expect(ReactNoop.getChildren()).toEqual([span('B')]);
     });
+
+    it('classes', async () => {
+      let transitionToPage;
+      class App extends React.Component {
+        state = {page: 'none'};
+        render() {
+          transitionToPage = page => this.setState({page});
+          let page = this.state.page;
+          if (page === 'none') {
+            return null;
+          }
+          return (
+            <Suspense fallback={<Text text="Loading..." />}>
+              <AsyncText text={page} ms={5000} />
+            </Suspense>
+          );
+        }
+      }
+
+      ReactNoop.render(<App />);
+      expect(Scheduler).toFlushAndYield([]);
+
+      // Initial render.
+      await ReactNoop.act(async () => {
+        React.unstable_withSuspenseConfig(
+          () => transitionToPage('A'),
+          SUSPENSE_CONFIG,
+        );
+
+        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        // Only a short time is needed to unsuspend the initial loading state.
+        Scheduler.unstable_advanceTime(400);
+        await advanceTimers(400);
+        expect(ReactNoop.getChildren()).toEqual([span('Loading...')]);
+      });
+
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(5000);
+      await advanceTimers(5000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+      expect(Scheduler).toFlushAndYield(['A']);
+      expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+      // Start transition.
+      await ReactNoop.act(async () => {
+        React.unstable_withSuspenseConfig(
+          () => transitionToPage('B'),
+          SUSPENSE_CONFIG,
+        );
+
+        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        Scheduler.unstable_advanceTime(1000);
+        await advanceTimers(1000);
+        // Even after a second, we have still not yet flushed the loading state.
+        expect(ReactNoop.getChildren()).toEqual([span('A')]);
+        Scheduler.unstable_advanceTime(1100);
+        await advanceTimers(1100);
+        // After the timeout, we do show the loading state.
+        expect(ReactNoop.getChildren()).toEqual([
+          hiddenSpan('A'),
+          span('Loading...'),
+        ]);
+      });
+      // Later we load the data.
+      Scheduler.unstable_advanceTime(3000);
+      await advanceTimers(3000);
+      expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+      expect(Scheduler).toFlushAndYield(['B']);
+      expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    });
+  });
+
+  it('disables suspense config when nothing is passed to withSuspenseConfig', async () => {
+    function App({page}) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <AsyncText text={page} ms={2000} />
+        </Suspense>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App page="A" />);
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    Scheduler.unstable_advanceTime(2000);
+    await advanceTimers(2000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    // Start transition.
+    React.unstable_withSuspenseConfig(
+      () => {
+        // When we schedule an inner transition without a suspense config
+        // so it should only suspend for a short time.
+        React.unstable_withSuspenseConfig(() =>
+          ReactNoop.render(<App page="B" />),
+        );
+      },
+      {timeoutMs: 2000},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+    // Suspended
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+    Scheduler.unstable_advanceTime(500);
+    await advanceTimers(500);
+    // Committed loading state.
+    expect(ReactNoop.getChildren()).toEqual([
+      hiddenSpan('A'),
+      span('Loading...'),
+    ]);
+
+    Scheduler.unstable_advanceTime(2000);
+    await advanceTimers(2000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(Scheduler).toFlushAndYield(['B']);
+    expect(ReactNoop.getChildren()).toEqual([span('B')]);
+
+    React.unstable_withSuspenseConfig(
+      () => {
+        // First we schedule an inner unrelated update.
+        React.unstable_withSuspenseConfig(() =>
+          ReactNoop.render(<App page="B" unrelated={true} />),
+        );
+        // Then we schedule another transition to a slow page,
+        // but at this scope we should suspend for longer.
+        Scheduler.unstable_next(() => ReactNoop.render(<App page="C" />));
+      },
+      {timeoutMs: 2000},
+    );
+    expect(Scheduler).toFlushAndYield([
+      'Suspend! [C]',
+      'Loading...',
+      'Suspend! [C]',
+      'Loading...',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    Scheduler.unstable_advanceTime(1200);
+    await advanceTimers(1200);
+    // Even after a second, we have still not yet flushed the loading state.
+    expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    Scheduler.unstable_advanceTime(1200);
+    await advanceTimers(1200);
+    // After the two second timeout we show the loading state.
+    expect(ReactNoop.getChildren()).toEqual([
+      hiddenSpan('B'),
+      span('Loading...'),
+    ]);
+  });
+
+  it('withSuspenseConfig timeout applies when we use an updated avoided boundary', async () => {
+    function App({page}) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Text text="Hi!" />
+          <Suspense
+            fallback={<Text text={'Loading ' + page + '...'} />}
+            unstable_avoidThisFallback={true}>
+            <AsyncText text={page} ms={3000} />
+          </Suspense>
+        </Suspense>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App page="A" />);
+    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [A]', 'Loading...']);
+    Scheduler.unstable_advanceTime(3000);
+    await advanceTimers(3000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+
+    // Start transition.
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App page="B" />),
+      {timeoutMs: 2000},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [B]', 'Loading B...']);
+
+    // Suspended
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+    Scheduler.unstable_advanceTime(1800);
+    await advanceTimers(1800);
+    expect(Scheduler).toFlushAndYield([]);
+    // We should still be suspended here because this loading state should be avoided.
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+    Scheduler.unstable_advanceTime(1500);
+    await advanceTimers(1500);
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Hi!'),
+      hiddenSpan('A'),
+      span('Loading B...'),
+    ]);
+  });
+
+  it('withSuspenseConfig timeout applies when we use a newly created avoided boundary', async () => {
+    function App({page}) {
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <Text text="Hi!" />
+          {page === 'A' ? (
+            <Text text="A" />
+          ) : (
+            <Suspense
+              fallback={<Text text={'Loading ' + page + '...'} />}
+              unstable_avoidThisFallback={true}>
+              <AsyncText text={page} ms={3000} />
+            </Suspense>
+          )}
+        </Suspense>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App page="A" />);
+    expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+
+    // Start transition.
+    React.unstable_withSuspenseConfig(
+      () => ReactNoop.render(<App page="B" />),
+      {timeoutMs: 2000},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [B]', 'Loading B...']);
+
+    // Suspended
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+    Scheduler.unstable_advanceTime(1800);
+    await advanceTimers(1800);
+    expect(Scheduler).toFlushAndYield([]);
+    // We should still be suspended here because this loading state should be avoided.
+    expect(ReactNoop.getChildren()).toEqual([span('Hi!'), span('A')]);
+    Scheduler.unstable_advanceTime(1500);
+    await advanceTimers(1500);
+    expect(Scheduler).toHaveYielded(['Promise resolved [B]']);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Hi!'),
+      span('Loading B...'),
+    ]);
+  });
+
+  it('supports delaying a busy spinner from disappearing', async () => {
+    function useLoadingIndicator(config) {
+      let [isLoading, setLoading] = React.useState(false);
+      let start = React.useCallback(
+        cb => {
+          setLoading(true);
+          Scheduler.unstable_next(() =>
+            React.unstable_withSuspenseConfig(() => {
+              setLoading(false);
+              cb();
+            }, config),
+          );
+        },
+        [setLoading, config],
+      );
+      return [isLoading, start];
+    }
+
+    const SUSPENSE_CONFIG = {
+      timeoutMs: 10000,
+      busyDelayMs: 500,
+      busyMinDurationMs: 400,
+    };
+
+    let transitionToPage;
+
+    function App() {
+      let [page, setPage] = React.useState('A');
+      let [isLoading, startLoading] = useLoadingIndicator(SUSPENSE_CONFIG);
+      transitionToPage = nextPage => startLoading(() => setPage(nextPage));
+      return (
+        <Fragment>
+          <Text text={page} />
+          {isLoading ? <Text text="L" /> : null}
+        </Fragment>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App />);
+    expect(Scheduler).toFlushAndYield(['A']);
+    expect(ReactNoop.getChildren()).toEqual([span('A')]);
+
+    await ReactNoop.act(async () => {
+      transitionToPage('B');
+      // Rendering B is quick and we didn't have enough
+      // time to show the loading indicator.
+      Scheduler.unstable_advanceTime(200);
+      await advanceTimers(200);
+      expect(Scheduler).toFlushAndYield(['A', 'L', 'B']);
+      expect(ReactNoop.getChildren()).toEqual([span('B')]);
+    });
+
+    await ReactNoop.act(async () => {
+      transitionToPage('C');
+      // Rendering C is a bit slower so we've already showed
+      // the loading indicator.
+      Scheduler.unstable_advanceTime(600);
+      await advanceTimers(600);
+      expect(Scheduler).toFlushAndYield(['B', 'L', 'C']);
+      // We're technically done now but we haven't shown the
+      // loading indicator for long enough yet so we'll suspend
+      // while we keep it on the screen a bit longer.
+      expect(ReactNoop.getChildren()).toEqual([span('B'), span('L')]);
+      Scheduler.unstable_advanceTime(400);
+      await advanceTimers(400);
+      expect(ReactNoop.getChildren()).toEqual([span('C')]);
+    });
+
+    await ReactNoop.act(async () => {
+      transitionToPage('D');
+      // Rendering D is very slow so we've already showed
+      // the loading indicator.
+      Scheduler.unstable_advanceTime(1000);
+      await advanceTimers(1000);
+      expect(Scheduler).toFlushAndYield(['C', 'L', 'D']);
+      // However, since we exceeded the minimum time to show
+      // the loading indicator, we commit immediately.
+      expect(ReactNoop.getChildren()).toEqual([span('D')]);
+    });
+  });
+
+  it("suspended commit remains suspended even if there's another update at same expiration", async () => {
+    // Regression test
+    function App({text}) {
+      return (
+        <Suspense fallback="Loading...">
+          <AsyncText ms={2000} text={text} />
+        </Suspense>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App text="Initial" />);
+    });
+
+    // Resolve initial render
+    await ReactNoop.act(async () => {
+      Scheduler.unstable_advanceTime(2000);
+      await advanceTimers(2000);
+    });
+    expect(Scheduler).toHaveYielded([
+      'Suspend! [Initial]',
+      'Promise resolved [Initial]',
+      'Initial',
+    ]);
+    expect(root).toMatchRenderedOutput(<span prop="Initial" />);
+
+    // Update. Since showing a fallback would hide content that's already
+    // visible, it should suspend for a bit without committing.
+    await ReactNoop.act(async () => {
+      root.render(<App text="First update" />);
+
+      expect(Scheduler).toFlushAndYield(['Suspend! [First update]']);
+      // Should not display a fallback
+      expect(root).toMatchRenderedOutput(<span prop="Initial" />);
+    });
+
+    // Update again. This should also suspend for a bit.
+    await ReactNoop.act(async () => {
+      root.render(<App text="Second update" />);
+
+      expect(Scheduler).toFlushAndYield(['Suspend! [Second update]']);
+      // Should not display a fallback
+      expect(root).toMatchRenderedOutput(<span prop="Initial" />);
+    });
+  });
+
+  it('regression test: resets current "debug phase" after suspending', async () => {
+    function App() {
+      return (
+        <Suspense fallback="Loading...">
+          <Foo suspend={false} />
+        </Suspense>
+      );
+    }
+
+    const thenable = {then() {}};
+
+    let foo;
+    class Foo extends React.Component {
+      state = {suspend: false};
+      render() {
+        foo = this;
+
+        if (this.state.suspend) {
+          Scheduler.unstable_yieldValue('Suspend!');
+          throw thenable;
+        }
+
+        return <Text text="Foo" />;
+      }
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+
+    expect(Scheduler).toHaveYielded(['Foo']);
+
+    await ReactNoop.act(async () => {
+      foo.setState({suspend: true});
+
+      // In the regression that this covers, we would neglect to reset the
+      // current debug phase after suspending (in the catch block), so React
+      // thinks we're still inside the render phase.
+      expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
+
+      // Then when this setState happens, React would incorrectly fire a warning
+      // about updates that happen the render phase (only fired by classes).
+      foo.setState({suspend: false});
+    });
+
+    expect(root).toMatchRenderedOutput(<span prop="Foo" />);
+  });
+
+  it('should not render hidden content while suspended on higher pri', async () => {
+    function Offscreen() {
+      Scheduler.unstable_yieldValue('Offscreen');
+      return 'Offscreen';
+    }
+    function App({showContent}) {
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('Commit');
+      });
+      return (
+        <>
+          <div hidden={true}>
+            <Offscreen />
+          </div>
+          <Suspense fallback={<Text text="Loading..." />}>
+            {showContent ? <AsyncText text="A" ms={2000} /> : null}
+          </Suspense>
+        </>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App showContent={false} />);
+    expect(Scheduler).toFlushAndYieldThrough(['Commit']);
+    expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
+
+    // Start transition.
+    React.unstable_withSuspenseConfig(
+      () => {
+        ReactNoop.render(<App showContent={true} />);
+      },
+      {timeoutMs: 2000},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    Scheduler.unstable_advanceTime(2000);
+    await advanceTimers(2000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <div hidden={true} />
+        <span prop="A" />
+      </>,
+    );
+    expect(Scheduler).toFlushAndYield(['Offscreen']);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <div hidden={true}>Offscreen</div>
+        <span prop="A" />
+      </>,
+    );
+  });
+
+  it('should be able to unblock higher pri content before suspended hidden', async () => {
+    function Offscreen() {
+      Scheduler.unstable_yieldValue('Offscreen');
+      return 'Offscreen';
+    }
+    function App({showContent}) {
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('Commit');
+      });
+      return (
+        <Suspense fallback={<Text text="Loading..." />}>
+          <div hidden={true}>
+            <AsyncText text="A" ms={2000} />
+            <Offscreen />
+          </div>
+          {showContent ? <AsyncText text="A" ms={2000} /> : null}
+        </Suspense>
+      );
+    }
+
+    // Initial render.
+    ReactNoop.render(<App showContent={false} />);
+    expect(Scheduler).toFlushAndYieldThrough(['Commit']);
+    expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
+
+    // Partially render through the hidden content.
+    expect(Scheduler).toFlushAndYieldThrough(['Suspend! [A]']);
+
+    // Start transition.
+    React.unstable_withSuspenseConfig(
+      () => {
+        ReactNoop.render(<App showContent={true} />);
+      },
+      {timeoutMs: 5000},
+    );
+
+    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    Scheduler.unstable_advanceTime(2000);
+    await advanceTimers(2000);
+    expect(Scheduler).toHaveYielded(['Promise resolved [A]']);
+    expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <div hidden={true} />
+        <span prop="A" />
+      </>,
+    );
+    expect(Scheduler).toFlushAndYield(['A', 'Offscreen']);
+    expect(ReactNoop).toMatchRenderedOutput(
+      <>
+        <div hidden={true}>
+          <span prop="A" />
+          Offscreen
+        </div>
+        <span prop="A" />
+      </>,
+    );
   });
 });


### PR DESCRIPTION
Tests now run against both versions of these flags, using the test-www-variant command. So we can remove the manual overrides.