### PR TITLE
ReactDOM.useEvent: Add DOM host event listener logic

### DIFF
--- a/packages/legacy-events/PluginModuleType.js
+++ b/packages/legacy-events/PluginModuleType.js
@@ -29,7 +29,7 @@ export type PluginModule<NativeEvent> = {
     nativeTarget: NativeEvent,
     nativeEventTarget: null | EventTarget,
     eventSystemFlags: EventSystemFlags,
-    container?: EventTarget,
+    container?: null | EventTarget,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
 };

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -15,6 +15,7 @@ import type {
   SuspenseInstance,
   Props,
 } from './ReactDOMHostConfig';
+import type {ReactDOMListener} from 'shared/ReactDOMTypes';
 
 import {
   HostComponent,
@@ -32,6 +33,7 @@ const randomKey = Math.random()
 const internalInstanceKey = '__reactInternalInstance$' + randomKey;
 const internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
 const internalContainerInstanceKey = '__reactContainere$' + randomKey;
+const internalEventListenersKey = '__reactEventListeners$' + randomKey;
 
 export function precacheFiberNode(
   hostInst: Fiber,
@@ -184,4 +186,19 @@ export function updateFiberProps(
   props: Props,
 ): void {
   (node: any)[internalEventHandlersKey] = props;
+}
+
+// This is used for useEvent listeners
+export function getListenersFromTarget(
+  target: EventTarget,
+): null | Set<ReactDOMListener> {
+  return (target: any)[internalEventListenersKey] || null;
+}
+
+// This is used for useEvent listeners
+export function initListenersSet(
+  target: EventTarget,
+  value: Set<ReactDOMListener>,
+): void {
+  (target: any)[internalEventListenersKey] = value;
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -69,7 +69,6 @@ import {
   enableUseEventAPI,
 } from 'shared/ReactFeatureFlags';
 import {HostComponent} from 'shared/ReactWorkTags';
-import invariant from 'shared/invariant';
 import {
   RESPONDER_EVENT_SYSTEM,
   IS_PASSIVE,
@@ -1093,14 +1092,6 @@ export function mountEventListener(listener: ReactDOMListener): void {
       // TODO (useEvent)
     } else if (isDOMElement(target)) {
       attachElementListener(listener);
-    } else {
-      // The user should never get to here or we missed something in
-      // validateEventListenerTarget below.
-      invariant(
-        false,
-        'A useEvent listener target instance was not handled. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
     }
   }
 }
@@ -1108,20 +1099,12 @@ export function mountEventListener(listener: ReactDOMListener): void {
 export function unmountEventListener(listener: ReactDOMListener): void {
   if (enableUseEventAPI) {
     const {target} = listener;
-    if (isDOMElement(target)) {
+    if (target === window) {
       // TODO (useEvent)
     } else if (isDOMDocument(target)) {
       // TODO (useEvent)
     } else if (isDOMElement(target)) {
       detachElementListener(listener);
-    } else {
-      // The user should never get to here or we missed something in
-      // validateEventListenerTarget below.
-      invariant(
-        false,
-        'A useEvent listener target instance was not handled. This error is ' +
-          'likely caused by a bug in React. Please file an issue.',
-      );
     }
   }
 }
@@ -1150,9 +1133,11 @@ export function validateEventListenerTarget(
     }
     if (__DEV__) {
       console.warn(
-        'Event listener method setListener() from useEvent() hook requires the first argument to be either a valid ' +
-          'DOM node that was rendered and managed by React, or either the "window" or "document" objects.' +
-          "If you are setting setListener from ref, ensure the ref's current value has been set and is not null.",
+        'Event listener method setListener() from useEvent() hook requires the first argument to be either:' +
+          '\n\n' +
+          '1. A valid DOM node that was rendered and managed by React' +
+          '2. The "window" object' +
+          '3. The "document" object',
       );
     }
   }

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -126,7 +126,7 @@ type QueuedReplayableEvent = {|
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
   nativeEvent: AnyNativeEvent,
-  container: EventTarget,
+  targetContainer: EventTarget | null,
 |};
 
 let hasScheduledReplayAttempt = false;
@@ -285,7 +285,7 @@ function createQueuedReplayableEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: EventTarget,
+  targetContainer: EventTarget | null,
   nativeEvent: AnyNativeEvent,
 ): QueuedReplayableEvent {
   return {
@@ -293,7 +293,7 @@ function createQueuedReplayableEvent(
     topLevelType,
     eventSystemFlags: eventSystemFlags | IS_REPLAYED,
     nativeEvent,
-    container,
+    targetContainer,
   };
 }
 
@@ -301,14 +301,14 @@ export function queueDiscreteEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: EventTarget,
+  targetContainer: EventTarget | null,
   nativeEvent: AnyNativeEvent,
 ): void {
   const queuedEvent = createQueuedReplayableEvent(
     blockedOn,
     topLevelType,
     eventSystemFlags,
-    container,
+    targetContainer,
     nativeEvent,
   );
   queuedDiscreteEvents.push(queuedEvent);
@@ -376,7 +376,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: EventTarget,
+  targetContainer: EventTarget | null,
   nativeEvent: AnyNativeEvent,
 ): QueuedReplayableEvent {
   if (
@@ -387,7 +387,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
       blockedOn,
       topLevelType,
       eventSystemFlags,
-      container,
+      targetContainer,
       nativeEvent,
     );
     if (blockedOn !== null) {
@@ -411,7 +411,7 @@ export function queueIfContinuousEvent(
   blockedOn: null | Container | SuspenseInstance,
   topLevelType: DOMTopLevelEventType,
   eventSystemFlags: EventSystemFlags,
-  container: EventTarget,
+  targetContainer: EventTarget | null,
   nativeEvent: AnyNativeEvent,
 ): boolean {
   // These set relatedTarget to null because the replayed event will be treated as if we
@@ -425,7 +425,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        targetContainer,
         focusEvent,
       );
       return true;
@@ -437,7 +437,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        targetContainer,
         dragEvent,
       );
       return true;
@@ -449,7 +449,7 @@ export function queueIfContinuousEvent(
         blockedOn,
         topLevelType,
         eventSystemFlags,
-        container,
+        targetContainer,
         mouseEvent,
       );
       return true;
@@ -464,7 +464,7 @@ export function queueIfContinuousEvent(
           blockedOn,
           topLevelType,
           eventSystemFlags,
-          container,
+          targetContainer,
           pointerEvent,
         ),
       );
@@ -480,7 +480,7 @@ export function queueIfContinuousEvent(
           blockedOn,
           topLevelType,
           eventSystemFlags,
-          container,
+          targetContainer,
           pointerEvent,
         ),
       );
@@ -557,7 +557,7 @@ function attemptReplayContinuousQueuedEvent(
   let nextBlockedOn = attemptToDispatchEvent(
     queuedEvent.topLevelType,
     queuedEvent.eventSystemFlags,
-    queuedEvent.container,
+    queuedEvent.targetContainer,
     queuedEvent.nativeEvent,
   );
   if (nextBlockedOn !== null) {
@@ -600,7 +600,7 @@ function replayUnblockedEvents() {
     let nextBlockedOn = attemptToDispatchEvent(
       nextDiscreteEvent.topLevelType,
       nextDiscreteEvent.eventSystemFlags,
-      nextDiscreteEvent.container,
+      nextDiscreteEvent.targetContainer,
       nextDiscreteEvent.nativeEvent,
     );
     if (nextBlockedOn !== null) {

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -63,7 +63,7 @@ let hasWarnedAboutDeprecatedMockComponent = false;
  */
 function simulateNativeEventOnNode(topLevelType, node, fakeNativeEvent) {
   fakeNativeEvent.target = node;
-  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, document, fakeNativeEvent);
+  dispatchEvent(topLevelType, PLUGIN_EVENT_SYSTEM, null, fakeNativeEvent);
 }
 
 /**

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -348,6 +348,5 @@
   "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
   "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React.",
   "349": "Expected a work-in-progress root. This is a bug in React. Please file an issue.",
-  "350": "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue.",
-  "351": "A useEvent listener target instance was not handled. This error is likely caused by a bug in React. Please file an issue."
+  "350": "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -348,5 +348,6 @@
   "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
   "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React.",
   "349": "Expected a work-in-progress root. This is a bug in React. Please file an issue.",
-  "350": "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue."
+  "350": "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue.",
+  "351": "A useEvent listener target instance was not handled. This error is likely caused by a bug in React. Please file an issue."
 }


### PR DESCRIPTION
This PR adds the DOM event listener logic. As the useEvent hook has not yet been wired up to the host config, it's not yet possible to add tests – but those will come in the next PR.

I've detailed with comments how each part of the event listener logic works with `useEvent` "listeners", so hopefully it should flow and makes sense for those reviewing. In essense, we have a new internal listeners Set that we attach to DOM target instances. Target instances, are those will be attached via `useEvent`'s `setListener` API. In a follow up PR, we'll use this listeners Set to find any attached listener functions, to know to fire them.