### PR TITLE
Revert "Move MS Windows build to CircleCI"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
-version: 2.1
-
-orbs:
-  win: circleci/windows@2.4.0
+version: 2
 
 aliases:
   - &docker
@@ -50,9 +47,6 @@ aliases:
           root: build
           paths:
             - bundle-sizes.json
-
-  - &ms_windows_environment
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 
 jobs:
   setup:
@@ -470,38 +464,6 @@ jobs:
             RELEASE_CHANNEL: experimental
           command: yarn test-build-prod --maxWorkers=2
 
-  test_ms_windows:
-    executor:
-      name: win/default
-    environment: *ms_windows_environment
-    steps:
-      - run:
-          # Fix line endings in Windows.
-          command: git config --global core.autocrlf input
-      - checkout
-      - restore_cache:
-          keys:
-            - v2-win-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - v2-win-node-{{ arch }}-{{ .Branch }}-
-            - v2-win-node-{{ arch }}-
-      - run:
-          command: node --version
-      - run:
-          command: choco install yarn
-      - *run_yarn
-      - save_cache:
-          key: v2-win-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-          paths:
-            - C:\Users\circleci\AppData\Local\Yarn
-      - run:
-          command: yarn lint
-      - run:
-          command: yarn build
-      - run:
-          command: yarn test
-      - run:
-          command: yarn prettier
-
 workflows:
   version: 2
   stable:
@@ -616,9 +578,3 @@ workflows:
       - test_fuzz:
           requires:
             - setup
-
-  ms_windows:
-    jobs:
-      - test_ms_windows
-
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+image: Visual Studio 2017
+
+# Fix line endings in Windows. (runs before repo cloning)
+init:
+  - git config --global core.autocrlf input
+
+environment:
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  matrix:
+    - nodejs_version: 10
+
+# Finish on first failed build
+matrix:
+  fast_finish: true
+
+platform:
+  - x64
+
+branches:
+  only:
+    - master
+
+# Disable Visual Studio build and deploy
+build: off
+deploy: off
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - yarn install --frozen-lockfile
+
+test_script:
+  - node --version
+  - yarn lint
+#  - yarn flow-ci
+  - yarn build
+  - yarn test
+  - yarn prettier
+
+cache:
+ - node_modules
+ - "%LOCALAPPDATA%/Yarn"


### PR DESCRIPTION
I'm reverting this because it slowed our CI times from ~6 minutes to ~23 minutes. That's because it runs the build command without concurrency.

I don't remember why the Windows jobs exist. I can see why testing on a Windows machine is useful, but I don't think we should have to build the artifacts on Windows. We could re-use the artifacts from the normal build job.

Let's figure it out then re-land.