### PR TITLE
Remove un-used function arg

### DIFF
--- a/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
+++ b/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
@@ -14,7 +14,6 @@ import {HostComponent} from 'shared/ReactWorkTags';
 
 export default function accumulateTwoPhaseListeners(
   event: ReactSyntheticEvent,
-  skipTarget?: boolean,
 ): void {
   const phasedRegistrationNames = event.dispatchConfig.phasedRegistrationNames;
   if (phasedRegistrationNames == null) {
@@ -24,12 +23,6 @@ export default function accumulateTwoPhaseListeners(
   const dispatchListeners = [];
   const dispatchInstances = [];
   let node = event._targetInst;
-
-  // If we skip the target, then start the node at the parent
-  // of the target.
-  if (skipTarget) {
-    node = node.return;
-  }
 
   // Accumulate all instances and listeners via the target -> root path.
   while (node !== null) {


### PR DESCRIPTION
We can remove the function arg as it's never used anywhere anymore (it was added to support the `ResponderPlugin`, but we ended up not going down that route).