### PR TITLE
Refine event system types + pass through priority

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -59,7 +59,7 @@ import {
 import {getListenerMapForElement} from '../events/DOMEventListenerMap';
 import {
   addResponderEventSystemEvent,
-  removeTrappedPassiveEventListener,
+  removeTrappedEventListener,
 } from '../events/ReactDOMEventListener.js';
 import {mediaEventTypes} from '../events/DOMTopLevelEventTypes';
 import {
@@ -1360,10 +1360,11 @@ export function listenToEventResponderEventTypes(
           const passiveKey = targetEventType + '_passive';
           const passiveListener = listenerMap.get(passiveKey);
           if (passiveListener != null) {
-            removeTrappedPassiveEventListener(
+            removeTrappedEventListener(
               document,
               targetEventType,
               passiveListener,
+              true,
             );
           }
         }

--- a/packages/react-dom/src/events/DOMEventListenerMap.js
+++ b/packages/react-dom/src/events/DOMEventListenerMap.js
@@ -18,9 +18,14 @@ const elementListenerMap:
   | WeakMap
   | Map<EventTarget, Map<DOMTopLevelEventType | string, null | (any => void)>> = new PossiblyWeakMap();
 
+export type ElementListenerMap = Map<
+  DOMTopLevelEventType | string,
+  null | (any => void),
+>;
+
 export function getListenerMapForElement(
   target: EventTarget,
-): Map<DOMTopLevelEventType | string, null | (any => void)> {
+): ElementListenerMap {
   let listenerMap = elementListenerMap.get(target);
   if (listenerMap === undefined) {
     listenerMap = new Map();

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,6 +8,7 @@
  */
 
 import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
+import type {EventPriority} from 'shared/ReactTypes';
 import type {FiberRoot} from 'react-reconciler/src/ReactFiberRoot';
 import type {Container, SuspenseInstance} from '../client/ReactDOMHostConfig';
 import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
@@ -137,10 +138,15 @@ export function addTrappedEventListener(
   capture: boolean,
   legacyFBSupport?: boolean,
   passive?: boolean,
+  priority?: EventPriority,
 ): any => void {
+  const eventPriority =
+    priority === undefined
+      ? getEventPriorityForPluginSystem(topLevelType)
+      : priority;
   let listener;
   let listenerWrapper;
-  switch (getEventPriorityForPluginSystem(topLevelType)) {
+  switch (eventPriority) {
     case DiscreteEvent:
       listenerWrapper = dispatchDiscreteEvent;
       break;
@@ -247,10 +253,11 @@ export function addTrappedEventListener(
   return fbListener || listener;
 }
 
-export function removeTrappedPassiveEventListener(
+export function removeTrappedEventListener(
   targetContainer: EventTarget,
   topLevelType: string,
   listener: any => void,
+  passive: boolean,
 ) {
   if (listener.remove != null) {
     listener.remove();
@@ -258,7 +265,7 @@ export function removeTrappedPassiveEventListener(
     if (passiveBrowserEventsSupported) {
       targetContainer.removeEventListener(topLevelType, listener, {
         capture: true,
-        passive: true,
+        passive,
       });
     } else {
       targetContainer.removeEventListener(topLevelType, listener, true);

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -10,6 +10,7 @@
 import type {AnyNativeEvent} from 'legacy-events/PluginModuleType';
 import type {Container, SuspenseInstance} from '../client/ReactDOMHostConfig';
 import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
+import type {ElementListenerMap} from '../events/DOMEventListenerMap';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 import type {FiberRoot} from 'react-reconciler/src/ReactFiberRoot';
 
@@ -216,7 +217,7 @@ export function isReplayableDiscreteEvent(
 function trapReplayableEventForContainer(
   topLevelType: DOMTopLevelEventType,
   container: Container,
-  listenerMap: Map<DOMTopLevelEventType | string, null | (any => void)>,
+  listenerMap: ElementListenerMap,
 ) {
   listenToTopLevelEvent(topLevelType, ((container: any): Element), listenerMap);
 }
@@ -224,7 +225,7 @@ function trapReplayableEventForContainer(
 function trapReplayableEventForDocument(
   topLevelType: DOMTopLevelEventType,
   document: Document,
-  listenerMap: Map<DOMTopLevelEventType | string, null | (any => void)>,
+  listenerMap: ElementListenerMap,
 ) {
   if (!enableModernEventSystem) {
     legacyListenToTopLevelEvent(topLevelType, document, listenerMap);


### PR DESCRIPTION
This PR is mostly cosmetic, it renames some functions and allows `priority` to be passed through to `addTrappedEventListener`. I also cleaned up some of the Flow types.