### PR TITLE
Warn against state updates from useEffect destroy functions

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -2818,7 +2818,7 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     // If we are currently flushing passive effects, change the warning text.
     if ((executionContext & PassiveEffectContext) !== NoContext) {
       console.error(
-        "Can't perform a React state update from within a passive effect destroy callback. " +
+        "Can't perform a React state update from within a useEffect cleanup function. " +
           'To fix, move state updates to the useEffect() body in %s.%s',
         tag === ClassComponent
           ? 'the componentWillUnmount method'

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -199,13 +199,14 @@ const {
 
 type ExecutionContext = number;
 
-const NoContext = /*                    */ 0b000000;
-const BatchedContext = /*               */ 0b000001;
-const EventContext = /*                 */ 0b000010;
-const DiscreteEventContext = /*         */ 0b000100;
-const LegacyUnbatchedContext = /*       */ 0b001000;
-const RenderContext = /*                */ 0b010000;
-const CommitContext = /*                */ 0b100000;
+const NoContext = /*                    */ 0b0000000;
+const BatchedContext = /*               */ 0b0000001;
+const EventContext = /*                 */ 0b0000010;
+const DiscreteEventContext = /*         */ 0b0000100;
+const LegacyUnbatchedContext = /*       */ 0b0001000;
+const RenderContext = /*                */ 0b0010000;
+const CommitContext = /*                */ 0b0100000;
+const PassiveEffectContext = /*         */ 0b1000000;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5;
 const RootIncomplete = 0;
@@ -2283,6 +2284,7 @@ function flushPassiveEffectsImpl() {
   );
   const prevExecutionContext = executionContext;
   executionContext |= CommitContext;
+  executionContext |= PassiveEffectContext;
   const prevInteractions = pushInteractions(root);
 
   if (runAllPassiveEffectDestroysBeforeCreates) {
@@ -2799,6 +2801,11 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
       if (pendingPassiveHookEffectsUnmount.indexOf(fiber) >= 0) {
         return;
       }
+    }
+
+    // If we are currently flushing passive effects, skip this warning.
+    if ((executionContext & PassiveEffectContext) !== NoContext) {
+      return;
     }
 
     // We show the whole stack but dedupe on the top component's name because

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1256,7 +1256,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         });
       });
 
-      it('still warns about state updates from within passive unmount function', () => {
+      it('does not warn about state updates from within passive unmount function', () => {
         function Component() {
           Scheduler.unstable_yieldValue('Component');
           const [didLoad, setDidLoad] = React.useState(false);
@@ -1282,11 +1282,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
           // Unmount but don't process pending passive destroy function
           ReactNoop.unmountRootWithID('root');
-          expect(() => {
-            expect(Scheduler).toFlushAndYield(['passive destroy']);
-          }).toErrorDev(
-            "Warning: Can't perform a React state update on an unmounted component.",
-          );
+          expect(Scheduler).toFlushAndYield(['passive destroy']);
         });
       });
     }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1258,7 +1258,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         });
       });
 
-      it('does not warn about state updates from within passive unmount function', () => {
+      it('shows a unique warning for state updates from within passive unmount function', () => {
         function Component() {
           Scheduler.unstable_yieldValue('Component');
           const [didLoad, setDidLoad] = React.useState(false);
@@ -1284,7 +1284,11 @@ describe('ReactHooksWithNoopRenderer', () => {
 
           // Unmount but don't process pending passive destroy function
           ReactNoop.unmountRootWithID('root');
-          expect(Scheduler).toFlushAndYield(['passive destroy']);
+          expect(() => {
+            expect(Scheduler).toFlushAndYield(['passive destroy']);
+          }).toErrorDev(
+            "Warning: Can't perform a React state update from within a passive effect destroy callback.",
+          );
         });
       });
     }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1025,8 +1025,10 @@ describe('ReactHooksWithNoopRenderer', () => {
     );
 
     if (
-      deferPassiveEffectCleanupDuringUnmount &&
-      runAllPassiveEffectDestroysBeforeCreates
+      require('shared/ReactFeatureFlags')
+        .deferPassiveEffectCleanupDuringUnmount &&
+      require('shared/ReactFeatureFlags')
+        .runAllPassiveEffectDestroysBeforeCreates
     ) {
       it('defers passive effect destroy functions during unmount', () => {
         function Child({bar, foo}) {

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1287,7 +1287,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           expect(() => {
             expect(Scheduler).toFlushAndYield(['passive destroy']);
           }).toErrorDev(
-            "Warning: Can't perform a React state update from within a passive effect destroy callback.",
+            "Warning: Can't perform a React state update from within a useEffect cleanup function.",
           );
         });
       });


### PR DESCRIPTION
Add clearer warning text for the specific case of updating state from within a passive effect's destroy function.

Also fixed a broken conditional that was preventing some of these tests from running after the recent test/variant refactor.