### PR TITLE
React Event System: Refactor ElementListenerMap for upgrading

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -1358,14 +1358,16 @@ export function listenToEventResponderEventTypes(
           // existing passive event listener before we add the
           // active event listener.
           const passiveKey = targetEventType + '_passive';
-          const passiveListener = listenerMap.get(passiveKey);
-          if (passiveListener != null) {
+          const passiveItem = listenerMap.get(passiveKey);
+          if (passiveItem !== undefined) {
             removeTrappedEventListener(
               document,
-              targetEventType,
-              passiveListener,
+              (targetEventType: any),
+              true,
+              passiveItem.listener,
               true,
             );
+            listenerMap.delete(passiveKey);
           }
         }
         const eventListener = addResponderEventSystemEvent(
@@ -1373,7 +1375,10 @@ export function listenToEventResponderEventTypes(
           targetEventType,
           isPassive,
         );
-        listenerMap.set(eventKey, eventListener);
+        listenerMap.set(eventKey, {
+          passive: isPassive,
+          listener: eventListener,
+        });
       }
     }
   }

--- a/packages/react-dom/src/events/DOMEventListenerMap.js
+++ b/packages/react-dom/src/events/DOMEventListenerMap.js
@@ -16,12 +16,17 @@ const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 const elementListenerMap:
   // $FlowFixMe Work around Flow bug
   | WeakMap
-  | Map<EventTarget, Map<DOMTopLevelEventType | string, null | (any => void)>> = new PossiblyWeakMap();
+  | Map<EventTarget, ElementListenerMap> = new PossiblyWeakMap();
 
 export type ElementListenerMap = Map<
   DOMTopLevelEventType | string,
-  null | (any => void),
+  ElementListenerMapEntry,
 >;
+
+export type ElementListenerMapEntry = {
+  passive: void | boolean,
+  listener: any => void,
+};
 
 export function getListenerMapForElement(
   target: EventTarget,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -255,20 +255,22 @@ export function addTrappedEventListener(
 
 export function removeTrappedEventListener(
   targetContainer: EventTarget,
-  topLevelType: string,
+  topLevelType: DOMTopLevelEventType,
+  capture: boolean,
   listener: any => void,
-  passive: boolean,
+  passive: void | boolean,
 ) {
   if (listener.remove != null) {
     listener.remove();
   } else {
+    const rawEventName = getRawEventName(topLevelType);
     if (passiveBrowserEventsSupported) {
-      targetContainer.removeEventListener(topLevelType, listener, {
-        capture: true,
+      targetContainer.removeEventListener(rawEventName, listener, {
+        capture,
         passive,
       });
     } else {
-      targetContainer.removeEventListener(topLevelType, listener, true);
+      targetContainer.removeEventListener(rawEventName, listener, capture);
     }
   }
 }

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -244,7 +244,7 @@ function trapReplayableEventForDocument(
         topLevelTypeString,
         false,
       );
-      listenerMap.set(activeEventKey, listener);
+      listenerMap.set(activeEventKey, {passive: false, listener});
     }
   }
 }

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -1648,5 +1648,107 @@ describe('DOMModernPluginEventSystem', () => {
       dispatchClickEvent(ref.current);
       expect(log).toEqual([{counter: 1}]);
     });
+
+    it('should correctly work for a basic "click" listener that upgrades', () => {
+      const clickEvent = jest.fn();
+      const buttonRef = React.createRef();
+      const button2Ref = React.createRef();
+
+      function Test2() {
+        const click = ReactDOM.unstable_useEvent('click', {
+          passive: false,
+        });
+
+        React.useEffect(() => {
+          click.setListener(button2Ref.current, clickEvent);
+        });
+
+        return <button ref={button2Ref}>Click me!</button>;
+      }
+
+      function Test({extra}) {
+        const click = ReactDOM.unstable_useEvent('click', {
+          passive: true,
+        });
+
+        React.useEffect(() => {
+          click.setListener(buttonRef.current, clickEvent);
+        });
+
+        return (
+          <>
+            <button ref={buttonRef}>Click me!</button>
+            {extra && <Test2 />}
+          </>
+        );
+      }
+
+      ReactDOM.render(<Test />, container);
+      Scheduler.unstable_flushAll();
+
+      let button = buttonRef.current;
+      dispatchClickEvent(button);
+      expect(clickEvent).toHaveBeenCalledTimes(1);
+
+      ReactDOM.render(<Test extra={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      clickEvent.mockClear();
+
+      button = button2Ref.current;
+      dispatchClickEvent(button);
+      expect(clickEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should correctly work for a basic "click" listener that upgrades #2', () => {
+      const clickEvent = jest.fn();
+      const buttonRef = React.createRef();
+      const button2Ref = React.createRef();
+
+      function Test2() {
+        const click = ReactDOM.unstable_useEvent('click', {
+          passive: false,
+        });
+
+        React.useEffect(() => {
+          click.setListener(button2Ref.current, clickEvent);
+        });
+
+        return <button ref={button2Ref}>Click me!</button>;
+      }
+
+      function Test({extra}) {
+        const click = ReactDOM.unstable_useEvent('click', {
+          passive: undefined,
+        });
+
+        React.useEffect(() => {
+          click.setListener(buttonRef.current, clickEvent);
+        });
+
+        return (
+          <>
+            <button ref={buttonRef}>Click me!</button>
+            {extra && <Test2 />}
+          </>
+        );
+      }
+
+      ReactDOM.render(<Test />, container);
+      Scheduler.unstable_flushAll();
+
+      let button = buttonRef.current;
+      dispatchClickEvent(button);
+      expect(clickEvent).toHaveBeenCalledTimes(1);
+
+      ReactDOM.render(<Test extra={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      clickEvent.mockClear();
+
+      button = button2Ref.current;
+      dispatchClickEvent(button);
+      expect(clickEvent).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
This PR refactors the `ElementListenerMap` properties of the existing modern event system, React Flare responder system and the legacy event systems. They all use `ElementListenerMap` to register an event type against a container. Unfortunately, they don't have a way of co-ordinating when event listeners should be "upgraded" – which is the process of removing and passive/default listener and adding an active listener.

There are three states for event listeners and their `passive` flag. They can be `true`, `false` or `void`. If they are `true`, then the listener is passive. If they are `false` then the listener is active and finally, if they are `void` then we use the browser default and we don't specify an option value for `passive` when creating the listener via `addEventListener`. To wire all this up, we have to unify the value of `ElementListenerMap`, so that it's an object telling us of the last previously used `passive` value. We represent this as `{ passive: void | boolean, listener: any => void }`. The upgrade order should go from `passive (true) -> default (void) -> active (false)`.

Now we have this refactor in place, it makes it possible for the modern event system and the work going into `useEvent` to live together nicely and have a nice optimial system where they can share event listeners together. For Flare, we change the pattern so it uses the new format, but it really doesn't affect the others as Flare will soon be removed, so we keep the `ElementListenerMap` keys different (they have a `_active`/`_passive` suffixes to not clash with the legacy/modern event system listeners).