### PR TITLE
useEvent: Small tweaks and changes

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1172,8 +1172,8 @@ export function validateEventListenerTarget(
       console.warn(
         'Event listener method setListener() from useEvent() hook requires the first argument to be either:' +
           '\n\n' +
-          '1. A valid DOM node that was rendered and managed by React' +
-          '2. The "window" object' +
+          '1. A valid DOM node that was rendered and managed by React\n' +
+          '2. The "window" object\n' +
           '3. The "document" object',
       );
     }

--- a/packages/react-dom/src/client/ReactDOMUseEvent.js
+++ b/packages/react-dom/src/client/ReactDOMUseEvent.js
@@ -46,7 +46,7 @@ export function useEvent(
 ): ReactDOMListenerMap {
   const dispatcher = resolveDispatcher();
   let capture = false;
-  let passive = false;
+  let passive = undefined; // Undefined means to use the browser default
   let priority = getEventPriorityForListenerSystem((type: any));
 
   if (options != null) {

--- a/packages/shared/ReactDOMTypes.js
+++ b/packages/shared/ReactDOMTypes.js
@@ -78,7 +78,7 @@ export type ReactDOMResponderContext = {
 
 export type ReactDOMListenerEvent = {|
   capture: boolean,
-  passive: boolean,
+  passive: void | boolean,
   priority: EventPriority,
   type: string,
 |};


### PR DESCRIPTION
This PR makes a few adjustments and tweaks to the current `useEvent` logic within the modern event system. Namely:

- `useEvent` uses the the browser default for `passive` as per the internal document, rather than `passive` being `true` by default.
- Fixed an issue in the error message where there was missing newlines
- Added another test to increase coverage when using `useEvent` together with standard `on*` events.