### PR TITLE
Don't support older isomorphic React with newer renderers

### DIFF
--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -29,7 +29,7 @@
     "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -22,7 +22,7 @@
     "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -18,7 +18,7 @@
     "react-server": "*"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -26,7 +26,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.13.0"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -25,7 +25,7 @@
     "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/shared/ReactLazyComponent.js
+++ b/packages/shared/ReactLazyComponent.js
@@ -38,11 +38,7 @@ export function initializeLazyComponentType(
   lazyComponent: LazyComponent<any>,
 ): void {
   if (lazyComponent._status === Uninitialized) {
-    let ctor = lazyComponent._result;
-    if (!ctor) {
-      // TODO: Remove this later. THis only exists in case you use an older "react" package.
-      ctor = ((lazyComponent: any)._ctor: typeof ctor);
-    }
+    const ctor = lazyComponent._result;
     const thenable = ctor();
     // Transition to the next state.
     const pending: PendingLazyComponent<any> = (lazyComponent: any);

--- a/packages/shared/ReactSharedInternals.js
+++ b/packages/shared/ReactSharedInternals.js
@@ -12,18 +12,4 @@ import * as React from 'react';
 const ReactSharedInternals =
   React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
-// Prevent newer renderers from RTE when used with older react package versions.
-// Current owner and dispatcher used to share the same ref,
-// but PR #14548 split them out to better support the react-debug-tools package.
-if (!ReactSharedInternals.hasOwnProperty('ReactCurrentDispatcher')) {
-  ReactSharedInternals.ReactCurrentDispatcher = {
-    current: null,
-  };
-}
-if (!ReactSharedInternals.hasOwnProperty('ReactCurrentBatchConfig')) {
-  ReactSharedInternals.ReactCurrentBatchConfig = {
-    suspense: null,
-  };
-}
-
 export default ReactSharedInternals;


### PR DESCRIPTION
I think we've already determined this is not gonna work as well as we hoped. Let's just stop supporting it. It's not a breaking change for newer versions of the renderers. We're just removing the guarantee implied by the peer version which we broke anyway several times before.

My actual goal is to remove the patching junk from the builds (see the end of the diff). Especially now that we're adding JSXRuntime and it's leaking there too.