### PR TITLE
Fix UMD Builds (ReactSharedInternals)

### DIFF
--- a/packages/react/src/forks/ReactSharedInternals.umd.js
+++ b/packages/react/src/forks/ReactSharedInternals.umd.js
@@ -12,11 +12,13 @@ import ReactCurrentDispatcher from '../ReactCurrentDispatcher';
 import ReactCurrentOwner from '../ReactCurrentOwner';
 import ReactDebugCurrentFrame from '../ReactDebugCurrentFrame';
 import IsSomeRendererActing from '../IsSomeRendererActing';
+import ReactCurrentBatchConfig from '../ReactCurrentBatchConfig';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
   ReactCurrentOwner,
   IsSomeRendererActing,
+  ReactCurrentBatchConfig,
   // Used by renderers to avoid bundling object-assign twice in UMD bundles:
   assign,
 };


### PR DESCRIPTION
`ReactCurrentBatchConfig.suspense` does not exist in `ReactSharedInternals.umd`. This PR adds it.