### PR TITLE
Refactor React.Children to reduce indirection

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -73,31 +73,6 @@ function getComponentKey(component, index) {
 }
 
 function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
-  function handleChild(child, childKey) {
-    let mappedChild = callback(child);
-    if (Array.isArray(mappedChild)) {
-      let escapedChildKey = '';
-      if (childKey != null) {
-        escapedChildKey = escapeUserProvidedKey(childKey) + '/';
-      }
-      mapIntoArray(mappedChild, array, escapedChildKey, c => c);
-    } else if (mappedChild != null) {
-      if (isValidElement(mappedChild)) {
-        mappedChild = cloneAndReplaceKey(
-          mappedChild,
-          // Keep both the (mapped) and old keys if they differ, just as
-          // traverseAllChildren used to do for objects as children
-          escapedPrefix +
-            (mappedChild.key && (!child || child.key !== mappedChild.key)
-              ? escapeUserProvidedKey(mappedChild.key) + '/'
-              : '') +
-            childKey,
-        );
-      }
-      array.push(mappedChild);
-    }
-  }
-
   const type = typeof children;
 
   if (type === 'undefined' || type === 'boolean') {
@@ -125,12 +100,33 @@ function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
   }
 
   if (invokeCallback) {
-    handleChild(
-      children,
-      // If it's the only child, treat the name as if it was wrapped in an array
-      // so that it's consistent if the number of children grows.
-      nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar,
-    );
+    const child = children;
+    let mappedChild = callback(child);
+    // If it's the only child, treat the name as if it was wrapped in an array
+    // so that it's consistent if the number of children grows:
+    let childKey =
+      nameSoFar === '' ? SEPARATOR + getComponentKey(child, 0) : nameSoFar;
+    if (Array.isArray(mappedChild)) {
+      let escapedChildKey = '';
+      if (childKey != null) {
+        escapedChildKey = escapeUserProvidedKey(childKey) + '/';
+      }
+      mapIntoArray(mappedChild, array, escapedChildKey, c => c);
+    } else if (mappedChild != null) {
+      if (isValidElement(mappedChild)) {
+        mappedChild = cloneAndReplaceKey(
+          mappedChild,
+          // Keep both the (mapped) and old keys if they differ, just as
+          // traverseAllChildren used to do for objects as children
+          escapedPrefix +
+            (mappedChild.key && (!child || child.key !== mappedChild.key)
+              ? escapeUserProvidedKey(mappedChild.key) + '/'
+              : '') +
+            childKey,
+        );
+      }
+      array.push(mappedChild);
+    }
     return 1;
   }
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -230,29 +230,6 @@ function forEachChildren(children, forEachFunc, forEachContext) {
   );
 }
 
-function mapSingleChildIntoContext(bookKeeping, child, childKey) {
-  const {result, keyPrefix, func, context} = bookKeeping;
-
-  let mappedChild = func.call(context, child, bookKeeping.count++);
-  if (Array.isArray(mappedChild)) {
-    mapIntoWithKeyPrefixInternal(mappedChild, result, childKey, c => c);
-  } else if (mappedChild != null) {
-    if (isValidElement(mappedChild)) {
-      mappedChild = cloneAndReplaceKey(
-        mappedChild,
-        // Keep both the (mapped) and old keys if they differ, just as
-        // traverseAllChildren used to do for objects as children
-        keyPrefix +
-          (mappedChild.key && (!child || child.key !== mappedChild.key)
-            ? escapeUserProvidedKey(mappedChild.key) + '/'
-            : '') +
-          childKey,
-      );
-    }
-    result.push(mappedChild);
-  }
-}
-
 function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
   let escapedPrefix = '';
   if (prefix != null) {
@@ -267,7 +244,28 @@ function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
   return traverseAllChildren(
     children,
     '',
-    mapSingleChildIntoContext,
+    (bookKeeping, child, childKey) => {
+      const {result, keyPrefix, func, context} = bookKeeping;
+
+      let mappedChild = func.call(context, child, bookKeeping.count++);
+      if (Array.isArray(mappedChild)) {
+        mapIntoWithKeyPrefixInternal(mappedChild, result, childKey, c => c);
+      } else if (mappedChild != null) {
+        if (isValidElement(mappedChild)) {
+          mappedChild = cloneAndReplaceKey(
+            mappedChild,
+            // Keep both the (mapped) and old keys if they differ, just as
+            // traverseAllChildren used to do for objects as children
+            keyPrefix +
+              (mappedChild.key && (!child || child.key !== mappedChild.key)
+                ? escapeUserProvidedKey(mappedChild.key) + '/'
+                : '') +
+              childKey,
+          );
+        }
+        result.push(mappedChild);
+      }
+    },
     traverseContext,
   );
 }

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -185,16 +185,16 @@ function getComponentKey(component, index) {
   return index.toString(36);
 }
 
-function mapIntoArray(children, array, prefix, func, context) {
-  let escapedPrefix = '';
-  if (prefix != null) {
-    escapedPrefix = escapeUserProvidedKey(prefix) + '/';
-  }
+function mapIntoArray(children, array, escapedPrefix, func, context) {
   let count = 0;
   return traverseAllChildren(children, '', (child, childKey) => {
     let mappedChild = func.call(context, child, count++);
     if (Array.isArray(mappedChild)) {
-      mapIntoArray(mappedChild, array, childKey, c => c);
+      let escapedChildKey = '';
+      if (childKey != null) {
+        escapedChildKey = escapeUserProvidedKey(childKey) + '/';
+      }
+      mapIntoArray(mappedChild, array, escapedChildKey, c => c);
     } else if (mappedChild != null) {
       if (isValidElement(mappedChild)) {
         mappedChild = cloneAndReplaceKey(
@@ -231,7 +231,7 @@ function mapChildren(children, func, context) {
     return children;
   }
   const result = [];
-  mapIntoArray(children, result, null, func, context);
+  mapIntoArray(children, result, '', func, context);
   return result;
 }
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -307,7 +307,7 @@ function countChildren(children) {
   if (children == null) {
     return 0;
   }
-  return traverseAllChildren(children, '', () => null, null);
+  return mapIntoWithKeyPrefixInternal(children, null, null, () => null);
 }
 
 /**

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -304,10 +304,9 @@ function mapChildren(children, func, context) {
  * @return {number} The number of children.
  */
 function countChildren(children) {
-  if (children == null) {
-    return 0;
-  }
-  return mapIntoWithKeyPrefixInternal(children, null, null, () => null);
+  let n = 0;
+  mapChildren(children, () => n++);
+  return n;
 }
 
 /**
@@ -317,12 +316,7 @@ function countChildren(children) {
  * See https://reactjs.org/docs/react-api.html#reactchildrentoarray
  */
 function toArray(children) {
-  if (children == null) {
-    return [];
-  }
-  const result = [];
-  mapIntoWithKeyPrefixInternal(children, result, null, child => child);
-  return result;
+  return mapChildren(children, child => child) || [];
 }
 
 /**

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -68,12 +68,7 @@ function createTraverseContext(mapResult, keyPrefix, mapFunction, mapContext) {
  * process.
  * @return {!number} The number of children in this subtree.
  */
-function traverseAllChildrenImpl(
-  children,
-  nameSoFar,
-  callback,
-  traverseContext,
-) {
+function traverseAllChildren(children, nameSoFar, callback, traverseContext) {
   const type = typeof children;
 
   if (type === 'undefined' || type === 'boolean') {
@@ -121,7 +116,7 @@ function traverseAllChildrenImpl(
     for (let i = 0; i < children.length; i++) {
       child = children[i];
       nextName = nextNamePrefix + getComponentKey(child, i);
-      subtreeCount += traverseAllChildrenImpl(
+      subtreeCount += traverseAllChildren(
         child,
         nextName,
         callback,
@@ -160,7 +155,7 @@ function traverseAllChildrenImpl(
       while (!(step = iterator.next()).done) {
         child = step.value;
         nextName = nextNamePrefix + getComponentKey(child, ii++);
-        subtreeCount += traverseAllChildrenImpl(
+        subtreeCount += traverseAllChildren(
           child,
           nextName,
           callback,
@@ -188,30 +183,6 @@ function traverseAllChildrenImpl(
   }
 
   return subtreeCount;
-}
-
-/**
- * Traverses children that are typically specified as `props.children`, but
- * might also be specified through attributes:
- *
- * - `traverseAllChildren(this.props.children, ...)`
- * - `traverseAllChildren(this.props.leftPanelChildren, ...)`
- *
- * The `traverseContext` is an optional argument that is passed through the
- * entire traversal. It can be used to store accumulations or anything else that
- * the callback might find relevant.
- *
- * @param {?*} children Children tree object.
- * @param {!function} callback To invoke upon traversing each child.
- * @param {?*} traverseContext Context for traversal.
- * @return {!number} The number of children in this subtree.
- */
-function traverseAllChildren(children, callback, traverseContext) {
-  if (children == null) {
-    return 0;
-  }
-
-  return traverseAllChildrenImpl(children, '', callback, traverseContext);
 }
 
 /**
@@ -255,7 +226,7 @@ function forEachSingleChild(bookKeeping, child, name) {
  */
 function forEachChildren(children, forEachFunc, forEachContext) {
   if (children == null) {
-    return children;
+    return;
   }
   const traverseContext = createTraverseContext(
     null,
@@ -263,7 +234,7 @@ function forEachChildren(children, forEachFunc, forEachContext) {
     forEachFunc,
     forEachContext,
   );
-  traverseAllChildren(children, forEachSingleChild, traverseContext);
+  traverseAllChildren(children, '', forEachSingleChild, traverseContext);
 }
 
 function mapSingleChildIntoContext(bookKeeping, child, childKey) {
@@ -300,7 +271,7 @@ function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
     func,
     context,
   );
-  traverseAllChildren(children, mapSingleChildIntoContext, traverseContext);
+  traverseAllChildren(children, '', mapSingleChildIntoContext, traverseContext);
 }
 
 /**
@@ -335,7 +306,10 @@ function mapChildren(children, func, context) {
  * @return {number} The number of children.
  */
 function countChildren(children) {
-  return traverseAllChildren(children, () => null, null);
+  if (children == null) {
+    return 0;
+  }
+  return traverseAllChildren(children, '', () => null, null);
 }
 
 /**
@@ -345,6 +319,9 @@ function countChildren(children) {
  * See https://reactjs.org/docs/react-api.html#reactchildrentoarray
  */
 function toArray(children) {
+  if (children == null) {
+    return [];
+  }
   const result = [];
   mapIntoWithKeyPrefixInternal(children, result, null, child => child);
   return result;

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -185,10 +185,9 @@ function getComponentKey(component, index) {
   return index.toString(36);
 }
 
-function mapIntoArray(children, array, escapedPrefix, func, context) {
-  let count = 0;
+function mapIntoArray(children, array, escapedPrefix, callback) {
   return traverseAllChildren(children, '', (child, childKey) => {
-    let mappedChild = func.call(context, child, count++);
+    let mappedChild = callback(child);
     if (Array.isArray(mappedChild)) {
       let escapedChildKey = '';
       if (childKey != null) {
@@ -231,7 +230,16 @@ function mapChildren(children, func, context) {
     return children;
   }
   const result = [];
-  mapIntoArray(children, result, '', func, context);
+  let count = 0;
+  mapIntoArray(
+    children,
+    result,
+    '',
+    function(child) {
+      return func.call(context, child, count++);
+    },
+    context,
+  );
   return result;
 }
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -207,29 +207,6 @@ function getComponentKey(component, index) {
   return index.toString(36);
 }
 
-/**
- * Iterates through children that are typically specified as `props.children`.
- *
- * See https://reactjs.org/docs/react-api.html#reactchildrenforeach
- *
- * The provided forEachFunc(child, index) will be called for each
- * leaf child.
- *
- * @param {?*} children Children tree container.
- * @param {function(*, int)} forEachFunc
- * @param {*} forEachContext Context for forEachContext.
- */
-function forEachChildren(children, forEachFunc, forEachContext) {
-  mapChildren(
-    children,
-    function() {
-      forEachFunc.apply(this, arguments);
-      // Don't return anything.
-    },
-    forEachContext,
-  );
-}
-
 function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
   let escapedPrefix = '';
   if (prefix != null) {
@@ -305,6 +282,29 @@ function countChildren(children) {
   let n = 0;
   mapChildren(children, () => n++);
   return n;
+}
+
+/**
+ * Iterates through children that are typically specified as `props.children`.
+ *
+ * See https://reactjs.org/docs/react-api.html#reactchildrenforeach
+ *
+ * The provided forEachFunc(child, index) will be called for each
+ * leaf child.
+ *
+ * @param {?*} children Children tree container.
+ * @param {function(*, int)} forEachFunc
+ * @param {*} forEachContext Context for forEachContext.
+ */
+function forEachChildren(children, forEachFunc, forEachContext) {
+  mapChildren(
+    children,
+    function() {
+      forEachFunc.apply(this, arguments);
+      // Don't return anything.
+    },
+    forEachContext,
+  );
 }
 
 /**

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -207,11 +207,6 @@ function getComponentKey(component, index) {
   return index.toString(36);
 }
 
-function forEachSingleChild(bookKeeping, child, name) {
-  const {func, context} = bookKeeping;
-  func.call(context, child, bookKeeping.count++);
-}
-
 /**
  * Iterates through children that are typically specified as `props.children`.
  *
@@ -225,16 +220,14 @@ function forEachSingleChild(bookKeeping, child, name) {
  * @param {*} forEachContext Context for forEachContext.
  */
 function forEachChildren(children, forEachFunc, forEachContext) {
-  if (children == null) {
-    return;
-  }
-  const traverseContext = createTraverseContext(
-    null,
-    null,
-    forEachFunc,
+  mapChildren(
+    children,
+    function() {
+      forEachFunc.apply(this, arguments);
+      // Don't return anything.
+    },
     forEachContext,
   );
-  traverseAllChildren(children, '', forEachSingleChild, traverseContext);
 }
 
 function mapSingleChildIntoContext(bookKeeping, child, childKey) {
@@ -271,7 +264,12 @@ function mapIntoWithKeyPrefixInternal(children, array, prefix, func, context) {
     func,
     context,
   );
-  traverseAllChildren(children, '', mapSingleChildIntoContext, traverseContext);
+  return traverseAllChildren(
+    children,
+    '',
+    mapSingleChildIntoContext,
+    traverseContext,
+  );
 }
 
 /**


### PR DESCRIPTION
This has been bugging me for a while. I know we don't plan to change their behavior because it's a legacy pattern anyway (although we don't have an alternative either). But it's a bit awkward to see this indirection in the bundle. It's also very confusing to read.

The original code was written assuming this is perf critical and we must avoid closures. I don't think it is. This pattern isn't super common and when you have it, you probably don't want to iterate over thousands of these anyway. In either case, my last implementation has minimal use of closures too. I removed pooling too which is a bit over-engineered for this use case and might actually hurt perf. Unlike with events, it's not observable.

I re-implemented count, forEach, and toArray in terms of map. I know they have slightly different semantics so a naïve implementation wouldn't work but I think I got it right (and when I did it wrong, tests failed). The original rationale to implement them separately was to reuse a lower level primitive that doesn't require any extra allocations. But since both `forEach` and `count` have other quirks (like counting holes) I don't expect them to actually be used that much in critical paths anymore. So I think it's okay `count` allocates an array now and later throws it away.

Each commit is fairly mechanical. At the end, I have a single recursive function as a core of map, and other functions expressed through map. Instead of a tangled web of indirections. Read individual commits. Although I guess reading the whole thing also works because you can follow it now.