### PR TITLE
Don't use EventListener Fork in Modern WWW Builds

### DIFF
--- a/packages/react-dom/src/events/EventListener.js
+++ b/packages/react-dom/src/events/EventListener.js
@@ -11,16 +11,18 @@ export function addEventBubbleListener(
   target: EventTarget,
   eventType: string,
   listener: Function,
-): void {
+): Function {
   target.addEventListener(eventType, listener, false);
+  return listener;
 }
 
 export function addEventCaptureListener(
   target: EventTarget,
   eventType: string,
   listener: Function,
-): void {
+): Function {
   target.addEventListener(eventType, listener, true);
+  return listener;
 }
 
 export function addEventCaptureListenerWithPassiveFlag(
@@ -28,11 +30,12 @@ export function addEventCaptureListenerWithPassiveFlag(
   eventType: string,
   listener: Function,
   passive: boolean,
-): void {
+): Function {
   target.addEventListener(eventType, listener, {
     capture: true,
     passive,
   });
+  return listener;
 }
 
 export function addEventBubbleListenerWithPassiveFlag(
@@ -40,8 +43,18 @@ export function addEventBubbleListenerWithPassiveFlag(
   eventType: string,
   listener: Function,
   passive: boolean,
-): void {
+): Function {
   target.addEventListener(eventType, listener, {
     passive,
   });
+  return listener;
+}
+
+export function removeEventListener(
+  target: EventTarget,
+  eventType: string,
+  listener: Function,
+  capture: boolean,
+): void {
+  target.removeEventListener(eventType, listener, capture);
 }

--- a/packages/react-dom/src/events/forks/EventListener-www.js
+++ b/packages/react-dom/src/events/forks/EventListener-www.js
@@ -56,6 +56,15 @@ export function addEventBubbleListenerWithPassiveFlag(
   );
 }
 
+export function removeEventListener(
+  target: EventTarget,
+  eventType: string,
+  listener: Function,
+  capture: boolean,
+) {
+  listener.remove();
+}
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -19,6 +19,15 @@ const {
 } = bundleTypes;
 const {RENDERER, RECONCILER} = moduleTypes;
 
+const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL;
+
+// Default to building in experimental mode. If the release channel is set via
+// an environment variable, then check if it's "experimental".
+const __EXPERIMENTAL__ =
+  typeof RELEASE_CHANNEL === 'string'
+    ? RELEASE_CHANNEL === 'experimental'
+    : true;
+
 // If you need to replace a file with another file for a specific environment,
 // add it to this list with the logic for choosing the right replacement.
 const forks = Object.freeze({
@@ -442,8 +451,13 @@ const forks = Object.freeze({
       case FB_WWW_DEV:
       case FB_WWW_PROD:
       case FB_WWW_PROFILING:
-        // Use the www fork which is integrated with TimeSlice profiling.
-        return 'react-dom/src/events/forks/EventListener-www.js';
+        if (__EXPERIMENTAL__) {
+          // In modern builds we don't use the indirection. We just use raw DOM.
+          return null;
+        } else {
+          // Use the www fork which is integrated with TimeSlice profiling.
+          return 'react-dom/src/events/forks/EventListener-www.js';
+        }
       default:
         return null;
     }


### PR DESCRIPTION
If [D20382065](https://our.internmc.facebook.com/intern/diff/D20382065/) successfully rolls out (has some issues still). Then we don't need this fork anymore.

We should start by at least removing it from Modern builds.

To do this I needed to fix the unsubscribing stuff mentioned in https://github.com/facebook/react/pull/18270#discussion_r394058260. Flare is now used by both the FB fork and without it so we should just compile to one or the other. I do that by always returning an unsubscribe listener and always passing that to a removeEventListener function. The indirections can then be compiled out.

