### PR TITLE
Revert accidental changes to package.json

### DIFF
--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -23,6 +23,9 @@
     "react": "^16.0.0",
     "react-test-renderer": "^16.0.0"
   },
+  "dependencies": {
+    "object-assign": "^4.1.1"
+  },
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -26,11 +26,10 @@
     "create-react-class": "^15.6.2",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
-    "scheduler": "^0.19.1"
+    "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -19,11 +19,10 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
-    "scheduler": "^0.19.1"
+    "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -26,13 +26,12 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.0"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
-    "scheduler": "^0.19.1"
+    "scheduler": "^0.19.0"
   },
   "browserify": {
     "transform": [

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -20,12 +20,12 @@
   "homepage": "https://reactjs.org/",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2",
     "react-is": "^16.8.6",
-    "scheduler": "^0.19.1"
+    "react-shallow-renderer": "^16.13.1",
+    "scheduler": "^0.19.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.13.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "loose-envify": "^1.1.0",
-    "object-assign": "^4.1.1",
-    "prop-types": "^15.6.2"
+    "object-assign": "^4.1.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
The publish script was written before we switched to running patch releases out-of-band, so when updating the local package.json version numbers, it accidentally reverted other changes that have landed to master since 16.13 was released.

Comparison to before the automated changes. Only differences are to the changelog and the version numbers: https://github.com/facebook/react/compare/8311cb5d24fd1648ddffb659bf9b3317f5f885d0...c4eda2b