### PR TITLE
ReactDOM.useEvent: support custom types

### DIFF
--- a/packages/legacy-events/ReactSyntheticEventType.js
+++ b/packages/legacy-events/ReactSyntheticEventType.js
@@ -19,14 +19,21 @@ export type DispatchConfig = {|
     captured: null | string,
   |},
   registrationName?: string,
-  eventPriority?: EventPriority,
-  customEvent?: boolean,
+  eventPriority: EventPriority,
+|};
+
+export type CustomDispatchConfig = {|
+  phasedRegistrationNames: {|
+    bubbled: null,
+    captured: null,
+  |},
+  customEvent: true,
 |};
 
 export type ReactSyntheticEvent = {|
-  dispatchConfig: DispatchConfig,
+  dispatchConfig: DispatchConfig | CustomDispatchConfig,
   getPooled: (
-    dispatchConfig: DispatchConfig,
+    dispatchConfig: DispatchConfig | CustomDispatchConfig,
     targetInst: Fiber,
     nativeTarget: Event,
     nativeEventTarget: EventTarget,

--- a/packages/legacy-events/ReactSyntheticEventType.js
+++ b/packages/legacy-events/ReactSyntheticEventType.js
@@ -13,13 +13,14 @@ import type {EventPriority} from 'shared/ReactTypes';
 import type {TopLevelType} from './TopLevelEventTypes';
 
 export type DispatchConfig = {|
-  dependencies: Array<TopLevelType>,
-  phasedRegistrationNames?: {|
-    bubbled: string,
-    captured: string,
+  dependencies?: Array<TopLevelType>,
+  phasedRegistrationNames: {|
+    bubbled: null | string,
+    captured: null | string,
   |},
   registrationName?: string,
-  eventPriority: EventPriority,
+  eventPriority?: EventPriority,
+  customEvent?: boolean,
 |};
 
 export type ReactSyntheticEvent = {|

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -12,7 +12,10 @@ import type {
   TopLevelType,
   DOMTopLevelEventType,
 } from 'legacy-events/TopLevelEventTypes';
-import type {DispatchConfig} from 'legacy-events/ReactSyntheticEventType';
+import type {
+  DispatchConfig,
+  CustomDispatchConfig,
+} from 'legacy-events/ReactSyntheticEventType';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
 import {
@@ -31,7 +34,7 @@ export const simpleEventPluginEventTypes = {};
 
 export const topLevelEventsToDispatchConfig: Map<
   TopLevelType,
-  DispatchConfig,
+  DispatchConfig | CustomDispatchConfig,
 > = new Map();
 
 const eventPriorities = new Map();

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -17,7 +17,10 @@ import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 import type {EventPriority} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {PluginModule} from 'legacy-events/PluginModuleType';
-import type {ReactSyntheticEvent} from 'legacy-events/ReactSyntheticEventType';
+import type {
+  ReactSyntheticEvent,
+  CustomDispatchConfig,
+} from 'legacy-events/ReactSyntheticEventType';
 import type {ReactDOMListener} from 'shared/ReactDOMTypes';
 
 import {registrationNameDependencies} from 'legacy-events/EventPluginRegistry';
@@ -118,7 +121,8 @@ const capturePhaseEvents = new Set([
   TOP_VOLUME_CHANGE,
   TOP_WAITING,
 ]);
-const emptyDispatchConfigForCustomEvents = {
+
+const emptyDispatchConfigForCustomEvents: CustomDispatchConfig = {
   customEvent: true,
   phasedRegistrationNames: {
     bubbled: null,
@@ -434,7 +438,7 @@ export function attachElementListener(listener: ReactDOMListener): void {
   // If we don't have a dispatchConfig, then we're dealing with
   // an event type that React does not know about (i.e. a custom event).
   // We need to register an event config for this or the SimpleEventPlugin
-  // will not appropiately provide a SyntheticEvent, so we use out empty
+  // will not appropriately provide a SyntheticEvent, so we use out empty
   // dispatch config for custom events.
   if (dispatchConfig === undefined) {
     topLevelEventsToDispatchConfig.set(

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -172,7 +172,10 @@ const SimpleEventPlugin: PluginModule<MouseEvent> = {
         break;
       default:
         if (__DEV__) {
-          if (knownHTMLTopLevelTypes.indexOf(topLevelType) === -1) {
+          if (
+            knownHTMLTopLevelTypes.indexOf(topLevelType) === -1 &&
+            dispatchConfig.customEvent !== true
+          ) {
             console.error(
               'SimpleEventPlugin: Unhandled event type, `%s`. This warning ' +
                 'is likely caused by a bug in React. Please file an issue.',

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -1787,7 +1787,7 @@ describe('DOMModernPluginEventSystem', () => {
             expect(clickEvent).toHaveBeenCalledTimes(1);
           });
 
-          it('handle propagation of custom user events', () => {
+          it('handles propagation of custom user events', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
             const log = [];
@@ -1799,33 +1799,39 @@ describe('DOMModernPluginEventSystem', () => {
             );
 
             function Test() {
-              let custom;
+              let customEventHandle;
 
               // Test that we get a warning when we don't provide an explicit priortiy
               expect(() => {
-                custom = ReactDOM.unstable_useEvent('custom-event');
+                customEventHandle = ReactDOM.unstable_useEvent('custom-event');
               }).toWarnDev(
                 'Warning: The event "type" provided to useEvent() does not have a known priority type. ' +
                   'It is recommended to provide a "priority" option to specify a priority.',
               );
 
-              custom = ReactDOM.unstable_useEvent('custom-event', {
+              customEventHandle = ReactDOM.unstable_useEvent('custom-event', {
                 priority: 0, // Discrete
               });
 
-              const customCapture = ReactDOM.unstable_useEvent('custom-event', {
-                capture: true,
-                priority: 0, // Discrete
-              });
+              const customCaptureHandle = ReactDOM.unstable_useEvent(
+                'custom-event',
+                {
+                  capture: true,
+                  priority: 0, // Discrete
+                },
+              );
 
               React.useEffect(() => {
-                custom.setListener(buttonRef.current, onCustomEvent);
-                customCapture.setListener(
+                customEventHandle.setListener(buttonRef.current, onCustomEvent);
+                customCaptureHandle.setListener(
                   buttonRef.current,
                   onCustomEventCapture,
                 );
-                custom.setListener(divRef.current, onCustomEvent);
-                customCapture.setListener(divRef.current, onCustomEventCapture);
+                customEventHandle.setListener(divRef.current, onCustomEvent);
+                customCaptureHandle.setListener(
+                  divRef.current,
+                  onCustomEventCapture,
+                );
               });
 
               return (

--- a/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
+++ b/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
@@ -20,9 +20,6 @@ export default function accumulateTwoPhaseListeners(
   accumulateUseEventListeners?: boolean,
 ): void {
   const phasedRegistrationNames = event.dispatchConfig.phasedRegistrationNames;
-  if (phasedRegistrationNames == null) {
-    return;
-  }
   const {bubbled, captured} = phasedRegistrationNames;
   const dispatchListeners = [];
   const dispatchInstances = [];
@@ -59,20 +56,25 @@ export default function accumulateTwoPhaseListeners(
           }
         }
       }
-      // Standard React on* listeners, i.e. onClick prop
-      const captureListener = getListener(node, captured);
-      if (captureListener != null) {
-        // Capture listeners/instances should go at the start, so we
-        // unshift them to the start of the array.
-        dispatchListeners.unshift(captureListener);
-        dispatchInstances.unshift(node);
+      //
+      if (captured !== null) {
+        // Standard React on* listeners, i.e. onClick prop
+        const captureListener = getListener(node, captured);
+        if (captureListener != null) {
+          // Capture listeners/instances should go at the start, so we
+          // unshift them to the start of the array.
+          dispatchListeners.unshift(captureListener);
+          dispatchInstances.unshift(node);
+        }
       }
-      const bubbleListener = getListener(node, bubbled);
-      if (bubbleListener != null) {
-        // Bubble listeners/instances should go at the end, so we
-        // push them to the end of the array.
-        dispatchListeners.push(bubbleListener);
-        dispatchInstances.push(node);
+      if (bubbled !== null) {
+        const bubbleListener = getListener(node, bubbled);
+        if (bubbleListener != null) {
+          // Bubble listeners/instances should go at the end, so we
+          // push them to the end of the array.
+          dispatchListeners.push(bubbleListener);
+          dispatchInstances.push(node);
+        }
       }
     }
     node = node.return;

--- a/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
+++ b/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
@@ -20,9 +20,9 @@ export default function accumulateTwoPhaseListeners(
   accumulateUseEventListeners?: boolean,
 ): void {
   const phasedRegistrationNames = event.dispatchConfig.phasedRegistrationNames;
-  const {bubbled, captured} = phasedRegistrationNames;
   const dispatchListeners = [];
   const dispatchInstances = [];
+  const {bubbled, captured} = phasedRegistrationNames;
   let node = event._targetInst;
 
   // Accumulate all instances and listeners via the target -> root path.
@@ -56,9 +56,8 @@ export default function accumulateTwoPhaseListeners(
           }
         }
       }
-      //
+      // Standard React on* listeners, i.e. onClick prop
       if (captured !== null) {
-        // Standard React on* listeners, i.e. onClick prop
         const captureListener = getListener(node, captured);
         if (captureListener != null) {
           // Capture listeners/instances should go at the start, so we


### PR DESCRIPTION
This PR adds support for custom user events to the `useEvent` system. I've also added tests demonstrating them working as expected. I also added an unnecessary `phasedRegistrationNames == null` check in `accumulateTwoPhaseListeners` that never occurs at runtime. This essentially allows this:

```jsx
function Component() {
  const ref = useRef(null)
  const foo = ReactDOM.unstable_useEvent('foo')

  useEvent(() => {
    foo.setListener(ref.current, () => {
      console.log('Custom user events work!');
    });
  });

  return <span ref={ref}>;
}

const event = document.createEvent('Event');
event.initEvent('foo', true, true);
document. getElementsByName('span')[0].dispatchEvent(event);
```