### PR TITLE
Stop syncing ReactTypes to RN

### DIFF
--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -87,11 +87,9 @@ async function copyWWWShims() {
 }
 
 async function copyRNShims() {
-  const reactTypesBuildTarget = 'build/react-native/shims/ReactTypes.js';
   await Promise.all([
     // React Native
     asyncCopyTo(`${__dirname}/shims/react-native`, 'build/react-native/shims'),
-    asyncCopyTo(require.resolve('shared/ReactTypes.js'), reactTypesBuildTarget),
     asyncCopyTo(
       require.resolve('react-native-renderer/src/ReactNativeTypes.js'),
       'build/react-native/shims/ReactNativeTypes.js'


### PR DESCRIPTION
This is a really old one and all callers have since been codemodded away anyway because of problems.

This file is not really as rigorously maintained as the official Flow types but has a few more specifics. However, the inconsistency causes problems when you try to pass files typed using the built-in Flow typing for React and mix it with these.

We just happen to get away with it because we compile out the types. If we didn't we would hit those problems by even using these in our renderers. We should only use the official types externally.

Ideally we should tighten up the external types and then just use those internally too.