### PR TITLE
ReactDOM.useEvent: add support for beforeblur/afterblur

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "test-persistent": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source-persistent.js",
     "debug-test-persistent": "cross-env NODE_ENV=development node --inspect-brk node_modules/jest/bin/jest.js --config ./scripts/jest/config.source-persistent.js --runInBand",
     "test-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.source.js",
+    "debug-test-prod": "cross-env NODE_ENV=production node --inspect-brk node_modules/jest/bin/jest.js --config ./scripts/jest/config.source.js --runInBand",
     "test-prod-build": "yarn test-build-prod",
     "test-build": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.build.js",
     "test-build-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.build.js",

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -520,6 +520,9 @@ function dispatchBeforeDetachedBlur(target: HTMLElement): void {
       // to dispatch the "beforeblur" event.
       ReactBrowserEventEmitterSetEnabled(true);
       const event = createEvent(TOP_BEFORE_BLUR);
+      // Dispatch "beforeblur" directly on the target,
+      // so it gets picked up by the event system and
+      // can propagate through the React internal tree.
       target.dispatchEvent(event);
     } finally {
       ReactBrowserEventEmitterSetEnabled(false);
@@ -542,24 +545,11 @@ function dispatchAfterDetachedBlur(target: HTMLElement): void {
     );
   }
   if (enableUseEventAPI) {
-    // This works differently from Flare above, because that piggy-backed
-    // the "blur" event internally. We don't want to do that here,
-    // otherwise we will invoke native event listeners listening to "blur"
-    // which would not normally be expecting that event. So we instead
-    // use a new type of event, like we did with "beforeblur". Also,
-    // technically this period is actually after "blur", as Chrome invokes
-    // "blur" natively just as the node gets removed, thus having a valid
-    // target. If we fire a custom blue at this point, it won't work as
-    // the node has been attached, thus the event system will not pick it
-    // up. We have to use the native system, rather than invoke internally,
-    // like we used to do with Flare because we listen on multiple roots
-    // and we don't know the ordering of propagation unless we invoke a
-    // native event.
     const event = createEvent(TOP_AFTER_BLUR);
     // So we know what was detached, make the relatedTarget the
     // detached target on the "afterblur" event.
     (event: any).relatedTarget = target;
-    // Dispatch the event on the document
+    // Dispatch the event on the document.
     document.dispatchEvent(event);
   }
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {TopLevelType} from 'legacy-events/TopLevelEventTypes';
 import type {RootType} from './ReactDOMRoot';
 
 import {
@@ -84,6 +85,7 @@ import {
   attachTargetEventListener,
 } from '../events/DOMModernPluginEventSystem';
 import {getListenerMapForElement} from '../events/DOMEventListenerMap';
+import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
 
 export type ReactListenerEvent = ReactDOMListenerEvent;
 export type ReactListenerMap = ReactDOMListenerMap;
@@ -238,11 +240,11 @@ export function resetAfterCommit(containerInfo: Container): void {
   restoreSelection(selectionInformation);
   ReactBrowserEventEmitterSetEnabled(eventsEnabled);
   eventsEnabled = null;
-  if (enableDeprecatedFlareAPI) {
+  if (enableDeprecatedFlareAPI || enableUseEventAPI) {
     const activeElementDetached = (selectionInformation: any)
       .activeElementDetached;
     if (activeElementDetached !== null) {
-      dispatchDetachedBlur(activeElementDetached);
+      dispatchAfterDetachedBlur(activeElementDetached);
     }
   }
   selectionInformation = null;
@@ -490,34 +492,76 @@ export function insertInContainerBefore(
   }
 }
 
+function createEvent(type: TopLevelType): Event {
+  const event = document.createEvent('Event');
+  event.initEvent(((type: any): string), false, false);
+  return event;
+}
+
 function dispatchBeforeDetachedBlur(target: HTMLElement): void {
   const targetInstance = getClosestInstanceFromNode(target);
   ((selectionInformation: any): SelectionInformation).activeElementDetached = target;
 
-  DEPRECATED_dispatchEventForResponderEventSystem(
-    'beforeblur',
-    targetInstance,
-    ({
+  if (enableDeprecatedFlareAPI) {
+    DEPRECATED_dispatchEventForResponderEventSystem(
+      'beforeblur',
+      targetInstance,
+      ({
+        target,
+        timeStamp: Date.now(),
+      }: any),
       target,
-      timeStamp: Date.now(),
-    }: any),
-    target,
-    RESPONDER_EVENT_SYSTEM | IS_PASSIVE,
-  );
+      RESPONDER_EVENT_SYSTEM | IS_PASSIVE,
+    );
+  }
+  if (enableUseEventAPI) {
+    try {
+      // We need to temporarily enable the event system
+      // to dispatch the "beforeblur" event.
+      ReactBrowserEventEmitterSetEnabled(true);
+      const event = createEvent(TOP_BEFORE_BLUR);
+      target.dispatchEvent(event);
+    } finally {
+      ReactBrowserEventEmitterSetEnabled(false);
+    }
+  }
 }
 
-function dispatchDetachedBlur(target: HTMLElement): void {
-  DEPRECATED_dispatchEventForResponderEventSystem(
-    'blur',
-    null,
-    ({
-      isTargetAttached: false,
+function dispatchAfterDetachedBlur(target: HTMLElement): void {
+  if (enableDeprecatedFlareAPI) {
+    DEPRECATED_dispatchEventForResponderEventSystem(
+      'blur',
+      null,
+      ({
+        isTargetAttached: false,
+        target,
+        timeStamp: Date.now(),
+      }: any),
       target,
-      timeStamp: Date.now(),
-    }: any),
-    target,
-    RESPONDER_EVENT_SYSTEM | IS_PASSIVE,
-  );
+      RESPONDER_EVENT_SYSTEM | IS_PASSIVE,
+    );
+  }
+  if (enableUseEventAPI) {
+    // This works differently from Flare above, because that piggy-backed
+    // the "blur" event internally. We don't want to do that here,
+    // otherwise we will invoke native event listeners listening to "blur"
+    // which would not normally be expecting that event. So we instead
+    // use a new type of event, like we did with "beforeblur". Also,
+    // technically this period is actually after "blur", as Chrome invokes
+    // "blur" natively just as the node gets removed, thus having a valid
+    // target. If we fire a custom blue at this point, it won't work as
+    // the node has been attached, thus the event system will not pick it
+    // up. We have to use the native system, rather than invoke internally,
+    // like we used to do with Flare because we listen on multiple roots
+    // and we don't know the ordering of propagation unless we invoke a
+    // native event.
+    const event = createEvent(TOP_AFTER_BLUR);
+    // So we know what was detached, make the relatedTarget the
+    // detached target on the "afterblur" event.
+    (event: any).relatedTarget = target;
+    // Dispatch the event on the document
+    document.dispatchEvent(event);
+  }
 }
 
 // This is a specific event for the React Flare
@@ -528,7 +572,7 @@ export function beforeRemoveInstance(
   instance: Instance | TextInstance | SuspenseInstance,
 ): void {
   if (
-    enableDeprecatedFlareAPI &&
+    (enableDeprecatedFlareAPI || enableUseEventAPI) &&
     selectionInformation &&
     instance === selectionInformation.focusedElem
   ) {
@@ -639,7 +683,7 @@ export function hideInstance(instance: Instance): void {
   // is ether the instance of a child or the instance. We need
   // to traverse the Fiber tree here rather than use node.contains()
   // as the child node might be inside a Portal.
-  if (enableDeprecatedFlareAPI && selectionInformation) {
+  if ((enableDeprecatedFlareAPI || enableUseEventAPI) && selectionInformation) {
     const focusedElem = selectionInformation.focusedElem;
     if (focusedElem !== null && instanceContainsElem(instance, focusedElem)) {
       dispatchBeforeDetachedBlur(((focusedElem: any): HTMLElement));

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -23,6 +23,7 @@ import {
   UserBlockingEvent,
   ContinuousEvent,
 } from 'shared/ReactTypes';
+import {enableUseEventAPI} from 'shared/ReactFeatureFlags';
 
 // Needed for SimpleEventPlugin, rather than
 // do it in two places, which duplicates logic
@@ -94,6 +95,13 @@ const otherDiscreteEvents = [
   DOMTopLevelEventTypes.TOP_COMPOSITION_END,
   DOMTopLevelEventTypes.TOP_COMPOSITION_UPDATE,
 ];
+
+if (enableUseEventAPI) {
+  otherDiscreteEvents.push(
+    DOMTopLevelEventTypes.TOP_BEFORE_BLUR,
+    DOMTopLevelEventTypes.TOP_AFTER_BLUR,
+  );
+}
 
 // prettier-ignore
 const userBlockingPairsForSimpleEventPlugin = [

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -75,6 +75,8 @@ import {
   TOP_PROGRESS,
   TOP_PLAYING,
   TOP_CLICK,
+  TOP_BEFORE_BLUR,
+  TOP_AFTER_BLUR,
 } from './DOMTopLevelEventTypes';
 import {
   getClosestInstanceFromNode,
@@ -84,7 +86,10 @@ import {
 import {COMMENT_NODE} from '../shared/HTMLNodeType';
 import {topLevelEventsToDispatchConfig} from './DOMEventProperties';
 
-import {enableLegacyFBSupport} from 'shared/ReactFeatureFlags';
+import {
+  enableLegacyFBSupport,
+  enableUseEventAPI,
+} from 'shared/ReactFeatureFlags';
 
 const capturePhaseEvents = new Set([
   TOP_FOCUS,
@@ -121,6 +126,11 @@ const capturePhaseEvents = new Set([
   TOP_VOLUME_CHANGE,
   TOP_WAITING,
 ]);
+
+if (enableUseEventAPI) {
+  capturePhaseEvents.add(TOP_BEFORE_BLUR);
+  capturePhaseEvents.add(TOP_AFTER_BLUR);
+}
 
 const emptyDispatchConfigForCustomEvents: CustomDispatchConfig = {
   customEvent: true,

--- a/packages/react-dom/src/events/DOMTopLevelEventTypes.js
+++ b/packages/react-dom/src/events/DOMTopLevelEventTypes.js
@@ -149,6 +149,9 @@ export const TOP_VOLUME_CHANGE = unsafeCastStringToDOMTopLevelType(
 export const TOP_WAITING = unsafeCastStringToDOMTopLevelType('waiting');
 export const TOP_WHEEL = unsafeCastStringToDOMTopLevelType('wheel');
 
+export const TOP_AFTER_BLUR = unsafeCastStringToDOMTopLevelType('afterblur');
+export const TOP_BEFORE_BLUR = unsafeCastStringToDOMTopLevelType('beforeblur');
+
 // List of events that need to be individually attached to media elements.
 // Note that events in this list will *not* be listened to at the top level
 // unless they're explicitly whitelisted in `ReactBrowserEventEmitter.listenTo`.

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -105,6 +105,8 @@ const SimpleEventPlugin: PluginModule<MouseEvent> = {
         break;
       case DOMTopLevelEventTypes.TOP_BLUR:
       case DOMTopLevelEventTypes.TOP_FOCUS:
+      case DOMTopLevelEventTypes.TOP_BEFORE_BLUR:
+      case DOMTopLevelEventTypes.TOP_AFTER_BLUR:
         EventConstructor = SyntheticFocusEvent;
         break;
       case DOMTopLevelEventTypes.TOP_CLICK:

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -9,10 +9,13 @@
 
 'use strict';
 
+import {createEventTarget} from 'dom-event-testing-library';
+
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let ReactDOMServer;
+let ReactTestUtils;
 let Scheduler;
 
 function dispatchEvent(element, type) {
@@ -64,6 +67,7 @@ describe('DOMModernPluginEventSystem', () => {
           ReactDOM = require('react-dom');
           Scheduler = require('scheduler');
           ReactDOMServer = require('react-dom/server');
+          ReactTestUtils = require('react-dom/test-utils');
           container = document.createElement('div');
           document.body.appendChild(container);
           startNativeEventListenerClearDown();
@@ -1092,6 +1096,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM = require('react-dom');
             Scheduler = require('scheduler');
             ReactDOMServer = require('react-dom/server');
+            ReactTestUtils = require('react-dom/test-utils');
           });
 
           if (!__EXPERIMENTAL__) {
@@ -2139,6 +2144,174 @@ describe('DOMModernPluginEventSystem', () => {
             expect(log[4]).toEqual(['bubble', divElement]);
             expect(log[5]).toEqual(['bubble', buttonElement]);
           });
+
+          it('beforeblur and afterblur are called after a focused element is unmounted', () => {
+            // We have to persist here because we want to read relatedTarget later.
+            const onAfterBlur = jest.fn(e => e.persist());
+            const onBeforeBlur = jest.fn();
+            const innerRef = React.createRef();
+            const innerRef2 = React.createRef();
+
+            const Component = ({show}) => {
+              const ref = React.useRef(null);
+              const afterBlurHandle = ReactDOM.unstable_useEvent('afterblur');
+              const beforeBlurHandle = ReactDOM.unstable_useEvent('beforeblur');
+
+              React.useEffect(() => {
+                afterBlurHandle.setListener(document, onAfterBlur);
+                beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+              });
+
+              return (
+                <div ref={ref}>
+                  {show && <input ref={innerRef} />}
+                  <div ref={innerRef2} />
+                </div>
+              );
+            };
+
+            ReactDOM.render(<Component show={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            const inner = innerRef.current;
+            const target = createEventTarget(inner);
+            target.focus();
+            expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+            expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+            ReactDOM.render(<Component show={false} />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledWith(
+              expect.objectContaining({relatedTarget: inner}),
+            );
+          });
+
+          it('beforeblur and afterblur are called after a nested focused element is unmounted', () => {
+            // We have to persist here because we want to read relatedTarget later.
+            const onAfterBlur = jest.fn(e => e.persist());
+            const onBeforeBlur = jest.fn();
+            const innerRef = React.createRef();
+            const innerRef2 = React.createRef();
+
+            const Component = ({show}) => {
+              const ref = React.useRef(null);
+              const afterBlurHandle = ReactDOM.unstable_useEvent('afterblur');
+              const beforeBlurHandle = ReactDOM.unstable_useEvent('beforeblur');
+
+              React.useEffect(() => {
+                afterBlurHandle.setListener(document, onAfterBlur);
+                beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+              });
+
+              return (
+                <div ref={ref}>
+                  {show && (
+                    <div>
+                      <input ref={innerRef} />
+                    </div>
+                  )}
+                  <div ref={innerRef2} />
+                </div>
+              );
+            };
+
+            ReactDOM.render(<Component show={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            const inner = innerRef.current;
+            const target = createEventTarget(inner);
+            target.focus();
+            expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+            expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+            ReactDOM.render(<Component show={false} />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledWith(
+              expect.objectContaining({relatedTarget: inner}),
+            );
+          });
+
+          it.experimental(
+            'beforeblur and afterblur are called after a focused element is suspended',
+            () => {
+              // We have to persist here because we want to read relatedTarget later.
+              const onAfterBlur = jest.fn(e => e.persist());
+              const onBeforeBlur = jest.fn();
+              const innerRef = React.createRef();
+              const Suspense = React.Suspense;
+              let suspend = false;
+              let resolve;
+              let promise = new Promise(
+                resolvePromise => (resolve = resolvePromise),
+              );
+
+              function Child() {
+                if (suspend) {
+                  throw promise;
+                } else {
+                  return <input ref={innerRef} />;
+                }
+              }
+
+              const Component = () => {
+                const ref = React.useRef(null);
+                const afterBlurHandle = ReactDOM.unstable_useEvent('afterblur');
+                const beforeBlurHandle = ReactDOM.unstable_useEvent(
+                  'beforeblur',
+                );
+
+                React.useEffect(() => {
+                  afterBlurHandle.setListener(document, onAfterBlur);
+                  beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+                });
+
+                return (
+                  <div ref={ref}>
+                    <Suspense fallback="Loading...">
+                      <Child />
+                    </Suspense>
+                  </div>
+                );
+              };
+
+              const container2 = document.createElement('div');
+              document.body.appendChild(container2);
+
+              let root = ReactDOM.createRoot(container2);
+
+              ReactTestUtils.act(() => {
+                root.render(<Component />);
+              });
+              jest.runAllTimers();
+
+              const inner = innerRef.current;
+              const target = createEventTarget(inner);
+              target.focus();
+              expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+              expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+              suspend = true;
+              ReactTestUtils.act(() => {
+                root.render(<Component />);
+              });
+              jest.runAllTimers();
+
+              expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+              expect(onAfterBlur).toHaveBeenCalledTimes(1);
+              expect(onAfterBlur).toHaveBeenCalledWith(
+                expect.objectContaining({relatedTarget: inner}),
+              );
+              resolve();
+
+              document.body.removeChild(container2);
+            },
+          );
         });
       },
     );

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -2146,9 +2146,13 @@ describe('DOMModernPluginEventSystem', () => {
           });
 
           it('beforeblur and afterblur are called after a focused element is unmounted', () => {
+            const log = [];
             // We have to persist here because we want to read relatedTarget later.
-            const onAfterBlur = jest.fn(e => e.persist());
-            const onBeforeBlur = jest.fn();
+            const onAfterBlur = jest.fn(e => {
+              e.persist();
+              log.push(e.type);
+            });
+            const onBeforeBlur = jest.fn(e => log.push(e.type));
             const innerRef = React.createRef();
             const innerRef2 = React.createRef();
 
@@ -2187,12 +2191,17 @@ describe('DOMModernPluginEventSystem', () => {
             expect(onAfterBlur).toHaveBeenCalledWith(
               expect.objectContaining({relatedTarget: inner}),
             );
+            expect(log).toEqual(['beforeblur', 'afterblur']);
           });
 
           it('beforeblur and afterblur are called after a nested focused element is unmounted', () => {
+            const log = [];
             // We have to persist here because we want to read relatedTarget later.
-            const onAfterBlur = jest.fn(e => e.persist());
-            const onBeforeBlur = jest.fn();
+            const onAfterBlur = jest.fn(e => {
+              e.persist();
+              log.push(e.type);
+            });
+            const onBeforeBlur = jest.fn(e => log.push(e.type));
             const innerRef = React.createRef();
             const innerRef2 = React.createRef();
 
@@ -2235,14 +2244,19 @@ describe('DOMModernPluginEventSystem', () => {
             expect(onAfterBlur).toHaveBeenCalledWith(
               expect.objectContaining({relatedTarget: inner}),
             );
+            expect(log).toEqual(['beforeblur', 'afterblur']);
           });
 
           it.experimental(
             'beforeblur and afterblur are called after a focused element is suspended',
             () => {
+              const log = [];
               // We have to persist here because we want to read relatedTarget later.
-              const onAfterBlur = jest.fn(e => e.persist());
-              const onBeforeBlur = jest.fn();
+              const onAfterBlur = jest.fn(e => {
+                e.persist();
+                log.push(e.type);
+              });
+              const onBeforeBlur = jest.fn(e => log.push(e.type));
               const innerRef = React.createRef();
               const Suspense = React.Suspense;
               let suspend = false;
@@ -2308,6 +2322,7 @@ describe('DOMModernPluginEventSystem', () => {
                 expect.objectContaining({relatedTarget: inner}),
               );
               resolve();
+              expect(log).toEqual(['beforeblur', 'afterblur']);
 
               document.body.removeChild(container2);
             },


### PR DESCRIPTION
This ports the existing Flare logic for handling `beforeblur` and `blur` over to the ReactDOM.useEvent system. The only real differences are:

- We don't invoke events directly into the modern event system, like we do with the Flare events (we invoke the Flare event system directly). Instead, we trigger a native DOM custom event and let the DOM event listeners catch it. We have to do this because we now listen to both roots and also EventTarget nodes. If we only trigger them directly to the event system then propagation is out of sequence because we can have many roots/portals listening with their native event listeners. If we have multiple ReactDOM's of different versions, they should also be able to know of this event too – if we only invoke it internally, they'll never know of the `beforeblur` event.
- Given the last point, I opted to move away from `blur` and instead we now use `afterblur`. Technically, that is also the correct name as `blur` occurs after the DOM node is removed and we're firing this in the commit phase that is actually after all the `blur` events would have been anyway. We do this because we're now invoking native events and over-firing a common event such as `blur` triggers listeners that previously never fired and we definitely don't want that. We nominate the `relatedTarget` to tell us what the detached node was and we fire it only on the `document`.