### PR TITLE
Flip the arguments of Blocks and make the query optional

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -152,7 +152,7 @@ export function reportGlobalError(response: Response, error: Error): void {
 }
 
 function readMaybeChunk<T>(maybeChunk: Chunk<T> | T): T {
-  if ((maybeChunk: any).$$typeof !== CHUNK_TYPE) {
+  if (maybeChunk == null || (maybeChunk: any).$$typeof !== CHUNK_TYPE) {
     // $FlowFixMe
     return maybeChunk;
   }

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -29,15 +29,15 @@ describe('ReactFlight', () => {
     act = ReactNoop.act;
   });
 
-  function block(render, query) {
+  function block(render, load) {
     return function(...args) {
-      if (query === undefined) {
+      if (load === undefined) {
         return [Symbol.for('react.server.block'), render];
       }
-      let curriedQuery = () => {
-        return query(...args);
+      let curriedLoad = () => {
+        return load(...args);
       };
-      return [Symbol.for('react.server.block'), render, curriedQuery];
+      return [Symbol.for('react.server.block'), render, curriedLoad];
     };
   }
 
@@ -73,7 +73,7 @@ describe('ReactFlight', () => {
   });
 
   if (ReactFeatureFlags.enableBlocksAPI) {
-    it('can transfer a Block to the client and render there, without a query', () => {
+    it('can transfer a Block to the client and render there, without data', () => {
       function User(props, data) {
         return (
           <span>
@@ -97,8 +97,8 @@ describe('ReactFlight', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span>Hello undefined</span>);
     });
 
-    it('can transfer a Block to the client and render there, with a query', () => {
-      function query(firstName, lastName) {
+    it('can transfer a Block to the client and render there, with data', () => {
+      function load(firstName, lastName) {
         return {name: firstName + ' ' + lastName};
       }
       function User(props, data) {
@@ -108,7 +108,7 @@ describe('ReactFlight', () => {
           </span>
         );
       }
-      let loadUser = block(User, query);
+      let loadUser = block(User, load);
       let model = {
         User: loadUser('Seb', 'Smith'),
       };

--- a/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -44,8 +44,11 @@ describe('ReactFlightDOMRelay', () => {
     return model;
   }
 
-  function block(query, render) {
+  function block(render, query) {
     return function(...args) {
+      if (query === undefined) {
+        return [Symbol.for('react.server.block'), render];
+      }
       let curriedQuery = () => {
         return query(...args);
       };
@@ -89,7 +92,7 @@ describe('ReactFlightDOMRelay', () => {
   });
 
   it.experimental('can transfer a Block to the client and render there', () => {
-    function Query(firstName, lastName) {
+    function query(firstName, lastName) {
       return {name: firstName + ' ' + lastName};
     }
     function User(props, data) {
@@ -99,7 +102,7 @@ describe('ReactFlightDOMRelay', () => {
         </span>
       );
     }
-    let loadUser = block(Query, User);
+    let loadUser = block(User, query);
     let model = {
       User: loadUser('Seb', 'Smith'),
     };

--- a/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -44,15 +44,15 @@ describe('ReactFlightDOMRelay', () => {
     return model;
   }
 
-  function block(render, query) {
+  function block(render, load) {
     return function(...args) {
-      if (query === undefined) {
+      if (load === undefined) {
         return [Symbol.for('react.server.block'), render];
       }
-      let curriedQuery = () => {
-        return query(...args);
+      let curriedLoad = () => {
+        return load(...args);
       };
-      return [Symbol.for('react.server.block'), render, curriedQuery];
+      return [Symbol.for('react.server.block'), render, curriedLoad];
     };
   }
 
@@ -92,7 +92,7 @@ describe('ReactFlightDOMRelay', () => {
   });
 
   it.experimental('can transfer a Block to the client and render there', () => {
-    function query(firstName, lastName) {
+    function load(firstName, lastName) {
       return {name: firstName + ' ' + lastName};
     }
     function User(props, data) {
@@ -102,7 +102,7 @@ describe('ReactFlightDOMRelay', () => {
         </span>
       );
     }
-    let loadUser = block(User, query);
+    let loadUser = block(User, load);
     let model = {
       User: loadUser('Seb', 'Smith'),
     };

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -62,7 +62,7 @@ describe('ReactFlightDOM', () => {
     };
   }
 
-  function block(render, query) {
+  function block(render, load) {
     let idx = webpackModuleIdx++;
     webpackModules[idx] = {
       d: render,
@@ -73,13 +73,13 @@ describe('ReactFlightDOM', () => {
       name: 'd',
     };
     return function(...args) {
-      if (query === undefined) {
+      if (load === undefined) {
         return [Symbol.for('react.server.block'), render];
       }
-      let curriedQuery = () => {
-        return query(...args);
+      let curriedLoad = () => {
+        return load(...args);
       };
-      return [Symbol.for('react.server.block'), 'path/' + idx, curriedQuery];
+      return [Symbol.for('react.server.block'), 'path/' + idx, curriedLoad];
     };
   }
 
@@ -291,7 +291,7 @@ describe('ReactFlightDOM', () => {
           reject(e);
         };
       });
-      function query() {
+      function load() {
         if (promise) {
           throw promise;
         }
@@ -303,8 +303,8 @@ describe('ReactFlightDOM', () => {
       function DelayedText({children}, data) {
         return <Text>{children}</Text>;
       }
-      let _block = block(DelayedText, query);
-      return [_block(), _resolve, _reject];
+      let loadBlock = block(DelayedText, load);
+      return [loadBlock(), _resolve, _reject];
     }
 
     const [FriendsModel, resolveFriendsModel] = makeDelayedText();

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -62,7 +62,7 @@ describe('ReactFlightDOM', () => {
     };
   }
 
-  function block(query, render) {
+  function block(render, query) {
     let idx = webpackModuleIdx++;
     webpackModules[idx] = {
       d: render,
@@ -73,6 +73,9 @@ describe('ReactFlightDOM', () => {
       name: 'd',
     };
     return function(...args) {
+      if (query === undefined) {
+        return [Symbol.for('react.server.block'), render];
+      }
       let curriedQuery = () => {
         return query(...args);
       };
@@ -288,7 +291,7 @@ describe('ReactFlightDOM', () => {
           reject(e);
         };
       });
-      function Query() {
+      function query() {
         if (promise) {
           throw promise;
         }
@@ -300,7 +303,7 @@ describe('ReactFlightDOM', () => {
       function DelayedText({children}, data) {
         return <Text>{children}</Text>;
       }
-      let _block = block(Query, DelayedText);
+      let _block = block(DelayedText, query);
       return [_block(), _resolve, _reject];
     }
 

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -72,7 +72,7 @@ describe('ReactBlocks', () => {
   });
 
   it.experimental('prints the name of the render function in warnings', () => {
-    function query(firstName) {
+    function load(firstName) {
       return {
         name: firstName,
       };
@@ -91,7 +91,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(User, query);
+    let loadUser = block(User, load);
 
     expect(() => {
       ReactNoop.act(() => {
@@ -108,8 +108,8 @@ describe('ReactBlocks', () => {
     );
   });
 
-  it.experimental('renders a component with a suspending query', async () => {
-    function query(id) {
+  it.experimental('renders a component with a suspending load', async () => {
+    function load(id) {
       return {
         id: id,
         name: readString('Sebastian'),
@@ -124,7 +124,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(Render, query);
+    let loadUser = block(Render, load);
 
     function App({User}) {
       return (
@@ -150,7 +150,7 @@ describe('ReactBlocks', () => {
   it.experimental(
     'does not support a lazy wrapper around a chunk',
     async () => {
-      function query(id) {
+      function load(id) {
         return {
           id: id,
           name: readString('Sebastian'),
@@ -165,7 +165,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Render, query);
+      let loadUser = block(Render, load);
 
       function App({User}) {
         return (
@@ -209,7 +209,7 @@ describe('ReactBlocks', () => {
   it.experimental(
     'can receive updated data for the same component',
     async () => {
-      function query(firstName) {
+      function load(firstName) {
         return {
           name: firstName,
         };
@@ -225,7 +225,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Render, query);
+      let loadUser = block(Render, load);
 
       function App({User}) {
         return (

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -49,8 +49,30 @@ describe('ReactBlocks', () => {
     };
   });
 
+  it.experimental('renders a simple component', () => {
+    function User(props, data) {
+      return <div>{typeof data}</div>;
+    }
+
+    function App({Component}) {
+      return (
+        <Suspense fallback={'Loading...'}>
+          <Component name="Name" />
+        </Suspense>
+      );
+    }
+
+    let loadUser = block(User);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App Component={loadUser()} />);
+    });
+
+    expect(ReactNoop).toMatchRenderedOutput(<div>undefined</div>);
+  });
+
   it.experimental('prints the name of the render function in warnings', () => {
-    function Query(firstName) {
+    function query(firstName) {
       return {
         name: firstName,
       };
@@ -69,7 +91,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(Query, User);
+    let loadUser = block(User, query);
 
     expect(() => {
       ReactNoop.act(() => {
@@ -87,7 +109,7 @@ describe('ReactBlocks', () => {
   });
 
   it.experimental('renders a component with a suspending query', async () => {
-    function Query(id) {
+    function query(id) {
       return {
         id: id,
         name: readString('Sebastian'),
@@ -102,7 +124,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(Query, Render);
+    let loadUser = block(Render, query);
 
     function App({User}) {
       return (
@@ -128,7 +150,7 @@ describe('ReactBlocks', () => {
   it.experimental(
     'does not support a lazy wrapper around a chunk',
     async () => {
-      function Query(id) {
+      function query(id) {
         return {
           id: id,
           name: readString('Sebastian'),
@@ -143,7 +165,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Query, Render);
+      let loadUser = block(Render, query);
 
       function App({User}) {
         return (
@@ -187,7 +209,7 @@ describe('ReactBlocks', () => {
   it.experimental(
     'can receive updated data for the same component',
     async () => {
-      function Query(firstName) {
+      function query(firstName) {
         return {
           name: firstName,
         };
@@ -203,7 +225,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Query, Render);
+      let loadUser = block(Render, query);
 
       function App({User}) {
         return (

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -191,11 +191,11 @@ export function resolveModelToJSON(
         }
       }
       case '2': {
-        // Query
-        let query: () => ReactModel = (value: any);
+        // Load function
+        let load: () => ReactModel = (value: any);
         try {
-          // Attempt to resolve the query.
-          return query();
+          // Attempt to resolve the data.
+          return load();
         } catch (x) {
           if (
             typeof x === 'object' &&
@@ -204,12 +204,12 @@ export function resolveModelToJSON(
           ) {
             // Something suspended, we'll need to create a new segment and resolve it later.
             request.pendingChunks++;
-            let newSegment = createSegment(request, query);
+            let newSegment = createSegment(request, load);
             let ping = newSegment.ping;
             x.then(ping, ping);
             return serializeIDRef(newSegment.id);
           } else {
-            // This query failed, encode the error as a separate row and reference that.
+            // This load failed, encode the error as a separate row and reference that.
             request.pendingChunks++;
             let errorId = request.nextChunkId++;
             emitErrorChunk(request, errorId, x);


### PR DESCRIPTION
The Query is an optional overload so I'll put that at the end instead. It also lines up with where the "data" argument goes into the render.

Originally I had some thought around how it would be better for types to infer the result of the first argument flowing into the second. Maybe as you're typing it out. But the current type systems and IDE wouldn't take advantage of this anyway so doesn't matter.

cc @devknoll 