### PR TITLE
ReactDOM.useEvent: Add support for experimental scopes API

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -15,6 +15,7 @@ import type {
   ReactProviderType,
   ReactEventResponder,
   ReactEventResponderListener,
+  ReactScopeMethods,
 } from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {Hook, TimeoutConfig} from 'react-reconciler/src/ReactFiberHooks';
@@ -44,7 +45,10 @@ type HookLogEntry = {
 
 type ReactDebugListenerMap = {|
   clear: () => void,
-  setListener: (target: EventTarget, callback: ?(Event) => void) => void,
+  setListener: (
+    target: EventTarget | ReactScopeMethods,
+    callback: ?(Event) => void,
+  ) => void,
 |};
 
 let hookLog: Array<HookLogEntry> = [];

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -318,16 +318,20 @@ function isMatchingRootContainer(
   );
 }
 
-export function isManagedDOMElement(target: Object): boolean {
+export function isManagedDOMElement(
+  target: EventTarget | ReactScopeMethods,
+): boolean {
   return getClosestInstanceFromNode(((target: any): Node)) !== null;
 }
 
-export function isValidEventTarget(target: Object): boolean {
-  return typeof target.addEventListener === 'function';
+export function isValidEventTarget(
+  target: EventTarget | ReactScopeMethods,
+): boolean {
+  return typeof (target: any).addEventListener === 'function';
 }
 
-export function isReactScope(target: Object): boolean {
-  return typeof target.getChildContextValues === 'function';
+export function isReactScope(target: EventTarget | ReactScopeMethods): boolean {
+  return typeof (target: any).getChildContextValues === 'function';
 }
 
 export function dispatchEventForPluginEventSystem(

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -14,7 +14,7 @@ import type {
   ElementListenerMapEntry,
 } from '../events/DOMEventListenerMap';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
-import type {EventPriority} from 'shared/ReactTypes';
+import type {EventPriority, ReactScopeMethods} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import type {PluginModule} from 'legacy-events/PluginModuleType';
 import type {
@@ -142,11 +142,23 @@ const emptyDispatchConfigForCustomEvents: CustomDispatchConfig = {
 
 const isArray = Array.isArray;
 
-// $FlowFixMe: Flow struggles with this pattern
-const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
+// TODO: we should remove the FlowFixMes and the casting to figure out how to make
+// these patterns work properly.
+// $FlowFixMe: Flow struggles with this pattern, so we also have to cast it.
+const PossiblyWeakMap = ((typeof WeakMap === 'function' ? WeakMap : Map): any);
+
 // $FlowFixMe: Flow cannot handle polymorphic WeakMaps
 export const eventTargetEventListenerStore: WeakMap<
   EventTarget,
+  Map<
+    DOMTopLevelEventType,
+    {bubbled: Set<ReactDOMListener>, captured: Set<ReactDOMListener>},
+  >,
+> = new PossiblyWeakMap();
+
+// $FlowFixMe: Flow cannot handle polymorphic WeakMaps
+export const reactScopeListenerStore: WeakMap<
+  ReactScopeMethods,
   Map<
     DOMTopLevelEventType,
     {bubbled: Set<ReactDOMListener>, captured: Set<ReactDOMListener>},
@@ -306,12 +318,16 @@ function isMatchingRootContainer(
   );
 }
 
-export function isManagedDOMElement(target: EventTarget): boolean {
+export function isManagedDOMElement(target: Object): boolean {
   return getClosestInstanceFromNode(((target: any): Node)) !== null;
 }
 
-export function isValidEventTarget(target: EventTarget): boolean {
+export function isValidEventTarget(target: Object): boolean {
   return typeof target.addEventListener === 'function';
+}
+
+export function isReactScope(target: Object): boolean {
+  return typeof target.getChildContextValues === 'function';
 }
 
 export function dispatchEventForPluginEventSystem(
@@ -446,18 +462,16 @@ function addEventTypeToDispatchConfig(type: DOMTopLevelEventType): void {
   }
 }
 
-export function attachListenerFromManagedDOMElement(
+export function attachListenerToManagedDOMElement(
   listener: ReactDOMListener,
 ): void {
   const {event, target} = listener;
   const {passive, priority, type} = event;
-  const possibleManagedTarget = ((target: any): Element);
-  let containerEventTarget = target;
-  if (getClosestInstanceFromNode(possibleManagedTarget)) {
-    containerEventTarget = getNearestRootOrPortalContainer(
-      possibleManagedTarget,
-    );
-  }
+
+  const managedTargetElement = ((target: any): Element);
+  const containerEventTarget = getNearestRootOrPortalContainer(
+    managedTargetElement,
+  );
   const listenerMap = getListenerMapForElement(containerEventTarget);
   // Add the event listener to the target container (falling back to
   // the target if we didn't find one).
@@ -469,11 +483,11 @@ export function attachListenerFromManagedDOMElement(
     priority,
   );
   // Get the internal listeners Set from the target instance.
-  let listeners = getListenersFromTarget(target);
+  let listeners = getListenersFromTarget(managedTargetElement);
   // If we don't have any listeners, then we need to init them.
   if (listeners === null) {
     listeners = new Set();
-    initListenersSet(target, listeners);
+    initListenersSet(managedTargetElement, listeners);
   }
   // Add our listener to the listeners Set.
   listeners.add(listener);
@@ -485,8 +499,9 @@ export function detachListenerFromManagedDOMElement(
   listener: ReactDOMListener,
 ): void {
   const {target} = listener;
+  const managedTargetElement = ((target: any): Element);
   // Get the internal listeners Set from the target instance.
-  const listeners = getListenersFromTarget(target);
+  const listeners = getListenersFromTarget(managedTargetElement);
   if (listeners !== null) {
     // Remove out listener from the listeners Set.
     listeners.delete(listener);
@@ -496,13 +511,21 @@ export function detachListenerFromManagedDOMElement(
 export function attachTargetEventListener(listener: ReactDOMListener): void {
   const {event, target} = listener;
   const {capture, passive, priority, type} = event;
-  const listenerMap = getListenerMapForElement(target);
+  const eventTarget = ((target: any): EventTarget);
+  const listenerMap = getListenerMapForElement(eventTarget);
   // Add the event listener to the TargetEvent object.
-  listenToTopLevelEvent(type, target, listenerMap, passive, priority, capture);
-  let eventTypeMap = eventTargetEventListenerStore.get(target);
+  listenToTopLevelEvent(
+    type,
+    eventTarget,
+    listenerMap,
+    passive,
+    priority,
+    capture,
+  );
+  let eventTypeMap = eventTargetEventListenerStore.get(eventTarget);
   if (eventTypeMap === undefined) {
     eventTypeMap = new Map();
-    eventTargetEventListenerStore.set(target, eventTypeMap);
+    eventTargetEventListenerStore.set(eventTarget, eventTypeMap);
   }
   // Get the listeners by the event type
   let listeners = eventTypeMap.get(type);
@@ -523,7 +546,51 @@ export function attachTargetEventListener(listener: ReactDOMListener): void {
 export function detachTargetEventListener(listener: ReactDOMListener): void {
   const {event, target} = listener;
   const {capture, type} = event;
-  const eventTypeMap = eventTargetEventListenerStore.get(target);
+  const validEventTarget = ((target: any): EventTarget);
+  const eventTypeMap = eventTargetEventListenerStore.get(validEventTarget);
+  if (eventTypeMap !== undefined) {
+    const listeners = eventTypeMap.get(type);
+    if (listeners !== undefined) {
+      // Remove out listener from the listeners Set.
+      if (capture) {
+        listeners.captured.delete(listener);
+      } else {
+        listeners.bubbled.delete(listener);
+      }
+    }
+  }
+}
+
+export function attachListenerToReactScope(listener: ReactDOMListener): void {
+  const {event, target} = listener;
+  const {capture, type} = event;
+  const reactScope = ((target: any): ReactScopeMethods);
+  let eventTypeMap = reactScopeListenerStore.get(reactScope);
+  if (eventTypeMap === undefined) {
+    eventTypeMap = new Map();
+    reactScopeListenerStore.set(reactScope, eventTypeMap);
+  }
+  // Get the listeners by the event type
+  let listeners = eventTypeMap.get(type);
+  if (listeners === undefined) {
+    listeners = {captured: new Set(), bubbled: new Set()};
+    eventTypeMap.set(type, listeners);
+  }
+  // Add our listener to the listeners Set.
+  if (capture) {
+    listeners.captured.add(listener);
+  } else {
+    listeners.bubbled.add(listener);
+  }
+  // Finally, add the event to our known event types list.
+  addEventTypeToDispatchConfig(type);
+}
+
+export function detachListenerFromReactScope(listener: ReactDOMListener): void {
+  const {event, target} = listener;
+  const {capture, type} = event;
+  const reactScope = ((target: any): ReactScopeMethods);
+  const eventTypeMap = reactScopeListenerStore.get(reactScope);
   if (eventTypeMap !== undefined) {
     const listeners = eventTypeMap.get(type);
     if (listeners !== undefined) {

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -2327,6 +2327,139 @@ describe('DOMModernPluginEventSystem', () => {
               document.body.removeChild(container2);
             },
           );
+
+          describe('Compatibility with Scopes API', () => {
+            beforeEach(() => {
+              jest.resetModules();
+              ReactFeatureFlags = require('shared/ReactFeatureFlags');
+              ReactFeatureFlags.enableModernEventSystem = true;
+              ReactFeatureFlags.enableUseEventAPI = true;
+              ReactFeatureFlags.enableScopeAPI = true;
+
+              React = require('react');
+              ReactDOM = require('react-dom');
+              Scheduler = require('scheduler');
+              ReactDOMServer = require('react-dom/server');
+            });
+
+            it('handle propagation of click events on a scope', () => {
+              const buttonRef = React.createRef();
+              const log = [];
+              const onClick = jest.fn(e =>
+                log.push(['bubble', e.currentTarget]),
+              );
+              const onClickCapture = jest.fn(e =>
+                log.push(['capture', e.currentTarget]),
+              );
+              const TestScope = React.unstable_createScope();
+
+              function Test() {
+                const click = ReactDOM.unstable_useEvent('click');
+                const clickCapture = ReactDOM.unstable_useEvent('click', {
+                  capture: true,
+                });
+                const scopeRef = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, onClick);
+                  clickCapture.setListener(scopeRef.current, onClickCapture);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <button ref={buttonRef} />
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(onClick).toHaveBeenCalledTimes(1);
+              expect(onClickCapture).toHaveBeenCalledTimes(1);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+            });
+
+            it('handle mixed propagation of click events on a scope', () => {
+              const buttonRef = React.createRef();
+              const divRef = React.createRef();
+              const log = [];
+              const onClick = jest.fn(e =>
+                log.push(['bubble', e.currentTarget]),
+              );
+              const onClickCapture = jest.fn(e =>
+                log.push(['capture', e.currentTarget]),
+              );
+              const TestScope = React.unstable_createScope();
+
+              function Test() {
+                const click = ReactDOM.unstable_useEvent('click');
+                const clickCapture = ReactDOM.unstable_useEvent('click', {
+                  capture: true,
+                });
+                const scopeRef = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, onClick);
+                  clickCapture.setListener(scopeRef.current, onClickCapture);
+                  click.setListener(buttonRef.current, onClick);
+                  clickCapture.setListener(buttonRef.current, onClickCapture);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <button ref={buttonRef}>
+                      <div
+                        ref={divRef}
+                        onClick={onClick}
+                        onClickCapture={onClickCapture}>
+                        Click me!
+                      </div>
+                    </button>
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(onClick).toHaveBeenCalledTimes(2);
+              expect(onClickCapture).toHaveBeenCalledTimes(2);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['capture', buttonElement],
+                ['bubble', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+
+              log.length = 0;
+              onClick.mockClear();
+              onClickCapture.mockClear();
+
+              const divElement = divRef.current;
+              dispatchClickEvent(divElement);
+
+              expect(onClick).toHaveBeenCalledTimes(3);
+              expect(onClickCapture).toHaveBeenCalledTimes(3);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['capture', buttonElement],
+                ['capture', divElement],
+                ['bubble', divElement],
+                ['bubble', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+            });
+          });
         });
       },
     );

--- a/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
+++ b/packages/react-dom/src/events/accumulateTwoPhaseListeners.js
@@ -11,13 +11,19 @@ import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 import type {ReactSyntheticEvent} from 'legacy-events/ReactSyntheticEventType';
 
-import {HostComponent} from 'react-reconciler/src/ReactWorkTags';
-import {enableUseEventAPI} from 'shared/ReactFeatureFlags';
+import {
+  HostComponent,
+  ScopeComponent,
+} from 'react-reconciler/src/ReactWorkTags';
+import {enableUseEventAPI, enableScopeAPI} from 'shared/ReactFeatureFlags';
 
 import getListener from 'legacy-events/getListener';
 import {getListenersFromTarget} from '../client/ReactDOMComponentTree';
 import {IS_TARGET_EVENT_ONLY} from 'legacy-events/EventSystemFlags';
-import {eventTargetEventListenerStore} from './DOMModernPluginEventSystem';
+import {
+  eventTargetEventListenerStore,
+  reactScopeListenerStore,
+} from './DOMModernPluginEventSystem';
 
 export default function accumulateTwoPhaseListeners(
   event: ReactSyntheticEvent,
@@ -76,11 +82,13 @@ export default function accumulateTwoPhaseListeners(
     // usual two phase accumulation using the React fiber tree to pick up
     // all relevant useEvent and on* prop events.
     let node = event._targetInst;
+    let lastHostComponent;
 
     // Accumulate all instances and listeners via the target -> root path.
     while (node !== null) {
-      // We only care for listeners that are on HostComponents (i.e. <div>)
+      // Handle listeners that are on HostComponents (i.e. <div>)
       if (node.tag === HostComponent) {
+        lastHostComponent = node.stateNode;
         // For useEvent listenrs
         if (enableUseEventAPI && accumulateUseEventListeners) {
           // useEvent event listeners
@@ -125,6 +133,30 @@ export default function accumulateTwoPhaseListeners(
             // push them to the end of the array.
             dispatchListeners.push(bubbleListener);
             dispatchInstances.push(node);
+          }
+        }
+      } else if (enableScopeAPI && node.tag === ScopeComponent) {
+        const reactScope = node.stateNode.methods;
+        const eventTypeMap = reactScopeListenerStore.get(reactScope);
+        if (eventTypeMap !== undefined) {
+          const type = ((event.type: any): DOMTopLevelEventType);
+          const listeners = eventTypeMap.get(type);
+          if (listeners !== undefined) {
+            const captureListeners = Array.from(listeners.captured);
+            const bubbleListeners = Array.from(listeners.bubbled);
+
+            for (let i = 0; i < captureListeners.length; i++) {
+              const listener = captureListeners[i];
+              const {callback} = listener;
+              dispatchListeners.unshift(callback);
+              dispatchInstances.unshift(((lastHostComponent: any): Element));
+            }
+            for (let i = 0; i < bubbleListeners.length; i++) {
+              const listener = bubbleListeners[i];
+              const {callback} = listener;
+              dispatchListeners.push(callback);
+              dispatchInstances.push(((lastHostComponent: any): Element));
+            }
           }
         }
       }

--- a/packages/react-dom/src/shared/ReactDOMTypes.js
+++ b/packages/react-dom/src/shared/ReactDOMTypes.js
@@ -12,6 +12,7 @@ import type {
   ReactEventResponder,
   ReactEventResponderInstance,
   EventPriority,
+  ReactScopeMethods,
 } from 'shared/ReactTypes';
 import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 
@@ -86,12 +87,15 @@ export type ReactDOMListenerEvent = {|
 
 export type ReactDOMListenerMap = {|
   clear: () => void,
-  setListener: (target: EventTarget, callback: ?(Event) => void) => void,
+  setListener: (
+    target: EventTarget | ReactScopeMethods,
+    callback: ?(Event) => void,
+  ) => void,
 |};
 
 export type ReactDOMListener = {|
   callback: Event => void,
   destroy: Node => void,
   event: ReactDOMListenerEvent,
-  target: EventTarget,
+  target: EventTarget | ReactScopeMethods,
 |};

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -14,6 +14,7 @@ import type {
   ReactEventResponder,
   ReactContext,
   ReactEventResponderListener,
+  ReactScopeMethods,
 } from 'shared/ReactTypes';
 import type {Fiber} from './ReactFiber';
 import type {ExpirationTime} from './ReactFiberExpirationTime';
@@ -1651,7 +1652,7 @@ function validateNotInFunctionRender(): boolean {
 function createReactListener(
   event: ReactListenerEvent,
   callback: Event => void,
-  target: EventTarget,
+  target: EventTarget | ReactScopeMethods,
   destroy: Node => void,
 ): ReactListener {
   return {
@@ -1665,7 +1666,10 @@ function createReactListener(
 function mountEventListener(event: ReactListenerEvent): ReactListenerMap {
   if (enableUseEventAPI) {
     const hook = mountWorkInProgressHook();
-    const listenerMap: Map<EventTarget, ReactListener> = new Map();
+    const listenerMap: Map<
+      EventTarget | ReactScopeMethods,
+      ReactListener,
+    > = new Map();
     const rootContainerInstance = getRootHostContainer();
 
     // Register the event to the current root to ensure event
@@ -1700,7 +1704,10 @@ function mountEventListener(event: ReactListenerEvent): ReactListenerMap {
 
     const reactListenerMap: ReactListenerMap = {
       clear,
-      setListener(target: EventTarget, callback: ?(Event) => void): void {
+      setListener(
+        target: EventTarget | ReactScopeMethods,
+        callback: ?(Event) => void,
+      ): void {
         if (
           validateNotInFunctionRender() &&
           validateEventListenerTarget(target, callback)


### PR DESCRIPTION
This is the last big piece of the `useEvent` API puzzle. It ports the existing behavior in React Flare, where you can attach listeners to the experimental Scopes API. This means that with `useEvent` you can attach events to a "scope" rather than a physical `EventTarget`, making way for us to be able to port the internal a11y components and their usages of this over to `useEvent`, allowing us to remove React Flare. This feature is a very important one, as it allows us to attach events to something that doesn't require a physical DOM element, as these can be problematic in places with `<table>` and `<select>`, plus adding in additional DOM wrapper elements can break the semantics of accessibility tools and CSS styling – which is why we offered this feature for Scopes with Flare.