### PR TITLE
Inlined DevTools event emitter impl

### DIFF
--- a/packages/react-devtools-shared/package.json
+++ b/packages/react-devtools-shared/package.json
@@ -11,7 +11,6 @@
     "@reach/menu-button": "^0.1.17",
     "@reach/tooltip": "^0.2.2",
     "clipboard-js": "^0.3.6",
-    "events": "^3.0.0",
     "local-storage-fallback": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^3.1.1",

--- a/packages/react-devtools-shared/src/__tests__/events-test.js
+++ b/packages/react-devtools-shared/src/__tests__/events-test.js
@@ -25,6 +25,10 @@ describe('events', () => {
 
     dispatcher.addListener('event', callback);
     dispatcher.addListener('event', callback);
+
+    dispatcher.emit('event', 123);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(123);
   });
 
   it('notifies all attached listeners of events', () => {
@@ -92,5 +96,31 @@ describe('events', () => {
     expect(callback1).not.toHaveBeenCalled();
     expect(callback2).not.toHaveBeenCalled();
     expect(callback3).not.toHaveBeenCalled();
+  });
+
+  it('should call the initial listeners even if others are added or removed during a dispatch', () => {
+    const callback1 = jest.fn(() => {
+      dispatcher.removeListener('event', callback2);
+      dispatcher.addListener('event', callback3);
+    });
+    const callback2 = jest.fn();
+    const callback3 = jest.fn();
+
+    dispatcher.addListener('event', callback1);
+    dispatcher.addListener('event', callback2);
+
+    dispatcher.emit('event', 123);
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith(123);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledWith(123);
+    expect(callback3).not.toHaveBeenCalled();
+
+    dispatcher.emit('event', 456);
+    expect(callback1).toHaveBeenCalledTimes(2);
+    expect(callback1).toHaveBeenCalledWith(456);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback3).toHaveBeenCalledTimes(1);
+    expect(callback3).toHaveBeenCalledWith(456);
   });
 });

--- a/packages/react-devtools-shared/src/__tests__/events-test.js
+++ b/packages/react-devtools-shared/src/__tests__/events-test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('events', () => {
+  let dispatcher;
+
+  beforeEach(() => {
+    const EventEmitter = require('../events').default;
+
+    dispatcher = new EventEmitter();
+  });
+
+  it('can dispatch an event with no listeners', () => {
+    dispatcher.emit('event', 123);
+  });
+
+  it('handles a listener being attached multiple times', () => {
+    const callback = jest.fn();
+
+    dispatcher.addListener('event', callback);
+    dispatcher.addListener('event', callback);
+  });
+
+  it('notifies all attached listeners of events', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const callback3 = jest.fn();
+
+    dispatcher.addListener('event', callback1);
+    dispatcher.addListener('event', callback2);
+    dispatcher.addListener('other-event', callback3);
+    dispatcher.emit('event', 123);
+
+    expect(callback1).toHaveBeenCalledTimes(1);
+    expect(callback1).toHaveBeenCalledWith(123);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledWith(123);
+    expect(callback3).not.toHaveBeenCalled();
+  });
+
+  it('calls later listeners before re-throwing if an earlier one throws', () => {
+    const callbackThatThrows = jest.fn(() => {
+      throw Error('expected');
+    });
+    const callback = jest.fn();
+
+    dispatcher.addListener('event', callbackThatThrows);
+    dispatcher.addListener('event', callback);
+
+    expect(() => {
+      dispatcher.emit('event', 123);
+    }).toThrow('expected');
+
+    expect(callbackThatThrows).toHaveBeenCalledTimes(1);
+    expect(callbackThatThrows).toHaveBeenCalledWith(123);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(123);
+  });
+
+  it('removes attached listeners', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+
+    dispatcher.addListener('event', callback1);
+    dispatcher.addListener('other-event', callback2);
+    dispatcher.removeListener('event', callback1);
+    dispatcher.emit('event', 123);
+    expect(callback1).not.toHaveBeenCalled();
+    dispatcher.emit('other-event', 123);
+    expect(callback2).toHaveBeenCalledTimes(1);
+    expect(callback2).toHaveBeenCalledWith(123);
+  });
+
+  it('removes all listeners', () => {
+    const callback1 = jest.fn();
+    const callback2 = jest.fn();
+    const callback3 = jest.fn();
+
+    dispatcher.addListener('event', callback1);
+    dispatcher.addListener('event', callback2);
+    dispatcher.addListener('other-event', callback3);
+    dispatcher.removeAllListeners();
+    dispatcher.emit('event', 123);
+    dispatcher.emit('other-event', 123);
+
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).not.toHaveBeenCalled();
+    expect(callback3).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import EventEmitter from 'events';
+import EventEmitter from '../events';
 import throttle from 'lodash.throttle';
 import {
   SESSION_STORAGE_LAST_SELECTION_KEY,

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import EventEmitter from 'events';
+import EventEmitter from './events';
 
 import type {ComponentFilter, Wall} from './types';
 import type {

--- a/packages/react-devtools-shared/src/devtools/ProfilerStore.js
+++ b/packages/react-devtools-shared/src/devtools/ProfilerStore.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import EventEmitter from 'events';
+import EventEmitter from '../events';
 import {prepareProfilingDataFrontendFromBackendAndStore} from './views/Profiler/utils';
 import ProfilingCache from './ProfilingCache';
 import Store from './store';

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import EventEmitter from 'events';
+import EventEmitter from '../events';
 import {inspect} from 'util';
 import {
   TREE_OPERATION_ADD,

--- a/packages/react-devtools-shared/src/events.js
+++ b/packages/react-devtools-shared/src/events.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default class EventEmitter<Events: Object> {
+  listenersMap: Map<string, Set<Function>> = new Map();
+
+  addListener<Event: $Keys<Events>>(
+    event: Event,
+    listener: (...$ElementType<Events, Event>) => any,
+  ): void {
+    let listeners = this.listenersMap.get(event);
+    if (listeners === undefined) {
+      listeners = new Set();
+
+      this.listenersMap.set(event, listeners);
+    }
+
+    listeners.add(listener);
+  }
+
+  emit<Event: $Keys<Events>>(
+    event: Event,
+    ...args: $ElementType<Events, Event>
+  ): void {
+    const listeners = this.listenersMap.get(event);
+    if (listeners !== undefined) {
+      let didThrow = false;
+      let caughtError = null;
+
+      listeners.forEach(listener => {
+        try {
+          listener.apply(null, args);
+        } catch (error) {
+          if (caughtError === null) {
+            didThrow = true;
+            caughtError = error;
+          }
+        }
+      });
+
+      if (didThrow) {
+        throw caughtError;
+      }
+    }
+  }
+
+  removeAllListeners(event?: $Keys<Events>): void {
+    if (event != null) {
+      this.listenersMap.delete(event);
+    } else {
+      this.listenersMap.clear();
+    }
+  }
+
+  removeListener(event: $Keys<Events>, listener: Function): void {
+    const listeners = this.listenersMap.get(event);
+    if (listeners !== undefined) {
+      listeners.delete(listener);
+    }
+  }
+}

--- a/scripts/flow/react-devtools.js
+++ b/scripts/flow/react-devtools.js
@@ -7,19 +7,4 @@
  * @flow
  */
 
-declare module 'events' {
-  declare class EventEmitter<Events: Object> {
-    addListener<Event: $Keys<Events>>(
-      event: Event,
-      listener: (...$ElementType<Events, Event>) => any,
-    ): void;
-    emit: <Event: $Keys<Events>>(
-      event: Event,
-      ...$ElementType<Events, Event>
-    ) => void;
-    removeListener(event: $Keys<Events>, listener: Function): void;
-    removeAllListeners(event?: $Keys<Events>): void;
-  }
-
-  declare export default typeof EventEmitter;
-}
+// No types


### PR DESCRIPTION
DevTools previously used the NPM [`events` package](https://www.npmjs.com/package/events) for dispatching events. This package has an unfortunate flaw though- if a listener throws during event dispatch, no subsequent listeners are called. I've replaced that event dispatcher with my own implementation that ensures all listeners are called before it re-throws an error.

---

[Here](https://codesandbox.io/s/getcommittree-mtgto) is an example app that breaks the Profiler UI without this change:
```js
const One = () => null;
const Two = () => null;

function App() {
  const [didMount, setDidMount] = useState(false);

  useEffect(() => {
    setDidMount(true);
  }, []);

  return (
    <>
      {didMount ? <Two /> : <One key={1} />}
      <One key={1} />
    </>
  );
}
```

This breaks the Profiler because the invalid `key` causes a DevTools `Store` invariant:
https://github.com/facebook/react/blob/0140118e8e2766abaac2c833775434f83df81d56/packages/react-devtools-shared/src/devtools/store.js#L929-L933

The `Store` happens to be listening to "operations" events ahead of the `ProfilerStore`, so the latter never gets notified of the commit. This causes the commit data to become corrupt.

<img width="986" alt="Screen Shot 2020-03-24 at 10 38 40 AM" src="https://user-images.githubusercontent.com/29597/77462499-6d69fe00-6dc1-11ea-9000-4fe27f2dfb48.png">

With this change in place, both stores are notified before the error is rethrown:

<img width="1027" alt="Screen Shot 2020-03-24 at 10 38 09 AM" src="https://user-images.githubusercontent.com/29597/77462477-6642f000-6dc1-11ea-975d-bc619e6e46d7.png">


This might be the underlying cause of a few DevTools errors (e.g. #18033).