### PR TITLE
Fix email cursor jump

### DIFF
--- a/fixtures/dom/src/components/Header.js
+++ b/fixtures/dom/src/components/Header.js
@@ -71,6 +71,7 @@ class Header extends React.Component {
                 <option value="/text-inputs">Text Inputs</option>
                 <option value="/number-inputs">Number Input</option>
                 <option value="/password-inputs">Password Input</option>
+                <option value="/email-inputs">Email Input</option>
                 <option value="/selects">Selects</option>
                 <option value="/textareas">Textareas</option>
                 <option value="/input-change-events">

--- a/fixtures/dom/src/components/fixtures/email-inputs/EmailDisabledAttributesTestCase.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/EmailDisabledAttributesTestCase.js
@@ -1,0 +1,39 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+class EmailDisabledAttributesTestCase extends React.Component {
+  state = {value: 'a@fb.com'};
+  onChange = event => {
+    this.setState({value: event.target.value});
+  };
+  render() {
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <input
+              type="email"
+              value={this.state.value}
+              onChange={this.onChange}
+            />
+            <span className="hint">
+              {' '}
+              Value: {JSON.stringify(this.state.value)}
+            </span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <input type="email" defaultValue="" />
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default EmailDisabledAttributesTestCase;

--- a/fixtures/dom/src/components/fixtures/email-inputs/EmailEnabledAttributesTestCase.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/EmailEnabledAttributesTestCase.js
@@ -1,0 +1,48 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+class EmailAttributesTestCase extends React.Component {
+  state = {value: 'a@fb.com'};
+  onChange = event => {
+    this.setState({value: event.target.value});
+  };
+  render() {
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <input
+              type="email"
+              pattern=".+@fb.com"
+              maxlength={17}
+              multiple={true}
+              value={this.state.value}
+              onChange={this.onChange}
+            />
+            <span className="hint">
+              {' '}
+              Value: {JSON.stringify(this.state.value)}
+            </span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <input
+              type="email"
+              defaultValue=""
+              pattern=".+@fb.com"
+              maxlength={17}
+              multiple={true}
+            />
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default EmailAttributesTestCase;

--- a/fixtures/dom/src/components/fixtures/email-inputs/JumpingCursorTestCase.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/JumpingCursorTestCase.js
@@ -1,0 +1,39 @@
+import Fixture from '../../Fixture';
+
+const React = window.React;
+
+class JumpingCursorTestCase extends React.Component {
+  state = {value: ''};
+  onChange = event => {
+    this.setState({value: event.target.value});
+  };
+  render() {
+    return (
+      <Fixture>
+        <div>{this.props.children}</div>
+
+        <div className="control-box">
+          <fieldset>
+            <legend>Controlled</legend>
+            <input
+              type="email"
+              value={this.state.value}
+              onChange={this.onChange}
+            />
+            <span className="hint">
+              {' '}
+              Value: {JSON.stringify(this.state.value)}
+            </span>
+          </fieldset>
+
+          <fieldset>
+            <legend>Uncontrolled</legend>
+            <input type="email" defaultValue="" />
+          </fieldset>
+        </div>
+      </Fixture>
+    );
+  }
+}
+
+export default JumpingCursorTestCase;

--- a/fixtures/dom/src/components/fixtures/email-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/index.js
@@ -19,9 +19,7 @@ function EmailInputs() {
           <li>Type character, space, character, delete last character</li>
         </TestCase.Steps>
 
-        <TestCase.ExpectedResult>
-          Cursor not moving.
-        </TestCase.ExpectedResult>
+        <TestCase.ExpectedResult>Cursor not moving.</TestCase.ExpectedResult>
 
         <JumpingCursorTestCase />
       </TestCase>

--- a/fixtures/dom/src/components/fixtures/email-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/index.js
@@ -1,6 +1,8 @@
 import FixtureSet from '../../FixtureSet';
 import TestCase from '../../TestCase';
 import JumpingCursorTestCase from './JumpingCursorTestCase';
+import EmailEnabledAttributesTestCase from './EmailEnabledAttributesTestCase';
+import EmailDisabledAttributesTestCase from './EmailDisabledAttributesTestCase';
 
 const React = window.React;
 
@@ -22,6 +24,42 @@ function EmailInputs() {
         <TestCase.ExpectedResult>Cursor not moving.</TestCase.ExpectedResult>
 
         <JumpingCursorTestCase />
+      </TestCase>
+
+      <TestCase
+        title="Attributes enabled"
+        description={`
+          Test enabled pattern, maxlength, multiple attributes.
+        `}>
+        <TestCase.Steps>
+          <li>Type after existing text ',b@tt.com'</li>
+          <li>Try to type spaces after typed text</li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          Spaces not added. When cursor hovered over input, popup "Please match
+          the requested format." is showed.
+        </TestCase.ExpectedResult>
+
+        <EmailEnabledAttributesTestCase />
+      </TestCase>
+
+      <TestCase
+        title="Attributes disabled"
+        description={`
+          Test disabled maxlength, multiple attributes.
+        `}>
+        <TestCase.Steps>
+          <li>Type after existing text ',b@tt.com'</li>
+          <li>Try to type spaces after typed text</li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          Spaces are added freely. When cursor hovered over input, popup "A part
+          following '@' should not contain the symbol ','." is showed.
+        </TestCase.ExpectedResult>
+
+        <EmailDisabledAttributesTestCase />
       </TestCase>
     </FixtureSet>
   );

--- a/fixtures/dom/src/components/fixtures/email-inputs/index.js
+++ b/fixtures/dom/src/components/fixtures/email-inputs/index.js
@@ -1,0 +1,32 @@
+import FixtureSet from '../../FixtureSet';
+import TestCase from '../../TestCase';
+import JumpingCursorTestCase from './JumpingCursorTestCase';
+
+const React = window.React;
+
+function EmailInputs() {
+  return (
+    <FixtureSet title="Email inputs">
+      <TestCase
+        title="Spaces in email inputs"
+        description={`
+          Some browsers are trying to remove spaces from email inputs and after
+          doing this place cursor to the beginning.
+        `}
+        affectedBrowsers="Chrome">
+        <TestCase.Steps>
+          <li>Type space and character</li>
+          <li>Type character, space, character, delete last character</li>
+        </TestCase.Steps>
+
+        <TestCase.ExpectedResult>
+          Cursor not moving.
+        </TestCase.ExpectedResult>
+
+        <JumpingCursorTestCase />
+      </TestCase>
+    </FixtureSet>
+  );
+}
+
+export default EmailInputs;

--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -410,8 +410,8 @@ export function setDefaultValue(
   value: *,
 ) {
   if (
-    // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
-    type !== 'number' ||
+    // Focused number and email inputs synchronize on blur. See ChangeEventPlugin.js
+    (type !== 'number' && type !== 'email') ||
     node.ownerDocument.activeElement !== node
   ) {
     if (value == null) {

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -236,13 +236,17 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
 function handleControlledInputBlur(node) {
   let state = node._wrapperState;
 
-  if (!state || !state.controlled || node.type !== 'number') {
+  if (
+    !state ||
+    !state.controlled ||
+    (node.type !== 'number' && node.type !== 'email')
+  ) {
     return;
   }
 
   if (!disableInputAttributeSyncing) {
     // If controlled, assign the value attribute to the current value on blur
-    setDefaultValue(node, 'number', node.value);
+    setDefaultValue(node, node.type, node.value);
   }
 }
 


### PR DESCRIPTION
fix #15418, #14551

Version of React: 16.13.1
Browser: Chrome 80

**Previous behavior:**
After deleting of second email separated by space cursor jumps to the beginning.
When typing a space in an empty email input and then literal, the space is deleted and cursor jumps to the beginning.

![email-jump](https://user-images.githubusercontent.com/16987322/77469656-3cc1ad00-6e31-11ea-943a-5b6797638407.gif)

**Altered behavior:**
Cursor not moving.

![email-fixed](https://user-images.githubusercontent.com/16987322/77469663-40edca80-6e31-11ea-8aea-d11d00ad9475.gif)
