### PR TITLE
Fix a mistake in ReactChildren refactor

### DIFF
--- a/packages/react-dom/src/client/ReactDOMOption.js
+++ b/packages/react-dom/src/client/ReactDOMOption.js
@@ -25,7 +25,7 @@ function flattenChildren(children) {
     if (child == null) {
       return;
     }
-    content += child;
+    content += (child: any);
     // Note: we don't warn about invalid children here.
     // Instead, this is done separately below so that
     // it happens during the hydration codepath too.
@@ -52,7 +52,7 @@ export function validateProps(element: Element, props: Object) {
         if (typeof child === 'string' || typeof child === 'number') {
           return;
         }
-        if (typeof child.type !== 'string') {
+        if (typeof (child: any).type !== 'string') {
           return;
         }
         if (!didWarnInvalidChild) {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -315,11 +315,11 @@ function flattenOptionChildren(children: mixed): ?string {
   let content = '';
   // Flatten children and warn if they aren't strings or numbers;
   // invalid types are ignored.
-  React.Children.forEach(children, function(child) {
+  React.Children.forEach((children: any), function(child) {
     if (child == null) {
       return;
     }
-    content += child;
+    content += (child: any);
     if (__DEV__) {
       if (
         !didWarnInvalidOptionChildren &&

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -111,7 +111,7 @@ function mapIntoArray(children, array, escapedPrefix, nameSoFar, callback) {
       if (childKey != null) {
         escapedChildKey = escapeUserProvidedKey(childKey) + '/';
       }
-      mapIntoArray(mappedChild, array, escapedChildKey, c => c);
+      mapIntoArray(mappedChild, array, escapedChildKey, '', c => c);
     } else if (mappedChild != null) {
       if (isValidElement(mappedChild)) {
         mappedChild = cloneAndReplaceKey(

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -230,16 +230,9 @@ function mapChildren(children, func, context) {
   }
   const result = [];
   let count = 0;
-  mapIntoArray(
-    children,
-    result,
-    '',
-    '',
-    function(child) {
-      return func.call(context, child, count++);
-    },
-    context,
-  );
+  mapIntoArray(children, result, '', '', function(child) {
+    return func.call(context, child, count++);
+  });
   return result;
 }
 
@@ -254,7 +247,10 @@ function mapChildren(children, func, context) {
  */
 function countChildren(children) {
   let n = 0;
-  mapChildren(children, () => n++);
+  mapChildren(children, () => {
+    n++;
+    // Don't return anything
+  });
   return n;
 }
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -55,22 +55,18 @@ function escapeUserProvidedKey(text: string): string {
 }
 
 /**
- * Generate a key string that identifies a component within a set.
+ * Generate a key string that identifies a element within a set.
  *
- * @param {*} component A component that could contain a manual key.
+ * @param {*} element A element that could contain a manual key.
  * @param {number} index Index that is used if a manual key is not provided.
  * @return {string}
  */
-function getComponentKey(component: any, index: number): string {
+function getElementKey(element: any, index: number): string {
   // Do some typechecking here since we call this blindly. We want to ensure
   // that we don't block potential future ES APIs.
-  if (
-    typeof component === 'object' &&
-    component !== null &&
-    component.key != null
-  ) {
+  if (typeof element === 'object' && element !== null && element.key != null) {
     // Explicit key
-    return escape('' + component.key);
+    return escape('' + element.key);
   }
   // Implicit key determined by the index in the set
   return index.toString(36);
@@ -115,7 +111,7 @@ function mapIntoArray(
     // If it's the only child, treat the name as if it was wrapped in an array
     // so that it's consistent if the number of children grows:
     let childKey =
-      nameSoFar === '' ? SEPARATOR + getComponentKey(child, 0) : nameSoFar;
+      nameSoFar === '' ? SEPARATOR + getElementKey(child, 0) : nameSoFar;
     if (Array.isArray(mappedChild)) {
       let escapedChildKey = '';
       if (childKey != null) {
@@ -151,7 +147,7 @@ function mapIntoArray(
   if (Array.isArray(children)) {
     for (let i = 0; i < children.length; i++) {
       child = children[i];
-      nextName = nextNamePrefix + getComponentKey(child, i);
+      nextName = nextNamePrefix + getElementKey(child, i);
       subtreeCount += mapIntoArray(
         child,
         array,
@@ -194,7 +190,7 @@ function mapIntoArray(
       let ii = 0;
       while (!(step = iterator.next()).done) {
         child = step.value;
-        nextName = nextNamePrefix + getComponentKey(child, ii++);
+        nextName = nextNamePrefix + getElementKey(child, ii++);
         subtreeCount += mapIntoArray(
           child,
           array,

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -29,13 +29,13 @@ const SUBSEPARATOR = ':';
  * @param {string} key to be escaped.
  * @return {string} the escaped key.
  */
-function escape(key: any): string {
+function escape(key: string): string {
   const escapeRegex = /[=:]/g;
   const escaperLookup = {
     '=': '=0',
     ':': '=2',
   };
-  const escapedString = ('' + key).replace(escapeRegex, function(match) {
+  const escapedString = key.replace(escapeRegex, function(match) {
     return escaperLookup[match];
   });
 
@@ -51,7 +51,7 @@ let didWarnAboutMaps = false;
 
 const userProvidedKeyEscapeRegex = /\/+/g;
 function escapeUserProvidedKey(text: string): string {
-  return ('' + text).replace(userProvidedKeyEscapeRegex, '$&/');
+  return text.replace(userProvidedKeyEscapeRegex, '$&/');
 }
 
 /**
@@ -61,7 +61,7 @@ function escapeUserProvidedKey(text: string): string {
  * @param {number} index Index that is used if a manual key is not provided.
  * @return {string}
  */
-function getComponentKey(component: mixed, index: number): string {
+function getComponentKey(component: any, index: number): string {
   // Do some typechecking here since we call this blindly. We want to ensure
   // that we don't block potential future ES APIs.
   if (
@@ -70,7 +70,7 @@ function getComponentKey(component: mixed, index: number): string {
     component.key != null
   ) {
     // Explicit key
-    return escape(component.key);
+    return escape('' + component.key);
   }
   // Implicit key determined by the index in the set
   return index.toString(36);
@@ -132,7 +132,7 @@ function mapIntoArray(
             // $FlowFixMe Flow incorrectly thinks React.Portal doesn't have a key
             (mappedChild.key && (!child || child.key !== mappedChild.key)
               ? // $FlowFixMe Flow incorrectly thinks existing element's key can be a number
-                escapeUserProvidedKey(mappedChild.key) + '/'
+                escapeUserProvidedKey('' + mappedChild.key) + '/'
               : '') +
             childKey,
         );

--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -866,6 +866,74 @@ describe('ReactChildren', () => {
     ]);
   });
 
+  it('should combine keys when map returns an array', () => {
+    const instance = (
+      <div>
+        <div key="a" />
+        {false}
+        <div key="b" />
+        <p />
+      </div>
+    );
+    const mappedChildren = React.Children.map(
+      instance.props.children,
+      // Try a few things: keyed, unkeyed, hole, and a cloned element.
+      kid => [
+        <span key="x" />,
+        null,
+        <span key="y" />,
+        kid,
+        kid && React.cloneElement(kid, {key: 'z'}),
+        <hr />,
+      ],
+    );
+    expect(mappedChildren.length).toBe(18);
+
+    // <div key="a">
+    expect(mappedChildren[0].type).toBe('span');
+    expect(mappedChildren[0].key).toBe('.$a/.$x');
+    expect(mappedChildren[1].type).toBe('span');
+    expect(mappedChildren[1].key).toBe('.$a/.$y');
+    expect(mappedChildren[2].type).toBe('div');
+    expect(mappedChildren[2].key).toBe('.$a/.$a');
+    expect(mappedChildren[3].type).toBe('div');
+    expect(mappedChildren[3].key).toBe('.$a/.$z');
+    expect(mappedChildren[4].type).toBe('hr');
+    expect(mappedChildren[4].key).toBe('.$a/.5');
+
+    // false
+    expect(mappedChildren[5].type).toBe('span');
+    expect(mappedChildren[5].key).toBe('.1/.$x');
+    expect(mappedChildren[6].type).toBe('span');
+    expect(mappedChildren[6].key).toBe('.1/.$y');
+    expect(mappedChildren[7].type).toBe('hr');
+    expect(mappedChildren[7].key).toBe('.1/.5');
+
+    // <div key="b">
+    expect(mappedChildren[8].type).toBe('span');
+    expect(mappedChildren[8].key).toBe('.$b/.$x');
+    expect(mappedChildren[9].type).toBe('span');
+    expect(mappedChildren[9].key).toBe('.$b/.$y');
+    expect(mappedChildren[10].type).toBe('div');
+    expect(mappedChildren[10].key).toBe('.$b/.$b');
+    expect(mappedChildren[11].type).toBe('div');
+    expect(mappedChildren[11].key).toBe('.$b/.$z');
+    expect(mappedChildren[12].type).toBe('hr');
+    expect(mappedChildren[12].key).toBe('.$b/.5');
+
+    // <p>
+    expect(mappedChildren[13].type).toBe('span');
+    expect(mappedChildren[13].key).toBe('.3/.$x');
+    expect(mappedChildren[14].type).toBe('span');
+    expect(mappedChildren[14].key).toBe('.3/.$y');
+    expect(mappedChildren[15].type).toBe('p');
+    expect(mappedChildren[15].key).toBe('.3/.3');
+    expect(mappedChildren[16].type).toBe('p');
+    expect(mappedChildren[16].key).toBe('.3/.$z');
+    expect(mappedChildren[17].type).toBe('hr');
+    expect(mappedChildren[17].key).toBe('.3/.5');
+  });
+
   it('should throw on object', () => {
     expect(function() {
       React.Children.forEach({a: 1, b: 2}, function() {}, null);


### PR DESCRIPTION
Of course I broke something in https://github.com/facebook/react/pull/18332. Luckily internal tests caught it.

>"there's probably at least not many bugs." — @sebmarkbage

I changed signature of one of the internal functions, but forgot to adjust the callsite. So there was a missing argument. **The fix for that is https://github.com/facebook/react/commit/20fc0bd3d8bac9c3869fba55ad3cf48996bdba8e.**

To prevent this from happening again and to turn my mistake into a learning experience, I added:

1. Regression test for `map` returning an array — we didn't have that. https://github.com/facebook/react/commit/344e56c89273c7b01da78467ddc88b63328cab8e
2. Flow types. https://github.com/facebook/react/commit/f66dc559599e3f4e7b786f4937a370296c55e844