### PR TITLE
feat(createContext): Include displayName in warning

### DIFF
--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -125,11 +125,12 @@ export function createContext<T>(
         get() {
           return context.displayName;
         },
-        set() {
+        set(displayName) {
           if (!hasWarnedAboutDisplayNameOnConsumer) {
             console.warn(
               'Setting `displayName` on Context.Consumer has no effect. ' +
-                "You should set it directly on the context with Context.displayName = 'NamedContext'.",
+                "You should set it directly on the context with Context.displayName = '%s'.",
+              displayName,
             );
             hasWarnedAboutDisplayNameOnConsumer = true;
           }

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -700,14 +700,14 @@ describe('ReactContextValidator', () => {
     const Context = React.createContext(null);
 
     expect(() => {
-      Context.Consumer.displayName = 'ignored';
+      Context.Consumer.displayName = 'IgnoredName';
     }).toWarnDev(
       'Warning: Setting `displayName` on Context.Consumer has no effect. ' +
-        "You should set it directly on the context with Context.displayName = 'NamedContext'.",
+        "You should set it directly on the context with Context.displayName = 'IgnoredName'.",
       {withoutStack: true},
     );
 
-    // warning is deduped so subsequent setting is fine
-    Context.Consumer.displayName = 'ignored';
+    // warning is deduped by Context so subsequent setting is fine
+    Context.Consumer.displayName = 'ADifferentName';
   });
 });


### PR DESCRIPTION
## Summary

[Seems like this is not only used internally at facebook](https://twitter.com/kentcdodds/status/1242678976645959681). I included the `displayName` that should be set when warning to make it more obvious where the warning is coming from.

This also explicitly documents the strategy by which this warning is deduped.

## Test Plan

- adjust test
- check usefulness in https://codesandbox.io/s/displayname-contextconsumer-warning-it2e8

```
react.development.js:319 Warning: Setting `displayName` on Context.Consumer has no effect. You should set it directly on the context with Context.displayName = 'Location.Consumer'.
printWarning @ react.development.js:319
react.development.js:319 Warning: Setting `displayName` on Context.Consumer has no effect. You should set it directly on the context with Context.displayName = 'Route.Consumer'.
```
Looks more useful to me.
