### PR TITLE
Remove "es6-symbol" package from DevTools

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -24,7 +24,6 @@
     "start:standalone": "cross-env NODE_ENV=development webpack --config webpack.standalone.js --watch"
   },
   "dependencies": {
-    "es6-symbol": "^3",
     "shell-quote": "^1.6.1",
     "ws": "^7"
   },

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -20,9 +20,7 @@
     "prepublish": "yarn run build",
     "start": "cross-env NODE_ENV=development webpack --config webpack.config.js --watch"
   },
-  "dependencies": {
-    "es6-symbol": "^3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.1.6",
     "@babel/plugin-proposal-class-properties": "^7.1.0",

--- a/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/HooksTree.js
@@ -124,7 +124,7 @@ function HookView({canEditHooks, hook, id, inspectPath, path}: HookViewProps) {
         hook !== null &&
         typeof hook === 'object' &&
         hook.hasOwnProperty(meta.type)
-          ? hook[meta.type]
+          ? hook[(meta.type: any)]
           : typeof value,
     },
     id: 'SelectedElement',

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import Symbol from 'es6-symbol';
 import {
   getDataType,
   getDisplayNameForReactElement,

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import Symbol from 'es6-symbol';
 import LRU from 'lru-cache';
 import {
   isElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4969,7 +4969,7 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
-es6-symbol@3.1.1, es6-symbol@^3, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
   integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=


### PR DESCRIPTION
This polyfill was copied over from DevTools v3 but given the [current browser compatibility for `Symbol`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol#Browser_compatibility), I think it's safe to remove.