### PR TITLE
Rules of hooks ignore list

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -51,6 +51,24 @@ Please refer to the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) 
 
 For feedback about the `exhaustive-deps` rule, please post in [this thread](https://github.com/facebook/react/issues/14920).
 
+## Options
+
+If your codebase contains functions with `use` prefix which are not React Hooks, and you are not able to rename them, you can configure `react-hooks/rules-of-hooks` to ignore them with the `ignoredNames` option:
+
+```js
+{
+  "plugins": [
+    // ...
+    "react-hooks"
+  ],
+  "rules": {
+    // ...
+    "react-hooks/rules-of-hooks": ["error", {ignoredNames: ["useThisIsNotAHook"]}],
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}
+```
+
 ## License
 
 MIT

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -378,6 +378,13 @@ const tests = {
         const [myState, setMyState] = useState(null);
       }
     `,
+    {
+      code: `
+             // Valid because function name is on the whitelist
+             useNotAHook()
+      `,
+      options: [{ignoredNames: ['useNotAHook']}],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -381,9 +381,23 @@ const tests = {
     {
       code: `
              // Valid because function name is on the whitelist
-             useNotAHook()
+             useNotAHook();
+             useNotAHookEither();
       `,
-      options: [{ignoredNames: ['useNotAHook']}],
+      options: [{ignoredNames: ['useNotAHook', 'useNotAHookEither']}],
+    },
+    {
+      code: `
+             // Valid because function name is on the whitelist
+             const buildSomething = () => {
+               useNotAHook();
+             };
+
+             function buildSomethingElse() {
+               useNotAHookEither();
+            }
+      `,
+      options: [{ignoredNames: ['useNotAHook', 'useNotAHookEither']}],
     },
   ],
   invalid: [
@@ -803,6 +817,17 @@ const tests = {
     },
     {
       code: `
+        // This is invalid because "use"-prefixed functions used in named
+        // functions are assumed to be hooks, and name is not on the whitelist
+        React.unknownFunction(function notAComponent(foo, bar) {
+          useProbablyAHook(bar)
+        });
+      `,
+      options: [{ignoredNames: ['useNotAHook', 'useNotAHookEither']}],
+      errors: [functionError('useProbablyAHook', 'notAComponent')],
+    },
+    {
+      code: `
         // Invalid because it's dangerous.
         // Normally, this would crash, but not if you use inline requires.
         // This *must* be invalid.
@@ -883,6 +908,14 @@ const tests = {
         (class {i() { useState(); }});
       `,
       errors: [classError('useState')],
+    },
+    {
+      code: `
+        // Invalid because top level called function is not on the whitelist
+        useProbablyAHook()
+      `,
+      options: [{ignoredNames: ['useNotAHook', 'useNotAHookEither']}],
+      errors: [topLevelError('useProbablyAHook')],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -109,6 +109,12 @@ function isInsideComponentOrHook(node) {
 }
 
 export default {
+  schema: [
+    {
+      type: 'object',
+      properties: {ignoredNames: {type: 'array', items: {type: 'string'}}},
+    },
+  ],
   create(context) {
     const ignoredNames =
       (context.options.length === 1 && context.options[0].ignoredNames) || [];

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -25,7 +25,10 @@ function isHookName(s) {
 
 function isHook(node, ignoredNames) {
   if (node.type === 'Identifier') {
-    return isHookName(node.name) && !ignoredNames.includes(node.name);
+    return (
+      isHookName(node.name) &&
+      (!ignoredNames || !ignoredNames.includes(node.name))
+    );
   } else if (
     node.type === 'MemberExpression' &&
     !node.computed &&
@@ -93,7 +96,7 @@ function isInsideComponentOrHook(node) {
   while (node) {
     const functionName = getFunctionName(node);
     if (functionName) {
-      if (isComponentName(functionName) || isHook(functionName, [])) {
+      if (isComponentName(functionName) || isHook(functionName)) {
         return true;
       }
     }
@@ -345,7 +348,7 @@ export default {
         );
         const isDirectlyInsideComponentOrHook = codePathFunctionName
           ? isComponentName(codePathFunctionName) ||
-            isHook(codePathFunctionName, [])
+            isHook(codePathFunctionName)
           : isForwardRefCallback(codePathNode) || isMemoCallback(codePathNode);
 
         // Compute the earliest finalizer level using information from the


### PR DESCRIPTION
## Summary

For historic reasons, our project contains a couple of very widely used functions with names that the heuristics of the `rules-of-hooks` linter rule falsely consider to be hooks.

- Renaming these functions could be an alternative option, but would incur the cost of a major breaking change in our project. And we would have to find new names ...
- Adding eslint ignores would likewise be a significant effort, and we would have to add those ignores to new code as well.

The option added with this pull request would allow us to enable the checks by `rules-of-hooks`, configuring the known exceptions in a single place -- from where we could also easily remove them if we later decide to rename the offending functions.

## Test Plan

I added test cases to check that only function names on the ignore list are actually ignored.

If you feel more test cases are needed, I would be happy to add them if you give me a pointer on what still needs to be covered.
