### PR TITLE
Make interaction tracing on by default in all WWW builds

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -40,7 +40,11 @@ export let enableUserTimingAPI = __DEV__ && !__EXPERIMENTAL__;
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
-export const enableSchedulerTracing = __PROFILE__;
+
+// Note: we'll want to remove this when we to userland implementation.
+// For now, we'll turn it on for everyone because it's *already* on for everyone in practice.
+// At least this will let us stop shipping <Profiler> implementation to all users.
+export const enableSchedulerTracing = true;
 export const enableSchedulerDebugging = true;
 
 export const warnAboutDeprecatedLifecycles = true;


### PR DESCRIPTION
As discussed [here](https://fb.workplace.com/groups/225341071639862/permalink/610880869752545/) internally, we are shipping a Profiling build to all FB5 users (as well as all Ads, and some other places). However, on FB5 we only *use* `<Profiler>` for a subset of users. So why do we ship this build to everyone on FB5? Because we *also* use interaction tracing there, which is controlled by the same flag.

Let's just enable interaction tracing everywhere for now, and decouple it from the idea of a profiling build internally. We plan to probably remove it anyway. This unblocks us to only ship the Profiling build when the `<Profiler>` is on. And ship the real Production build to everyone else.