### PR TITLE
fix: Prevent crash when resuming class component inside SuspenseList

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -95,6 +95,8 @@ import {
   REACT_BLOCK_TYPE,
 } from 'shared/ReactSymbols';
 
+import {initializeUpdateQueue} from './ReactUpdateQueue';
+
 let hasBadMapPolyfill;
 
 if (__DEV__) {
@@ -546,6 +548,15 @@ export function resetWorkInProgress(
     workInProgress.child = null;
     workInProgress.memoizedProps = null;
     workInProgress.memoizedState = null;
+    // updateQueue must never be null on ClassComponent or HostRoot
+    if (
+      workInProgress.tag === ClassComponent ||
+      workInProgress.tag === HostRoot
+    ) {
+      initializeUpdateQueue(workInProgress);
+    } else {
+      workInProgress.updateQueue = null;
+    }
 
     workInProgress.dependencies = null;
 

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -546,7 +546,6 @@ export function resetWorkInProgress(
     workInProgress.child = null;
     workInProgress.memoizedProps = null;
     workInProgress.memoizedState = null;
-    workInProgress.updateQueue = null;
 
     workInProgress.dependencies = null;
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -885,8 +885,13 @@ function resumeMountClassInstance(
     nextContext = getMaskedContext(workInProgress, nextLegacyUnmaskedContext);
   }
 
-  if (workInProgress.updateQueue === null) {
-    initializeUpdateQueue(workInProgress);
+  if (__DEV__) {
+    if (workInProgress.updateQueue === null) {
+      console.error(
+        'Class fiber is missing an updateQueue. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+    }
   }
 
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -885,6 +885,10 @@ function resumeMountClassInstance(
     nextContext = getMaskedContext(workInProgress, nextLegacyUnmaskedContext);
   }
 
+  if (workInProgress.updateQueue === null) {
+    initializeUpdateQueue(workInProgress);
+  }
+
   const getDerivedStateFromProps = ctor.getDerivedStateFromProps;
   const hasNewLifecycles =
     typeof getDerivedStateFromProps === 'function' ||

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -2486,20 +2486,12 @@ describe('ReactSuspenseList', () => {
     );
   });
 
-  it('crashes if an error boundary wraps a suspense boundary when revealed together', async () => {
+  it('crashes when it contains class components when revealed together', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');
 
-    class ErrorBoundary extends React.Component {
-      state = {didThrow: false};
-      static getDerivedStateFromError() {
-        return {didThrow: true};
-      }
-
+    class ClassComponent extends React.Component {
       render() {
-        if (this.state.didThrow) {
-          return this.props.fallback;
-        }
         return this.props.children;
       }
     }
@@ -2508,16 +2500,16 @@ describe('ReactSuspenseList', () => {
       return (
         <Suspense fallback={<Text text="Loading" />}>
           <SuspenseList revealOrder="together">
-            <ErrorBoundary fallback="A crashed">
+            <ClassComponent>
               <Suspense fallback={<Text text="Loading A" />}>
                 <A />
               </Suspense>
-            </ErrorBoundary>
-            <ErrorBoundary fallback={<Text text="B crashed" />}>
+            </ClassComponent>
+            <ClassComponent>
               <Suspense fallback={<Text text="Loading B" />}>
                 <B />
               </Suspense>
-            </ErrorBoundary>
+            </ClassComponent>
           </SuspenseList>
         </Suspense>
       );

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -2486,7 +2486,7 @@ describe('ReactSuspenseList', () => {
     );
   });
 
-  it('crashes when it contains class components when revealed together', async () => {
+  it('can resume class components when revealed together', async () => {
     let A = createAsyncText('A');
     let B = createAsyncText('B');
 


### PR DESCRIPTION
## Summary

Test for #18429 (includes a fix but it's unclear if the semantics are correct) 

## Test Plan

~Might be interesting add matchers for the case where one of the error boundaries is actually triggered.~ No longer concerned with error boundaries. They caused the crash originally but the bug could be reduced to basic class components.
