### PR TITLE
[ESLint] Add opt-in support for dangerous autofix

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6336,6 +6336,34 @@ const tests = {
         },
       ],
     },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const local = {};
+          useEffect(() => {
+            console.log(local);
+          }, []);
+        }
+      `,
+      // Dangerous autofix is enabled due to the option:
+      output: normalizeIndent`
+        function MyComponent() {
+          const local = {};
+          useEffect(() => {
+            console.log(local);
+          }, [local]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'local'. " +
+            'Either include it or remove the dependency array.',
+        },
+      ],
+      // Keep this until major IDEs and VS Code FB ESLint plugin support Suggestions API.
+      options: [{enableDangerousAutofixThisMayCauseInfiniteLoops: true}],
+    },
   ],
 };
 


### PR DESCRIPTION
We've removed the autofix support from our ESLint rule in 2.4.0 in favor of the new Suggestions API. But some people are asking (https://github.com/facebook/react/issues/18235, https://github.com/facebook/react/issues/18099) for autofix. Some IDEs haven't updated yet. Coincidentally, FB's VS Code ESLint extension doesn't support this either. So we can't update the rule internally.

This PR adds an escape hatch. Pass `{ enableDangerousAutofixThisMayCauseInfiniteLoops: true }` and you get the old behavior. You've been warned.

If you actually apply fix suggestions automatically, you **don't** want to enable this.