### PR TITLE
Remove disableMapsAsChildren flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -295,9 +295,8 @@ describe('ReactMultiChild', () => {
     }
     const container = document.createElement('div');
     expect(() => ReactDOM.render(<Parent />, container)).toErrorDev(
-      'Warning: Using Maps as children is unsupported and will likely yield ' +
-        'unexpected results. Convert it to a sequence/iterable of keyed ' +
-        'ReactElements instead.\n' +
+      'Using Maps as children is not supported. ' +
+        'Use an array of keyed ReactElements instead.\n' +
         '    in div (at **)\n' +
         '    in Parent (at **)',
     );

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -998,9 +998,8 @@ function ChildReconciler(shouldTrackSideEffects) {
       if ((newChildrenIterable: any).entries === iteratorFn) {
         if (!didWarnAboutMaps) {
           console.error(
-            'Using Maps as children is unsupported and will likely yield ' +
-              'unexpected results. Convert it to a sequence/iterable of keyed ' +
-              'ReactElements instead.',
+            'Using Maps as children is not supported. ' +
+              'Use an array of keyed ReactElements instead.',
           );
         }
         didWarnAboutMaps = true;

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -15,7 +15,6 @@ import {
   REACT_ELEMENT_TYPE,
   REACT_PORTAL_TYPE,
 } from 'shared/ReactSymbols';
-import {disableMapsAsChildren} from 'shared/ReactFeatureFlags';
 
 import {isValidElement, cloneAndReplaceKey} from './ReactElement';
 import ReactDebugCurrentFrame from './ReactDebugCurrentFrame';
@@ -162,23 +161,14 @@ function mapIntoArray(
       const iterableChildren: Iterable<React$Node> & {
         entries: any,
       } = (children: any);
-      if (disableMapsAsChildren) {
-        invariant(
-          iteratorFn !== iterableChildren.entries,
-          'Maps are not valid as a React child (found: %s). Consider converting ' +
-            'children to an array of keyed ReactElements instead.',
-          iterableChildren,
-        );
-      }
 
       if (__DEV__) {
         // Warn about using Maps as children
         if (iteratorFn === iterableChildren.entries) {
           if (!didWarnAboutMaps) {
             console.warn(
-              'Using Maps as children is deprecated and will be removed in ' +
-                'a future major release. Consider converting children to ' +
-                'an array of keyed ReactElements instead.',
+              'Using Maps as children is not supported. ' +
+                'Use an array of keyed ReactElements instead.',
             );
           }
           didWarnAboutMaps = true;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -121,9 +121,6 @@ export const disableLegacyContext = false;
 // Disables children for <textarea> elements
 export const disableTextareaChildren = false;
 
-// Disables Maps as ReactElement children
-export const disableMapsAsChildren = false;
-
 export const disableModulePatternComponents = false;
 
 // We should remove this flag once the above flag becomes enabled

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -37,7 +37,6 @@ export const disableLegacyContext = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -36,7 +36,6 @@ export const disableLegacyContext = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -36,7 +36,6 @@ export const disableLegacyContext = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -36,7 +36,6 @@ export const disableLegacyContext = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -36,7 +36,6 @@ export const disableLegacyContext = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = false;
-export const disableMapsAsChildren = false;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -36,7 +36,6 @@ export const disableLegacyContext = __EXPERIMENTAL__;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableTrustedTypesIntegration = false;
 export const disableTextareaChildren = __EXPERIMENTAL__;
-export const disableMapsAsChildren = __EXPERIMENTAL__;
 export const disableModulePatternComponents = false;
 export const warnUnstableRenderSubtreeIntoContainer = false;
 export const deferPassiveEffectCleanupDuringUnmount = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -65,8 +65,6 @@ export const flushSuspenseFallbacksInTests = true;
 
 export const disableTextareaChildren = __EXPERIMENTAL__;
 
-export const disableMapsAsChildren = __EXPERIMENTAL__;
-
 export const disableModulePatternComponents = __EXPERIMENTAL__;
 
 export const warnUnstableRenderSubtreeIntoContainer = false;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -345,7 +345,6 @@
   "344": "Expected prepareToHydrateHostSuspenseInstance() to never be called. This error is likely caused by a bug in React. Please file an issue.",
   "345": "Root did not complete. This is a bug in React.",
   "346": "An event responder context was used outside of an event cycle.",
-  "347": "Maps are not valid as a React child (found: %s). Consider converting children to an array of keyed ReactElements instead.",
   "348": "ensureListeningTo(): received a container that was not an element node. This is likely a bug in React.",
   "349": "Expected a work-in-progress root. This is a bug in React. Please file an issue.",
   "350": "Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue.",


### PR DESCRIPTION
Change warning to say the case is unsupported (not that it will be deprecated).

New warning:
> Using Maps as children is not supported. Use an array of keyed ReactElements instead.