### PR TITLE
Fix intermittent CI failures

### DIFF
--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -80,6 +80,7 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
 }
 
 async function copyWWWShims() {
+  await asyncRimRaf('build/facebook-www/shims');
   await asyncCopyTo(
     `${__dirname}/shims/facebook-www`,
     'build/facebook-www/shims'
@@ -87,6 +88,7 @@ async function copyWWWShims() {
 }
 
 async function copyRNShims() {
+  await asyncRimRaf('build/react-native/shims');
   await Promise.all([
     // React Native
     asyncCopyTo(`${__dirname}/shims/react-native`, 'build/react-native/shims'),


### PR DESCRIPTION
We've been hitting a few intermittent CI failures recently on both [Code Sandbox](https://ci.codesandbox.io/status/facebook/react/pr/18445/builds/17291) and [Circle CI](https://circleci.com/gh/facebook/react/114746#tests/containers/18). These probably indicate some kind of race condition in how we're cleaning up from previous builds.

Our script starts by cleaning up the previous build artifacts:
https://github.com/facebook/react/blob/4de3a603256ab36fc58026ce2d75b4ad9e3556bc/scripts/rollup/build.js#L715-L717

But in cases where we force push, maybe CI ends up kicking off the new script before the previous one has finished running?

Either way, I added an explicit cleanup to the shim copying stage (since that's what always seems to break). It's hard to test the exact case but I tried to simulate what I suspect is happening, and this fixed it.