### PR TITLE
Reset stateNode in resetWorkInProgress

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -542,6 +542,8 @@ export function resetWorkInProgress(
 
     workInProgress.dependencies = null;
 
+    workInProgress.stateNode = null;
+
     if (enableProfilerTimer) {
       // Note: We don't reset the actualTime counts. It's useful to accumulate
       // actual time across multiple render passes.


### PR DESCRIPTION
Alternative fix to #18432

`resetWorkInProgress` is supposed to put the Fiber into the same state as if it was just created by child fiber reconciliation. For newly created fibers, that means that stateNode is null.
