### PR TITLE
Enable prefer-const lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -126,6 +126,7 @@ module.exports = {
       },
       rules: {
         'no-var': ERROR,
+        'prefer-const': ERROR,
         strict: OFF,
       },
     },

--- a/packages/babel-plugin-react-jsx/src/TransformJSXToReactBabelPlugin.js
+++ b/packages/babel-plugin-react-jsx/src/TransformJSXToReactBabelPlugin.js
@@ -115,7 +115,7 @@ You can turn on the 'throwIfNamespace' flag to bypass this warning.`,
           'Fragment tags are only supported in React 16 and up.',
         );
       }
-      let callExpr = buildJSXFragmentCall(path, file);
+      const callExpr = buildJSXFragmentCall(path, file);
 
       if (callExpr) {
         path.replaceWith(t.inherits(callExpr, path.node));

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -62,10 +62,10 @@ export default {
     const scopeManager = context.getSourceCode().scopeManager;
 
     // Should be shared between visitors.
-    let setStateCallSites = new WeakMap();
-    let stateVariables = new WeakSet();
-    let staticKnownValueCache = new WeakMap();
-    let functionWithoutCapturedValueCache = new WeakMap();
+    const setStateCallSites = new WeakMap();
+    const stateVariables = new WeakSet();
+    const staticKnownValueCache = new WeakMap();
+    const functionWithoutCapturedValueCache = new WeakMap();
     function memoizeWithWeakMap(fn, map) {
       return function(arg) {
         if (map.has(arg)) {
@@ -400,12 +400,12 @@ export default {
         // Search the direct component subscopes for
         // top-level function definitions matching this reference.
         const fnNode = def.node;
-        let childScopes = componentScope.childScopes;
+        const childScopes = componentScope.childScopes;
         let fnScope = null;
         let i;
         for (i = 0; i < childScopes.length; i++) {
-          let childScope = childScopes[i];
-          let childScopeBlock = childScope.block;
+          const childScope = childScopes[i];
+          const childScopeBlock = childScope.block;
           if (
             // function handleChange() {}
             (fnNode.type === 'FunctionDeclaration' &&
@@ -597,7 +597,7 @@ export default {
 
       // Warn about assigning to variables in the outer scope.
       // Those are usually bugs.
-      let staleAssignments = new Set();
+      const staleAssignments = new Set();
       function reportStaleAssignment(writeExpr, key) {
         if (staleAssignments.has(key)) {
           return;
@@ -664,7 +664,7 @@ export default {
           });
         });
         if (setStateInsideEffectWithoutDeps) {
-          let {suggestedDependencies} = collectRecommendations({
+          const {suggestedDependencies} = collectRecommendations({
             dependencies,
             declaredDependencies: [],
             optionalDependencies,
@@ -945,7 +945,7 @@ export default {
       // a `this` value. This warning can be confusing.
       // So if we're going to show it, append a clarification.
       if (!extraWarning && missingDependencies.has('props')) {
-        let propDep = dependencies.get('props');
+        const propDep = dependencies.get('props');
         if (propDep == null) {
           return;
         }
@@ -1213,9 +1213,9 @@ function collectRecommendations({
 
   // Tree manipulation helpers.
   function getOrCreateNodeByPath(rootNode, path) {
-    let keys = path.split('.');
+    const keys = path.split('.');
     let node = rootNode;
-    for (let key of keys) {
+    for (const key of keys) {
       let child = node.children.get(key);
       if (!child) {
         child = createDepTree();
@@ -1226,10 +1226,10 @@ function collectRecommendations({
     return node;
   }
   function markAllParentsByPath(rootNode, path, fn) {
-    let keys = path.split('.');
+    const keys = path.split('.');
     let node = rootNode;
-    for (let key of keys) {
-      let child = node.children.get(key);
+    for (const key of keys) {
+      const child = node.children.get(key);
       if (!child) {
         return;
       }
@@ -1239,8 +1239,8 @@ function collectRecommendations({
   }
 
   // Now we can learn which dependencies are missing or necessary.
-  let missingDependencies = new Set();
-  let satisfyingDependencies = new Set();
+  const missingDependencies = new Set();
+  const satisfyingDependencies = new Set();
   scanTreeRecursively(
     depTree,
     missingDependencies,
@@ -1277,9 +1277,9 @@ function collectRecommendations({
   }
 
   // Collect suggestions in the order they were originally specified.
-  let suggestedDependencies = [];
-  let unnecessaryDependencies = new Set();
-  let duplicateDependencies = new Set();
+  const suggestedDependencies = [];
+  const unnecessaryDependencies = new Set();
+  const duplicateDependencies = new Set();
   declaredDependencies.forEach(({key}) => {
     // Does this declared dep satisfy a real need?
     if (satisfyingDependencies.has(key)) {
@@ -1337,7 +1337,7 @@ function scanForDeclaredBareFunctions({
       if (fnRef == null) {
         return null;
       }
-      let fnNode = fnRef.defs[0];
+      const fnNode = fnRef.defs[0];
       if (fnNode == null) {
         return null;
       }
@@ -1461,7 +1461,7 @@ function getNodeWithoutReactNamespace(node, options) {
 // 1 for useImperativeHandle(ref, fn).
 // For additionally configured Hooks, assume that they're like useEffect (0).
 function getReactiveHookCallbackIndex(calleeNode, options) {
-  let node = getNodeWithoutReactNamespace(calleeNode);
+  const node = getNodeWithoutReactNamespace(calleeNode);
   if (node.type !== 'Identifier') {
     return -1;
   }
@@ -1507,7 +1507,7 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
  * - agnostic to AST node types, it looks for `{ type: string, ... }`
  */
 function fastFindReferenceWithParent(start, target) {
-  let queue = [start];
+  const queue = [start];
   let item = null;
 
   while (queue.length) {
@@ -1521,7 +1521,7 @@ function fastFindReferenceWithParent(start, target) {
       continue;
     }
 
-    for (let [key, value] of Object.entries(item)) {
+    for (const [key, value] of Object.entries(item)) {
       if (key === 'parent') {
         continue;
       }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -789,7 +789,7 @@ export default {
         });
       }
 
-      let {
+      const {
         suggestedDependencies,
         unnecessaryDependencies,
         missingDependencies,
@@ -801,6 +801,8 @@ export default {
         externalDependencies,
         isEffect,
       });
+
+      let suggestedDeps = suggestedDependencies;
 
       const problemCount =
         duplicateDependencies.size +
@@ -871,7 +873,7 @@ export default {
       // for effects though because those have legit
       // use cases for over-specifying deps.
       if (!isEffect && missingDependencies.size > 0) {
-        suggestedDependencies = collectRecommendations({
+        suggestedDeps = collectRecommendations({
           dependencies,
           declaredDependencies: [], // Pretend we don't know
           optionalDependencies,
@@ -890,7 +892,7 @@ export default {
         return declaredDepKeys.join(',') === sortedDeclaredDepKeys.join(',');
       }
       if (areDeclaredDepsAlphabetized()) {
-        suggestedDependencies.sort();
+        suggestedDeps.sort();
       }
 
       function getWarningMessage(deps, singlePrefix, label, fixVerb) {
@@ -1146,14 +1148,14 @@ export default {
           extraWarning,
         suggest: [
           {
-            desc: `Update the dependencies array to be: [${suggestedDependencies.join(
+            desc: `Update the dependencies array to be: [${suggestedDeps.join(
               ', ',
             )}]`,
             fix(fixer) {
               // TODO: consider preserving the comments or formatting?
               return fixer.replaceText(
                 declaredDependenciesNode,
-                `[${suggestedDependencies.join(', ')}]`,
+                `[${suggestedDeps.join(', ')}]`,
               );
             },
           },

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -226,7 +226,7 @@ export default {
         function countPathsToEnd(segment, pathHistory) {
           const {cache} = countPathsToEnd;
           let paths = cache.get(segment.id);
-          let pathList = new Set(pathHistory);
+          const pathList = new Set(pathHistory);
 
           // If `pathList` includes the current segment then we've found a cycle!
           // We need to fill `cyclic` with all segments inside cycle

--- a/packages/jest-react/src/JestReact.js
+++ b/packages/jest-react/src/JestReact.js
@@ -99,7 +99,7 @@ function jsonChildrenToJSXChildren(jsonChildren) {
     if (jsonChildren.length === 1) {
       return jsonChildToJSXChild(jsonChildren[0]);
     } else if (jsonChildren.length > 1) {
-      let jsxChildren = [];
+      const jsxChildren = [];
       let allJSXChildrenAreStrings = true;
       let jsxChildrenString = '';
       for (let i = 0; i < jsonChildren.length; i++) {

--- a/packages/legacy-events/getListener.js
+++ b/packages/legacy-events/getListener.js
@@ -46,8 +46,6 @@ function shouldPreventMouseEvent(name, type, props) {
  * @return {?function} The stored callback.
  */
 export default function getListener(inst: Fiber, registrationName: string) {
-  let listener;
-
   // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
   // live here; needs to be moved to a better place soon
   const stateNode = inst.stateNode;
@@ -60,7 +58,7 @@ export default function getListener(inst: Fiber, registrationName: string) {
     // Work in progress.
     return null;
   }
-  listener = props[registrationName];
+  const listener = props[registrationName];
   if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
     return null;
   }

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -68,7 +68,7 @@ function createEventHandler(instance) {
 
 function destroyEventListeners(instance) {
   if (instance._subscriptions) {
-    for (let type in instance._subscriptions) {
+    for (const type in instance._subscriptions) {
       instance._subscriptions[type]();
     }
   }
@@ -170,7 +170,7 @@ function applyNodeProps(instance, props, prevProps = {}) {
     }
   }
 
-  for (let type in EVENT_TYPES) {
+  for (const type in EVENT_TYPES) {
     addEventListeners(instance, EVENT_TYPES[type], props[type]);
   }
 }

--- a/packages/react-cache/src/ReactCache.js
+++ b/packages/react-cache/src/ReactCache.js
@@ -97,7 +97,7 @@ function accessResult<I, K, V>(
     entriesForResource = new Map();
     entries.set(resource, entriesForResource);
   }
-  let entry = entriesForResource.get(key);
+  const entry = entriesForResource.get(key);
   if (entry === undefined) {
     const thenable = fetch(input);
     thenable.then(

--- a/packages/react-cache/src/__tests__/ReactCache-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCache-test.internal.js
@@ -303,7 +303,7 @@ describe('ReactCache', () => {
     const BadTextResource = createResource(
       ([text, ms = 0]) => {
         let listeners = null;
-        let value = null;
+        const value = null;
         return {
           then(resolve, reject) {
             if (value !== null) {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -62,7 +62,7 @@ function Chunk(status: any, value: any) {
   this._value = value;
 }
 Chunk.prototype.then = function<T>(resolve: () => mixed) {
-  let chunk: SomeChunk<T> = this;
+  const chunk: SomeChunk<T> = this;
   if (chunk._status === PENDING) {
     if (chunk._value === null) {
       chunk._value = [];
@@ -81,8 +81,8 @@ export type Response<T> = {
 };
 
 function readRoot<T>(): T {
-  let response: Response<T> = this;
-  let rootChunk = response.rootChunk;
+  const response: Response<T> = this;
+  const rootChunk = response.rootChunk;
   if (rootChunk._status === RESOLVED) {
     return rootChunk._value;
   } else if (rootChunk._status === PENDING) {
@@ -94,10 +94,10 @@ function readRoot<T>(): T {
 }
 
 export function createResponse<T>(): Response<T> {
-  let rootChunk: SomeChunk<any> = createPendingChunk();
-  let chunks: Map<number, SomeChunk<any>> = new Map();
+  const rootChunk: SomeChunk<any> = createPendingChunk();
+  const chunks: Map<number, SomeChunk<any>> = new Map();
   chunks.set(0, rootChunk);
-  let response = {
+  const response = {
     partialRow: '',
     rootChunk,
     chunks: chunks,
@@ -117,7 +117,7 @@ function createErrorChunk(error: Error): ErroredChunk {
 function wakeChunk(listeners: null | Array<() => mixed>) {
   if (listeners !== null) {
     for (let i = 0; i < listeners.length; i++) {
-      let listener = listeners[i];
+      const listener = listeners[i];
       listener();
     }
   }
@@ -128,8 +128,8 @@ function triggerErrorOnChunk<T>(chunk: SomeChunk<T>, error: Error): void {
     // We already resolved. We didn't expect to see this.
     return;
   }
-  let listeners = chunk._value;
-  let erroredChunk: ErroredChunk = (chunk: any);
+  const listeners = chunk._value;
+  const erroredChunk: ErroredChunk = (chunk: any);
   erroredChunk._status = ERRORED;
   erroredChunk._value = error;
   wakeChunk(listeners);
@@ -144,8 +144,8 @@ function resolveChunk<T>(chunk: SomeChunk<T>, value: T): void {
     // We already resolved. We didn't expect to see this.
     return;
   }
-  let listeners = chunk._value;
-  let resolvedChunk: ResolvedChunk<T> = (chunk: any);
+  const listeners = chunk._value;
+  const resolvedChunk: ResolvedChunk<T> = (chunk: any);
   resolvedChunk._status = RESOLVED;
   resolvedChunk._value = value;
   wakeChunk(listeners);
@@ -170,7 +170,7 @@ function readMaybeChunk<T>(maybeChunk: SomeChunk<T> | T): T {
     // $FlowFixMe
     return maybeChunk;
   }
-  let chunk: SomeChunk<T> = (maybeChunk: any);
+  const chunk: SomeChunk<T> = (maybeChunk: any);
   if (chunk._status === RESOLVED) {
     return chunk._value;
   } else if (chunk._status === PENDING) {
@@ -232,18 +232,18 @@ function initializeBlock<Props, Data>(
   tuple: UninitializedBlockPayload<Data>,
 ): BlockComponent<Props, Data> {
   // Require module first and then data. The ordering matters.
-  let moduleMetaData: ModuleMetaData = readMaybeChunk(tuple[1]);
-  let moduleReference: ModuleReference<
+  const moduleMetaData: ModuleMetaData = readMaybeChunk(tuple[1]);
+  const moduleReference: ModuleReference<
     BlockRenderFunction<Props, Data>,
   > = resolveModuleReference(moduleMetaData);
   // TODO: Do this earlier, as the chunk is resolved.
   preloadModule(moduleReference);
 
-  let moduleExport = requireModule(moduleReference);
+  const moduleExport = requireModule(moduleReference);
 
   // The ordering here is important because this call might suspend.
   // We don't want that to prevent the module graph for being initialized.
-  let data: Data = readMaybeChunk(tuple[2]);
+  const data: Data = readMaybeChunk(tuple[2]);
 
   return {
     $$typeof: REACT_BLOCK_TYPE,
@@ -256,7 +256,7 @@ function initializeBlock<Props, Data>(
 function createLazyBlock<Props, Data>(
   tuple: UninitializedBlockPayload<Data>,
 ): LazyComponent<BlockComponent<Props, Data>, UninitializedBlockPayload<Data>> {
-  let lazyType: LazyComponent<
+  const lazyType: LazyComponent<
     BlockComponent<Props, Data>,
     UninitializedBlockPayload<Data>,
   > = {
@@ -281,8 +281,8 @@ export function parseModelFromJSON<T>(
         // This was an escaped string value.
         return value.substring(1);
       } else {
-        let id = parseInt(value.substring(1), 16);
-        let chunks = response.chunks;
+        const id = parseInt(value.substring(1), 16);
+        const chunks = response.chunks;
         let chunk = chunks.get(id);
         if (!chunk) {
           chunk = createPendingChunk();
@@ -296,7 +296,7 @@ export function parseModelFromJSON<T>(
     }
   }
   if (typeof value === 'object' && value !== null) {
-    let tuple: [mixed, mixed, mixed, mixed] = (value: any);
+    const tuple: [mixed, mixed, mixed, mixed] = (value: any);
     switch (tuple[0]) {
       case REACT_ELEMENT_TYPE: {
         // TODO: Consider having React just directly accept these arrays as elements.
@@ -317,8 +317,8 @@ export function resolveModelChunk<T, M>(
   id: number,
   model: M,
 ): void {
-  let chunks = response.chunks;
-  let chunk = chunks.get(id);
+  const chunks = response.chunks;
+  const chunk = chunks.get(id);
   if (!chunk) {
     chunks.set(id, createResolvedChunk(model));
   } else {
@@ -332,10 +332,10 @@ export function resolveErrorChunk<T>(
   message: string,
   stack: string,
 ): void {
-  let error = new Error(message);
+  const error = new Error(message);
   error.stack = stack;
-  let chunks = response.chunks;
-  let chunk = chunks.get(id);
+  const chunks = response.chunks;
+  const chunk = chunks.get(id);
   if (!chunk) {
     chunks.set(id, createErrorChunk(error));
   } else {

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -31,7 +31,7 @@ export type Response<T> = ResponseBase<T> & {
 };
 
 export function createResponse<T>(): Response<T> {
-  let response: Response<T> = (createResponseImpl(): any);
+  const response: Response<T> = (createResponseImpl(): any);
   response.fromJSON = function(key: string, value: JSONValue) {
     return parseModelFromJSON(response, this, key, value);
   };
@@ -45,27 +45,27 @@ function processFullRow<T>(response: Response<T>, row: string): void {
   if (row === '') {
     return;
   }
-  let tag = row[0];
+  const tag = row[0];
   switch (tag) {
     case 'J': {
-      let colon = row.indexOf(':', 1);
-      let id = parseInt(row.substring(1, colon), 16);
-      let json = row.substring(colon + 1);
-      let model = JSON.parse(json, response.fromJSON);
+      const colon = row.indexOf(':', 1);
+      const id = parseInt(row.substring(1, colon), 16);
+      const json = row.substring(colon + 1);
+      const model = JSON.parse(json, response.fromJSON);
       resolveModelChunk(response, id, model);
       return;
     }
     case 'E': {
-      let colon = row.indexOf(':', 1);
-      let id = parseInt(row.substring(1, colon), 16);
-      let json = row.substring(colon + 1);
-      let errorInfo = JSON.parse(json);
+      const colon = row.indexOf(':', 1);
+      const id = parseInt(row.substring(1, colon), 16);
+      const json = row.substring(colon + 1);
+      const errorInfo = JSON.parse(json);
       resolveErrorChunk(response, id, errorInfo.message, errorInfo.stack);
       return;
     }
     default: {
       // Assume this is the root model.
-      let model = JSON.parse(row, response.fromJSON);
+      const model = JSON.parse(row, response.fromJSON);
       resolveModelChunk(response, 0, model);
       return;
     }
@@ -79,7 +79,7 @@ export function processStringChunk<T>(
 ): void {
   let linebreak = chunk.indexOf('\n', offset);
   while (linebreak > -1) {
-    let fullrow = response.partialRow + chunk.substring(offset, linebreak);
+    const fullrow = response.partialRow + chunk.substring(offset, linebreak);
     processFullRow(response, fullrow);
     response.partialRow = '';
     offset = linebreak + 1;
@@ -95,10 +95,10 @@ export function processBinaryChunk<T>(
   if (!supportsBinaryStreams) {
     throw new Error("This environment don't support binary chunks.");
   }
-  let stringDecoder = response.stringDecoder;
+  const stringDecoder = response.stringDecoder;
   let linebreak = chunk.indexOf(10); // newline
   while (linebreak > -1) {
-    let fullrow =
+    const fullrow =
       response.partialRow +
       readFinalStringChunk(stringDecoder, chunk.subarray(0, linebreak));
     processFullRow(response, fullrow);

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -38,7 +38,7 @@ describe('ReactFlight', () => {
       };
     }
     return function(...args) {
-      let curriedLoad = () => {
+      const curriedLoad = () => {
         return load(...args);
       };
       return ReactNoopFlightServerRuntime.serverBlock(render, curriedLoad);
@@ -58,10 +58,10 @@ describe('ReactFlight', () => {
         ),
       };
     }
-    let transport = ReactNoopFlightServer.render({
+    const transport = ReactNoopFlightServer.render({
       foo: <Foo />,
     });
-    let model = ReactNoopFlightClient.read(transport);
+    const model = ReactNoopFlightClient.read(transport);
     expect(model).toEqual({
       foo: {
         bar: (
@@ -84,16 +84,16 @@ describe('ReactFlight', () => {
           </span>
         );
       }
-      let loadUser = block(User);
-      let model = {
+      const loadUser = block(User);
+      const model = {
         User: loadUser('Seb', 'Smith'),
       };
 
-      let transport = ReactNoopFlightServer.render(model);
+      const transport = ReactNoopFlightServer.render(model);
 
       act(() => {
-        let rootModel = ReactNoopFlightClient.read(transport);
-        let UserClient = rootModel.User;
+        const rootModel = ReactNoopFlightClient.read(transport);
+        const UserClient = rootModel.User;
         ReactNoop.render(<UserClient greeting="Hello" />);
       });
 
@@ -111,16 +111,16 @@ describe('ReactFlight', () => {
           </span>
         );
       }
-      let loadUser = block(User, load);
-      let model = {
+      const loadUser = block(User, load);
+      const model = {
         User: loadUser('Seb', 'Smith'),
       };
 
-      let transport = ReactNoopFlightServer.render(model);
+      const transport = ReactNoopFlightServer.render(model);
 
       act(() => {
-        let rootModel = ReactNoopFlightClient.read(transport);
-        let UserClient = rootModel.User;
+        const rootModel = ReactNoopFlightClient.read(transport);
+        const UserClient = rootModel.User;
         ReactNoop.render(<UserClient greeting="Hello" />);
       });
 

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -65,7 +65,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
   // This initializes a cache of all primitive hooks so that the top
   // most stack frames added by calling the primitive hook can be removed.
   if (primitiveStackCache === null) {
-    let cache = new Map();
+    const cache = new Map();
     let readHookLog;
     try {
       // Use all hooks here to add them to the hook log.
@@ -94,7 +94,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
       hookLog = [];
     }
     for (let i = 0; i < readHookLog.length; i++) {
-      let hook = readHookLog[i];
+      const hook = readHookLog[i];
       cache.set(hook.primitive, ErrorStackParser.parse(hook.stackError));
     }
     primitiveStackCache = cache;
@@ -104,7 +104,7 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
 
 let currentHook: null | Hook = null;
 function nextHook(): null | Hook {
-  let hook = currentHook;
+  const hook = currentHook;
   if (hook !== null) {
     currentHook = hook.next;
   }
@@ -134,8 +134,8 @@ function useContext<T>(
 function useState<S>(
   initialState: (() => S) | S,
 ): [S, Dispatch<BasicStateAction<S>>] {
-  let hook = nextHook();
-  let state: S =
+  const hook = nextHook();
+  const state: S =
     hook !== null
       ? hook.memoizedState
       : typeof initialState === 'function'
@@ -151,7 +151,7 @@ function useReducer<S, I, A>(
   initialArg: I,
   init?: I => S,
 ): [S, Dispatch<A>] {
-  let hook = nextHook();
+  const hook = nextHook();
   let state;
   if (hook !== null) {
     state = hook.memoizedState;
@@ -167,8 +167,8 @@ function useReducer<S, I, A>(
 }
 
 function useRef<T>(initialValue: T): {|current: T|} {
-  let hook = nextHook();
-  let ref = hook !== null ? hook.memoizedState : {current: initialValue};
+  const hook = nextHook();
+  const ref = hook !== null ? hook.memoizedState : {current: initialValue};
   hookLog.push({
     primitive: 'Ref',
     stackError: new Error(),
@@ -227,7 +227,7 @@ function useDebugValue(value: any, formatterFn: ?(value: any) => any) {
 }
 
 function useCallback<T>(callback: T, inputs: Array<mixed> | void | null): T {
-  let hook = nextHook();
+  const hook = nextHook();
   hookLog.push({
     primitive: 'Callback',
     stackError: new Error(),
@@ -240,8 +240,8 @@ function useMemo<T>(
   nextCreate: () => T,
   inputs: Array<mixed> | void | null,
 ): T {
-  let hook = nextHook();
-  let value = hook !== null ? hook.memoizedState[0] : nextCreate();
+  const hook = nextHook();
+  const value = hook !== null ? hook.memoizedState[0] : nextCreate();
   hookLog.push({primitive: 'Memo', stackError: new Error(), value});
   return value;
 }
@@ -367,7 +367,7 @@ export type HooksTree = Array<HooksNode>;
 let mostLikelyAncestorIndex = 0;
 
 function findSharedIndex(hookStack, rootStack, rootIndex) {
-  let source = rootStack[rootIndex].source;
+  const source = rootStack[rootIndex].source;
   hookSearch: for (let i = 0; i < hookStack.length; i++) {
     if (hookStack[i].source === source) {
       // This looks like a match. Validate that the rest of both stack match up.
@@ -412,7 +412,7 @@ function isReactWrapper(functionName, primitiveName) {
   if (!functionName) {
     return false;
   }
-  let expectedPrimitiveName = 'use' + primitiveName;
+  const expectedPrimitiveName = 'use' + primitiveName;
   if (functionName.length < expectedPrimitiveName.length) {
     return false;
   }
@@ -423,8 +423,8 @@ function isReactWrapper(functionName, primitiveName) {
 }
 
 function findPrimitiveIndex(hookStack, hook) {
-  let stackCache = getPrimitiveStackCache();
-  let primitiveStack = stackCache.get(hook.primitive);
+  const stackCache = getPrimitiveStackCache();
+  const primitiveStack = stackCache.get(hook.primitive);
   if (primitiveStack === undefined) {
     return -1;
   }
@@ -453,9 +453,9 @@ function findPrimitiveIndex(hookStack, hook) {
 function parseTrimmedStack(rootStack, hook) {
   // Get the stack trace between the primitive hook function and
   // the root function call. I.e. the stack frames of custom hooks.
-  let hookStack = ErrorStackParser.parse(hook.stackError);
-  let rootIndex = findCommonAncestorIndex(rootStack, hookStack);
-  let primitiveIndex = findPrimitiveIndex(hookStack, hook);
+  const hookStack = ErrorStackParser.parse(hook.stackError);
+  const rootIndex = findCommonAncestorIndex(rootStack, hookStack);
+  const primitiveIndex = findPrimitiveIndex(hookStack, hook);
   if (
     rootIndex === -1 ||
     primitiveIndex === -1 ||
@@ -482,14 +482,14 @@ function parseCustomHookName(functionName: void | string): string {
 }
 
 function buildTree(rootStack, readHookLog): HooksTree {
-  let rootChildren = [];
+  const rootChildren = [];
   let prevStack = null;
   let levelChildren = rootChildren;
   let nativeHookID = 0;
-  let stackOfChildren = [];
+  const stackOfChildren = [];
   for (let i = 0; i < readHookLog.length; i++) {
-    let hook = readHookLog[i];
-    let stack = parseTrimmedStack(rootStack, hook);
+    const hook = readHookLog[i];
+    const stack = parseTrimmedStack(rootStack, hook);
     if (stack !== null) {
       // Note: The indices 0 <= n < length-1 will contain the names.
       // The indices 1 <= n < length will contain the source locations.
@@ -499,8 +499,9 @@ function buildTree(rootStack, readHookLog): HooksTree {
       if (prevStack !== null) {
         // Compare the current level's stack to the new stack.
         while (commonSteps < stack.length && commonSteps < prevStack.length) {
-          let stackSource = stack[stack.length - commonSteps - 1].source;
-          let prevSource = prevStack[prevStack.length - commonSteps - 1].source;
+          const stackSource = stack[stack.length - commonSteps - 1].source;
+          const prevSource =
+            prevStack[prevStack.length - commonSteps - 1].source;
           if (stackSource !== prevSource) {
             break;
           }
@@ -514,7 +515,7 @@ function buildTree(rootStack, readHookLog): HooksTree {
       // The remaining part of the new stack are custom hooks. Push them
       // to the tree.
       for (let j = stack.length - commonSteps - 1; j >= 1; j--) {
-        let children = [];
+        const children = [];
         levelChildren.push({
           id: null,
           isStateEditable: false,
@@ -563,7 +564,7 @@ function processDebugValues(
   hooksTree: HooksTree,
   parentHooksNode: HooksNode | null,
 ): void {
-  let debugValueHooksNodes: Array<HooksNode> = [];
+  const debugValueHooksNodes: Array<HooksNode> = [];
 
   for (let i = 0; i < hooksTree.length; i++) {
     const hooksNode = hooksTree[i];
@@ -599,7 +600,7 @@ export function inspectHooks<Props>(
     currentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
   }
 
-  let previousDispatcher = currentDispatcher.current;
+  const previousDispatcher = currentDispatcher.current;
   let readHookLog;
   currentDispatcher.current = Dispatcher;
   let ancestorStackError;
@@ -611,7 +612,7 @@ export function inspectHooks<Props>(
     hookLog = [];
     currentDispatcher.current = previousDispatcher;
   }
-  let rootStack = ErrorStackParser.parse(ancestorStackError);
+  const rootStack = ErrorStackParser.parse(ancestorStackError);
   return buildTree(rootStack, readHookLog);
 }
 
@@ -642,7 +643,7 @@ function inspectHooksOfForwardRef<Props, Ref>(
   ref: Ref,
   currentDispatcher: CurrentDispatcherRef,
 ): HooksTree {
-  let previousDispatcher = currentDispatcher.current;
+  const previousDispatcher = currentDispatcher.current;
   let readHookLog;
   currentDispatcher.current = Dispatcher;
   let ancestorStackError;
@@ -654,7 +655,7 @@ function inspectHooksOfForwardRef<Props, Ref>(
     hookLog = [];
     currentDispatcher.current = previousDispatcher;
   }
-  let rootStack = ErrorStackParser.parse(ancestorStackError);
+  const rootStack = ErrorStackParser.parse(ancestorStackError);
   return buildTree(rootStack, readHookLog);
 }
 
@@ -663,7 +664,7 @@ function resolveDefaultProps(Component, baseProps) {
     // Resolve default props. Taken from ReactElement
     const props = Object.assign({}, baseProps);
     const defaultProps = Component.defaultProps;
-    for (let propName in defaultProps) {
+    for (const propName in defaultProps) {
       if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];
       }
@@ -695,7 +696,7 @@ export function inspectHooksOfFiber(
   }
   // Warm up the cache so that it doesn't consume the currentHook.
   getPrimitiveStackCache();
-  let type = fiber.type;
+  const type = fiber.type;
   let props = fiber.memoizedProps;
   if (type !== fiber.elementType) {
     props = resolveDefaultProps(type, props);
@@ -703,7 +704,7 @@ export function inspectHooksOfFiber(
   // Set up the current hook so that we can step through and read the
   // current state from them.
   currentHook = (fiber.memoizedState: Hook);
-  let contextMap = new Map();
+  const contextMap = new Map();
   try {
     setupContexts(contextMap, fiber);
     if (fiber.tag === ForwardRef) {

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.internal.js
@@ -39,7 +39,7 @@ describe('ReactHooksInspection', () => {
       });
       return <div DEPRECATED_flareListeners={listener}>Hello world</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -65,7 +65,7 @@ describe('ReactHooksInspection', () => {
       React.useEffect(effect);
       return <div ref={ref}>Hello world</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -22,10 +22,10 @@ describe('ReactHooksInspection', () => {
 
   it('should inspect a simple useState hook', () => {
     function Foo(props) {
-      let [state] = React.useState('hello world');
+      const [state] = React.useState('hello world');
       return <div>{state}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: true,
@@ -39,15 +39,15 @@ describe('ReactHooksInspection', () => {
 
   it('should inspect a simple custom hook', () => {
     function useCustom(value) {
-      let [state] = React.useState(value);
+      const [state] = React.useState(value);
       React.useDebugValue('custom hook label');
       return state;
     }
     function Foo(props) {
-      let value = useCustom('hello world');
+      const value = useCustom('hello world');
       return <div>{value}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -70,20 +70,20 @@ describe('ReactHooksInspection', () => {
   it('should inspect a tree of multiple hooks', () => {
     function effect() {}
     function useCustom(value) {
-      let [state] = React.useState(value);
+      const [state] = React.useState(value);
       React.useEffect(effect);
       return state;
     }
     function Foo(props) {
-      let value1 = useCustom('hello');
-      let value2 = useCustom('world');
+      const value1 = useCustom('hello');
+      const value2 = useCustom('world');
       return (
         <div>
           {value1} {value2}
         </div>
       );
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -135,30 +135,30 @@ describe('ReactHooksInspection', () => {
   it('should inspect a tree of multiple levels of hooks', () => {
     function effect() {}
     function useCustom(value) {
-      let [state] = React.useReducer((s, a) => s, value);
+      const [state] = React.useReducer((s, a) => s, value);
       React.useEffect(effect);
       return state;
     }
     function useBar(value) {
-      let result = useCustom(value);
+      const result = useCustom(value);
       React.useLayoutEffect(effect);
       return result;
     }
     function useBaz(value) {
       React.useLayoutEffect(effect);
-      let result = useCustom(value);
+      const result = useCustom(value);
       return result;
     }
     function Foo(props) {
-      let value1 = useBar('hello');
-      let value2 = useBaz('world');
+      const value1 = useBar('hello');
+      const value2 = useBaz('world');
       return (
         <div>
           {value1} {value2}
         </div>
       );
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -238,12 +238,12 @@ describe('ReactHooksInspection', () => {
   });
 
   it('should inspect the default value using the useContext hook', () => {
-    let MyContext = React.createContext('default');
+    const MyContext = React.createContext('default');
     function Foo(props) {
-      let value = React.useContext(MyContext);
+      const value = React.useContext(MyContext);
       return <div>{value}</div>;
     }
-    let tree = ReactDebugTools.inspectHooks(Foo, {});
+    const tree = ReactDebugTools.inspectHooks(Foo, {});
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -257,15 +257,15 @@ describe('ReactHooksInspection', () => {
 
   it('should support an injected dispatcher', () => {
     function Foo(props) {
-      let [state] = React.useState('hello world');
+      const [state] = React.useState('hello world');
       return <div>{state}</div>;
     }
 
-    let initial = {};
+    const initial = {};
     let current = initial;
     let getterCalls = 0;
-    let setterCalls = [];
-    let FakeDispatcherRef = {
+    const setterCalls = [];
+    const FakeDispatcherRef = {
       get current() {
         getterCalls++;
         return current;
@@ -299,7 +299,7 @@ describe('ReactHooksInspection', () => {
         React.useDebugValue('this is invalid');
         return null;
       }
-      let tree = ReactDebugTools.inspectHooks(Foo, {});
+      const tree = ReactDebugTools.inspectHooks(Foo, {});
       expect(tree).toHaveLength(0);
     });
 
@@ -312,7 +312,7 @@ describe('ReactHooksInspection', () => {
         useCustom();
         return null;
       }
-      let tree = ReactDebugTools.inspectHooks(Foo, {});
+      const tree = ReactDebugTools.inspectHooks(Foo, {});
       expect(tree).toEqual([
         {
           isStateEditable: false,

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -27,17 +27,17 @@ describe('ReactHooksInspectionIntegration', () => {
   });
 
   it('should inspect the current state of useState hooks', () => {
-    let useState = React.useState;
+    const useState = React.useState;
     function Foo(props) {
-      let [state1, setState1] = useState('hello');
-      let [state2, setState2] = useState('world');
+      const [state1, setState1] = useState('hello');
+      const [state2, setState2] = useState('world');
       return (
         <div onMouseDown={setState1} onMouseUp={setState2}>
           {state1} {state2}
         </div>
       );
     }
-    let renderer = ReactTestRenderer.create(<Foo prop="prop" />);
+    const renderer = ReactTestRenderer.create(<Foo prop="prop" />);
 
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
     let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
@@ -58,7 +58,7 @@ describe('ReactHooksInspectionIntegration', () => {
       },
     ]);
 
-    let {
+    const {
       onMouseDown: setStateA,
       onMouseUp: setStateB,
     } = renderer.root.findByType('div').props;
@@ -109,12 +109,12 @@ describe('ReactHooksInspectionIntegration', () => {
   });
 
   it('should inspect the current state of all stateful hooks', () => {
-    let outsideRef = React.createRef();
+    const outsideRef = React.createRef();
     function effect() {}
     function Foo(props) {
-      let [state1, setState] = React.useState('a');
-      let [state2, dispatch] = React.useReducer((s, a) => a.value, 'b');
-      let ref = React.useRef('c');
+      const [state1, setState] = React.useState('a');
+      const [state2, dispatch] = React.useReducer((s, a) => a.value, 'b');
+      const ref = React.useRef('c');
 
       React.useLayoutEffect(effect);
       React.useEffect(effect);
@@ -139,7 +139,7 @@ describe('ReactHooksInspectionIntegration', () => {
         });
         ref.current = 'C';
       }
-      let memoizedUpdate = React.useCallback(update, []);
+      const memoizedUpdate = React.useCallback(update, []);
       return (
         <div onClick={memoizedUpdate}>
           {state1} {state2}
@@ -153,7 +153,7 @@ describe('ReactHooksInspectionIntegration', () => {
 
     let childFiber = renderer.root.findByType(Foo)._currentFiber();
 
-    let {onClick: updateStates} = renderer.root.findByType('div').props;
+    const {onClick: updateStates} = renderer.root.findByType('div').props;
 
     let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
@@ -269,18 +269,18 @@ describe('ReactHooksInspectionIntegration', () => {
   });
 
   it('should inspect the value of the current provider in useContext', () => {
-    let MyContext = React.createContext('default');
+    const MyContext = React.createContext('default');
     function Foo(props) {
-      let value = React.useContext(MyContext);
+      const value = React.useContext(MyContext);
       return <div>{value}</div>;
     }
-    let renderer = ReactTestRenderer.create(
+    const renderer = ReactTestRenderer.create(
       <MyContext.Provider value="contextual">
         <Foo prop="prop" />
       </MyContext.Provider>,
     );
-    let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    const childFiber = renderer.root.findByType(Foo)._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -293,16 +293,16 @@ describe('ReactHooksInspectionIntegration', () => {
   });
 
   it('should inspect forwardRef', () => {
-    let obj = function() {};
-    let Foo = React.forwardRef(function(props, ref) {
+    const obj = function() {};
+    const Foo = React.forwardRef(function(props, ref) {
       React.useImperativeHandle(ref, () => obj);
       return <div />;
     });
-    let ref = React.createRef();
-    let renderer = ReactTestRenderer.create(<Foo ref={ref} />);
+    const ref = React.createRef();
+    const renderer = ReactTestRenderer.create(<Foo ref={ref} />);
 
-    let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    const childFiber = renderer.root.findByType(Foo)._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -316,14 +316,14 @@ describe('ReactHooksInspectionIntegration', () => {
 
   it('should inspect memo', () => {
     function InnerFoo(props) {
-      let [value] = React.useState('hello');
+      const [value] = React.useState('hello');
       return <div>{value}</div>;
     }
-    let Foo = React.memo(InnerFoo);
-    let renderer = ReactTestRenderer.create(<Foo />);
+    const Foo = React.memo(InnerFoo);
+    const renderer = ReactTestRenderer.create(<Foo />);
     // TODO: Test renderer findByType is broken for memo. Have to search for the inner.
-    let childFiber = renderer.root.findByType(InnerFoo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    const childFiber = renderer.root.findByType(InnerFoo)._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {
         isStateEditable: true,
@@ -337,16 +337,16 @@ describe('ReactHooksInspectionIntegration', () => {
 
   it('should inspect custom hooks', () => {
     function useCustom() {
-      let [value] = React.useState('hello');
+      const [value] = React.useState('hello');
       return value;
     }
     function Foo(props) {
-      let value = useCustom();
+      const value = useCustom();
       return <div>{value}</div>;
     }
-    let renderer = ReactTestRenderer.create(<Foo />);
-    let childFiber = renderer.root.findByType(Foo)._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    const renderer = ReactTestRenderer.create(<Foo />);
+    const childFiber = renderer.root.findByType(Foo)._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {
         isStateEditable: false,
@@ -373,9 +373,9 @@ describe('ReactHooksInspectionIntegration', () => {
         const memoizedValue = React.useMemo(() => 'hello', []);
         return <div>{memoizedValue}</div>;
       }
-      let renderer = ReactTestRenderer.create(<Foo />);
-      let childFiber = renderer.root.findByType(Foo)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Foo />);
+      const childFiber = renderer.root.findByType(Foo)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           id: 0,
@@ -402,9 +402,9 @@ describe('ReactHooksInspectionIntegration', () => {
         const [state] = React.useState(() => 'hello', []);
         return <div>{state}</div>;
       }
-      let renderer = ReactTestRenderer.create(<Foo />);
-      let childFiber = renderer.root.findByType(Foo)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Foo />);
+      const childFiber = renderer.root.findByType(Foo)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           id: 0,
@@ -427,12 +427,12 @@ describe('ReactHooksInspectionIntegration', () => {
   describe('useDebugValue', () => {
     it('should support inspectable values for multiple custom hooks', () => {
       function useLabeledValue(label) {
-        let [value] = React.useState(label);
+        const [value] = React.useState(label);
         React.useDebugValue(`custom label ${label}`);
         return value;
       }
       function useAnonymous(label) {
-        let [value] = React.useState(label);
+        const [value] = React.useState(label);
         return value;
       }
       function Example() {
@@ -442,9 +442,9 @@ describe('ReactHooksInspectionIntegration', () => {
         useLabeledValue('d');
         return null;
       }
-      let renderer = ReactTestRenderer.create(<Example />);
-      let childFiber = renderer.root.findByType(Example)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Example />);
+      const childFiber = renderer.root.findByType(Example)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           isStateEditable: false,
@@ -514,9 +514,9 @@ describe('ReactHooksInspectionIntegration', () => {
         useOuter();
         return null;
       }
-      let renderer = ReactTestRenderer.create(<Example />);
-      let childFiber = renderer.root.findByType(Example)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Example />);
+      const childFiber = renderer.root.findByType(Example)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           isStateEditable: false,
@@ -561,9 +561,9 @@ describe('ReactHooksInspectionIntegration', () => {
         useSingleLabelCustom('two');
         return null;
       }
-      let renderer = ReactTestRenderer.create(<Example />);
-      let childFiber = renderer.root.findByType(Example)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Example />);
+      const childFiber = renderer.root.findByType(Example)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           isStateEditable: false,
@@ -618,9 +618,9 @@ describe('ReactHooksInspectionIntegration', () => {
         React.useDebugValue('this is invalid');
         return null;
       }
-      let renderer = ReactTestRenderer.create(<Example />);
-      let childFiber = renderer.root.findByType(Example)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Example />);
+      const childFiber = renderer.root.findByType(Example)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toHaveLength(0);
     });
 
@@ -633,9 +633,9 @@ describe('ReactHooksInspectionIntegration', () => {
         useCustom();
         return null;
       }
-      let renderer = ReactTestRenderer.create(<Example />);
-      let childFiber = renderer.root.findByType(Example)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Example />);
+      const childFiber = renderer.root.findByType(Example)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           isStateEditable: false,
@@ -657,10 +657,10 @@ describe('ReactHooksInspectionIntegration', () => {
   });
 
   it('should support defaultProps and lazy', async () => {
-    let Suspense = React.Suspense;
+    const Suspense = React.Suspense;
 
     function Foo(props) {
-      let [value] = React.useState(props.defaultValue.substr(0, 3));
+      const [value] = React.useState(props.defaultValue.substr(0, 3));
       return <div>{value}</div>;
     }
     Foo.defaultProps = {
@@ -671,9 +671,9 @@ describe('ReactHooksInspectionIntegration', () => {
       return {default: result};
     }
 
-    let LazyFoo = React.lazy(() => fakeImport(Foo));
+    const LazyFoo = React.lazy(() => fakeImport(Foo));
 
-    let renderer = ReactTestRenderer.create(
+    const renderer = ReactTestRenderer.create(
       <Suspense fallback="Loading...">
         <LazyFoo />
       </Suspense>,
@@ -683,8 +683,8 @@ describe('ReactHooksInspectionIntegration', () => {
 
     Scheduler.unstable_flushAll();
 
-    let childFiber = renderer.root._currentFiber();
-    let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+    const childFiber = renderer.root._currentFiber();
+    const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
       {
         isStateEditable: true,
@@ -698,15 +698,15 @@ describe('ReactHooksInspectionIntegration', () => {
 
   it('should support an injected dispatcher', () => {
     function Foo(props) {
-      let [state] = React.useState('hello world');
+      const [state] = React.useState('hello world');
       return <div>{state}</div>;
     }
 
-    let initial = {};
+    const initial = {};
     let current = initial;
     let getterCalls = 0;
-    let setterCalls = [];
-    let FakeDispatcherRef = {
+    const setterCalls = [];
+    const FakeDispatcherRef = {
       get current() {
         getterCalls++;
         return current;
@@ -717,8 +717,8 @@ describe('ReactHooksInspectionIntegration', () => {
       },
     };
 
-    let renderer = ReactTestRenderer.create(<Foo />);
-    let childFiber = renderer.root._currentFiber();
+    const renderer = ReactTestRenderer.create(<Foo />);
+    const childFiber = renderer.root._currentFiber();
     expect(() => {
       ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
     }).toThrow(
@@ -798,9 +798,9 @@ describe('ReactHooksInspectionIntegration', () => {
         React.useMemo(() => 'memo', []);
         return <div />;
       }
-      let renderer = ReactTestRenderer.create(<Foo />);
-      let childFiber = renderer.root.findByType(Foo)._currentFiber();
-      let tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
+      const renderer = ReactTestRenderer.create(<Foo />);
+      const childFiber = renderer.root.findByType(Foo)._currentFiber();
+      const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
       expect(tree).toEqual([
         {
           id: 0,

--- a/packages/react-devtools-core/src/editor.js
+++ b/packages/react-devtools-core/src/editor.js
@@ -156,10 +156,12 @@ export function launchEditor(
     return;
   }
 
-  let [editor, ...args] = guessEditor();
+  const [editor, ...destructuredArgs] = guessEditor();
   if (!editor) {
     return;
   }
+
+  let args = destructuredArgs;
 
   if (lineNumber) {
     args = args.concat(getArgumentsForLineNumber(editor, filePath, lineNumber));

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -228,11 +228,11 @@ function createPanelIfReactLoaded() {
       cloneStyleTags = () => {
         const linkTags = [];
         // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-        for (let linkTag of document.getElementsByTagName('link')) {
+        for (const linkTag of document.getElementsByTagName('link')) {
           if (linkTag.rel === 'stylesheet') {
             const newLinkTag = document.createElement('link');
             // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-            for (let attribute of linkTag.attributes) {
+            for (const attribute of linkTag.attributes) {
               newLinkTag.setAttribute(attribute.nodeName, attribute.nodeValue);
             }
             linkTags.push(newLinkTag);

--- a/packages/react-devtools-extensions/src/panel.js
+++ b/packages/react-devtools-extensions/src/panel.js
@@ -12,7 +12,7 @@ window.injectStyles = getLinkTags => {
     const linkTags = getLinkTags();
 
     // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-    for (let linkTag of linkTags) {
+    for (const linkTag of linkTags) {
       document.head.appendChild(linkTag);
     }
   }

--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -72,7 +72,7 @@ describe('ProfilingCache', () => {
     utils.act(() => ReactDOM.render(<Parent count={0} />, containerA));
     utils.act(() => store.profilerStore.stopProfiling());
 
-    let allProfilingDataForRoots = [];
+    const allProfilingDataForRoots = [];
 
     function Validator({previousProfilingDataForRoot, rootID}) {
       const profilingDataForRoot = store.profilerStore.getDataForRoot(rootID);

--- a/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
@@ -37,7 +37,7 @@ describe('StoreStress (Legacy Mode)', () => {
       // We'll be manually flipping this component back and forth in the test.
       // We only do this for a single node in order to verify that DevTools
       // can handle a subtree switching alternates while other subtrees are memoized.
-      let [showX, _setShowX] = React.useState(false);
+      const [showX, _setShowX] = React.useState(false);
       setShowX = _setShowX;
       return showX ? <X /> : 'c';
     };
@@ -87,7 +87,7 @@ describe('StoreStress (Legacy Mode)', () => {
     // These cases are picked so that rendering them sequentially in the same
     // container results in a combination of mounts, updates, unmounts, and reorders.
     // prettier-ignore
-    let cases = [
+    const cases = [
       [a, b, c, d, e],
       [[a], b, c, d, e],
       [[a, b], c, d, e],
@@ -183,7 +183,7 @@ describe('StoreStress (Legacy Mode)', () => {
     const e = <E key="e" />;
 
     // prettier-ignore
-    let steps = [
+    const steps = [
       a,
       b,
       c,
@@ -207,7 +207,7 @@ describe('StoreStress (Legacy Mode)', () => {
     };
 
     // 1. Capture the expected render result.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
       act(() => ReactDOM.render(<Root>{steps[i]}</Root>, container));
@@ -308,7 +308,7 @@ describe('StoreStress (Legacy Mode)', () => {
 
     // 1. For each step, check Suspense can render them as initial primary content.
     // This is the only step where we use Jest snapshots.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
       act(() =>
@@ -719,7 +719,7 @@ describe('StoreStress (Legacy Mode)', () => {
 
     // 1. For each step, check Suspense can render them as initial primary content.
     // This is the only step where we use Jest snapshots.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     for (let i = 0; i < steps.length; i++) {
       act(() =>
@@ -744,7 +744,7 @@ describe('StoreStress (Legacy Mode)', () => {
     // 2. Verify check Suspense can render same steps as initial fallback content.
     // We don't actually assert here because the tree includes <MaybeSuspend>
     // which is different from the snapshots above. So we take more snapshots.
-    let fallbackSnapshots = [];
+    const fallbackSnapshots = [];
     for (let i = 0; i < steps.length; i++) {
       act(() =>
         ReactDOM.render(

--- a/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
@@ -42,7 +42,7 @@ describe('StoreStressConcurrent', () => {
       // We'll be manually flipping this component back and forth in the test.
       // We only do this for a single node in order to verify that DevTools
       // can handle a subtree switching alternates while other subtrees are memoized.
-      let [showX, _setShowX] = React.useState(false);
+      const [showX, _setShowX] = React.useState(false);
       setShowX = _setShowX;
       return showX ? <X /> : 'c';
     };
@@ -115,7 +115,7 @@ describe('StoreStressConcurrent', () => {
     // These cases are picked so that rendering them sequentially in the same
     // container results in a combination of mounts, updates, unmounts, and reorders.
     // prettier-ignore
-    let cases = [
+    const cases = [
       [a, b, c, d, e],
       [[a], b, c, d, e],
       [[a, b], c, d, e],
@@ -215,7 +215,7 @@ describe('StoreStressConcurrent', () => {
     const e = <E key="e" />;
 
     // prettier-ignore
-    let steps = [
+    const steps = [
       a,
       b,
       c,
@@ -239,7 +239,7 @@ describe('StoreStressConcurrent', () => {
     };
 
     // 1. Capture the expected render result.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     // $FlowFixMe
     let root = ReactDOM.createRoot(container);
@@ -401,7 +401,7 @@ describe('StoreStressConcurrent', () => {
 
     // 1. For each step, check Suspense can render them as initial primary content.
     // This is the only step where we use Jest snapshots.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     // $FlowFixMe
     let root = ReactDOM.createRoot(container);
@@ -890,7 +890,7 @@ describe('StoreStressConcurrent', () => {
 
     // 1. For each step, check Suspense can render them as initial primary content.
     // This is the only step where we use Jest snapshots.
-    let snapshots = [];
+    const snapshots = [];
     let container = document.createElement('div');
     // $FlowFixMe
     let root = ReactDOM.createRoot(container);
@@ -915,7 +915,7 @@ describe('StoreStressConcurrent', () => {
     // 2. Verify check Suspense can render same steps as initial fallback content.
     // We don't actually assert here because the tree includes <MaybeSuspend>
     // which is different from the snapshots above. So we take more snapshots.
-    let fallbackSnapshots = [];
+    const fallbackSnapshots = [];
     for (let i = 0; i < steps.length; i++) {
       act(() =>
         root.render(

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -482,7 +482,7 @@ describe('TreeListContext', () => {
       utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
       expect(state).toMatchSnapshot('1: initial state');
 
-      let parentID = ((store.getElementIDAtIndex(1): any): number);
+      const parentID = ((store.getElementIDAtIndex(1): any): number);
       utils.act(() => dispatch({type: 'SELECT_OWNER', payload: parentID}));
       utils.act(() => renderer.update(<Contexts />));
       expect(state).toMatchSnapshot('2: parent owners tree');
@@ -507,7 +507,7 @@ describe('TreeListContext', () => {
       utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
       expect(state).toMatchSnapshot('1: initial state');
 
-      let parentID = ((store.getElementIDAtIndex(1): any): number);
+      const parentID = ((store.getElementIDAtIndex(1): any): number);
       utils.act(() => dispatch({type: 'SELECT_OWNER', payload: parentID}));
       utils.act(() => renderer.update(<Contexts />));
       expect(state).toMatchSnapshot('2: parent owners tree');
@@ -545,7 +545,7 @@ describe('TreeListContext', () => {
       utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
       expect(state).toMatchSnapshot('1: initial state');
 
-      let childID = ((store.getElementIDAtIndex(1): any): number);
+      const childID = ((store.getElementIDAtIndex(1): any): number);
       utils.act(() => dispatch({type: 'SELECT_OWNER', payload: childID}));
       utils.act(() => renderer.update(<Contexts />));
       expect(state).toMatchSnapshot('2: child owners tree');
@@ -553,7 +553,7 @@ describe('TreeListContext', () => {
       await utils.actAsync(() => ReactDOM.render(<Parent />, container));
       expect(state).toMatchSnapshot('3: remove child');
 
-      let parentID = ((store.getElementIDAtIndex(0): any): number);
+      const parentID = ((store.getElementIDAtIndex(0): any): number);
       utils.act(() => dispatch({type: 'SELECT_OWNER', payload: parentID}));
       utils.act(() => renderer.update(<Contexts />));
       expect(state).toMatchSnapshot('4: parent owners tree');

--- a/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
+++ b/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
@@ -171,7 +171,7 @@ function measureStyle(
 
 function shallowClone(object: Object): Object {
   const cloned = {};
-  for (let n in object) {
+  for (const n in object) {
     cloned[n] = object[n];
   }
   return cloned;

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -211,7 +211,7 @@ export default class Agent extends EventEmitter<{|
   }
 
   getIDForNode(node: Object): number | null {
-    for (let rendererID in this._rendererInterfaces) {
+    for (const rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);
@@ -389,7 +389,7 @@ export default class Agent extends EventEmitter<{|
 
     setTraceUpdatesEnabled(traceUpdatesEnabled);
 
-    for (let rendererID in this._rendererInterfaces) {
+    for (const rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);
@@ -413,7 +413,7 @@ export default class Agent extends EventEmitter<{|
   startProfiling = (recordChangeDescriptions: boolean) => {
     this._recordChangeDescriptions = recordChangeDescriptions;
     this._isProfiling = true;
-    for (let rendererID in this._rendererInterfaces) {
+    for (const rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);
@@ -425,7 +425,7 @@ export default class Agent extends EventEmitter<{|
   stopProfiling = () => {
     this._isProfiling = false;
     this._recordChangeDescriptions = false;
-    for (let rendererID in this._rendererInterfaces) {
+    for (const rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);
@@ -456,7 +456,7 @@ export default class Agent extends EventEmitter<{|
   };
 
   updateComponentFilters = (componentFilters: Array<ComponentFilter>) => {
-    for (let rendererID in this._rendererInterfaces) {
+    for (const rendererID in this._rendererInterfaces) {
       const renderer = ((this._rendererInterfaces[
         (rendererID: any)
       ]: any): RendererInterface);

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -27,7 +27,7 @@ const injectedRenderers: Map<
 
 let targetConsole: Object = console;
 let targetConsoleMethods = {};
-for (let method in console) {
+for (const method in console) {
   targetConsoleMethods[method] = console[method];
 }
 
@@ -40,7 +40,7 @@ export function dangerous_setTargetConsoleForTesting(
   targetConsole = targetConsoleForTesting;
 
   targetConsoleMethods = {};
-  for (let method in targetConsole) {
+  for (const method in targetConsole) {
     targetConsoleMethods[method] = console[method];
   }
 }
@@ -77,7 +77,7 @@ export function patch(): void {
   const originalConsoleMethods = {};
 
   unpatchFn = () => {
-    for (let method in originalConsoleMethods) {
+    for (const method in originalConsoleMethods) {
       try {
         // $FlowFixMe property error|warn is not writable.
         targetConsole[method] = originalConsoleMethods[method];
@@ -101,7 +101,7 @@ export function patch(): void {
             // If there's a component stack for at least one of the injected renderers, append it.
             // We don't handle the edge case of stacks for more than one (e.g. interleaved renderers?)
             // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-            for (let {
+            for (const {
               getCurrentFiber,
               getDisplayNameForFiber,
             } of injectedRenderers.values()) {

--- a/packages/react-devtools-shared/src/backend/describeComponentFrame.js
+++ b/packages/react-devtools-shared/src/backend/describeComponentFrame.js
@@ -21,7 +21,7 @@ export default function describeComponentFrame(
 ) {
   let sourceInfo = '';
   if (source) {
-    let path = source.fileName;
+    const path = source.fileName;
     let fileName = path.replace(BEFORE_SLASH_RE, '');
     if (__DEV__) {
       // In DEV, include code for a common special case:

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -87,7 +87,7 @@ function getElementType(internalInstance: InternalInstance): ElementType {
 }
 
 function getChildren(internalInstance: Object): Array<any> {
-  let children = [];
+  const children = [];
 
   // If the parent is a native node without rendered children, but with
   // multiple string children, then the `element` that gets passed in here is
@@ -106,7 +106,7 @@ function getChildren(internalInstance: Object): Array<any> {
     }
   } else if (internalInstance._renderedChildren) {
     const renderedChildren = internalInstance._renderedChildren;
-    for (let name in renderedChildren) {
+    for (const name in renderedChildren) {
       const child = renderedChildren[name];
       if (getElementType(child) !== ElementTypeOtherOrUnknown) {
         children.push(child);
@@ -386,8 +386,8 @@ export function attach(
           ? getID(internalInstance._currentElement._owner)
           : 0;
 
-      let displayNameStringID = getStringID(displayName);
-      let keyStringID = getStringID(key);
+      const displayNameStringID = getStringID(displayName);
+      const keyStringID = getStringID(key);
       pushOperation(TREE_OPERATION_ADD);
       pushOperation(id);
       pushOperation(type);
@@ -447,7 +447,7 @@ export function attach(
       renderer.Mount._instancesByReactRootID ||
       renderer.Mount._instancesByContainerID;
 
-    for (let key in roots) {
+    for (const key in roots) {
       const internalInstance = roots[key];
       const id = getID(internalInstance);
       crawlAndRecordInitialMounts(id, 0, id);
@@ -455,8 +455,8 @@ export function attach(
     }
   }
 
-  let pendingOperations: Array<number> = [];
-  let pendingStringTable: Map<string, number> = new Map();
+  const pendingOperations: Array<number> = [];
+  const pendingStringTable: Map<string, number> = new Map();
   let pendingUnmountedIDs: Array<number> = [];
   let pendingStringTableLength: number = 0;
   let pendingUnmountedRootID: number | null = null;

--- a/packages/react-devtools-shared/src/backend/legacy/utils.js
+++ b/packages/react-devtools-shared/src/backend/legacy/utils.js
@@ -29,7 +29,7 @@ export function decorateMany(
 }
 
 export function restoreMany(source: Object, olds: Object): void {
-  for (let name in olds) {
+  for (const name in olds) {
     source[name] = olds[name];
   }
 }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -543,7 +543,7 @@ export function attach(
 
   // Highlight updates
   let traceUpdatesEnabled: boolean = false;
-  let traceUpdatesForNodes: Set<NativeType> = new Set();
+  const traceUpdatesForNodes: Set<NativeType> = new Set();
 
   function applyComponentFilters(componentFilters: Array<ComponentFilter>) {
     hideElementsWithTypes.clear();
@@ -675,7 +675,7 @@ export function attach(
       const displayName = getDisplayNameForFiber(fiber);
       if (displayName != null) {
         // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-        for (let displayNameRegExp of hideElementsWithDisplayNames) {
+        for (const displayNameRegExp of hideElementsWithDisplayNames) {
           if (displayNameRegExp.test(displayName)) {
             return true;
           }
@@ -686,7 +686,7 @@ export function attach(
     if (_debugSource != null && hideElementsWithPaths.size > 0) {
       const {fileName} = _debugSource;
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (let pathRegExp of hideElementsWithPaths) {
+      for (const pathRegExp of hideElementsWithPaths) {
         if (pathRegExp.test(fileName)) {
           return true;
         }
@@ -960,7 +960,7 @@ export function attach(
     const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
     const changedKeys = [];
     // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-    for (let key of keys) {
+    for (const key of keys) {
       if (prev[key] !== next[key]) {
         changedKeys.push(key);
       }
@@ -994,11 +994,11 @@ export function attach(
     }
   }
 
-  let pendingOperations: Array<number> = [];
-  let pendingRealUnmountedIDs: Array<number> = [];
-  let pendingSimulatedUnmountedIDs: Array<number> = [];
+  const pendingOperations: Array<number> = [];
+  const pendingRealUnmountedIDs: Array<number> = [];
+  const pendingSimulatedUnmountedIDs: Array<number> = [];
   let pendingOperationsQueue: Array<Array<number>> | null = [];
-  let pendingStringTable: Map<string, number> = new Map();
+  const pendingStringTable: Map<string, number> = new Map();
   let pendingStringTableLength: number = 0;
   let pendingUnmountedRootID: number | null = null;
 
@@ -1173,12 +1173,12 @@ export function attach(
         ? getFiberID(getPrimaryFiber(parentFiber))
         : 0;
 
-      let displayNameStringID = getStringID(displayName);
+      const displayNameStringID = getStringID(displayName);
 
       // This check is a guard to handle a React element that has been modified
       // in such a way as to bypass the default stringification of the "key" property.
-      let keyString = key === null ? null : '' + key;
-      let keyStringID = getStringID(keyString);
+      const keyString = key === null ? null : '' + key;
+      const keyStringID = getStringID(keyString);
 
       pushOperation(TREE_OPERATION_ADD);
       pushOperation(id);
@@ -1974,7 +1974,7 @@ export function attach(
       return null;
     }
 
-    let alternate = fiber.alternate;
+    const alternate = fiber.alternate;
     if (!alternate) {
       // If there is no alternate, then we only need to check if it is mounted.
       const state = isFiberMountedImpl(fiber);
@@ -1992,12 +1992,12 @@ export function attach(
     let a: Fiber = fiber;
     let b: Fiber = alternate;
     while (true) {
-      let parentA = a.return;
+      const parentA = a.return;
       if (parentA === null) {
         // We're at the root.
         break;
       }
-      let parentB = parentA.alternate;
+      const parentB = parentA.alternate;
       if (parentB === null) {
         // There is no alternate. This is an unusual case. Currently, it only
         // happens when a Suspense component is hidden. An extra fragment fiber
@@ -2131,7 +2131,7 @@ export function attach(
   }
 
   function prepareViewElementSource(id: number): void {
-    let fiber = idToFiberMap.get(id);
+    const fiber = idToFiberMap.get(id);
     if (fiber == null) {
       console.warn(`Could not find Fiber with id "${id}"`);
       return;
@@ -2163,7 +2163,7 @@ export function attach(
   }
 
   function getOwnersList(id: number): Array<Owner> | null {
-    let fiber = findCurrentFiberUsingSlowPathById(id);
+    const fiber = findCurrentFiberUsingSlowPathById(id);
     if (fiber == null) {
       return null;
     }
@@ -2200,7 +2200,7 @@ export function attach(
     let instance = null;
     let style = null;
 
-    let fiber = findCurrentFiberUsingSlowPathById(id);
+    const fiber = findCurrentFiberUsingSlowPathById(id);
     if (fiber !== null) {
       instance = fiber.stateNode;
 
@@ -2213,7 +2213,7 @@ export function attach(
   }
 
   function inspectElementRaw(id: number): InspectedElement | null {
-    let fiber = findCurrentFiberUsingSlowPathById(id);
+    const fiber = findCurrentFiberUsingSlowPathById(id);
     if (fiber == null) {
       return null;
     }
@@ -2328,7 +2328,7 @@ export function attach(
       const originalConsoleMethods = {};
 
       // Temporarily disable all console logging before re-running the hook.
-      for (let method in console) {
+      for (const method in console) {
         try {
           originalConsoleMethods[method] = console[method];
           // $FlowFixMe property error|warn is not writable.
@@ -2343,7 +2343,7 @@ export function attach(
         );
       } finally {
         // Restore original console functionality.
-        for (let method in originalConsoleMethods) {
+        for (const method in originalConsoleMethods) {
           try {
             // $FlowFixMe property error|warn is not writable.
             console[method] = originalConsoleMethods[method];
@@ -2462,7 +2462,7 @@ export function attach(
   function updateSelectedElement(inspectedElement: InspectedElement): void {
     const {hooks, id, props} = inspectedElement;
 
-    let fiber = idToFiberMap.get(id);
+    const fiber = idToFiberMap.get(id);
     if (fiber == null) {
       console.warn(`Could not find Fiber with id "${id}"`);
       return;
@@ -2912,7 +2912,7 @@ export function attach(
     return false;
   }
 
-  let forceFallbackForSuspenseIDs = new Set();
+  const forceFallbackForSuspenseIDs = new Set();
   function shouldSuspendFiberAccordingToSet(fiber) {
     const id = getFiberID(getPrimaryFiber(((fiber: any): Fiber)));
     return forceFallbackForSuspenseIDs.has(id);

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -155,11 +155,11 @@ export default class Overlay {
 
   constructor() {
     // Find the root window, because overlays are positioned relative to it.
-    let currentWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const currentWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.window = currentWindow;
 
     // When opened in shells/dev, the tooltip should be bound by the app iframe, not by the topmost window.
-    let tipBoundsWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+    const tipBoundsWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
     this.tipBoundsWindow = tipBoundsWindow;
 
     const doc = currentWindow.document;

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -135,7 +135,7 @@ function measureNode(node: Object): Rect | null {
     return null;
   }
 
-  let currentWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
+  const currentWindow = window.__REACT_DEVTOOLS_TARGET_WINDOW__ || window;
 
   return getNestedBoundingClientRect(node, currentWindow);
 }

--- a/packages/react-devtools-shared/src/devtools/ProfilerStore.js
+++ b/packages/react-devtools-shared/src/devtools/ProfilerStore.js
@@ -297,7 +297,7 @@ export default class ProfilerStore extends EventEmitter<{|
 
       // Record all renderer IDs initially too (in case of unmount)
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (let rendererID of this._store.rootIDToRendererID.values()) {
+      for (const rendererID of this._store.rootIDToRendererID.values()) {
         if (!this._initialRendererIDs.has(rendererID)) {
           this._initialRendererIDs.add(rendererID);
         }

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -479,7 +479,7 @@ export default class Store extends EventEmitter<{|
 
   getOwnersListForElement(ownerID: number): Array<Element> {
     const list = [];
-    let element = this._idToElement.get(ownerID);
+    const element = this._idToElement.get(ownerID);
     if (element != null) {
       list.push({
         ...element,

--- a/packages/react-devtools-shared/src/devtools/utils.js
+++ b/packages/react-devtools-shared/src/devtools/utils.js
@@ -44,7 +44,8 @@ export function printElement(element: Element, includeWeight: boolean = false) {
     }
   }
 
-  let hocs = hocDisplayNames === null ? '' : ` [${hocDisplayNames.join('][')}]`;
+  const hocs =
+    hocDisplayNames === null ? '' : ` [${hocDisplayNames.join('][')}]`;
 
   let suffix = '';
   if (includeWeight) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -351,16 +351,19 @@ function hydrateHelper(
   path?: Array<string | number>,
 ): Object | null {
   if (dehydratedData !== null) {
-    let {cleaned, data, unserializable} = dehydratedData;
+    const {cleaned, data, unserializable} = dehydratedData;
 
     if (path) {
       const {length} = path;
       if (length > 0) {
         // Hydration helper requires full paths, but inspection dehydrates with relative paths.
         // In that event it's important that we adjust the "cleaned" paths to match.
-        cleaned = cleaned.map(cleanedPath => cleanedPath.slice(length));
-        unserializable = unserializable.map(unserializablePath =>
-          unserializablePath.slice(length),
+        return hydrate(
+          data,
+          cleaned.map(cleanedPath => cleanedPath.slice(length)),
+          unserializable.map(unserializablePath =>
+            unserializablePath.slice(length),
+          ),
         );
       }
     }

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -76,7 +76,7 @@ const resource: Resource<
   InspectedElementFrontend,
 > = createResource(
   (element: Element) => {
-    let request = inProgressRequests.get(element);
+    const request = inProgressRequests.get(element);
     if (request != null) {
       return request.promise;
     }

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -217,7 +217,7 @@ export default function KeyValue({
       const hasChildren = entries.length > 0;
       const displayName = getMetaValueLabel(value);
 
-      let areChildrenReadOnly = isReadOnly || !!value[meta.readonly];
+      const areChildrenReadOnly = isReadOnly || !!value[meta.readonly];
       children = entries.map<Element<any>>(([key, keyValue]) => (
         <KeyValue
           key={key}

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
@@ -57,7 +57,7 @@ const resource: Resource<
   StyleAndLayoutFrontend,
 > = createResource(
   (element: Element) => {
-    let request = inProgressRequests.get(element);
+    const request = inProgressRequests.get(element);
     if (request != null) {
       return request.promise;
     }
@@ -108,7 +108,7 @@ function NativeStyleContextController({children}: Props) {
   // This effect handler invalidates the suspense cache and schedules rendering updates with React.
   useEffect(() => {
     const onStyleAndLayout = ({id, layout, style}: StyleAndLayoutBackend) => {
-      let element = store.getElementByID(id);
+      const element = store.getElementByID(id);
       if (element !== null) {
         const styleAndLayout: StyleAndLayoutFrontend = {
           layout,

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
@@ -35,7 +35,7 @@ type InProgressRequest = {|
 const inProgressRequests: WeakMap<Element, InProgressRequest> = new WeakMap();
 const resource: Resource<Element, Element, Array<Owner>> = createResource(
   (element: Element) => {
-    let request = inProgressRequests.get(element);
+    const request = inProgressRequests.get(element);
     if (request != null) {
       return request.promise;
     }

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -409,7 +409,7 @@ function updateIndentationSizeVar(
   let maxIndentationSize: number = indentationSizeRef.current;
 
   // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-  for (let child of innerDiv.children) {
+  for (const child of innerDiv.children) {
     const depth = parseInt(child.getAttribute('data-depth'), 10) || 0;
 
     let childWidth: number = 0;

--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -157,7 +157,8 @@ type State = {|
 |};
 
 function reduceTreeState(store: Store, state: State, action: Action): State {
-  let {numElements, ownerID, selectedElementIndex, selectedElementID} = state;
+  let {numElements, selectedElementIndex, selectedElementID} = state;
+  const ownerID = state.ownerID;
 
   let lookupIDForIndex = true;
 
@@ -277,13 +278,13 @@ function reduceTreeState(store: Store, state: State, action: Action): State {
 
 function reduceSearchState(store: Store, state: State, action: Action): State {
   let {
-    ownerID,
     searchIndex,
     searchResults,
     searchText,
     selectedElementID,
     selectedElementIndex,
   } = state;
+  const ownerID = state.ownerID;
 
   const prevSearchIndex = searchIndex;
   const prevSearchText = searchText;
@@ -452,10 +453,8 @@ function reduceOwnersState(store: Store, state: State, action: Action): State {
     selectedElementIndex,
     ownerID,
     ownerFlatTree,
-    searchIndex,
-    searchResults,
-    searchText,
   } = state;
+  const {searchIndex, searchResults, searchText} = state;
 
   let prevSelectedElementIndex = selectedElementIndex;
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -734,7 +734,7 @@ function TreeContextController({
       prevSelectedElementID.current = state.selectedElementID;
 
       if (state.selectedElementID !== null) {
-        let element = store.getElementByID(state.selectedElementID);
+        const element = store.getElementByID(state.selectedElementID);
         if (element !== null && element.parentID > 0) {
           store.toggleIsCollapsed(element.parentID, false);
         }

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -107,10 +107,12 @@ export default function DevTools({
   viewAttributeSourceFunction,
   viewElementSourceFunction,
 }: Props) {
-  let [tab, setTab] = useLocalStorage<TabID>(
+  const [currentTab, setTab] = useLocalStorage<TabID>(
     'React::DevTools::defaultTab',
     defaultTab,
   );
+
+  let tab = currentTab;
 
   if (overrideTab != null) {
     tab = overrideTab;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraphListItem.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraphListItem.js
@@ -64,7 +64,7 @@ function CommitFlamegraphListItem({data, index, style}: Props) {
 
   const row = rows[index];
 
-  let selectedNodeOffset = scaleX(
+  const selectedNodeOffset = scaleX(
     selectedChartNode !== null ? selectedChartNode.offset : 0,
     width,
   );

--- a/packages/react-devtools-shared/src/events.js
+++ b/packages/react-devtools-shared/src/events.js
@@ -14,7 +14,7 @@ export default class EventEmitter<Events: Object> {
     event: Event,
     listener: (...$ElementType<Events, Event>) => any,
   ): void {
-    let listeners = this.listenersMap.get(event);
+    const listeners = this.listenersMap.get(event);
     if (listeners === undefined) {
       this.listenersMap.set(event, [listener]);
     } else {

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -287,7 +287,7 @@ export function dehydrate(
         return createDehydrated(type, true, data, cleaned, path);
       } else {
         const object = {};
-        for (let name in data) {
+        for (const name in data) {
           object[name] = dehydrate(
             data[name],
             cleaned,

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -49,7 +49,7 @@ const cachedDisplayNames: WeakMap<Function, string> = new WeakMap();
 
 // On large trees, encoding takes significant time.
 // Try to reuse the already encoded strings.
-let encodedStringCache = new LRU({max: 1000});
+const encodedStringCache = new LRU({max: 1000});
 
 export function alphaSortKeys(a: string, b: string): number {
   if (a > b) {
@@ -96,7 +96,7 @@ export function utfDecodeString(array: Array<number>): string {
 }
 
 export function utfEncodeString(string: string): Array<number> {
-  let cached = encodedStringCache.get(string);
+  const cached = encodedStringCache.get(string);
   if (cached !== undefined) {
     return cached;
   }
@@ -281,12 +281,12 @@ export function separateDisplayNameAndHOCs(
 // Pulled from react-compat
 // https://github.com/developit/preact-compat/blob/7c5de00e7c85e2ffd011bf3af02899b63f699d3a/src/index.js#L349
 export function shallowDiffers(prev: Object, next: Object): boolean {
-  for (let attribute in prev) {
+  for (const attribute in prev) {
     if (!(attribute in next)) {
       return true;
     }
   }
-  for (let attribute in next) {
+  for (const attribute in next) {
     if (prev[attribute] !== next[attribute]) {
       return true;
     }

--- a/packages/react-devtools-shell/src/app/SuspenseTree/index.js
+++ b/packages/react-devtools-shell/src/app/SuspenseTree/index.js
@@ -47,13 +47,13 @@ function PrimaryFallbackTest({initialSuspend}) {
 }
 
 function useTestSequence(label, T1, T2) {
-  let [step, setStep] = useState(0);
-  let next = (
+  const [step, setStep] = useState(0);
+  const next = (
     <button onClick={() => setStep(s => (s + 1) % allSteps.length)}>
       next {label} content
     </button>
   );
-  let allSteps = [
+  const allSteps = [
     <Fragment>{next}</Fragment>,
     <Fragment>
       {next} <T1 prop={step}>mount</T1>

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -143,7 +143,7 @@ describe('ReactCompositeComponent-state', () => {
 
     ReactDOM.unmountComponentAtNode(container);
 
-    let expected = [
+    const expected = [
       // there is no state when getInitialState() is called
       ['getInitialState', null],
       ['componentWillMount-start', 'red'],
@@ -380,7 +380,7 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   it('should treat assigning to this.state inside cWRP as a replaceState, with a warning', () => {
-    let ops = [];
+    const ops = [];
     class Test extends React.Component {
       state = {step: 1, extra: true};
       UNSAFE_componentWillReceiveProps() {
@@ -423,7 +423,7 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   it('should treat assigning to this.state inside cWM as a replaceState, with a warning', () => {
-    let ops = [];
+    const ops = [];
     class Test extends React.Component {
       state = {step: 1, extra: true};
       UNSAFE_componentWillMount() {

--- a/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponentState-test.js
@@ -283,8 +283,6 @@ describe('ReactCompositeComponent-state', () => {
   });
 
   it('should batch unmounts', () => {
-    let outer;
-
     class Inner extends React.Component {
       render() {
         return <div />;
@@ -306,7 +304,7 @@ describe('ReactCompositeComponent-state', () => {
     }
 
     const container = document.createElement('div');
-    outer = ReactDOM.render(<Outer />, container);
+    const outer = ReactDOM.render(<Outer />, container);
     expect(() => {
       ReactDOM.unmountComponentAtNode(container);
     }).not.toThrow();

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -564,8 +564,8 @@ describe('ReactDOMComponent', () => {
             {'></div><script>alert("hi")</script>': 'selected'},
             null,
           );
-          let result1 = ReactDOMServer.renderToString(element1);
-          let result2 = ReactDOMServer.renderToString(element2);
+          const result1 = ReactDOMServer.renderToString(element1);
+          const result2 = ReactDOMServer.renderToString(element2);
           expect(result1.toLowerCase()).not.toContain('onclick');
           expect(result2.toLowerCase()).not.toContain('script');
         }
@@ -588,8 +588,8 @@ describe('ReactDOMComponent', () => {
             {'></x-foo-component><script>alert("hi")</script>': 'selected'},
             null,
           );
-          let result1 = ReactDOMServer.renderToString(element1);
-          let result2 = ReactDOMServer.renderToString(element2);
+          const result1 = ReactDOMServer.renderToString(element1);
+          const result2 = ReactDOMServer.renderToString(element2);
           expect(result1.toLowerCase()).not.toContain('onclick');
           expect(result2.toLowerCase()).not.toContain('script');
         }
@@ -1166,7 +1166,7 @@ describe('ReactDOMComponent', () => {
       let realToString;
       try {
         realToString = Object.prototype.toString;
-        let wrappedToString = function() {
+        const wrappedToString = function() {
           // Emulate browser behavior which is missing in jsdom
           if (this instanceof window.HTMLUnknownElement) {
             return '[object HTMLUnknownElement]';
@@ -2553,10 +2553,10 @@ describe('ReactDOMComponent', () => {
   });
 
   it('receives events in specific order', () => {
-    let eventOrder = [];
-    let track = tag => () => eventOrder.push(tag);
-    let outerRef = React.createRef();
-    let innerRef = React.createRef();
+    const eventOrder = [];
+    const track = tag => () => eventOrder.push(tag);
+    const outerRef = React.createRef();
+    const innerRef = React.createRef();
 
     function OuterReactApp() {
       return (

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -12,7 +12,7 @@
 describe('ReactDOMEventListener', () => {
   let React;
   let ReactDOM;
-  let ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
   beforeEach(() => {
     jest.resetModules();

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -211,7 +211,7 @@ describe('ReactDOMFiber', () => {
   };
 
   const assertNamespacesMatch = function(tree) {
-    let testContainer = document.createElement('div');
+    const testContainer = document.createElement('div');
     svgEls = [];
     htmlEls = [];
     mathEls = [];
@@ -1224,7 +1224,7 @@ describe('ReactDOMFiber', () => {
 
   // Regression test for https://github.com/facebook/react/issues/12643#issuecomment-413727104
   it('should not diff memoized host components', () => {
-    let inputRef = React.createRef();
+    const inputRef = React.createRef();
     let didCallOnChange = false;
 
     class Child extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.internal.js
@@ -49,7 +49,7 @@ describe('ReactDOMFiberAsync', () => {
   });
 
   it('flushSync batches sync updates and flushes them at the end of the batch', () => {
-    let ops = [];
+    const ops = [];
     let instance;
 
     class Component extends React.Component {
@@ -87,7 +87,7 @@ describe('ReactDOMFiberAsync', () => {
   });
 
   it('flushSync flushes updates even if nested inside another flushSync', () => {
-    let ops = [];
+    const ops = [];
     let instance;
 
     class Component extends React.Component {
@@ -156,9 +156,9 @@ describe('ReactDOMFiberAsync', () => {
     });
 
     it.experimental('does not perform deferred updates synchronously', () => {
-      let inputRef = React.createRef();
-      let asyncValueRef = React.createRef();
-      let syncValueRef = React.createRef();
+      const inputRef = React.createRef();
+      const asyncValueRef = React.createRef();
+      const syncValueRef = React.createRef();
 
       class Counter extends React.Component {
         state = {asyncValue: '', syncValue: ''};
@@ -246,7 +246,7 @@ describe('ReactDOMFiberAsync', () => {
     });
 
     it.experimental('flushSync flushes updates before end of the tick', () => {
-      let ops = [];
+      const ops = [];
       let instance;
 
       class Component extends React.Component {
@@ -317,7 +317,7 @@ describe('ReactDOMFiberAsync', () => {
         Scheduler.unstable_flushAll();
         expect(container.textContent).toEqual('1');
 
-        let ops = [];
+        const ops = [];
         ReactDOM.unstable_flushControlled(() => {
           inst.increment();
           ReactDOM.unstable_flushControlled(() => {
@@ -350,7 +350,7 @@ describe('ReactDOMFiberAsync', () => {
         }
         ReactDOM.render(<Counter />, container);
 
-        let ops = [];
+        const ops = [];
         ReactDOM.unstable_batchedUpdates(() => {
           inst.increment();
           ReactDOM.unstable_flushControlled(() => {
@@ -428,22 +428,22 @@ describe('ReactDOMFiberAsync', () => {
         // Flush
         Scheduler.unstable_flushAll();
 
-        let disableButton = disableButtonRef.current;
+        const disableButton = disableButtonRef.current;
         expect(disableButton.tagName).toBe('BUTTON');
 
         // Dispatch a click event on the Disable-button.
-        let firstEvent = document.createEvent('Event');
+        const firstEvent = document.createEvent('Event');
         firstEvent.initEvent('click', true, true);
         disableButton.dispatchEvent(firstEvent);
 
         // There should now be a pending update to disable the form.
 
         // This should not have flushed yet since it's in concurrent mode.
-        let submitButton = submitButtonRef.current;
+        const submitButton = submitButtonRef.current;
         expect(submitButton.tagName).toBe('BUTTON');
 
         // In the meantime, we can dispatch a new client event on the submit button.
-        let secondEvent = document.createEvent('Event');
+        const secondEvent = document.createEvent('Event');
         secondEvent.initEvent('click', true, true);
         // This should force the pending update to flush which disables the submit button before the event is invoked.
         submitButton.dispatchEvent(secondEvent);
@@ -499,22 +499,22 @@ describe('ReactDOMFiberAsync', () => {
         // Flush
         Scheduler.unstable_flushAll();
 
-        let disableButton = disableButtonRef.current;
+        const disableButton = disableButtonRef.current;
         expect(disableButton.tagName).toBe('BUTTON');
 
         // Dispatch a click event on the Disable-button.
-        let firstEvent = document.createEvent('Event');
+        const firstEvent = document.createEvent('Event');
         firstEvent.initEvent('click', true, true);
         disableButton.dispatchEvent(firstEvent);
 
         // There should now be a pending update to disable the form.
 
         // This should not have flushed yet since it's in concurrent mode.
-        let submitButton = submitButtonRef.current;
+        const submitButton = submitButtonRef.current;
         expect(submitButton.tagName).toBe('BUTTON');
 
         // In the meantime, we can dispatch a new client event on the submit button.
-        let secondEvent = document.createEvent('Event');
+        const secondEvent = document.createEvent('Event');
         secondEvent.initEvent('click', true, true);
         // This should force the pending update to flush which disables the submit button before the event is invoked.
         submitButton.dispatchEvent(secondEvent);
@@ -562,22 +562,22 @@ describe('ReactDOMFiberAsync', () => {
         // Flush
         Scheduler.unstable_flushAll();
 
-        let enableButton = enableButtonRef.current;
+        const enableButton = enableButtonRef.current;
         expect(enableButton.tagName).toBe('BUTTON');
 
         // Dispatch a click event on the Enable-button.
-        let firstEvent = document.createEvent('Event');
+        const firstEvent = document.createEvent('Event');
         firstEvent.initEvent('click', true, true);
         enableButton.dispatchEvent(firstEvent);
 
         // There should now be a pending update to enable the form.
 
         // This should not have flushed yet since it's in concurrent mode.
-        let submitButton = submitButtonRef.current;
+        const submitButton = submitButtonRef.current;
         expect(submitButton.tagName).toBe('BUTTON');
 
         // In the meantime, we can dispatch a new client event on the submit button.
-        let secondEvent = document.createEvent('Event');
+        const secondEvent = document.createEvent('Event');
         secondEvent.initEvent('click', true, true);
         // This should force the pending update to flush which enables the submit button before the event is invoked.
         submitButton.dispatchEvent(secondEvent);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -24,10 +24,10 @@ describe('ReactDOMFizzServer', () => {
   });
 
   async function readResult(stream) {
-    let reader = stream.getReader();
+    const reader = stream.getReader();
     let result = '';
     while (true) {
-      let {done, value} = await reader.read();
+      const {done, value} = await reader.read();
       if (done) {
         return result;
       }
@@ -36,10 +36,10 @@ describe('ReactDOMFizzServer', () => {
   }
 
   it('should call renderToReadableStream', async () => {
-    let stream = ReactDOMFizzServer.renderToReadableStream(
+    const stream = ReactDOMFizzServer.renderToReadableStream(
       <div>hello world</div>,
     );
-    let result = await readResult(stream);
+    const result = await readResult(stream);
     expect(result).toBe('<div>hello world</div>');
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -23,7 +23,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   function getTestWritable() {
-    let writable = new Stream.PassThrough();
+    const writable = new Stream.PassThrough();
     writable.setEncoding('utf8');
     writable.result = '';
     writable.on('data', chunk => (writable.result += chunk));
@@ -31,7 +31,7 @@ describe('ReactDOMFizzServer', () => {
   }
 
   it('should call pipeToNodeWritable', () => {
-    let writable = getTestWritable();
+    const writable = getTestWritable();
     ReactDOMFizzServer.pipeToNodeWritable(<div>hello world</div>, writable);
     jest.runAllTimers();
     expect(writable.result).toBe('<div>hello world</div>');

--- a/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHooks-test.js
@@ -32,8 +32,8 @@ describe('ReactDOMHooks', () => {
   });
 
   it('can ReactDOM.render() from useEffect', () => {
-    let container2 = document.createElement('div');
-    let container3 = document.createElement('div');
+    const container2 = document.createElement('div');
+    const container3 = document.createElement('div');
 
     function Example1({n}) {
       React.useEffect(() => {

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -379,7 +379,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should display `defaultValue` of number 0', () => {
-    let stub = <input type="text" defaultValue={0} />;
+    const stub = <input type="text" defaultValue={0} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.getAttribute('value')).toBe('0');
@@ -411,14 +411,14 @@ describe('ReactDOMInput', () => {
   });
 
   it('should display "true" for `defaultValue` of `true`', () => {
-    let stub = <input type="text" defaultValue={true} />;
+    const stub = <input type="text" defaultValue={true} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('true');
   });
 
   it('should display "false" for `defaultValue` of `false`', () => {
-    let stub = <input type="text" defaultValue={false} />;
+    const stub = <input type="text" defaultValue={false} />;
     const node = ReactDOM.render(stub, container);
 
     expect(node.value).toBe('false');
@@ -883,7 +883,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should set a value on a submit input', () => {
-    let stub = <input type="submit" value="banana" />;
+    const stub = <input type="submit" value="banana" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 
@@ -891,7 +891,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not set an undefined value on a submit input', () => {
-    let stub = <input type="submit" value={undefined} />;
+    const stub = <input type="submit" value={undefined} />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 
@@ -904,7 +904,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not set an undefined value on a reset input', () => {
-    let stub = <input type="reset" value={undefined} />;
+    const stub = <input type="reset" value={undefined} />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 
@@ -917,7 +917,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not set a null value on a submit input', () => {
-    let stub = <input type="submit" value={null} />;
+    const stub = <input type="submit" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
     }).toErrorDev('`value` prop on `input` should not be null');
@@ -932,7 +932,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should not set a null value on a reset input', () => {
-    let stub = <input type="reset" value={null} />;
+    const stub = <input type="reset" value={null} />;
     expect(() => {
       ReactDOM.render(stub, container);
     }).toErrorDev('`value` prop on `input` should not be null');
@@ -947,7 +947,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should set a value on a reset input', () => {
-    let stub = <input type="reset" value="banana" />;
+    const stub = <input type="reset" value="banana" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 
@@ -955,7 +955,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should set an empty string value on a submit input', () => {
-    let stub = <input type="submit" value="" />;
+    const stub = <input type="submit" value="" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 
@@ -963,7 +963,7 @@ describe('ReactDOMInput', () => {
   });
 
   it('should set an empty string value on a reset input', () => {
-    let stub = <input type="reset" value="" />;
+    const stub = <input type="reset" value="" />;
     ReactDOM.render(stub, container);
     const node = container.firstChild;
 

--- a/packages/react-dom/src/__tests__/ReactDOMOption-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMOption-test.js
@@ -22,7 +22,7 @@ describe('ReactDOMOption', () => {
   });
 
   it('should flatten children to a string', () => {
-    let stub = (
+    const stub = (
       <option>
         {1} {'foo'}
       </option>
@@ -50,7 +50,7 @@ describe('ReactDOMOption', () => {
   });
 
   it('should ignore null/undefined/false children without warning', () => {
-    let stub = (
+    const stub = (
       <option>
         {1} {false}
         {true}
@@ -92,7 +92,7 @@ describe('ReactDOMOption', () => {
   it('should support element-ish child', () => {
     // This is similar to <fbt>.
     // It's important that we toString it.
-    let obj = {
+    const obj = {
       $$typeof: Symbol.for('react.element'),
       type: props => props.content,
       ref: null,
@@ -134,7 +134,7 @@ describe('ReactDOMOption', () => {
   });
 
   it('should be able to use dangerouslySetInnerHTML on option', () => {
-    let stub = <option dangerouslySetInnerHTML={{__html: 'foobar'}} />;
+    const stub = <option dangerouslySetInnerHTML={{__html: 'foobar'}} />;
     const node = ReactTestUtils.renderIntoDocument(stub);
 
     expect(node.innerHTML).toBe('foobar');
@@ -153,7 +153,7 @@ describe('ReactDOMOption', () => {
 
   it('should allow ignoring `value` on option', () => {
     const a = 'a';
-    let stub = (
+    const stub = (
       <select value="giraffe" onChange={() => {}}>
         <option>monkey</option>
         <option>gir{a}ffe</option>

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -26,7 +26,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `defaultValue`', () => {
-    let stub = (
+    const stub = (
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -75,7 +75,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `defaultValue` with multiple', () => {
-    let stub = (
+    const stub = (
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -104,7 +104,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `value`', () => {
-    let stub = (
+    const stub = (
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -128,7 +128,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should default to the first non-disabled option', () => {
-    let stub = (
+    const stub = (
       <select defaultValue="">
         <option disabled={true}>Disabled</option>
         <option disabled={true}>Still Disabled</option>
@@ -143,7 +143,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `value` to __proto__', () => {
-    let stub = (
+    const stub = (
       <select value="__proto__" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="__proto__">A giraffe!</option>
@@ -175,7 +175,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `value` with multiple', () => {
-    let stub = (
+    const stub = (
       <select multiple={true} value={['giraffe', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -204,7 +204,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow setting `value` to __proto__ with multiple', () => {
-    let stub = (
+    const stub = (
       <select multiple={true} value={['__proto__', 'gorilla']} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="__proto__">A __proto__!</option>
@@ -233,7 +233,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should not select other options automatically', () => {
-    let stub = (
+    const stub = (
       <select multiple={true} value={['12']} onChange={noop}>
         <option value="1">one</option>
         <option value="2">two</option>
@@ -248,7 +248,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should reset child options selected when they are changed and `value` is set', () => {
-    let stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
+    const stub = <select multiple={true} value={['a', 'b']} onChange={noop} />;
     const container = document.createElement('div');
     const node = ReactDOM.render(stub, container);
 
@@ -306,7 +306,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow switching to multiple', () => {
-    let stub = (
+    const stub = (
       <select defaultValue="giraffe">
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -335,7 +335,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should allow switching from multiple', () => {
-    let stub = (
+    const stub = (
       <select multiple={true} defaultValue={['giraffe', 'gorilla']}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -389,7 +389,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should remember value when switching to uncontrolled', () => {
-    let stub = (
+    const stub = (
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -412,7 +412,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should remember updated value when switching to uncontrolled', () => {
-    let stub = (
+    const stub = (
       <select value={'giraffe'} onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -663,7 +663,7 @@ describe('ReactDOMSelect', () => {
   });
 
   it('should refresh state on change', () => {
-    let stub = (
+    const stub = (
       <select value="giraffe" onChange={noop}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>
@@ -725,7 +725,7 @@ describe('ReactDOMSelect', () => {
     }
 
     const container = document.createElement('div');
-    let stub = (
+    const stub = (
       <select value="giraffe" onChange={changeView}>
         <option value="monkey">A monkey!</option>
         <option value="giraffe">A giraffe!</option>

--- a/packages/react-dom/src/__tests__/ReactDOMSelection-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelection-test.internal.js
@@ -60,7 +60,7 @@ describe('ReactDOMSelection', () => {
         if (i === node.childNodes.length) {
           break;
         }
-        let n = node.childNodes[i];
+        const n = node.childNodes[i];
         traverse(n);
       }
     }

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationBasic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationBasic-test.js
@@ -63,37 +63,37 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('a string', async render => {
-      let e = await render('Hello');
+      const e = await render('Hello');
       expect(e.nodeType).toBe(3);
       expect(e.nodeValue).toMatch('Hello');
     });
 
     itRenders('a number', async render => {
-      let e = await render(42);
+      const e = await render(42);
       expect(e.nodeType).toBe(3);
       expect(e.nodeValue).toMatch('42');
     });
 
     itRenders('an array with one child', async render => {
-      let e = await render([<div key={1}>text1</div>]);
-      let parent = e.parentNode;
+      const e = await render([<div key={1}>text1</div>]);
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
     });
 
     itRenders('an array with several children', async render => {
-      let Header = props => {
+      const Header = props => {
         return <p>header</p>;
       };
-      let Footer = props => {
+      const Footer = props => {
         return [<h2 key={1}>footer</h2>, <h3 key={2}>about</h3>];
       };
-      let e = await render([
+      const e = await render([
         <div key={1}>text1</div>,
         <span key={2}>text2</span>,
         <Header key={3} />,
         <Footer key={4} />,
       ]);
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');
@@ -102,12 +102,12 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('a nested array', async render => {
-      let e = await render([
+      const e = await render([
         [<div key={1}>text1</div>],
         <span key={1}>text2</span>,
         [[[null, <p key={1} />], false]],
       ]);
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');
@@ -128,8 +128,8 @@ describe('ReactDOMServerIntegration', () => {
           };
         },
       };
-      let e = await render(threeDivIterable);
-      let parent = e.parentNode;
+      const e = await render(threeDivIterable);
+      const parent = e.parentNode;
       expect(parent.childNodes.length).toBe(3);
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('DIV');
@@ -137,7 +137,7 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('emptyish values', async render => {
-      let e = await render(0);
+      const e = await render(0);
       expect(e.nodeType).toBe(TEXT_NODE_TYPE);
       expect(e.nodeValue).toMatch('0');
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationClassContextType-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationClassContextType-test.js
@@ -257,7 +257,7 @@ describe('ReactDOMServerIntegration', () => {
           </LanguageConsumer>
         </div>
       );
-      let e = await render(<App />);
+      const e = await render(<App />);
       expect(e.querySelector('#theme1').textContent).toBe('dark');
       expect(e.querySelector('#theme2').textContent).toBe('light');
       expect(e.querySelector('#theme3').textContent).toBe('blue');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -128,9 +128,8 @@ describe('ReactDOMServerIntegration', () => {
             Text<span>More Text</span>
           </div>,
         );
-        let spanNode;
         expect(e.childNodes.length).toBe(2);
-        spanNode = e.childNodes[1];
+        const spanNode = e.childNodes[1];
         expectTextNode(e.childNodes[0], 'Text');
         expect(spanNode.tagName).toBe('SPAN');
         expect(spanNode.childNodes.length).toBe(1);
@@ -758,11 +757,10 @@ describe('ReactDOMServerIntegration', () => {
             </div>,
           );
           expect(e.id).toBe('parent');
-          let child1, child2, textNode;
           expect(e.childNodes.length).toBe(3);
-          child1 = e.childNodes[0];
-          textNode = e.childNodes[1];
-          child2 = e.childNodes[2];
+          const child1 = e.childNodes[0];
+          const textNode = e.childNodes[1];
+          const child2 = e.childNodes[2];
           expect(child1.id).toBe('child1');
           expect(child1.childNodes.length).toBe(0);
           expectTextNode(textNode, ' ');
@@ -776,11 +774,10 @@ describe('ReactDOMServerIntegration', () => {
         async render => {
           // prettier-ignore
           const e = await render(<div id="parent">  <div id="child" />   </div>); // eslint-disable-line no-multi-spaces
-          let textNode1, child, textNode2;
           expect(e.childNodes.length).toBe(3);
-          textNode1 = e.childNodes[0];
-          child = e.childNodes[1];
-          textNode2 = e.childNodes[2];
+          const textNode1 = e.childNodes[0];
+          const child = e.childNodes[1];
+          const textNode2 = e.childNodes[2];
           expect(e.id).toBe('parent');
           expectTextNode(textNode1, '  ');
           expect(child.id).toBe('child');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -397,7 +397,7 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders('svg child element with an attribute', async render => {
-        let e = await render(<svg viewBox="0 0 0 0" />);
+        const e = await render(<svg viewBox="0 0 0 0" />);
         expect(e.childNodes.length).toBe(0);
         expect(e.tagName).toBe('svg');
         expect(e.namespaceURI).toBe('http://www.w3.org/2000/svg');
@@ -439,14 +439,14 @@ describe('ReactDOMServerIntegration', () => {
       });
 
       itRenders('svg element with a tabIndex attribute', async render => {
-        let e = await render(<svg tabIndex="1" />);
+        const e = await render(<svg tabIndex="1" />);
         expect(e.tabIndex).toBe(1);
       });
 
       itRenders(
         'svg element with a badly cased tabIndex attribute',
         async render => {
-          let e = await render(<svg tabindex="1" />, 1);
+          const e = await render(<svg tabindex="1" />, 1);
           expect(e.tabIndex).toBe(1);
         },
       );
@@ -795,7 +795,7 @@ describe('ReactDOMServerIntegration', () => {
           <Component>{['a', 'b', [undefined], [[false, 'c']]]}</Component>,
         );
 
-        let parent = e.parentNode;
+        const parent = e.parentNode;
         if (
           render === serverRender ||
           render === clientRenderOnServerString ||

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
@@ -41,20 +41,20 @@ describe('ReactDOMServerIntegration', () => {
 
   describe('React.Fragment', () => {
     itRenders('a fragment with one child', async render => {
-      let e = await render(
+      const e = await render(
         <>
           <div>text1</div>
         </>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
     });
 
     itRenders('a fragment with several children', async render => {
-      let Header = props => {
+      const Header = props => {
         return <p>header</p>;
       };
-      let Footer = props => {
+      const Footer = props => {
         return (
           <>
             <h2>footer</h2>
@@ -62,7 +62,7 @@ describe('ReactDOMServerIntegration', () => {
           </>
         );
       };
-      let e = await render(
+      const e = await render(
         <>
           <div>text1</div>
           <span>text2</span>
@@ -70,7 +70,7 @@ describe('ReactDOMServerIntegration', () => {
           <Footer />
         </>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');
@@ -79,7 +79,7 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('a nested fragment', async render => {
-      let e = await render(
+      const e = await render(
         <>
           <>
             <div>text1</div>
@@ -96,7 +96,7 @@ describe('ReactDOMServerIntegration', () => {
           </>
         </>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.internal.js
@@ -121,7 +121,7 @@ describe('ReactDOMServerHooks', () => {
         return <span>{children}</span>;
       }
       function Counter() {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         return (
           <div>
             <UpdateCount setCount={setCount} count={count}>
@@ -140,7 +140,7 @@ describe('ReactDOMServerHooks', () => {
       async render => {
         class Counter extends React.Component {
           render() {
-            let [count] = useState(0);
+            const [count] = useState(0);
             return <Text text={count} />;
           }
         }
@@ -157,7 +157,7 @@ describe('ReactDOMServerHooks', () => {
 
     itRenders('multiple times when an updater is called', async render => {
       function Counter() {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         if (count < 12) {
           setCount(c => c + 1);
           setCount(c => c + 1);
@@ -172,7 +172,7 @@ describe('ReactDOMServerHooks', () => {
 
     itRenders('until there are no more new updates', async render => {
       function Counter() {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         if (count < 3) {
           setCount(count + 1);
         }
@@ -187,7 +187,7 @@ describe('ReactDOMServerHooks', () => {
       'after too many iterations',
       async render => {
         function Counter() {
-          let [count, setCount] = useState(0);
+          const [count, setCount] = useState(0);
           setCount(count + 1);
           return <span>{count}</span>;
         }
@@ -204,7 +204,7 @@ describe('ReactDOMServerHooks', () => {
         return action === 'increment' ? state + 1 : state;
       }
       function Counter() {
-        let [count] = useReducer(reducer, 0);
+        const [count] = useReducer(reducer, 0);
         yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
@@ -221,7 +221,7 @@ describe('ReactDOMServerHooks', () => {
         return action === 'increment' ? state + 1 : state;
       }
       function Counter() {
-        let [count] = useReducer(reducer, 0, c => c + 1);
+        const [count] = useReducer(reducer, 0, c => c + 1);
         yieldValue('Render: ' + count);
         return <Text text={count} />;
       }
@@ -240,7 +240,7 @@ describe('ReactDOMServerHooks', () => {
           return action === 'increment' ? state + 1 : state;
         }
         function Counter() {
-          let [count, dispatch] = useReducer(reducer, 0);
+          const [count, dispatch] = useReducer(reducer, 0);
           if (count < 3) {
             dispatch('increment');
           }
@@ -286,8 +286,8 @@ describe('ReactDOMServerHooks', () => {
         }
 
         function Counter() {
-          let [reducer, setReducer] = useState(() => reducerA);
-          let [count, dispatch] = useReducer(reducer, 0);
+          const [reducer, setReducer] = useState(() => reducerA);
+          const [count, dispatch] = useReducer(reducer, 0);
           if (count < 20) {
             dispatch('increment');
             // Swap reducers each time we increment
@@ -630,7 +630,7 @@ describe('ReactDOMServerHooks', () => {
         const Context = React.createContext({}, () => {});
         class Counter extends React.Component {
           render() {
-            let [count] = useContext(Context);
+            const [count] = useContext(Context);
             return <Text text={count} />;
           }
         }
@@ -705,7 +705,7 @@ describe('ReactDOMServerHooks', () => {
   );
 
   itRenders('warns when bitmask is passed to useContext', async render => {
-    let Context = React.createContext('Hi');
+    const Context = React.createContext('Hi');
 
     function Foo() {
       return <span>{useContext(Context, 1)}</span>;
@@ -815,12 +815,12 @@ describe('ReactDOMServerHooks', () => {
       const Context = React.createContext(42);
 
       function ReadInMemo(props) {
-        let count = React.useMemo(() => readContext(Context), []);
+        const count = React.useMemo(() => readContext(Context), []);
         return <Text text={count} />;
       }
 
       function ReadInReducer(props) {
-        let [count, dispatch] = React.useReducer(() => readContext(Context));
+        const [count, dispatch] = React.useReducer(() => readContext(Context));
         if (count !== 42) {
           dispatch();
         }

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -69,7 +69,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
       }
     }
 
-    let lifecycleContextLog = [];
+    const lifecycleContextLog = [];
     class LegacyClsConsumer extends React.Component {
       static contextTypes = {
         foo() {},
@@ -113,7 +113,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
   });
 
   itRenders('modern context', async render => {
-    let Ctx = React.createContext();
+    const Ctx = React.createContext();
 
     class Provider extends React.Component {
       render() {
@@ -131,7 +131,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
       }
     }
 
-    let lifecycleContextLog = [];
+    const lifecycleContextLog = [];
     class ContextTypeConsumer extends React.Component {
       static contextType = Ctx;
       shouldComponentUpdate(nextProps, nextState, nextContext) {

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
@@ -41,20 +41,20 @@ describe('ReactDOMServerIntegration', () => {
 
   describe('React.StrictMode', () => {
     itRenders('a strict mode with one child', async render => {
-      let e = await render(
+      const e = await render(
         <React.StrictMode>
           <div>text1</div>
         </React.StrictMode>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
     });
 
     itRenders('a strict mode with several children', async render => {
-      let Header = props => {
+      const Header = props => {
         return <p>header</p>;
       };
-      let Footer = props => {
+      const Footer = props => {
         return (
           <React.StrictMode>
             <h2>footer</h2>
@@ -62,7 +62,7 @@ describe('ReactDOMServerIntegration', () => {
           </React.StrictMode>
         );
       };
-      let e = await render(
+      const e = await render(
         <React.StrictMode>
           <div>text1</div>
           <span>text2</span>
@@ -70,7 +70,7 @@ describe('ReactDOMServerIntegration', () => {
           <Footer />
         </React.StrictMode>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');
@@ -79,7 +79,7 @@ describe('ReactDOMServerIntegration', () => {
     });
 
     itRenders('a nested strict mode', async render => {
-      let e = await render(
+      const e = await render(
         <React.StrictMode>
           <React.StrictMode>
             <div>text1</div>
@@ -96,7 +96,7 @@ describe('ReactDOMServerIntegration', () => {
           </React.StrictMode>
         </React.StrictMode>,
       );
-      let parent = e.parentNode;
+      const parent = e.parentNode;
       expect(parent.childNodes[0].tagName).toBe('DIV');
       expect(parent.childNodes[1].tagName).toBe('SPAN');
       expect(parent.childNodes[2].tagName).toBe('P');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -287,7 +287,7 @@ describe('ReactDOMServerIntegration', () => {
           </Language.Consumer>
         </div>
       );
-      let e = await render(<App />);
+      const e = await render(<App />);
       expect(e.querySelector('#theme1').textContent).toBe('dark');
       expect(e.querySelector('#theme2').textContent).toBe('light');
       expect(e.querySelector('#theme3').textContent).toBe('blue');
@@ -442,11 +442,11 @@ describe('ReactDOMServerIntegration', () => {
         </CurrentIndex.Provider>
       );
 
-      let streams = [];
+      const streams = [];
 
       // Test with more than 32 streams to test that growing the thread count
       // works properly.
-      let streamCount = 34;
+      const streamCount = 34;
 
       for (let i = 0; i < streamCount; i++) {
         streams[i] = ReactDOMServer.renderToNodeStream(

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -139,7 +139,7 @@ function runTests(itRenders, itRejectsRendering, expectToReject) {
   );
 
   it('rejects a javascript protocol href if it is added during an update', () => {
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<a href="thisisfine">click me</a>, container);
     expectToReject(() => {
       ReactDOM.render(<a href="javascript:notfine">click me</a>, container);
@@ -244,7 +244,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
     }
 
     let toStringCalls = 0;
-    let firstIsSafe = {
+    const firstIsSafe = {
       toString() {
         // This tries to avoid the validation by pretending to be safe
         // the first times it is called and then becomes dangerous.
@@ -262,7 +262,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', (
   });
 
   it('rejects a javascript protocol href if it is added during an update twice', () => {
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     ReactDOM.render(<a href="thisisfine">click me</a>, container);
     expectToReject(() => {
       ReactDOM.render(<a href="javascript:notfine">click me</a>, container);

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -96,8 +96,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('hydrates a parent even if a child Suspense boundary is blocked', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -123,17 +123,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // this may have suspense points on the server but here we want
     // to test the completed HTML. Don't suspend on the server.
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -154,7 +154,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('calls the hydration callbacks after hydration or deletion', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
     function Child() {
       if (suspend) {
         throw promise;
@@ -164,7 +164,7 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     let suspend2 = false;
-    let promise2 = new Promise(() => {});
+    const promise2 = new Promise(() => {});
     function Child2() {
       if (suspend2) {
         throw promise2;
@@ -191,19 +191,19 @@ describe('ReactDOMServerPartialHydration', () => {
     // to test the completed HTML. Don't suspend on the server.
     suspend = false;
     suspend2 = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let hydrated = [];
-    let deleted = [];
+    const hydrated = [];
+    const deleted = [];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
     suspend2 = true;
-    let root = ReactDOM.createRoot(container, {
+    const root = ReactDOM.createRoot(container, {
       hydrate: true,
       hydrationOptions: {
         onHydrated(node) {
@@ -243,7 +243,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('calls the onDeleted hydration callback if the parent gets deleted', async () => {
     let suspend = false;
-    let promise = new Promise(() => {});
+    const promise = new Promise(() => {});
     function Child() {
       if (suspend) {
         throw promise;
@@ -266,17 +266,17 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let deleted = [];
+    const deleted = [];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {
+    const root = ReactDOM.createRoot(container, {
       hydrate: true,
       hydrationOptions: {
         onDeleted(node) {
@@ -301,8 +301,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('warns and replaces the boundary content in legacy mode', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -326,12 +326,12 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Don't suspend on the server.
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we try to hydrate.
     suspend = true;
@@ -353,7 +353,7 @@ describe('ReactDOMServerPartialHydration', () => {
     // We're now in loading state.
     expect(container.textContent).toBe('Loading...');
 
-    let span2 = container.getElementsByTagName('span')[0];
+    const span2 = container.getElementsByTagName('span')[0];
     // This is a new node.
     expect(span).not.toBe(span2);
     expect(ref.current).toBe(span2);
@@ -371,7 +371,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('can insert siblings before the dehydrated boundary', () => {
     let suspend = false;
-    let promise = new Promise(() => {});
+    const promise = new Promise(() => {});
     let showSibling;
 
     function Child() {
@@ -383,7 +383,7 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     function Sibling() {
-      let [visible, setVisibilty] = React.useState(false);
+      const [visible, setVisibilty] = React.useState(false);
       showSibling = () => setVisibilty(true);
       if (visible) {
         return <div>First</div>;
@@ -405,8 +405,8 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
@@ -414,7 +414,7 @@ describe('ReactDOMServerPartialHydration', () => {
     suspend = true;
 
     act(() => {
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
     });
 
@@ -429,7 +429,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('can delete the dehydrated boundary before it is hydrated', () => {
     let suspend = false;
-    let promise = new Promise(() => {});
+    const promise = new Promise(() => {});
     let hideMiddle;
 
     function Child() {
@@ -446,7 +446,7 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     function App() {
-      let [visible, setVisibilty] = React.useState(true);
+      const [visible, setVisibilty] = React.useState(true);
       hideMiddle = () => setVisibilty(false);
 
       return (
@@ -463,15 +463,15 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
     act(() => {
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
     });
 
@@ -486,8 +486,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('blocks updates to hydrate the content first if props have changed', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({text}) {
       if (suspend) {
@@ -510,18 +510,18 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <App text="Hello" className="hello" />,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App text="Hello" className="hello" />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -543,7 +543,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // The new span should be the same since we should have successfully hydrated
     // before changing it.
-    let newSpan = container.getElementsByTagName('span')[0];
+    const newSpan = container.getElementsByTagName('span')[0];
     expect(span).toBe(newSpan);
 
     // We should now have fully rendered with a ref on the new span.
@@ -557,8 +557,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('shows the fallback if props have changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({text}) {
       if (suspend) {
@@ -581,16 +581,16 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <App text="Hello" className="hello" />,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App text="Hello" className="hello" />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -616,7 +616,7 @@ describe('ReactDOMServerPartialHydration', () => {
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(span.textContent).toBe('Hi');
     expect(span.className).toBe('hi');
     expect(ref.current).toBe(span);
@@ -628,8 +628,8 @@ describe('ReactDOMServerPartialHydration', () => {
     // This should be a noop.
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({text}) {
       if (suspend) {
@@ -654,16 +654,16 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <App text="Hello" className="hello" />,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App text="Hello" className="hello" />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -689,7 +689,7 @@ describe('ReactDOMServerPartialHydration', () => {
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(span.textContent).toBe('Hi');
     expect(span.className).toBe('hi');
     expect(ref.current).toBe(span);
@@ -699,8 +699,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('clears nested suspense boundaries if they did not hydrate yet', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({text}) {
       if (suspend) {
@@ -726,16 +726,16 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <App text="Hello" className="hello" />,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App text="Hello" className="hello" />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -761,7 +761,7 @@ describe('ReactDOMServerPartialHydration', () => {
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(span.textContent).toBe('Hi');
     expect(span.className).toBe('hi');
     expect(ref.current).toBe(span);
@@ -771,8 +771,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('hydrates first if props changed but we are able to resolve within a timeout', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({text}) {
       if (suspend) {
@@ -795,18 +795,18 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <App text="Hello" className="hello" />,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App text="Hello" className="hello" />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -837,7 +837,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // The new span should be the same since we should have successfully hydrated
     // before changing it.
-    let newSpan = container.getElementsByTagName('span')[0];
+    const newSpan = container.getElementsByTagName('span')[0];
     expect(span).toBe(newSpan);
 
     // We should now have fully rendered with a ref on the new span.
@@ -851,12 +851,12 @@ describe('ReactDOMServerPartialHydration', () => {
   it('blocks the update to hydrate first if context has changed', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
-    let Context = React.createContext(null);
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+    const Context = React.createContext(null);
 
     function Child() {
-      let {text, className} = React.useContext(Context);
+      const {text, className} = React.useContext(Context);
       if (suspend) {
         throw promise;
       } else {
@@ -879,20 +879,20 @@ describe('ReactDOMServerPartialHydration', () => {
     });
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <Context.Provider value={{text: 'Hello', className: 'hello'}}>
         <App />
       </Context.Provider>,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(
       <Context.Provider value={{text: 'Hello', className: 'hello'}}>
         <App />
@@ -921,7 +921,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // Since this should have been hydrated, this should still be the same span.
-    let newSpan = container.getElementsByTagName('span')[0];
+    const newSpan = container.getElementsByTagName('span')[0];
     expect(newSpan).toBe(span);
 
     // We should now have fully rendered with a ref on the new span.
@@ -935,12 +935,12 @@ describe('ReactDOMServerPartialHydration', () => {
   it('shows the fallback if context has changed before hydration completes and is still suspended', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
-    let Context = React.createContext(null);
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
+    const Context = React.createContext(null);
 
     function Child() {
-      let {text, className} = React.useContext(Context);
+      const {text, className} = React.useContext(Context);
       if (suspend) {
         throw promise;
       } else {
@@ -963,18 +963,18 @@ describe('ReactDOMServerPartialHydration', () => {
     });
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <Context.Provider value={{text: 'Hello', className: 'hello'}}>
         <App />
       </Context.Provider>,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(
       <Context.Provider value={{text: 'Hello', className: 'hello'}}>
         <App />
@@ -1008,7 +1008,7 @@ describe('ReactDOMServerPartialHydration', () => {
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(span.textContent).toBe('Hi');
     expect(span.className).toBe('hi');
     expect(ref.current).toBe(span);
@@ -1017,8 +1017,8 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('replaces the fallback with client content if it is not rendered by the server', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1044,29 +1044,29 @@ describe('ReactDOMServerPartialHydration', () => {
     // this may have suspense points on the server but here we want
     // to test the completed HTML. Don't suspend on the server.
     suspend = true;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     expect(container.getElementsByTagName('span').length).toBe(0);
 
     // On the client we have the data available quickly for some reason.
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 
     expect(container.textContent).toBe('Hello');
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(ref.current).toBe(span);
   });
 
   it('replaces the fallback within the suspended time if there is a nested suspense', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1100,15 +1100,15 @@ describe('ReactDOMServerPartialHydration', () => {
     // this may have suspense points on the server but here we want
     // to test the completed HTML. Don't suspend on the server.
     suspend = true;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     expect(container.getElementsByTagName('span').length).toBe(0);
 
     // On the client we have the data available quickly for some reason.
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     // This will have exceeded the suspended time so we should timeout.
@@ -1118,14 +1118,14 @@ describe('ReactDOMServerPartialHydration', () => {
 
     expect(container.textContent).toBe('Hello');
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(ref.current).toBe(span);
   });
 
   it('replaces the fallback within the suspended time if there is a nested suspense in a nested suspense', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1161,15 +1161,15 @@ describe('ReactDOMServerPartialHydration', () => {
     // this may have suspense points on the server but here we want
     // to test the completed HTML. Don't suspend on the server.
     suspend = true;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     expect(container.getElementsByTagName('span').length).toBe(0);
 
     // On the client we have the data available quickly for some reason.
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     // This will have exceeded the suspended time so we should timeout.
@@ -1179,14 +1179,14 @@ describe('ReactDOMServerPartialHydration', () => {
 
     expect(container.textContent).toBe('Hello');
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
     expect(ref.current).toBe(span);
   });
 
   it('waits for pending content to come in from the server and then hydrates it', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1212,15 +1212,15 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // First we generate the HTML of the loading state.
     suspend = true;
-    let loadingHTML = ReactDOMServer.renderToString(<App />);
+    const loadingHTML = ReactDOMServer.renderToString(<App />);
     // Then we generate the HTML of the final content.
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = loadingHTML;
 
-    let suspenseNode = container.firstChild.firstChild;
+    const suspenseNode = container.firstChild.firstChild;
     expect(suspenseNode.nodeType).toBe(8);
     // Put the suspense node in hydration state.
     suspenseNode.data = '$?';
@@ -1228,11 +1228,11 @@ describe('ReactDOMServerPartialHydration', () => {
     // This will simulates new content streaming into the document and
     // replacing the fallback with final content.
     function streamInContent() {
-      let temp = document.createElement('div');
+      const temp = document.createElement('div');
       temp.innerHTML = finalHTML;
-      let finalSuspenseNode = temp.firstChild.firstChild;
-      let fallbackContent = suspenseNode.nextSibling;
-      let finalContent = finalSuspenseNode.nextSibling;
+      const finalSuspenseNode = temp.firstChild.firstChild;
+      const fallbackContent = suspenseNode.nextSibling;
+      const finalContent = finalSuspenseNode.nextSibling;
       suspenseNode.parentNode.replaceChild(finalContent, fallbackContent);
       suspenseNode.data = '$';
       if (suspenseNode._reactRetry) {
@@ -1245,7 +1245,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Attempt to hydrate the content.
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -1258,7 +1258,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // The final HTML is now in place.
     expect(container.textContent).toBe('Hello');
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // But it is not yet hydrated.
     expect(ref.current).toBe(null);
@@ -1272,8 +1272,8 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('handles an error on the client if the server ends up erroring', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1314,12 +1314,12 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // First we generate the HTML of the loading state.
     suspend = true;
-    let loadingHTML = ReactDOMServer.renderToString(<App />);
+    const loadingHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = loadingHTML;
 
-    let suspenseNode = container.firstChild.firstChild;
+    const suspenseNode = container.firstChild.firstChild;
     expect(suspenseNode.nodeType).toBe(8);
     // Put the suspense node in hydration state.
     suspenseNode.data = '$?';
@@ -1338,7 +1338,7 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Attempt to hydrate the content.
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -1360,15 +1360,15 @@ describe('ReactDOMServerPartialHydration', () => {
     // Hydrating should've generated an error and replaced the suspense boundary.
     expect(container.textContent).toBe('Error Message');
 
-    let div = container.getElementsByTagName('div')[0];
+    const div = container.getElementsByTagName('div')[0];
     expect(ref.current).toBe(div);
   });
 
   it('shows inserted items in a SuspenseList before content is hydrated', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({children}) {
       if (suspend) {
@@ -1409,14 +1409,14 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let html = ReactDOMServer.renderToString(<App showMore={false} />);
+    const html = ReactDOMServer.renderToString(<App showMore={false} />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = html;
 
-    let spanB = container.getElementsByTagName('span')[1];
+    const spanB = container.getElementsByTagName('span')[1];
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
 
     suspend = true;
     act(() => {
@@ -1452,8 +1452,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('shows is able to hydrate boundaries even if others in a list are pending', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({children}) {
       if (suspend) {
@@ -1463,7 +1463,7 @@ describe('ReactDOMServerPartialHydration', () => {
       }
     }
 
-    let promise2 = new Promise(() => {});
+    const promise2 = new Promise(() => {});
     function AlwaysSuspend() {
       throw promise2;
     }
@@ -1491,14 +1491,14 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let html = ReactDOMServer.renderToString(<App showMore={false} />);
+    const html = ReactDOMServer.renderToString(<App showMore={false} />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = html;
 
-    let spanA = container.getElementsByTagName('span')[0];
+    const spanA = container.getElementsByTagName('span')[0];
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
 
     suspend = true;
     act(() => {
@@ -1526,8 +1526,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('shows inserted items before pending in a SuspenseList as fallbacks', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child({children}) {
       if (suspend) {
@@ -1568,17 +1568,17 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let html = ReactDOMServer.renderToString(<App showMore={false} />);
+    const html = ReactDOMServer.renderToString(<App showMore={false} />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = html;
 
-    let suspenseNode = container.firstChild;
+    const suspenseNode = container.firstChild;
     expect(suspenseNode.nodeType).toBe(8);
     // Put the suspense node in pending state.
     suspenseNode.data = '$?';
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
 
     suspend = true;
     act(() => {
@@ -1616,8 +1616,8 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('can client render nested boundaries', async () => {
     let suspend = false;
-    let promise = new Promise(() => {});
-    let ref = React.createRef();
+    const promise = new Promise(() => {});
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -1647,15 +1647,15 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = true;
-    let html = ReactDOMServer.renderToString(<App />);
+    const html = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = html + '<!--unrelated comment-->';
 
-    let span = container.getElementsByTagName('span')[1];
+    const span = container.getElementsByTagName('span')[1];
 
     suspend = false;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -1669,8 +1669,8 @@ describe('ReactDOMServerPartialHydration', () => {
   });
 
   it('can hydrate TWO suspense boundaries', async () => {
-    let ref1 = React.createRef();
-    let ref2 = React.createRef();
+    const ref1 = React.createRef();
+    const ref2 = React.createRef();
 
     function App() {
       return (
@@ -1688,17 +1688,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // First we render the final HTML. With the streaming renderer
     // this may have suspense points on the server but here we want
     // to test the completed HTML. Don't suspend on the server.
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span1 = container.getElementsByTagName('span')[0];
-    let span2 = container.getElementsByTagName('span')[1];
+    const span1 = container.getElementsByTagName('span')[0];
+    const span2 = container.getElementsByTagName('span')[1];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -1709,12 +1709,12 @@ describe('ReactDOMServerPartialHydration', () => {
 
   it('regenerates if it cannot hydrate before changes to props/context expire', async () => {
     let suspend = false;
-    let promise = new Promise(resolvePromise => {});
-    let ref = React.createRef();
-    let ClassName = React.createContext(null);
+    const promise = new Promise(resolvePromise => {});
+    const ref = React.createRef();
+    const ClassName = React.createContext(null);
 
     function Child({text}) {
-      let className = React.useContext(ClassName);
+      const className = React.useContext(ClassName);
       if (suspend && className !== 'hi' && text !== 'Hi') {
         // Never suspends on the newer data.
         throw promise;
@@ -1738,20 +1738,20 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(
+    const finalHTML = ReactDOMServer.renderToString(
       <ClassName.Provider value={'hello'}>
         <App text="Hello" />
       </ClassName.Provider>,
     );
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(
       <ClassName.Provider value={'hello'}>
         <App text="Hello" />
@@ -1777,7 +1777,7 @@ describe('ReactDOMServerPartialHydration', () => {
     jest.runAllTimers();
 
     // This will now be a new span because we weren't able to hydrate before
-    let newSpan = container.getElementsByTagName('span')[0];
+    const newSpan = container.getElementsByTagName('span')[0];
     expect(newSpan).not.toBe(span);
 
     // We should now have fully rendered with a ref on the new span.
@@ -1791,7 +1791,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('does not invoke an event on a hydrated node until it commits', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Sibling({text}) {
       if (suspend) {
@@ -1804,7 +1804,7 @@ describe('ReactDOMServerPartialHydration', () => {
     let clicks = 0;
 
     function Button() {
-      let [clicked, setClicked] = React.useState(false);
+      const [clicked, setClicked] = React.useState(false);
       if (clicked) {
         return null;
       }
@@ -1831,19 +1831,19 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let a = container.getElementsByTagName('a')[0];
+    const a = container.getElementsByTagName('a')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -1872,7 +1872,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('does not invoke an event on a hydrated EventResponder until it commits', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Sibling({text}) {
       if (suspend) {
@@ -1892,7 +1892,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
 
     function Button() {
-      let listener = React.DEPRECATED_useResponder(TestResponder, {});
+      const listener = React.DEPRECATED_useResponder(TestResponder, {});
       return <a DEPRECATED_flareListeners={listener}>Click me</a>;
     }
 
@@ -1908,19 +1908,19 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let a = container.getElementsByTagName('a')[0];
+    const a = container.getElementsByTagName('a')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // We'll do one click before hydrating.
@@ -1953,7 +1953,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('invokes discrete events on nested suspense boundaries in a root (legacy system)', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     let clicks = 0;
 
@@ -1989,19 +1989,19 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let a = container.getElementsByTagName('a')[0];
+    const a = container.getElementsByTagName('a')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // We'll do one click before hydrating.
@@ -2032,7 +2032,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('invokes discrete events on nested suspense boundaries in a root (responder system)', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     const onEvent = jest.fn();
     const TestResponder = React.DEPRECATED_createResponder(
@@ -2044,7 +2044,7 @@ describe('ReactDOMServerPartialHydration', () => {
     );
 
     function Button() {
-      let listener = React.DEPRECATED_useResponder(TestResponder, {});
+      const listener = React.DEPRECATED_useResponder(TestResponder, {});
       return <a DEPRECATED_flareListeners={listener}>Click me</a>;
     }
 
@@ -2069,19 +2069,19 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let a = container.getElementsByTagName('a')[0];
+    const a = container.getElementsByTagName('a')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // We'll do one click before hydrating.
@@ -2114,7 +2114,7 @@ describe('ReactDOMServerPartialHydration', () => {
   it('does not invoke the parent of dehydrated boundary event', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     let clicksOnParent = 0;
     let clicksOnChild = 0;
@@ -2148,19 +2148,19 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let span = container.getElementsByTagName('span')[0];
+    const span = container.getElementsByTagName('span')[0];
 
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
@@ -2188,10 +2188,10 @@ describe('ReactDOMServerPartialHydration', () => {
   it('does not invoke an event on a parent tree when a subtree is dehydrated', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     let clicks = 0;
-    let childSlotRef = React.createRef();
+    const childSlotRef = React.createRef();
 
     function Parent() {
       return <div onClick={() => clicks++} ref={childSlotRef} />;
@@ -2215,17 +2215,17 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
-    let parentContainer = document.createElement('div');
-    let childContainer = document.createElement('div');
+    const parentContainer = document.createElement('div');
+    const childContainer = document.createElement('div');
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(parentContainer);
 
     // We're going to use a different root as a parent.
     // This lets us detect whether an event goes through React's event system.
-    let parentRoot = ReactDOM.createRoot(parentContainer);
+    const parentRoot = ReactDOM.createRoot(parentContainer);
     parentRoot.render(<Parent />);
     Scheduler.unstable_flushAll();
 
@@ -2233,12 +2233,12 @@ describe('ReactDOMServerPartialHydration', () => {
 
     childContainer.innerHTML = finalHTML;
 
-    let a = childContainer.getElementsByTagName('a')[0];
+    const a = childContainer.getElementsByTagName('a')[0];
 
     suspend = true;
 
     // Hydrate asynchronously.
-    let root = ReactDOM.createRoot(childContainer, {hydrate: true});
+    const root = ReactDOM.createRoot(childContainer, {hydrate: true});
     root.render(<App />);
     jest.runAllTimers();
     Scheduler.unstable_flushAll();
@@ -2265,10 +2265,10 @@ describe('ReactDOMServerPartialHydration', () => {
   it('blocks only on the last continuous event (legacy system)', async () => {
     let suspend1 = false;
     let resolve1;
-    let promise1 = new Promise(resolvePromise => (resolve1 = resolvePromise));
+    const promise1 = new Promise(resolvePromise => (resolve1 = resolvePromise));
     let suspend2 = false;
     let resolve2;
-    let promise2 = new Promise(resolvePromise => (resolve2 = resolvePromise));
+    const promise2 = new Promise(resolvePromise => (resolve2 = resolvePromise));
 
     function First({text}) {
       if (suspend1) {
@@ -2286,7 +2286,7 @@ describe('ReactDOMServerPartialHydration', () => {
       }
     }
 
-    let ops = [];
+    const ops = [];
 
     function App() {
       return (
@@ -2311,16 +2311,16 @@ describe('ReactDOMServerPartialHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
-    let container = document.createElement('div');
+    const finalHTML = ReactDOMServer.renderToString(<App />);
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let appDiv = container.getElementsByTagName('div')[0];
-    let firstSpan = appDiv.getElementsByTagName('span')[0];
-    let secondSpan = appDiv.getElementsByTagName('span')[1];
+    const appDiv = container.getElementsByTagName('div')[0];
+    const firstSpan = appDiv.getElementsByTagName('span')[0];
+    const secondSpan = appDiv.getElementsByTagName('span')[1];
     expect(firstSpan.textContent).toBe('');
     expect(secondSpan.textContent).toBe('World');
 
@@ -2328,7 +2328,7 @@ describe('ReactDOMServerPartialHydration', () => {
     // hydrating anyway.
     suspend1 = true;
     suspend2 = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     Scheduler.unstable_flushAll();
@@ -2372,10 +2372,14 @@ describe('ReactDOMServerPartialHydration', () => {
 
       let suspend1 = false;
       let resolve1;
-      let promise1 = new Promise(resolvePromise => (resolve1 = resolvePromise));
+      const promise1 = new Promise(
+        resolvePromise => (resolve1 = resolvePromise),
+      );
       let suspend2 = false;
       let resolve2;
-      let promise2 = new Promise(resolvePromise => (resolve2 = resolvePromise));
+      const promise2 = new Promise(
+        resolvePromise => (resolve2 = resolvePromise),
+      );
 
       function First({text}) {
         if (suspend1) {
@@ -2393,7 +2397,7 @@ describe('ReactDOMServerPartialHydration', () => {
         }
       }
 
-      let ops = [];
+      const ops = [];
 
       function App() {
         const listener1 = useHover({
@@ -2429,16 +2433,16 @@ describe('ReactDOMServerPartialHydration', () => {
         );
       }
 
-      let finalHTML = ReactDOMServer.renderToString(<App />);
-      let container = document.createElement('div');
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      const container = document.createElement('div');
       container.innerHTML = finalHTML;
 
       // We need this to be in the document since we'll dispatch events on it.
       document.body.appendChild(container);
 
-      let appDiv = container.getElementsByTagName('div')[0];
-      let firstSpan = appDiv.getElementsByTagName('span')[0];
-      let secondSpan = appDiv.getElementsByTagName('span')[1];
+      const appDiv = container.getElementsByTagName('div')[0];
+      const firstSpan = appDiv.getElementsByTagName('span')[0];
+      const secondSpan = appDiv.getElementsByTagName('span')[1];
       expect(firstSpan.textContent).toBe('');
       expect(secondSpan.textContent).toBe('World');
 
@@ -2446,7 +2450,7 @@ describe('ReactDOMServerPartialHydration', () => {
       // hydrating anyway.
       suspend1 = true;
       suspend2 = true;
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
 
       Scheduler.unstable_flushAll();
@@ -2488,8 +2492,8 @@ describe('ReactDOMServerPartialHydration', () => {
   it('finishes normal pri work before continuing to hydrate a retry', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-    let ref = React.createRef();
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const ref = React.createRef();
 
     function Child() {
       if (suspend) {
@@ -2527,14 +2531,14 @@ describe('ReactDOMServerPartialHydration', () => {
     }
 
     suspend = false;
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
     expect(Scheduler).toHaveYielded(['Child']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     suspend = true;
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App showSibling={false} />);
     expect(Scheduler).toFlushAndYield([]);
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -95,7 +95,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
   beforeEach(() => {
     jest.resetModuleRegistry();
 
-    let ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableDeprecatedFlareAPI = true;
     ReactFeatureFlags.debugRenderPhaseSideEffectsForStrictMode = false;
 
@@ -140,19 +140,19 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
     container.innerHTML = finalHTML;
 
-    let span = container.getElementsByTagName('span')[1];
+    const span = container.getElementsByTagName('span')[1];
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
@@ -160,7 +160,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
     // This should synchronously hydrate the root App and the second suspense
     // boundary.
-    let result = dispatchClickEvent(span);
+    const result = dispatchClickEvent(span);
 
     // The event should have been canceled because we called preventDefault.
     expect(result).toBe(false);
@@ -177,7 +177,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
   it('hydrates at higher pri if sync did not work first time', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Child({text}) {
       if ((text === 'A' || text === 'D') && suspend) {
@@ -215,30 +215,30 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
     container.innerHTML = finalHTML;
 
-    let spanD = container.getElementsByTagName('span')[3];
+    const spanD = container.getElementsByTagName('span')[3];
 
     suspend = true;
 
     // A and D will be suspended. We'll click on D which should take
     // priority, after we unsuspend.
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
     expect(Scheduler).toHaveYielded([]);
 
     // This click target cannot be hydrated yet because it's suspended.
-    let result = dispatchClickEvent(spanD);
+    const result = dispatchClickEvent(spanD);
 
     expect(Scheduler).toHaveYielded(['App']);
 
@@ -261,7 +261,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
   it('hydrates at higher pri for secondary discrete events', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Child({text}) {
       if ((text === 'A' || text === 'D') && suspend) {
@@ -299,25 +299,25 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
     container.innerHTML = finalHTML;
 
-    let spanA = container.getElementsByTagName('span')[0];
-    let spanC = container.getElementsByTagName('span')[2];
-    let spanD = container.getElementsByTagName('span')[3];
+    const spanA = container.getElementsByTagName('span')[0];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
 
     suspend = true;
 
     // A and D will be suspended. We'll click on D which should take
     // priority, after we unsuspend.
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
@@ -352,7 +352,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
   if (__EXPERIMENTAL__) {
     it('hydrates the target boundary synchronously during a click (flare)', async () => {
-      let usePress = require('react-interactions/events/press').usePress;
+      const usePress = require('react-interactions/events/press').usePress;
 
       function Child({text}) {
         Scheduler.unstable_yieldValue(text);
@@ -379,29 +379,29 @@ describe('ReactDOMServerSelectiveHydration', () => {
         );
       }
 
-      let finalHTML = ReactDOMServer.renderToString(<App />);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
 
       expect(Scheduler).toHaveYielded(['App', 'A', 'B']);
 
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       // We need this to be in the document since we'll dispatch events on it.
       document.body.appendChild(container);
 
       container.innerHTML = finalHTML;
 
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
 
       // Nothing has been hydrated so far.
       expect(Scheduler).toHaveYielded([]);
 
-      let span = container.getElementsByTagName('span')[1];
+      const span = container.getElementsByTagName('span')[1];
 
-      let target = createEventTarget(span);
+      const target = createEventTarget(span);
 
       // This should synchronously hydrate the root App and the second suspense
       // boundary.
-      let preventDefault = jest.fn();
+      const preventDefault = jest.fn();
       target.virtualclick({preventDefault});
 
       // The event should have been canceled because we called preventDefault.
@@ -417,10 +417,10 @@ describe('ReactDOMServerSelectiveHydration', () => {
     });
 
     it('hydrates at higher pri if sync did not work first time (flare)', async () => {
-      let usePress = require('react-interactions/events/press').usePress;
+      const usePress = require('react-interactions/events/press').usePress;
       let suspend = false;
       let resolve;
-      let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+      const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
       function Child({text}) {
         if ((text === 'A' || text === 'D') && suspend) {
@@ -456,30 +456,30 @@ describe('ReactDOMServerSelectiveHydration', () => {
         );
       }
 
-      let finalHTML = ReactDOMServer.renderToString(<App />);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
 
       expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       // We need this to be in the document since we'll dispatch events on it.
       document.body.appendChild(container);
 
       container.innerHTML = finalHTML;
 
-      let spanD = container.getElementsByTagName('span')[3];
+      const spanD = container.getElementsByTagName('span')[3];
 
       suspend = true;
 
       // A and D will be suspended. We'll click on D which should take
       // priority, after we unsuspend.
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
 
       // Nothing has been hydrated so far.
       expect(Scheduler).toHaveYielded([]);
 
       // This click target cannot be hydrated yet because it's suspended.
-      let result = dispatchClickEvent(spanD);
+      const result = dispatchClickEvent(spanD);
 
       expect(Scheduler).toHaveYielded(['App']);
 
@@ -500,10 +500,10 @@ describe('ReactDOMServerSelectiveHydration', () => {
     });
 
     it('hydrates at higher pri for secondary discrete events (flare)', async () => {
-      let usePress = require('react-interactions/events/press').usePress;
+      const usePress = require('react-interactions/events/press').usePress;
       let suspend = false;
       let resolve;
-      let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+      const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
       function Child({text}) {
         if ((text === 'A' || text === 'D') && suspend) {
@@ -539,25 +539,25 @@ describe('ReactDOMServerSelectiveHydration', () => {
         );
       }
 
-      let finalHTML = ReactDOMServer.renderToString(<App />);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
 
       expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       // We need this to be in the document since we'll dispatch events on it.
       document.body.appendChild(container);
 
       container.innerHTML = finalHTML;
 
-      let spanA = container.getElementsByTagName('span')[0];
-      let spanC = container.getElementsByTagName('span')[2];
-      let spanD = container.getElementsByTagName('span')[3];
+      const spanA = container.getElementsByTagName('span')[0];
+      const spanC = container.getElementsByTagName('span')[2];
+      const spanD = container.getElementsByTagName('span')[3];
 
       suspend = true;
 
       // A and D will be suspended. We'll click on D which should take
       // priority, after we unsuspend.
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<App />);
 
       // Nothing has been hydrated so far.
@@ -594,7 +594,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
   it('hydrates the hovered targets as higher priority for continuous events', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Child({text}) {
       if ((text === 'A' || text === 'D') && suspend) {
@@ -636,25 +636,25 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
     container.innerHTML = finalHTML;
 
-    let spanB = container.getElementsByTagName('span')[1];
-    let spanC = container.getElementsByTagName('span')[2];
-    let spanD = container.getElementsByTagName('span')[3];
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
 
     suspend = true;
 
     // A and D will be suspended. We'll click on D which should take
     // priority, after we unsuspend.
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
@@ -694,7 +694,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
   it('hydrates the last target path first for continuous events', async () => {
     let suspend = false;
     let resolve;
-    let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+    const promise = new Promise(resolvePromise => (resolve = resolvePromise));
 
     function Child({text}) {
       if ((text === 'A' || text === 'D') && suspend) {
@@ -734,25 +734,25 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C', 'D']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
     container.innerHTML = finalHTML;
 
-    let spanB = container.getElementsByTagName('span')[1];
-    let spanC = container.getElementsByTagName('span')[2];
-    let spanD = container.getElementsByTagName('span')[3];
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
+    const spanD = container.getElementsByTagName('span')[3];
 
     suspend = true;
 
     // A and D will be suspended. We'll click on D which should take
     // priority, after we unsuspend.
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
@@ -799,17 +799,17 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App />);
+    const finalHTML = ReactDOMServer.renderToString(<App />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'B', 'C']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
-    let spanB = container.getElementsByTagName('span')[1];
-    let spanC = container.getElementsByTagName('span')[2];
+    const spanB = container.getElementsByTagName('span')[1];
+    const spanC = container.getElementsByTagName('span')[2];
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     root.render(<App />);
 
     // Nothing has been hydrated so far.
@@ -829,7 +829,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       Scheduler.unstable_yieldValue(text);
       return <span>{text}</span>;
     }
-    let ChildWithBoundary = React.memo(function({text}) {
+    const ChildWithBoundary = React.memo(function({text}) {
       return (
         <Suspense fallback="Loading...">
           <Child text={text} />
@@ -852,21 +852,21 @@ describe('ReactDOMServerSelectiveHydration', () => {
       );
     }
 
-    let finalHTML = ReactDOMServer.renderToString(<App a="A" />);
+    const finalHTML = ReactDOMServer.renderToString(<App a="A" />);
 
     expect(Scheduler).toHaveYielded(['App', 'A', 'a', 'B', 'b', 'C', 'c']);
 
-    let container = document.createElement('div');
+    const container = document.createElement('div');
     container.innerHTML = finalHTML;
 
     // We need this to be in the document since we'll dispatch events on it.
     document.body.appendChild(container);
 
-    let spanA = container.getElementsByTagName('span')[0];
-    let spanB = container.getElementsByTagName('span')[2];
-    let spanC = container.getElementsByTagName('span')[4];
+    const spanA = container.getElementsByTagName('span')[0];
+    const spanB = container.getElementsByTagName('span')[2];
+    const spanC = container.getElementsByTagName('span')[4];
 
-    let root = ReactDOM.createRoot(container, {hydrate: true});
+    const root = ReactDOM.createRoot(container, {hydrate: true});
     ReactTestUtils.act(() => {
       root.render(<App a="A" />);
 
@@ -923,7 +923,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
       ]);
     });
 
-    let spanA2 = container.getElementsByTagName('span')[0];
+    const spanA2 = container.getElementsByTagName('span')[0];
     // This is supposed to have been hydrated, not replaced.
     expect(spanA).toBe(spanA2);
 

--- a/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSuspensePlaceholder-test.js
@@ -72,7 +72,7 @@ describe('ReactDOMSuspensePlaceholder', () => {
   }
 
   it('hides and unhides timed out DOM elements', async () => {
-    let divs = [
+    const divs = [
       React.createRef(null),
       React.createRef(null),
       React.createRef(null),
@@ -244,7 +244,7 @@ describe('ReactDOMSuspensePlaceholder', () => {
     let suspendOnce = Promise.resolve();
     function Suspend() {
       if (suspendOnce) {
-        let promise = suspendOnce;
+        const promise = suspendOnce;
         suspendOnce = null;
         throw promise;
       }

--- a/packages/react-dom/src/__tests__/ReactDOMTextComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextComponent-test.js
@@ -41,8 +41,8 @@ describe('ReactDOMTextComponent', () => {
     );
     let nodes = filterOutComments(inst.childNodes);
 
-    let foo = nodes[1];
-    let bar = nodes[2];
+    const foo = nodes[1];
+    const bar = nodes[2];
     expect(foo.data).toBe('foo');
     expect(bar.data).toBe('bar');
 
@@ -75,7 +75,7 @@ describe('ReactDOMTextComponent', () => {
     );
 
     let childNodes = filterOutComments(inst.childNodes);
-    let childDiv = childNodes[1];
+    const childDiv = childNodes[1];
 
     inst = ReactDOM.render(
       <div>
@@ -200,8 +200,8 @@ describe('ReactDOMTextComponent', () => {
       el,
     );
 
-    let childNodes = filterOutComments(inst.childNodes);
-    let textNode = childNodes[1];
+    const childNodes = filterOutComments(inst.childNodes);
+    const textNode = childNodes[1];
     textNode.textContent = 'foo';
     inst.insertBefore(
       document.createTextNode('bar'),
@@ -237,8 +237,8 @@ describe('ReactDOMTextComponent', () => {
       el,
     );
 
-    let childNodes = filterOutComments(inst.childNodes);
-    let textNode = childNodes[3];
+    const childNodes = filterOutComments(inst.childNodes);
+    const textNode = childNodes[3];
     textNode.textContent = 'foo';
     inst.insertBefore(
       document.createTextNode('bar'),
@@ -248,7 +248,7 @@ describe('ReactDOMTextComponent', () => {
       document.createTextNode('baz'),
       childNodes[3].nextSibling,
     );
-    let secondTextNode = childNodes[5];
+    const secondTextNode = childNodes[5];
     secondTextNode.textContent = 'bar';
     inst.insertBefore(
       document.createTextNode('foo'),

--- a/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js
@@ -1043,8 +1043,8 @@ describe('ReactErrorBoundaries', () => {
   });
 
   it('resets object refs if mounting aborts', () => {
-    let childRef = React.createRef();
-    let errorMessageRef = React.createRef();
+    const childRef = React.createRef();
+    const errorMessageRef = React.createRef();
 
     const container = document.createElement('div');
     ReactDOM.render(
@@ -2073,7 +2073,7 @@ describe('ReactErrorBoundaries', () => {
     let err2;
 
     try {
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       expect(() => ReactDOM.render(<X />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
@@ -2083,7 +2083,7 @@ describe('ReactErrorBoundaries', () => {
       err1 = err;
     }
     try {
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       expect(() => ReactDOM.render(<Y />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +

--- a/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
+++ b/packages/react-dom/src/__tests__/ReactErrorLoggingRecovery-test.js
@@ -39,7 +39,7 @@ class Bad extends React.Component {
 }
 
 describe('ReactErrorLoggingRecovery', () => {
-  let originalConsoleError = console.error;
+  const originalConsoleError = console.error;
 
   beforeEach(() => {
     console.error = error => {

--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -51,7 +51,7 @@ describe('ReactLegacyContextDisabled', () => {
       }
     }
 
-    let lifecycleContextLog = [];
+    const lifecycleContextLog = [];
     class LegacyClsConsumer extends React.Component {
       static contextTypes = {
         foo() {},
@@ -146,7 +146,7 @@ describe('ReactLegacyContextDisabled', () => {
   });
 
   it('renders a tree with modern context', () => {
-    let Ctx = React.createContext();
+    const Ctx = React.createContext();
 
     class Provider extends React.Component {
       render() {
@@ -164,7 +164,7 @@ describe('ReactLegacyContextDisabled', () => {
       }
     }
 
-    let lifecycleContextLog = [];
+    const lifecycleContextLog = [];
     class ContextTypeConsumer extends React.Component {
       static contextType = Ctx;
       shouldComponentUpdate(nextProps, nextState, nextContext) {

--- a/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyErrorBoundaries-test.internal.js
@@ -1093,8 +1093,8 @@ describe('ReactLegacyErrorBoundaries', () => {
   });
 
   it('resets object refs if mounting aborts', () => {
-    let childRef = React.createRef();
-    let errorMessageRef = React.createRef();
+    const childRef = React.createRef();
+    const errorMessageRef = React.createRef();
 
     const container = document.createElement('div');
     ReactDOM.render(
@@ -2080,7 +2080,7 @@ describe('ReactLegacyErrorBoundaries', () => {
     let err2;
 
     try {
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       expect(() => ReactDOM.render(<X />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +
@@ -2090,7 +2090,7 @@ describe('ReactLegacyErrorBoundaries', () => {
       err1 = err;
     }
     try {
-      let container = document.createElement('div');
+      const container = document.createElement('div');
       expect(() => ReactDOM.render(<Y />, container)).toErrorDev(
         'React.createElement: type is invalid -- expected a string ' +
           '(for built-in components) or a class/function ' +

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -14,7 +14,7 @@ let React;
 let ReactDOMServer;
 let PropTypes;
 let ReactCurrentDispatcher;
-let enableSuspenseServerRenderer = require('shared/ReactFeatureFlags')
+const enableSuspenseServerRenderer = require('shared/ReactFeatureFlags')
   .enableSuspenseServerRenderer;
 
 function normalizeCodeLocInfo(str) {

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -494,10 +494,10 @@ describe('ReactDOMServerHydration', () => {
   it.experimental(
     'does not re-enter hydration after committing the first one',
     () => {
-      let finalHTML = ReactDOMServer.renderToString(<div />);
-      let container = document.createElement('div');
+      const finalHTML = ReactDOMServer.renderToString(<div />);
+      const container = document.createElement('div');
       container.innerHTML = finalHTML;
-      let root = ReactDOM.createRoot(container, {hydrate: true});
+      const root = ReactDOM.createRoot(container, {hydrate: true});
       root.render(<div />);
       Scheduler.unstable_flushAll();
       root.render(null);
@@ -512,8 +512,8 @@ describe('ReactDOMServerHydration', () => {
   it('Suspense + hydration in legacy mode', () => {
     const element = document.createElement('div');
     element.innerHTML = '<div>Hello World</div>';
-    let div = element.firstChild;
-    let ref = React.createRef();
+    const div = element.firstChild;
+    const ref = React.createRef();
     expect(() =>
       ReactDOM.hydrate(
         <React.Suspense fallback={null}>
@@ -536,8 +536,8 @@ describe('ReactDOMServerHydration', () => {
   it('Suspense + hydration in legacy mode with no fallback', () => {
     const element = document.createElement('div');
     element.innerHTML = '<div>Hello World</div>';
-    let div = element.firstChild;
-    let ref = React.createRef();
+    const div = element.firstChild;
+    const ref = React.createRef();
     ReactDOM.hydrate(
       <React.Suspense>
         <div ref={ref}>Hello World</div>

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -186,7 +186,7 @@ function runActTests(label, render, unmount, rerender) {
 
       it('flushes effects on every call', () => {
         function App() {
-          let [ctr, setCtr] = React.useState(0);
+          const [ctr, setCtr] = React.useState(0);
           React.useEffect(() => {
             Scheduler.unstable_yieldValue(ctr);
           });
@@ -222,7 +222,7 @@ function runActTests(label, render, unmount, rerender) {
 
       it("should keep flushing effects until the're done", () => {
         function App() {
-          let [ctr, setCtr] = React.useState(0);
+          const [ctr, setCtr] = React.useState(0);
           React.useEffect(() => {
             if (ctr < 5) {
               setCtr(x => x + 1);
@@ -261,7 +261,7 @@ function runActTests(label, render, unmount, rerender) {
       it('warns if a setState is called outside of act(...)', () => {
         let setValue = null;
         function App() {
-          let [value, _setValue] = React.useState(0);
+          const [value, _setValue] = React.useState(0);
           setValue = _setValue;
           return value;
         }
@@ -286,9 +286,9 @@ function runActTests(label, render, unmount, rerender) {
 
         it('lets a ticker update', () => {
           function App() {
-            let [toggle, setToggle] = React.useState(0);
+            const [toggle, setToggle] = React.useState(0);
             React.useEffect(() => {
-              let timeout = setTimeout(() => {
+              const timeout = setTimeout(() => {
                 setToggle(1);
               }, 200);
               return () => clearTimeout(timeout);
@@ -308,7 +308,7 @@ function runActTests(label, render, unmount, rerender) {
 
         it('can use the async version to catch microtasks', async () => {
           function App() {
-            let [toggle, setToggle] = React.useState(0);
+            const [toggle, setToggle] = React.useState(0);
             React.useEffect(() => {
               // just like the previous test, except we
               // use a promise and schedule the update
@@ -332,7 +332,7 @@ function runActTests(label, render, unmount, rerender) {
           // this component triggers an effect, that waits a tick,
           // then sets state. repeats this 5 times.
           function App() {
-            let [state, setState] = React.useState(0);
+            const [state, setState] = React.useState(0);
             async function ticker() {
               await null;
               setState(x => x + 1);
@@ -353,7 +353,7 @@ function runActTests(label, render, unmount, rerender) {
 
         it('flushes immediate re-renders with act', () => {
           function App() {
-            let [ctr, setCtr] = React.useState(0);
+            const [ctr, setCtr] = React.useState(0);
             React.useEffect(() => {
               if (ctr === 0) {
                 setCtr(1);
@@ -408,7 +408,7 @@ function runActTests(label, render, unmount, rerender) {
     describe('asynchronous tests', () => {
       it('works with timeouts', async () => {
         function App() {
-          let [ctr, setCtr] = React.useState(0);
+          const [ctr, setCtr] = React.useState(0);
           function doSomething() {
             setTimeout(() => {
               setCtr(1);
@@ -432,7 +432,7 @@ function runActTests(label, render, unmount, rerender) {
 
       it('flushes microtasks before exiting', async () => {
         function App() {
-          let [ctr, setCtr] = React.useState(0);
+          const [ctr, setCtr] = React.useState(0);
           async function someAsyncFunction() {
             // queue a bunch of promises to be sure they all flush
             await null;
@@ -486,7 +486,7 @@ function runActTests(label, render, unmount, rerender) {
 
       it('async commits and effects are guaranteed to be flushed', async () => {
         function App() {
-          let [state, setState] = React.useState(0);
+          const [state, setState] = React.useState(0);
           async function something() {
             await null;
             setState(1);
@@ -513,7 +513,7 @@ function runActTests(label, render, unmount, rerender) {
         // this component triggers an effect, that waits a tick,
         // then sets state. repeats this 5 times.
         function App() {
-          let [state, setState] = React.useState(0);
+          const [state, setState] = React.useState(0);
           async function ticker() {
             await null;
             setState(x => x + 1);

--- a/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsActUnmockedScheduler-test.js
@@ -64,7 +64,7 @@ it('can use act to flush effects', () => {
 
 it('flushes effects on every call', () => {
   function App() {
-    let [ctr, setCtr] = React.useState(0);
+    const [ctr, setCtr] = React.useState(0);
     React.useEffect(() => {
       yields.push(ctr);
     });
@@ -102,7 +102,7 @@ it('flushes effects on every call', () => {
 
 it("should keep flushing effects until the're done", () => {
   function App() {
-    let [ctr, setCtr] = React.useState(0);
+    const [ctr, setCtr] = React.useState(0);
     React.useEffect(() => {
       if (ctr < 5) {
         setCtr(x => x + 1);
@@ -142,7 +142,7 @@ it('can handle cascading promises', async () => {
   // this component triggers an effect, that waits a tick,
   // then sets state. repeats this 5 times.
   function App() {
-    let [state, setState] = React.useState(0);
+    const [state, setState] = React.useState(0);
     async function ticker() {
       await null;
       setState(x => x + 1);

--- a/packages/react-dom/src/__tests__/ReactTreeTraversal-test.js
+++ b/packages/react-dom/src/__tests__/ReactTreeTraversal-test.js
@@ -11,7 +11,7 @@
 
 let React;
 let ReactDOM;
-let ReactFeatureFlags = require('shared/ReactFeatureFlags');
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 const ChildComponent = ({id, eventHandler}) => (
   <div

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1102,7 +1102,7 @@ describe('ReactUpdates', () => {
     'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       'should both flush in the immediately subsequent commit',
     () => {
-      let ops = [];
+      const ops = [];
       class Foo extends React.Component {
         state = {a: false, b: false};
         UNSAFE_componentWillUpdate(_, nextState) {
@@ -1145,7 +1145,7 @@ describe('ReactUpdates', () => {
     'in legacy mode, updates in componentWillUpdate and componentDidUpdate ' +
       '(on a sibling) should both flush in the immediately subsequent commit',
     () => {
-      let ops = [];
+      const ops = [];
       class Foo extends React.Component {
         state = {a: false};
         UNSAFE_componentWillUpdate(_, nextState) {
@@ -1213,7 +1213,7 @@ describe('ReactUpdates', () => {
   );
 
   it('uses correct base state for setState inside render phase', () => {
-    let ops = [];
+    const ops = [];
 
     class Foo extends React.Component {
       state = {step: 0};
@@ -1236,7 +1236,7 @@ describe('ReactUpdates', () => {
   });
 
   it('does not re-render if state update is null', () => {
-    let container = document.createElement('div');
+    const container = document.createElement('div');
 
     let instance;
     let ops = [];
@@ -1626,7 +1626,7 @@ describe('ReactUpdates', () => {
 
       let error = null;
       let stack = null;
-      let originalConsoleError = console.error;
+      const originalConsoleError = console.error;
       console.error = (e, s) => {
         error = e;
         stack = s;

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -526,7 +526,6 @@ describe('ReactUpdates', () => {
 
     const bContainer = document.createElement('div');
 
-    let a;
     let b;
 
     let aUpdated = false;
@@ -560,7 +559,7 @@ describe('ReactUpdates', () => {
       }
     }
 
-    a = ReactTestUtils.renderIntoDocument(<A />);
+    const a = ReactTestUtils.renderIntoDocument(<A />);
     ReactDOM.unstable_batchedUpdates(function() {
       a.setState({x: 1});
       b.setState({x: 1});
@@ -733,11 +732,8 @@ describe('ReactUpdates', () => {
       }
     }
 
-    let x;
-    let y;
-
-    x = ReactTestUtils.renderIntoDocument(<X />);
-    y = ReactTestUtils.renderIntoDocument(<Y />);
+    const x = ReactTestUtils.renderIntoDocument(<X />);
+    const y = ReactTestUtils.renderIntoDocument(<Y />);
     expect(ReactDOM.findDOMNode(x).textContent).toBe('0');
 
     y.forceUpdate();

--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -145,7 +145,7 @@ module.exports = function(initModules) {
     return await expectErrors(
       () =>
         new Promise(resolve => {
-          let writable = new DrainWritable();
+          const writable = new DrainWritable();
           ReactDOMServer.renderToNodeStream(reactElement).pipe(writable);
           writable.on('finish', () => resolve(writable.buffer));
         }),
@@ -174,7 +174,7 @@ module.exports = function(initModules) {
     const markup = await renderIntoString(element, errorCount);
     resetModules();
 
-    let container = getContainerFromMarkup(element, markup);
+    const container = getContainerFromMarkup(element, markup);
     let serverNode = container.firstChild;
 
     const firstClientNode = await renderIntoDom(
@@ -205,7 +205,7 @@ module.exports = function(initModules) {
   const clientRenderOnBadMarkup = async (element, errorCount = 0) => {
     // First we render the top of bad mark up.
 
-    let container = getContainerFromMarkup(
+    const container = getContainerFromMarkup(
       element,
       shouldUseDocument(element)
         ? '<html><body><div id="badIdWhichWillCauseMismatch" /></body></html>'

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -114,7 +114,7 @@ export function getClosestInstanceFromNode(targetNode: Node): null | Fiber {
           // have had an internalInstanceKey on it.
           // Let's get the fiber associated with the SuspenseComponent
           // as the deepest instance.
-          let targetSuspenseInst = suspenseInstance[internalInstanceKey];
+          const targetSuspenseInst = suspenseInstance[internalInstanceKey];
           if (targetSuspenseInst) {
             return targetSuspenseInst;
           }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -191,7 +191,7 @@ export function getRootHostContext(
     case DOCUMENT_NODE:
     case DOCUMENT_FRAGMENT_NODE: {
       type = nodeType === DOCUMENT_NODE ? '#document' : '#fragment';
-      let root = (rootContainerInstance: any).documentElement;
+      const root = (rootContainerInstance: any).documentElement;
       namespace = root ? root.namespaceURI : getChildNamespace(null, '');
       break;
     }
@@ -620,10 +620,10 @@ export function clearSuspenseBoundary(
   // deep we are and only break out when we're back on top.
   let depth = 0;
   do {
-    let nextNode = node.nextSibling;
+    const nextNode = node.nextSibling;
     parentInstance.removeChild(node);
     if (nextNode && nextNode.nodeType === COMMENT_NODE) {
-      let data = ((nextNode: any).data: string);
+      const data = ((nextNode: any).data: string);
       if (data === SUSPENSE_END_DATA) {
         if (depth === 0) {
           parentInstance.removeChild(nextNode);
@@ -867,7 +867,7 @@ export function getNextHydratableInstanceAfterSuspenseInstance(
   let depth = 0;
   while (node) {
     if (node.nodeType === COMMENT_NODE) {
-      let data = ((node: any).data: string);
+      const data = ((node: any).data: string);
       if (data === SUSPENSE_END_DATA) {
         if (depth === 0) {
           return getNextHydratableSibling((node: any));
@@ -901,7 +901,7 @@ export function getParentSuspenseInstance(
   let depth = 0;
   while (node) {
     if (node.nodeType === COMMENT_NODE) {
-      let data = ((node: any).data: string);
+      const data = ((node: any).data: string);
       if (
         data === SUSPENSE_START_DATA ||
         data === SUSPENSE_FALLBACK_START_DATA ||

--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -225,7 +225,7 @@ export function findDOMNode(
   componentOrElement: Element | ?React$Component<any, any>,
 ): null | Element | Text {
   if (__DEV__) {
-    let owner = (ReactCurrentOwner.current: any);
+    const owner = (ReactCurrentOwner.current: any);
     if (owner !== null && owner.stateNode !== null) {
       const warnedAboutRefsInRender = owner.stateNode._warnedAboutRefsInRender;
       if (!warnedAboutRefsInRender) {

--- a/packages/react-dom/src/client/ReactDOMSelect.js
+++ b/packages/react-dom/src/client/ReactDOMSelect.js
@@ -78,8 +78,8 @@ function updateOptions(
   const options: IndexableHTMLOptionsCollection = node.options;
 
   if (multiple) {
-    let selectedValues = (propValue: Array<string>);
-    let selectedValue = {};
+    const selectedValues = (propValue: Array<string>);
+    const selectedValue = {};
     for (let i = 0; i < selectedValues.length; i++) {
       // Prefix to avoid chaos with special keys.
       selectedValue['$' + selectedValues[i]] = true;
@@ -96,7 +96,7 @@ function updateOptions(
   } else {
     // Do not set `select.value` as exact behavior isn't consistent across all
     // browsers for all cases.
-    let selectedValue = toString(getToStringValue((propValue: any)));
+    const selectedValue = toString(getToStringValue((propValue: any)));
     let defaultSelected = null;
     for (let i = 0; i < options.length; i++) {
       if (options[i].value === selectedValue) {

--- a/packages/react-dom/src/client/ReactDOMSelection.js
+++ b/packages/react-dom/src/client/ReactDOMSelection.js
@@ -169,7 +169,7 @@ export function setOffsets(node, offsets) {
   // IE 11 uses modern selection, but doesn't support the extend method.
   // Flip backward selections, so we can set with a single range.
   if (!selection.extend && start > end) {
-    let temp = end;
+    const temp = end;
     end = start;
     start = temp;
   }

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -181,7 +181,8 @@ export function getSelection(input) {
  * -@offsets   Object of same form that is returned from get*
  */
 export function setSelection(input, offsets) {
-  let {start, end} = offsets;
+  const start = offsets.start;
+  let end = offsets.end;
   if (end === undefined) {
     end = start;
   }

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -54,7 +54,7 @@ describe('when Trusted Types are available in global object', () => {
   });
 
   it('should not stringify trusted values for dangerouslySetInnerHTML', () => {
-    let innerHTMLDescriptor = Object.getOwnPropertyDescriptor(
+    const innerHTMLDescriptor = Object.getOwnPropertyDescriptor(
       Element.prototype,
       'innerHTML',
     );
@@ -97,7 +97,7 @@ describe('when Trusted Types are available in global object', () => {
   });
 
   it('should not stringify trusted values for setAttribute (unknown attribute)', () => {
-    let setAttribute = Element.prototype.setAttribute;
+    const setAttribute = Element.prototype.setAttribute;
     try {
       const setAttributeCalls = [];
       Element.prototype.setAttribute = function(name, value) {
@@ -125,7 +125,7 @@ describe('when Trusted Types are available in global object', () => {
   });
 
   it('should not stringify trusted values for setAttribute (known attribute)', () => {
-    let setAttribute = Element.prototype.setAttribute;
+    const setAttribute = Element.prototype.setAttribute;
     try {
       const setAttributeCalls = [];
       Element.prototype.setAttribute = function(name, value) {
@@ -153,7 +153,7 @@ describe('when Trusted Types are available in global object', () => {
   });
 
   it('should not stringify trusted values for setAttributeNS', () => {
-    let setAttributeNS = Element.prototype.setAttributeNS;
+    const setAttributeNS = Element.prototype.setAttributeNS;
     try {
       const setAttributeNSCalls = [];
       Element.prototype.setAttributeNS = function(ns, name, value) {

--- a/packages/react-dom/src/client/setTextContent.js
+++ b/packages/react-dom/src/client/setTextContent.js
@@ -18,9 +18,9 @@ import {TEXT_NODE} from '../shared/HTMLNodeType';
  * @param {string} text
  * @internal
  */
-let setTextContent = function(node: Element, text: string): void {
+const setTextContent = function(node: Element, text: string): void {
   if (text) {
-    let firstChild = node.firstChild;
+    const firstChild = node.firstChild;
 
     if (
       firstChild &&

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -159,8 +159,8 @@ if (__DEV__) {
   };
 
   updatedAncestorInfo = function(oldInfo, tag) {
-    let ancestorInfo = {...(oldInfo || emptyAncestorInfo)};
-    let info = {tag};
+    const ancestorInfo = {...(oldInfo || emptyAncestorInfo)};
+    const info = {tag};
 
     if (inScopeTags.indexOf(tag) !== -1) {
       ancestorInfo.aTagInScope = null;

--- a/packages/react-dom/src/events/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/ChangeEventPlugin.js
@@ -234,7 +234,7 @@ function getTargetInstForInputOrChangeEvent(topLevelType, targetInst) {
 }
 
 function handleControlledInputBlur(node) {
-  let state = node._wrapperState;
+  const state = node._wrapperState;
 
   if (
     !state ||

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -452,7 +452,7 @@ function getNearestRootOrPortalContainer(instance: Element): Element {
 }
 
 function addEventTypeToDispatchConfig(type: DOMTopLevelEventType): void {
-  let dispatchConfig = topLevelEventsToDispatchConfig.get(type);
+  const dispatchConfig = topLevelEventsToDispatchConfig.get(type);
   // If we don't have a dispatchConfig, then we're dealing with
   // an event type that React does not know about (i.e. a custom event).
   // We need to register an event config for this or the SimpleEventPlugin

--- a/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
@@ -175,10 +175,10 @@ const eventResponderContext: ReactDOMResponderContext = {
     validateResponderContext();
     for (let i = 0; i < rootEventTypes.length; i++) {
       const rootEventType = rootEventTypes[i];
-      let rootEventResponders = rootEventTypesToEventResponderInstances.get(
+      const rootEventResponders = rootEventTypesToEventResponderInstances.get(
         rootEventType,
       );
-      let rootEventTypesSet = ((currentInstance: any): ReactDOMEventResponderInstance)
+      const rootEventTypesSet = ((currentInstance: any): ReactDOMEventResponderInstance)
         .rootEventTypes;
       if (rootEventTypesSet !== null) {
         rootEventTypesSet.delete(rootEventType);
@@ -462,7 +462,7 @@ export function unmountEventResponder(
   const responder = ((responderInstance.responder: any): ReactDOMEventResponder);
   const onUnmount = responder.onUnmount;
   if (onUnmount !== null) {
-    let {props, state} = responderInstance;
+    const {props, state} = responderInstance;
     const previousInstance = currentInstance;
     currentInstance = responderInstance;
     try {
@@ -477,7 +477,7 @@ export function unmountEventResponder(
 
     for (let i = 0; i < rootEventTypes.length; i++) {
       const topLevelEventType = rootEventTypes[i];
-      let rootEventResponderInstances = rootEventTypesToEventResponderInstances.get(
+      const rootEventResponderInstances = rootEventTypesToEventResponderInstances.get(
         topLevelEventType,
       );
       if (rootEventResponderInstances !== undefined) {

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -424,14 +424,14 @@ export function attemptToDispatchEvent(
   let targetInst = getClosestInstanceFromNode(nativeEventTarget);
 
   if (targetInst !== null) {
-    let nearestMounted = getNearestMountedFiber(targetInst);
+    const nearestMounted = getNearestMountedFiber(targetInst);
     if (nearestMounted === null) {
       // This tree has been unmounted already. Dispatch without a target.
       targetInst = null;
     } else {
       const tag = nearestMounted.tag;
       if (tag === SuspenseComponent) {
-        let instance = getSuspenseInstanceFromFiber(nearestMounted);
+        const instance = getSuspenseInstanceFromFiber(nearestMounted);
         if (instance !== null) {
           // Queue the event to be replayed later. Abort dispatching since we
           // don't want this event dispatched twice through the event system.

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -133,18 +133,18 @@ type QueuedReplayableEvent = {|
 let hasScheduledReplayAttempt = false;
 
 // The queue of discrete events to be replayed.
-let queuedDiscreteEvents: Array<QueuedReplayableEvent> = [];
+const queuedDiscreteEvents: Array<QueuedReplayableEvent> = [];
 
 // Indicates if any continuous event targets are non-null for early bailout.
-let hasAnyQueuedContinuousEvents: boolean = false;
+const hasAnyQueuedContinuousEvents: boolean = false;
 // The last of each continuous event type. We only need to replay the last one
 // if the last target was dehydrated.
 let queuedFocus: null | QueuedReplayableEvent = null;
 let queuedDrag: null | QueuedReplayableEvent = null;
 let queuedMouse: null | QueuedReplayableEvent = null;
 // For pointer events there can be one latest event per pointerId.
-let queuedPointers: Map<number, QueuedReplayableEvent> = new Map();
-let queuedPointerCaptures: Map<number, QueuedReplayableEvent> = new Map();
+const queuedPointers: Map<number, QueuedReplayableEvent> = new Map();
+const queuedPointerCaptures: Map<number, QueuedReplayableEvent> = new Map();
 // We could consider replaying selectionchange and touchmoves too.
 
 type QueuedHydrationTarget = {|
@@ -152,7 +152,7 @@ type QueuedHydrationTarget = {|
   target: Node,
   priority: number,
 |};
-let queuedExplicitHydrationTargets: Array<QueuedHydrationTarget> = [];
+const queuedExplicitHydrationTargets: Array<QueuedHydrationTarget> = [];
 
 export function hasQueuedDiscreteEvents(): boolean {
   return queuedDiscreteEvents.length > 0;
@@ -318,7 +318,7 @@ export function queueDiscreteEvent(
       // If this was the first discrete event, we might be able to
       // synchronously unblock it so that preventDefault still works.
       while (queuedEvent.blockedOn !== null) {
-        let fiber = getInstanceFromNode(queuedEvent.blockedOn);
+        const fiber = getInstanceFromNode(queuedEvent.blockedOn);
         if (fiber === null) {
           break;
         }
@@ -359,13 +359,13 @@ export function clearIfContinuousEvent(
       break;
     case TOP_POINTER_OVER:
     case TOP_POINTER_OUT: {
-      let pointerId = ((nativeEvent: any): PointerEvent).pointerId;
+      const pointerId = ((nativeEvent: any): PointerEvent).pointerId;
       queuedPointers.delete(pointerId);
       break;
     }
     case TOP_GOT_POINTER_CAPTURE:
     case TOP_LOST_POINTER_CAPTURE: {
-      let pointerId = ((nativeEvent: any): PointerEvent).pointerId;
+      const pointerId = ((nativeEvent: any): PointerEvent).pointerId;
       queuedPointerCaptures.delete(pointerId);
       break;
     }
@@ -384,7 +384,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
     existingQueuedEvent === null ||
     existingQueuedEvent.nativeEvent !== nativeEvent
   ) {
-    let queuedEvent = createQueuedReplayableEvent(
+    const queuedEvent = createQueuedReplayableEvent(
       blockedOn,
       topLevelType,
       eventSystemFlags,
@@ -392,7 +392,7 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
       nativeEvent,
     );
     if (blockedOn !== null) {
-      let fiber = getInstanceFromNode(blockedOn);
+      const fiber = getInstanceFromNode(blockedOn);
       if (fiber !== null) {
         // Attempt to increase the priority of this target.
         attemptContinuousHydration(fiber);
@@ -505,13 +505,13 @@ function attemptExplicitHydrationTarget(
   // TODO: This function shares a lot of logic with attemptToDispatchEvent.
   // Try to unify them. It's a bit tricky since it would require two return
   // values.
-  let targetInst = getClosestInstanceFromNode(queuedTarget.target);
+  const targetInst = getClosestInstanceFromNode(queuedTarget.target);
   if (targetInst !== null) {
-    let nearestMounted = getNearestMountedFiber(targetInst);
+    const nearestMounted = getNearestMountedFiber(targetInst);
     if (nearestMounted !== null) {
       const tag = nearestMounted.tag;
       if (tag === SuspenseComponent) {
-        let instance = getSuspenseInstanceFromFiber(nearestMounted);
+        const instance = getSuspenseInstanceFromFiber(nearestMounted);
         if (instance !== null) {
           // We're blocked on hydrating this boundary.
           // Increase its priority.
@@ -537,7 +537,7 @@ function attemptExplicitHydrationTarget(
 
 export function queueExplicitHydrationTarget(target: Node): void {
   if (enableSelectiveHydration) {
-    let priority = getCurrentPriorityLevel();
+    const priority = getCurrentPriorityLevel();
     const queuedTarget: QueuedHydrationTarget = {
       blockedOn: null,
       target: target,
@@ -562,10 +562,10 @@ function attemptReplayContinuousQueuedEvent(
   if (queuedEvent.blockedOn !== null) {
     return false;
   }
-  let targetContainers = queuedEvent.targetContainers;
+  const targetContainers = queuedEvent.targetContainers;
   while (targetContainers.length > 0) {
-    let targetContainer = targetContainers[0];
-    let nextBlockedOn = attemptToDispatchEvent(
+    const targetContainer = targetContainers[0];
+    const nextBlockedOn = attemptToDispatchEvent(
       queuedEvent.topLevelType,
       queuedEvent.eventSystemFlags,
       targetContainer,
@@ -573,7 +573,7 @@ function attemptReplayContinuousQueuedEvent(
     );
     if (nextBlockedOn !== null) {
       // We're still blocked. Try again later.
-      let fiber = getInstanceFromNode(nextBlockedOn);
+      const fiber = getInstanceFromNode(nextBlockedOn);
       if (fiber !== null) {
         attemptContinuousHydration(fiber);
       }
@@ -600,21 +600,21 @@ function replayUnblockedEvents() {
   hasScheduledReplayAttempt = false;
   // First replay discrete events.
   while (queuedDiscreteEvents.length > 0) {
-    let nextDiscreteEvent = queuedDiscreteEvents[0];
+    const nextDiscreteEvent = queuedDiscreteEvents[0];
     if (nextDiscreteEvent.blockedOn !== null) {
       // We're still blocked.
       // Increase the priority of this boundary to unblock
       // the next discrete event.
-      let fiber = getInstanceFromNode(nextDiscreteEvent.blockedOn);
+      const fiber = getInstanceFromNode(nextDiscreteEvent.blockedOn);
       if (fiber !== null) {
         attemptUserBlockingHydration(fiber);
       }
       break;
     }
-    let targetContainers = nextDiscreteEvent.targetContainers;
+    const targetContainers = nextDiscreteEvent.targetContainers;
     while (targetContainers.length > 0) {
-      let targetContainer = targetContainers[0];
-      let nextBlockedOn = attemptToDispatchEvent(
+      const targetContainer = targetContainers[0];
+      const nextBlockedOn = attemptToDispatchEvent(
         nextDiscreteEvent.topLevelType,
         nextDiscreteEvent.eventSystemFlags,
         targetContainer,
@@ -674,7 +674,7 @@ export function retryIfBlockedOn(
     // worth it because we expect very few discrete events to queue up and once
     // we are actually fully unblocked it will be fast to replay them.
     for (let i = 1; i < queuedDiscreteEvents.length; i++) {
-      let queuedEvent = queuedDiscreteEvents[i];
+      const queuedEvent = queuedDiscreteEvents[i];
       if (queuedEvent.blockedOn === unblocked) {
         queuedEvent.blockedOn = null;
       }
@@ -696,14 +696,14 @@ export function retryIfBlockedOn(
   queuedPointerCaptures.forEach(unblock);
 
   for (let i = 0; i < queuedExplicitHydrationTargets.length; i++) {
-    let queuedTarget = queuedExplicitHydrationTargets[i];
+    const queuedTarget = queuedExplicitHydrationTargets[i];
     if (queuedTarget.blockedOn === unblocked) {
       queuedTarget.blockedOn = null;
     }
   }
 
   while (queuedExplicitHydrationTargets.length > 0) {
-    let nextExplicitTarget = queuedExplicitHydrationTargets[0];
+    const nextExplicitTarget = queuedExplicitHydrationTargets[0];
     if (nextExplicitTarget.blockedOn !== null) {
       // We're still blocked.
       break;

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -28,7 +28,7 @@ function dispatchClickEvent(element) {
   dispatchEvent(element, 'click');
 }
 
-let eventListenersToClear = [];
+const eventListenersToClear = [];
 
 function startNativeEventListenerClearDown() {
   const nativeWindowEventListener = window.addEventListener;
@@ -106,7 +106,7 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Test />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
 
           expect(onClick).toHaveBeenCalledTimes(1);
@@ -114,7 +114,7 @@ describe('DOMModernPluginEventSystem', () => {
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -159,14 +159,14 @@ describe('DOMModernPluginEventSystem', () => {
           ReactDOM.render(<Parent />, container);
           ReactDOM.render(<Child />, childRef.current);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -211,14 +211,14 @@ describe('DOMModernPluginEventSystem', () => {
           buttonRef.current.appendChild(disjointedNode);
           ReactDOM.render(<Child />, disjointedNode);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -266,14 +266,14 @@ describe('DOMModernPluginEventSystem', () => {
           buttonRef.current.appendChild(disjointedNode);
           ReactDOM.render(<Child />, disjointedNode);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -323,14 +323,14 @@ describe('DOMModernPluginEventSystem', () => {
           spanRef.current.appendChild(disjointedNode);
           ReactDOM.render(<Child />, disjointedNode);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -376,14 +376,14 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -437,12 +437,12 @@ describe('DOMModernPluginEventSystem', () => {
           async () => {
             let suspend = false;
             let resolve;
-            let promise = new Promise(
+            const promise = new Promise(
               resolvePromise => (resolve = resolvePromise),
             );
 
             let clicks = 0;
-            let childSlotRef = React.createRef();
+            const childSlotRef = React.createRef();
 
             function Parent() {
               return <div onClick={() => clicks++} ref={childSlotRef} />;
@@ -466,17 +466,17 @@ describe('DOMModernPluginEventSystem', () => {
             }
 
             suspend = false;
-            let finalHTML = ReactDOMServer.renderToString(<App />);
+            const finalHTML = ReactDOMServer.renderToString(<App />);
 
-            let parentContainer = document.createElement('div');
-            let childContainer = document.createElement('div');
+            const parentContainer = document.createElement('div');
+            const childContainer = document.createElement('div');
 
             // We need this to be in the document since we'll dispatch events on it.
             document.body.appendChild(parentContainer);
 
             // We're going to use a different root as a parent.
             // This lets us detect whether an event goes through React's event system.
-            let parentRoot = ReactDOM.createRoot(parentContainer);
+            const parentRoot = ReactDOM.createRoot(parentContainer);
             parentRoot.render(<Parent />);
             Scheduler.unstable_flushAll();
 
@@ -484,12 +484,12 @@ describe('DOMModernPluginEventSystem', () => {
 
             childContainer.innerHTML = finalHTML;
 
-            let a = childContainer.getElementsByTagName('a')[0];
+            const a = childContainer.getElementsByTagName('a')[0];
 
             suspend = true;
 
             // Hydrate asynchronously.
-            let root = ReactDOM.createRoot(childContainer, {hydrate: true});
+            const root = ReactDOM.createRoot(childContainer, {hydrate: true});
             root.render(<App />);
             jest.runAllTimers();
             Scheduler.unstable_flushAll();
@@ -641,14 +641,14 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           dispatchClickEvent(buttonElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(1);
           expect(onClickCapture).toHaveBeenCalledTimes(1);
@@ -684,14 +684,14 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Test />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
           expect(onFocusCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           divElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(3);
           expect(onFocusCapture).toHaveBeenCalledTimes(3);
@@ -737,14 +737,14 @@ describe('DOMModernPluginEventSystem', () => {
           ReactDOM.render(<Parent />, container);
           ReactDOM.render(<Child />, childRef.current);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
           expect(onFocusCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           divElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(3);
           expect(onFocusCapture).toHaveBeenCalledTimes(3);
@@ -791,14 +791,14 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
           expect(onFocusCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           divElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(3);
           expect(onFocusCapture).toHaveBeenCalledTimes(3);
@@ -858,14 +858,14 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
           expect(onFocusCapture).toHaveBeenCalledTimes(1);
           expect(log[0]).toEqual(['capture', buttonElement]);
           expect(log[1]).toEqual(['bubble', buttonElement]);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           divElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
           expect(onFocusCapture).toHaveBeenCalledTimes(1);
@@ -906,7 +906,7 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.dispatchEvent(
             new MouseEvent('mouseover', {
               bubbles: true,
@@ -918,7 +918,7 @@ describe('DOMModernPluginEventSystem', () => {
           expect(onMouseLeave).toHaveBeenCalledTimes(0);
           expect(log[0]).toEqual(buttonElement);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           buttonElement.dispatchEvent(
             new MouseEvent('mouseout', {
               bubbles: true,
@@ -977,7 +977,7 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Parent />, container);
 
-          let buttonElement = buttonRef.current;
+          const buttonElement = buttonRef.current;
           buttonElement.dispatchEvent(
             new MouseEvent('mouseover', {
               bubbles: true,
@@ -989,7 +989,7 @@ describe('DOMModernPluginEventSystem', () => {
           expect(onMouseLeave).toHaveBeenCalledTimes(0);
           expect(log[0]).toEqual(buttonElement);
 
-          let divElement = divRef.current;
+          const divElement = divRef.current;
           buttonElement.dispatchEvent(
             new MouseEvent('mouseout', {
               bubbles: true,
@@ -1042,7 +1042,7 @@ describe('DOMModernPluginEventSystem', () => {
           );
 
           function Root() {
-            let portalTargetRef = React.useRef(null);
+            const portalTargetRef = React.useRef(null);
             React.useLayoutEffect(() => {
               portalTargetRef.current.appendChild(portalContainer);
             });
@@ -1056,7 +1056,7 @@ describe('DOMModernPluginEventSystem', () => {
 
           ReactDOM.render(<Root />, container);
 
-          let divElement = targetRef.current;
+          const divElement = targetRef.current;
           dispatchClickEvent(divElement);
           expect(log).toEqual([
             'capture root',
@@ -1105,7 +1105,7 @@ describe('DOMModernPluginEventSystem', () => {
           }
 
           it('should create the same event listener map', () => {
-            let listenerMaps = [];
+            const listenerMaps = [];
 
             function Test() {
               const listenerMap = ReactDOM.unstable_useEvent('click');
@@ -1231,7 +1231,7 @@ describe('DOMModernPluginEventSystem', () => {
             log = [];
 
             // Clicking the button should also work
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(log).toEqual([
               {
@@ -1334,7 +1334,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let textNode = buttonRef.current.firstChild;
+            const textNode = buttonRef.current.firstChild;
             dispatchClickEvent(textNode);
             expect(clickEvent).toBeCalledTimes(1);
           });
@@ -1371,7 +1371,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(onClick).toHaveBeenCalledTimes(1);
             expect(onClickCapture).toHaveBeenCalledTimes(1);
@@ -1382,7 +1382,7 @@ describe('DOMModernPluginEventSystem', () => {
             onClick.mockClear();
             onClickCapture.mockClear();
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchClickEvent(divElement);
             expect(onClick).toHaveBeenCalledTimes(2);
             expect(onClickCapture).toHaveBeenCalledTimes(2);
@@ -1427,14 +1427,14 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(onClick).toHaveBeenCalledTimes(1);
             expect(onClickCapture).toHaveBeenCalledTimes(1);
             expect(log[0]).toEqual(['capture', buttonElement]);
             expect(log[1]).toEqual(['bubble', buttonElement]);
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchClickEvent(divElement);
             expect(onClick).toHaveBeenCalledTimes(3);
             expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -1504,7 +1504,7 @@ describe('DOMModernPluginEventSystem', () => {
             expect(clickEvent).toBeCalledTimes(2);
 
             // Clicking the button should not work
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(clickEvent).toBeCalledTimes(2);
           });
@@ -1577,7 +1577,7 @@ describe('DOMModernPluginEventSystem', () => {
           it('should correctly handle stopPropagation corrrectly for target events', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
-            let clickEvent = jest.fn();
+            const clickEvent = jest.fn();
 
             function Test() {
               const click1 = ReactDOM.unstable_useEvent('click', {
@@ -1602,7 +1602,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchClickEvent(divElement);
             expect(clickEvent).toHaveBeenCalledTimes(0);
           });
@@ -1633,7 +1633,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(targetListerner1).toHaveBeenCalledTimes(1);
             expect(targetListerner2).toHaveBeenCalledTimes(1);
@@ -1671,7 +1671,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(targetListerner1).toHaveBeenCalledTimes(1);
             expect(targetListerner2).toHaveBeenCalledTimes(1);
@@ -1698,7 +1698,7 @@ describe('DOMModernPluginEventSystem', () => {
                 return <button ref={ref}>Press me</button>;
               }
 
-              let root = ReactDOM.createRoot(container);
+              const root = ReactDOM.createRoot(container);
               root.render(<Test counter={0} />);
 
               // Dev double-render
@@ -1926,7 +1926,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(onClick).toHaveBeenCalledTimes(2);
             expect(onClickCapture).toHaveBeenCalledTimes(2);
@@ -1939,7 +1939,7 @@ describe('DOMModernPluginEventSystem', () => {
             onClick.mockClear();
             onClickCapture.mockClear();
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchClickEvent(divElement);
             expect(onClick).toHaveBeenCalledTimes(3);
             expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -1981,7 +1981,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(rootListerner1).toHaveBeenCalledTimes(1);
             expect(targetListerner1).toHaveBeenCalledTimes(0);
@@ -2020,7 +2020,7 @@ describe('DOMModernPluginEventSystem', () => {
 
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(rootListerner1).toHaveBeenCalledTimes(1);
             expect(rootListerner2).toHaveBeenCalledTimes(1);
@@ -2064,7 +2064,7 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchClickEvent(buttonElement);
             expect(onClick).toHaveBeenCalledTimes(3);
             expect(onClickCapture).toHaveBeenCalledTimes(3);
@@ -2079,7 +2079,7 @@ describe('DOMModernPluginEventSystem', () => {
             onClick.mockClear();
             onClickCapture.mockClear();
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchClickEvent(divElement);
             expect(onClick).toHaveBeenCalledTimes(4);
             expect(onClickCapture).toHaveBeenCalledTimes(4);
@@ -2150,14 +2150,14 @@ describe('DOMModernPluginEventSystem', () => {
             ReactDOM.render(<Test />, container);
             Scheduler.unstable_flushAll();
 
-            let buttonElement = buttonRef.current;
+            const buttonElement = buttonRef.current;
             dispatchEvent(buttonElement, 'custom-event');
             expect(onCustomEvent).toHaveBeenCalledTimes(1);
             expect(onCustomEventCapture).toHaveBeenCalledTimes(1);
             expect(log[0]).toEqual(['capture', buttonElement]);
             expect(log[1]).toEqual(['bubble', buttonElement]);
 
-            let divElement = divRef.current;
+            const divElement = divRef.current;
             dispatchEvent(divElement, 'custom-event');
             expect(onCustomEvent).toHaveBeenCalledTimes(3);
             expect(onCustomEventCapture).toHaveBeenCalledTimes(3);
@@ -2283,7 +2283,7 @@ describe('DOMModernPluginEventSystem', () => {
               const Suspense = React.Suspense;
               let suspend = false;
               let resolve;
-              let promise = new Promise(
+              const promise = new Promise(
                 resolvePromise => (resolve = resolvePromise),
               );
 
@@ -2319,7 +2319,7 @@ describe('DOMModernPluginEventSystem', () => {
               const container2 = document.createElement('div');
               document.body.appendChild(container2);
 
-              let root = ReactDOM.createRoot(container2);
+              const root = ReactDOM.createRoot(container2);
 
               ReactTestUtils.act(() => {
                 root.render(<Component />);
@@ -2506,7 +2506,7 @@ describe('DOMModernPluginEventSystem', () => {
               ReactDOM.render(<Test />, container);
               Scheduler.unstable_flushAll();
 
-              let textNode = buttonRef.current.firstChild;
+              const textNode = buttonRef.current.firstChild;
               dispatchClickEvent(textNode);
               // This should not work, as the target instance will be the
               // <button>, which is actually outside the scope.

--- a/packages/react-dom/src/events/__tests__/DeprecatedDOMEventResponderSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DeprecatedDOMEventResponderSystem-test.internal.js
@@ -149,7 +149,7 @@ describe('DOMEventResponderSystem', () => {
 
   it('the event responders should fire on click event', () => {
     let eventResponderFiredCount = 0;
-    let eventLog = [];
+    const eventLog = [];
     const buttonRef = React.createRef();
 
     const TestResponder = createEventResponder({
@@ -208,7 +208,7 @@ describe('DOMEventResponderSystem', () => {
     const checkPassiveEvents = require('react-dom/src/events/checkPassiveEvents');
     checkPassiveEvents.passiveBrowserEventsSupported = true;
 
-    let eventLog = [];
+    const eventLog = [];
     const buttonRef = React.createRef();
 
     const TestResponder = createEventResponder({
@@ -235,7 +235,7 @@ describe('DOMEventResponderSystem', () => {
     ReactDOM.render(<Test />, container);
 
     // Clicking the button should trigger the event responder onEvent()
-    let buttonElement = buttonRef.current;
+    const buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
     expect(eventLog.length).toBe(1);
     expect(eventLog).toEqual([
@@ -393,7 +393,7 @@ describe('DOMEventResponderSystem', () => {
   });
 
   it('nested event responders should fire in the correct order #2', () => {
-    let eventLog = [];
+    const eventLog = [];
     const buttonRef = React.createRef();
 
     const TestResponder = createEventResponder({
@@ -422,14 +422,14 @@ describe('DOMEventResponderSystem', () => {
     ReactDOM.render(<Test />, container);
 
     // Clicking the button should trigger the event responder onEvent()
-    let buttonElement = buttonRef.current;
+    const buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
     expect(eventLog).toEqual(['B [bubble]']);
   });
 
   it('custom event dispatching for click -> magicClick works', () => {
-    let eventLog = [];
+    const eventLog = [];
     const buttonRef = React.createRef();
 
     const TestResponder = createEventResponder({
@@ -468,7 +468,7 @@ describe('DOMEventResponderSystem', () => {
     ReactDOM.render(<Test />, container);
 
     // Clicking the button should trigger the event responder onEvent()
-    let buttonElement = buttonRef.current;
+    const buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
     expect(eventLog).toEqual(['magic event fired', 'magicclick', 'bubble']);
@@ -626,7 +626,7 @@ describe('DOMEventResponderSystem', () => {
   it('the event responder target listeners should correctly fire for only their events', () => {
     let clickEventComponent1Fired = 0;
     let clickEventComponent2Fired = 0;
-    let eventLog = [];
+    const eventLog = [];
     const buttonRef = React.createRef();
 
     const TestResponderA = createEventResponder({
@@ -666,7 +666,7 @@ describe('DOMEventResponderSystem', () => {
 
     ReactDOM.render(<Test />, container);
 
-    let buttonElement = buttonRef.current;
+    const buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
 
     expect(clickEventComponent1Fired).toBe(1);
@@ -698,7 +698,7 @@ describe('DOMEventResponderSystem', () => {
     });
 
     let handler;
-    let buttonRef = React.createRef();
+    const buttonRef = React.createRef();
     const Test = () => {
       const listener = React.DEPRECATED_useResponder(TestResponder, {
         onClick: handler,
@@ -811,7 +811,7 @@ describe('DOMEventResponderSystem', () => {
       );
     }
 
-    let root = ReactDOM.createRoot(container);
+    const root = ReactDOM.createRoot(container);
     root.render(<Test counter={0} />);
     expect(Scheduler).toFlushAndYield(__DEV__ ? ['Test', 'Test'] : ['Test']);
 
@@ -981,7 +981,7 @@ describe('DOMEventResponderSystem', () => {
     ReactDOM.render(<Test />, container);
     expect(container.innerHTML).toBe('<button>Click me!</button>');
 
-    let buttonElement = buttonRef.current;
+    const buttonElement = buttonRef.current;
     dispatchClickEvent(buttonElement);
     expect(eventResponderFiredCount).toBe(1);
     dispatchClickEvent(buttonElement);

--- a/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
+++ b/packages/react-dom/src/events/__tests__/EnterLeaveEventPlugin-test.js
@@ -40,7 +40,7 @@ describe('EnterLeaveEventPlugin', () => {
     );
     iframeDocument.close();
 
-    let leaveEvents = [];
+    const leaveEvents = [];
     const node = ReactDOM.render(
       <div
         onMouseLeave={e => {
@@ -73,7 +73,7 @@ describe('EnterLeaveEventPlugin', () => {
     );
     iframeDocument.close();
 
-    let enterEvents = [];
+    const enterEvents = [];
     const node = ReactDOM.render(
       <div
         onMouseEnter={e => {

--- a/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/SimpleEventPlugin-test.internal.js
@@ -184,7 +184,7 @@ describe('SimpleEventPlugin', function() {
     container = document.createElement('div');
     document.body.appendChild(container);
 
-    let ops = [];
+    const ops = [];
     let button;
     class Button extends React.Component {
       state = {count: 0};

--- a/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticEvent-test.js
@@ -29,7 +29,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should be able to `preventDefault`', () => {
-    let node;
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {
@@ -40,7 +39,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -50,7 +49,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should be prevented if nativeEvent is prevented', () => {
-    let node;
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {
@@ -58,7 +56,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     let event;
     event = document.createEvent('Event');
@@ -83,7 +81,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should be able to `stopPropagation`', () => {
-    let node;
     let expectedCount = 0;
 
     const eventHandler = syntheticEvent => {
@@ -93,7 +90,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -103,7 +100,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should be able to `persist`', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -115,7 +111,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -128,7 +124,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should be nullified and log warnings if the synthetic event has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -137,7 +132,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -165,7 +160,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should warn when setting properties of a synthetic event that has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -174,7 +168,7 @@ describe('SyntheticEvent', () => {
 
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -194,7 +188,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should warn when calling `preventDefault` if the synthetic event has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -202,7 +195,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -222,7 +215,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should warn when calling `stopPropagation` if the synthetic event has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -230,7 +222,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -251,7 +243,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should warn when calling `isPropagationStopped` if the synthetic event has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -259,7 +250,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -279,7 +270,6 @@ describe('SyntheticEvent', () => {
   });
 
   it('should warn when calling `isDefaultPrevented` if the synthetic event has not been persisted', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -287,7 +277,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);
@@ -332,7 +322,6 @@ describe('SyntheticEvent', () => {
   // Or we might disallow this pattern altogether:
   // https://github.com/facebook/react/issues/13224
   xit('should warn if a property is added to the synthetic event', () => {
-    let node;
     let expectedCount = 0;
     let syntheticEvent;
 
@@ -349,7 +338,7 @@ describe('SyntheticEvent', () => {
       syntheticEvent = e;
       expectedCount++;
     };
-    node = ReactDOM.render(<div onClick={eventHandler} />, container);
+    const node = ReactDOM.render(<div onClick={eventHandler} />, container);
 
     const event = document.createEvent('Event');
     event.initEvent('click', true, true);

--- a/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
@@ -466,7 +466,7 @@ describe('SyntheticKeyboardEvent', () => {
         expect(event.isPropagationStopped()).toBe(true);
         expectedCount++;
       };
-      let div = ReactDOM.render(
+      const div = ReactDOM.render(
         <div
           onKeyDown={eventHandler}
           onKeyUp={eventHandler}
@@ -508,7 +508,7 @@ describe('SyntheticKeyboardEvent', () => {
         expect(event.isPersistent()).toBe(true);
         persistentEvents.push(event);
       };
-      let div = ReactDOM.render(
+      const div = ReactDOM.render(
         <div
           onKeyDown={eventHandler}
           onKeyUp={eventHandler}

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -24,7 +24,7 @@ function pipeToNodeWritable(
   children: ReactNodeList,
   destination: Writable,
 ): void {
-  let request = createRequest(children, destination);
+  const request = createRequest(children, destination);
   destination.on('drain', createDrainHandler(destination, request));
   startWork(request);
 }

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -88,9 +88,9 @@ const toArray = ((React.Children.toArray: any): toArrayType);
 // Each entry is `this.stack` from a currently executing renderer instance.
 // (There may be more than one because ReactDOMServer is reentrant).
 // Each stack is an array of frames which may contain nested stacks of elements.
-let currentDebugStacks = [];
+const currentDebugStacks = [];
 
-let ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 let ReactDebugCurrentFrame;
 let prevGetCurrentStackImpl = null;
 let getCurrentServerStackImpl = () => '';
@@ -160,7 +160,7 @@ if (__DEV__) {
     }
     // ReactDOMServer is reentrant so there may be multiple calls at the same time.
     // Take the frames from the innermost call which is the last in the array.
-    let frames = currentDebugStacks[currentDebugStacks.length - 1];
+    const frames = currentDebugStacks[currentDebugStacks.length - 1];
     let stack = '';
     // Go through every frame in the stack from the innermost one.
     for (let i = frames.length - 1; i >= 0; i--) {
@@ -168,7 +168,7 @@ if (__DEV__) {
       // Every frame might have more than one debug element stack entry associated with it.
       // This is because single-child nesting doesn't create materialized frames.
       // Instead it would push them through `pushElementToDebugStack()`.
-      let debugElementStack = ((frame: any): FrameDev).debugElementStack;
+      const debugElementStack = ((frame: any): FrameDev).debugElementStack;
       for (let ii = debugElementStack.length - 1; ii >= 0; ii--) {
         stack += describeStackFrame(debugElementStack[ii]);
       }
@@ -416,8 +416,8 @@ function resolve(
 |} {
   while (React.isValidElement(child)) {
     // Safe because we just checked it's an element.
-    let element: ReactElement = (child: any);
-    let Component = element.type;
+    const element: ReactElement = (child: any);
+    const Component = element.type;
     if (__DEV__) {
       pushElementToDebugStack(element);
     }
@@ -434,7 +434,7 @@ function resolve(
 
     let queue = [];
     let replace = false;
-    let updater = {
+    const updater = {
       isMounted: function(publicInstance) {
         return false;
       },
@@ -480,7 +480,7 @@ function resolve(
           }
         }
 
-        let partialState = Component.getDerivedStateFromProps.call(
+        const partialState = Component.getDerivedStateFromProps.call(
           null,
           element.props,
           inst.state,
@@ -612,8 +612,8 @@ function resolve(
         inst.UNSAFE_componentWillMount();
       }
       if (queue.length) {
-        let oldQueue = queue;
-        let oldReplace = replace;
+        const oldQueue = queue;
+        const oldReplace = replace;
         queue = null;
         replace = false;
 
@@ -623,8 +623,8 @@ function resolve(
           let nextState = oldReplace ? oldQueue[0] : inst.state;
           let dontMutate = true;
           for (let i = oldReplace ? 1 : 0; i < oldQueue.length; i++) {
-            let partial = oldQueue[i];
-            let partialState =
+            const partial = oldQueue[i];
+            const partialState =
               typeof partial === 'function'
                 ? partial.call(inst, nextState, element.props, publicContext)
                 : partial;
@@ -657,7 +657,7 @@ function resolve(
     let childContext;
     if (disableLegacyContext) {
       if (__DEV__) {
-        let childContextTypes = Component.childContextTypes;
+        const childContextTypes = Component.childContextTypes;
         if (childContextTypes !== undefined) {
           console.error(
             '%s uses the legacy childContextTypes API which is no longer supported. ' +
@@ -668,10 +668,10 @@ function resolve(
       }
     } else {
       if (typeof inst.getChildContext === 'function') {
-        let childContextTypes = Component.childContextTypes;
+        const childContextTypes = Component.childContextTypes;
         if (typeof childContextTypes === 'object') {
           childContext = inst.getChildContext();
-          for (let contextKey in childContext) {
+          for (const contextKey in childContext) {
             invariant(
               contextKey in childContextTypes,
               '%s.getChildContext(): key "%s" is not defined in childContextTypes.',
@@ -843,7 +843,7 @@ class ReactDOMServerRenderer {
     try {
       // Markup generated within <Suspense> ends up buffered until we know
       // nothing in that boundary suspended
-      let out = [''];
+      const out = [''];
       let suspended = false;
       while (out[0].length < bytes) {
         if (this.stack.length === 0) {
@@ -1112,7 +1112,7 @@ class ReactDOMServerRenderer {
           }
           case REACT_MEMO_TYPE: {
             const element: ReactElement = ((nextChild: any): ReactElement);
-            let nextChildren = [
+            const nextChildren = [
               React.createElement(
                 elementType.type,
                 Object.assign({ref: element.ref}, element.props),
@@ -1245,9 +1245,9 @@ class ReactDOMServerRenderer {
             // Attempt to initialize lazy component regardless of whether the
             // suspense server-side renderer is enabled so synchronously
             // resolved constructors are supported.
-            let payload = lazyComponent._payload;
-            let init = lazyComponent._init;
-            let result = init(payload);
+            const payload = lazyComponent._payload;
+            const init = lazyComponent._init;
+            const result = init(payload);
             const nextChildren = [
               React.createElement(
                 result,

--- a/packages/react-dom/src/server/ReactPartialRendererContext.js
+++ b/packages/react-dom/src/server/ReactPartialRendererContext.js
@@ -70,7 +70,7 @@ export function processContext(
     const contextType = type.contextType;
     if (__DEV__) {
       if ('contextType' in (type: any)) {
-        let isValid =
+        const isValid =
           // Allow null for conditional declaration
           contextType === null ||
           (contextType !== undefined &&

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -223,7 +223,7 @@ function readContext<T>(
   context: ReactContext<T>,
   observedBits: void | number | boolean,
 ): T {
-  let threadID = currentThreadID;
+  const threadID = currentThreadID;
   validateContextBounds(context, threadID);
   if (__DEV__) {
     if (isInHookUserCodeInDev) {
@@ -246,7 +246,7 @@ function useContext<T>(
     currentHookNameInDev = 'useContext';
   }
   resolveCurrentlyRenderingComponent();
-  let threadID = currentThreadID;
+  const threadID = currentThreadID;
   validateContextBounds(context, threadID);
   return context[threadID];
 }

--- a/packages/react-dom/src/server/ReactThreadIDAllocator.js
+++ b/packages/react-dom/src/server/ReactThreadIDAllocator.js
@@ -22,9 +22,9 @@ for (let i = 0; i < 15; i++) {
 nextAvailableThreadIDs[15] = 0;
 
 function growThreadCountAndReturnNextAvailable() {
-  let oldArray = nextAvailableThreadIDs;
-  let oldSize = oldArray.length;
-  let newSize = oldSize * 2;
+  const oldArray = nextAvailableThreadIDs;
+  const oldSize = oldArray.length;
+  const newSize = oldSize * 2;
   invariant(
     newSize <= 0x10000,
     'Maximum number of concurrent React renderers exceeded. ' +
@@ -32,7 +32,7 @@ function growThreadCountAndReturnNextAvailable() {
       'Ensure that you call .destroy() on it if you no longer want to read from it, ' +
       'and did not read to the end. If you use .pipe() this should be automatic.',
   );
-  let newArray = new Uint16Array(newSize);
+  const newArray = new Uint16Array(newSize);
   newArray.set(oldArray);
   nextAvailableThreadIDs = newArray;
   nextAvailableThreadIDs[0] = oldSize + 1;
@@ -44,7 +44,7 @@ function growThreadCountAndReturnNextAvailable() {
 }
 
 export function allocThreadID(): ThreadID {
-  let nextID = nextAvailableThreadIDs[0];
+  const nextID = nextAvailableThreadIDs[0];
   if (nextID === 0) {
     return growThreadCountAndReturnNextAvailable();
   }

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -415,8 +415,6 @@ function shouldPreventMouseEvent(name, type, props) {
  * @return {?function} The stored callback.
  */
 function getListener(inst: Fiber, registrationName: string) {
-  let listener;
-
   // TODO: shouldPreventMouseEvent is DOM-specific and definitely should not
   // live here; needs to be moved to a better place soon
   const stateNode = inst.stateNode;
@@ -429,7 +427,7 @@ function getListener(inst: Fiber, registrationName: string) {
     // Work in progress.
     return null;
   }
-  listener = props[registrationName];
+  const listener = props[registrationName];
   if (shouldPreventMouseEvent(registrationName, inst.type, props)) {
     return null;
   }

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -90,7 +90,7 @@ function findAllInRenderedFiberTreeInternal(fiber, test) {
     return [];
   }
   let node = currentParent;
-  let ret = [];
+  const ret = [];
   while (true) {
     if (
       node.tag === HostComponent ||

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -84,12 +84,10 @@ function act(callback: () => Thenable<mixed>): Thenable<void> {
     }
   }
   const previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousIsSomeRendererActing;
-  let previousIsThisRendererActing;
   actingUpdatesScopeDepth++;
 
-  previousIsSomeRendererActing = IsSomeRendererActing.current;
-  previousIsThisRendererActing = IsThisRendererActing.current;
+  const previousIsSomeRendererActing = IsSomeRendererActing.current;
+  const previousIsThisRendererActing = IsThisRendererActing.current;
   IsSomeRendererActing.current = true;
   IsThisRendererActing.current = true;
 

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -83,7 +83,7 @@ function act(callback: () => Thenable<mixed>): Thenable<void> {
       );
     }
   }
-  let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+  const previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousIsSomeRendererActing;
   let previousIsThisRendererActing;
   actingUpdatesScopeDepth++;

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -24,7 +24,7 @@ function parseModel<T>(response: Response<T>, targetObj, key, value) {
         (value: any)[i] = parseModel(response, value, '' + i, value[i]);
       }
     } else {
-      for (let innerKey in value) {
+      for (const innerKey in value) {
         (value: any)[innerKey] = parseModel(
           response,
           value,

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -20,7 +20,7 @@ function render(
   destination: Destination,
   config: BundlerConfig,
 ): void {
-  let request = createRequest(model, destination, config);
+  const request = createRequest(model, destination, config);
   startWork(request);
 }
 

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -84,17 +84,17 @@ function convertModelToJSON(
   key: string,
   model: ReactModel,
 ): JSONValue {
-  let json = resolveModelToJSON(request, parent, key, model);
+  const json = resolveModelToJSON(request, parent, key, model);
   if (typeof json === 'object' && json !== null) {
     if (Array.isArray(json)) {
-      let jsonArray: Array<JSONValue> = [];
+      const jsonArray: Array<JSONValue> = [];
       for (let i = 0; i < json.length; i++) {
         jsonArray[i] = convertModelToJSON(request, json, '' + i, json[i]);
       }
       return jsonArray;
     } else {
-      let jsonObj: {[key: string]: JSONValue} = {};
-      for (let nextKey in json) {
+      const jsonObj: {[key: string]: JSONValue} = {};
+      for (const nextKey in json) {
         jsonObj[nextKey] = convertModelToJSON(
           request,
           json,
@@ -113,7 +113,7 @@ export function processModelChunk(
   id: number,
   model: ReactModel,
 ): Chunk {
-  let json = convertModelToJSON(request, {}, '', model);
+  const json = convertModelToJSON(request, {}, '', model);
   return {
     type: 'json',
     id: id,

--- a/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-flight-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -27,9 +27,9 @@ describe('ReactFlightDOMRelay', () => {
   });
 
   function readThrough(data) {
-    let response = ReactDOMFlightRelayClient.createResponse();
+    const response = ReactDOMFlightRelayClient.createResponse();
     for (let i = 0; i < data.length; i++) {
-      let chunk = data[i];
+      const chunk = data[i];
       if (chunk.type === 'json') {
         ReactDOMFlightRelayClient.resolveModel(response, chunk.id, chunk.json);
       } else {
@@ -42,7 +42,7 @@ describe('ReactFlightDOMRelay', () => {
       }
     }
     ReactDOMFlightRelayClient.close(response);
-    let model = response.readRoot();
+    const model = response.readRoot();
     return model;
   }
 
@@ -51,7 +51,7 @@ describe('ReactFlightDOMRelay', () => {
       return ReactDOMFlightRelayServerRuntime.serverBlock(render);
     }
     return function(...args) {
-      let curriedLoad = () => {
+      const curriedLoad = () => {
         return load(...args);
       };
       return ReactDOMFlightRelayServerRuntime.serverBlock(render, curriedLoad);
@@ -71,7 +71,7 @@ describe('ReactFlightDOMRelay', () => {
         ),
       };
     }
-    let transport = [];
+    const transport = [];
     ReactDOMFlightRelayServer.render(
       {
         foo: <Foo />,
@@ -79,7 +79,7 @@ describe('ReactFlightDOMRelay', () => {
       transport,
     );
 
-    let model = readThrough(transport);
+    const model = readThrough(transport);
     expect(model).toEqual({
       foo: {
         bar: (
@@ -104,20 +104,20 @@ describe('ReactFlightDOMRelay', () => {
         </span>
       );
     }
-    let loadUser = block(User, load);
-    let model = {
+    const loadUser = block(User, load);
+    const model = {
       User: loadUser('Seb', 'Smith'),
     };
 
-    let transport = [];
+    const transport = [];
     ReactDOMFlightRelayServer.render(model, transport);
 
-    let modelClient = readThrough(transport);
+    const modelClient = readThrough(transport);
 
-    let container = document.createElement('div');
-    let root = ReactDOM.createRoot(container);
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
     act(() => {
-      let UserClient = modelClient.User;
+      const UserClient = modelClient.User;
       root.render(<UserClient greeting="Hello" />);
     });
 

--- a/packages/react-flight-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -31,14 +31,14 @@ const chunkCache: Map<string, null | Promise<any> | Error> = new Map();
 // Start preloading the modules since we might need them soon.
 // This function doesn't suspend.
 export function preloadModule<T>(moduleData: ModuleReference<T>): void {
-  let chunks = moduleData.chunks;
+  const chunks = moduleData.chunks;
   for (let i = 0; i < chunks.length; i++) {
-    let chunkId = chunks[i];
-    let entry = chunkCache.get(chunkId);
+    const chunkId = chunks[i];
+    const entry = chunkCache.get(chunkId);
     if (entry === undefined) {
-      let thenable = __webpack_chunk_load__(chunkId);
-      let resolve = chunkCache.set.bind(chunkCache, chunkId, null);
-      let reject = chunkCache.set.bind(chunkCache, chunkId);
+      const thenable = __webpack_chunk_load__(chunkId);
+      const resolve = chunkCache.set.bind(chunkCache, chunkId, null);
+      const reject = chunkCache.set.bind(chunkCache, chunkId);
       thenable.then(resolve, reject);
       chunkCache.set(chunkId, thenable);
     }
@@ -48,10 +48,10 @@ export function preloadModule<T>(moduleData: ModuleReference<T>): void {
 // Actually require the module or suspend if it's not yet ready.
 // Increase priority if necessary.
 export function requireModule<T>(moduleData: ModuleReference<T>): T {
-  let chunks = moduleData.chunks;
+  const chunks = moduleData.chunks;
   for (let i = 0; i < chunks.length; i++) {
-    let chunkId = chunks[i];
-    let entry = chunkCache.get(chunkId);
+    const chunkId = chunks[i];
+    const entry = chunkCache.get(chunkId);
     if (entry !== null) {
       // We assume that preloadModule has been called before.
       // So we don't expect to see entry being undefined here, that's an error.

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
@@ -21,13 +21,13 @@ function startReadingFromStream<T>(
   response: FlightResponse<T>,
   stream: ReadableStream,
 ): void {
-  let reader = stream.getReader();
+  const reader = stream.getReader();
   function progress({done, value}) {
     if (done) {
       close(response);
       return;
     }
-    let buffer: Uint8Array = (value: any);
+    const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, buffer);
     return reader.read().then(progress, error);
   }
@@ -40,7 +40,7 @@ function startReadingFromStream<T>(
 function createFromReadableStream<T>(
   stream: ReadableStream,
 ): FlightResponse<T> {
-  let response: FlightResponse<T> = createResponse();
+  const response: FlightResponse<T> = createResponse();
   startReadingFromStream(response, stream);
   return response;
 }
@@ -48,7 +48,7 @@ function createFromReadableStream<T>(
 function createFromFetch<T>(
   promiseForResponse: Promise<Response>,
 ): FlightResponse<T> {
-  let response: FlightResponse<T> = createResponse();
+  const response: FlightResponse<T> = createResponse();
   promiseForResponse.then(
     function(r) {
       startReadingFromStream(response, (r.body: any));
@@ -61,10 +61,10 @@ function createFromFetch<T>(
 }
 
 function createFromXHR<T>(request: XMLHttpRequest): FlightResponse<T> {
-  let response: FlightResponse<T> = createResponse();
+  const response: FlightResponse<T> = createResponse();
   let processedLength = 0;
   function progress(e: ProgressEvent): void {
-    let chunk = request.responseText;
+    const chunk = request.responseText;
     processStringChunk(response, chunk, processedLength);
     processedLength = chunk.length;
   }

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -26,7 +26,7 @@ function pipeToNodeWritable(
   destination: Writable,
   webpackMap: BundlerConfig,
 ): void {
-  let request = createRequest(model, destination, webpackMap);
+  const request = createRequest(model, destination, webpackMap);
   destination.on('drain', createDrainHandler(destination, request));
   startWork(request);
 }

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -47,8 +47,8 @@ describe('ReactFlightDOM', () => {
   });
 
   function getTestStream() {
-    let writable = new Stream.PassThrough();
-    let readable = new ReadableStream({
+    const writable = new Stream.PassThrough();
+    const readable = new ReadableStream({
       start(controller) {
         writable.on('data', chunk => {
           controller.enqueue(chunk);
@@ -65,7 +65,7 @@ describe('ReactFlightDOM', () => {
   }
 
   function block(render, load) {
-    let idx = webpackModuleIdx++;
+    const idx = webpackModuleIdx++;
     webpackModules[idx] = {
       d: render,
     };
@@ -80,7 +80,7 @@ describe('ReactFlightDOM', () => {
       };
     }
     return function(...args) {
-      let curriedLoad = () => {
+      const curriedLoad = () => {
         return load(...args);
       };
       return ReactFlightDOMServerRuntime.serverBlock(
@@ -118,17 +118,17 @@ describe('ReactFlightDOM', () => {
     }
 
     function App() {
-      let model = {
+      const model = {
         html: <HTML />,
       };
       return model;
     }
 
-    let {writable, readable} = getTestStream();
+    const {writable, readable} = getTestStream();
     ReactFlightDOMServer.pipeToNodeWritable(<App />, writable, webpackMap);
-    let response = ReactFlightDOMClient.createFromReadableStream(readable);
+    const response = ReactFlightDOMClient.createFromReadableStream(readable);
     await waitForSuspense(() => {
-      let model = response.readRoot();
+      const model = response.readRoot();
       expect(model).toEqual({
         html: (
           <div>
@@ -141,7 +141,7 @@ describe('ReactFlightDOM', () => {
   });
 
   it.experimental('should resolve the root', async () => {
-    let {Suspense} = React;
+    const {Suspense} = React;
 
     // Model
     function Text({children}) {
@@ -173,16 +173,16 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    let {writable, readable} = getTestStream();
+    const {writable, readable} = getTestStream();
     ReactFlightDOMServer.pipeToNodeWritable(
       <RootModel />,
       writable,
       webpackMap,
     );
-    let response = ReactFlightDOMClient.createFromReadableStream(readable);
+    const response = ReactFlightDOMClient.createFromReadableStream(readable);
 
-    let container = document.createElement('div');
-    let root = ReactDOM.createRoot(container);
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
     await act(async () => {
       root.render(<App response={response} />);
     });
@@ -192,7 +192,7 @@ describe('ReactFlightDOM', () => {
   });
 
   it.experimental('should not get confused by $', async () => {
-    let {Suspense} = React;
+    const {Suspense} = React;
 
     // Model
     function RootModel() {
@@ -211,16 +211,16 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    let {writable, readable} = getTestStream();
+    const {writable, readable} = getTestStream();
     ReactFlightDOMServer.pipeToNodeWritable(
       <RootModel />,
       writable,
       webpackMap,
     );
-    let response = ReactFlightDOMClient.createFromReadableStream(readable);
+    const response = ReactFlightDOMClient.createFromReadableStream(readable);
 
-    let container = document.createElement('div');
-    let root = ReactDOM.createRoot(container);
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
     await act(async () => {
       root.render(<App response={response} />);
     });
@@ -228,7 +228,7 @@ describe('ReactFlightDOM', () => {
   });
 
   it.experimental('should not get confused by @', async () => {
-    let {Suspense} = React;
+    const {Suspense} = React;
 
     // Model
     function RootModel() {
@@ -247,16 +247,16 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    let {writable, readable} = getTestStream();
+    const {writable, readable} = getTestStream();
     ReactFlightDOMServer.pipeToNodeWritable(
       <RootModel />,
       writable,
       webpackMap,
     );
-    let response = ReactFlightDOMClient.createFromReadableStream(readable);
+    const response = ReactFlightDOMClient.createFromReadableStream(readable);
 
-    let container = document.createElement('div');
-    let root = ReactDOM.createRoot(container);
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
     await act(async () => {
       root.render(<App response={response} />);
     });
@@ -264,7 +264,7 @@ describe('ReactFlightDOM', () => {
   });
 
   it.experimental('should progressively reveal Blocks', async () => {
-    let {Suspense} = React;
+    const {Suspense} = React;
 
     class ErrorBoundary extends React.Component {
       state = {hasError: false, error: null};
@@ -311,7 +311,7 @@ describe('ReactFlightDOM', () => {
       function DelayedText({children}, data) {
         return <Text>{children}</Text>;
       }
-      let loadBlock = block(DelayedText, load);
+      const loadBlock = block(DelayedText, load);
       return [loadBlock(), _resolve, _reject];
     }
 
@@ -328,7 +328,7 @@ describe('ReactFlightDOM', () => {
         games: <GamesModel>:games:</GamesModel>,
       };
     }
-    let profileModel = {
+    const profileModel = {
       photos: <PhotosModel>:photos:</PhotosModel>,
       name: <NameModel>:name:</NameModel>,
       more: <ProfileMore />,
@@ -336,7 +336,7 @@ describe('ReactFlightDOM', () => {
 
     // View
     function ProfileDetails({response}) {
-      let model = response.readRoot();
+      const model = response.readRoot();
       return (
         <div>
           {model.name}
@@ -345,7 +345,7 @@ describe('ReactFlightDOM', () => {
       );
     }
     function ProfileSidebar({response}) {
-      let model = response.readRoot();
+      const model = response.readRoot();
       return (
         <div>
           {model.photos}
@@ -380,12 +380,12 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    let {writable, readable} = getTestStream();
+    const {writable, readable} = getTestStream();
     ReactFlightDOMServer.pipeToNodeWritable(profileModel, writable, webpackMap);
-    let response = ReactFlightDOMClient.createFromReadableStream(readable);
+    const response = ReactFlightDOMClient.createFromReadableStream(readable);
 
-    let container = document.createElement('div');
-    let root = ReactDOM.createRoot(container);
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
     await act(async () => {
       root.render(<ProfilePage response={response} />);
     });

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -55,16 +55,16 @@ describe('ReactFlightDOMBrowser', () => {
     }
 
     function App() {
-      let model = {
+      const model = {
         html: <HTML />,
       };
       return model;
     }
 
-    let stream = ReactFlightDOMServer.renderToReadableStream(<App />);
-    let response = ReactFlightDOMClient.createFromReadableStream(stream);
+    const stream = ReactFlightDOMServer.renderToReadableStream(<App />);
+    const response = ReactFlightDOMClient.createFromReadableStream(stream);
     await waitForSuspense(() => {
-      let model = response.readRoot();
+      const model = response.readRoot();
       expect(model).toEqual({
         html: (
           <div>

--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -174,8 +174,7 @@ function createPressEvent(
     ({altKey, ctrlKey, metaKey, shiftKey} = nativeEvent);
     // Only check for one property, checking for all of them is costly. We can assume
     // if clientX exists, so do the rest.
-    let eventObject;
-    eventObject = (touchEvent: any) || (nativeEvent: any);
+    const eventObject = (touchEvent: any) || (nativeEvent: any);
     if (eventObject) {
       ({clientX, clientY, pageX, pageY, screenX, screenY} = eventObject);
     }
@@ -671,7 +670,8 @@ const pressResponderImpl = {
     props: PressProps,
     state: PressState,
   ): void {
-    let {pointerType, target, type} = event;
+    const {pointerType, type} = event;
+    let target = event.target;
 
     const nativeEvent: any = event.nativeEvent;
     const isPressed = state.isPressed;

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -350,7 +350,9 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
         const Suspense = React.Suspense;
         let suspend = false;
         let resolve;
-        let promise = new Promise(resolvePromise => (resolve = resolvePromise));
+        const promise = new Promise(
+          resolvePromise => (resolve = resolvePromise),
+        );
 
         function Child() {
           if (suspend) {
@@ -378,7 +380,7 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
         const container2 = document.createElement('div');
         document.body.appendChild(container2);
 
-        let root = ReactDOM.createRoot(container2);
+        const root = ReactDOM.createRoot(container2);
         root.render(<Component />);
         Scheduler.unstable_flushAll();
         jest.runAllTimers();

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -615,7 +615,7 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       });
 
       it('press retention offset can be configured', () => {
-        let localEvents = [];
+        const localEvents = [];
         const localRef = React.createRef();
         const createEventHandler = msg => () => {
           localEvents.push(msg);

--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -12,7 +12,7 @@ function getInstanceFromInstance(instanceHandle) {
 }
 
 function getTagFromInstance(inst) {
-  let nativeInstance = inst.stateNode.canonical;
+  const nativeInstance = inst.stateNode.canonical;
   invariant(
     nativeInstance._nativeTag,
     'All native instances should have a tag.',

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -82,7 +82,7 @@ class ReactNativeFiberHostComponent {
       // Already a node handle
       relativeNode = relativeToNativeNode;
     } else {
-      let nativeNode: ReactNativeFiberHostComponent = (relativeToNativeNode: any);
+      const nativeNode: ReactNativeFiberHostComponent = (relativeToNativeNode: any);
       if (nativeNode._nativeTag) {
         relativeNode = nativeNode._nativeTag;
       }

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -219,7 +219,7 @@ setBatchingImplementation(
 );
 
 function computeComponentStackForErrorReporting(reactTag: number): string {
-  let fiber = getClosestInstanceFromNode(reactTag);
+  const fiber = getClosestInstanceFromNode(reactTag);
   if (!fiber) {
     return '';
   }

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -28,7 +28,7 @@ function dumpSubtree(info, indent) {
 
 const RCTFabricUIManager = {
   __dumpChildSetForJestTestsOnly: function(childSet) {
-    let result = [];
+    const result = [];
     // eslint-disable-next-line no-for-of-loops/no-for-of-loops
     for (const child of childSet) {
       result.push(dumpSubtree(child, 0));
@@ -36,7 +36,7 @@ const RCTFabricUIManager = {
     return result.join('\n');
   },
   __dumpHierarchyForJestTestsOnly: function() {
-    let result = [];
+    const result = [];
     // eslint-disable-next-line no-for-of-loops/no-for-of-loops
     for (const [rootTag, childSet] of roots) {
       result.push(rootTag);

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/UIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/UIManager.js
@@ -15,7 +15,7 @@ import invariant from 'shared/invariant';
 
 // Map of viewTag -> {children: [childTag], parent: ?parentTag}
 const roots = [];
-let views = new Map();
+const views = new Map();
 
 function autoCreateRoot(tag) {
   // Seriously, this is how we distinguish roots in RN.

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -613,18 +613,18 @@ describe('ReactFabric', () => {
       1,
     );
 
-    let [
+    const [
       ,
       ,
       ,
       ,
       instanceHandle,
     ] = nativeFabricUIManager.createNode.mock.calls[0];
-    let [
+    const [
       dispatchEvent,
     ] = nativeFabricUIManager.registerEventHandler.mock.calls[0];
 
-    let touchEvent = {
+    const touchEvent = {
       touches: [],
       changedTouches: [],
     };
@@ -708,7 +708,7 @@ describe('ReactFabric', () => {
       1,
     );
 
-    let [
+    const [
       dispatchEvent,
     ] = nativeFabricUIManager.registerEventHandler.mock.calls[0];
 
@@ -894,7 +894,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let viewRef = React.createRef();
+    const viewRef = React.createRef();
     ReactFabric.render(<View ref={viewRef} />, 11);
 
     expect(TextInputState.blurTextInput).not.toBeCalled();
@@ -911,7 +911,7 @@ describe('ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let viewRef = React.createRef();
+    const viewRef = React.createRef();
     ReactFabric.render(<View ref={viewRef} />, 11);
 
     expect(TextInputState.focusTextInput).not.toBeCalled();

--- a/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabricAndNative-test.internal.js
@@ -40,7 +40,7 @@ describe('created with ReactFabric called with ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     class Component extends React.Component {
       render() {
@@ -50,7 +50,7 @@ describe('created with ReactFabric called with ReactNative', () => {
 
     ReactFabric.render(<Component ref={ref} />, 11);
 
-    let instance = ReactNative.findHostInstance_DEPRECATED(ref.current);
+    const instance = ReactNative.findHostInstance_DEPRECATED(ref.current);
     expect(instance._nativeTag).toBe(2);
   });
 
@@ -60,7 +60,7 @@ describe('created with ReactFabric called with ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     class Component extends React.Component {
       render() {
@@ -70,7 +70,7 @@ describe('created with ReactFabric called with ReactNative', () => {
 
     ReactFabric.render(<Component ref={ref} />, 11);
 
-    let handle = ReactNative.findNodeHandle(ref.current);
+    const handle = ReactNative.findNodeHandle(ref.current);
     expect(handle).toBe(2);
   });
 
@@ -81,7 +81,7 @@ describe('created with ReactFabric called with ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     ReactFabric.render(<View title="bar" ref={ref} />, 11);
     expect(nativeFabricUIManager.dispatchCommand).not.toBeCalled();
@@ -118,7 +118,7 @@ describe('created with ReactNative called with ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     class Component extends React.Component {
       render() {
@@ -128,7 +128,7 @@ describe('created with ReactNative called with ReactFabric', () => {
 
     ReactNative.render(<Component ref={ref} />, 11);
 
-    let instance = ReactFabric.findHostInstance_DEPRECATED(ref.current);
+    const instance = ReactFabric.findHostInstance_DEPRECATED(ref.current);
     expect(instance._nativeTag).toBe(3);
   });
 
@@ -138,7 +138,7 @@ describe('created with ReactNative called with ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     class Component extends React.Component {
       render() {
@@ -148,7 +148,7 @@ describe('created with ReactNative called with ReactFabric', () => {
 
     ReactNative.render(<Component ref={ref} />, 11);
 
-    let handle = ReactFabric.findNodeHandle(ref.current);
+    const handle = ReactFabric.findNodeHandle(ref.current);
     expect(handle).toBe(3);
   });
 
@@ -159,7 +159,7 @@ describe('created with ReactNative called with ReactFabric', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let ref = React.createRef();
+    const ref = React.createRef();
 
     ReactNative.render(<View title="bar" ref={ref} />, 11);
     expect(UIManager.dispatchViewManagerCommand).not.toBeCalled();

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -68,9 +68,9 @@ describe('ReactNativeError', () => {
 
     ReactNative.render(<ClassComponent />, 1);
 
-    let reactTag = ReactNative.findNodeHandle(ref.current);
+    const reactTag = ReactNative.findNodeHandle(ref.current);
 
-    let componentStack = normalizeCodeLocInfo(
+    const componentStack = normalizeCodeLocInfo(
       computeComponentStackForErrorReporting(reactTag),
     );
 

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -604,7 +604,7 @@ describe('ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let viewRef = React.createRef();
+    const viewRef = React.createRef();
     ReactNative.render(<View ref={viewRef} />, 11);
 
     expect(TextInputState.blurTextInput).not.toBeCalled();
@@ -621,7 +621,7 @@ describe('ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    let viewRef = React.createRef();
+    const viewRef = React.createRef();
     ReactNative.render(<View ref={viewRef} />, 11);
 
     expect(TextInputState.focusTextInput).not.toBeCalled();

--- a/packages/react-noop-renderer/flight-modules.js
+++ b/packages/react-noop-renderer/flight-modules.js
@@ -9,11 +9,11 @@
 
 // This file is used as temporary storage for modules generated in Flight tests.
 let moduleIdx = 0;
-let modules: Map<string, Function> = new Map();
+const modules: Map<string, Function> = new Map();
 
 // This simulates what the compiler will do when it replaces render functions with server blocks.
 export function saveModule(render: Function): string {
-  let idx = '' + moduleIdx++;
+  const idx = '' + moduleIdx++;
   modules.set(idx, render);
   return idx;
 }

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -32,7 +32,7 @@ const {createResponse, processStringChunk, close} = ReactFlightClient({
 });
 
 function read<T>(source: Source): T {
-  let response = createResponse(source);
+  const response = createResponse(source);
   for (let i = 0; i < source.length; i++) {
     processStringChunk(response, source[i], 0);
   }

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -48,9 +48,9 @@ const ReactNoopFlightServer = ReactFlightServer({
 });
 
 function render(model: ReactModel): Destination {
-  let destination: Destination = [];
-  let bundlerConfig = undefined;
-  let request = ReactNoopFlightServer.createRequest(
+  const destination: Destination = [];
+  const bundlerConfig = undefined;
+  const request = ReactNoopFlightServer.createRequest(
     model,
     destination,
     bundlerConfig,

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -41,8 +41,8 @@ const ReactNoopServer = ReactFizzServer({
 });
 
 function render(children: React$Element<any>): Destination {
-  let destination: Destination = [];
-  let request = ReactNoopServer.createRequest(children, destination);
+  const destination: Destination = [];
+  const request = ReactNoopServer.createRequest(children, destination);
   ReactNoopServer.startWork(request);
   return destination;
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -958,7 +958,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         return;
       }
 
-      let bufferedLog = [];
+      const bufferedLog = [];
       function log(...args) {
         bufferedLog.push(...args, '\n');
       }
@@ -988,7 +988,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       function logUpdateQueue(updateQueue: UpdateQueue<mixed>, depth) {
         log('  '.repeat(depth + 1) + 'QUEUED UPDATES');
         const first = updateQueue.firstBaseUpdate;
-        let update = first;
+        const update = first;
         if (update !== null) {
           do {
             log(
@@ -1001,7 +1001,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         const lastPending = updateQueue.shared.pending;
         if (lastPending !== null) {
           const firstPending = lastPending.next;
-          let pendingUpdate = firstPending;
+          const pendingUpdate = firstPending;
           if (pendingUpdate !== null) {
             do {
               log(

--- a/packages/react-reconciler/src/ReactChildFiber.js
+++ b/packages/react-reconciler/src/ReactChildFiber.js
@@ -110,7 +110,7 @@ function coerceRef(
   current: Fiber | null,
   element: ReactElement,
 ) {
-  let mixedRef = element.ref;
+  const mixedRef = element.ref;
   if (
     mixedRef !== null &&
     typeof mixedRef !== 'function' &&
@@ -271,8 +271,8 @@ function resolveLazyType<T, P>(
 ): LazyComponent<T, P> | T {
   try {
     // If we can, let's peek at the resulting type.
-    let payload = lazyComponent._payload;
-    let init = lazyComponent._init;
+    const payload = lazyComponent._payload;
+    const init = lazyComponent._init;
     return init(payload);
   } catch (x) {
     // Leave it in place and let it throw again in the begin phase.

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -610,8 +610,6 @@ export function createFiberFromTypeAndProps(
   mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
-  let fiber;
-
   let fiberTag = IndeterminateComponent;
   // The resolved type is set if we know what the final type will be. I.e. it's not lazy.
   let resolvedType = type;
@@ -731,7 +729,7 @@ export function createFiberFromTypeAndProps(
     }
   }
 
-  fiber = createFiber(fiberTag, pendingProps, key, mode);
+  const fiber = createFiber(fiberTag, pendingProps, key, mode);
   fiber.elementType = type;
   fiber.type = resolvedType;
   fiber.expirationTime = expirationTime;

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -528,7 +528,7 @@ export function resetWorkInProgress(
   workInProgress.firstEffect = null;
   workInProgress.lastEffect = null;
 
-  let current = workInProgress.alternate;
+  const current = workInProgress.alternate;
   if (current === null) {
     // Reset to createFiber's initial values.
     workInProgress.childExpirationTime = NoWork;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -370,7 +370,7 @@ function updateMemoComponent(
   renderExpirationTime: ExpirationTime,
 ): null | Fiber {
   if (current === null) {
-    let type = Component.type;
+    const type = Component.type;
     if (
       isSimpleFunctionComponent(type) &&
       Component.compare === null &&
@@ -411,7 +411,7 @@ function updateMemoComponent(
         );
       }
     }
-    let child = createFiberFromTypeAndProps(
+    const child = createFiberFromTypeAndProps(
       Component.type,
       null,
       nextProps,
@@ -438,7 +438,7 @@ function updateMemoComponent(
       );
     }
   }
-  let currentChild = ((current.child: any): Fiber); // This is always exactly one child
+  const currentChild = ((current.child: any): Fiber); // This is always exactly one child
   if (updateExpirationTime < renderExpirationTime) {
     // This will be the props with resolved defaultProps,
     // unlike current.memoizedProps which will be the unresolved ones.
@@ -456,7 +456,7 @@ function updateMemoComponent(
   }
   // React DevTools reads this flag.
   workInProgress.effectTag |= PerformedWork;
-  let newChild = createWorkInProgress(currentChild, nextProps);
+  const newChild = createWorkInProgress(currentChild, nextProps);
   newChild.ref = workInProgress.ref;
   newChild.return = workInProgress;
   workInProgress.child = newChild;
@@ -485,8 +485,8 @@ function updateSimpleMemoComponent(
         // so let's just skip over it to find memo() outer wrapper.
         // Inner props for memo are validated later.
         const lazyComponent: LazyComponentType<any, any> = outerMemoType;
-        let payload = lazyComponent._payload;
-        let init = lazyComponent._init;
+        const payload = lazyComponent._payload;
+        const init = lazyComponent._init;
         try {
           outerMemoType = init(payload);
         } catch (x) {
@@ -855,7 +855,7 @@ function updateClassComponent(
     renderExpirationTime,
   );
   if (__DEV__) {
-    let inst = workInProgress.stateNode;
+    const inst = workInProgress.stateNode;
     if (inst.props !== nextProps) {
       if (!didWarnAboutReassigningProps) {
         console.error(
@@ -1015,7 +1015,7 @@ function updateHostRoot(current, workInProgress, renderExpirationTime) {
     // be any children to hydrate which is effectively the same thing as
     // not hydrating.
 
-    let child = mountChildFibers(
+    const child = mountChildFibers(
       workInProgress,
       null,
       nextChildren,
@@ -1127,9 +1127,9 @@ function mountLazyComponent(
   }
 
   const props = workInProgress.pendingProps;
-  let lazyComponent: LazyComponentType<any, any> = elementType;
-  let payload = lazyComponent._payload;
-  let init = lazyComponent._init;
+  const lazyComponent: LazyComponentType<any, any> = elementType;
+  const payload = lazyComponent._payload;
+  const init = lazyComponent._init;
   let Component = init(payload);
   // Store the unwrapped component in the type.
   workInProgress.type = Component;
@@ -2194,9 +2194,9 @@ function mountDehydratedSuspenseComponent(
     // a protocol to transfer that time, we'll just estimate it by using the current
     // time. This will mean that Suspense timeouts are slightly shifted to later than
     // they should be.
-    let serverDisplayTime = requestCurrentTimeForUpdate();
+    const serverDisplayTime = requestCurrentTimeForUpdate();
     // Schedule a normal pri update to render this content.
-    let newExpirationTime = computeAsyncExpiration(serverDisplayTime);
+    const newExpirationTime = computeAsyncExpiration(serverDisplayTime);
     if (enableSchedulerTracing) {
       markSpawnedWork(newExpirationTime);
     }
@@ -2252,7 +2252,7 @@ function updateDehydratedSuspenseComponent(
       if (suspenseState.retryTime <= renderExpirationTime) {
         // This render is even higher pri than we've seen before, let's try again
         // at even higher pri.
-        let attemptHydrationAtExpirationTime = renderExpirationTime + 1;
+        const attemptHydrationAtExpirationTime = renderExpirationTime + 1;
         suspenseState.retryTime = attemptHydrationAtExpirationTime;
         scheduleUpdateOnFiber(current, attemptHydrationAtExpirationTime);
         // TODO: Early abort this render.
@@ -2332,7 +2332,7 @@ function scheduleWorkOnFiber(
   if (fiber.expirationTime < renderExpirationTime) {
     fiber.expirationTime = renderExpirationTime;
   }
-  let alternate = fiber.alternate;
+  const alternate = fiber.alternate;
   if (alternate !== null && alternate.expirationTime < renderExpirationTime) {
     alternate.expirationTime = renderExpirationTime;
   }
@@ -2391,7 +2391,7 @@ function findLastContentRow(firstChild: null | Fiber): null | Fiber {
   let row = firstChild;
   let lastContentRow: null | Fiber = null;
   while (row !== null) {
-    let currentRow = row.alternate;
+    const currentRow = row.alternate;
     // New rows can't be content rows.
     if (currentRow !== null && findFirstSuspended(currentRow) === null) {
       lastContentRow = row;
@@ -2483,10 +2483,11 @@ function validateTailOptions(
 
 function validateSuspenseListNestedChild(childSlot: mixed, index: number) {
   if (__DEV__) {
-    let isArray = Array.isArray(childSlot);
-    let isIterable = !isArray && typeof getIteratorFn(childSlot) === 'function';
+    const isArray = Array.isArray(childSlot);
+    const isIterable =
+      !isArray && typeof getIteratorFn(childSlot) === 'function';
     if (isArray || isIterable) {
-      let type = isArray ? 'array' : 'iterable';
+      const type = isArray ? 'array' : 'iterable';
       console.error(
         'A nested %s was passed to row #%s in <SuspenseList />. Wrap it in ' +
           'an additional SuspenseList to configure its revealOrder: ' +
@@ -2521,7 +2522,7 @@ function validateSuspenseListChildren(
           }
         }
       } else {
-        let iteratorFn = getIteratorFn(children);
+        const iteratorFn = getIteratorFn(children);
         if (typeof iteratorFn === 'function') {
           const childrenIterator = iteratorFn.call(children);
           if (childrenIterator) {
@@ -2555,7 +2556,7 @@ function initSuspenseListRenderState(
   tailMode: SuspenseListTailMode,
   lastEffectBeforeRendering: null | Fiber,
 ): void {
-  let renderState: null | SuspenseListRenderState =
+  const renderState: null | SuspenseListRenderState =
     workInProgress.memoizedState;
   if (renderState === null) {
     workInProgress.memoizedState = ({
@@ -2606,7 +2607,7 @@ function updateSuspenseListComponent(
 
   let suspenseContext: SuspenseContext = suspenseStackCursor.current;
 
-  let shouldForceFallback = hasSuspenseContext(
+  const shouldForceFallback = hasSuspenseContext(
     suspenseContext,
     (ForceSuspenseFallback: SuspenseContext),
   );
@@ -2640,7 +2641,7 @@ function updateSuspenseListComponent(
   } else {
     switch (revealOrder) {
       case 'forwards': {
-        let lastContentRow = findLastContentRow(workInProgress.child);
+        const lastContentRow = findLastContentRow(workInProgress.child);
         let tail;
         if (lastContentRow === null) {
           // The whole list is part of the tail.
@@ -2672,14 +2673,14 @@ function updateSuspenseListComponent(
         let row = workInProgress.child;
         workInProgress.child = null;
         while (row !== null) {
-          let currentRow = row.alternate;
+          const currentRow = row.alternate;
           // New rows can't be content rows.
           if (currentRow !== null && findFirstSuspended(currentRow) === null) {
             // This is the beginning of the main content.
             workInProgress.child = row;
             break;
           }
-          let nextRow = row.sibling;
+          const nextRow = row.sibling;
           row.sibling = tail;
           tail = row;
           row = nextRow;
@@ -3227,7 +3228,7 @@ function beginWork(
           // If nothing suspended before and we're rendering the same children,
           // then the tail doesn't matter. Anything new that suspends will work
           // in the "together" mode, so we can continue from the state we had.
-          let renderState = workInProgress.memoizedState;
+          const renderState = workInProgress.memoizedState;
           if (renderState !== null) {
             // Reset to the "together" mode in case we've started a different
             // update in the past but didn't complete it.

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -540,7 +540,7 @@ function constructClassInstance(
 
   if (__DEV__) {
     if ('contextType' in ctor) {
-      let isValid =
+      const isValid =
         // Allow null for conditional declaration
         contextType === null ||
         (contextType !== undefined &&

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -347,7 +347,7 @@ function commitBeforeMutationLifeCycles(
 
 function commitHookEffectListUnmount(tag: number, finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-  let lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
   if (lastEffect !== null) {
     const firstEffect = lastEffect.next;
     let effect = firstEffect;
@@ -367,7 +367,7 @@ function commitHookEffectListUnmount(tag: number, finishedWork: Fiber) {
 
 function commitHookEffectListMount(tag: number, finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-  let lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
   if (lastEffect !== null) {
     const firstEffect = lastEffect.next;
     let effect = firstEffect;
@@ -419,7 +419,7 @@ function commitHookEffectListMount(tag: number, finishedWork: Fiber) {
 function schedulePassiveEffects(finishedWork: Fiber) {
   if (runAllPassiveEffectDestroysBeforeCreates) {
     const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-    let lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+    const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
     if (lastEffect !== null) {
       const firstEffect = lastEffect.next;
       let effect = firstEffect;
@@ -1755,7 +1755,7 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
 }
 
 function commitSuspenseComponent(finishedWork: Fiber) {
-  let newState: SuspenseState | null = finishedWork.memoizedState;
+  const newState: SuspenseState | null = finishedWork.memoizedState;
 
   let newDidTimeout;
   let primaryChildParent = finishedWork;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -443,7 +443,7 @@ if (supportsMutation) {
       // No changes, just reuse the existing instance.
     } else {
       const container = portalOrRoot.containerInfo;
-      let newChildSet = createContainerChildSet(container);
+      const newChildSet = createContainerChildSet(container);
       // If children might have changed, we have to add them all to the set.
       appendAllChildrenToContainer(newChildSet, workInProgress, false, false);
       portalOrRoot.pendingChildren = newChildSet;
@@ -489,7 +489,7 @@ if (supportsMutation) {
       workInProgress.stateNode = currentInstance;
       return;
     }
-    let newInstance = cloneInstance(
+    const newInstance = cloneInstance(
       currentInstance,
       updatePayload,
       type,
@@ -672,7 +672,7 @@ function completeWork(
       if (current === null || current.child === null) {
         // If we hydrated, pop so that we can delete any remaining children
         // that weren't hydrated.
-        let wasHydrated = popHydrationState(workInProgress);
+        const wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
           // If we hydrated, then we'll need to schedule an update for
           // the commit side-effects on the root.
@@ -722,7 +722,7 @@ function completeWork(
         // "stack" as the parent. Then append children as we go in beginWork
         // or completeWork depending on whether we want to add them top->down or
         // bottom->up. Top->down is faster in IE11.
-        let wasHydrated = popHydrationState(workInProgress);
+        const wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
           // TODO: Move this and createInstance step into the beginPhase
           // to consolidate.
@@ -748,7 +748,7 @@ function completeWork(
             }
           }
         } else {
-          let instance = createInstance(
+          const instance = createInstance(
             type,
             newProps,
             rootContainerInstance,
@@ -796,7 +796,7 @@ function completeWork(
       return null;
     }
     case HostText: {
-      let newText = newProps;
+      const newText = newProps;
       if (current && workInProgress.stateNode != null) {
         const oldText = current.memoizedProps;
         // If we have an alternate, that means this is an update and we need
@@ -813,7 +813,7 @@ function completeWork(
         }
         const rootContainerInstance = getRootHostContainer();
         const currentHostContext = getHostContext();
-        let wasHydrated = popHydrationState(workInProgress);
+        const wasHydrated = popHydrationState(workInProgress);
         if (wasHydrated) {
           if (prepareToHydrateHostTextInstance(workInProgress)) {
             markUpdate(workInProgress);
@@ -836,7 +836,7 @@ function completeWork(
       if (enableSuspenseServerRenderer) {
         if (nextState !== null && nextState.dehydrated !== null) {
           if (current === null) {
-            let wasHydrated = popHydrationState(workInProgress);
+            const wasHydrated = popHydrationState(workInProgress);
             invariant(
               wasHydrated,
               'A dehydrated suspense component was completed without a hydrated node. ' +
@@ -1002,7 +1002,7 @@ function completeWork(
       let didSuspendAlready =
         (workInProgress.effectTag & DidCapture) !== NoEffect;
 
-      let renderedTail = renderState.rendering;
+      const renderedTail = renderState.rendering;
       if (renderedTail === null) {
         // We just rendered the head.
         if (!didSuspendAlready) {
@@ -1017,13 +1017,13 @@ function completeWork(
           // something in the previous committed pass suspended. Otherwise,
           // there's no chance so we can skip the expensive call to
           // findFirstSuspended.
-          let cannotBeSuspended =
+          const cannotBeSuspended =
             renderHasNotSuspendedYet() &&
             (current === null || (current.effectTag & DidCapture) === NoEffect);
           if (!cannotBeSuspended) {
             let row = workInProgress.child;
             while (row !== null) {
-              let suspended = findFirstSuspended(row);
+              const suspended = findFirstSuspended(row);
               if (suspended !== null) {
                 didSuspendAlready = true;
                 workInProgress.effectTag |= DidCapture;
@@ -1041,7 +1041,7 @@ function completeWork(
                 // We might bail out of the loop before finding any but that
                 // doesn't matter since that means that the other boundaries that
                 // we did find already has their listeners attached.
-                let newThennables = suspended.updateQueue;
+                const newThennables = suspended.updateQueue;
                 if (newThennables !== null) {
                   workInProgress.updateQueue = newThennables;
                   workInProgress.effectTag |= Update;
@@ -1078,14 +1078,14 @@ function completeWork(
       } else {
         // Append the rendered row to the child list.
         if (!didSuspendAlready) {
-          let suspended = findFirstSuspended(renderedTail);
+          const suspended = findFirstSuspended(renderedTail);
           if (suspended !== null) {
             workInProgress.effectTag |= DidCapture;
             didSuspendAlready = true;
 
             // Ensure we transfer the update queue to the parent so that it doesn't
             // get lost if this row ends up dropped during a second pass.
-            let newThennables = suspended.updateQueue;
+            const newThennables = suspended.updateQueue;
             if (newThennables !== null) {
               workInProgress.updateQueue = newThennables;
               workInProgress.effectTag |= Update;
@@ -1101,7 +1101,7 @@ function completeWork(
               // We need to delete the row we just rendered.
               // Reset the effect list to what it was before we rendered this
               // child. The nested children have already appended themselves.
-              let lastEffect = (workInProgress.lastEffect =
+              const lastEffect = (workInProgress.lastEffect =
                 renderState.lastEffect);
               // Remove any effects that were appended after this point.
               if (lastEffect !== null) {
@@ -1147,7 +1147,7 @@ function completeWork(
           renderedTail.sibling = workInProgress.child;
           workInProgress.child = renderedTail;
         } else {
-          let previousSibling = renderState.last;
+          const previousSibling = renderState.last;
           if (previousSibling !== null) {
             previousSibling.sibling = renderedTail;
           } else {
@@ -1172,7 +1172,7 @@ function completeWork(
           // It should probably use a global start time value instead.
         }
         // Pop a row.
-        let next = renderState.tail;
+        const next = renderState.tail;
         renderState.rendering = next;
         renderState.tail = next.sibling;
         renderState.lastEffect = workInProgress.lastEffect;

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -31,9 +31,11 @@ if (__DEV__) {
 }
 
 // A cursor to the current merged context object on the stack.
-let contextStackCursor: StackCursor<Object> = createCursor(emptyContextObject);
+const contextStackCursor: StackCursor<Object> = createCursor(
+  emptyContextObject,
+);
 // A cursor to a boolean indicating whether the context has changed.
-let didPerformWorkStackCursor: StackCursor<boolean> = createCursor(false);
+const didPerformWorkStackCursor: StackCursor<boolean> = createCursor(false);
 // Keep track of the previous context object that was on the stack.
 // We use this to get access to the parent context after we have already
 // pushed the next context provider, and now need to merge their contexts.
@@ -97,7 +99,7 @@ function getMaskedContext(
     }
 
     const context = {};
-    for (let key in contextTypes) {
+    for (const key in contextTypes) {
       context[key] = unmaskedContext[key];
     }
 
@@ -203,7 +205,7 @@ function processChildContext(
 
     let childContext;
     childContext = instance.getChildContext();
-    for (let contextKey in childContext) {
+    for (const contextKey in childContext) {
       invariant(
         contextKey in childContextTypes,
         '%s.getChildContext(): key "%s" is not defined in childContextTypes.',

--- a/packages/react-reconciler/src/ReactFiberContext.js
+++ b/packages/react-reconciler/src/ReactFiberContext.js
@@ -203,8 +203,7 @@ function processChildContext(
       return parentContext;
     }
 
-    let childContext;
-    childContext = instance.getChildContext();
+    const childContext = instance.getChildContext();
     for (const contextKey in childContext) {
       invariant(
         contextKey in childContextTypes,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -597,7 +597,7 @@ function updateWorkInProgressHook(): Hook {
   // the dispatcher used for mounts.
   let nextCurrentHook: null | Hook;
   if (currentHook === null) {
-    let current = currentlyRenderingFiber.alternate;
+    const current = currentlyRenderingFiber.alternate;
     if (current !== null) {
       nextCurrentHook = current.memoizedState;
     } else {
@@ -708,14 +708,14 @@ function updateReducer<S, I, A>(
   let baseQueue = current.baseQueue;
 
   // The last pending update that hasn't been processed yet.
-  let pendingQueue = queue.pending;
+  const pendingQueue = queue.pending;
   if (pendingQueue !== null) {
     // We have new updates that haven't been processed yet.
     // We'll add them to the base queue.
     if (baseQueue !== null) {
       // Merge the pending queue and the base queue.
-      let baseFirst = baseQueue.next;
-      let pendingFirst = pendingQueue.next;
+      const baseFirst = baseQueue.next;
+      const pendingFirst = pendingQueue.next;
       baseQueue.next = pendingFirst;
       pendingQueue.next = baseFirst;
     }
@@ -735,7 +735,7 @@ function updateReducer<S, I, A>(
 
   if (baseQueue !== null) {
     // We have a queue to process.
-    let first = baseQueue.next;
+    const first = baseQueue.next;
     let newState = current.baseState;
 
     let newBaseState = null;

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -972,9 +972,10 @@ function useMutableSource<Source, Snapshot>(
 
   const dispatcher = ReactCurrentDispatcher.current;
 
-  let [snapshot, setSnapshot] = dispatcher.useState(() =>
+  const [currentSnapshot, setSnapshot] = dispatcher.useState(() =>
     readFromUnsubcribedMutableSource(root, source, getSnapshot),
   );
+  let snapshot = currentSnapshot;
 
   // Grab a handle to the state hook as well.
   // We use it to clear the pending update queue if we have a new source.

--- a/packages/react-reconciler/src/ReactFiberHostContext.js
+++ b/packages/react-reconciler/src/ReactFiberHostContext.js
@@ -19,15 +19,15 @@ import {createCursor, push, pop} from './ReactFiberStack';
 declare class NoContextT {}
 const NO_CONTEXT: NoContextT = ({}: any);
 
-let contextStackCursor: StackCursor<HostContext | NoContextT> = createCursor(
+const contextStackCursor: StackCursor<HostContext | NoContextT> = createCursor(
   NO_CONTEXT,
 );
-let contextFiberStackCursor: StackCursor<Fiber | NoContextT> = createCursor(
+const contextFiberStackCursor: StackCursor<Fiber | NoContextT> = createCursor(
   NO_CONTEXT,
 );
-let rootInstanceStackCursor: StackCursor<Container | NoContextT> = createCursor(
-  NO_CONTEXT,
-);
+const rootInstanceStackCursor: StackCursor<
+  Container | NoContextT,
+> = createCursor(NO_CONTEXT);
 
 function requiredContext<Value>(c: Value | NoContextT): Value {
   invariant(

--- a/packages/react-reconciler/src/ReactFiberHotReloading.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.js
@@ -62,7 +62,7 @@ let resolveFamily: RefreshHandler | null = null;
 // $FlowFixMe Flow gets confused by a WeakSet feature check below.
 let failedBoundaries: WeakSet<Fiber> | null = null;
 
-export let setRefreshHandler = (handler: RefreshHandler | null): void => {
+export const setRefreshHandler = (handler: RefreshHandler | null): void => {
   if (__DEV__) {
     resolveFamily = handler;
   }
@@ -74,7 +74,7 @@ export function resolveFunctionForHotReloading(type: any): any {
       // Hot reloading is disabled.
       return type;
     }
-    let family = resolveFamily(type);
+    const family = resolveFamily(type);
     if (family === undefined) {
       return type;
     }
@@ -96,7 +96,7 @@ export function resolveForwardRefForHotReloading(type: any): any {
       // Hot reloading is disabled.
       return type;
     }
-    let family = resolveFamily(type);
+    const family = resolveFamily(type);
     if (family === undefined) {
       // Check if we're dealing with a real forwardRef. Don't want to crash early.
       if (
@@ -225,7 +225,7 @@ export function markFailedErrorBoundaryForHotReloading(fiber: Fiber) {
   }
 }
 
-export let scheduleRefresh: ScheduleRefresh = (
+export const scheduleRefresh: ScheduleRefresh = (
   root: FiberRoot,
   update: RefreshUpdate,
 ): void => {
@@ -246,7 +246,7 @@ export let scheduleRefresh: ScheduleRefresh = (
   }
 };
 
-export let scheduleRoot: ScheduleRoot = (
+export const scheduleRoot: ScheduleRoot = (
   root: FiberRoot,
   element: ReactNodeList,
 ): void => {
@@ -338,7 +338,7 @@ function scheduleFibersWithFamiliesRecursively(
   }
 }
 
-export let findHostInstancesForRefresh: FindHostInstancesForRefresh = (
+export const findHostInstancesForRefresh: FindHostInstancesForRefresh = (
   root: FiberRoot,
   families: Array<Family>,
 ): Set<Instance> => {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -381,8 +381,8 @@ function prepareToHydrateHostSuspenseInstance(fiber: Fiber): void {
     );
   }
 
-  let suspenseState: null | SuspenseState = fiber.memoizedState;
-  let suspenseInstance: null | SuspenseInstance =
+  const suspenseState: null | SuspenseState = fiber.memoizedState;
+  const suspenseInstance: null | SuspenseInstance =
     suspenseState !== null ? suspenseState.dehydrated : null;
   invariant(
     suspenseInstance,
@@ -402,8 +402,8 @@ function skipPastDehydratedSuspenseInstance(
         'This error is likely caused by a bug in React. Please file an issue.',
     );
   }
-  let suspenseState: null | SuspenseState = fiber.memoizedState;
-  let suspenseInstance: null | SuspenseInstance =
+  const suspenseState: null | SuspenseState = fiber.memoizedState;
+  const suspenseInstance: null | SuspenseInstance =
     suspenseState !== null ? suspenseState.dehydrated : null;
   invariant(
     suspenseInstance,

--- a/packages/react-reconciler/src/ReactFiberLazyComponent.js
+++ b/packages/react-reconciler/src/ReactFiberLazyComponent.js
@@ -12,7 +12,7 @@ export function resolveDefaultProps(Component: any, baseProps: Object): Object {
     // Resolve default props. Taken from ReactElement
     const props = Object.assign({}, baseProps);
     const defaultProps = Component.defaultProps;
-    for (let propName in defaultProps) {
+    for (const propName in defaultProps) {
       if (props[propName] === undefined) {
         props[propName] = defaultProps[propName];
       }

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -164,7 +164,7 @@ export function scheduleWorkOnParentPath(
   // the alternates.
   let node = parent;
   while (node !== null) {
-    let alternate = node.alternate;
+    const alternate = node.alternate;
     if (node.childExpirationTime < renderExpirationTime) {
       node.childExpirationTime = renderExpirationTime;
       if (
@@ -229,7 +229,7 @@ export function propagateContextChange(
           if (fiber.expirationTime < renderExpirationTime) {
             fiber.expirationTime = renderExpirationTime;
           }
-          let alternate = fiber.alternate;
+          const alternate = fiber.alternate;
           if (
             alternate !== null &&
             alternate.expirationTime < renderExpirationTime
@@ -260,7 +260,7 @@ export function propagateContextChange(
       // If a dehydrated suspense bounudary is in this subtree, we don't know
       // if it will have any context consumers in it. The best we can do is
       // mark it as having updates.
-      let parentSuspense = fiber.return;
+      const parentSuspense = fiber.return;
       invariant(
         parentSuspense !== null,
         'We just came from a parent so we must have had a parent. This is a bug in React.',
@@ -268,7 +268,7 @@ export function propagateContextChange(
       if (parentSuspense.expirationTime < renderExpirationTime) {
         parentSuspense.expirationTime = renderExpirationTime;
       }
-      let alternate = parentSuspense.alternate;
+      const alternate = parentSuspense.alternate;
       if (
         alternate !== null &&
         alternate.expirationTime < renderExpirationTime
@@ -298,7 +298,7 @@ export function propagateContextChange(
           nextFiber = null;
           break;
         }
-        let sibling = nextFiber.sibling;
+        const sibling = nextFiber.sibling;
         if (sibling !== null) {
           // Set the return pointer of the sibling to the work-in-progress fiber.
           sibling.return = nextFiber.return;
@@ -369,7 +369,7 @@ export function readContext<T>(
       resolvedObservedBits = observedBits;
     }
 
-    let contextItem = {
+    const contextItem = {
       context: ((context: any): ReactContext<mixed>),
       observedBits: resolvedObservedBits,
       next: null,

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -592,12 +592,10 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
   }
 
   const previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
-  let previousIsSomeRendererActing;
-  let previousIsThisRendererActing;
   actingUpdatesScopeDepth++;
 
-  previousIsSomeRendererActing = IsSomeRendererActing.current;
-  previousIsThisRendererActing = IsThisRendererActing.current;
+  const previousIsSomeRendererActing = IsSomeRendererActing.current;
+  const previousIsThisRendererActing = IsThisRendererActing.current;
   IsSomeRendererActing.current = true;
   IsThisRendererActing.current = true;
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -331,7 +331,7 @@ export function getPublicRootInstance(
 export function attemptSynchronousHydration(fiber: Fiber): void {
   switch (fiber.tag) {
     case HostRoot:
-      let root: FiberRoot = fiber.stateNode;
+      const root: FiberRoot = fiber.stateNode;
       if (root.hydrate) {
         // Flush the first scheduled "update".
         flushRoot(root, root.firstPendingTime);
@@ -342,7 +342,7 @@ export function attemptSynchronousHydration(fiber: Fiber): void {
       // If we're still blocked after this, we need to increase
       // the priority of any promises resolving within this
       // boundary so that they next attempt also has higher pri.
-      let retryExpTime = computeInteractiveExpiration(
+      const retryExpTime = computeInteractiveExpiration(
         requestCurrentTimeForUpdate(),
       );
       markRetryTimeIfNotHydrated(fiber, retryExpTime);
@@ -351,7 +351,7 @@ export function attemptSynchronousHydration(fiber: Fiber): void {
 }
 
 function markRetryTimeImpl(fiber: Fiber, retryTime: ExpirationTime) {
-  let suspenseState: null | SuspenseState = fiber.memoizedState;
+  const suspenseState: null | SuspenseState = fiber.memoizedState;
   if (suspenseState !== null && suspenseState.dehydrated !== null) {
     if (suspenseState.retryTime < retryTime) {
       suspenseState.retryTime = retryTime;
@@ -362,7 +362,7 @@ function markRetryTimeImpl(fiber: Fiber, retryTime: ExpirationTime) {
 // Increases the priority of thennables when they resolve within this boundary.
 function markRetryTimeIfNotHydrated(fiber: Fiber, retryTime: ExpirationTime) {
   markRetryTimeImpl(fiber, retryTime);
-  let alternate = fiber.alternate;
+  const alternate = fiber.alternate;
   if (alternate) {
     markRetryTimeImpl(alternate, retryTime);
   }
@@ -376,7 +376,7 @@ export function attemptUserBlockingHydration(fiber: Fiber): void {
     // Suspense.
     return;
   }
-  let expTime = computeInteractiveExpiration(requestCurrentTimeForUpdate());
+  const expTime = computeInteractiveExpiration(requestCurrentTimeForUpdate());
   scheduleUpdateOnFiber(fiber, expTime);
   markRetryTimeIfNotHydrated(fiber, expTime);
 }
@@ -591,7 +591,7 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
     }
   }
 
-  let previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
+  const previousActingUpdatesScopeDepth = actingUpdatesScopeDepth;
   let previousIsSomeRendererActing;
   let previousIsThisRendererActing;
   actingUpdatesScopeDepth++;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.js
@@ -120,7 +120,7 @@ export function findFirstSuspended(row: Fiber): null | Fiber {
       // keep track of whether it suspended or not.
       node.memoizedProps.revealOrder !== undefined
     ) {
-      let didSuspend = (node.effectTag & DidCapture) !== NoEffect;
+      const didSuspend = (node.effectTag & DidCapture) !== NoEffect;
       if (didSuspend) {
         return node;
       }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -164,7 +164,7 @@ function attachPingListener(
   if (!threadIDs.has(renderExpirationTime)) {
     // Memoize using the thread ID to prevent redundant listeners.
     threadIDs.add(renderExpirationTime);
-    let ping = pingSuspendedRoot.bind(
+    const ping = pingSuspendedRoot.bind(
       null,
       root,
       wakeable,
@@ -197,7 +197,7 @@ function throwException(
     if ((sourceFiber.mode & BlockingMode) === NoMode) {
       // Reset the memoizedState to what it was before we attempted
       // to render it.
-      let currentSource = sourceFiber.alternate;
+      const currentSource = sourceFiber.alternate;
       if (currentSource) {
         sourceFiber.updateQueue = currentSource.updateQueue;
         sourceFiber.memoizedState = currentSource.memoizedState;
@@ -208,7 +208,7 @@ function throwException(
       }
     }
 
-    let hasInvisibleParentBoundary = hasSuspenseContext(
+    const hasInvisibleParentBoundary = hasSuspenseContext(
       suspenseStackCursor.current,
       (InvisibleParentSuspenseContext: SuspenseContext),
     );

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -125,7 +125,7 @@ function assertIsMounted(fiber) {
 }
 
 export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
-  let alternate = fiber.alternate;
+  const alternate = fiber.alternate;
   if (!alternate) {
     // If there is no alternate, then we only need to check if it is mounted.
     const nearestMounted = getNearestMountedFiber(fiber);
@@ -144,12 +144,12 @@ export function findCurrentFiberUsingSlowPath(fiber: Fiber): Fiber | null {
   let a: Fiber = fiber;
   let b: Fiber = alternate;
   while (true) {
-    let parentA = a.return;
+    const parentA = a.return;
     if (parentA === null) {
       // We're at the root.
       break;
     }
-    let parentB = parentA.alternate;
+    const parentB = parentA.alternate;
     if (parentB === null) {
       // There is no alternate. This is an unusual case. Currently, it only
       // happens when a Suspense component is hidden. An extra fragment fiber

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -740,7 +740,7 @@ function finishConcurrentRender(
         // and after that's fixed it can only be a retry. We're going to
         // throttle committing retries so that we don't show too many
         // loading states too quickly.
-        let msUntilTimeout =
+        const msUntilTimeout =
           globalMostRecentFallbackTime + FALLBACK_THROTTLE_MS - now();
         // Don't bother with a very short suspense time.
         if (msUntilTimeout > 10) {
@@ -2064,7 +2064,7 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
     // updates, and deletions. To avoid needing to add a case for every possible
     // bitmap value, we remove the secondary effects from the effect tag and
     // switch on that value.
-    let primaryEffectTag =
+    const primaryEffectTag =
       effectTag & (Placement | Update | Deletion | Hydrating);
     switch (primaryEffectTag) {
       case Placement: {
@@ -2238,7 +2238,7 @@ function flushPassiveEffectsImpl() {
     // Layout effects have the same constraint.
 
     // First pass: Destroy stale passive effects.
-    let unmountEffects = pendingPassiveHookEffectsUnmount;
+    const unmountEffects = pendingPassiveHookEffectsUnmount;
     pendingPassiveHookEffectsUnmount = [];
     for (let i = 0; i < unmountEffects.length; i += 2) {
       const effect = ((unmountEffects[i]: any): HookEffect);
@@ -2289,7 +2289,7 @@ function flushPassiveEffectsImpl() {
       }
     }
     // Second pass: Create new passive effects.
-    let mountEffects = pendingPassiveHookEffectsMount;
+    const mountEffects = pendingPassiveHookEffectsMount;
     pendingPassiveHookEffectsMount = [];
     for (let i = 0; i < mountEffects.length; i += 2) {
       const effect = ((mountEffects[i]: any): HookEffect);
@@ -2368,7 +2368,7 @@ function flushPassiveEffectsImpl() {
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {
-    let profilerEffects = pendingPassiveProfilerEffects;
+    const profilerEffects = pendingPassiveProfilerEffects;
     pendingPassiveProfilerEffects = [];
     for (let i = 0; i < profilerEffects.length; i++) {
       const fiber = ((profilerEffects[i]: any): Fiber);
@@ -2765,7 +2765,7 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
 
 let beginWork;
 if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
-  let dummyFiber = null;
+  const dummyFiber = null;
   beginWork = (current, unitOfWork, expirationTime) => {
     // If a component throws an error, we replay it again in a synchronously
     // dispatched event, so that the debugger will treat it as an uncaught

--- a/packages/react-reconciler/src/ReactMutableSource.js
+++ b/packages/react-reconciler/src/ReactMutableSource.js
@@ -17,8 +17,8 @@ import {NoWork} from './ReactFiberExpirationTime';
 // Work in progress version numbers only apply to a single render,
 // and should be reset before starting a new render.
 // This tracks which mutable sources need to be reset after a render.
-let workInProgressPrimarySources: Array<MutableSource<any>> = [];
-let workInProgressSecondarySources: Array<MutableSource<any>> = [];
+const workInProgressPrimarySources: Array<MutableSource<any>> = [];
+const workInProgressSecondarySources: Array<MutableSource<any>> = [];
 
 let rendererSigil;
 if (__DEV__) {

--- a/packages/react-reconciler/src/ReactUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.js
@@ -188,7 +188,7 @@ export function createUpdate(
   expirationTime: ExpirationTime,
   suspenseConfig: null | SuspenseConfig,
 ): Update<*> {
-  let update: Update<*> = {
+  const update: Update<*> = {
     expirationTime,
     suspenseConfig,
 
@@ -524,7 +524,7 @@ export function processUpdateQueue<State>(
         const callback = update.callback;
         if (callback !== null) {
           workInProgress.effectTag |= Callback;
-          let effects = queue.effects;
+          const effects = queue.effects;
           if (effects === null) {
             queue.effects = [update];
           } else {

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.js
@@ -69,7 +69,7 @@ export const requestPaint =
 let syncQueue: Array<SchedulerCallback> | null = null;
 let immediateQueueCallbackNode: mixed | null = null;
 let isFlushingSyncQueue: boolean = false;
-let initialTimeMs: number = Scheduler_now();
+const initialTimeMs: number = Scheduler_now();
 
 // If the initial timestamp is reasonably small, use Scheduler's `now` directly.
 // This will be the case for modern browsers that support `performance.now`. In

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -27,7 +27,7 @@ describe('ReactBlocks', () => {
     block = React.block;
     useState = React.useState;
     Suspense = React.Suspense;
-    let cache = new Map();
+    const cache = new Map();
     readString = function(text) {
       let entry = cache.get(text);
       if (!entry) {
@@ -62,7 +62,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(User);
+    const loadUser = block(User);
 
     ReactNoop.act(() => {
       ReactNoop.render(<App Component={loadUser()} />);
@@ -79,7 +79,7 @@ describe('ReactBlocks', () => {
     }
 
     function User(props, data) {
-      let array = [<span>{data.name}</span>];
+      const array = [<span>{data.name}</span>];
       return <div>{array}</div>;
     }
 
@@ -91,7 +91,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(User, load);
+    const loadUser = block(User, load);
 
     expect(() => {
       ReactNoop.act(() => {
@@ -124,7 +124,7 @@ describe('ReactBlocks', () => {
       );
     }
 
-    let loadUser = block(Render, load);
+    const loadUser = block(Render, load);
 
     function App({User}) {
       return (
@@ -165,7 +165,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Render, load);
+      const loadUser = block(Render, load);
 
       function App({User}) {
         return (
@@ -176,7 +176,7 @@ describe('ReactBlocks', () => {
       }
 
       let resolveLazy;
-      let LazyUser = React.lazy(
+      const LazyUser = React.lazy(
         () =>
           new Promise(resolve => {
             resolveLazy = function() {
@@ -216,7 +216,7 @@ describe('ReactBlocks', () => {
       }
 
       function Render(props, data) {
-        let [initialName] = useState(data.name);
+        const [initialName] = useState(data.name);
         return (
           <>
             <span>Initial name: {initialName}</span>
@@ -225,7 +225,7 @@ describe('ReactBlocks', () => {
         );
       }
 
-      let loadUser = block(Render, load);
+      const loadUser = block(Render, load);
 
       function App({User}) {
         return (

--- a/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
@@ -29,14 +29,14 @@ describe('ReactSuspenseList', () => {
 
   function createAsyncText(text) {
     let resolved = false;
-    let Component = function() {
+    const Component = function() {
       if (!resolved) {
         Scheduler.unstable_yieldValue('Suspend! [' + text + ']');
         throw promise;
       }
       return <Text text={text} />;
     };
-    let promise = new Promise(resolve => {
+    const promise = new Promise(resolve => {
       Component.resolve = function() {
         resolved = true;
         return resolve();

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.internal.js
@@ -182,8 +182,8 @@ describe('ReactExpiration', () => {
   );
 
   it('cannot update at the same expiration time that is already rendering', () => {
-    let store = {text: 'initial'};
-    let subscribers = [];
+    const store = {text: 'initial'};
+    const subscribers = [];
     class Connected extends React.Component {
       state = {text: store.text};
       componentDidMount() {

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -72,7 +72,7 @@ describe('ReactFiberHostContext', () => {
   });
 
   it('should send the context to prepareForCommit and resetAfterCommit', () => {
-    let rootContext = {};
+    const rootContext = {};
     const Renderer = ReactFiberReconciler({
       prepareForCommit: function(hostContext) {
         expect(hostContext).toBe(rootContext);

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1287,7 +1287,7 @@ describe('ReactHooks', () => {
       };
     }
 
-    let renderer = ReactTestRenderer.create(null);
+    const renderer = ReactTestRenderer.create(null);
 
     renderCount = 0;
     renderer.update(<NoHooks />);
@@ -1485,7 +1485,7 @@ describe('ReactHooks', () => {
     // We don't include useImperativeHandleHelper in this set,
     // because it generates an additional warning about the inputs length changing.
     // We test it below with its own test.
-    let orderedHooks = [
+    const orderedHooks = [
       useCallbackHelper,
       useContextHelper,
       useDebugValueHelper,
@@ -1499,7 +1499,7 @@ describe('ReactHooks', () => {
 
     // We don't include useContext or useDebugValue in this set,
     // because they aren't added to the hooks list and so won't throw.
-    let hooksInList = [
+    const hooksInList = [
       useCallbackHelper,
       useEffectHelper,
       useImperativeHandleHelper,
@@ -1692,7 +1692,7 @@ describe('ReactHooks', () => {
           return null;
           /* eslint-enable no-unused-vars */
         }
-        let root = ReactTestRenderer.create(<App update={false} />);
+        const root = ReactTestRenderer.create(<App update={false} />);
         expect(() => {
           try {
             root.update(<App update={true} />);
@@ -1738,7 +1738,7 @@ describe('ReactHooks', () => {
         return null;
         /* eslint-enable no-unused-vars */
       }
-      let root = ReactTestRenderer.create(<App update={false} />);
+      const root = ReactTestRenderer.create(<App update={false} />);
       expect(() => {
         expect(() => root.update(<App update={true} />)).toThrow(
           'custom error',
@@ -1757,7 +1757,7 @@ describe('ReactHooks', () => {
 
   // Regression test for #14674
   it('does not swallow original error when updating another component in render phase', async () => {
-    let {useState} = React;
+    const {useState} = React;
     spyOnDev(console, 'error');
 
     let _setState;
@@ -1795,7 +1795,7 @@ describe('ReactHooks', () => {
 
   // Regression test for https://github.com/facebook/react/issues/15057
   it('does not fire a false positive warning when previous effect unmounts the component', () => {
-    let {useState, useEffect} = React;
+    const {useState, useEffect} = React;
     let globalListener;
 
     function A() {

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -299,7 +299,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     });
 
     it('returns the same updater function every time', () => {
-      let updaters = [];
+      const updaters = [];
       function Counter() {
         const [count, updateCount] = useState(0);
         updaters.push(updateCount);
@@ -403,8 +403,8 @@ describe('ReactHooksWithNoopRenderer', () => {
   describe('updates during the render phase', () => {
     it('restarts the render function and applies the new updates on top', () => {
       function ScrollView({row: newRow}) {
-        let [isScrollingDown, setIsScrollingDown] = useState(false);
-        let [row, setRow] = useState(null);
+        const [isScrollingDown, setIsScrollingDown] = useState(false);
+        const [row, setRow] = useState(null);
 
         if (row !== newRow) {
           // Row changed since last render. Update isScrollingDown.
@@ -497,7 +497,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     it('keeps restarting until there are no more new updates', () => {
       function Counter({row: newRow}) {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         if (count < 3) {
           setCount(count + 1);
         }
@@ -518,7 +518,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     it('updates multiple times within same render function', () => {
       function Counter({row: newRow}) {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         if (count < 12) {
           setCount(c => c + 1);
           setCount(c => c + 1);
@@ -543,7 +543,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     it('throws after too many iterations', () => {
       function Counter({row: newRow}) {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         setCount(count + 1);
         Scheduler.unstable_yieldValue('Render: ' + count);
         return <Text text={count} />;
@@ -560,7 +560,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return action === 'increment' ? state + 1 : state;
       }
       function Counter({row: newRow}) {
-        let [count, dispatch] = useReducer(reducer, 0);
+        const [count, dispatch] = useReducer(reducer, 0);
         if (count < 3) {
           dispatch('increment');
         }
@@ -601,8 +601,8 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       function Counter({row: newRow}, ref) {
-        let [reducer, setReducer] = useState(() => reducerA);
-        let [count, dispatch] = useReducer(reducer, 0);
+        const [reducer, setReducer] = useState(() => reducerA);
+        const [count, dispatch] = useReducer(reducer, 0);
         useImperativeHandle(ref, () => ({dispatch}));
         if (count < 20) {
           dispatch('increment');
@@ -658,8 +658,8 @@ describe('ReactHooksWithNoopRenderer', () => {
       }
 
       function Bar({signal: newSignal}) {
-        let [counter, setCounter] = useState(0);
-        let [signal, setSignal] = useState(true);
+        const [counter, setCounter] = useState(0);
+        const [signal, setSignal] = useState(true);
 
         // Increment a counter every time the signal changes
         if (signal !== newSignal) {
@@ -703,7 +703,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
       let setLabel;
       function Bar({signal: newSignal}) {
-        let [counter, setCounter] = useState(0);
+        const [counter, setCounter] = useState(0);
 
         if (counter === 1) {
           // We're suspending during a render that includes render phase
@@ -712,7 +712,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           throw thenable;
         }
 
-        let [signal, setSignal] = useState(true);
+        const [signal, setSignal] = useState(true);
 
         // Increment a counter every time the signal changes
         if (signal !== newSignal) {
@@ -720,7 +720,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           setSignal(newSignal);
         }
 
-        let [label, _setLabel] = useState('A');
+        const [label, _setLabel] = useState('A');
         setLabel = _setLabel;
 
         return <Text text={`${label}:${counter}`} />;
@@ -754,8 +754,8 @@ describe('ReactHooksWithNoopRenderer', () => {
     it.experimental('calling startTransition inside render phase', async () => {
       let startTransition;
       function App() {
-        let [counter, setCounter] = useState(0);
-        let [_startTransition] = useTransition();
+        const [counter, setCounter] = useState(0);
+        const [_startTransition] = useTransition();
         startTransition = _startTransition;
 
         if (counter === 0) {
@@ -937,7 +937,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         }, []);
         return <Text text="Passive" />;
       }
-      let passive = <PassiveEffect key="p" />;
+      const passive = <PassiveEffect key="p" />;
       act(() => {
         ReactNoop.render([<LayoutEffect key="l" />, passive]);
         expect(Scheduler).toFlushAndYieldThrough([
@@ -967,7 +967,7 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text="Passive" />;
       }
       function LayoutEffect(props) {
-        let [count, setCount] = useState(0);
+        const [count, setCount] = useState(0);
         useLayoutEffect(() => {
           // Scheduling work shouldn't interfere with the queued passive effect
           if (count === 0) {

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.internal.js
@@ -2476,10 +2476,10 @@ describe('ReactIncremental', () => {
   });
 
   xit('should reuse memoized work if pointers are updated before calling lifecycles', () => {
-    let cduNextProps = [];
-    let cduPrevProps = [];
-    let scuNextProps = [];
-    let scuPrevProps = [];
+    const cduNextProps = [];
+    const cduPrevProps = [];
+    const scuNextProps = [];
+    const scuPrevProps = [];
     let renderCounter = 0;
 
     function SecondChild(props) {
@@ -2559,7 +2559,7 @@ describe('ReactIncremental', () => {
   });
 
   it('updates descendants with new context values', () => {
-    let rendered = [];
+    const rendered = [];
     let instance;
 
     class TopContextProvider extends React.Component {
@@ -2616,7 +2616,7 @@ describe('ReactIncremental', () => {
   });
 
   it('updates descendants with multiple context-providing ancestors with new context values', () => {
-    let rendered = [];
+    const rendered = [];
     let instance;
 
     class TopContextProvider extends React.Component {
@@ -2679,7 +2679,7 @@ describe('ReactIncremental', () => {
   });
 
   it('should not update descendants with new context values if shouldComponentUpdate returns false', () => {
-    let rendered = [];
+    const rendered = [];
     let instance;
 
     class TopContextProvider extends React.Component {
@@ -2751,7 +2751,7 @@ describe('ReactIncremental', () => {
   });
 
   it('should update descendants with new context values if setState() is called in the middle of the tree', () => {
-    let rendered = [];
+    const rendered = [];
     let middleInstance;
     let topInstance;
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1451,7 +1451,7 @@ describe('ReactIncrementalErrorHandling', () => {
   it('error boundaries capture non-errors', () => {
     spyOnProd(console, 'error');
     spyOnDev(console, 'error');
-    let ops = [];
+    const ops = [];
 
     class ErrorBoundary extends React.Component {
       state = {error: null};

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.internal.js
@@ -32,7 +32,7 @@ describe('ReactIncrementalErrorReplay-test', () => {
     expect(realFiber).toEqual(stash);
 
     // Mutate the original.
-    for (let key in realFiber) {
+    for (const key in realFiber) {
       realFiber[key] = key + '_' + Math.random();
     }
     expect(realFiber).not.toEqual(stash);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.internal.js
@@ -143,7 +143,7 @@ describe('ReactIncrementalReflection', () => {
       // We ignore warnings fired by findInstance because we are testing
       // that the actual behavior still works as expected even though it
       // is deprecated.
-      let oldConsoleError = console.error;
+      const oldConsoleError = console.error;
       console.error = jest.fn();
       try {
         return ReactNoop.findInstance(inst);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.internal.js
@@ -324,7 +324,7 @@ describe('ReactIncrementalScheduling', () => {
 
   it('nested updates are always deferred, even inside unbatchedUpdates', () => {
     let instance;
-    let ops = [];
+    const ops = [];
     class Foo extends React.Component {
       state = {step: 0};
       componentDidUpdate() {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.internal.js
@@ -167,7 +167,7 @@ describe('ReactIncrementalTriangle', () => {
   }
 
   function randomActions(n) {
-    let actions = [];
+    const actions = [];
     for (let i = 0; i < n; i++) {
       actions.push(randomAction());
     }
@@ -180,7 +180,7 @@ describe('ReactIncrementalTriangle', () => {
 
     let triangles = [];
     let leafTriangles = [];
-    let yieldAfterEachRender = false;
+    const yieldAfterEachRender = false;
     class Triangle extends React.Component {
       constructor(props) {
         super();
@@ -325,7 +325,7 @@ describe('ReactIncrementalTriangle', () => {
       let expectedCounter = counter;
 
       for (let i = 0; i < children.length; i++) {
-        let child = children[i];
+        const child = children[i];
 
         const output = JSON.parse(child.prop);
         const prop = output.prop;
@@ -376,8 +376,8 @@ describe('ReactIncrementalTriangle', () => {
       const app = reset();
       let expectedCounterAtEnd = app.state.counter;
 
-      let activeIndices = new Set();
-      let activeLeafIndices = new Set();
+      const activeIndices = new Set();
+      const activeLeafIndices = new Set();
       let action;
       while (true) {
         action = yield;
@@ -441,7 +441,7 @@ describe('ReactIncrementalTriangle', () => {
       // Call this once to prepare the generator
       gen.next();
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (let action of actions) {
+      for (const action of actions) {
         gen.next(action);
       }
       gen.next(STOP);
@@ -528,7 +528,7 @@ ${formatActions(actions)}
     function simulateMultipleRoots(...actions) {
       const roots = new Map();
       // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-      for (let rootID of rootIDs) {
+      for (const rootID of rootIDs) {
         const simulator = TriangleSimulator(rootID);
         const generator = simulator.simulateAndYield();
         // Call this once to prepare the generator

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.internal.js
@@ -298,7 +298,7 @@ describe('ReactIncrementalUpdates', () => {
   });
 
   it('does not call callbacks that are scheduled by another callback until a later commit', () => {
-    let ops = [];
+    const ops = [];
     class Foo extends React.Component {
       state = {};
       componentDidMount() {
@@ -366,7 +366,7 @@ describe('ReactIncrementalUpdates', () => {
 
   it('enqueues setState inside an updater function as if the in-progress update is progressed (and warns)', () => {
     let instance;
-    let ops = [];
+    const ops = [];
     class Foo extends React.Component {
       state = {};
       render() {

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.internal.js
@@ -1673,7 +1673,7 @@ describe('ReactNewContext', () => {
     }
 
     function randomActions(n) {
-      let actions = [];
+      const actions = [];
       for (let i = 0; i < n; i++) {
         actions.push(randomAction());
       }

--- a/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
@@ -21,7 +21,7 @@ describe('ReactNoop.act()', () => {
       return null;
     }
 
-    let calledLog = [];
+    const calledLog = [];
     ReactNoop.act(() => {
       ReactNoop.render(
         <App
@@ -37,7 +37,7 @@ describe('ReactNoop.act()', () => {
 
   it('should work with async/await', async () => {
     function App() {
-      let [ctr, setCtr] = React.useState(0);
+      const [ctr, setCtr] = React.useState(0);
       async function someAsyncFunction() {
         Scheduler.unstable_yieldValue('stage 1');
         await null;

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -345,17 +345,17 @@ describe('ReactScope', () => {
       // this may have suspense points on the server but here we want
       // to test the completed HTML. Don't suspend on the server.
       suspend = false;
-      let finalHTML = ReactDOMServer.renderToString(<App />);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
 
-      let container2 = document.createElement('div');
+      const container2 = document.createElement('div');
       container2.innerHTML = finalHTML;
 
-      let span = container2.getElementsByTagName('span')[0];
+      const span = container2.getElementsByTagName('span')[0];
 
       // On the client we don't have all data yet but we want to start
       // hydrating anyway.
       suspend = true;
-      let root = ReactDOM.createRoot(container2, {hydrate: true});
+      const root = ReactDOM.createRoot(container2, {hydrate: true});
       root.render(<App />);
       Scheduler.unstable_flushAll();
       jest.runAllTimers();

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -199,7 +199,7 @@ describe('ReactSuspense', () => {
 
   it('interrupts current render if promise resolves before current render phase', () => {
     let didResolve = false;
-    let listeners = [];
+    const listeners = [];
 
     const thenable = {
       then(resolve) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.internal.js
@@ -32,7 +32,7 @@ describe('ReactSuspense', () => {
   function createThenable() {
     let completed = false;
     const resolveRef = {current: null};
-    let promise = {
+    const promise = {
       then(resolve, reject) {
         resolveRef.current = () => {
           completed = true;
@@ -149,11 +149,11 @@ describe('ReactSuspense', () => {
   it('nested suspense promises are reported only for their tier', () => {
     const {promise, PromiseComp} = createThenable();
 
-    let ops1 = [];
+    const ops1 = [];
     const suspenseCallback1 = thenables => {
       ops1.push(thenables);
     };
-    let ops2 = [];
+    const ops2 = [];
     const suspenseCallback2 = thenables => {
       ops2.push(thenables);
     };
@@ -250,7 +250,7 @@ describe('ReactSuspense', () => {
       // you can probably just delete it. It's not worth the hassle.
       jest.resetModules();
 
-      let errors = [];
+      const errors = [];
       let hasCaughtError = false;
       jest.mock('shared/ReactErrorUtils', () => ({
         invokeGuardedCallback(name, fn, context, ...args) {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFuzz-test.internal.js
@@ -226,7 +226,7 @@ describe('ReactSuspenseFuzz', () => {
               {value: 2, weight: 1},
             ]);
 
-            let updates = [];
+            const updates = [];
             for (let i = 0; i < numberOfUpdates; i++) {
               updates.push({
                 beginAfter: rand.intBetween(0, 10000),
@@ -249,7 +249,7 @@ describe('ReactSuspenseFuzz', () => {
               {value: 2, weight: 1},
             ]);
 
-            let updates = [];
+            const updates = [];
             for (let i = 0; i < numberOfUpdates; i++) {
               updates.push({
                 remountAfter: rand.intBetween(0, 10000),

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.internal.js
@@ -31,14 +31,14 @@ describe('ReactSuspenseList', () => {
 
   function createAsyncText(text) {
     let resolved = false;
-    let Component = function() {
+    const Component = function() {
       if (!resolved) {
         Scheduler.unstable_yieldValue('Suspend! [' + text + ']');
         throw promise;
       }
       return <Text text={text} />;
     };
-    let promise = new Promise(resolve => {
+    const promise = new Promise(resolve => {
       Component.resolve = function() {
         resolved = true;
         return resolve();
@@ -185,9 +185,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('shows content independently by default', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -251,9 +251,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('shows content independently in legacy mode regardless of option', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -323,9 +323,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays all "together"', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -392,9 +392,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays all "together" even when nested as siblings', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -477,9 +477,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays all "together" in nested SuspenseLists', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -538,9 +538,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays all "together" in nested SuspenseLists where the inner is default', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -597,10 +597,10 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays all "together" during an update', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
-    let D = createAsyncText('D');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
+    const D = createAsyncText('D');
 
     function Foo({step}) {
       return (
@@ -681,9 +681,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('avoided boundaries can be coordinate with SuspenseList', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo({showMore}) {
       return (
@@ -779,9 +779,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays each items in "forwards" order', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -844,9 +844,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays each items in "backwards" order', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -909,12 +909,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays added row at the top "together" and the bottom in "forwards" order', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
-    let D = createAsyncText('D');
-    let E = createAsyncText('E');
-    let F = createAsyncText('F');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
+    const D = createAsyncText('D');
+    const E = createAsyncText('E');
+    const F = createAsyncText('F');
 
     function Foo({items}) {
       return (
@@ -1063,10 +1063,10 @@ describe('ReactSuspenseList', () => {
   });
 
   it('displays added row at the top "together" and the bottom in "backwards" order', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let D = createAsyncText('D');
-    let F = createAsyncText('F');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const D = createAsyncText('D');
+    const F = createAsyncText('F');
 
     function createSyncText(text) {
       return function() {
@@ -1074,12 +1074,12 @@ describe('ReactSuspenseList', () => {
       };
     }
 
-    let As = createSyncText('A');
-    let Bs = createSyncText('B');
-    let Cs = createSyncText('C');
-    let Ds = createSyncText('D');
-    let Es = createSyncText('E');
-    let Fs = createSyncText('F');
+    const As = createSyncText('A');
+    const Bs = createSyncText('B');
+    const Cs = createSyncText('C');
+    const Ds = createSyncText('D');
+    const Es = createSyncText('E');
+    const Fs = createSyncText('F');
 
     function Foo({items}) {
       return (
@@ -1309,9 +1309,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('only shows one loading state at a time for "collapsed" tail insertions', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -1484,12 +1484,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('adding to the middle does not collapse insertions (forwards)', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
-    let D = createAsyncText('D');
-    let E = createAsyncText('E');
-    let F = createAsyncText('F');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
+    const D = createAsyncText('D');
+    const E = createAsyncText('E');
+    const F = createAsyncText('F');
 
     function Foo({items}) {
       return (
@@ -1626,12 +1626,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('adding to the middle does not collapse insertions (backwards)', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
-    let D = createAsyncText('D');
-    let E = createAsyncText('E');
-    let F = createAsyncText('F');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
+    const D = createAsyncText('D');
+    const E = createAsyncText('E');
+    const F = createAsyncText('F');
 
     function Foo({items}) {
       return (
@@ -1773,12 +1773,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('adding to the middle of committed tail does not collapse insertions', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
-    let D = createAsyncText('D');
-    let E = createAsyncText('E');
-    let F = createAsyncText('F');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
+    const D = createAsyncText('D');
+    const E = createAsyncText('E');
+    const F = createAsyncText('F');
 
     function SyncD() {
       return <Text text="D" />;
@@ -1930,9 +1930,9 @@ describe('ReactSuspenseList', () => {
   });
 
   it('only shows no initial loading state "hidden" tail insertions', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
-    let C = createAsyncText('C');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
+    const C = createAsyncText('C');
 
     function Foo() {
       return (
@@ -1993,7 +1993,7 @@ describe('ReactSuspenseList', () => {
   });
 
   it('eventually resolves a nested forwards suspense list', async () => {
-    let B = createAsyncText('B');
+    const B = createAsyncText('B');
 
     function Foo() {
       return (
@@ -2055,7 +2055,7 @@ describe('ReactSuspenseList', () => {
   });
 
   it('eventually resolves a nested forwards suspense list with a hidden tail', async () => {
-    let B = createAsyncText('B');
+    const B = createAsyncText('B');
 
     function Foo() {
       return (
@@ -2101,7 +2101,7 @@ describe('ReactSuspenseList', () => {
   });
 
   it('eventually resolves two nested forwards suspense lists with a hidden tail', async () => {
-    let B = createAsyncText('B');
+    const B = createAsyncText('B');
 
     function Foo({showB}) {
       return (
@@ -2170,7 +2170,7 @@ describe('ReactSuspenseList', () => {
   it('can do unrelated adjacent updates', async () => {
     let updateAdjacent;
     function Adjacent() {
-      let [text, setText] = React.useState('-');
+      const [text, setText] = React.useState('-');
       updateAdjacent = setText;
       return <Text text={text} />;
     }
@@ -2214,12 +2214,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('is able to re-suspend the last rows during an update with hidden', async () => {
-    let AsyncB = createAsyncText('B');
+    const AsyncB = createAsyncText('B');
 
     let setAsyncB;
 
     function B() {
-      let [shouldBeAsync, setAsync] = React.useState(false);
+      const [shouldBeAsync, setAsync] = React.useState(false);
       setAsyncB = setAsync;
 
       return shouldBeAsync ? (
@@ -2253,7 +2253,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    let previousInst = setAsyncB;
+    const previousInst = setAsyncB;
 
     // During an update we suspend on B.
     ReactNoop.act(() => setAsyncB(true));
@@ -2302,12 +2302,12 @@ describe('ReactSuspenseList', () => {
   });
 
   it('is able to re-suspend the last rows during an update with hidden', async () => {
-    let AsyncB = createAsyncText('B');
+    const AsyncB = createAsyncText('B');
 
     let setAsyncB;
 
     function B() {
-      let [shouldBeAsync, setAsync] = React.useState(false);
+      const [shouldBeAsync, setAsync] = React.useState(false);
       setAsyncB = setAsync;
 
       return shouldBeAsync ? (
@@ -2341,7 +2341,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    let previousInst = setAsyncB;
+    const previousInst = setAsyncB;
 
     // During an update we suspend on B.
     ReactNoop.act(() => setAsyncB(true));
@@ -2390,19 +2390,19 @@ describe('ReactSuspenseList', () => {
   });
 
   it('is able to interrupt a partially rendered tree and continue later', async () => {
-    let AsyncA = createAsyncText('A');
+    const AsyncA = createAsyncText('A');
 
     let updateLowPri;
     let updateHighPri;
 
     function Bar() {
-      let [highPriState, setHighPriState] = React.useState(false);
+      const [highPriState, setHighPriState] = React.useState(false);
       updateHighPri = setHighPriState;
       return highPriState ? <AsyncA /> : null;
     }
 
     function Foo() {
-      let [lowPriState, setLowPriState] = React.useState(false);
+      const [lowPriState, setLowPriState] = React.useState(false);
       updateLowPri = setLowPriState;
       return (
         <SuspenseList revealOrder="forwards" tail="hidden">
@@ -2487,8 +2487,8 @@ describe('ReactSuspenseList', () => {
   });
 
   it('can resume class components when revealed together', async () => {
-    let A = createAsyncText('A');
-    let B = createAsyncText('B');
+    const A = createAsyncText('A');
+    const B = createAsyncText('B');
 
     class ClassComponent extends React.Component {
       render() {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -1467,7 +1467,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     });
 
     it('does not drop mounted effects', async () => {
-      let never = {then() {}};
+      const never = {then() {}};
 
       let setShouldSuspend;
       function App() {
@@ -1974,7 +1974,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('does not warn when a low priority update suspends inside a high priority update for functional components', async () => {
     let _setShow;
     function App() {
-      let [show, setShow] = React.useState(false);
+      const [show, setShow] = React.useState(false);
       _setShow = setShow;
       return (
         <Suspense fallback="Loading...">
@@ -2121,7 +2121,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('normal priority updates suspending do not warn for functional components', async () => {
     let _setShow;
     function App() {
-      let [show, setShow] = React.useState(false);
+      const [show, setShow] = React.useState(false);
       _setShow = setShow;
       return (
         <Suspense fallback="Loading...">
@@ -2388,7 +2388,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     it('hooks', async () => {
       let transitionToPage;
       function App() {
-        let [page, setPage] = React.useState('none');
+        const [page, setPage] = React.useState('none');
         transitionToPage = setPage;
         if (page === 'none') {
           return null;
@@ -2458,7 +2458,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         state = {page: 'none'};
         render() {
           transitionToPage = page => this.setState({page});
-          let page = this.state.page;
+          const page = this.state.page;
           if (page === 'none') {
             return null;
           }
@@ -2699,8 +2699,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   it('supports delaying a busy spinner from disappearing', async () => {
     function useLoadingIndicator(config) {
-      let [isLoading, setLoading] = React.useState(false);
-      let start = React.useCallback(
+      const [isLoading, setLoading] = React.useState(false);
+      const start = React.useCallback(
         cb => {
           setLoading(true);
           Scheduler.unstable_next(() =>
@@ -2724,8 +2724,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     let transitionToPage;
 
     function App() {
-      let [page, setPage] = React.useState('A');
-      let [isLoading, startLoading] = useLoadingIndicator(SUSPENSE_CONFIG);
+      const [page, setPage] = React.useState('A');
+      const [isLoading, startLoading] = useLoadingIndicator(SUSPENSE_CONFIG);
       transitionToPage = nextPage => startLoading(() => setPage(nextPage));
       return (
         <Fragment>

--- a/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransition-test.internal.js
@@ -43,14 +43,14 @@ describe('ReactTransition', () => {
 
   function createAsyncText(text) {
     let resolved = false;
-    let Component = function() {
+    const Component = function() {
       if (!resolved) {
         Scheduler.unstable_yieldValue('Suspend! [' + text + ']');
         throw promise;
       }
       return <Text text={text} />;
     };
-    let promise = new Promise(resolve => {
+    const promise = new Promise(resolve => {
       Component.resolve = function() {
         resolved = true;
         return resolve();

--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -251,7 +251,7 @@ export default function(babel, opts = {}) {
     };
   }
 
-  let hasForceResetCommentByFile = new WeakMap();
+  const hasForceResetCommentByFile = new WeakMap();
 
   // We let user do /* @refresh reset */ to reset state in the whole file.
   function hasForceResetComment(path) {
@@ -279,7 +279,7 @@ export default function(babel, opts = {}) {
     const {key, customHooks} = signature;
 
     let forceReset = hasForceResetComment(scope.path);
-    let customHooksInScope = [];
+    const customHooksInScope = [];
     customHooks.forEach(callee => {
       // Check if a corresponding binding exists where we emit the signature.
       let bindingName;
@@ -335,11 +335,11 @@ export default function(babel, opts = {}) {
     return args;
   }
 
-  let seenForRegistration = new WeakSet();
-  let seenForSignature = new WeakSet();
-  let seenForOutro = new WeakSet();
+  const seenForRegistration = new WeakSet();
+  const seenForSignature = new WeakSet();
+  const seenForOutro = new WeakSet();
 
-  let hookCalls = new WeakMap();
+  const hookCalls = new WeakMap();
   const HookCallsVisitor = {
     CallExpression(path) {
       const node = path.node;
@@ -370,7 +370,7 @@ export default function(babel, opts = {}) {
       if (!hookCalls.has(fnNode)) {
         hookCalls.set(fnNode, []);
       }
-      let hookCallsForFn = hookCalls.get(fnNode);
+      const hookCallsForFn = hookCalls.get(fnNode);
       let key = '';
       if (path.parent.type === 'VariableDeclarator') {
         // TODO: if there is no LHS, consider some other heuristic.

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -62,20 +62,20 @@ WeakMap<any, Family> | Map<any, Family> = new PossiblyWeakMap();
 let pendingUpdates: Array<[Family, any]> = [];
 
 // This is injected by the renderer via DevTools global hook.
-let helpersByRendererID: Map<number, RendererHelpers> = new Map();
+const helpersByRendererID: Map<number, RendererHelpers> = new Map();
 
-let helpersByRoot: Map<FiberRoot, RendererHelpers> = new Map();
+const helpersByRoot: Map<FiberRoot, RendererHelpers> = new Map();
 
 // We keep track of mounted roots so we can schedule updates.
-let mountedRoots: Set<FiberRoot> = new Set();
+const mountedRoots: Set<FiberRoot> = new Set();
 // If a root captures an error, we remember it so we can retry on edit.
-let failedRoots: Set<FiberRoot> = new Set();
+const failedRoots: Set<FiberRoot> = new Set();
 
 // In environments that support WeakMap, we also remember the last element for every root.
 // It needs to be weak because we do this even for roots that failed to mount.
 // If there is no WeakMap, we won't attempt to do retrying.
 // $FlowIssue
-let rootElements: WeakMap<any, ReactNodeList> | null = // $FlowIssue
+const rootElements: WeakMap<any, ReactNodeList> | null = // $FlowIssue
   typeof WeakMap === 'function' ? new WeakMap() : null;
 
 let isPerformingRefresh = false;
@@ -164,14 +164,14 @@ function resolveFamily(type) {
 
 // If we didn't care about IE11, we could use new Map/Set(iterable).
 function cloneMap<K, V>(map: Map<K, V>): Map<K, V> {
-  let clone = new Map();
+  const clone = new Map();
   map.forEach((value, key) => {
     clone.set(key, value);
   });
   return clone;
 }
 function cloneSet<T>(set: Set<T>): Set<T> {
-  let clone = new Set();
+  const clone = new Set();
   set.forEach(value => {
     clone.add(value);
   });
@@ -233,9 +233,9 @@ export function performReactRefresh(): RefreshUpdate | null {
     // If we don't do this, there is a risk they will be mutated while
     // we iterate over them. For example, trying to recover a failed root
     // may cause another root to be added to the failed list -- an infinite loop.
-    let failedRootsSnapshot = cloneSet(failedRoots);
-    let mountedRootsSnapshot = cloneSet(mountedRoots);
-    let helpersByRootSnapshot = cloneMap(helpersByRoot);
+    const failedRootsSnapshot = cloneSet(failedRoots);
+    const mountedRootsSnapshot = cloneSet(mountedRoots);
+    const helpersByRootSnapshot = cloneMap(helpersByRoot);
 
     failedRootsSnapshot.forEach(root => {
       const helpers = helpersByRootSnapshot.get(root);
@@ -397,7 +397,7 @@ export function findAffectedHostInstances(
   families: Array<Family>,
 ): Set<Instance> {
   if (__DEV__) {
-    let affectedInstances = new Set();
+    const affectedInstances = new Set();
     mountedRoots.forEach(root => {
       const helpers = helpersByRoot.get(root);
       if (helpers === undefined) {

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -77,7 +77,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for compatible types', () => {
     if (__DEV__) {
-      let HelloV1 = render(() => {
+      const HelloV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -100,7 +100,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let HelloV2 = patch(() => {
+      const HelloV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -167,7 +167,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for forwardRef', () => {
     if (__DEV__) {
-      let OuterV1 = render(() => {
+      const OuterV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -193,7 +193,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let OuterV2 = patch(() => {
+      const OuterV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -257,7 +257,7 @@ describe('ReactFresh', () => {
 
   it('should not consider two forwardRefs around the same type to be equivalent', () => {
     if (__DEV__) {
-      let ParentV1 = render(
+      const ParentV1 = render(
         () => {
           function Hello() {
             const [val, setVal] = React.useState(0);
@@ -274,9 +274,9 @@ describe('ReactFresh', () => {
           }
           // Both of these are wrappers around the same inner function.
           // They should be treated as distinct types across reloads.
-          let ForwardRefA = React.forwardRef(renderInner);
+          const ForwardRefA = React.forwardRef(renderInner);
           $RefreshReg$(ForwardRefA, 'ForwardRefA');
-          let ForwardRefB = React.forwardRef(renderInner);
+          const ForwardRefB = React.forwardRef(renderInner);
           $RefreshReg$(ForwardRefB, 'ForwardRefB');
 
           function Parent({cond}) {
@@ -324,7 +324,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Patch to change the color.
-      let ParentV2 = patch(() => {
+      const ParentV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -340,9 +340,9 @@ describe('ReactFresh', () => {
         }
         // Both of these are wrappers around the same inner function.
         // They should be treated as distinct types across reloads.
-        let ForwardRefA = React.forwardRef(renderInner);
+        const ForwardRefA = React.forwardRef(renderInner);
         $RefreshReg$(ForwardRefA, 'ForwardRefA');
-        let ForwardRefB = React.forwardRef(renderInner);
+        const ForwardRefB = React.forwardRef(renderInner);
         $RefreshReg$(ForwardRefB, 'ForwardRefB');
 
         function Parent({cond}) {
@@ -493,7 +493,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for simple memo', () => {
     if (__DEV__) {
-      let OuterV1 = render(() => {
+      const OuterV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -519,7 +519,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let OuterV2 = patch(() => {
+      const OuterV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -583,7 +583,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for memo with custom comparison', () => {
     if (__DEV__) {
-      let OuterV1 = render(() => {
+      const OuterV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -608,7 +608,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let OuterV2 = patch(() => {
+      const OuterV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -718,7 +718,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for memo(forwardRef)', () => {
     if (__DEV__) {
-      let OuterV1 = render(() => {
+      const OuterV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -744,7 +744,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let OuterV2 = patch(() => {
+      const OuterV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -808,7 +808,7 @@ describe('ReactFresh', () => {
 
   it('can preserve state for lazy after resolution', async () => {
     if (__DEV__) {
-      let AppV1 = render(() => {
+      const AppV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -855,7 +855,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let AppV2 = patch(() => {
+      const AppV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -1627,7 +1627,7 @@ describe('ReactFresh', () => {
 
   it('can force remount by changing signature', () => {
     if (__DEV__) {
-      let HelloV1 = render(() => {
+      const HelloV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -1652,7 +1652,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let HelloV2 = patch(() => {
+      const HelloV2 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -1673,7 +1673,7 @@ describe('ReactFresh', () => {
       expect(el.style.color).toBe('red');
 
       // Perform a hot update.
-      let HelloV3 = patch(() => {
+      const HelloV3 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -1758,7 +1758,7 @@ describe('ReactFresh', () => {
 
   it('keeps a valid tree when forcing remount', () => {
     if (__DEV__) {
-      let HelloV1 = prepare(() => {
+      const HelloV1 = prepare(() => {
         function Hello() {
           return null;
         }
@@ -1773,7 +1773,7 @@ describe('ReactFresh', () => {
 
       // Each of those renders three instances of HelloV1,
       // but in different ways.
-      let trees = [
+      const trees = [
         <div>
           <HelloV1 />
           <div>
@@ -2914,7 +2914,7 @@ describe('ReactFresh', () => {
       expect(container.innerHTML).toBe('<h1>Fixed!</h1>');
 
       // Verify next hot reload doesn't remount anything.
-      let helloNode = container.firstChild;
+      const helloNode = container.firstChild;
       patch(() => {
         function Hello() {
           return <h1>Nice.</h1>;
@@ -2993,15 +2993,15 @@ describe('ReactFresh', () => {
 
   it('regression test: does not get into an infinite loop', () => {
     if (__DEV__) {
-      let containerA = document.createElement('div');
-      let containerB = document.createElement('div');
+      const containerA = document.createElement('div');
+      const containerB = document.createElement('div');
 
       // Initially, nothing interesting.
-      let RootAV1 = () => {
+      const RootAV1 = () => {
         return 'A1';
       };
       $RefreshReg$(RootAV1, 'RootA');
-      let RootBV1 = () => {
+      const RootBV1 = () => {
         return 'B1';
       };
       $RefreshReg$(RootBV1, 'RootB');
@@ -3014,7 +3014,7 @@ describe('ReactFresh', () => {
       expect(containerB.innerHTML).toBe('B1');
 
       // Then make the first root fail.
-      let RootAV2 = () => {
+      const RootAV2 = () => {
         throw new Error('A2!');
       };
       $RefreshReg$(RootAV2, 'RootA');
@@ -3025,7 +3025,7 @@ describe('ReactFresh', () => {
       // Then patch the first root, but make it fail in the commit phase.
       // This used to trigger an infinite loop due to a list of failed roots
       // being mutated while it was being iterated on.
-      let RootAV3 = () => {
+      const RootAV3 = () => {
         React.useLayoutEffect(() => {
           throw new Error('A3!');
         }, []);
@@ -3036,7 +3036,7 @@ describe('ReactFresh', () => {
       expect(containerA.innerHTML).toBe('');
       expect(containerB.innerHTML).toBe('B1');
 
-      let RootAV4 = () => {
+      const RootAV4 = () => {
         return 'A4';
       };
       $RefreshReg$(RootAV4, 'RootA');
@@ -3048,7 +3048,7 @@ describe('ReactFresh', () => {
 
   it('remounts classes on every edit', () => {
     if (__DEV__) {
-      let HelloV1 = render(() => {
+      const HelloV1 = render(() => {
         class Hello extends React.Component {
           state = {count: 0};
           handleClick = () => {
@@ -3083,7 +3083,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update.
-      let HelloV2 = patch(() => {
+      const HelloV2 = patch(() => {
         class Hello extends React.Component {
           state = {count: 0};
           handleClick = () => {
@@ -3120,7 +3120,7 @@ describe('ReactFresh', () => {
       expect(newEl.style.color).toBe('red');
       expect(newEl.textContent).toBe('1');
 
-      let HelloV3 = patch(() => {
+      const HelloV3 = patch(() => {
         class Hello extends React.Component {
           state = {count: 0};
           handleClick = () => {
@@ -3235,7 +3235,7 @@ describe('ReactFresh', () => {
 
   it('remounts on conversion from class to function and back', () => {
     if (__DEV__) {
-      let HelloV1 = render(() => {
+      const HelloV1 = render(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -3258,7 +3258,7 @@ describe('ReactFresh', () => {
       expect(el.textContent).toBe('1');
 
       // Perform a hot update that turns it into a class.
-      let HelloV2 = patch(() => {
+      const HelloV2 = patch(() => {
         class Hello extends React.Component {
           state = {count: 0};
           handleClick = () => {
@@ -3296,7 +3296,7 @@ describe('ReactFresh', () => {
       expect(newEl.textContent).toBe('1');
 
       // Now convert it back to a function.
-      let HelloV3 = patch(() => {
+      const HelloV3 = patch(() => {
         function Hello() {
           const [val, setVal] = React.useState(0);
           return (
@@ -3479,9 +3479,9 @@ describe('ReactFresh', () => {
       ReactFreshRuntime.performReactRefresh();
 
       // Mount three roots.
-      let cont1 = document.createElement('div');
-      let cont2 = document.createElement('div');
-      let cont3 = document.createElement('div');
+      const cont1 = document.createElement('div');
+      const cont2 = document.createElement('div');
+      const cont3 = document.createElement('div');
       document.body.appendChild(cont1);
       document.body.appendChild(cont2);
       document.body.appendChild(cont3);
@@ -3601,10 +3601,10 @@ describe('ReactFresh', () => {
       expect(ReactFreshRuntime.isLikelyComponentType(useTheme)).toBe(false);
 
       // These seem like function components.
-      let Button = () => {};
+      const Button = () => {};
       expect(ReactFreshRuntime.isLikelyComponentType(Button)).toBe(true);
       expect(ReactFreshRuntime.isLikelyComponentType(Widget)).toBe(true);
-      let anon = (() => () => {})();
+      const anon = (() => () => {})();
       anon.displayName = 'Foo';
       expect(ReactFreshRuntime.isLikelyComponentType(anon)).toBe(true);
 
@@ -3717,7 +3717,7 @@ describe('ReactFresh', () => {
       // This is a minimal shim for the global hook installed by DevTools.
       // The real one is in packages/react-devtools-shared/src/hook.js.
       let idCounter = 0;
-      let renderers = new Map();
+      const renderers = new Map();
       global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
         renderers,
         supportsFiber: true,

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-let babel = require('@babel/core');
-let {wrap} = require('jest-snapshot-serializer-raw');
-let freshPlugin = require('react-refresh/babel');
+const babel = require('@babel/core');
+const {wrap} = require('jest-snapshot-serializer-raw');
+const freshPlugin = require('react-refresh/babel');
 
 function transform(input, options = {}) {
   return wrap(

--- a/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshIntegration-test.js
@@ -16,8 +16,8 @@ let ReactDOM;
 let ReactFreshRuntime;
 let act;
 
-let babel = require('@babel/core');
-let freshPlugin = require('react-refresh/babel');
+const babel = require('@babel/core');
+const freshPlugin = require('react-refresh/babel');
 
 describe('ReactFreshIntegration', () => {
   let container;
@@ -100,7 +100,7 @@ describe('ReactFreshIntegration', () => {
       // (In a real module system we'd do this for *all* exports.)
       // For example, this can happen if you convert a class to a function.
       // Or if you wrap something in a HOC.
-      let didExportsChange =
+      const didExportsChange =
         ReactFreshRuntime.getFamilyByType(prevExports.default) !==
         ReactFreshRuntime.getFamilyByType(nextExports.default);
       if (didExportsChange) {

--- a/packages/react-refresh/src/__tests__/ReactFreshMultipleRenderer-test.internal.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshMultipleRenderer-test.internal.js
@@ -10,18 +10,18 @@
 'use strict';
 
 jest.resetModules();
-let React = require('react');
+const React = require('react');
 let ReactFreshRuntime;
 if (__DEV__) {
   ReactFreshRuntime = require('react-refresh/runtime');
   ReactFreshRuntime.injectIntoGlobalHook(global);
 }
-let ReactDOM = require('react-dom');
+const ReactDOM = require('react-dom');
 
 jest.resetModules();
-let ReactART = require('react-art');
-let ARTSVGMode = require('art/modes/svg');
-let ARTCurrentMode = require('art/modes/current');
+const ReactART = require('react-art');
+const ARTSVGMode = require('art/modes/svg');
+const ARTCurrentMode = require('art/modes/current');
 ARTCurrentMode.setCurrent(ARTSVGMode);
 
 describe('ReactFresh', () => {
@@ -43,12 +43,12 @@ describe('ReactFresh', () => {
 
   it('can update components managd by different renderers independently', () => {
     if (__DEV__) {
-      let InnerV1 = function() {
+      const InnerV1 = function() {
         return <ReactART.Shape fill="blue" />;
       };
       ReactFreshRuntime.register(InnerV1, 'Inner');
 
-      let OuterV1 = function() {
+      const OuterV1 = function() {
         return (
           <div style={{color: 'blue'}}>
             <ReactART.Surface>
@@ -66,7 +66,7 @@ describe('ReactFresh', () => {
       expect(pathEl.getAttributeNS(null, 'fill')).toBe('rgb(0, 0, 255)');
 
       // Perform a hot update to the ART-rendered component.
-      let InnerV2 = function() {
+      const InnerV2 = function() {
         return <ReactART.Shape fill="red" />;
       };
       ReactFreshRuntime.register(InnerV2, 'Inner');
@@ -78,7 +78,7 @@ describe('ReactFresh', () => {
       expect(pathEl.getAttributeNS(null, 'fill')).toBe('rgb(255, 0, 0)');
 
       // Perform a hot update to the DOM-rendered component.
-      let OuterV2 = function() {
+      const OuterV2 = function() {
         return (
           <div style={{color: 'red'}}>
             <ReactART.Surface>

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -37,13 +37,13 @@ export function createRequest(
 }
 
 function performWork(request: OpaqueRequest): void {
-  let element = (request.children: any);
+  const element = (request.children: any);
   request.children = null;
   if (element && element.$$typeof !== REACT_ELEMENT_TYPE) {
     return;
   }
-  let type = element.type;
-  let props = element.props;
+  const type = element.type;
+  const props = element.props;
   if (typeof type !== 'string') {
     return;
   }
@@ -56,14 +56,14 @@ function performWork(request: OpaqueRequest): void {
 }
 
 function flushCompletedChunks(request: OpaqueRequest) {
-  let destination = request.destination;
-  let chunks = request.completedChunks;
+  const destination = request.destination;
+  const chunks = request.completedChunks;
   request.completedChunks = [];
 
   beginWriting(destination);
   try {
     for (let i = 0; i < chunks.length; i++) {
-      let chunk = chunks[i];
+      const chunk = chunks[i];
       writeChunk(destination, chunk);
     }
   } finally {

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -84,8 +84,8 @@ export function processErrorChunk(
   message: string,
   stack: string,
 ): Chunk {
-  let errorInfo = {message, stack};
-  let row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
+  const errorInfo = {message, stack};
+  const row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
   return convertStringToBuffer(row);
 }
 
@@ -94,7 +94,7 @@ export function processModelChunk(
   id: number,
   model: ReactModel,
 ): Chunk {
-  let json = stringify(model, request.toJSON);
+  const json = stringify(model, request.toJSON);
   let row;
   if (id === 0) {
     row = json + '\n';

--- a/packages/react-server/src/ReactFlightServerRuntime.js
+++ b/packages/react-server/src/ReactFlightServerRuntime.js
@@ -30,7 +30,7 @@ export function serverBlock<Props, Data>(
   moduleReference: ModuleReference<BlockRenderFunction<Props, Data>>,
   loadData: () => Data,
 ): ServerBlock<Props> {
-  let blockComponent: ServerBlockComponent<Props, Data> = [
+  const blockComponent: ServerBlockComponent<Props, Data> = [
     REACT_SERVER_BLOCK_TYPE,
     moduleReference,
     loadData,
@@ -43,7 +43,7 @@ export function serverBlock<Props, Data>(
 export function serverBlockNoData<Props>(
   moduleReference: ModuleReference<BlockRenderFunction<Props, void>>,
 ): ServerBlock<Props> {
-  let blockComponent: ServerBlockComponent<Props, void> = [
+  const blockComponent: ServerBlockComponent<Props, void> = [
     REACT_SERVER_BLOCK_TYPE,
     moduleReference,
   ];

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -46,7 +46,7 @@ export function writeChunk(
   destination: Destination,
   buffer: Uint8Array,
 ): boolean {
-  let nodeBuffer = ((buffer: any): Buffer); // close enough
+  const nodeBuffer = ((buffer: any): Buffer); // close enough
   return destination.write(nodeBuffer);
 }
 

--- a/packages/react-server/src/__tests__/ReactServer-test.js
+++ b/packages/react-server/src/__tests__/ReactServer-test.js
@@ -22,7 +22,7 @@ describe('ReactServer', () => {
   });
 
   it('can call render', () => {
-    let result = ReactNoopServer.render(<div>hello world</div>);
+    const result = ReactNoopServer.render(<div>hello world</div>);
     expect(result).toEqual([{type: 'div', props: {children: 'hello world'}}]);
   });
 });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRenderer-test.js
@@ -930,7 +930,7 @@ describe('ReactShallowRenderer', () => {
     let result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div>value:0</div>);
 
-    let instance = shallowRenderer.getMountedInstance();
+    const instance = shallowRenderer.getMountedInstance();
     instance.updateState();
     result = shallowRenderer.getRenderOutput();
     expect(result).toEqual(<div>value:1</div>);
@@ -1170,7 +1170,7 @@ describe('ReactShallowRenderer', () => {
     }
 
     const shallowRenderer = createRenderer();
-    let result = shallowRenderer.render(<SimpleComponent />, {
+    const result = shallowRenderer.render(<SimpleComponent />, {
       foo: 'foo',
       bar: 'bar',
     });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -216,7 +216,7 @@ describe('ReactShallowRenderer with hooks', () => {
     }
 
     const shallowRenderer = createRenderer();
-    let result = shallowRenderer.render(<SomeComponent initialCount={0} />);
+    const result = shallowRenderer.render(<SomeComponent initialCount={0} />);
 
     expect(result).toEqual(
       <div>
@@ -228,7 +228,7 @@ describe('ReactShallowRenderer with hooks', () => {
   });
 
   it('should not trigger effects', () => {
-    let effectsCalled = [];
+    const effectsCalled = [];
 
     function SomeComponent({defaultName}) {
       React.useEffect(() => {
@@ -260,8 +260,8 @@ describe('ReactShallowRenderer with hooks', () => {
     }
 
     const shallowRenderer = createRenderer();
-    let firstResult = shallowRenderer.render(<SomeComponent />);
-    let secondResult = shallowRenderer.render(<SomeComponent />);
+    const firstResult = shallowRenderer.render(<SomeComponent />);
+    const secondResult = shallowRenderer.render(<SomeComponent />);
 
     expect(firstResult).toEqual(secondResult);
   });
@@ -280,8 +280,8 @@ describe('ReactShallowRenderer with hooks', () => {
     }
 
     const shallowRenderer = createRenderer();
-    let firstResult = shallowRenderer.render(<SomeComponent />);
-    let secondResult = shallowRenderer.render(<SomeComponent />);
+    const firstResult = shallowRenderer.render(<SomeComponent />);
+    const secondResult = shallowRenderer.render(<SomeComponent />);
 
     expect(firstResult).toEqual(secondResult);
   });
@@ -300,7 +300,7 @@ describe('ReactShallowRenderer with hooks', () => {
     }
 
     const shallowRenderer = createRenderer();
-    let result = shallowRenderer.render(<SomeComponent />);
+    const result = shallowRenderer.render(<SomeComponent />);
 
     expect(result).toEqual(
       <div>
@@ -368,8 +368,8 @@ describe('ReactShallowRenderer with hooks', () => {
     });
 
     const shallowRenderer = createRenderer();
-    let firstResult = shallowRenderer.render(<SomeComponent />);
-    let secondResult = shallowRenderer.render(<SomeComponent />);
+    const firstResult = shallowRenderer.render(<SomeComponent />);
+    const secondResult = shallowRenderer.render(<SomeComponent />);
 
     expect(firstResult).toEqual(secondResult);
   });

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererMemo-test.js
@@ -957,7 +957,7 @@ describe('ReactShallowRendererMemo', () => {
     let result = shallowRenderer.render(<SimpleComponent />);
     expect(result).toEqual(<div>value:0</div>);
 
-    let instance = shallowRenderer.getMountedInstance();
+    const instance = shallowRenderer.getMountedInstance();
     instance.updateState();
     result = shallowRenderer.getRenderOutput();
     expect(result).toEqual(<div>value:1</div>);
@@ -1215,7 +1215,7 @@ describe('ReactShallowRendererMemo', () => {
     );
 
     const shallowRenderer = createRenderer();
-    let result = shallowRenderer.render(<SimpleComponent />, {
+    const result = shallowRenderer.render(<SimpleComponent />, {
       foo: 'foo',
       bar: 'bar',
     });

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAct-test.js
@@ -15,14 +15,14 @@ describe('ReactTestRenderer.act()', () => {
   });
   it('can use .act() to flush effects', () => {
     function App(props) {
-      let [ctr, setCtr] = React.useState(0);
+      const [ctr, setCtr] = React.useState(0);
       React.useEffect(() => {
         props.callback();
         setCtr(1);
       }, []);
       return ctr;
     }
-    let calledLog = [];
+    const calledLog = [];
     let root;
     act(() => {
       root = ReactTestRenderer.create(
@@ -41,7 +41,7 @@ describe('ReactTestRenderer.act()', () => {
   it("warns if you don't use .act", () => {
     let setCtr;
     function App(props) {
-      let [ctr, _setCtr] = React.useState(0);
+      const [ctr, _setCtr] = React.useState(0);
       setCtr = _setCtr;
       return ctr;
     }
@@ -63,7 +63,7 @@ describe('ReactTestRenderer.act()', () => {
         });
       }
       function App() {
-        let [details, setDetails] = React.useState(0);
+        const [details, setDetails] = React.useState(0);
 
         React.useEffect(() => {
           async function fetchDetails() {

--- a/packages/react/src/ReactBlock.js
+++ b/packages/react/src/ReactBlock.js
@@ -99,7 +99,7 @@ export function block<Args: Iterable<any>, Props, Data>(
 
   if (load === undefined) {
     return function(): Block<Props> {
-      let blockComponent: BlockComponent<Props, void> = {
+      const blockComponent: BlockComponent<Props, void> = {
         $$typeof: REACT_BLOCK_TYPE,
         _data: undefined,
         // $FlowFixMe: Data must be void in this scenario.
@@ -112,18 +112,18 @@ export function block<Args: Iterable<any>, Props, Data>(
   }
 
   // Trick to let Flow refine this.
-  let loadFn = load;
+  const loadFn = load;
 
   return function(): Block<Props> {
-    let args: Args = arguments;
+    const args: Args = arguments;
 
-    let payload: Payload<Props, Args, Data> = {
+    const payload: Payload<Props, Args, Data> = {
       load: loadFn,
       args: args,
       render: render,
     };
 
-    let lazyType: LazyComponent<
+    const lazyType: LazyComponent<
       BlockComponent<Props, Data>,
       Payload<Props, Args, Data>,
     > = {

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -109,7 +109,7 @@ function mapIntoArray(
     let mappedChild = callback(child);
     // If it's the only child, treat the name as if it was wrapped in an array
     // so that it's consistent if the number of children grows:
-    let childKey =
+    const childKey =
       nameSoFar === '' ? SEPARATOR + getElementKey(child, 0) : nameSoFar;
     if (Array.isArray(mappedChild)) {
       let escapedChildKey = '';

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -98,13 +98,13 @@ function lazyInitializer<T>(payload: Payload<T>): T {
 export function lazy<T>(
   ctor: () => Thenable<{default: T, ...}>,
 ): LazyComponent<T, Payload<T>> {
-  let payload: Payload<T> = {
+  const payload: Payload<T> = {
     // We use these fields to store the result.
     _status: -1,
     _result: ctor,
   };
 
-  let lazyType: LazyComponent<T, Payload<T>> = {
+  const lazyType: LazyComponent<T, Payload<T>> = {
     $$typeof: REACT_LAZY_TYPE,
     _payload: payload,
     _init: lazyInitializer,

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -600,7 +600,7 @@ describe('ReactDOMTracing', () => {
 
     describe('hydration', () => {
       it('traces interaction across hydration', async done => {
-        let ref = React.createRef();
+        const ref = React.createRef();
 
         function Child() {
           return 'Hello';
@@ -651,8 +651,10 @@ describe('ReactDOMTracing', () => {
       it('traces interaction across suspended hydration', async done => {
         let suspend = false;
         let resolve;
-        let promise = new Promise(resolvePromise => (resolve = resolvePromise));
-        let ref = React.createRef();
+        const promise = new Promise(
+          resolvePromise => (resolve = resolvePromise),
+        );
+        const ref = React.createRef();
 
         function Child() {
           if (suspend) {
@@ -720,8 +722,8 @@ describe('ReactDOMTracing', () => {
 
       it('traces interaction across client-rendered hydration', async done => {
         let suspend = false;
-        let promise = new Promise(() => {});
-        let ref = React.createRef();
+        const promise = new Promise(() => {});
+        const ref = React.createRef();
 
         function Child() {
           if (suspend) {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -818,7 +818,7 @@ describe('Profiler', () => {
             // The initial work was thrown away in this case,
             // So the actual and base times should only include the final rendered tree times.
             expect(callback).toHaveBeenCalledTimes(1);
-            let call = callback.mock.calls[0];
+            const call = callback.mock.calls[0];
             expect(call[2]).toBe(5); // actual time
             expect(call[3]).toBe(5); // base time
             expect(call[4]).toBe(115); // start time
@@ -1075,7 +1075,7 @@ describe('Profiler', () => {
                   expect(callback).toHaveBeenCalledTimes(2);
 
                   // Callbacks bubble (reverse order).
-                  let [mountCall, updateCall] = callback.mock.calls;
+                  const [mountCall, updateCall] = callback.mock.calls;
 
                   // The initial mount only includes the ErrorBoundary (which takes 2)
                   // But it spends time rendering all of the failed subtree also.
@@ -1154,7 +1154,7 @@ describe('Profiler', () => {
                   expect(callback).toHaveBeenCalledTimes(1);
 
                   // Callbacks bubble (reverse order).
-                  let [mountCall] = callback.mock.calls;
+                  const [mountCall] = callback.mock.calls;
 
                   // The initial mount includes the ErrorBoundary's error state,
                   // But it also spends actual time rendering UI that fails and isn't included.
@@ -3500,7 +3500,7 @@ describe('Profiler', () => {
       expect(onPostCommit).not.toHaveBeenCalled();
       expect(Scheduler).toFlushAndYield(['Child:1', 'onPostCommit']);
       expect(onPostCommit).toHaveBeenCalledTimes(1);
-      let call = onPostCommit.mock.calls[0];
+      const call = onPostCommit.mock.calls[0];
       expect(call[0]).toEqual('test-profiler');
       expect(call[4]).toMatchInteractions(
         ReactFeatureFlags.enableSchedulerTracing ? [interaction] : [],
@@ -3934,7 +3934,7 @@ describe('Profiler', () => {
       it('handles high-pri renderers between suspended and resolved (async) trees', async () => {
         // Set up an initial shell. We need to set this up before the test sceanrio
         // because we want initial render to suspend on navigation to the initial state.
-        let renderer = ReactTestRenderer.create(
+        const renderer = ReactTestRenderer.create(
           <React.Profiler id="app" onRender={() => {}}>
             <React.Suspense fallback={<Text text="loading" />} />
           </React.Profiler>,

--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -206,7 +206,7 @@ function workLoop(hasTimeRemaining, initialTime) {
   if (currentTask !== null) {
     return true;
   } else {
-    let firstTimer = peek(timerQueue);
+    const firstTimer = peek(timerQueue);
     if (firstTimer !== null) {
       requestHostTimeout(handleTimeout, firstTimer.startTime - currentTime);
     }

--- a/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
@@ -252,7 +252,7 @@ describe('SchedulerBrowser', () => {
   });
 
   it('schedule new task after a cancellation', () => {
-    let handle = scheduleCallback(NormalPriority, () => {
+    const handle = scheduleCallback(NormalPriority, () => {
       runtime.log('A');
     });
 

--- a/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
@@ -39,7 +39,7 @@ describe('SchedulerNoDOM', () => {
   });
 
   it('runAllTimers flushes all scheduled callbacks', () => {
-    let log = [];
+    const log = [];
     scheduleCallback(NormalPriority, () => {
       log.push('A');
     });
@@ -55,7 +55,7 @@ describe('SchedulerNoDOM', () => {
   });
 
   it('executes callbacks in order of priority', () => {
-    let log = [];
+    const log = [];
 
     scheduleCallback(NormalPriority, () => {
       log.push('A');

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -121,7 +121,7 @@ if (
 
   // TODO: Make this configurable
   // TODO: Adjust this based on priority?
-  let maxYieldInterval = 300;
+  const maxYieldInterval = 300;
   let needsPaint = false;
 
   if (

--- a/packages/shared/__tests__/ReactErrorUtils-test.internal.js
+++ b/packages/shared/__tests__/ReactErrorUtils-test.internal.js
@@ -133,7 +133,7 @@ describe('ReactErrorUtils', () => {
     const ReactErrorUtils2 = require('shared/ReactErrorUtils');
     expect(ReactErrorUtils1).not.toEqual(ReactErrorUtils2);
 
-    let ops = [];
+    const ops = [];
 
     ReactErrorUtils1.invokeGuardedCallback(
       null,

--- a/packages/shared/__tests__/ReactErrorUtils-test.internal.js
+++ b/packages/shared/__tests__/ReactErrorUtils-test.internal.js
@@ -82,7 +82,6 @@ describe('ReactErrorUtils', () => {
     const err1 = new Error();
     let err2;
     const err3 = new Error();
-    let err4;
     ReactErrorUtils.invokeGuardedCallback(
       'foo',
       function() {
@@ -98,7 +97,7 @@ describe('ReactErrorUtils', () => {
       },
       null,
     );
-    err4 = ReactErrorUtils.clearCaughtError();
+    const err4 = ReactErrorUtils.clearCaughtError();
 
     expect(err2).toBe(err1);
     expect(err4).toBe(err3);

--- a/packages/shared/__tests__/describeComponentFrame-test.js
+++ b/packages/shared/__tests__/describeComponentFrame-test.js
@@ -96,7 +96,7 @@ describe('Component stack trace displaying', () => {
     if (__DEV__) {
       let i = 0;
       expect(console.error.calls.count()).toBe(Object.keys(fileNames).length);
-      for (let fileName in fileNames) {
+      for (const fileName in fileNames) {
         if (!fileNames.hasOwnProperty(fileName)) {
           continue;
         }

--- a/packages/shared/checkPropTypes.js
+++ b/packages/shared/checkPropTypes.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-let loggedTypeFailures = {};
+const loggedTypeFailures = {};
 
 export default function checkPropTypes(
   typeSpecs: Object,
@@ -17,8 +17,8 @@ export default function checkPropTypes(
 ): void {
   if (__DEV__) {
     // $FlowFixMe This is okay but Flow doesn't know it.
-    let has = Function.call.bind(Object.prototype.hasOwnProperty);
-    for (let typeSpecName in typeSpecs) {
+    const has = Function.call.bind(Object.prototype.hasOwnProperty);
+    for (const typeSpecName in typeSpecs) {
       if (has(typeSpecs, typeSpecName)) {
         let error;
         // Prop type validation may throw. In case they do, we don't want to
@@ -28,7 +28,7 @@ export default function checkPropTypes(
           // This is intentionally an invariant that gets caught. It's the same
           // behavior as without this statement except with a better message.
           if (typeof typeSpecs[typeSpecName] !== 'function') {
-            let err = Error(
+            const err = Error(
               (componentName || 'React class') +
                 ': ' +
                 location +

--- a/packages/shared/describeComponentFrame.js
+++ b/packages/shared/describeComponentFrame.js
@@ -16,7 +16,7 @@ export default function(
 ) {
   let sourceInfo = '';
   if (source) {
-    let path = source.fileName;
+    const path = source.fileName;
     let fileName = path.replace(BEFORE_SLASH_RE, '');
     if (__DEV__) {
       // In DEV, include code for a common special case:

--- a/packages/shared/enqueueTask.js
+++ b/packages/shared/enqueueTask.js
@@ -15,8 +15,8 @@ export default function enqueueTask(task: () => void) {
     try {
       // read require off the module object to get around the bundlers.
       // we don't want them to detect a require and bundle a Node polyfill.
-      let requireString = ('require' + Math.random()).slice(0, 7);
-      let nodeRequire = module && module[requireString];
+      const requireString = ('require' + Math.random()).slice(0, 7);
+      const nodeRequire = module && module[requireString];
       // assuming we're in node, let's try to get node's
       // version of setImmediate, bypassing fake timers if any.
       enqueueTaskImpl = nodeRequire('timers').setImmediate;

--- a/packages/shared/forks/invokeGuardedCallbackImpl.www.js
+++ b/packages/shared/forks/invokeGuardedCallbackImpl.www.js
@@ -14,7 +14,7 @@ invariant(
   'Expected ReactFbErrorUtils.invokeGuardedCallback to be a function.',
 );
 
-let invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(
+const invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(
   name: string | null,
   func: (a: A, b: B, c: C, d: D, e: E, f: F) => mixed,
   context: Context,

--- a/packages/shared/forks/object-assign.inline-umd.js
+++ b/packages/shared/forks/object-assign.inline-umd.js
@@ -5,7 +5,7 @@
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const _assign = function(to, from) {
-  for (let key in from) {
+  for (const key in from) {
     if (hasOwnProperty.call(from, key)) {
       to[key] = from[key];
     }

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -90,8 +90,8 @@ function getComponentName(type: mixed): string | null {
         return getComponentName(type._render);
       case REACT_LAZY_TYPE: {
         const lazyComponent: LazyComponent<any, any> = (type: any);
-        let payload = lazyComponent._payload;
-        let init = lazyComponent._init;
+        const payload = lazyComponent._payload;
+        const init = lazyComponent._init;
         try {
           return getComponentName(init(payload));
         } catch (x) {

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -96,7 +96,7 @@ if (__DEV__) {
       // Keeps track of the value of window.event so that we can reset it
       // during the callback to let user code access window.event in the
       // browsers that support it.
-      let windowEvent = window.event;
+      const windowEvent = window.event;
 
       // Keeps track of the descriptor of window.event to restore it after event
       // dispatching: https://github.com/facebook/react/issues/13688

--- a/packages/use-subscription/src/__tests__/useSubscription-test.internal.js
+++ b/packages/use-subscription/src/__tests__/useSubscription-test.internal.js
@@ -152,7 +152,7 @@ describe('useSubscription', () => {
       return null;
     }
 
-    let subscriptions = [];
+    const subscriptions = [];
 
     function Subscription({source}) {
       const value = useSubscription(
@@ -213,7 +213,7 @@ describe('useSubscription', () => {
       return null;
     }
 
-    let subscriptions = [];
+    const subscriptions = [];
 
     function Subscription({source}) {
       const value = useSubscription({

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -24,7 +24,7 @@ function writeConfig(renderer, rendererInfo, isServerSupported) {
 
   const serverRenderer = isServerSupported ? renderer : 'custom';
 
-  let ignoredPaths = [];
+  const ignoredPaths = [];
 
   inlinedHostConfigs.forEach(otherRenderer => {
     if (otherRenderer === rendererInfo) {


### PR DESCRIPTION
Stylistically I really dislike this lint rule. I also don't think it should be necessary since it's trivial to infer. However, as noted in https://github.com/facebook/react/pull/18449, Closure Compiler does take advantage of this information.

Alternatively we could add a transform that does this for us but it'd be nice to minimize the complexity of the compilation toolchain.

Build diff https://github.com/sebmarkbage/react-builds/commit/5392791a3ce6ee0503f3a3bd856f2654a3219ea7