### PR TITLE
Remove state update warning for passive effect cleanup functions

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.internal.js
@@ -1305,7 +1305,49 @@ describe('ReactHooksWithNoopRenderer', () => {
         });
       });
 
-      it('shows a warning when a component updates its own state from within passive unmount function', () => {
+      it('still warns if there are updates after pending passive unmount effects have been flushed', () => {
+        let updaterFunction;
+
+        function Component() {
+          Scheduler.unstable_yieldValue('Component');
+          const [state, setState] = React.useState(false);
+          updaterFunction = setState;
+          React.useEffect(() => {
+            Scheduler.unstable_yieldValue('passive create');
+            return () => {
+              Scheduler.unstable_yieldValue('passive destroy');
+            };
+          }, []);
+          return state;
+        }
+
+        act(() => {
+          ReactNoop.renderToRootWithID(<Component />, 'root', () =>
+            Scheduler.unstable_yieldValue('Sync effect'),
+          );
+        });
+        expect(Scheduler).toHaveYielded([
+          'Component',
+          'Sync effect',
+          'passive create',
+        ]);
+
+        ReactNoop.unmountRootWithID('root');
+        expect(Scheduler).toFlushAndYield(['passive destroy']);
+
+        act(() => {
+          expect(() => {
+            updaterFunction(true);
+          }).toErrorDev(
+            "Warning: Can't perform a React state update on an unmounted component. " +
+              'This is a no-op, but it indicates a memory leak in your application. ' +
+              'To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.\n' +
+              '    in Component (at **)',
+          );
+        });
+      });
+
+      it('does not show a warning when a component updates its own state from within passive unmount function', () => {
         function Component() {
           Scheduler.unstable_yieldValue('Component');
           const [didLoad, setDidLoad] = React.useState(false);
@@ -1331,17 +1373,11 @@ describe('ReactHooksWithNoopRenderer', () => {
 
           // Unmount but don't process pending passive destroy function
           ReactNoop.unmountRootWithID('root');
-          expect(() => {
-            expect(Scheduler).toFlushAndYield(['passive destroy']);
-          }).toErrorDev(
-            "Warning: Can't perform a React state update from within a useEffect cleanup function. " +
-              'To fix, move state updates to the useEffect() body.\n' +
-              '    in Component (at **)',
-          );
+          expect(Scheduler).toFlushAndYield(['passive destroy']);
         });
       });
 
-      it('shows a warning when a component updates a childs state from within passive unmount function', () => {
+      it('does not show a warning when a component updates a childs state from within passive unmount function', () => {
         function Parent() {
           Scheduler.unstable_yieldValue('Parent');
           const updaterRef = React.useRef(null);
@@ -1376,13 +1412,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
           // Unmount but don't process pending passive destroy function
           ReactNoop.unmountRootWithID('root');
-          expect(() => {
-            expect(Scheduler).toFlushAndYield(['Parent passive destroy']);
-          }).toErrorDev(
-            "Warning: Can't perform a React state update from within a useEffect cleanup function. " +
-              'To fix, move state updates to the useEffect() body.\n' +
-              '    in Parent (at **)',
-          );
+          expect(Scheduler).toFlushAndYield(['Parent passive destroy']);
         });
       });
 

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const jestDiff = require('jest-diff').default;
+const jestDiff = require('jest-diff');
 const util = require('util');
 const shouldIgnoreConsoleError = require('../shouldIgnoreConsoleError');
 


### PR DESCRIPTION
We've recently identified a couple of valid patterns for updating component state from within an effect cleanup function:
* Updating an ancestor that a component had registered itself with on mount.
* Resetting state when a component is hidden after going offscreen. (Upcoming API.)

Because of this, I'm rolling back the more specific warning I added recently. In short:
* React **will no longer warn** about state updates from **inside of an effect cleanup function**.
* React **will still warn** about any other state updates from an unmount component.

# Fix test infra
This PR also fixes a broken import in one of our test helpers that I noticed while writing a new test.

#### Before:
<img width="430" alt="Screen Shot 2020-04-01 at 10 12 33 AM" src="https://user-images.githubusercontent.com/29597/78166960-7f235500-7402-11ea-994e-877c34a96518.png">

#### After:
<img width="854" alt="Screen Shot 2020-04-01 at 10 12 43 AM" src="https://user-images.githubusercontent.com/29597/78166966-80ed1880-7402-11ea-8c46-9204d62e5747.png">