### PR TITLE
Fixed race condition in release script

### DIFF
--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -80,7 +80,6 @@ function getBundleOutputPaths(bundleType, filename, packageName) {
 }
 
 async function copyWWWShims() {
-  await asyncRimRaf('build/facebook-www/shims');
   await asyncCopyTo(
     `${__dirname}/shims/facebook-www`,
     'build/facebook-www/shims'
@@ -88,15 +87,14 @@ async function copyWWWShims() {
 }
 
 async function copyRNShims() {
-  await asyncRimRaf('build/react-native/shims');
-  await Promise.all([
-    // React Native
-    asyncCopyTo(`${__dirname}/shims/react-native`, 'build/react-native/shims'),
-    asyncCopyTo(
-      require.resolve('react-native-renderer/src/ReactNativeTypes.js'),
-      'build/react-native/shims/ReactNativeTypes.js'
-    ),
-  ]);
+  await asyncCopyTo(
+    `${__dirname}/shims/react-native`,
+    'build/react-native/shims'
+  );
+  await asyncCopyTo(
+    require.resolve('react-native-renderer/src/ReactNativeTypes.js'),
+    'build/react-native/shims/ReactNativeTypes.js'
+  );
 }
 
 async function copyAllShims() {


### PR DESCRIPTION
I misinterpreted the cause of this failure before.

<img width="787" alt="Screen Shot 2020-04-01 at 1 21 54 PM" src="https://user-images.githubusercontent.com/29597/78182862-cbc75a00-741b-11ea-818d-2044273ea91c.png">

The `ReactNativeTypes.js` copy operation should not be invoked before the other shims are copied.