### PR TITLE
Don't close "Needs Investigation" issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ exemptLabels:
   - "Resolution: Backlog"
   - "Type: Bug"
   - "Type: Discussion"
+  - "Type: Needs Investigation"
   - "Type: Regression"
 # Label to use when marking an issue as stale
 staleLabel: "Resolution: Stale"


### PR DESCRIPTION
If it "needs investigation" it's not stale. It means it needs investigation. It's a possible bug.