### PR TITLE
Remove a flag for style collision warning

### DIFF
--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -11,8 +11,6 @@ import dangerousStyleValue from './dangerousStyleValue';
 import hyphenateStyleName from './hyphenateStyleName';
 import warnValidStyle from './warnValidStyle';
 
-import {warnAboutShorthandPropertyCollision} from 'shared/ReactFeatureFlags';
-
 /**
  * Operations for dealing with CSS properties.
  */
@@ -128,10 +126,6 @@ export function validateShorthandPropertyCollisionInDev(
   nextStyles,
 ) {
   if (__DEV__) {
-    if (!warnAboutShorthandPropertyCollision) {
-      return;
-    }
-
     if (!nextStyles) {
       return;
     }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -40,10 +40,6 @@ export const enableSchedulerDebugging = false;
 // Disable javascript: URL strings in href for XSS protection.
 export const disableJavaScriptURLs = false;
 
-// Warns when a combination of updates on a dom can cause a style declaration
-// that clashes with a previous one https://github.com/facebook/react/pull/14181
-export const warnAboutShorthandPropertyCollision = true;
-
 // Experimental React Flare event system and event components support.
 export const enableDeprecatedFlareAPI = false;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -17,7 +17,6 @@ export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;
 export const enableBlocksAPI = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const debugRenderPhaseSideEffectsForStrictMode = true;
 export const disableJavaScriptURLs = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -21,7 +21,6 @@ export const enableSelectiveHydration = false;
 export const enableBlocksAPI = false;
 export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -21,7 +21,6 @@ export const enableSelectiveHydration = false;
 export const enableBlocksAPI = false;
 export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -19,7 +19,6 @@ export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;
 export const enableBlocksAPI = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -21,7 +21,6 @@ export const enableSelectiveHydration = false;
 export const enableBlocksAPI = false;
 export const disableJavaScriptURLs = false;
 export const disableInputAttributeSyncing = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = false;
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -21,7 +21,6 @@ export const enableSelectiveHydration = true;
 export const enableBlocksAPI = true;
 export const disableJavaScriptURLs = true;
 export const disableInputAttributeSyncing = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const enableSchedulerDebugging = false;
 export const enableDeprecatedFlareAPI = true;
 export const enableFundamentalAPI = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -25,7 +25,6 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 // Update the tests so that they pass in either mode, then set these
 // to __VARIANT__.
 export const enableTrustedTypesIntegration = false;
-export const warnAboutShorthandPropertyCollision = true;
 export const disableInputAttributeSyncing = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const enableModernEventSystem = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -19,7 +19,6 @@ export const {
   disableModulePatternComponents,
   disableInputAttributeSyncing,
   enableTrustedTypesIntegration,
-  warnAboutShorthandPropertyCollision,
   disableSchedulerTimeoutBasedOnReactExpirationTime,
   warnAboutSpreadingKeyToJSX,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,


### PR DESCRIPTION
It's already released to open source and on for 80% on WWW. Let's just enable it statically.