### PR TITLE
Modern Event System: refine flags and handling of enableLegacyFBSupport

### DIFF
--- a/packages/legacy-events/EventSystemFlags.js
+++ b/packages/legacy-events/EventSystemFlags.js
@@ -11,10 +11,10 @@ export type EventSystemFlags = number;
 
 export const PLUGIN_EVENT_SYSTEM = 1;
 export const RESPONDER_EVENT_SYSTEM = 1 << 1;
-export const IS_PASSIVE = 1 << 2;
-export const IS_ACTIVE = 1 << 3;
-export const PASSIVE_NOT_SUPPORTED = 1 << 4;
-export const IS_REPLAYED = 1 << 5;
-export const IS_FIRST_ANCESTOR = 1 << 6;
-export const IS_TARGET_EVENT_ONLY = 1 << 7;
+export const USE_EVENT_SYSTEM = 1 << 2;
+export const IS_TARGET_PHASE_ONLY = 1 << 3;
+export const IS_PASSIVE = 1 << 4;
+export const PASSIVE_NOT_SUPPORTED = 1 << 5;
+export const IS_REPLAYED = 1 << 6;
+export const IS_FIRST_ANCESTOR = 1 << 7;
 export const LEGACY_FB_SUPPORT = 1 << 8;

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -14,6 +14,7 @@ describe('ReactDOMComponent', () => {
   let ReactTestUtils;
   let ReactDOM;
   let ReactDOMServer;
+  const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
   function normalizeCodeLocInfo(str) {
     return str && str.replace(/\(at .+?:\d+\)/g, '(at **)');
@@ -2595,14 +2596,30 @@ describe('ReactDOMComponent', () => {
       // might depend on this.
       //
       // @see https://github.com/facebook/react/pull/12919#issuecomment-395224674
-      expect(eventOrder).toEqual([
-        'document capture',
-        'inner capture',
-        'inner bubble',
-        'outer capture',
-        'outer bubble',
-        'document bubble',
-      ]);
+      if (
+        ReactFeatureFlags.enableModernEventSystem &
+        ReactFeatureFlags.enableLegacyFBSupport
+      ) {
+        // The order will change here, as the legacy FB support adds
+        // the event listener onto the document after the one above has.
+        expect(eventOrder).toEqual([
+          'document capture',
+          'document bubble',
+          'inner capture',
+          'inner bubble',
+          'outer capture',
+          'outer bubble',
+        ]);
+      } else {
+        expect(eventOrder).toEqual([
+          'document capture',
+          'inner capture',
+          'inner bubble',
+          'outer capture',
+          'outer bubble',
+          'document bubble',
+        ]);
+      }
     } finally {
       document.body.removeChild(container);
     }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -76,6 +76,8 @@ import {HostComponent} from 'react-reconciler/src/ReactWorkTags';
 import {
   RESPONDER_EVENT_SYSTEM,
   IS_PASSIVE,
+  PLUGIN_EVENT_SYSTEM,
+  USE_EVENT_SYSTEM,
 } from 'legacy-events/EventSystemFlags';
 import {
   isManagedDOMElement,
@@ -1156,6 +1158,7 @@ export function registerEvent(
     type,
     rootContainerInstance,
     listenerMap,
+    PLUGIN_EVENT_SYSTEM | USE_EVENT_SYSTEM,
     passive,
     priority,
   );

--- a/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
+++ b/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
@@ -21,7 +21,10 @@ import {
   HostComponent,
   HostText,
 } from 'react-reconciler/src/ReactWorkTags';
-import {IS_FIRST_ANCESTOR} from 'legacy-events/EventSystemFlags';
+import {
+  IS_FIRST_ANCESTOR,
+  PLUGIN_EVENT_SYSTEM,
+} from 'legacy-events/EventSystemFlags';
 import {batchedEventUpdates} from 'legacy-events/ReactGenericBatching';
 import {runEventsInBatch} from 'legacy-events/EventBatching';
 import {plugins} from 'legacy-events/EventPluginRegistry';
@@ -372,7 +375,12 @@ export function legacyTrapBubbledEvent(
   element: Document | Element,
   listenerMap?: ElementListenerMap,
 ): void {
-  const listener = addTrappedEventListener(element, topLevelType, false);
+  const listener = addTrappedEventListener(
+    element,
+    topLevelType,
+    PLUGIN_EVENT_SYSTEM,
+    false,
+  );
   if (listenerMap) {
     listenerMap.set(topLevelType, {passive: undefined, listener});
   }
@@ -383,6 +391,11 @@ export function legacyTrapCapturedEvent(
   element: Document | Element,
   listenerMap: ElementListenerMap,
 ): void {
-  const listener = addTrappedEventListener(element, topLevelType, true);
+  const listener = addTrappedEventListener(
+    element,
+    topLevelType,
+    PLUGIN_EVENT_SYSTEM,
+    true,
+  );
   listenerMap.set(topLevelType, {passive: undefined, listener});
 }

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -118,7 +118,7 @@ import {
   TOP_FOCUS,
   TOP_BLUR,
 } from './DOMTopLevelEventTypes';
-import {IS_REPLAYED} from 'legacy-events/EventSystemFlags';
+import {IS_REPLAYED, PLUGIN_EVENT_SYSTEM} from 'legacy-events/EventSystemFlags';
 import {legacyListenToTopLevelEvent} from './DOMLegacyEventPluginSystem';
 import {listenToTopLevelEvent} from './DOMModernPluginEventSystem';
 
@@ -219,7 +219,12 @@ function trapReplayableEventForContainer(
   container: Container,
   listenerMap: ElementListenerMap,
 ) {
-  listenToTopLevelEvent(topLevelType, ((container: any): Element), listenerMap);
+  listenToTopLevelEvent(
+    topLevelType,
+    ((container: any): Element),
+    listenerMap,
+    PLUGIN_EVENT_SYSTEM,
+  );
 }
 
 function trapReplayableEventForDocument(

--- a/packages/react-dom/src/events/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/SimpleEventPlugin.js
@@ -17,6 +17,7 @@ import type {PluginModule} from 'legacy-events/PluginModuleType';
 import type {EventSystemFlags} from 'legacy-events/EventSystemFlags';
 
 import SyntheticEvent from 'legacy-events/SyntheticEvent';
+import {IS_TARGET_PHASE_ONLY} from 'legacy-events/EventSystemFlags';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
 import {
@@ -38,7 +39,7 @@ import SyntheticWheelEvent from './SyntheticWheelEvent';
 import getEventCharCode from './getEventCharCode';
 import accumulateTwoPhaseListeners from './accumulateTwoPhaseListeners';
 import accumulateEventTargetListeners from './accumulateEventTargetListeners';
-import {IS_TARGET_EVENT_ONLY} from 'legacy-events/EventSystemFlags';
+
 import {enableUseEventAPI} from 'shared/ReactFeatureFlags';
 
 // Only used in DEV for exhaustiveness validation.
@@ -210,7 +211,7 @@ const SimpleEventPlugin: PluginModule<MouseEvent> = {
     if (
       enableUseEventAPI &&
       eventSystemFlags !== undefined &&
-      eventSystemFlags & IS_TARGET_EVENT_ONLY &&
+      eventSystemFlags & IS_TARGET_PHASE_ONLY &&
       targetContainer != null
     ) {
       accumulateEventTargetListeners(event, targetContainer);


### PR DESCRIPTION
This PR fixes some issues with `enableLegacyFBSupport` and the modern event system. I took the time to clean up how flags are passed around, allowing us to handle some specific cases better which were the cause of why some of our tests fail if run with specific www flags enabled. With these changes they should all now pass.