### PR TITLE
[Flight] Lazily parse models and allow any value to suspend

### DIFF
--- a/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+export type UninitializedModel = string;
+
 export type StringDecoder = TextDecoder;
 
 export const supportsBinaryStreams = true;

--- a/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigBrowser.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-export type UninitializedModel = string;
-
 export type StringDecoder = TextDecoder;
 
 export const supportsBinaryStreams = true;

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -10,7 +10,7 @@
 import type {ResponseBase} from './ReactFlightClient';
 import type {StringDecoder} from './ReactFlightClientHostConfig';
 
-export type Response<T> = ResponseBase<T> & {
+export type Response = ResponseBase & {
   partialRow: string,
   fromJSON: (key: string, value: JSONValue) => any,
   stringDecoder: StringDecoder,
@@ -18,9 +18,6 @@ export type Response<T> = ResponseBase<T> & {
 
 export type UninitializedModel = string;
 
-export function parseModel<T, R>(
-  response: Response<R>,
-  json: UninitializedModel,
-): T {
+export function parseModel<T>(response: Response, json: UninitializedModel): T {
   return JSON.parse(json, response.fromJSON);
 }

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -11,13 +11,13 @@ import type {ResponseBase} from './ReactFlightClient';
 import type {StringDecoder} from './ReactFlightClientHostConfig';
 
 export type Response = ResponseBase & {
-  partialRow: string,
-  fromJSON: (key: string, value: JSONValue) => any,
-  stringDecoder: StringDecoder,
+  _partialRow: string,
+  _fromJSON: (key: string, value: JSONValue) => any,
+  _stringDecoder: StringDecoder,
 };
 
 export type UninitializedModel = string;
 
 export function parseModel<T>(response: Response, json: UninitializedModel): T {
-  return JSON.parse(json, response.fromJSON);
+  return JSON.parse(json, response._fromJSON);
 }

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ResponseBase} from './ReactFlightClient';
+import type {StringDecoder} from './ReactFlightClientHostConfig';
+
+export type Response<T> = ResponseBase<T> & {
+  partialRow: string,
+  fromJSON: (key: string, value: JSONValue) => any,
+  stringDecoder: StringDecoder,
+};
+
+export type UninitializedModel = string;
+
+export function parseModel<T, R>(
+  response: Response<R>,
+  json: UninitializedModel,
+): T {
+  return JSON.parse(json, response.fromJSON);
+}

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -62,13 +62,13 @@ export function processStringChunk(
 ): void {
   let linebreak = chunk.indexOf('\n', offset);
   while (linebreak > -1) {
-    const fullrow = response.partialRow + chunk.substring(offset, linebreak);
+    const fullrow = response._partialRow + chunk.substring(offset, linebreak);
     processFullRow(response, fullrow);
-    response.partialRow = '';
+    response._partialRow = '';
     offset = linebreak + 1;
     linebreak = chunk.indexOf('\n', offset);
   }
-  response.partialRow += chunk.substring(offset);
+  response._partialRow += chunk.substring(offset);
 }
 
 export function processBinaryChunk(
@@ -78,18 +78,18 @@ export function processBinaryChunk(
   if (!supportsBinaryStreams) {
     throw new Error("This environment don't support binary chunks.");
   }
-  const stringDecoder = response.stringDecoder;
+  const stringDecoder = response._stringDecoder;
   let linebreak = chunk.indexOf(10); // newline
   while (linebreak > -1) {
     const fullrow =
-      response.partialRow +
+      response._partialRow +
       readFinalStringChunk(stringDecoder, chunk.subarray(0, linebreak));
     processFullRow(response, fullrow);
-    response.partialRow = '';
+    response._partialRow = '';
     chunk = chunk.subarray(linebreak + 1);
     linebreak = chunk.indexOf(10); // newline
   }
-  response.partialRow += readPartialStringChunk(stringDecoder, chunk);
+  response._partialRow += readPartialStringChunk(stringDecoder, chunk);
 }
 
 function createFromJSONCallback(response: Response) {
@@ -110,12 +110,12 @@ export function createResponse(): Response {
   // It should be inlined to one object literal but minor changes can break it.
   const stringDecoder = supportsBinaryStreams ? createStringDecoder() : null;
   const response: any = createResponseBase();
-  response.partialRow = '';
+  response._partialRow = '';
   if (supportsBinaryStreams) {
-    response.stringDecoder = stringDecoder;
+    response._stringDecoder = stringDecoder;
   }
   // Don't inline this call because it causes closure to outline the call above.
-  response.fromJSON = createFromJSONCallback(response);
+  response._fromJSON = createFromJSONCallback(response);
   return response;
 }
 

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -26,7 +26,7 @@ import {
 
 export type {Response};
 
-function processFullRow<T>(response: Response<T>, row: string): void {
+function processFullRow(response: Response, row: string): void {
   if (row === '') {
     return;
   }
@@ -55,8 +55,8 @@ function processFullRow<T>(response: Response<T>, row: string): void {
   }
 }
 
-export function processStringChunk<T>(
-  response: Response<T>,
+export function processStringChunk(
+  response: Response,
   chunk: string,
   offset: number,
 ): void {
@@ -71,8 +71,8 @@ export function processStringChunk<T>(
   response.partialRow += chunk.substring(offset);
 }
 
-export function processBinaryChunk<T>(
-  response: Response<T>,
+export function processBinaryChunk(
+  response: Response,
   chunk: Uint8Array,
 ): void {
   if (!supportsBinaryStreams) {
@@ -92,7 +92,7 @@ export function processBinaryChunk<T>(
   response.partialRow += readPartialStringChunk(stringDecoder, chunk);
 }
 
-function createFromJSONCallback<T>(response: Response<T>) {
+function createFromJSONCallback(response: Response) {
   return function(key: string, value: JSONValue) {
     if (typeof value === 'string') {
       // We can't use .bind here because we need the "this" value.
@@ -105,7 +105,7 @@ function createFromJSONCallback<T>(response: Response<T>) {
   };
 }
 
-export function createResponse<T>(): Response<T> {
+export function createResponse(): Response {
   // NOTE: CHECK THE COMPILER OUTPUT EACH TIME YOU CHANGE THIS.
   // It should be inlined to one object literal but minor changes can break it.
   const stringDecoder = supportsBinaryStreams ? createStringDecoder() : null;

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -25,7 +25,7 @@
 
 declare var $$$hostConfig: any;
 
-export type Response<T> = any; // eslint-disable-line no-unused-vars
+export type Response = any;
 export opaque type ModuleMetaData = mixed; // eslint-disable-line no-undef
 export opaque type ModuleReference<T> = mixed; // eslint-disable-line no-undef
 export const resolveModuleReference = $$$hostConfig.resolveModuleReference;

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -32,6 +32,9 @@ export const preloadModule = $$$hostConfig.preloadModule;
 export const requireModule = $$$hostConfig.requireModule;
 
 export opaque type Source = mixed; // eslint-disable-line no-undef
+
+export type UninitializedModel = string;
+
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 
 export const supportsBinaryStreams = $$$hostConfig.supportsBinaryStreams;

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.custom.js
@@ -25,6 +25,7 @@
 
 declare var $$$hostConfig: any;
 
+export type Response<T> = any; // eslint-disable-line no-unused-vars
 export opaque type ModuleMetaData = mixed; // eslint-disable-line no-undef
 export opaque type ModuleReference<T> = mixed; // eslint-disable-line no-undef
 export const resolveModuleReference = $$$hostConfig.resolveModuleReference;
@@ -34,6 +35,7 @@ export const requireModule = $$$hostConfig.requireModule;
 export opaque type Source = mixed; // eslint-disable-line no-undef
 
 export type UninitializedModel = string;
+export const parseModel = $$$hostConfig.parseModel;
 
 export opaque type StringDecoder = mixed; // eslint-disable-line no-undef
 

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-browser.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-browser.js
@@ -8,4 +8,5 @@
  */
 
 export * from 'react-client/src/ReactFlightClientHostConfigBrowser';
+export * from 'react-client/src/ReactFlightClientHostConfigStream';
 export * from 'react-flight-dom-webpack/src/ReactFlightClientWebpackBundlerConfig';

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.dom.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.dom.js
@@ -8,4 +8,5 @@
  */
 
 export * from 'react-client/src/ReactFlightClientHostConfigBrowser';
+export * from 'react-client/src/ReactFlightClientHostConfigStream';
 export * from 'react-flight-dom-webpack/src/ReactFlightClientWebpackBundlerConfig';

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -7,51 +7,9 @@
  * @flow
  */
 
-import type {Response, JSONValue} from 'react-client/src/ReactFlightClient';
-
-import {
+export {
   createResponse,
-  parseModelFromJSON,
-  resolveModelChunk,
-  resolveErrorChunk,
+  resolveModel,
+  resolveError,
   close,
 } from 'react-client/src/ReactFlightClient';
-
-function parseModel<T>(response: Response<T>, targetObj, key, value) {
-  if (typeof value === 'object' && value !== null) {
-    if (Array.isArray(value)) {
-      for (let i = 0; i < value.length; i++) {
-        (value: any)[i] = parseModel(response, value, '' + i, value[i]);
-      }
-    } else {
-      for (const innerKey in value) {
-        (value: any)[innerKey] = parseModel(
-          response,
-          value,
-          innerKey,
-          value[innerKey],
-        );
-      }
-    }
-  }
-  return parseModelFromJSON(response, targetObj, key, value);
-}
-
-export {createResponse, close};
-
-export function resolveModel<T>(
-  response: Response<T>,
-  id: number,
-  json: JSONValue,
-) {
-  resolveModelChunk(response, id, parseModel(response, {}, '', json));
-}
-
-export function resolveError<T>(
-  response: Response<T>,
-  id: number,
-  message: string,
-  stack: string,
-) {
-  resolveErrorChunk(response, id, message, stack);
-}

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {JSONValue} from 'react-client/src/ReactFlightClient';
+
 export {
   resolveModuleReference,
   preloadModule,
@@ -17,3 +19,5 @@ export type {
   ModuleReference,
   ModuleMetaData,
 } from 'ReactFlightDOMRelayClientIntegration';
+
+export type UninitializedModel = JSONValue;

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -7,7 +7,12 @@
  * @flow
  */
 
-import type {JSONValue} from 'react-client/src/ReactFlightClient';
+import type {JSONValue, ResponseBase} from 'react-client/src/ReactFlightClient';
+
+import {
+  parseModelString,
+  parseModelTuple,
+} from 'react-client/src/ReactFlightClient';
 
 export {
   resolveModuleReference,
@@ -20,4 +25,38 @@ export type {
   ModuleMetaData,
 } from 'ReactFlightDOMRelayClientIntegration';
 
-export type UninitializedModel = JSONValue;
+export opaque type UninitializedModel = JSONValue;
+
+export type Response<T> = ResponseBase<T>;
+
+function parseModelRecursively<T>(response: Response<T>, parentObj, value) {
+  if (typeof value === 'string') {
+    return parseModelString(response, parentObj, value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        (value: any)[i] = parseModelRecursively(response, value, value[i]);
+      }
+      return parseModelTuple(response, value);
+    } else {
+      for (const innerKey in value) {
+        (value: any)[innerKey] = parseModelRecursively(
+          response,
+          value,
+          value[innerKey],
+        );
+      }
+    }
+  }
+  return value;
+}
+
+const dummy = {};
+
+export function parseModel<T, R>(
+  response: Response<R>,
+  json: UninitializedModel,
+): T {
+  return (parseModelRecursively(response, dummy, json): any);
+}

--- a/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-flight-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -27,9 +27,9 @@ export type {
 
 export opaque type UninitializedModel = JSONValue;
 
-export type Response<T> = ResponseBase<T>;
+export type Response = ResponseBase;
 
-function parseModelRecursively<T>(response: Response<T>, parentObj, value) {
+function parseModelRecursively(response: Response, parentObj, value) {
   if (typeof value === 'string') {
     return parseModelString(response, parentObj, value);
   }
@@ -54,9 +54,6 @@ function parseModelRecursively<T>(response: Response<T>, parentObj, value) {
 
 const dummy = {};
 
-export function parseModel<T, R>(
-  response: Response<R>,
-  json: UninitializedModel,
-): T {
+export function parseModel<T>(response: Response, json: UninitializedModel): T {
   return (parseModelRecursively(response, dummy, json): any);
 }

--- a/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-flight-dom-webpack/src/ReactFlightDOMClient.js
@@ -17,8 +17,8 @@ import {
   close,
 } from 'react-client/src/ReactFlightClientStream';
 
-function startReadingFromStream<T>(
-  response: FlightResponse<T>,
+function startReadingFromStream(
+  response: FlightResponse,
   stream: ReadableStream,
 ): void {
   const reader = stream.getReader();
@@ -37,18 +37,16 @@ function startReadingFromStream<T>(
   reader.read().then(progress, error);
 }
 
-function createFromReadableStream<T>(
-  stream: ReadableStream,
-): FlightResponse<T> {
-  const response: FlightResponse<T> = createResponse();
+function createFromReadableStream(stream: ReadableStream): FlightResponse {
+  const response: FlightResponse = createResponse();
   startReadingFromStream(response, stream);
   return response;
 }
 
-function createFromFetch<T>(
+function createFromFetch(
   promiseForResponse: Promise<Response>,
-): FlightResponse<T> {
-  const response: FlightResponse<T> = createResponse();
+): FlightResponse {
+  const response: FlightResponse = createResponse();
   promiseForResponse.then(
     function(r) {
       startReadingFromStream(response, (r.body: any));
@@ -60,8 +58,8 @@ function createFromFetch<T>(
   return response;
 }
 
-function createFromXHR<T>(request: XMLHttpRequest): FlightResponse<T> {
-  const response: FlightResponse<T> = createResponse();
+function createFromXHR(request: XMLHttpRequest): FlightResponse {
+  const response: FlightResponse = createResponse();
   let processedLength = 0;
   function progress(e: ProgressEvent): void {
     const chunk = request.responseText;

--- a/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-flight-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -286,7 +286,7 @@ describe('ReactFlightDOM', () => {
     function Text({children}) {
       return children;
     }
-    function makeDelayedText() {
+    function makeDelayedTextBlock() {
       let error, _resolve, _reject;
       let promise = new Promise((resolve, reject) => {
         _resolve = () => {
@@ -315,11 +315,36 @@ describe('ReactFlightDOM', () => {
       return [loadBlock(), _resolve, _reject];
     }
 
+    function makeDelayedText() {
+      let error, _resolve, _reject;
+      let promise = new Promise((resolve, reject) => {
+        _resolve = () => {
+          promise = null;
+          resolve();
+        };
+        _reject = e => {
+          error = e;
+          promise = null;
+          reject(e);
+        };
+      });
+      function DelayedText({children}, data) {
+        if (promise) {
+          throw promise;
+        }
+        if (error) {
+          throw error;
+        }
+        return <Text>{children}</Text>;
+      }
+      return [DelayedText, _resolve, _reject];
+    }
+
     const [FriendsModel, resolveFriendsModel] = makeDelayedText();
     const [NameModel, resolveNameModel] = makeDelayedText();
-    const [PostsModel, resolvePostsModel] = makeDelayedText();
-    const [PhotosModel, resolvePhotosModel] = makeDelayedText();
-    const [GamesModel, , rejectGamesModel] = makeDelayedText();
+    const [PostsModel, resolvePostsModel] = makeDelayedTextBlock();
+    const [PhotosModel, resolvePhotosModel] = makeDelayedTextBlock();
+    const [GamesModel, , rejectGamesModel] = makeDelayedTextBlock();
     function ProfileMore() {
       return {
         avatar: <Text>:avatar:</Text>,

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -29,6 +29,9 @@ const {createResponse, processStringChunk, close} = ReactFlightClient({
   requireModule(idx: string) {
     return readModule(idx);
   },
+  parseModel(response: Response, json) {
+    return JSON.parse(json, response._fromJSON);
+  },
 });
 
 function read<T>(source: Source): T {

--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -68,10 +68,11 @@ function runESLint({onlyChanged}) {
   if (typeof onlyChanged !== 'boolean') {
     throw new Error('Pass options.onlyChanged as a boolean.');
   }
-  const {errorCount, warningCount, output} = runESLintOnFilesWithOptions(
-    allPaths,
-    onlyChanged
-  );
+  const {
+    errorCount,
+    warningCount,
+    output,
+  } = runESLintOnFilesWithOptions(allPaths, onlyChanged, {fix: true});
   console.log(output);
   return errorCount === 0 && warningCount === 0;
 }

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -27,6 +27,7 @@ module.exports = [
       'react-flight-dom-webpack/server.node',
       'react-flight-dom-webpack/server-runtime',
       'react-flight-dom-webpack/src/ReactFlightDOMServerNode.js', // react-flight-dom-webpack/server.browser
+      'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.
       'react-interactions',
     ],
     isFlowTyped: true,
@@ -51,6 +52,7 @@ module.exports = [
       'react-flight-dom-webpack/server.browser',
       'react-flight-dom-webpack/server-runtime',
       'react-flight-dom-webpack/src/ReactFlightDOMServerBrowser.js', // react-flight-dom-webpack/server.browser
+      'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.
     ],
     isFlowTyped: true,
     isServerSupported: true,
@@ -103,7 +105,12 @@ module.exports = [
       'react-server/flight',
       'react-server/flight-server-runtime',
     ],
-    paths: [],
+    paths: [
+      'react-client/flight',
+      'react-server/flight',
+      'react-server/flight-server-runtime',
+      'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.
+    ],
     isFlowTyped: true,
     isServerSupported: true,
   },


### PR DESCRIPTION
There's a bunch of refactoring here but there are two key features that this unlocks:

1) We now parse the model lazily instead of when it arrives. This improves initial perf since not all models will actually be used during initial render, and it allows this work to be properly scheduled along with other React work. This also allow us to suspend when parsing a model. We can use this to allow arbitrary values to suspend. I.e. any value can be replaced with a "reference" (e.g. "$123") and if it's not available, the whole model suspends. Instead of getters/proxies. Blocks are special in that they can suspend at the React component level and therefore don't suspend the whole model.
2) This in turn lets us emit incomplete React elements as future references. Therefore, server components can now suspend and then fill in the content later.