### PR TITLE
Fix performance issue in react-devtools when highlight enabled

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -114,21 +114,21 @@ function prepareToDraw(): void {
   redrawTimeoutID = null;
 
   const now = getCurrentTime();
-  let expirationTimeout = Number.NEGATIVE_INFINITY;
+  let earliestExpiration = Number.MAX_VALUE;
 
   // Remove any items that have already expired.
   nodeToData.forEach((data, node) => {
     if (data.expirationTime < now) {
       nodeToData.delete(node);
     } else {
-      expirationTimeout = Math.max(expirationTimeout, data.expirationTime);
+      earliestExpiration = Math.min(earliestExpiration, data.expirationTime);
     }
   });
 
   draw(nodeToData);
 
-  if (expirationTimeout > 0) {
-    redrawTimeoutID = setTimeout(prepareToDraw, expirationTimeout - now);
+  if (earliestExpiration !== Number.MAX_VALUE) {
+    redrawTimeoutID = setTimeout(prepareToDraw, earliestExpiration - now);
   }
 }
 

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -114,20 +114,22 @@ function prepareToDraw(): void {
   redrawTimeoutID = null;
 
   const now = getCurrentTime();
-  let earliestExpiration = Number.MAX_VALUE;
+  let expirationTimeout = Number.NEGATIVE_INFINITY;
 
   // Remove any items that have already expired.
   nodeToData.forEach((data, node) => {
     if (data.expirationTime < now) {
       nodeToData.delete(node);
     } else {
-      earliestExpiration = Math.min(earliestExpiration, data.expirationTime);
+      expirationTimeout = Math.max(expirationTimeout, data.expirationTime);
     }
   });
 
   draw(nodeToData);
 
-  redrawTimeoutID = setTimeout(prepareToDraw, earliestExpiration - now);
+  if (expirationTimeout > 0) {
+    redrawTimeoutID = setTimeout(prepareToDraw, expirationTimeout - now);
+  }
 }
 
 function measureNode(node: Object): Rect | null {


### PR DESCRIPTION
fix #17935 

## Problem
Problem with high CPU usage when option `Highlight updates when components render` by passing `Number.MAX_VALUE` to `setTimeout` argument. This causes an integer overflow (when using delays larger than 2,147,483,647ms), resulting in the timeout being executed immediately and continuous redrawing canvas with 1ms rate. 

## Solution
Condition prevent to invoke `setTimeout` when `expirationTimeout` (default `NEGATIVE_INFINITY`) is negative number.
```javascript
if (expirationTimeout > 0) {
    redrawTimeoutID = setTimeout(prepareToDraw, expirationTimeout - now);
  }
```
Using `Number.MAX_VALUE` as a default could be more confusing and required condition like`expirationTimeout !== Number.MAX_VALUE`. At first look it's hard to verify what does it mean.

In my opinion timeout should be set only if required expiration time has a value greater than zero and it's more intuitive.

