### PR TITLE
React Event System: cleanup plugins + break out update batching logic

### DIFF
--- a/packages/legacy-events/EventPluginRegistry.js
+++ b/packages/legacy-events/EventPluginRegistry.js
@@ -241,3 +241,20 @@ export function injectEventPluginsByName(
     recomputePluginOrdering();
   }
 }
+
+export function injectEventPlugins(
+  eventPlugins: [PluginModule<AnyNativeEvent>],
+): void {
+  for (let i = 0; i < eventPlugins.length; i++) {
+    const pluginModule = eventPlugins[i];
+    plugins.push(pluginModule);
+    const publishedEvents = pluginModule.eventTypes;
+    for (const eventName in publishedEvents) {
+      publishEventForPlugin(
+        publishedEvents[eventName],
+        pluginModule,
+        eventName,
+      );
+    }
+  }
+}

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -39,13 +39,6 @@ import {
 } from 'react-reconciler/src/ReactFiberReconciler';
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import {setBatchingImplementation} from 'legacy-events/ReactGenericBatching';
-import {
-  setRestoreImplementation,
-  enqueueStateRestore,
-  restoreStateIfNeeded,
-} from 'legacy-events/ReactControlledComponent';
-import {runEventsInBatch} from 'legacy-events/EventBatching';
 import {
   eventNameDispatchConfigs,
   injectEventPluginsByName,
@@ -69,6 +62,12 @@ import {
   setAttemptHydrationAtCurrentPriority,
   queueExplicitHydrationTarget,
 } from '../events/ReactDOMEventReplaying';
+import {setBatchingImplementation} from '../events/ReactDOMUpdateBatching';
+import {
+  setRestoreImplementation,
+  enqueueStateRestore,
+  restoreStateIfNeeded,
+} from '../events/ReactDOMControlledComponent';
 
 setAttemptSynchronousHydration(attemptSynchronousHydration);
 setAttemptUserBlockingHydration(attemptUserBlockingHydration);
@@ -183,7 +182,6 @@ const Internals = {
     enqueueStateRestore,
     restoreStateIfNeeded,
     dispatchEvent,
-    runEventsInBatch,
     flushPassiveEffects,
     IsThisRendererActing,
   ],

--- a/packages/react-dom/src/client/ReactDOMClientInjection.js
+++ b/packages/react-dom/src/client/ReactDOMClientInjection.js
@@ -20,43 +20,55 @@ import SimpleEventPlugin from '../events/SimpleEventPlugin';
 import {
   injectEventPluginOrder,
   injectEventPluginsByName,
+  injectEventPlugins,
 } from 'legacy-events/EventPluginRegistry';
+import {enableModernEventSystem} from 'shared/ReactFeatureFlags';
 
-/**
- * Specifies a deterministic ordering of `EventPlugin`s. A convenient way to
- * reason about plugins, without having to package every one of them. This
- * is better than having plugins be ordered in the same order that they
- * are injected because that ordering would be influenced by the packaging order.
- * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
- * preventing default on events is convenient in `SimpleEventPlugin` handlers.
- */
-const DOMEventPluginOrder = [
-  'ResponderEventPlugin',
-  'SimpleEventPlugin',
-  'EnterLeaveEventPlugin',
-  'ChangeEventPlugin',
-  'SelectEventPlugin',
-  'BeforeInputEventPlugin',
-];
+if (enableModernEventSystem) {
+  injectEventPlugins([
+    SimpleEventPlugin,
+    EnterLeaveEventPlugin,
+    ChangeEventPlugin,
+    SelectEventPlugin,
+    BeforeInputEventPlugin,
+  ]);
+} else {
+  /**
+   * Specifies a deterministic ordering of `EventPlugin`s. A convenient way to
+   * reason about plugins, without having to package every one of them. This
+   * is better than having plugins be ordered in the same order that they
+   * are injected because that ordering would be influenced by the packaging order.
+   * `ResponderEventPlugin` must occur before `SimpleEventPlugin` so that
+   * preventing default on events is convenient in `SimpleEventPlugin` handlers.
+   */
+  const DOMEventPluginOrder = [
+    'ResponderEventPlugin',
+    'SimpleEventPlugin',
+    'EnterLeaveEventPlugin',
+    'ChangeEventPlugin',
+    'SelectEventPlugin',
+    'BeforeInputEventPlugin',
+  ];
 
-/**
- * Inject modules for resolving DOM hierarchy and plugin ordering.
- */
-injectEventPluginOrder(DOMEventPluginOrder);
-setComponentTree(
-  getFiberCurrentPropsFromNode,
-  getInstanceFromNode,
-  getNodeFromInstance,
-);
+  /**
+   * Inject modules for resolving DOM hierarchy and plugin ordering.
+   */
+  injectEventPluginOrder(DOMEventPluginOrder);
+  setComponentTree(
+    getFiberCurrentPropsFromNode,
+    getInstanceFromNode,
+    getNodeFromInstance,
+  );
 
-/**
- * Some important event plugins included by default (without having to require
- * them).
- */
-injectEventPluginsByName({
-  SimpleEventPlugin: SimpleEventPlugin,
-  EnterLeaveEventPlugin: EnterLeaveEventPlugin,
-  ChangeEventPlugin: ChangeEventPlugin,
-  SelectEventPlugin: SelectEventPlugin,
-  BeforeInputEventPlugin: BeforeInputEventPlugin,
-});
+  /**
+   * Some important event plugins included by default (without having to require
+   * them).
+   */
+  injectEventPluginsByName({
+    SimpleEventPlugin: SimpleEventPlugin,
+    EnterLeaveEventPlugin: EnterLeaveEventPlugin,
+    ChangeEventPlugin: ChangeEventPlugin,
+    SelectEventPlugin: SelectEventPlugin,
+    BeforeInputEventPlugin: BeforeInputEventPlugin,
+  });
+}

--- a/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
+++ b/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
@@ -22,7 +22,6 @@ import {
   HostText,
 } from 'react-reconciler/src/ReactWorkTags';
 import {IS_FIRST_ANCESTOR, PLUGIN_EVENT_SYSTEM} from './EventSystemFlags';
-import {batchedEventUpdates} from 'legacy-events/ReactGenericBatching';
 import {runEventsInBatch} from 'legacy-events/EventBatching';
 import {plugins} from 'legacy-events/EventPluginRegistry';
 import accumulateInto from 'legacy-events/accumulateInto';
@@ -45,6 +44,7 @@ import {
   mediaEventTypes,
 } from './DOMTopLevelEventTypes';
 import {addTrappedEventListener} from './ReactDOMEventListener';
+import {batchedEventUpdates} from './ReactDOMUpdateBatching';
 
 /**
  * Summary of `DOMEventPluginSystem` event handling:

--- a/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
@@ -30,13 +30,13 @@ import {
   discreteUpdates,
   flushDiscreteUpdatesIfNeeded,
   executeUserEventHandler,
-} from 'legacy-events/ReactGenericBatching';
-import {enqueueStateRestore} from 'legacy-events/ReactControlledComponent';
+} from './ReactDOMUpdateBatching';
 import type {Fiber} from 'react-reconciler/src/ReactFiber';
 import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
 
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';
+import {enqueueStateRestore} from './ReactDOMControlledComponent';
 import {
   ContinuousEvent,
   UserBlockingEvent,

--- a/packages/react-dom/src/events/ReactDOMControlledComponent.js
+++ b/packages/react-dom/src/events/ReactDOMControlledComponent.js
@@ -8,11 +8,10 @@
  */
 
 import invariant from 'shared/invariant';
-
 import {
   getInstanceFromNode,
   getFiberCurrentPropsFromNode,
-} from './EventPluginUtils';
+} from '../client/ReactDOMComponentTree';
 
 // Use to restore controlled state after a change event has fired.
 
@@ -20,7 +19,7 @@ let restoreImpl = null;
 let restoreTarget = null;
 let restoreQueue = null;
 
-function restoreStateOfTarget(target) {
+function restoreStateOfTarget(target: Node) {
   // We perform this translation at the end of the event loop so that we
   // always receive the correct fiber here
   const internalInstance = getInstanceFromNode(target);
@@ -47,7 +46,7 @@ export function setRestoreImplementation(
   restoreImpl = impl;
 }
 
-export function enqueueStateRestore(target: EventTarget): void {
+export function enqueueStateRestore(target: Node): void {
   if (restoreTarget) {
     if (restoreQueue) {
       restoreQueue.push(target);

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -17,10 +17,6 @@ import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
 // CommonJS interop named imports.
 import * as Scheduler from 'scheduler';
 
-import {
-  discreteUpdates,
-  flushDiscreteUpdatesIfNeeded,
-} from 'legacy-events/ReactGenericBatching';
 import {DEPRECATED_dispatchEventForResponderEventSystem} from './DeprecatedDOMEventResponderSystem';
 import {
   isReplayableDiscreteEvent,
@@ -70,6 +66,10 @@ import {
 import {getEventPriorityForPluginSystem} from './DOMEventProperties';
 import {dispatchEventForLegacyPluginEventSystem} from './DOMLegacyEventPluginSystem';
 import {dispatchEventForPluginEventSystem} from './DOMModernPluginEventSystem';
+import {
+  flushDiscreteUpdatesIfNeeded,
+  discreteUpdates,
+} from './ReactDOMUpdateBatching';
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,

--- a/packages/react-dom/src/events/ReactDOMUpdateBatching.js
+++ b/packages/react-dom/src/events/ReactDOMUpdateBatching.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  needsStateRestore,
+  restoreStateIfNeeded,
+} from './ReactDOMControlledComponent';
+
+import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
+import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
+
+// Used as a way to call batchedUpdates when we don't have a reference to
+// the renderer. Such as when we're dispatching events or if third party
+// libraries need to call batchedUpdates. Eventually, this API will go away when
+// everything is batched by default. We'll then have a similar API to opt-out of
+// scheduled work and instead do synchronous work.
+
+// Defaults
+let batchedUpdatesImpl = function(fn, bookkeeping) {
+  return fn(bookkeeping);
+};
+let discreteUpdatesImpl = function(fn, a, b, c, d) {
+  return fn(a, b, c, d);
+};
+let flushDiscreteUpdatesImpl = function() {};
+let batchedEventUpdatesImpl = batchedUpdatesImpl;
+
+let isInsideEventHandler = false;
+let isBatchingEventUpdates = false;
+
+function finishEventHandler() {
+  // Here we wait until all updates have propagated, which is important
+  // when using controlled components within layers:
+  // https://github.com/facebook/react/issues/1698
+  // Then we restore state of any controlled component.
+  const controlledComponentsHavePendingUpdates = needsStateRestore();
+  if (controlledComponentsHavePendingUpdates) {
+    // If a controlled event was fired, we may need to restore the state of
+    // the DOM node back to the controlled value. This is necessary when React
+    // bails out of the update without touching the DOM.
+    flushDiscreteUpdatesImpl();
+    restoreStateIfNeeded();
+  }
+}
+
+export function batchedUpdates(fn, bookkeeping) {
+  if (isInsideEventHandler) {
+    // If we are currently inside another batch, we need to wait until it
+    // fully completes before restoring state.
+    return fn(bookkeeping);
+  }
+  isInsideEventHandler = true;
+  try {
+    return batchedUpdatesImpl(fn, bookkeeping);
+  } finally {
+    isInsideEventHandler = false;
+    finishEventHandler();
+  }
+}
+
+export function batchedEventUpdates(fn, a, b) {
+  if (isBatchingEventUpdates) {
+    // If we are currently inside another batch, we need to wait until it
+    // fully completes before restoring state.
+    return fn(a, b);
+  }
+  isBatchingEventUpdates = true;
+  try {
+    return batchedEventUpdatesImpl(fn, a, b);
+  } finally {
+    isBatchingEventUpdates = false;
+    finishEventHandler();
+  }
+}
+
+// This is for the React Flare event system
+export function executeUserEventHandler(fn: any => void, value: any): void {
+  const previouslyInEventHandler = isInsideEventHandler;
+  try {
+    isInsideEventHandler = true;
+    const type = typeof value === 'object' && value !== null ? value.type : '';
+    invokeGuardedCallbackAndCatchFirstError(type, fn, undefined, value);
+  } finally {
+    isInsideEventHandler = previouslyInEventHandler;
+  }
+}
+
+export function discreteUpdates(fn, a, b, c, d) {
+  const prevIsInsideEventHandler = isInsideEventHandler;
+  isInsideEventHandler = true;
+  try {
+    return discreteUpdatesImpl(fn, a, b, c, d);
+  } finally {
+    isInsideEventHandler = prevIsInsideEventHandler;
+    if (!isInsideEventHandler) {
+      finishEventHandler();
+    }
+  }
+}
+
+let lastFlushedEventTimeStamp = 0;
+export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
+  // event.timeStamp isn't overly reliable due to inconsistencies in
+  // how different browsers have historically provided the time stamp.
+  // Some browsers provide high-resolution time stamps for all events,
+  // some provide low-resolution time stamps for all events. FF < 52
+  // even mixes both time stamps together. Some browsers even report
+  // negative time stamps or time stamps that are 0 (iOS9) in some cases.
+  // Given we are only comparing two time stamps with equality (!==),
+  // we are safe from the resolution differences. If the time stamp is 0
+  // we bail-out of preventing the flush, which can affect semantics,
+  // such as if an earlier flush removes or adds event listeners that
+  // are fired in the subsequent flush. However, this is the same
+  // behaviour as we had before this change, so the risks are low.
+  if (
+    !isInsideEventHandler &&
+    (!enableDeprecatedFlareAPI ||
+      timeStamp === 0 ||
+      lastFlushedEventTimeStamp !== timeStamp)
+  ) {
+    lastFlushedEventTimeStamp = timeStamp;
+    flushDiscreteUpdatesImpl();
+  }
+}
+
+export function setBatchingImplementation(
+  _batchedUpdatesImpl,
+  _discreteUpdatesImpl,
+  _flushDiscreteUpdatesImpl,
+  _batchedEventUpdatesImpl,
+) {
+  batchedUpdatesImpl = _batchedUpdatesImpl;
+  discreteUpdatesImpl = _discreteUpdatesImpl;
+  flushDiscreteUpdatesImpl = _flushDiscreteUpdatesImpl;
+  batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
+}

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -26,7 +26,6 @@ const [
   enqueueStateRestore,
   restoreStateIfNeeded,
   dispatchEvent,
-  runEventsInBatch,
   /* eslint-enable no-unused-vars */
   flushPassiveEffects,
   IsThisRendererActing,


### PR DESCRIPTION
This PR cleans up a bunch of things with the existing plugin event system that should simplify things and also remove some of the indirection that exists when we try to share things between different renderers to keep things DRY but actually ship irrelevant parts of the code with that when we do.

- When the modern event system flag is enabled we now staticlly inject the event plugin modules – removing the need to recompute the list of plugins dynamically. In the future this will complement https://github.com/facebook/react/pull/18483.
- `ReactGenericBatching.js` has been forked for ReactDOM. That version is called `ReactDOMUpdateBatching.js` and contains all the ReactDOM parts, which have been removed from `ReactGenericBatching.js`.
- `ReactControlledComponent.js` has been moved into ReactDOM and has been renamed `ReactDOMControlledComponent.js` to reflect that no other renderer, but ReactDOM uses it.
- Updated `ReactTestUtils` with an inlined version of `runEventsInBatch` and removed the export from ReactDOM internals.