### PR TITLE
Profiler tooltip shows self duration

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.css
@@ -27,7 +27,7 @@
 }
 
 .CurrentCommit {
-  margin-top: 0.25rem;
+  margin: 0.25rem 0;
   display: block;
   width: 100%;
   text-align: left;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import {Fragment, useContext} from 'react';
 import {ProfilerContext} from './ProfilerContext';
-import {formatDuration, formatTime} from './utils';
+import {formatDuration} from './utils';
 import WhatChanged from './WhatChanged';
 import {StoreContext} from '../context';
 
@@ -44,18 +44,17 @@ export default function HoveredFiberInfo({fiberData}: Props) {
   for (i = 0; i < commitIndices.length; i++) {
     const commitIndex = commitIndices[i];
     if (selectedCommitIndex === commitIndex) {
-      const {duration, timestamp} = profilerStore.getCommitData(
-        ((rootID: any): number),
-        commitIndex,
-      );
+      const {
+        fiberActualDurations,
+        fiberSelfDurations,
+      } = profilerStore.getCommitData(((rootID: any): number), commitIndex);
+      const actualDuration = fiberActualDurations.get(id) || 0;
+      const selfDuration = fiberSelfDurations.get(id) || 0;
 
       renderDurationInfo = (
-        <Fragment>
-          <label className={styles.Label}>Rendered at:</label>
-          <div key={commitIndex} className={styles.CurrentCommit}>
-            {formatTime(timestamp)}s for {formatDuration(duration)}ms
-          </div>
-        </Fragment>
+        <div key={commitIndex} className={styles.CurrentCommit}>
+          {formatDuration(selfDuration)}ms of {formatDuration(actualDuration)}ms
+        </div>
       );
 
       break;
@@ -68,10 +67,10 @@ export default function HoveredFiberInfo({fiberData}: Props) {
         <div className={styles.Component}>{name}</div>
       </div>
       <div className={styles.Content}>
-        <WhatChanged fiberID={((id: any): number)} />
         {renderDurationInfo || (
           <div>Did not render during this profiling session.</div>
         )}
+        <WhatChanged fiberID={((id: any): number)} />
       </div>
     </Fragment>
   );


### PR DESCRIPTION
The tooltip duration was previously showing less important duration info (about the commit itself, not the thing being hovered). This PR fixes that! I also shifted things around a little to put the more important info (IMO) first.

## Before
### No advanced metrics
![profiler-tooltip-before-Kapture 2020-04-06 at 9 13 45](https://user-images.githubusercontent.com/29597/78582456-2250e180-77ea-11ea-9b52-85d07e026ad3.gif)

### With advanced metrics
![devtools-profiiler-before-plus-Kapture 2020-04-06 at 9 23 04](https://user-images.githubusercontent.com/29597/78582436-1d8c2d80-77ea-11ea-94bb-5ccdcf71fd11.gif)

## After
### No advanced metrics
![devtools-profiler-after-Kapture 2020-04-06 at 9 21 58](https://user-images.githubusercontent.com/29597/78582451-20871e00-77ea-11ea-8ba6-c8820515541f.gif)

### With advanced metrics
![devtools-profiler-after-with-Kapture 2020-04-06 at 9 33 29](https://user-images.githubusercontent.com/29597/78582453-21b84b00-77ea-11ea-80bb-341ab75714b7.gif)