### PR TITLE
Experiment: investigate if clearing alternate improves GC profile

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1117,6 +1117,8 @@ function detachFiber(current: Fiber) {
   current.stateNode = null;
   current.alternate = null;
   if (alternate !== null) {
+    // Stop the alternate from going back to the current fiber.
+    alternate.alternate = null;
     detachFiber(alternate);
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1115,7 +1115,6 @@ function detachFiber(current: Fiber) {
   current.pendingProps = null;
   current.memoizedProps = null;
   current.stateNode = null;
-  current.alternate = null;
   if (alternate !== null) {
     // Stop the alternate from going back to the current fiber.
     alternate.alternate = null;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1115,6 +1115,7 @@ function detachFiber(current: Fiber) {
   current.pendingProps = null;
   current.memoizedProps = null;
   current.stateNode = null;
+  current.alternate = null;
   if (alternate !== null) {
     detachFiber(alternate);
   }


### PR DESCRIPTION
Here's maybe a controversial PR, but one I think we should use to assist our internal investigation. I've had a hunch for a long time that we sometimes leak fibers on the alternates. Although this change is not a fix for the underlying issue, if this proves to improve the memory profile, then it can point us in a direction and maybe provide temporary cover.