### PR TITLE
DevTools Profiler: Fix "cannot read property 'memoizedState' of null"

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -918,7 +918,7 @@ export function attach(
   }
 
   function didHooksChange(prev: any, next: any): boolean {
-    if (next == null) {
+    if (prev == null || next == null) {
       return false;
     }
 


### PR DESCRIPTION
Resolves #18514

cc @bradzacher