### PR TITLE
Investigation: clear all fibers with nextEffect

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1097,7 +1097,7 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(current: Fiber) {
+function detachFiber(current: Fiber, detatchAlternate: boolean) {
   const alternate = current.alternate;
   // Cut off the return pointers to disconnect it from the tree. Ideally, we
   // should clear the child pointer of the parent alternate to let this
@@ -1115,8 +1115,8 @@ function detachFiber(current: Fiber) {
   current.pendingProps = null;
   current.memoizedProps = null;
   current.stateNode = null;
-  if (alternate !== null) {
-    detachFiber(alternate);
+  if (detatchAlternate && alternate !== null) {
+    detachFiber(alternate, false);
   }
 }
 
@@ -1513,7 +1513,7 @@ function commitDeletion(
     // Detach refs and call componentWillUnmount() on the whole subtree.
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
   }
-  detachFiber(current);
+  detachFiber(current, true);
 }
 
 function commitWork(current: Fiber | null, finishedWork: Fiber): void {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1097,8 +1097,7 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(current: Fiber, detatchAlternate: boolean) {
-  const alternate = current.alternate;
+function detachFiber(current: Fiber) {
   // Cut off the return pointers to disconnect it from the tree. Ideally, we
   // should clear the child pointer of the parent alternate to let this
   // get GC:ed but we don't know which for sure which parent is the current
@@ -1109,15 +1108,11 @@ function detachFiber(current: Fiber, detatchAlternate: boolean) {
   current.memoizedState = null;
   current.updateQueue = null;
   current.dependencies = null;
-  current.alternate = null;
   current.firstEffect = null;
   current.lastEffect = null;
   current.pendingProps = null;
   current.memoizedProps = null;
   current.stateNode = null;
-  if (detatchAlternate && alternate !== null) {
-    detachFiber(alternate, false);
-  }
 }
 
 function emptyPortalContainer(current: Fiber) {
@@ -1513,7 +1508,11 @@ function commitDeletion(
     // Detach refs and call componentWillUnmount() on the whole subtree.
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
   }
-  detachFiber(current, true);
+  detachFiber(current);
+  const alternate = current.alternate;
+  if (alternate !== null) {
+    detachFiber(alternate);
+  }
 }
 
 function commitWork(current: Fiber | null, finishedWork: Fiber): void {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1944,16 +1944,12 @@ function commitRootImpl(root, renderPriorityLevel) {
     // nextEffect pointers to assist with GC. If we have passive effects, we'll
     // clear this in flushPassiveEffects.
     nextEffect = firstEffect;
+    clearNextEffectList();
     while (nextEffect !== null) {
       const nextNextEffect = nextEffect.nextEffect;
       nextEffect.nextEffect = null;
       nextEffect = nextNextEffect;
     }
-    // Clear the nextEffect pointers of an alternates
-    for (let i = 0; i < nextEffectsToClear.length; i++) {
-      nextEffectsToClear[i].nextEffect = null;
-    }
-    nextEffectsToClear = [];
   }
 
   // Check if there's remaining work on this root
@@ -2122,10 +2118,10 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
         // If the effect has a nextEffect, add it to our list
         if (nextEffect.nextEffect !== null) {
           nextEffectsToClear.push(nextEffect);
-          const alternate = nextEffect.alternate;
-          if (alternate !== null && alternate.nextEffect !== null) {
-            nextEffectsToClear.push(alternate);
-          }
+        }
+        const alternate = nextEffect.alternate;
+        if (alternate !== null && alternate.nextEffect !== null) {
+          nextEffectsToClear.push(alternate);
         }
         break;
       }
@@ -2386,6 +2382,7 @@ function flushPassiveEffectsImpl() {
       effect = nextNextEffect;
     }
   }
+  clearNextEffectList();
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {
     const profilerEffects = pendingPassiveProfilerEffects;
@@ -3189,4 +3186,12 @@ function finishPendingInteractions(root, committedExpirationTime) {
       },
     );
   }
+}
+
+function clearNextEffectList() {
+  // Clear the nextEffect pointers of an alternates
+  for (let i = 0; i < nextEffectsToClear.length; i++) {
+    nextEffectsToClear[i].nextEffect = null;
+  }
+  nextEffectsToClear = [];
 }


### PR DESCRIPTION
This PR aims are clearing the `nextEffect` field on fibers that have detatched. We can't clear the `nextEffect` field during the `detatchFiber` stage, because we need this field to traverse through the effect tree. However, we can store the fiber in an array and clear the fields later (if they have a `nextEffect`). We can use this internally to validate if this fixes the memory leak. It's a pretty heavy handed approach, but might help us until we refactor the `nextEffect` logic in the future.

I also made `detachFiber` a bit more optimized so it doesn't unnecessarily call itself again.