### PR TITLE
Export unstable_useEvent for www FB ReactDOM builds

### DIFF
--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -36,4 +36,5 @@ export {
   unstable_scheduleHydration,
   unstable_renderSubtreeIntoContainer,
   unstable_createPortal,
+  unstable_useEvent,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -19,4 +19,5 @@ export {
   unstable_flushDiscreteUpdates,
   unstable_flushControlled,
   unstable_scheduleHydration,
+  unstable_useEvent,
 } from './src/client/ReactDOM';


### PR DESCRIPTION
I've been testing with local builds of ReactDOM where this flag is enabled, now we want to start trying it out in Fiddles with a small amount of internal engineers. Let's enable the flag so they can do this.