### PR TITLE
Add a failing test for #18486

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.internal.js
@@ -3664,19 +3664,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           setMirror(text);
         }
 
-        if (text !== '') {
-          // Inlined so that it's in the same component.
-          try {
-            Scheduler.unstable_yieldValue(text);
-            readText(text);
-          } catch (e) {
-            if (e && typeof e.then === 'function') {
-              Scheduler.unstable_yieldValue('Suspend! [' + text + ']');
-            }
-            throw e;
-          }
-        }
-
         setTextWithTransition = value => {
           startTransition(() => {
             setText(value);
@@ -3686,7 +3673,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         return (
           <>
             {isPending ? <Text text="Pending..." /> : null}
-            <Text text={text} />
+            {text !== '' ? <AsyncText text={text} /> : <Text text={text} />}
           </>
         );
       }
@@ -3714,7 +3701,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         expect(Scheduler).toFlushAndYield([
           'Pending...',
           '',
-          'a',
           'Suspend! [a]',
           'Loading...',
         ]);
@@ -3732,10 +3718,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         setTextWithTransition('b');
         expect(Scheduler).toFlushAndYield([
           // Neither is resolved yet.
-          'a',
+          'Pending...',
           'Suspend! [a]',
           'Loading...',
-          'b',
           'Suspend! [b]',
           'Loading...',
         ]);
@@ -3754,8 +3739,6 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
       expect(Scheduler).toHaveYielded([
         'Promise resolved [a]',
-        'a',
-        'a',
         'Pending...',
         'a',
       ]);


### PR DESCRIPTION
Failing test for https://github.com/facebook/react/issues/18486.
I think this matches the sandbox issue.

The pending state gets stuck:

<img width="404" alt="Screenshot 2020-04-08 at 00 46 10" src="https://user-images.githubusercontent.com/810438/78729655-7e268200-7932-11ea-9442-a26110122e63.png">

If you comment out the render phase update and adjust the Scheduler yield checks, then it doesn't get stuck. So I think this demonstrates the issue but the actual yields would need to be adjusted according to the fix. I don't know where the bug is yet.