### PR TITLE
Fix fiber memory leak with runAllPassiveEffectDestroysBeforeCreates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2368,12 +2368,15 @@ function flushPassiveEffectsImpl() {
         }
       }
     }
-  } else {
-    // Note: This currently assumes there are no passive effects on the root fiber
-    // because the root is not part of its own effect list.
-    // This could change in the future.
-    let effect = root.current.firstEffect;
-    while (effect !== null) {
+  }
+  // Note: This currently assumes there are no passive effects on the root fiber
+  // because the root is not part of its own effect list.
+  // This could change in the future.
+  let effect = root.current.firstEffect;
+  while (effect !== null) {
+    // We do this work above if this flag is enabled, so we shouldn't be
+    // doing it here.
+    if (!runAllPassiveEffectDestroysBeforeCreates) {
       if (__DEV__) {
         setCurrentDebugFiberInDEV(effect);
         invokeGuardedCallback(null, commitPassiveHookEffects, null, effect);
@@ -2391,12 +2394,12 @@ function flushPassiveEffectsImpl() {
           captureCommitPhaseError(effect, error);
         }
       }
-
-      const nextNextEffect = effect.nextEffect;
-      // Remove nextEffect pointer to assist GC
-      effect.nextEffect = null;
-      effect = nextNextEffect;
     }
+
+    const nextNextEffect = effect.nextEffect;
+    // Remove nextEffect pointer to assist GC
+    effect.nextEffect = null;
+    effect = nextNextEffect;
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2368,12 +2368,15 @@ function flushPassiveEffectsImpl() {
         }
       }
     }
-  } else {
-    // Note: This currently assumes there are no passive effects on the root fiber
-    // because the root is not part of its own effect list.
-    // This could change in the future.
-    let effect = root.current.firstEffect;
-    while (effect !== null) {
+  }
+  // Note: This currently assumes there are no passive effects on the root fiber
+  // because the root is not part of its own effect list.
+  // This could change in the future.
+  let effect = root.current.firstEffect;
+  while (effect !== null) {
+    // We do this work above if this flag is enabled, so we shouldn't be
+    // doing it here.
+    if (!runAllPassiveEffectDestroysBeforeCreates) {
       if (__DEV__) {
         setCurrentDebugFiberInDEV(effect);
         invokeGuardedCallback(null, commitPassiveHookEffects, null, effect);
@@ -2391,12 +2394,12 @@ function flushPassiveEffectsImpl() {
           captureCommitPhaseError(effect, error);
         }
       }
-
-      const nextNextEffect = effect.nextEffect;
-      // Remove nextEffect pointer to assist GC
-      effect.nextEffect = null;
-      effect = nextNextEffect;
     }
+
+    const nextNextEffect = effect.nextEffect;
+    // Remove nextEffect pointer to assist GC
+    effect.nextEffect = null;
+    effect = nextNextEffect;
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {


### PR DESCRIPTION
This PR should fix the memory leak we saw internally when the `runAllPassiveEffectDestroysBeforeCreates` was enabled. I tested this both on our tests and also on our internal website and tests (with my deletion array collection approach) and can confirm the issue did not come up with that approach so I'm pretty confident that this particular memory leak is resolved.

The approach I took was to re-include the while loop that we had from before (but was in the old code path that gets executed without this flag). This time we only apply the `nextEffect = null` logic, excluding the execution of passive effects, and we get the result I described above.