### PR TITLE
Refactor detachFiber to a later stage

### DIFF
--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -22,6 +22,7 @@ const initializeModules = hasPointerEvents => {
   setPointerEvent(hasPointerEvents);
   jest.resetModules();
   ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.enableScopeAPI = true;
   ReactFeatureFlags.enableDeprecatedFlareAPI = true;
   React = require('react');
   ReactDOM = require('react-dom');
@@ -362,6 +363,40 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onBlurWithin).toHaveBeenCalledWith(
         expect.objectContaining({isTargetAttached: false}),
       );
+    });
+
+    // @gate experimental
+    it('is called after a nested focused element is unmounted (with scope query)', () => {
+      const TestScope = React.unstable_createScope();
+      const testScopeQuery = (type, props) => true;
+      let targetNodes;
+      let targetNode;
+
+      const Component = ({show}) => {
+        const scopeRef = React.useRef(null);
+        const listener = useFocusWithin({
+          onBeforeBlurWithin(event) {
+            const scope = scopeRef.current;
+            targetNode = innerRef.current;
+            targetNodes = scope.DO_NOT_USE_queryAllNodes(testScopeQuery);
+          },
+        });
+
+        return (
+          <TestScope ref={scopeRef} DEPRECATED_flareListeners={[listener]}>
+            {show && <input ref={innerRef} />}
+          </TestScope>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      ReactDOM.render(<Component show={false} />, container);
+      expect(targetNodes).toEqual([targetNode]);
     });
 
     // @gate experimental

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1110,25 +1110,6 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(fiber: Fiber) {
-  // Cut off the return pointers to disconnect it from the tree. Ideally, we
-  // should clear the child pointer of the parent alternate to let this
-  // get GC:ed but we don't know which for sure which parent is the current
-  // one so we'll settle for GC:ing the subtree of this child. This child
-  // itself will be GC:ed when the parent updates the next time.
-  fiber.return = null;
-  fiber.child = null;
-  fiber.memoizedState = null;
-  fiber.updateQueue = null;
-  fiber.dependencies = null;
-  fiber.alternate = null;
-  fiber.firstEffect = null;
-  fiber.lastEffect = null;
-  fiber.pendingProps = null;
-  fiber.memoizedProps = null;
-  fiber.stateNode = null;
-}
-
 function emptyPortalContainer(current: Fiber) {
   if (!supportsPersistence) {
     return;
@@ -1521,11 +1502,6 @@ function commitDeletion(
   } else {
     // Detach refs and call componentWillUnmount() on the whole subtree.
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
-  }
-  const alternate = current.alternate;
-  detachFiber(current);
-  if (alternate !== null) {
-    detachFiber(alternate);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1110,25 +1110,6 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(fiber: Fiber) {
-  // Cut off the return pointers to disconnect it from the tree. Ideally, we
-  // should clear the child pointer of the parent alternate to let this
-  // get GC:ed but we don't know which for sure which parent is the current
-  // one so we'll settle for GC:ing the subtree of this child. This child
-  // itself will be GC:ed when the parent updates the next time.
-  fiber.return = null;
-  fiber.child = null;
-  fiber.memoizedState = null;
-  fiber.updateQueue = null;
-  fiber.dependencies = null;
-  fiber.alternate = null;
-  fiber.firstEffect = null;
-  fiber.lastEffect = null;
-  fiber.pendingProps = null;
-  fiber.memoizedProps = null;
-  fiber.stateNode = null;
-}
-
 function emptyPortalContainer(current: Fiber) {
   if (!supportsPersistence) {
     return;
@@ -1521,11 +1502,6 @@ function commitDeletion(
   } else {
     // Detach refs and call componentWillUnmount() on the whole subtree.
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
-  }
-  const alternate = current.alternate;
-  detachFiber(current);
-  if (alternate !== null) {
-    detachFiber(alternate);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1919,6 +1919,15 @@ function commitRootImpl(root, renderPriorityLevel) {
       }
     } while (nextEffect !== null);
 
+    nextEffect = firstEffect;
+    while (nextEffect !== null) {
+      const nextNextEffect = nextEffect.nextEffect;
+      if (nextEffect.effectTag & Deletion) {
+        detachFiberPair(nextEffect);
+      }
+      nextEffect = nextNextEffect;
+    }
+
     nextEffect = null;
 
     // Tell Scheduler to yield at the end of the frame, so the browser has an
@@ -3409,5 +3418,36 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
         resolve();
       },
     };
+  }
+}
+
+function detachFiberPair(fiber: Fiber) {
+  const alternate = fiber.alternate;
+  detachFiber(fiber);
+  if (alternate !== null) {
+    detachFiber(alternate);
+  }
+}
+
+function detachFiber(fiber: Fiber) {
+  // Cut off the return pointers to disconnect it from the tree. Ideally, we
+  // should clear the child pointer of the parent alternate to let this
+  // get GC:ed but we don't know which for sure which parent is the current
+  // one so we'll settle for GC:ing the subtree of this child. This child
+  // itself will be GC:ed when the parent updates the next time.
+  fiber.alternate = null;
+  fiber.child = null;
+  fiber.dependencies = null;
+  fiber.firstEffect = null;
+  fiber.lastEffect = null;
+  fiber.memoizedProps = null;
+  fiber.memoizedState = null;
+  fiber.pendingProps = null;
+  fiber.return = null;
+  fiber.sibling = null;
+  fiber.stateNode = null;
+  fiber.updateQueue = null;
+  if (__DEV__) {
+    fiber._debugOwner = null;
   }
 }


### PR DESCRIPTION
This PR is kind of a follow up to these PRs:

https://github.com/facebook/react/pull/18529
https://github.com/facebook/react/pull/18556

Specifically, in https://github.com/facebook/react/pull/18556, which cleared the `sibling` Fiber field, we encountered a failing internal test. The test related to `onBeforeBlur` and using scopes. Specifically, the problem was that we were trying to traverse a fiber tree at a point where a bunch of the siblings were already "deatached" – as in we already cleared their fields. This wasn't ideal, as `onBeforeBlur` gets called during the same phase as where we detatch fibers so we want to be able to accurately traverse the fiber tree still.

This PR moves `detachFiber` to a later stage, as mentioned in the comment by @bvaughn.