### PR TITLE
ESLint rule to forbid cross fork imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,7 @@ module.exports = {
     'react-internal/invariant-args': ERROR,
     'react-internal/warning-args': ERROR,
     'react-internal/no-production-logging': ERROR,
+    'react-internal/no-cross-fork-imports': ERROR,
   },
 
   overrides: [
@@ -161,8 +162,8 @@ module.exports = {
     {
       files: ['packages/react-flight-dom-webpack/**/*.js'],
       globals: {
-        '__webpack_chunk_load__': true,
-        '__webpack_require__': true,
+        __webpack_chunk_load__: true,
+        __webpack_require__: true,
       },
     },
   ],

--- a/scripts/eslint-rules/__tests__/no-cross-fork-imports-test.internal.js
+++ b/scripts/eslint-rules/__tests__/no-cross-fork-imports-test.internal.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const rule = require('../no-cross-fork-imports');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('eslint-rules/no-cross-fork-imports', rule, {
+  valid: [
+    {
+      code: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop';",
+      filename: 'ReactFiberWorkLoop.js',
+    },
+    {
+      code: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.new';",
+      filename: 'ReactFiberWorkLoop.new.js',
+    },
+    {
+      code:
+        "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.new.js';",
+      filename: 'ReactFiberWorkLoop.new.js',
+    },
+    {
+      code: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.old';",
+      filename: 'ReactFiberWorkLoop.old.js',
+    },
+    {
+      code:
+        "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.old.js';",
+      filename: 'ReactFiberWorkLoop.old.js',
+    },
+  ],
+  invalid: [
+    {
+      code: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.new';",
+      filename: 'ReactFiberWorkLoop.old.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the old fork cannot import a module ' +
+            'from the new fork.',
+        },
+      ],
+    },
+    {
+      code:
+        "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.new.js';",
+      filename: 'ReactFiberWorkLoop.old.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the old fork cannot import a module ' +
+            'from the new fork.',
+        },
+      ],
+    },
+    {
+      code: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.old';",
+      filename: 'ReactFiberWorkLoop.new.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the new fork cannot import a module ' +
+            'from the old fork.',
+        },
+      ],
+    },
+    {
+      code:
+        "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.old.js';",
+      filename: 'ReactFiberWorkLoop.new.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the new fork cannot import a module ' +
+            'from the old fork.',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/eslint-rules/index.js
+++ b/scripts/eslint-rules/index.js
@@ -7,5 +7,6 @@ module.exports = {
     'warning-args': require('./warning-args'),
     'invariant-args': require('./invariant-args'),
     'no-production-logging': require('./no-production-logging'),
+    'no-cross-fork-imports': require('./no-cross-fork-imports'),
   },
 };

--- a/scripts/eslint-rules/no-cross-fork-imports.js
+++ b/scripts/eslint-rules/no-cross-fork-imports.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+function isOldFork(filename) {
+  return filename.endsWith('.old.js') || filename.endsWith('.old');
+}
+
+function isNewFork(filename) {
+  return filename.endsWith('.new.js') || filename.endsWith('.new');
+}
+
+module.exports = context => {
+  const sourceFilename = context.getFilename();
+
+  if (isOldFork(sourceFilename)) {
+    return {
+      ImportDeclaration(node) {
+        const importFilename = node.source.value;
+        if (isNewFork(importFilename)) {
+          context.report(
+            node,
+            'A module that belongs to the old fork cannot import a module ' +
+              'from the new fork.'
+          );
+        }
+      },
+    };
+  }
+
+  if (isNewFork(sourceFilename)) {
+    return {
+      ImportDeclaration(node) {
+        const importFilename = node.source.value;
+        if (isOldFork(importFilename)) {
+          context.report(
+            node,
+            'A module that belongs to the new fork cannot import a module ' +
+              'from the old fork.'
+          );
+        }
+      },
+    };
+  }
+
+  return {};
+};


### PR DESCRIPTION
Modules that belong to one fork should not import modules that belong to the other fork.

Helps make sure you correctly update imports when syncing changes across implementations.

Also could help protect against code size regressions that might happen if one of the forks accidentally depends on two copies of the same module.
