### PR TITLE
Failing test related to usage of Suspense and Context in memoized component

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -21,6 +21,7 @@ import {
   HostRoot,
   SuspenseComponent,
   IncompleteClassComponent,
+  SimpleMemoComponent,
 } from './ReactWorkTags';
 import {
   DidCapture,
@@ -264,6 +265,10 @@ function throwException(
               update.tag = ForceUpdate;
               enqueueUpdate(sourceFiber, update);
             }
+          } else if (sourceFiber.tag === SimpleMemoComponent) {
+            const update = createUpdate(NoWork, Sync, null);
+            update.tag = ForceUpdate;
+            enqueueUpdate(sourceFiber, update);
           }
 
           // The source fiber did not complete. Mark it with Sync priority to

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -21,6 +21,7 @@ import {
   HostRoot,
   SuspenseComponent,
   IncompleteClassComponent,
+  SimpleMemoComponent,
 } from './ReactWorkTags';
 import {
   DidCapture,
@@ -264,6 +265,10 @@ function throwException(
               update.tag = ForceUpdate;
               enqueueUpdate(sourceFiber, update);
             }
+          } else if (sourceFiber.tag === SimpleMemoComponent) {
+            const update = createUpdate(Sync, null);
+            update.tag = ForceUpdate;
+            enqueueUpdate(sourceFiber, update);
           }
 
           // The source fiber did not complete. Mark it with Sync priority to

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -652,11 +652,10 @@ describe('ReactSuspense', () => {
       );
     }
 
-    const root = ReactTestRenderer.create(<App />, {unstable_isConcurrent: true});
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [default]',
-      'Loading...',
-    ]);
+    const root = ReactTestRenderer.create(<App />, {
+      unstable_isConcurrent: true,
+    });
+    expect(Scheduler).toFlushAndYield(['Suspend! [default]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
     jest.advanceTimersByTime(1000);
 
@@ -665,10 +664,7 @@ describe('ReactSuspense', () => {
     expect(root).toMatchRenderedOutput('default');
 
     act(() => setValue('new value'));
-    expect(Scheduler).toHaveYielded([
-      'Suspend! [new value]',
-      'Loading...'
-    ]);
+    expect(Scheduler).toHaveYielded(['Suspend! [new value]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
     jest.advanceTimersByTime(1000);
 


### PR DESCRIPTION
Failing test as requested related to #17356.

This is a failing test which shows that when useContext and throwing a promise are used in a memoized component, it fails to update after the promise has resolved.