### PR TITLE
Add test helpers for gating by feature

### DIFF
--- a/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactCompositeComponent-test.js
@@ -108,8 +108,10 @@ describe('ReactCompositeComponent', () => {
     };
   });
 
-  if (require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('should not support module pattern components', () => {
+  it.gate(
+    'disableModulePatternComponents',
+    'should not support module pattern components',
+    () => {
       function Child({test}) {
         return {
           render() {
@@ -132,9 +134,12 @@ describe('ReactCompositeComponent', () => {
       );
 
       expect(el.textContent).toBe('');
-    });
-  } else {
-    it('should support module pattern components', () => {
+    },
+  );
+  it.gate(
+    '!disableModulePatternComponents',
+    'should support module pattern components',
+    () => {
       function Child({test}) {
         return {
           render() {
@@ -153,8 +158,8 @@ describe('ReactCompositeComponent', () => {
       );
 
       expect(el.textContent).toBe('test');
-    });
-  }
+    },
+  );
 
   it('should support rendering to different child types over time', () => {
     const instance = ReactTestUtils.renderIntoDocument(<MorphingComponent />);

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -369,8 +369,10 @@ describe('ReactElement.jsx', () => {
     );
   });
 
-  if (require('shared/ReactFeatureFlags').warnAboutSpreadingKeyToJSX) {
-    it('should warn when keys are passed as part of props', () => {
+  it.gate(
+    flags => flags.warnAboutSpreadingKeyToJSX || !__DEV__,
+    'should warn when keys are passed as part of props',
+    () => {
       const container = document.createElement('div');
       class Child extends React.Component {
         render() {
@@ -391,8 +393,8 @@ describe('ReactElement.jsx', () => {
           'Explicitly pass a key after spreading props in your JSX call. ' +
           'E.g. <Child {...props} key={key} />',
       );
-    });
-  }
+    },
+  );
 
   it('should not warn when unkeyed children are passed to jsxs', () => {
     const container = document.createElement('div');

--- a/scripts/jest/installGatedTestHelpers.js
+++ b/scripts/jest/installGatedTestHelpers.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+const noop = () => {};
+
+async function expectTestToFail(callback, errorMsg) {
+  if (callback.length > 0) {
+    throw Error(
+      'Gated test helpers do not support the `done` callback. Return a ' +
+        'promise instead.'
+    );
+  }
+  try {
+    const maybePromise = callback();
+    if (
+      maybePromise !== undefined &&
+      maybePromise !== null &&
+      typeof maybePromise.then === 'function'
+    ) {
+      await maybePromise;
+    }
+  } catch (error) {
+    // Failed as expected
+    return;
+  }
+  throw Error(errorMsg);
+}
+
+function readFlag(flags, flagName) {
+  if (flagName.startsWith('!')) {
+    flagName = flagName.slice(1);
+    const flagValue = flags[flagName];
+    if (flagValue === undefined) {
+      throw Error('Missing feature flag: ' + flagName);
+    }
+    if (flagValue === true) {
+      return `Test is expected to fail because ${flagName} is true.`;
+    }
+  } else {
+    const flagValue = flags[flagName];
+    if (flagValue === undefined) {
+      throw Error('Missing feature flag: ' + flagName);
+    }
+    if (flagValue === false) {
+      return `Test is expected to fail because ${flagName} is false.`;
+    }
+  }
+  return null;
+}
+
+function testGate(testFn, flagNames, testName, fn) {
+  const featureFlags = require('shared/ReactFeatureFlags');
+
+  let errorMessage;
+  if (typeof flagNames === 'string') {
+    errorMessage = readFlag(featureFlags, flagNames);
+  } else if (Array.isArray(flagNames)) {
+    for (const flagName of flagNames) {
+      errorMessage = readFlag(featureFlags, flagName);
+      if (errorMessage !== null) {
+        break;
+      }
+    }
+  } else if (typeof flagNames === 'function') {
+    const shouldPass = flagNames(featureFlags);
+    errorMessage = shouldPass
+      ? null
+      : 'Gated test was expected to fail, but it passed.';
+  } else {
+    throw Error('testGate: Must pass one or more feature flags.');
+  }
+
+  // Expect test to pass
+  if (errorMessage !== null) {
+    testFn(`[GATED, SHOULD FAIL] ${testName}`, () =>
+      expectTestToFail(fn, errorMessage)
+    );
+  } else {
+    testFn(testName, fn);
+  }
+}
+
+function installGatedTestHelpers(channel) {
+  const it = global.it;
+  const fit = global.fit;
+  const xit = global.xit;
+
+  if (channel === 'stable') {
+    // Experimental tests should fail when running in the stable channel. For
+    // all other channels, the tests should run normally.
+    // TODO: What about "classic" and "modern"? It's ambiguous whether the
+    // tests should pass or fail in those modes. Maybe we should favor checking
+    // the feature flags instead.
+    const errorMessage =
+      'Tests marked experimental are expected to fail, but this one passed.';
+    it.experimental = (name, fn) =>
+      it(`[GATED, SHOULD FAIL] ${name}`, () =>
+        expectTestToFail(fn, errorMessage));
+    fit.experimental = it.only.experimental = (name, fn) =>
+      fit(`[GATED, SHOULD FAIL] ${name}`, () =>
+        expectTestToFail(fn, errorMessage));
+
+    xit.experimental = it.skip.experimental = (name, fn) =>
+      xit(`[GATED, SHOULD FAIL] ${name}`, noop);
+  } else {
+    it.experimental = it;
+    fit.experimental = it.only.experimental = fit;
+    xit.experimental = it.skip.experimental = xit;
+    global.testExperimental = fn => fn();
+  }
+
+  it.gate = testGate.bind(null, it);
+  fit.gate = it.gate.only = it.only.gate = testGate.bind(null, fit);
+  xit.gate = it.gate.skip = it.skip.gate = testGate.bind(null, xit);
+
+  it.old = testGate.bind(null, it, '!enableNewReconciler');
+  fit.old = it.old.only = it.only.old = testGate.bind(
+    null,
+    fit,
+    '!enableNewReconciler'
+  );
+  xit.old = it.old.skip = it.skip.old = testGate.bind(
+    null,
+    xit,
+    '!enableNewReconciler'
+  );
+
+  it.new = testGate.bind(null, it, 'enableNewReconciler');
+  fit.new = it.new.only = it.only.new = testGate.bind(
+    null,
+    fit,
+    'enableNewReconciler'
+  );
+  xit.new = it.new.skip = it.skip.new = testGate.bind(
+    null,
+    xit,
+    'enableNewReconciler'
+  );
+}
+
+module.exports = installGatedTestHelpers;


### PR DESCRIPTION
Adds a new test helper, `it.gate`. You pass it the name of a feature flag, and if the flag is enabled, it asserts that the test passes. If  the flag is off, it asserts that the test fails. Example:

```js
it.gate('enableNewReconciler', 'test that only passes in new reconciler', () => {
  // ... test goes here
});
```

(`test.gate` is equivalent and makes perhaps makes more grammatical sense, but I'm using `it.gate` in these examples since we use `it` everywhere in our tests.)

You can test multiple flags by passing an array:

```js
it.gate(
  ['enableNewReconciler', 'enableModernEventSystem'],
  'test that passes only in new reconciler with modern event system', () => {
    // ... test goes here
  }
);
```

If any of the flags are disabled, the test is expected to fail.

You can check if a flag is off by adding a `!` to the front:

```js
it.gate(
  '!enableNewReconciler',
  'test that passes only in the old reconciler', () => {
    // ... test goes here
  }
);
```

For anything more advanced, you can pass a function:

```js
it.gate(
  flags => flags.warnAboutSpreadingKeyToJSX || !__DEV__,
  'should warn when keys are passed as part of props', () => {
    // Test passes when the flag is enabled, or in prod since
    // there are no warnings in prod
  }
);
```

I also added aliases for `it.old` and `it.new`, for testing the different reconciler forks:

```js
it.old('test that passes only in the old reconciler', () => {
  // ... test goes here
});
it.new('test that passes only in the new reconciler', () => {
  // ... test goes here
});
```

##  Next steps

Longer term I think it would nice if these were implemented as pragmas instead:

```js
// @gate enableNewReconciler
it('test that passes only in the new reconciler', () => {
  // ... test goes here
});
```