### PR TITLE
Feature: Add support to `exhaustive-deps` rule for any hook ending with `Effect`

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -360,12 +360,41 @@ const tests = {
     {
       code: normalizeIndent`
         function MyComponent(props) {
+          useCustomHook(() => {
+            console.log(props.foo);
+          });
+        }
+      `,
+      options: [{additionalHooks: 'useCustomHook'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomHook(() => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{additionalHooks: 'useCustomHook'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomHook(() => {
+            console.log(props.foo);
+          }, []);
+        }
+      `,
+      options: [{additionalHooks: 'useAnotherHook'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
           useCustomEffect(() => {
             console.log(props.foo);
           });
         }
       `,
-      options: [{additionalHooks: 'useCustomEffect'}],
     },
     {
       code: normalizeIndent`
@@ -375,17 +404,6 @@ const tests = {
           }, [props.foo]);
         }
       `,
-      options: [{additionalHooks: 'useCustomEffect'}],
-    },
-    {
-      code: normalizeIndent`
-        function MyComponent(props) {
-          useCustomEffect(() => {
-            console.log(props.foo);
-          }, []);
-        }
-      `,
-      options: [{additionalHooks: 'useAnotherEffect'}],
     },
     {
       // Valid because we don't care about hooks outside of components.
@@ -3005,6 +3023,105 @@ const tests = {
     {
       code: normalizeIndent`
         function MyComponent(props) {
+          useCustomHook(() => {
+            console.log(props.foo);
+          }, []);
+          useEffect(() => {
+            console.log(props.foo);
+          }, []);
+          React.useEffect(() => {
+            console.log(props.foo);
+          }, []);
+          React.useCustomHook(() => {
+            console.log(props.foo);
+          }, []);
+        }
+      `,
+      options: [{additionalHooks: 'useCustomHook'}],
+      errors: [
+        {
+          message:
+            "React Hook useCustomHook has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomHook(() => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                  useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  React.useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  React.useCustomHook(() => {
+                    console.log(props.foo);
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomHook(() => {
+                    console.log(props.foo);
+                  }, []);
+                  useEffect(() => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                  React.useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  React.useCustomHook(() => {
+                    console.log(props.foo);
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message:
+            "React Hook React.useEffect has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomHook(() => {
+                    console.log(props.foo);
+                  }, []);
+                  useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  React.useEffect(() => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                  React.useCustomHook(() => {
+                    console.log(props.foo);
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
           useCustomEffect(() => {
             console.log(props.foo);
           }, []);
@@ -3019,7 +3136,6 @@ const tests = {
           }, []);
         }
       `,
-      options: [{additionalHooks: 'useCustomEffect'}],
       errors: [
         {
           message:

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -4171,6 +4171,36 @@ const tests = {
       options: [{additionalHooks: 'useLayoutEffect_SAFE_FOR_SSR'}],
     },
     {
+      code: `
+        function MyComponent() {
+          const myRef = useRef();
+          useIsomorphicLayoutEffect(() => {
+            const handleMove = () => {};
+            myRef.current.addEventListener('mousemove', handleMove);
+            return () => myRef.current.removeEventListener('mousemove', handleMove);
+          });
+          return <div ref={myRef} />;
+        }
+      `,
+      output: `
+        function MyComponent() {
+          const myRef = useRef();
+          useIsomorphicLayoutEffect(() => {
+            const handleMove = () => {};
+            myRef.current.addEventListener('mousemove', handleMove);
+            return () => myRef.current.removeEventListener('mousemove', handleMove);
+          });
+          return <div ref={myRef} />;
+        }
+      `,
+      errors: [
+        `The ref value 'myRef.current' will likely have changed by the time ` +
+          `this effect cleanup function runs. If this ref points to a node ` +
+          `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
+          `and use that variable in the cleanup function.`,
+      ],
+    },
+    {
       // Autofix ignores constant primitives (leaving the ones that are there).
       code: normalizeIndent`
         function MyComponent() {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1504,7 +1504,9 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
       // useImperativeHandle(ref, fn)
       return 1;
     default:
-      if (node === calleeNode && options && options.additionalHooks) {
+      if (node === calleeNode && node.name.match(/use.+Effect/)) {
+        return 0;
+      } else if (node === calleeNode && options && options.additionalHooks) {
         // Allow the user to provide a regular expression which enables the lint to
         // target custom reactive hooks.
         let name;


### PR DESCRIPTION
## Summary

Following up on @gaearon 's comment [here](https://github.com/facebook/react/pull/16912#issuecomment-611724673). My original motivation was to document the `additionalHooks` option in the `exhaustive-deps` lint rule. He suggested an alternate solution by linting any hook ending with `Effect`. This PR adds support for that.

## Test Plan

I find that eslint rule tests are pretty thorough so all my testing is just through those test cases. I copied all the tests I could find for the `additionalHooks` option and reworked them to use a `useXEffect` naming convention instead of the `additionalHooks` option. I also tweaked some of the `additionalHooks` tests that were testing for `useCustomEffect` and changed it to `useCustomHook` because `useCustomEffect` would get caught anyway after these changes.
