### PR TITLE
Fix "missing flag" error for non-boolean types

### DIFF
--- a/scripts/babel/__tests__/transform-test-gate-pragma-test.js
+++ b/scripts/babel/__tests__/transform-test-gate-pragma-test.js
@@ -173,6 +173,13 @@ describe('transform test-gate-pragma: actual runtime', () => {
     }
   });
 
+  // @gate build === "development"
+  test('strings', () => {
+    if (!__DEV__) {
+      throw Error("Doesn't work in production!");
+    }
+  });
+
   // Always should fail because of the unguarded console.error
   // @gate false
   test('works with console.error tracking', () => {

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -58,7 +58,7 @@ function getTestFlags() {
     {
       get(flags, flagName) {
         const flagValue = flags[flagName];
-        if (typeof flagValue !== 'boolean' && typeof flagName === 'string') {
+        if (flagValue === undefined && typeof flagName === 'string') {
           throw Error(
             `Feature flag "${flagName}" does not exist. See TestFlags.js ` +
               'for more details.'


### PR DESCRIPTION
Not all test flags are booleans, e.g. the build type