### PR TITLE
Fix www tests not running in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             RELEASE_CHANNEL: stable
           command: yarn test-www-variant --maxWorkers=2
 
-  RELEASE_CHANNEL_stable_NODE_ENV_production_yarn_test_www:
+  RELEASE_CHANNEL_stable_yarn_test_prod_www:
     docker: *docker
     environment: *environment
     steps:
@@ -147,11 +147,10 @@ jobs:
       - *run_yarn
       - run:
           environment:
-            NODE_ENV: production
             RELEASE_CHANNEL: stable
-          command: yarn test-www --maxWorkers=2
+          command: yarn test-prod-www --maxWorkers=2
 
-  RELEASE_CHANNEL_stable_NODE_ENV_production_yarn_test_www_variant:
+  RELEASE_CHANNEL_stable_yarn_test_prod_www_variant:
     docker: *docker
     environment: *environment
     steps:
@@ -160,9 +159,8 @@ jobs:
       - *run_yarn
       - run:
           environment:
-            NODE_ENV: production
             RELEASE_CHANNEL: stable
-          command: yarn test-www-variant --maxWorkers=2
+          command: yarn test-prod-www-variant --maxWorkers=2
 
   yarn_test_www:
     docker: *docker
@@ -188,7 +186,7 @@ jobs:
             RELEASE_CHANNEL: experimental
           command: yarn test-www-variant --maxWorkers=2
 
-  NODE_ENV_production_yarn_test_www:
+  yarn_test_prod_www:
     docker: *docker
     environment: *environment
     steps:
@@ -197,11 +195,10 @@ jobs:
       - *run_yarn
       - run:
           environment:
-            NODE_ENV: production
             RELEASE_CHANNEL: experimental
-          command: yarn test-www --maxWorkers=2
+          command: yarn test-prod-www --maxWorkers=2
 
-  NODE_ENV_production_yarn_test_www_variant:
+  yarn_test_prod_www_variant:
     docker: *docker
     environment: *environment
     steps:
@@ -210,7 +207,6 @@ jobs:
       - *run_yarn
       - run:
           environment:
-            NODE_ENV: production
             RELEASE_CHANNEL: experimental
           command: yarn test-www-variant --maxWorkers=2
 
@@ -489,10 +485,10 @@ workflows:
       - RELEASE_CHANNEL_stable_yarn_test_www_variant:
           requires:
             - setup
-      - RELEASE_CHANNEL_stable_NODE_ENV_production_yarn_test_www:
+      - RELEASE_CHANNEL_stable_yarn_test_prod_www:
           requires:
             - setup
-      - RELEASE_CHANNEL_stable_NODE_ENV_production_yarn_test_www_variant:
+      - RELEASE_CHANNEL_stable_yarn_test_prod_www_variant:
           requires:
             - setup
       - RELEASE_CHANNEL_stable_yarn_build:
@@ -532,10 +528,10 @@ workflows:
       - yarn_test_www_variant:
           requires:
             - setup
-      - NODE_ENV_production_yarn_test_www:
+      - yarn_test_prod_www:
           requires:
             - setup
-      - NODE_ENV_production_yarn_test_www_variant:
+      - yarn_test_prod_www_variant:
           requires:
             - setup
       - yarn_build:

--- a/package.json
+++ b/package.json
@@ -110,6 +110,8 @@
     "test": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js",
     "test-www": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source-www.js",
     "test-www-variant": "cross-env NODE_ENV=development VARIANT=true jest --config ./scripts/jest/config.source-www.js",
+    "test-prod-www": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.source-www.js",
+    "test-prod-www-variant": "cross-env NODE_ENV=production VARIANT=true jest --config ./scripts/jest/config.source-www.js",
     "test-persistent": "cross-env NODE_ENV=development jest --config ./scripts/jest/config.source-persistent.js",
     "debug-test-persistent": "cross-env NODE_ENV=development node --inspect-brk node_modules/jest/bin/jest.js --config ./scripts/jest/config.source-persistent.js --runInBand",
     "test-prod": "cross-env NODE_ENV=production jest --config ./scripts/jest/config.source.js",


### PR DESCRIPTION
I made a mistake when setting these up a while ago. Setting the `NODE_ENV` in the CircleCI config doesn't work because it's also set in the node script command.  So it turns out they've been running in prod the whole time. I noticed this when iterating on the new reconciler, which is only enabled in one of the www variants.

The number of test commands is getting out of control. Might need to fix it at some point. Like one command with arguments.



