### PR TITLE
Adds clarity to test renderer expectOne error

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -417,10 +417,7 @@ function expectOne(
     return all[0];
   }
 
-  const prefix =
-    all.length === 0
-      ? 'No instances found '
-      : `Expected 1 but found ${all.length} instances `;
+  const prefix = `Expected 1 but found ${all.length} instances `;
 
   throw new Error(prefix + message);
 }

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1030,6 +1030,8 @@ describe('ReactTestRenderer', () => {
 
     expect(() => {
       renderer.root.findByType(NonComponent);
-    }).toThrowError(`No instances found with node type: "Unknown"`);
+    }).toThrowError(
+      `Expected 1 but found 0 instances with node type: "Unknown"`,
+    );
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

For newcomers poking in the dark using ReactTestRenderer, the various find
functions are used without realizing they will throw an error when they
find anytying but a single match.

The previous error of `No instances found with node type: "xxx"`
is not as clear about expectations as when expectOne finds more than
one: `Expected 1 but found 2 instances with node type "xxx"`

This change simplifies the code by just using the second version and
adds clarity for people unfamiliar with RTR's find functions

The new version: `Expected 1 but found 0 instances with node type "xxx"`

This inherently tells the user how many are expected and how many are found.
At the same time it provides contextual clues that the previous version lacked.
