### PR TITLE
Experimental test selector API

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -244,6 +244,7 @@ function applyTextProps(instance, props, prevProps = {}) {
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 
 export function appendInitialChild(parentInstance, child) {
   if (typeof child === 'string') {

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -14,7 +14,7 @@ describe('ReactDOMTestSelectors', () => {
 
   let act;
   let createComponentSelector;
-  //let createHasPsuedoClassSelector;
+  let createHasPsuedoClassSelector;
   let createRoleSelector;
   let createTextSelector;
   let createTestNameSelector;
@@ -35,7 +35,7 @@ describe('ReactDOMTestSelectors', () => {
     const ReactDOM = require('react-dom/testing');
     act = ReactDOM.act;
     createComponentSelector = ReactDOM.createComponentSelector;
-    //createHasPsuedoClassSelector = ReactDOM.createHasPsuedoClassSelector;
+    createHasPsuedoClassSelector = ReactDOM.createHasPsuedoClassSelector;
     createRoleSelector = ReactDOM.createRoleSelector;
     createTextSelector = ReactDOM.createTextSelector;
     createTestNameSelector = ReactDOM.createTestNameSelector;
@@ -400,6 +400,41 @@ describe('ReactDOMTestSelectors', () => {
       const matches = findAllNodes(document.body, [
         createComponentSelector(Example),
         createRoleSelector('checkbox'),
+      ]);
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match');
+    });
+
+    it('should support searching ahead with the has() selector', () => {
+      function Example() {
+        return (
+          <div>
+            <article>
+              <h1>Should match</h1>
+              <p>
+                <button id="match">Like</button>
+              </p>
+            </article>
+            <article>
+              <h1>Should not match</h1>
+              <p>
+                <button>Like</button>
+              </p>
+            </article>
+          </div>
+        );
+      }
+
+      render(<Example />, container);
+
+      const matches = findAllNodes(document.body, [
+        createComponentSelector(Example),
+        createRoleSelector('article'),
+        createHasPsuedoClassSelector([
+          createRoleSelector('heading'),
+          createTextSelector('Should match'),
+        ]),
+        createRoleSelector('button'),
       ]);
       expect(matches).toHaveLength(1);
       expect(matches[0].id).toBe('match');

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -937,9 +937,9 @@ No matching component was found for:
       expect(didFocus).toBe(false);
     });
 
-    it('should return false if the only focusable elements are visible', () => {
+    it('should return false if the only focusable elements are hidden', () => {
       function Example() {
-        return <button style={{display: 'none'}}>not clickable</button>;
+        return <button hidden={true}>not clickable</button>;
       }
 
       render(<Example />, container);
@@ -968,7 +968,7 @@ No matching component was found for:
       }
       function FirstChild() {
         return (
-          <button style={{display: 'none'}} onFocus={handleFirstFocus}>
+          <button hidden={true} onFocus={handleFirstFocus}>
             not clickable
           </button>
         );

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -1,0 +1,1186 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+
+describe('ReactDOMTestSelectors', () => {
+  let container;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom/testing');
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  describe('findAllNodes', () => {
+    it('should support searching from the document root', () => {
+      function Example() {
+        return (
+          <div>
+            <div data-testname="match" id="match" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const matches = ReactDOM.findAllNodes(document.body, [Example], 'match');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match');
+    });
+
+    it('should support searching from the container', () => {
+      function Example() {
+        return (
+          <div>
+            <div data-testname="match" id="match" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const matches = ReactDOM.findAllNodes(container, [Example], 'match');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match');
+    });
+
+    it('should support searching from a previous match', () => {
+      function Outer() {
+        return (
+          <div data-testname="outer" id="outer">
+            <Inner />
+          </div>
+        );
+      }
+
+      function Inner() {
+        return <div data-testname="inner" id="inner" />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      let matches = ReactDOM.findAllNodes(container, [Outer], 'outer');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('outer');
+
+      matches = ReactDOM.findAllNodes(matches[0], [Inner], 'inner');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('inner');
+    });
+
+    it('should support an multiple component types in the selector array', () => {
+      function Outer() {
+        return (
+          <>
+            <div data-testname="match" id="match1" />
+            <Middle />
+          </>
+        );
+      }
+      function Middle() {
+        return (
+          <>
+            <div data-testname="match" id="match2" />
+            <Inner />
+          </>
+        );
+      }
+      function Inner() {
+        return (
+          <>
+            <div data-testname="match" id="match3" />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      let matches = ReactDOM.findAllNodes(
+        document.body,
+        [Outer, Middle],
+        'match',
+      );
+      expect(matches).toHaveLength(2);
+      expect(matches.map(m => m.id).sort()).toEqual(['match2', 'match3']);
+
+      matches = ReactDOM.findAllNodes(
+        document.body,
+        [Outer, Middle, Inner],
+        'match',
+      );
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match3');
+
+      matches = ReactDOM.findAllNodes(document.body, [Outer, Inner], 'match');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match3');
+    });
+
+    it('should support an empty component type selector array', () => {
+      function Example() {
+        return (
+          <div>
+            <div data-testname="match" id="match" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const matches = ReactDOM.findAllNodes(document.body, [], 'match');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].id).toBe('match');
+    });
+
+    it('should find multiple matches', () => {
+      function Example1() {
+        return (
+          <div>
+            <div data-testname="match" id="match1" />
+          </div>
+        );
+      }
+
+      function Example2() {
+        return (
+          <div>
+            <div data-testname="match" id="match2" />
+            <div data-testname="match" id="match3" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(
+        <>
+          <Example1 />
+          <Example2 />
+        </>,
+        container,
+      );
+
+      const matches = ReactDOM.findAllNodes(document.body, [], 'match');
+      expect(matches).toHaveLength(3);
+      expect(matches.map(m => m.id).sort()).toEqual([
+        'match1',
+        'match2',
+        'match3',
+      ]);
+    });
+
+    it('should find nested matches', () => {
+      function Example() {
+        return (
+          <div data-testname="match" id="match1">
+            <div data-testname="match" id="match2" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const matches = ReactDOM.findAllNodes(document.body, [Example], 'match');
+      expect(matches).toHaveLength(2);
+      expect(matches.map(m => m.id).sort()).toEqual(['match1', 'match2']);
+    });
+
+    it('should enforce the specific order of components types', () => {
+      function Outer() {
+        return (
+          <>
+            <div data-testname="match" id="match1" />
+            <Inner />
+          </>
+        );
+      }
+      function Inner() {
+        return <div data-testname="match" id="match1" />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      expect(
+        ReactDOM.findAllNodes(document.body, [Inner, Outer], 'match'),
+      ).toHaveLength(0);
+    });
+
+    it('should only search the subtree within the component types selector', () => {
+      function Outer() {
+        return (
+          <>
+            <div data-testname="match" id="match1" />
+            <Inner />
+          </>
+        );
+      }
+      function Inner() {
+        return <div />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      expect(
+        ReactDOM.findAllNodes(document.body, [Outer, Inner], 'match'),
+      ).toHaveLength(0);
+
+      expect(
+        ReactDOM.findAllNodes(document.body, [Inner], 'match'),
+      ).toHaveLength(0);
+    });
+
+    it('should not search within hidden subtrees', () => {
+      const ref1 = React.createRef(null);
+      const ref2 = React.createRef(null);
+
+      function Outer() {
+        return (
+          <>
+            <Inner />
+            <div hidden={true}>
+              <div ref={ref1} data-testname="match" />
+            </div>
+          </>
+        );
+      }
+      function Inner() {
+        return <div ref={ref2} data-testname="match" />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      const matches = ReactDOM.findAllNodes(document.body, [Outer], 'match');
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toBe(ref2.current);
+    });
+
+    it('should throw if no container can be found', () => {
+      expect(() => ReactDOM.findAllNodes(document.body, [], 'match')).toThrow(
+        'Could not find React container within specified host subtree.',
+      );
+    });
+
+    it('should throw if an invalid host root is specified', () => {
+      const ref = React.createRef();
+      function Example() {
+        return <div ref={ref} />;
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      expect(() => ReactDOM.findAllNodes(ref.current, [], 'match')).toThrow(
+        'Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes().',
+      );
+    });
+  });
+
+  describe('getFindAllNodesFailureDescription', () => {
+    it('should describe findAllNodes failures caused by the component type selector', () => {
+      function Outer() {
+        return <Middle />;
+      }
+      function Middle() {
+        return <div />;
+      }
+      function NotRendered() {
+        return <div data-testname="match" />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      const description = ReactDOM.getFindAllNodesFailureDescription(
+        document.body,
+        [Outer, Middle, NotRendered],
+        'match',
+      );
+
+      expect(description).toEqual(
+        `findAllNodes was able to match part of the selector:
+  Outer > Middle
+
+No matching component was found for:
+  NotRendered`,
+      );
+    });
+
+    it('should describe findAllNodes failures caused by a failed test-name match', () => {
+      function Example() {
+        return (
+          <>
+            <Example1 />
+            <Example2 />
+          </>
+        );
+      }
+
+      function Example1() {
+        return (
+          <div>
+            <div data-testname="match1" />
+          </div>
+        );
+      }
+
+      function Example2() {
+        return (
+          <div>
+            <div data-testname="match2" />
+            <Example3 />
+          </div>
+        );
+      }
+
+      function Example3() {
+        return (
+          <>
+            <div data-testname="match2" />
+            <div data-testname="match3" />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const description = ReactDOM.getFindAllNodesFailureDescription(
+        document.body,
+        [Example],
+        'match',
+      );
+
+      expect(description).toEqual(
+        `No host element was found with the test name "match".
+
+The following test names were found in the matched subtree:
+  match1
+  match2
+  match3`,
+      );
+    });
+
+    it('should return null if findAllNodes was able to find a match', () => {
+      function Example() {
+        return (
+          <div>
+            <div data-testname="match" id="match" />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const description = ReactDOM.getFindAllNodesFailureDescription(
+        document.body,
+        [Example],
+        'match',
+      );
+
+      expect(description).toBe(null);
+    });
+  });
+
+  describe('findBoundingRects', () => {
+    // Stub out getBoundingClientRect for the specified target.
+    // This API is required by the test selectors but it isn't implemented by jsdom.
+    function setBoundingClientRect(target, {x, y, width, height}) {
+      target.getBoundingClientRect = function() {
+        return {
+          width,
+          height,
+          left: x,
+          right: x + width,
+          top: y,
+          bottom: y + height,
+        };
+      };
+    }
+
+    it('should return a single rect for a component that returns a single root host element', () => {
+      const ref = React.createRef();
+
+      function Example() {
+        return (
+          <div ref={ref}>
+            <div />
+            <div />
+          </div>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      setBoundingClientRect(ref.current, {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+
+      const rects = ReactDOM.findBoundingRects(document.body, [Example]);
+      expect(rects).toHaveLength(1);
+      expect(rects).toContainEqual({
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+    });
+
+    it('should return a multiple rects for multiple matches', () => {
+      const outerRef = React.createRef();
+      const innerRef = React.createRef();
+
+      function Outer() {
+        return (
+          <>
+            <div ref={outerRef} />
+            <Inner />
+          </>
+        );
+      }
+      function Inner() {
+        return <div ref={innerRef} />;
+      }
+
+      ReactDOM.render(<Outer />, container);
+
+      setBoundingClientRect(outerRef.current, {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+      setBoundingClientRect(innerRef.current, {
+        x: 110,
+        y: 120,
+        width: 250,
+        height: 150,
+      });
+
+      const rects = ReactDOM.findBoundingRects(document.body, [Outer]);
+      expect(rects).toHaveLength(2);
+      expect(rects).toContainEqual({
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+      expect(rects).toContainEqual({
+        x: 110,
+        y: 120,
+        width: 250,
+        height: 150,
+      });
+    });
+
+    it('should return a multiple rects for single match that returns a fragment', () => {
+      const refA = React.createRef();
+      const refB = React.createRef();
+
+      function Example() {
+        return (
+          <>
+            <div ref={refA}>
+              <div />
+              <div />
+            </div>
+            <div ref={refB} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      setBoundingClientRect(refA.current, {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+      setBoundingClientRect(refB.current, {
+        x: 110,
+        y: 120,
+        width: 250,
+        height: 150,
+      });
+
+      const rects = ReactDOM.findBoundingRects(document.body, [Example]);
+      expect(rects).toHaveLength(2);
+      expect(rects).toContainEqual({
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      });
+      expect(rects).toContainEqual({
+        x: 110,
+        y: 120,
+        width: 250,
+        height: 150,
+      });
+    });
+
+    it('should merge overlapping rects', () => {
+      const refA = React.createRef();
+      const refB = React.createRef();
+      const refC = React.createRef();
+
+      function Example() {
+        return (
+          <>
+            <div ref={refA} />
+            <div ref={refB} />
+            <div ref={refC} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      setBoundingClientRect(refA.current, {
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+      setBoundingClientRect(refB.current, {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 10,
+      });
+      setBoundingClientRect(refC.current, {
+        x: 100,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+
+      const rects = ReactDOM.findBoundingRects(document.body, [Example]);
+      expect(rects).toHaveLength(2);
+      expect(rects).toContainEqual({
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+      expect(rects).toContainEqual({
+        x: 100,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+    });
+
+    it('should not search within hidden subtrees', () => {
+      const refA = React.createRef();
+      const refB = React.createRef();
+      const refC = React.createRef();
+
+      function Example() {
+        return (
+          <>
+            <div ref={refA} />
+            <div hidden={true} ref={refB} />
+            <div ref={refC} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      setBoundingClientRect(refA.current, {
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+      setBoundingClientRect(refB.current, {
+        x: 100,
+        y: 10,
+        width: 20,
+        height: 10,
+      });
+      setBoundingClientRect(refC.current, {
+        x: 200,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+
+      const rects = ReactDOM.findBoundingRects(document.body, [Example]);
+      expect(rects).toHaveLength(2);
+      expect(rects).toContainEqual({
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+      expect(rects).toContainEqual({
+        x: 200,
+        y: 10,
+        width: 50,
+        height: 25,
+      });
+    });
+  });
+
+  describe('focusWithin', () => {
+    beforeEach(() => {
+      // JSdom does not do actual layout and so doesn't return meaningful values here.
+      // For the purposes of our tests though, we need somewhat meaningful values here,
+      // else the DOM host config will assume elements are not visible.
+      Object.defineProperties(HTMLElement.prototype, {
+        offsetWidth: {
+          get: function() {
+            return parseInt(this.style.width, 10) || 0;
+          },
+        },
+        offsetHeight: {
+          get: function() {
+            return parseInt(this.style.height, 10) || 0;
+          },
+        },
+      });
+    });
+
+    it('should return false if the specified component path has no matches', () => {
+      function Example() {
+        return <Child />;
+      }
+      function Child() {
+        return null;
+      }
+      function NotUsed() {
+        return null;
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example, NotUsed]);
+      expect(didFocus).toBe(false);
+    });
+
+    it('should return false if there are no focusable elements within the matched subtree', () => {
+      function Example() {
+        return <Child />;
+      }
+      function Child() {
+        return 'not focusable';
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example, Child]);
+      expect(didFocus).toBe(false);
+    });
+
+    it('should return false if the only focusable elements are disabled', () => {
+      function Example() {
+        return (
+          <button disabled={true} style={{width: 10, height: 10}}>
+            not clickable
+          </button>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example]);
+      expect(didFocus).toBe(false);
+    });
+
+    it('should return false if the only focusable elements are visible', () => {
+      function Example() {
+        return <button style={{display: 'none'}}>not clickable</button>;
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example]);
+      expect(didFocus).toBe(false);
+    });
+
+    it('should successfully focus the first focusable element within the tree', () => {
+      const secondRef = React.createRef(null);
+
+      const handleFirstFocus = jest.fn();
+      const handleSecondFocus = jest.fn();
+      const handleThirdFocus = jest.fn();
+
+      function Example() {
+        return (
+          <>
+            <FirstChild />
+            <SecondChild />
+            <ThirdChild />
+          </>
+        );
+      }
+      function FirstChild() {
+        return (
+          <button style={{display: 'none'}} onFocus={handleFirstFocus}>
+            not clickable
+          </button>
+        );
+      }
+      function SecondChild() {
+        return (
+          <button
+            ref={secondRef}
+            style={{width: 10, height: 10}}
+            onFocus={handleSecondFocus}>
+            clickable
+          </button>
+        );
+      }
+      function ThirdChild() {
+        return (
+          <button style={{width: 10, height: 10}} onFocus={handleThirdFocus}>
+            clickable
+          </button>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example]);
+      expect(didFocus).toBe(true);
+      expect(document.activeElement).not.toBeNull();
+      expect(document.activeElement).toBe(secondRef.current);
+      expect(handleFirstFocus).not.toHaveBeenCalled();
+      expect(handleSecondFocus).toHaveBeenCalledTimes(1);
+      expect(handleThirdFocus).not.toHaveBeenCalled();
+    });
+
+    it('should successfully focus the first focusable element even if application logic interferes', () => {
+      const ref = React.createRef(null);
+
+      const handleFocus = jest.fn(event => {
+        event.target.blur();
+      });
+
+      function Example() {
+        return (
+          <button
+            ref={ref}
+            style={{width: 10, height: 10}}
+            onFocus={handleFocus}>
+            clickable
+          </button>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example]);
+      expect(didFocus).toBe(true);
+      expect(ref.current).not.toBeNull();
+      expect(ref.current).not.toBe(document.activeElement);
+      expect(handleFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not focus within hidden subtrees', () => {
+      const secondRef = React.createRef(null);
+
+      const handleFirstFocus = jest.fn();
+      const handleSecondFocus = jest.fn();
+      const handleThirdFocus = jest.fn();
+
+      function Example() {
+        return (
+          <>
+            <FirstChild />
+            <SecondChild />
+            <ThirdChild />
+          </>
+        );
+      }
+      function FirstChild() {
+        return (
+          <div hidden={true}>
+            <button style={{width: 10, height: 10}} onFocus={handleFirstFocus}>
+              hidden
+            </button>
+          </div>
+        );
+      }
+      function SecondChild() {
+        return (
+          <button
+            ref={secondRef}
+            style={{width: 10, height: 10}}
+            onFocus={handleSecondFocus}>
+            clickable
+          </button>
+        );
+      }
+      function ThirdChild() {
+        return (
+          <button style={{width: 10, height: 10}} onFocus={handleThirdFocus}>
+            clickable
+          </button>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      const didFocus = ReactDOM.focusWithin(document.body, [Example]);
+      expect(didFocus).toBe(true);
+      expect(document.activeElement).not.toBeNull();
+      expect(document.activeElement).toBe(secondRef.current);
+      expect(handleFirstFocus).not.toHaveBeenCalled();
+      expect(handleSecondFocus).toHaveBeenCalledTimes(1);
+      expect(handleThirdFocus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('observeVisibleRects', () => {
+    // Stub out getBoundingClientRect for the specified target.
+    // This API is required by the test selectors but it isn't implemented by jsdom.
+    function setBoundingClientRect(target, {x, y, width, height}) {
+      target.getBoundingClientRect = function() {
+        return {
+          width,
+          height,
+          left: x,
+          right: x + width,
+          top: y,
+          bottom: y + height,
+        };
+      };
+    }
+
+    function simulateIntersection(...entries) {
+      callback(
+        entries.map(([target, rect, ratio]) => ({
+          boundingClientRect: {
+            top: rect.y,
+            left: rect.x,
+            width: rect.width,
+            height: rect.height,
+          },
+          intersectionRatio: ratio,
+          target,
+        })),
+      );
+    }
+
+    let callback;
+    let observedTargets;
+
+    beforeEach(() => {
+      callback = null;
+      observedTargets = [];
+
+      class IntersectionObserver {
+        constructor() {
+          callback = arguments[0];
+        }
+
+        disconnect() {
+          callback = null;
+          observedTargets.splice(0);
+        }
+
+        observe(target) {
+          observedTargets.push(target);
+        }
+
+        unobserve(target) {
+          const index = observedTargets.indexOf(target);
+          if (index >= 0) {
+            observedTargets.splice(index, 1);
+          }
+        }
+      }
+
+      // This is a broken polyfill.
+      // It is only intended to provide bare minimum test coverage.
+      // More meaningful tests will require the use of fixtures.
+      window.IntersectionObserver = IntersectionObserver;
+    });
+
+    it('should notify a listener when the underlying instance intersection changes', () => {
+      const ref = React.createRef(null);
+
+      function Example() {
+        return <div ref={ref} />;
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      // Stub out the size of the element this test will be observing.
+      const rect = {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref.current, rect);
+
+      const handleVisibilityChange = jest.fn();
+      ReactDOM.observeVisibleRects(
+        document.body,
+        [Example],
+        handleVisibilityChange,
+      );
+
+      expect(callback).not.toBeNull();
+      expect(observedTargets).toHaveLength(1);
+      expect(handleVisibilityChange).not.toHaveBeenCalled();
+
+      // Simulate IntersectionObserver notification.
+      simulateIntersection([ref.current, rect, 0.5]);
+
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([{rect, ratio: 0.5}]);
+    });
+
+    it('should notify a listener of multiple targets when the underlying instance intersection changes', () => {
+      const ref1 = React.createRef(null);
+      const ref2 = React.createRef(null);
+
+      function Example() {
+        return (
+          <>
+            <div ref={ref1} />
+            <div ref={ref2} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      // Stub out the size of the element this test will be observing.
+      const rect1 = {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      let rect2 = {
+        x: 210,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref1.current, rect1);
+      setBoundingClientRect(ref2.current, rect2);
+
+      const handleVisibilityChange = jest.fn();
+      ReactDOM.observeVisibleRects(
+        document.body,
+        [Example],
+        handleVisibilityChange,
+      );
+
+      expect(callback).not.toBeNull();
+      expect(observedTargets).toHaveLength(2);
+      expect(handleVisibilityChange).not.toHaveBeenCalled();
+
+      // Simulate IntersectionObserver notification.
+      simulateIntersection([ref1.current, rect1, 0.5]);
+
+      // Even though only one of the rects changed intersection,
+      // the test selector should describe the current state of both.
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([
+        {rect: rect1, ratio: 0.5},
+        {rect: rect2, ratio: 0},
+      ]);
+
+      handleVisibilityChange.mockReset();
+
+      rect2 = {
+        x: 210,
+        y: 20,
+        width: 200,
+        height: 200,
+      };
+
+      // Simulate another IntersectionObserver notification.
+      simulateIntersection(
+        [ref1.current, rect1, 1],
+        [ref2.current, rect2, 0.25],
+      );
+
+      // The newly changed display rect should also be provided for the second target.
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([
+        {rect: rect1, ratio: 1},
+        {rect: rect2, ratio: 0.25},
+      ]);
+    });
+
+    it('should stop listening when its disconnected', () => {
+      const ref = React.createRef(null);
+
+      function Example() {
+        return <div ref={ref} />;
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      // Stub out the size of the element this test will be observing.
+      const rect = {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref.current, rect);
+
+      const handleVisibilityChange = jest.fn();
+      const {disconnect} = ReactDOM.observeVisibleRects(
+        document.body,
+        [Example],
+        handleVisibilityChange,
+      );
+
+      expect(callback).not.toBeNull();
+      expect(observedTargets).toHaveLength(1);
+      expect(handleVisibilityChange).not.toHaveBeenCalled();
+
+      disconnect();
+      expect(callback).toBeNull();
+    });
+
+    it('should update which targets its listening to after a commit', () => {
+      const ref1 = React.createRef(null);
+      const ref2 = React.createRef(null);
+
+      let increment;
+
+      function Example() {
+        const [count, setCount] = React.useState(0);
+        increment = () => setCount(count + 1);
+        return (
+          <>
+            {count < 2 && <div ref={ref1} />}
+            {count > 0 && <div ref={ref2} />}
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      // Stub out the size of the element this test will be observing.
+      const rect1 = {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref1.current, rect1);
+
+      const handleVisibilityChange = jest.fn();
+      ReactDOM.observeVisibleRects(
+        document.body,
+        [Example],
+        handleVisibilityChange,
+      );
+
+      // Simulate IntersectionObserver notification.
+      simulateIntersection([ref1.current, rect1, 1]);
+
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([
+        {rect: rect1, ratio: 1},
+      ]);
+
+      ReactDOM.act(() => increment());
+
+      const rect2 = {
+        x: 110,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref2.current, rect2);
+
+      handleVisibilityChange.mockReset();
+
+      simulateIntersection(
+        [ref1.current, rect1, 0.5],
+        [ref2.current, rect2, 0.25],
+      );
+
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([
+        {rect: rect1, ratio: 0.5},
+        {rect: rect2, ratio: 0.25},
+      ]);
+
+      ReactDOM.act(() => increment());
+
+      handleVisibilityChange.mockReset();
+
+      simulateIntersection([ref2.current, rect2, 0.75]);
+
+      expect(handleVisibilityChange).toHaveBeenCalledTimes(1);
+      expect(handleVisibilityChange).toHaveBeenCalledWith([
+        {rect: rect2, ratio: 0.75},
+      ]);
+    });
+
+    it('should not observe components within hidden subtrees', () => {
+      const ref1 = React.createRef(null);
+      const ref2 = React.createRef(null);
+
+      function Example() {
+        return (
+          <>
+            <div ref={ref1} />
+            <div hidden={true} ref={ref2} />
+          </>
+        );
+      }
+
+      ReactDOM.render(<Example />, container);
+
+      // Stub out the size of the element this test will be observing.
+      const rect1 = {
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      const rect2 = {
+        x: 210,
+        y: 20,
+        width: 200,
+        height: 100,
+      };
+      setBoundingClientRect(ref1.current, rect1);
+      setBoundingClientRect(ref2.current, rect2);
+
+      const handleVisibilityChange = jest.fn();
+      ReactDOM.observeVisibleRects(
+        document.body,
+        [Example],
+        handleVisibilityChange,
+      );
+
+      expect(callback).not.toBeNull();
+      expect(observedTargets).toHaveLength(1);
+      expect(observedTargets[0]).toBe(ref1.current);
+    });
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -710,6 +710,105 @@ No matching component was found for:
       });
     });
 
+    it('should merge some types of adjacent rects (if they are the same in one dimension)', () => {
+      const refA = React.createRef();
+      const refB = React.createRef();
+      const refC = React.createRef();
+      const refD = React.createRef();
+      const refE = React.createRef();
+      const refF = React.createRef();
+      const refG = React.createRef();
+
+      function Example() {
+        return (
+          <>
+            <div ref={refA} data-debug="A" />
+            <div ref={refB} data-debug="B" />
+            <div ref={refC} data-debug="C" />
+            <div ref={refD} data-debug="D" />
+            <div ref={refE} data-debug="E" />
+            <div ref={refF} data-debug="F" />
+            <div ref={refG} data-debug="G" />
+          </>
+        );
+      }
+
+      render(<Example />, container);
+
+      // A, B, and C are all adjacent and/or overlapping, with the same height.
+      setBoundingClientRect(refA.current, {
+        x: 30,
+        y: 0,
+        width: 40,
+        height: 25,
+      });
+      setBoundingClientRect(refB.current, {
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 25,
+      });
+      setBoundingClientRect(refC.current, {
+        x: 70,
+        y: 0,
+        width: 20,
+        height: 25,
+      });
+
+      // D is partially overlapping with A and B, but is too tall to be merged.
+      setBoundingClientRect(refD.current, {
+        x: 20,
+        y: 0,
+        width: 20,
+        height: 30,
+      });
+
+      // Same thing but for a vertical group.
+      // Some of them could intersect with the horizontal group,
+      // except they're too far to the right.
+      setBoundingClientRect(refE.current, {
+        x: 100,
+        y: 25,
+        width: 25,
+        height: 50,
+      });
+      setBoundingClientRect(refF.current, {
+        x: 100,
+        y: 0,
+        width: 25,
+        height: 25,
+      });
+      setBoundingClientRect(refG.current, {
+        x: 100,
+        y: 75,
+        width: 25,
+        height: 10,
+      });
+
+      const rects = findBoundingRects(document.body, [
+        createComponentSelector(Example),
+      ]);
+      expect(rects).toHaveLength(3);
+      expect(rects).toContainEqual({
+        x: 0,
+        y: 0,
+        width: 90,
+        height: 25,
+      });
+      expect(rects).toContainEqual({
+        x: 20,
+        y: 0,
+        width: 20,
+        height: 30,
+      });
+      expect(rects).toContainEqual({
+        x: 100,
+        y: 0,
+        width: 25,
+        height: 85,
+      });
+    });
+
     it('should not search within hidden subtrees', () => {
       const refA = React.createRef();
       const refB = React.createRef();

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -1111,7 +1111,7 @@ No matching component was found for:
         {rect: rect2, ratio: 0},
       ]);
 
-      handleVisibilityChange.mockReset();
+      handleVisibilityChange.mockClear();
 
       rect2 = {
         x: 210,
@@ -1167,6 +1167,8 @@ No matching component was found for:
       expect(callback).toBeNull();
     });
 
+    // This test reuires gating because it relies on the __DEV__ only commit hook to work.
+    // @gate __DEV__
     it('should update which targets its listening to after a commit', () => {
       const ref1 = React.createRef(null);
       const ref2 = React.createRef(null);
@@ -1220,7 +1222,7 @@ No matching component was found for:
       };
       setBoundingClientRect(ref2.current, rect2);
 
-      handleVisibilityChange.mockReset();
+      handleVisibilityChange.mockClear();
 
       simulateIntersection(
         [ref1.current, rect1, 0.5],
@@ -1235,7 +1237,7 @@ No matching component was found for:
 
       act(() => increment());
 
-      handleVisibilityChange.mockReset();
+      handleVisibilityChange.mockClear();
 
       simulateIntersection([ref2.current, rect2, 0.75]);
 

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -865,24 +865,6 @@ No matching component was found for:
   });
 
   describe('focusWithin', () => {
-    beforeEach(() => {
-      // JSdom does not do actual layout and so doesn't return meaningful values here.
-      // For the purposes of our tests though, we need somewhat meaningful values here,
-      // else the DOM host config will assume elements are not visible.
-      Object.defineProperties(HTMLElement.prototype, {
-        offsetWidth: {
-          get: function() {
-            return parseInt(this.style.width, 10) || 0;
-          },
-        },
-        offsetHeight: {
-          get: function() {
-            return parseInt(this.style.height, 10) || 0;
-          },
-        },
-      });
-    });
-
     it('should return false if the specified component path has no matches', () => {
       function Example() {
         return <Child />;

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -361,6 +361,30 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    it('should support filtering by explicit secondary accessibiliy role', () => {
+      const ref = React.createRef();
+
+      function Example() {
+        return (
+          <div>
+            <div>foo</div>
+            <div>
+              <div ref={ref} role="meter progressbar" />
+            </div>
+          </div>
+        );
+      }
+
+      render(<Example />, container);
+
+      const matches = findAllNodes(document.body, [
+        createComponentSelector(Example),
+        createRoleSelector('progressbar'),
+      ]);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toBe(ref.current);
+    });
+
     it('should support filtering by implicit accessibiliy role', () => {
       function Example() {
         return (

--- a/packages/react-dom/src/client/DOMAccessibilityRoles.js
+++ b/packages/react-dom/src/client/DOMAccessibilityRoles.js
@@ -131,7 +131,6 @@ function getExplicitRole(element: Element): string | null {
 // https://w3c.github.io/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html
 export function getRole(element: Element): string | null {
   const explicitRole = getExplicitRole(element);
-
   if (explicitRole !== null) {
     return explicitRole;
   }

--- a/packages/react-dom/src/client/DOMAccessibilityRoles.js
+++ b/packages/react-dom/src/client/DOMAccessibilityRoles.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Below code forked from dom-accessibility-api
+
+const tagToRoleMappings = {
+  ARTICLE: 'article',
+  ASIDE: 'complementary',
+  BODY: 'document',
+  BUTTON: 'button',
+  DATALIST: 'listbox',
+  DD: 'definition',
+  DETAILS: 'group',
+  DIALOG: 'dialog',
+  DT: 'term',
+  FIELDSET: 'group',
+  FIGURE: 'figure',
+  // WARNING: Only with an accessible name
+  FORM: 'form',
+  FOOTER: 'contentinfo',
+  H1: 'heading',
+  H2: 'heading',
+  H3: 'heading',
+  H4: 'heading',
+  H5: 'heading',
+  H6: 'heading',
+  HEADER: 'banner',
+  HR: 'separator',
+  LEGEND: 'legend',
+  LI: 'listitem',
+  MATH: 'math',
+  MAIN: 'main',
+  MENU: 'list',
+  NAV: 'navigation',
+  OL: 'list',
+  OPTGROUP: 'group',
+  // WARNING: Only in certain context
+  OPTION: 'option',
+  OUTPUT: 'status',
+  PROGRESS: 'progressbar',
+  // WARNING: Only with an accessible name
+  SECTION: 'region',
+  SUMMARY: 'button',
+  TABLE: 'table',
+  TBODY: 'rowgroup',
+  TEXTAREA: 'textbox',
+  TFOOT: 'rowgroup',
+  // WARNING: Only in certain context
+  TD: 'cell',
+  TH: 'columnheader',
+  THEAD: 'rowgroup',
+  TR: 'row',
+  UL: 'list',
+};
+
+function getImplicitRole(element: Element): string | null {
+  const mappedByTag = tagToRoleMappings[element.tagName];
+  if (mappedByTag !== undefined) {
+    return mappedByTag;
+  }
+
+  switch (element.tagName) {
+    case 'A':
+    case 'AREA':
+    case 'LINK':
+      if (element.hasAttribute('href')) {
+        return 'link';
+      }
+      break;
+    case 'IMG':
+      if ((element.getAttribute('alt') || '').length > 0) {
+        return 'img';
+      }
+      break;
+    case 'INPUT': {
+      const type = (element: any).type;
+      switch (type) {
+        case 'button':
+        case 'image':
+        case 'reset':
+        case 'submit':
+          return 'button';
+        case 'checkbox':
+        case 'radio':
+          return type;
+        case 'range':
+          return 'slider';
+        case 'email':
+        case 'tel':
+        case 'text':
+        case 'url':
+          if (element.hasAttribute('list')) {
+            return 'combobox';
+          }
+          return 'textbox';
+        case 'search':
+          if (element.hasAttribute('list')) {
+            return 'combobox';
+          }
+          return 'searchbox';
+        default:
+          return null;
+      }
+    }
+
+    case 'SELECT':
+      if (element.hasAttribute('multiple') || (element: any).size > 1) {
+        return 'listbox';
+      }
+      return 'combobox';
+  }
+
+  return null;
+}
+
+function getExplicitRole(element: Element): string | null {
+  const role = element.getAttribute('role');
+  if (role) {
+    return role.trim().split(' ')[0];
+  }
+
+  return null;
+}
+
+// https://w3c.github.io/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html
+export function getRole(element: Element): string | null {
+  const explicitRole = getExplicitRole(element);
+
+  if (explicitRole !== null) {
+    return explicitRole;
+  }
+
+  return getImplicitRole(element);
+}

--- a/packages/react-dom/src/client/DOMAccessibilityRoles.js
+++ b/packages/react-dom/src/client/DOMAccessibilityRoles.js
@@ -119,21 +119,21 @@ function getImplicitRole(element: Element): string | null {
   return null;
 }
 
-function getExplicitRole(element: Element): string | null {
+function getExplicitRoles(element: Element): Array<string> | null {
   const role = element.getAttribute('role');
   if (role) {
-    return role.trim().split(' ')[0];
+    return role.trim().split(' ');
   }
 
   return null;
 }
 
 // https://w3c.github.io/html-aria/#document-conformance-requirements-for-use-of-aria-attributes-in-html
-export function getRole(element: Element): string | null {
-  const explicitRole = getExplicitRole(element);
-  if (explicitRole !== null) {
-    return explicitRole;
+export function hasRole(element: Element, role: string): boolean {
+  const explicitRoles = getExplicitRoles(element);
+  if (explicitRoles !== null && explicitRoles.indexOf(role) >= 0) {
+    return true;
   }
 
-  return getImplicitRole(element);
+  return role === getImplicitRole(element);
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1224,7 +1224,7 @@ export function setFocusIfFocusable(node: Instance): boolean {
   const element = ((node: any): HTMLElement);
   try {
     element.addEventListener('focus', handleFocus);
-    element.focus();
+    (element.focus || HTMLElement.prototype.focus).call(element);
   } finally {
     element.removeEventListener('focus', handleFocus);
   }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -30,6 +30,7 @@ import {
   getInstanceFromNode as getInstanceFromNodeDOMTree,
   isContainerMarkedAsRoot,
 } from './ReactDOMComponentTree';
+import {getRole} from './DOMAccessibilityRoles';
 import {
   createElement,
   createTextNode,
@@ -77,6 +78,7 @@ import {
   enableModernEventSystem,
   enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
+import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
 import {listenToEvent} from '../events/DOMModernPluginEventSystem';
 
@@ -1155,8 +1157,9 @@ export const supportsTestSelectors = true;
 
 export function findRootFiber(node: Instance): null | Fiber {
   const stack = [node];
-  while (stack.length > 0) {
-    const current = stack.shift();
+  let index = 0;
+  while (index < stack.length) {
+    const current = stack[index++];
     if (isContainerMarkedAsRoot(current)) {
       const root = ((getInstanceFromNodeDOMTree(current): any): Fiber);
       return root.stateNode.current;
@@ -1174,6 +1177,43 @@ export function getBoundingRect(node: Instance): BoundingRect {
     width: rect.width,
     height: rect.height,
   };
+}
+
+export function matchAccessibilityRole(
+  fiber: Fiber,
+  targetRole: string,
+): boolean {
+  if (fiber.tag === HostComponent) {
+    const node = fiber.stateNode;
+    const inferredRole = getRole(node);
+    if (targetRole === inferredRole) {
+      return true;
+    }
+    if (node.getAttribute('role') === targetRole) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getTextContent(fiber: Fiber): string | null {
+  switch (fiber.tag) {
+    case HostComponent:
+      let textContent = '';
+      const childNodes = fiber.stateNode.childNodes;
+      for (let i = 0; i < childNodes.length; i++) {
+        const childNode = childNodes[i];
+        if (childNode.nodeType === Node.TEXT_NODE) {
+          textContent += childNode.textContent;
+        }
+      }
+      return textContent;
+    case HostText:
+      return fiber.stateNode.textContent;
+  }
+
+  return null;
 }
 
 export function isHiddenSubtree(workInProgress: Fiber): boolean {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1210,49 +1210,18 @@ export function isHiddenSubtree(fiber: Fiber): boolean {
 }
 
 export function setFocusIfFocusable(node: Instance): boolean {
-  if (node.nodeType !== Node.ELEMENT_NODE) {
-    // Text and comment nodes aren't focusable.
-    // Technically this check should not be necessary,
-    // since React treats elements (Instances) and text (TextInstance) differently.
-    return false;
-  }
-
-  if (((node: any): HTMLInputElement).disabled === true) {
-    // Disabled inputs can't be focused.
-    return false;
-  }
-
-  const element = ((node: any): HTMLElement);
-
-  if (element.tabIndex === null || element.tabIndex < 0) {
-    // The HTML spec says that negative tab index values indicate an element should be,
-    // "click focusable but not sequentially focusable".
-    // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute
-    //
-    // The HTML focusable spec also says,
-    // "User agents should consider focusable areas with non-null tabindex values to be click focusable."
-    // https://html.spec.whatwg.org/multipage/interaction.html#focusable
-    //
-    // Despite this, it seems like some browsers (e.g. Chrome, Firefox) return -1 even for elements
-    // that don't accept focus, like HTMLImageElement or the outermost HTMLElement tag.
-    // I think this method should (at least for now) only concern itself with "sequentially focusable" elements.
-    // https://html.spec.whatwg.org/multipage/interaction.html#sequentially-focusable
-    return false;
-  }
-
-  if (element.offsetWidth === 0 || element.offsetHeight === 0) {
-    // Hidden items can't be focused.
-    return false;
-  }
-
-  // At this point we assume the element accepts focus, so let's try and see.
-  // Listen for a "focus" event to verify that focus was set.
+  // The logic for determining if an element is focusable is kind of complex,
+  // and since we want to actually change focus anyway- we can just skip it.
+  // Instead we'll just listen for a "focus" event to verify that focus was set.
+  //
   // We could compare the node to document.activeElement after focus,
   // but this would not handle the case where application code managed focus to automatically blur.
   let didFocus = false;
   const handleFocus = () => {
     didFocus = true;
   };
+
+  const element = ((node: any): HTMLElement);
   try {
     element.addEventListener('focus', handleFocus);
     element.focus();

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -30,7 +30,7 @@ import {
   getInstanceFromNode as getInstanceFromNodeDOMTree,
   isContainerMarkedAsRoot,
 } from './ReactDOMComponentTree';
-import {getRole} from './DOMAccessibilityRoles';
+import {hasRole} from './DOMAccessibilityRoles';
 import {
   createElement,
   createTextNode,
@@ -1179,7 +1179,7 @@ export function getBoundingRect(node: Instance): BoundingRect {
 }
 
 export function matchAccessibilityRole(node: Instance, role: string): boolean {
-  if (role === getRole(node)) {
+  if (hasRole(node, role)) {
     return true;
   }
 

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1155,7 +1155,7 @@ export function getInstanceFromScope(
 
 export const supportsTestSelectors = true;
 
-export function findRootFiber(node: Instance): null | FiberRoot {
+export function findFiberRoot(node: Instance): null | FiberRoot {
   const stack = [node];
   let index = 0;
   while (index < stack.length) {
@@ -1178,12 +1178,9 @@ export function getBoundingRect(node: Instance): BoundingRect {
   };
 }
 
-export function matchAccessibilityRole(fiber: Fiber, role: string): boolean {
-  if (fiber.tag === HostComponent) {
-    const node = fiber.stateNode;
-    if (role === getRole(node)) {
-      return true;
-    }
+export function matchAccessibilityRole(node: Instance, role: string): boolean {
+  if (role === getRole(node)) {
+    return true;
   }
 
   return false;
@@ -1208,8 +1205,8 @@ export function getTextContent(fiber: Fiber): string | null {
   return null;
 }
 
-export function isHiddenSubtree(workInProgress: Fiber): boolean {
-  return workInProgress.pendingProps.hidden === true;
+export function isHiddenSubtree(fiber: Fiber): boolean {
+  return fiber.tag === HostComponent && fiber.memoizedProps.hidden === true;
 }
 
 export function setFocusIfFocusable(node: Instance): boolean {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -8,7 +8,7 @@
  */
 
 import type {TopLevelType} from 'legacy-events/TopLevelEventTypes';
-import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {Fiber, FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
 import type {
   BoundingRect,
   IntersectionObserverOptions,
@@ -1155,14 +1155,13 @@ export function getInstanceFromScope(
 
 export const supportsTestSelectors = true;
 
-export function findRootFiber(node: Instance): null | Fiber {
+export function findRootFiber(node: Instance): null | FiberRoot {
   const stack = [node];
   let index = 0;
   while (index < stack.length) {
     const current = stack[index++];
     if (isContainerMarkedAsRoot(current)) {
-      const root = ((getInstanceFromNodeDOMTree(current): any): Fiber);
-      return root.stateNode.current;
+      return ((getInstanceFromNodeDOMTree(current): any): FiberRoot);
     }
     stack.push(...current.children);
   }
@@ -1179,17 +1178,10 @@ export function getBoundingRect(node: Instance): BoundingRect {
   };
 }
 
-export function matchAccessibilityRole(
-  fiber: Fiber,
-  targetRole: string,
-): boolean {
+export function matchAccessibilityRole(fiber: Fiber, role: string): boolean {
   if (fiber.tag === HostComponent) {
     const node = fiber.stateNode;
-    const inferredRole = getRole(node);
-    if (targetRole === inferredRole) {
-      return true;
-    }
-    if (node.getAttribute('role') === targetRole) {
+    if (role === getRole(node)) {
       return true;
     }
   }

--- a/packages/react-dom/testing.classic.fb.js
+++ b/packages/react-dom/testing.classic.fb.js
@@ -8,4 +8,16 @@
  */
 
 export * from './index.classic.fb.js';
-export {act} from 'react-reconciler/src/ReactFiberReconciler';
+export {
+  act,
+  createComponentSelector,
+  createHasPsuedoClassSelector,
+  createRoleSelector,
+  createTestNameSelector,
+  createTextSelector,
+  getFindAllNodesFailureDescription,
+  findAllNodes,
+  findBoundingRects,
+  focusWithin,
+  observeVisibleRects,
+} from 'react-reconciler/src/ReactFiberReconciler';

--- a/packages/react-dom/testing.js
+++ b/packages/react-dom/testing.js
@@ -10,6 +10,11 @@
 export * from './index.js';
 export {
   act,
+  createComponentSelector,
+  createHasPsuedoClassSelector,
+  createRoleSelector,
+  createTestNameSelector,
+  createTextSelector,
   getFindAllNodesFailureDescription,
   findAllNodes,
   findBoundingRects,

--- a/packages/react-dom/testing.js
+++ b/packages/react-dom/testing.js
@@ -8,4 +8,11 @@
  */
 
 export * from './index.js';
-export {act} from 'react-reconciler/src/ReactFiberReconciler';
+export {
+  act,
+  getFindAllNodesFailureDescription,
+  findAllNodes,
+  findBoundingRects,
+  focusWithin,
+  observeVisibleRects,
+} from 'react-reconciler/src/ReactFiberReconciler';

--- a/packages/react-dom/testing.modern.fb.js
+++ b/packages/react-dom/testing.modern.fb.js
@@ -8,4 +8,16 @@
  */
 
 export * from './index.modern.fb.js';
-export {act} from 'react-reconciler/src/ReactFiberReconciler';
+export {
+  act,
+  createComponentSelector,
+  createHasPsuedoClassSelector,
+  createRoleSelector,
+  createTestNameSelector,
+  createTextSelector,
+  getFindAllNodesFailureDescription,
+  findAllNodes,
+  findBoundingRects,
+  focusWithin,
+  observeVisibleRects,
+} from 'react-reconciler/src/ReactFiberReconciler';

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -184,6 +184,7 @@ class ReactFabricHostComponent {
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMutation';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 
 export function appendInitialChild(
   parentInstance: Instance,

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -88,6 +88,7 @@ function recursivelyUncacheFiberNode(node: Instance | TextInstance) {
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 
 export function appendInitialChild(
   parentInstance: Instance,

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors.js
@@ -23,7 +23,7 @@ function shim(...args: any) {
 
 // Test selectors (when unsupported)
 export const supportsTestSelectors = false;
-export const findRootFiber = shim;
+export const findFiberRoot = shim;
 export const getBoundingRect = shim;
 export const getTextContent = shim;
 export const isHiddenSubtree = shim;

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors.js
@@ -25,4 +25,8 @@ function shim(...args: any) {
 export const supportsTestSelectors = false;
 export const findRootFiber = shim;
 export const getBoundingRect = shim;
-export const canBeFocused = shim;
+export const getTextContent = shim;
+export const isHiddenSubtree = shim;
+export const matchAccessibilityRole = shim;
+export const setFocusIfFocusable = shim;
+export const setupIntersectionObserver = shim;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -39,6 +39,11 @@ import {
   injectIntoDevTools as injectIntoDevTools_old,
   act as act_old,
   createPortal as createPortal_old,
+  createComponentSelector as createComponentSelector_old,
+  createHasPsuedoClassSelector as createHasPsuedoClassSelector_old,
+  createRoleSelector as createRoleSelector_old,
+  createTestNameSelector as createTestNameSelector_old,
+  createTextSelector as createTextSelector_old,
   getFindAllNodesFailureDescription as getFindAllNodesFailureDescription_old,
   findAllNodes as findAllNodes_old,
   findBoundingRects as findBoundingRects_old,
@@ -71,6 +76,11 @@ import {
   injectIntoDevTools as injectIntoDevTools_new,
   act as act_new,
   createPortal as createPortal_new,
+  createComponentSelector as createComponentSelector_new,
+  createHasPsuedoClassSelector as createHasPsuedoClassSelector_new,
+  createRoleSelector as createRoleSelector_new,
+  createTestNameSelector as createTestNameSelector_new,
+  createTextSelector as createTextSelector_new,
   getFindAllNodesFailureDescription as getFindAllNodesFailureDescription_new,
   findAllNodes as findAllNodes_new,
   findBoundingRects as findBoundingRects_new,
@@ -146,6 +156,21 @@ export const act = enableNewReconciler ? act_new : act_old;
 export const createPortal = enableNewReconciler
   ? createPortal_new
   : createPortal_old;
+export const createComponentSelector = enableNewReconciler
+  ? createComponentSelector_new
+  : createComponentSelector_old;
+export const createHasPsuedoClassSelector = enableNewReconciler
+  ? createHasPsuedoClassSelector_new
+  : createHasPsuedoClassSelector_old;
+export const createRoleSelector = enableNewReconciler
+  ? createRoleSelector_new
+  : createRoleSelector_old;
+export const createTextSelector = enableNewReconciler
+  ? createTextSelector_new
+  : createTextSelector_old;
+export const createTestNameSelector = enableNewReconciler
+  ? createTestNameSelector_new
+  : createTestNameSelector_old;
 export const getFindAllNodesFailureDescription = enableNewReconciler
   ? getFindAllNodesFailureDescription_new
   : getFindAllNodesFailureDescription_old;

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -39,6 +39,11 @@ import {
   injectIntoDevTools as injectIntoDevTools_old,
   act as act_old,
   createPortal as createPortal_old,
+  getFindAllNodesFailureDescription as getFindAllNodesFailureDescription_old,
+  findAllNodes as findAllNodes_old,
+  findBoundingRects as findBoundingRects_old,
+  focusWithin as focusWithin_old,
+  observeVisibleRects as observeVisibleRects_old,
 } from './ReactFiberReconciler.old';
 
 import {
@@ -66,6 +71,11 @@ import {
   injectIntoDevTools as injectIntoDevTools_new,
   act as act_new,
   createPortal as createPortal_new,
+  getFindAllNodesFailureDescription as getFindAllNodesFailureDescription_new,
+  findAllNodes as findAllNodes_new,
+  findBoundingRects as findBoundingRects_new,
+  focusWithin as focusWithin_new,
+  observeVisibleRects as observeVisibleRects_new,
 } from './ReactFiberReconciler.new';
 
 export const createContainer = enableNewReconciler
@@ -136,3 +146,18 @@ export const act = enableNewReconciler ? act_new : act_old;
 export const createPortal = enableNewReconciler
   ? createPortal_new
   : createPortal_old;
+export const getFindAllNodesFailureDescription = enableNewReconciler
+  ? getFindAllNodesFailureDescription_new
+  : getFindAllNodesFailureDescription_old;
+export const findAllNodes = enableNewReconciler
+  ? findAllNodes_new
+  : findAllNodes_old;
+export const findBoundingRects = enableNewReconciler
+  ? findBoundingRects_new
+  : findBoundingRects_old;
+export const focusWithin = enableNewReconciler
+  ? focusWithin_new
+  : focusWithin_old;
+export const observeVisibleRects = enableNewReconciler
+  ? observeVisibleRects_new
+  : observeVisibleRects_old;

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -88,6 +88,13 @@ import {
 } from './ReactFiberHotReloading.new';
 
 export {createPortal} from './ReactPortal';
+export {
+  getFindAllNodesFailureDescription,
+  findAllNodes,
+  findBoundingRects,
+  focusWithin,
+  observeVisibleRects,
+} from './ReactTestSelectors';
 
 type OpaqueRoot = FiberRoot;
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -89,6 +89,11 @@ import {
 
 export {createPortal} from './ReactPortal';
 export {
+  createComponentSelector,
+  createHasPsuedoClassSelector,
+  createRoleSelector,
+  createTestNameSelector,
+  createTextSelector,
   getFindAllNodesFailureDescription,
   findAllNodes,
   findBoundingRects,

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -86,6 +86,13 @@ import {
 } from './ReactFiberHotReloading.old';
 
 export {createPortal} from './ReactPortal';
+export {
+  getFindAllNodesFailureDescription,
+  findAllNodes,
+  findBoundingRects,
+  focusWithin,
+  observeVisibleRects,
+} from './ReactTestSelectors';
 
 type OpaqueRoot = FiberRoot;
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -87,6 +87,11 @@ import {
 
 export {createPortal} from './ReactPortal';
 export {
+  createComponentSelector,
+  createHasPsuedoClassSelector,
+  createRoleSelector,
+  createTestNameSelector,
+  createTextSelector,
   getFindAllNodesFailureDescription,
   findAllNodes,
   findBoundingRects,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -192,7 +192,8 @@ import {
   hasCaughtError,
   clearCaughtError,
 } from 'shared/ReactErrorUtils';
-import {onCommitRoot} from './ReactFiberDevToolsHook.new';
+import {onCommitRoot as onCommitRootDevTools} from './ReactFiberDevToolsHook.new';
+import {onCommitRoot as onCommitRootTestSelector} from './ReactTestSelectors';
 
 // Used by `act`
 import enqueueTask from 'shared/enqueueTask';
@@ -1995,7 +1996,11 @@ function commitRootImpl(root, renderPriorityLevel) {
     nestedUpdateCount = 0;
   }
 
-  onCommitRoot(finishedWork.stateNode, renderPriorityLevel);
+  onCommitRootDevTools(finishedWork.stateNode, renderPriorityLevel);
+
+  if (__DEV__) {
+    onCommitRootTestSelector();
+  }
 
   // Always call this before exiting `commitRoot`, to ensure that any
   // additional work on this root is scheduled.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -189,7 +189,8 @@ import {
   hasCaughtError,
   clearCaughtError,
 } from 'shared/ReactErrorUtils';
-import {onCommitRoot} from './ReactFiberDevToolsHook.old';
+import {onCommitRoot as onCommitRootDevTools} from './ReactFiberDevToolsHook.old';
+import {onCommitRoot as onCommitRootTestSelector} from './ReactTestSelectors';
 
 // Used by `act`
 import enqueueTask from 'shared/enqueueTask';
@@ -2119,7 +2120,11 @@ function commitRootImpl(root, renderPriorityLevel) {
     nestedUpdateCount = 0;
   }
 
-  onCommitRoot(finishedWork.stateNode, expirationTime);
+  onCommitRootDevTools(finishedWork.stateNode, expirationTime);
+
+  if (__DEV__) {
+    onCommitRootTestSelector();
+  }
 
   // Always call this before exiting `commitRoot`, to ensure that any
   // additional work on this root is scheduled.

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -122,12 +122,14 @@ function findRootFiberForHostRoot(hostRoot: Instance): Fiber {
     );
     return ((maybeFiber: any): Fiber);
   } else {
-    const root = findRootFiber(hostRoot);
+    const fiberRoot = findRootFiber(hostRoot);
     invariant(
-      root !== null,
+      fiberRoot !== null,
       'Could not find React container within specified host subtree.',
     );
-    return root;
+    // The Flow type for FiberRoot is a little funky.
+    // createFiberRoot() cheats this by treating the root as :any and adding stateNode lazily.
+    return ((fiberRoot: any).stateNode.current: Fiber);
   }
 }
 

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -1,0 +1,404 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {Instance} from './ReactFiberHostConfig';
+
+import invariant from 'shared/invariant';
+import {HostComponent} from 'react-reconciler/src/ReactWorkTags';
+import getComponentName from 'shared/getComponentName';
+import {
+  findRootFiber,
+  getBoundingRect,
+  getInstanceFromNode,
+  isHiddenSubtree,
+  setFocusIfFocusable,
+  setupIntersectionObserver,
+  supportsTestSelectors,
+} from './ReactFiberHostConfig';
+
+type ComponentTypeSelector = Array<React$AbstractComponent<empty, mixed>>;
+
+function findRootFiberForHostRoot(hostRoot: Instance): Fiber {
+  const maybeFiber = getInstanceFromNode((hostRoot: any));
+  if (maybeFiber != null) {
+    invariant(
+      typeof maybeFiber.memoizedProps['data-testname'] === 'string',
+      'Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes().',
+    );
+    return ((maybeFiber: any): Fiber);
+  } else {
+    const root = findRootFiber(hostRoot);
+    invariant(
+      root !== null,
+      'Could not find React container within specified host subtree.',
+    );
+    return root;
+  }
+}
+
+function findPathsMatchingComponentTypesSelector(
+  root: Fiber,
+  componentTypeSelector: ComponentTypeSelector,
+): Array<Fiber> {
+  const componentTypePaths: Array<Fiber> = [];
+
+  const stack = [root, 0];
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+    let componentTypeIndex = ((stack.shift(): any): number);
+
+    if (node.type === componentTypeSelector[componentTypeIndex]) {
+      componentTypeIndex++;
+    }
+
+    if (componentTypeIndex === componentTypeSelector.length) {
+      componentTypePaths.push(node);
+    } else {
+      let child = node.child;
+      while (child !== null) {
+        stack.push(child, componentTypeIndex);
+        child = child.sibling;
+      }
+    }
+  }
+
+  return componentTypePaths;
+}
+
+function matchTestName(fiber: Fiber, targetTestName: string): boolean {
+  if (fiber.tag === HostComponent) {
+    const dataTestName = fiber.memoizedProps['data-testname'];
+    return (
+      typeof dataTestName === 'string' &&
+      dataTestName.toLowerCase() === targetTestName.toLowerCase()
+    );
+  }
+  return false;
+}
+
+export function findAllNodes(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+  dataTestName: string,
+): Array<Instance> {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const root = findRootFiberForHostRoot(hostRoot);
+
+  const componentTypePaths = findPathsMatchingComponentTypesSelector(
+    root,
+    componentTypeSelector,
+  );
+
+  const matchingInstances: Array<Instance> = [];
+
+  const stack = Array.from(componentTypePaths);
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+
+    if (node.tag === HostComponent) {
+      if (isHiddenSubtree(node)) {
+        continue;
+      }
+      if (matchTestName(node, dataTestName)) {
+        matchingInstances.push(node.stateNode);
+      }
+    }
+
+    let child = node.child;
+    while (child !== null) {
+      stack.push(child);
+      child = child.sibling;
+    }
+  }
+
+  return matchingInstances;
+}
+
+export function getFindAllNodesFailureDescription(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+  dataTestName: string,
+): string | null {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const root = findRootFiberForHostRoot(hostRoot);
+
+  const componentTypePaths: Array<Fiber> = [];
+
+  let maxComponentTypeIndex: number = 0;
+  const matchedNames = [];
+
+  // The logic of this loop should be kept in sync with findPathsMatchingComponentTypesSelector()
+  let stack = [root, 0];
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+    let componentTypeIndex = ((stack.shift(): any): number);
+
+    if (node.type === componentTypeSelector[componentTypeIndex]) {
+      matchedNames.push(getComponentName(node.type));
+      componentTypeIndex++;
+      if (componentTypeIndex > maxComponentTypeIndex) {
+        maxComponentTypeIndex = componentTypeIndex;
+      }
+    }
+
+    if (componentTypeIndex === componentTypeSelector.length) {
+      componentTypePaths.push(node);
+    } else {
+      let child = node.child;
+      while (child !== null) {
+        stack.push(child, componentTypeIndex);
+        child = child.sibling;
+      }
+    }
+  }
+
+  if (maxComponentTypeIndex < componentTypeSelector.length) {
+    const unmatchedNames = [];
+
+    for (let i = maxComponentTypeIndex; i < componentTypeSelector.length; i++) {
+      unmatchedNames.push(getComponentName(componentTypeSelector[i]));
+    }
+
+    return (
+      'findAllNodes was able to match part of the selector:\n' +
+      `  ${matchedNames.join(' > ')}\n\n` +
+      'No matching component was found for:\n' +
+      `  ${unmatchedNames.join(' > ')}`
+    );
+  }
+
+  const dataTestNames: Set<string> = new Set();
+
+  stack = Array.from(componentTypePaths);
+
+  // The logic of this loop shouild be kept in sync with Test selector API
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+
+    if (node.tag === HostComponent) {
+      if (isHiddenSubtree(node)) {
+        continue;
+      }
+
+      if (matchTestName(node, dataTestName)) {
+        // If we find at least one match, there's nothing for this method to return.
+        return null;
+      } else {
+        // If this component has a testname, add it to the set.
+        const name = node.memoizedProps['data-testname'];
+        if (typeof name === 'string') {
+          dataTestNames.add(name);
+        }
+      }
+    }
+
+    let child = node.child;
+    while (child !== null) {
+      stack.push(child);
+      child = child.sibling;
+    }
+  }
+
+  return (
+    `No host element was found with the test name "${dataTestName}".\n\n` +
+    'The following test names were found in the matched subtree:\n' +
+    '  ' +
+    Array.from(dataTestNames)
+      .sort((a, b) => a.localeCompare(b))
+      .join('\n  ')
+  );
+}
+
+function findInstanceRoots(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+): Array<Instance> {
+  const root = findRootFiberForHostRoot(hostRoot);
+  const componentTypePaths = findPathsMatchingComponentTypesSelector(
+    root,
+    componentTypeSelector,
+  );
+
+  const instanceRoots: Array<Instance> = [];
+  const stack = Array.from(componentTypePaths);
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+    if (node.tag === HostComponent) {
+      if (isHiddenSubtree(node)) {
+        continue;
+      }
+      instanceRoots.push(node.stateNode);
+    } else {
+      let child = node.child;
+      while (child !== null) {
+        stack.push(child);
+        child = child.sibling;
+      }
+    }
+  }
+
+  return instanceRoots;
+}
+
+export type BoundingRect = {|
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+|};
+
+export function findBoundingRects(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+): Array<BoundingRect> {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const instanceRoots = findInstanceRoots(hostRoot, componentTypeSelector);
+
+  const boundingRects: Array<BoundingRect> = [];
+  for (let i = 0; i < instanceRoots.length; i++) {
+    boundingRects.push(getBoundingRect(instanceRoots[i]));
+  }
+
+  for (let i = boundingRects.length - 1; i >= 0; i--) {
+    const targetRect = boundingRects[i];
+    for (let j = boundingRects.length - 1; j >= 0; j--) {
+      if (i !== j) {
+        const otherRect = boundingRects[j];
+        if (
+          targetRect.x >= otherRect.x &&
+          targetRect.y >= otherRect.y &&
+          targetRect.x + targetRect.width <= otherRect.x + otherRect.width &&
+          targetRect.y + targetRect.height <= otherRect.y + otherRect.height
+        ) {
+          boundingRects.splice(i, 1);
+          break;
+        }
+      }
+    }
+  }
+
+  // TODO We may also want to combine rects that intersect or are adjacent.
+  // We could at least handle the most common cases (e.g. same in one dimension).
+
+  return boundingRects;
+}
+
+export function focusWithin(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+): boolean {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const root = findRootFiberForHostRoot(hostRoot);
+  const componentTypePaths = findPathsMatchingComponentTypesSelector(
+    root,
+    componentTypeSelector,
+  );
+
+  const stack = Array.from(componentTypePaths);
+  while (stack.length > 0) {
+    const node = ((stack.shift(): any): Fiber);
+    if (node.tag === HostComponent) {
+      if (isHiddenSubtree(node)) {
+        continue;
+      }
+      if (setFocusIfFocusable(node.stateNode)) {
+        return true;
+      }
+    }
+
+    let child = node.child;
+    while (child !== null) {
+      stack.push(child);
+      child = child.sibling;
+    }
+  }
+
+  return false;
+}
+
+const commitHooks: Array<Function> = [];
+
+export function onCommitRoot(): void {
+  if (supportsTestSelectors) {
+    commitHooks.forEach(commitHook => commitHook());
+  }
+}
+
+export type IntersectionObserverOptions = Object;
+
+export type ObserveVisibleRectsCallback = (
+  intersections: Array<{ratio: number, rect: BoundingRect}>,
+) => void;
+
+export function observeVisibleRects(
+  hostRoot: Instance,
+  componentTypeSelector: ComponentTypeSelector,
+  callback: (intersections: Array<{ratio: number, rect: BoundingRect}>) => void,
+  options?: IntersectionObserverOptions,
+): {|disconnect: () => void|} {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const instanceRoots = findInstanceRoots(hostRoot, componentTypeSelector);
+
+  const {disconnect, observe, unobserve} = setupIntersectionObserver(
+    instanceRoots,
+    callback,
+    options,
+  );
+
+  // When React mutates the host environment, we may need to change what we're listening to.
+  const commitHook = () => {
+    const nextInstanceRoots = findInstanceRoots(
+      hostRoot,
+      componentTypeSelector,
+    );
+
+    instanceRoots.forEach(target => {
+      if (nextInstanceRoots.indexOf(target) < 0) {
+        unobserve(target);
+      }
+    });
+
+    nextInstanceRoots.forEach(target => {
+      if (instanceRoots.indexOf(target) < 0) {
+        observe(target);
+      }
+    });
+  };
+
+  commitHooks.push(commitHook);
+
+  return {
+    disconnect: () => {
+      // Stop listening for React mutations:
+      const index = commitHooks.indexOf(commitHook);
+      if (index >= 0) {
+        commitHooks.splice(index, 1);
+      }
+
+      // Disconnect the host observer:
+      disconnect();
+    },
+  };
+}

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -11,26 +11,114 @@ import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {Instance} from './ReactFiberHostConfig';
 
 import invariant from 'shared/invariant';
-import {HostComponent} from 'react-reconciler/src/ReactWorkTags';
+import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 import {
   findRootFiber,
   getBoundingRect,
   getInstanceFromNode,
+  getTextContent,
   isHiddenSubtree,
+  matchAccessibilityRole,
   setFocusIfFocusable,
   setupIntersectionObserver,
   supportsTestSelectors,
 } from './ReactFiberHostConfig';
 
-type ComponentTypeSelector = Array<React$AbstractComponent<empty, mixed>>;
+let COMPONENT_TYPE = 0b000;
+let HAS_PSEUDO_CLASS_TYPE = 0b001;
+let ROLE_TYPE = 0b010;
+let TEST_NAME_TYPE = 0b011;
+let TEXT_TYPE = 0b100;
+
+if (typeof Symbol === 'function' && Symbol.for) {
+  const symbolFor = Symbol.for;
+  COMPONENT_TYPE = symbolFor('selector.component');
+  HAS_PSEUDO_CLASS_TYPE = symbolFor('selector.has_pseudo_class');
+  ROLE_TYPE = symbolFor('selector.role');
+  TEST_NAME_TYPE = symbolFor('selector.test_id');
+  TEXT_TYPE = symbolFor('selector.text');
+}
+
+type Type = Symbol | number;
+
+type ComponentSelector = {|
+  $$typeof: Type,
+  value: React$AbstractComponent<empty, mixed>,
+|};
+
+type HasPsuedoClassSelector = {|
+  $$typeof: Type,
+  value: Array<Selector>,
+|};
+
+type RoleSelector = {|
+  $$typeof: Type,
+  value: string,
+|};
+
+type TextSelector = {|
+  $$typeof: Type,
+  value: string,
+|};
+
+type TestNameSelector = {|
+  $$typeof: Type,
+  value: string,
+|};
+
+type Selector =
+  | ComponentSelector
+  | HasPsuedoClassSelector
+  | RoleSelector
+  | TextSelector
+  | TestNameSelector;
+
+export function createComponentSelector(
+  component: React$AbstractComponent<empty, mixed>,
+): ComponentSelector {
+  return {
+    $$typeof: COMPONENT_TYPE,
+    value: component,
+  };
+}
+
+export function createHasPsuedoClassSelector(
+  selectors: Array<Selector>,
+): HasPsuedoClassSelector {
+  return {
+    $$typeof: HAS_PSEUDO_CLASS_TYPE,
+    value: selectors,
+  };
+}
+
+export function createRoleSelector(role: string): RoleSelector {
+  return {
+    $$typeof: ROLE_TYPE,
+    value: role,
+  };
+}
+
+export function createTextSelector(text: string): TextSelector {
+  return {
+    $$typeof: TEXT_TYPE,
+    value: text,
+  };
+}
+
+export function createTestNameSelector(id: string): TestNameSelector {
+  return {
+    $$typeof: TEST_NAME_TYPE,
+    value: id,
+  };
+}
 
 function findRootFiberForHostRoot(hostRoot: Instance): Fiber {
   const maybeFiber = getInstanceFromNode((hostRoot: any));
   if (maybeFiber != null) {
     invariant(
       typeof maybeFiber.memoizedProps['data-testname'] === 'string',
-      'Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes().',
+      'Invalid host root specified. Should be either a React container or a node with a testname attribute.',
     );
     return ((maybeFiber: any): Fiber);
   } else {
@@ -43,199 +131,125 @@ function findRootFiberForHostRoot(hostRoot: Instance): Fiber {
   }
 }
 
-function findPathsMatchingComponentTypesSelector(
-  root: Fiber,
-  componentTypeSelector: ComponentTypeSelector,
-): Array<Fiber> {
-  const componentTypePaths: Array<Fiber> = [];
+function matchSelector(fiber: Fiber, selector: Selector): boolean {
+  switch (selector.$$typeof) {
+    case COMPONENT_TYPE:
+      if (fiber.type === selector.value) {
+        return true;
+      }
+      break;
+    case HAS_PSEUDO_CLASS_TYPE:
+      // TODO (test-selectors) Implement this selector type.
+      break;
+    case ROLE_TYPE:
+      if (fiber.tag === HostComponent) {
+        if (
+          matchAccessibilityRole(fiber, ((selector: any): RoleSelector).value)
+        ) {
+          return true;
+        }
+      }
+      break;
+    case TEXT_TYPE:
+      if (fiber.tag === HostComponent || fiber.tag === HostText) {
+        const textContent = getTextContent(fiber);
+        if (
+          textContent !== null &&
+          textContent.indexOf(((selector: any): TextSelector).value) >= 0
+        ) {
+          return true;
+        }
+      }
+      break;
+    case TEST_NAME_TYPE:
+      if (fiber.tag === HostComponent) {
+        const dataTestID = fiber.memoizedProps['data-testname'];
+        if (
+          typeof dataTestID === 'string' &&
+          dataTestID.toLowerCase() ===
+            ((selector: any): TestNameSelector).value.toLowerCase()
+        ) {
+          return true;
+        }
+      }
+      break;
+    default:
+      invariant(null, 'Invalid selector type %s specified', selector);
+      break;
+  }
+
+  return false;
+}
+
+function selectorToString(selector: Selector): string | null {
+  switch (selector.$$typeof) {
+    case COMPONENT_TYPE:
+      const displayName = getComponentName(selector.value) || 'Unknown';
+      return `<${displayName}>`;
+    case HAS_PSEUDO_CLASS_TYPE:
+      // TODO (test-selectors) Implement this selector type.
+      break;
+    case ROLE_TYPE:
+      return `[role="${((selector: any): RoleSelector).value}"]`;
+    case TEXT_TYPE:
+      return `"${((selector: any): TextSelector).value}"`;
+    case TEST_NAME_TYPE:
+      return `[data-testname="${((selector: any): TestNameSelector).value}"]`;
+    default:
+      invariant(null, 'Invalid selector type %s specified', selector);
+      break;
+  }
+
+  return null;
+}
+
+function findPaths(root: Fiber, selectors: Array<Selector>): Array<Fiber> {
+  const matchingFibers: Array<Fiber> = [];
 
   const stack = [root, 0];
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
-    let componentTypeIndex = ((stack.shift(): any): number);
+  let index = 0;
+  while (index < stack.length) {
+    const fiber = ((stack[index++]: any): Fiber);
+    let selectorIndex = ((stack[index++]: any): number);
+    const selector = selectors[selectorIndex];
 
-    if (node.type === componentTypeSelector[componentTypeIndex]) {
-      componentTypeIndex++;
+    if (fiber.tag === HostComponent && isHiddenSubtree(fiber)) {
+      continue;
+    } else if (matchSelector(fiber, selector)) {
+      selectorIndex++;
     }
 
-    if (componentTypeIndex === componentTypeSelector.length) {
-      componentTypePaths.push(node);
+    if (selectorIndex === selectors.length) {
+      matchingFibers.push(fiber);
     } else {
-      let child = node.child;
+      let child = fiber.child;
       while (child !== null) {
-        stack.push(child, componentTypeIndex);
+        stack.push(child, selectorIndex);
         child = child.sibling;
       }
     }
   }
 
-  return componentTypePaths;
-}
-
-function matchTestName(fiber: Fiber, targetTestName: string): boolean {
-  if (fiber.tag === HostComponent) {
-    const dataTestName = fiber.memoizedProps['data-testname'];
-    return (
-      typeof dataTestName === 'string' &&
-      dataTestName.toLowerCase() === targetTestName.toLowerCase()
-    );
-  }
-  return false;
+  return matchingFibers;
 }
 
 export function findAllNodes(
   hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
-  dataTestName: string,
+  selectors: Array<Selector>,
 ): Array<Instance> {
   if (!supportsTestSelectors) {
     invariant(false, 'Test selector API is not supported by this renderer.');
   }
 
   const root = findRootFiberForHostRoot(hostRoot);
-
-  const componentTypePaths = findPathsMatchingComponentTypesSelector(
-    root,
-    componentTypeSelector,
-  );
-
-  const matchingInstances: Array<Instance> = [];
-
-  const stack = Array.from(componentTypePaths);
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
-
-    if (node.tag === HostComponent) {
-      if (isHiddenSubtree(node)) {
-        continue;
-      }
-      if (matchTestName(node, dataTestName)) {
-        matchingInstances.push(node.stateNode);
-      }
-    }
-
-    let child = node.child;
-    while (child !== null) {
-      stack.push(child);
-      child = child.sibling;
-    }
-  }
-
-  return matchingInstances;
-}
-
-export function getFindAllNodesFailureDescription(
-  hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
-  dataTestName: string,
-): string | null {
-  if (!supportsTestSelectors) {
-    invariant(false, 'Test selector API is not supported by this renderer.');
-  }
-
-  const root = findRootFiberForHostRoot(hostRoot);
-
-  const componentTypePaths: Array<Fiber> = [];
-
-  let maxComponentTypeIndex: number = 0;
-  const matchedNames = [];
-
-  // The logic of this loop should be kept in sync with findPathsMatchingComponentTypesSelector()
-  let stack = [root, 0];
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
-    let componentTypeIndex = ((stack.shift(): any): number);
-
-    if (node.type === componentTypeSelector[componentTypeIndex]) {
-      matchedNames.push(getComponentName(node.type));
-      componentTypeIndex++;
-      if (componentTypeIndex > maxComponentTypeIndex) {
-        maxComponentTypeIndex = componentTypeIndex;
-      }
-    }
-
-    if (componentTypeIndex === componentTypeSelector.length) {
-      componentTypePaths.push(node);
-    } else {
-      let child = node.child;
-      while (child !== null) {
-        stack.push(child, componentTypeIndex);
-        child = child.sibling;
-      }
-    }
-  }
-
-  if (maxComponentTypeIndex < componentTypeSelector.length) {
-    const unmatchedNames = [];
-
-    for (let i = maxComponentTypeIndex; i < componentTypeSelector.length; i++) {
-      unmatchedNames.push(getComponentName(componentTypeSelector[i]));
-    }
-
-    return (
-      'findAllNodes was able to match part of the selector:\n' +
-      `  ${matchedNames.join(' > ')}\n\n` +
-      'No matching component was found for:\n' +
-      `  ${unmatchedNames.join(' > ')}`
-    );
-  }
-
-  const dataTestNames: Set<string> = new Set();
-
-  stack = Array.from(componentTypePaths);
-
-  // The logic of this loop shouild be kept in sync with Test selector API
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
-
-    if (node.tag === HostComponent) {
-      if (isHiddenSubtree(node)) {
-        continue;
-      }
-
-      if (matchTestName(node, dataTestName)) {
-        // If we find at least one match, there's nothing for this method to return.
-        return null;
-      } else {
-        // If this component has a testname, add it to the set.
-        const name = node.memoizedProps['data-testname'];
-        if (typeof name === 'string') {
-          dataTestNames.add(name);
-        }
-      }
-    }
-
-    let child = node.child;
-    while (child !== null) {
-      stack.push(child);
-      child = child.sibling;
-    }
-  }
-
-  return (
-    `No host element was found with the test name "${dataTestName}".\n\n` +
-    'The following test names were found in the matched subtree:\n' +
-    '  ' +
-    Array.from(dataTestNames)
-      .sort((a, b) => a.localeCompare(b))
-      .join('\n  ')
-  );
-}
-
-function findInstanceRoots(
-  hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
-): Array<Instance> {
-  const root = findRootFiberForHostRoot(hostRoot);
-  const componentTypePaths = findPathsMatchingComponentTypesSelector(
-    root,
-    componentTypeSelector,
-  );
+  const matchingFibers = findPaths(root, selectors);
 
   const instanceRoots: Array<Instance> = [];
-  const stack = Array.from(componentTypePaths);
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
+
+  const stack = Array.from(matchingFibers);
+  let index = 0;
+  while (index < stack.length) {
+    const node = ((stack[index++]: any): Fiber);
     if (node.tag === HostComponent) {
       if (isHiddenSubtree(node)) {
         continue;
@@ -253,6 +267,64 @@ function findInstanceRoots(
   return instanceRoots;
 }
 
+export function getFindAllNodesFailureDescription(
+  hostRoot: Instance,
+  selectors: Array<Selector>,
+): string | null {
+  if (!supportsTestSelectors) {
+    invariant(false, 'Test selector API is not supported by this renderer.');
+  }
+
+  const root = findRootFiberForHostRoot(hostRoot);
+
+  let maxSelectorIndex: number = 0;
+  const matchedNames = [];
+
+  // The logic of this loop should be kept in sync with findPaths()
+  const stack = [root, 0];
+  let index = 0;
+  while (index < stack.length) {
+    const fiber = ((stack[index++]: any): Fiber);
+    let selectorIndex = ((stack[index++]: any): number);
+    const selector = selectors[selectorIndex];
+
+    if (fiber.tag === HostComponent && isHiddenSubtree(fiber)) {
+      continue;
+    } else if (matchSelector(fiber, selector)) {
+      matchedNames.push(selectorToString(selector));
+      selectorIndex++;
+
+      if (selectorIndex > maxSelectorIndex) {
+        maxSelectorIndex = selectorIndex;
+      }
+    }
+
+    if (selectorIndex < selectors.length) {
+      let child = fiber.child;
+      while (child !== null) {
+        stack.push(child, selectorIndex);
+        child = child.sibling;
+      }
+    }
+  }
+
+  if (maxSelectorIndex < selectors.length) {
+    const unmatchedNames = [];
+    for (let i = maxSelectorIndex; i < selectors.length; i++) {
+      unmatchedNames.push(selectorToString(selectors[i]));
+    }
+
+    return (
+      'findAllNodes was able to match part of the selector:\n' +
+      `  ${matchedNames.join(' > ')}\n\n` +
+      'No matching component was found for:\n' +
+      `  ${unmatchedNames.join(' > ')}`
+    );
+  }
+
+  return null;
+}
+
 export type BoundingRect = {|
   x: number,
   y: number,
@@ -262,13 +334,13 @@ export type BoundingRect = {|
 
 export function findBoundingRects(
   hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
+  selectors: Array<Selector>,
 ): Array<BoundingRect> {
   if (!supportsTestSelectors) {
     invariant(false, 'Test selector API is not supported by this renderer.');
   }
 
-  const instanceRoots = findInstanceRoots(hostRoot, componentTypeSelector);
+  const instanceRoots = findAllNodes(hostRoot, selectors);
 
   const boundingRects: Array<BoundingRect> = [];
   for (let i = 0; i < instanceRoots.length; i++) {
@@ -301,21 +373,19 @@ export function findBoundingRects(
 
 export function focusWithin(
   hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
+  selectors: Array<Selector>,
 ): boolean {
   if (!supportsTestSelectors) {
     invariant(false, 'Test selector API is not supported by this renderer.');
   }
 
   const root = findRootFiberForHostRoot(hostRoot);
-  const componentTypePaths = findPathsMatchingComponentTypesSelector(
-    root,
-    componentTypeSelector,
-  );
+  const matchingFibers = findPaths(root, selectors);
 
-  const stack = Array.from(componentTypePaths);
-  while (stack.length > 0) {
-    const node = ((stack.shift(): any): Fiber);
+  const stack = Array.from(matchingFibers);
+  let index = 0;
+  while (index < stack.length) {
+    const node = ((stack[index++]: any): Fiber);
     if (node.tag === HostComponent) {
       if (isHiddenSubtree(node)) {
         continue;
@@ -351,7 +421,7 @@ export type ObserveVisibleRectsCallback = (
 
 export function observeVisibleRects(
   hostRoot: Instance,
-  componentTypeSelector: ComponentTypeSelector,
+  selectors: Array<Selector>,
   callback: (intersections: Array<{ratio: number, rect: BoundingRect}>) => void,
   options?: IntersectionObserverOptions,
 ): {|disconnect: () => void|} {
@@ -359,7 +429,7 @@ export function observeVisibleRects(
     invariant(false, 'Test selector API is not supported by this renderer.');
   }
 
-  const instanceRoots = findInstanceRoots(hostRoot, componentTypeSelector);
+  const instanceRoots = findAllNodes(hostRoot, selectors);
 
   const {disconnect, observe, unobserve} = setupIntersectionObserver(
     instanceRoots,
@@ -369,10 +439,7 @@ export function observeVisibleRects(
 
   // When React mutates the host environment, we may need to change what we're listening to.
   const commitHook = () => {
-    const nextInstanceRoots = findInstanceRoots(
-      hostRoot,
-      componentTypeSelector,
-    );
+    const nextInstanceRoots = findAllNodes(hostRoot, selectors);
 
     instanceRoots.forEach(target => {
       if (nextInstanceRoots.indexOf(target) < 0) {

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -93,7 +93,7 @@ export const getInstanceFromScope = $$$hostConfig.getInstanceFromScope;
 //     (optional)
 // -------------------
 export const supportsTestSelectors = $$$hostConfig.supportsTestSelectors;
-export const findRootFiber = $$$hostConfig.findRootFiber;
+export const findFiberRoot = $$$hostConfig.findFiberRoot;
 export const getBoundingRect = $$$hostConfig.getBoundingRect;
 export const getTextContent = $$$hostConfig.getTextContent;
 export const isHiddenSubtree = $$$hostConfig.isHiddenSubtree;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -89,6 +89,20 @@ export const prepareScopeUnmount = $$$hostConfig.prepareScopeUnmount;
 export const getInstanceFromScope = $$$hostConfig.getInstanceFromScope;
 
 // -------------------
+//      Test selectors
+//     (optional)
+// -------------------
+export const supportsTestSelectors = $$$hostConfig.supportsTestSelectors;
+export const findRootFiber = $$$hostConfig.findRootFiber;
+export const getBoundingRect = $$$hostConfig.getBoundingRect;
+export const getTextContent = $$$hostConfig.getTextContent;
+export const isHiddenSubtree = $$$hostConfig.isHiddenSubtree;
+export const matchAccessibilityRole = $$$hostConfig.matchAccessibilityRole;
+export const setFocusIfFocusable = $$$hostConfig.setFocusIfFocusable;
+export const setupIntersectionObserver =
+  $$$hostConfig.setupIntersectionObserver;
+
+// -------------------
 //      Mutation
 //     (optional)
 // -------------------

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -56,6 +56,7 @@ export type RendererInspectionConfig = $ReadOnly<{||}>;
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 
 const EVENT_COMPONENT_CONTEXT = {};
 const NO_CONTEXT = {};

--- a/packages/shared/HostConfigWithNoTestSelectors.js
+++ b/packages/shared/HostConfigWithNoTestSelectors.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from 'shared/invariant';
+
+// Renderers that don't support test selectors
+// can re-export everything from this module.
+
+function shim(...args: any) {
+  invariant(
+    false,
+    'The current renderer does not support test selectors. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
+}
+
+// Test selectors (when unsupported)
+export const supportsTestSelectors = false;
+export const findRootFiber = shim;
+export const getBoundingRect = shim;
+export const canBeFocused = shim;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -364,5 +364,12 @@
   "364": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
   "365": "Test selector API is not supported by this renderer.",
   "366": "Could not find React container within specified host subtree.",
-  "367": "Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes()."
+  "367": "Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes().",
+  "368": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
+  "369": "findAllNodes() is not supported by this renderer.",
+  "370": "Could not find React container within specified host subtree.",
+  "371": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
+  "372": "Test selector API is not supported by this renderer.",
+  "373": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
+  "374": "Invalid selector type %s specified"
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -357,5 +357,12 @@
   "357": "The current renderer does not support React Scopes. This error is likely caused by a bug in React. Please file an issue.",
   "358": "Invalid update priority: %s. This is a bug in React.",
   "359": "Invalid transition priority: %s. This is a bug in React.",
-  "360": "Invalid lane: %s. This is a bug in React."
+  "360": "Invalid lane: %s. This is a bug in React.",
+  "361": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
+  "362": "findAllNodes() is not supported by this renderer.",
+  "363": "Could not find React container within specified host subtree.",
+  "364": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
+  "365": "Test selector API is not supported by this renderer.",
+  "366": "Could not find React container within specified host subtree.",
+  "367": "Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes()."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -371,5 +371,10 @@
   "371": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
   "372": "Test selector API is not supported by this renderer.",
   "373": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
-  "374": "Invalid selector type %s specified"
+  "374": "Invalid selector type %s specified",
+  "375": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
+  "376": "Could not find React container within specified host subtree.",
+  "377": "Test selector API is not supported by this renderer.",
+  "378": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
+  "379": "Invalid selector type %s specified."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -1,3 +1,4 @@
+
 {
   "0": "React.addons.createFragment(...): Encountered an invalid child; DOM elements are not valid children of React components.",
   "1": "update(): expected target of %s to be an array; got %s.",
@@ -359,22 +360,8 @@
   "359": "Invalid transition priority: %s. This is a bug in React.",
   "360": "Invalid lane: %s. This is a bug in React.",
   "361": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
-  "362": "findAllNodes() is not supported by this renderer.",
-  "363": "Could not find React container within specified host subtree.",
-  "364": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
-  "365": "Test selector API is not supported by this renderer.",
-  "366": "Could not find React container within specified host subtree.",
-  "367": "Invalid host root specified. Should be either a React container or a node previously returned by findAllNodes().",
-  "368": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
-  "369": "findAllNodes() is not supported by this renderer.",
-  "370": "Could not find React container within specified host subtree.",
-  "371": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
-  "372": "Test selector API is not supported by this renderer.",
-  "373": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
-  "374": "Invalid selector type %s specified",
-  "375": "The current renderer does not support test selectors. This error is likely caused by a bug in React. Please file an issue.",
-  "376": "Could not find React container within specified host subtree.",
-  "377": "Test selector API is not supported by this renderer.",
-  "378": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
-  "379": "Invalid selector type %s specified."
+  "362": "Could not find React container within specified host subtree.",
+  "363": "Test selector API is not supported by this renderer.",
+  "364": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
+  "365": "Invalid selector type %s specified."
 }


### PR DESCRIPTION
Adds several new experimental APIs to aid with automated testing.

This is not an RFC, although the PR includes some basic documentation in a similar format.

## Types of selectors

Each of the methods below accepts an array of "selectors" that identifies a path (or paths) through a React tree. There are four basic selector types:
* **Component**: Matches `Fibers` with the specified React component type
* **Role**: Matches Host Instances matching the (explicit or implicit) accessibility role.
* **Test name**: Matches Host Instances with a `data-testname` attribute.
* **Text**: Matches Host Instances that **directly** contain the specified text.

There is also a special *lookahead* selector type that enables further matching within a path (without actually including the path in the result). This selector type was inspired by the [`:has()` CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has). It enables e.g. matching a `<section>` that contained a specific header text, then finding a like button within that `<section>`.

## API

### `findAllNodes()`

Finds all Host Instances (e.g. `HTMLElement`) within a host subtree that match the specified selector criteria.

```js
function findAllNodes(
  hostRoot: Instance,
  selector: Array<Selector>
): Array<Instance>
```

#### How does it work?

* This method starts searching at the specified root, which must be either:
    * A host parent node above the React container (e.g. `document.body`) in which case, React will traverse the native tree until it finds the first React container, or...
    * A React container, or...
    * A React-rendered Host Instance with a `data-testname` attribute (e.g. a match from an earlier `findAllNodes` query).
* Starting from the root (or React container) React traverses the internal `Fiber` tree ¹ looking for all paths matching the specified selector.
    * While traversing the tree, each node will be compared to the current selector index.
        * If the criteria is satisfied, the selector index is advanced.
        * Otherwise the tree traversal continues.
    * Once all selector criteria have been satisfied, the remaining subtree is searched for the topmost Host Instances (might be several for Fragments).

¹ Traversing the `Fiber` tree (instead of the host tree) provides several benefits:
* Easier to implement and share cross-renderer logic.
* Portals (e.g. tooltips) can be matched even if they are in a different host tree.

#### What does it return?

* An array of the topmost Host Instances (e.g. `HTMLElement`s) that match the specified criteria. (This array will be empty if no matches are found.)

## `getFindAllNodesFailureDescription()`

Returns an error string describing the matched and unmatched portions of the selector query.

```js
function getFindAllNodesFailureDescription(
  hostRoot: Instance,
  selector: Array<Selector>
): string | null
```

#### How does it work?

* This methods processes selectors in the same way as findAllNodes.

#### What does it return?

* If the full selector query is able to be matched, this method returns null.
* Otherwise, it returns a string describing how far it was able to match. For example:
```
findAllNodes was able to match part of the selector:
  <App> > <Navigation>

No matching component was found for:
  <UserProfiler> > [data-testname="edit"]
```

### `findBoundingRects()`

For all React components within a host subtree that match the specified selector criteria, return a set of bounding boxes that covers the bounds of the nearest (shallowed) Host Instances within those trees.

```js
function findBoundingRects(
  hostRoot: Instance,
  selector: Array<Selector>
): Array<Rect>
```

#### How does it work?

* This methods processes selectors in the same way as `findAllNodes`.
* Within each matching path:
    * Find the first Host Instances in the matched component. (Might be several for Fragments.)
    * For each Host Instance, call a `getBoundingClientRect` Host Config method. Add the result to a list of matched boxes.
    * Optionally merge adjacent boxes and exclude boxes that are fully covered by other boxes. (This ensure less reliance on implementation details like how many nodes make up the tree.)
* Return the list of matches bounds.

#### What does it return?

* An array of bounding boxes relative to the viewport. E.g. `{ x: number, y: number, width: number, height: number }`
* (This array will be empty if no matches are found.) 

#### What can this API be used for?

* Clicking or hovering over the center of a Component.
* Take a snapshot of the Component for screen shot tests.
* Assert on the maximum size a component is expected to take up.
* Scrolling the Component into view.

### `observeVisibleRects()`

For all React components within a host subtree that match the specified selector criteria, observe if it’s bounding rect is visible in the viewport and is not occluded.

```js
function observeVisibleRects(
  hostRoot: Instance,
  selector: Array<Selector>,
  callback: (intersectingRects: Array<{ ratio: number, rect: Rect }>) => void,
  options: IntersectionObserverOptions,
): { disconnect(): void }
```

How does it work?

* Create a new [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/) or equivalent `HostConfig` specific API, passing a callback and options argument to it.
    *  Note: Host Config implementation needs to convert each entry into an object containing only `{ ratio, rect }`, otherwise this callback works the same as the DOM version.
* This methods processes selectors in the same way as `findAllNodes`.
* Within each matching path:
    * Find the first Host Instances in the matched component. (Might be several for Fragments.)
    * For each Host Instance, call the `observe(intersectionObserver, instance)` Host Config method to add it to the list to be observed.
* Attach an internal (for test builds only) callback to the React reconciler that is called every time React commits a new update.
    * When this callback is invoked, disconnect the `Observer` and start over from the top to attach a new one. This makes this observation live updating. This prevents accidentally relying on implementation details such as if a DOM node is reused or remounted.

#### What does it return?

* An object containing a `disconnect()` method. When this method is called, we disconnect the `IntersectionObserver` and disconnect the callback in the React reconciler.

#### What can this API be used for?

* Waiting for a Component to become visible before doing further operations.
* Asserting that a Component is already visible.

#### Why is this API necessary?

* Ideally `findBoundingRects` would be enough for this but these APIs don’t give access to where in the DOM this component is, nor really all the other things that might obscuring the bounding rect. This lets us solve this use case without exposing more implementation details and we can build in details such as if it’s obscured by something virtual (e.g. if an ART component is covered by another ART component within a canvas).

### focusWithin()

For all React components within a host subtree that match the specified selector criteria, set focus within the first focusable Host Instance (as if you started before this component in the tree and moved focus forwards one step).

```js
function focusWithin(
  hostRoot: Instance,
  selector: Array<Selector>
): boolean
```

The internal structure of a node is an implementation detail. However, you can start from the outside of a component and move forward (e.g. hit tab) to focus within a component. This has behavior that is defined, and so it can be thought of as part of the public API fo the component.

With the Focus Selectors API used for a11y we might be able to even expose more specific capabilities for the outside of a component move focus into a child.

#### How does it work?

* This methods processes selectors in the same way as `findAllNodes`.
* Within each matching path:
    * Find the first Host Instances in the matched component. (Might be several for Fragments.)
    * For each Host Instance:
        * Focus the Host Instance IIF it is considered Focusable by the Host Config.
        * Return true once we’ve found a focusable Host Instance.
* If we didn’t find a focusable Host Instance, return false.

#### What does it return?

* A boolean indicating if something focusable was found and focus was set on it.

#### What can this API be used for?

* Setting focus on the canonical part of a Component such as text input.

## Usage examples

Coming soon. (For now, refer to unit tests.)