### PR TITLE
Fix incorrect unmounted state update warning

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -116,7 +116,7 @@ import {
   Snapshot,
   Callback,
   Passive,
-  PassiveUnmountPending,
+  PassiveUnmountPendingDev,
   Incomplete,
   HostEffectMask,
   Hydrating,
@@ -2313,10 +2313,10 @@ export function enqueuePendingPassiveHookEffectUnmount(
     pendingPassiveHookEffectsUnmount.push(effect, fiber);
     if (__DEV__) {
       if (deferPassiveEffectCleanupDuringUnmount) {
-        fiber.effectTag |= PassiveUnmountPending;
+        fiber.effectTag |= PassiveUnmountPendingDev;
         const alternate = fiber.alternate;
         if (alternate !== null) {
-          alternate.effectTag |= PassiveUnmountPending;
+          alternate.effectTag |= PassiveUnmountPendingDev;
         }
       }
     }
@@ -2385,10 +2385,10 @@ function flushPassiveEffectsImpl() {
 
       if (__DEV__) {
         if (deferPassiveEffectCleanupDuringUnmount) {
-          fiber.effectTag &= ~PassiveUnmountPending;
+          fiber.effectTag &= ~PassiveUnmountPendingDev;
           const alternate = fiber.alternate;
           if (alternate !== null) {
-            alternate.effectTag &= ~PassiveUnmountPending;
+            alternate.effectTag &= ~PassiveUnmountPendingDev;
           }
         }
       }
@@ -2872,7 +2872,7 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     ) {
       // If there are pending passive effects unmounts for this Fiber,
       // we can assume that they would have prevented this update.
-      if ((fiber.effectTag & PassiveUnmountPending) !== NoEffect) {
+      if ((fiber.effectTag & PassiveUnmountPendingDev) !== NoEffect) {
         return;
       }
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -260,6 +260,7 @@ let pendingPassiveEffectsRenderPriority: ReactPriorityLevel = NoPriority;
 let pendingPassiveEffectsExpirationTime: ExpirationTime = NoWork;
 let pendingPassiveHookEffectsMount: Array<HookEffect | Fiber> = [];
 let pendingPassiveHookEffectsUnmount: Array<HookEffect | Fiber> = [];
+let pendingPassiveHookEffectsUnmountAlternatesDEV: Array<Fiber> = [];
 let pendingPassiveProfilerEffects: Array<Fiber> = [];
 
 let rootsWithPendingDiscreteUpdates: Map<
@@ -2329,6 +2330,15 @@ export function enqueuePendingPassiveHookEffectUnmount(
 ): void {
   if (runAllPassiveEffectDestroysBeforeCreates) {
     pendingPassiveHookEffectsUnmount.push(effect, fiber);
+    if (__DEV__) {
+      if (deferPassiveEffectCleanupDuringUnmount) {
+        if (fiber.alternate !== null) {
+          // Alternate pointers get disconnected during unmount.
+          // Track alternates explicitly here to avoid warning about state updates for unmounted components.
+          pendingPassiveHookEffectsUnmountAlternatesDEV.push(fiber.alternate);
+        }
+      }
+    }
     if (!rootDoesHavePassiveEffects) {
       rootDoesHavePassiveEffects = true;
       scheduleCallback(NormalPriority, () => {
@@ -2386,6 +2396,14 @@ function flushPassiveEffectsImpl() {
     // First pass: Destroy stale passive effects.
     const unmountEffects = pendingPassiveHookEffectsUnmount;
     pendingPassiveHookEffectsUnmount = [];
+    if (__DEV__) {
+      if (
+        deferPassiveEffectCleanupDuringUnmount &&
+        runAllPassiveEffectDestroysBeforeCreates
+      ) {
+        pendingPassiveHookEffectsUnmountAlternatesDEV = [];
+      }
+    }
     for (let i = 0; i < unmountEffects.length; i += 2) {
       const effect = ((unmountEffects[i]: any): HookEffect);
       const fiber = ((unmountEffects[i + 1]: any): Fiber);
@@ -2873,7 +2891,10 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     ) {
       // If there are pending passive effects unmounts for this Fiber,
       // we can assume that they would have prevented this update.
-      if (pendingPassiveHookEffectsUnmount.indexOf(fiber) >= 0) {
+      if (
+        pendingPassiveHookEffectsUnmount.indexOf(fiber) >= 0 ||
+        pendingPassiveHookEffectsUnmountAlternatesDEV.indexOf(fiber) >= 0
+      ) {
         return;
       }
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -116,7 +116,7 @@ import {
   Snapshot,
   Callback,
   Passive,
-  PassiveUnmountPending,
+  PassiveUnmountPendingDev,
   Incomplete,
   HostEffectMask,
   Hydrating,
@@ -2332,10 +2332,10 @@ export function enqueuePendingPassiveHookEffectUnmount(
     pendingPassiveHookEffectsUnmount.push(effect, fiber);
     if (__DEV__) {
       if (deferPassiveEffectCleanupDuringUnmount) {
-        fiber.effectTag |= PassiveUnmountPending;
+        fiber.effectTag |= PassiveUnmountPendingDev;
         const alternate = fiber.alternate;
         if (alternate !== null) {
-          alternate.effectTag |= PassiveUnmountPending;
+          alternate.effectTag |= PassiveUnmountPendingDev;
         }
       }
     }
@@ -2404,10 +2404,10 @@ function flushPassiveEffectsImpl() {
 
       if (__DEV__) {
         if (deferPassiveEffectCleanupDuringUnmount) {
-          fiber.effectTag &= ~PassiveUnmountPending;
+          fiber.effectTag &= ~PassiveUnmountPendingDev;
           const alternate = fiber.alternate;
           if (alternate !== null) {
-            alternate.effectTag &= ~PassiveUnmountPending;
+            alternate.effectTag &= ~PassiveUnmountPendingDev;
           }
         }
       }
@@ -2894,7 +2894,7 @@ function warnAboutUpdateOnUnmountedFiberInDEV(fiber) {
     ) {
       // If there are pending passive effects unmounts for this Fiber,
       // we can assume that they would have prevented this update.
-      if ((fiber.effectTag & PassiveUnmountPending) !== NoEffect) {
+      if ((fiber.effectTag & PassiveUnmountPendingDev) !== NoEffect) {
         return;
       }
     }

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -10,29 +10,29 @@
 export type SideEffectTag = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoEffect = /*              */ 0b00000000000000;
-export const PerformedWork = /*         */ 0b00000000000001;
+export const NoEffect = /*                 */ 0b00000000000000;
+export const PerformedWork = /*            */ 0b00000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*             */ 0b00000000000010;
-export const Update = /*                */ 0b00000000000100;
-export const PlacementAndUpdate = /*    */ 0b00000000000110;
-export const Deletion = /*              */ 0b00000000001000;
-export const ContentReset = /*          */ 0b00000000010000;
-export const Callback = /*              */ 0b00000000100000;
-export const DidCapture = /*            */ 0b00000001000000;
-export const Ref = /*                   */ 0b00000010000000;
-export const Snapshot = /*              */ 0b00000100000000;
-export const Passive = /*               */ 0b00001000000000;
-export const PassiveUnmountPending = /* */ 0b10000000000000;
-export const Hydrating = /*             */ 0b00010000000000;
-export const HydratingAndUpdate = /*    */ 0b00010000000100;
+export const Placement = /*                */ 0b00000000000010;
+export const Update = /*                   */ 0b00000000000100;
+export const PlacementAndUpdate = /*       */ 0b00000000000110;
+export const Deletion = /*                 */ 0b00000000001000;
+export const ContentReset = /*             */ 0b00000000010000;
+export const Callback = /*                 */ 0b00000000100000;
+export const DidCapture = /*               */ 0b00000001000000;
+export const Ref = /*                      */ 0b00000010000000;
+export const Snapshot = /*                 */ 0b00000100000000;
+export const Passive = /*                  */ 0b00001000000000;
+export const PassiveUnmountPendingDev = /* */ 0b10000000000000;
+export const Hydrating = /*                */ 0b00010000000000;
+export const HydratingAndUpdate = /*       */ 0b00010000000100;
 
 // Passive & Update & Callback & Ref & Snapshot
-export const LifecycleEffectMask = /*   */ 0b00001110100100;
+export const LifecycleEffectMask = /*      */ 0b00001110100100;
 
 // Union of all host effects
-export const HostEffectMask = /*        */ 0b00011111111111;
+export const HostEffectMask = /*           */ 0b00011111111111;
 
-export const Incomplete = /*            */ 0b00100000000000;
-export const ShouldCapture = /*         */ 0b01000000000000;
+export const Incomplete = /*               */ 0b00100000000000;
+export const ShouldCapture = /*            */ 0b01000000000000;

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -10,28 +10,29 @@
 export type SideEffectTag = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoEffect = /*              */ 0b0000000000000;
-export const PerformedWork = /*         */ 0b0000000000001;
+export const NoEffect = /*              */ 0b00000000000000;
+export const PerformedWork = /*         */ 0b00000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*             */ 0b0000000000010;
-export const Update = /*                */ 0b0000000000100;
-export const PlacementAndUpdate = /*    */ 0b0000000000110;
-export const Deletion = /*              */ 0b0000000001000;
-export const ContentReset = /*          */ 0b0000000010000;
-export const Callback = /*              */ 0b0000000100000;
-export const DidCapture = /*            */ 0b0000001000000;
-export const Ref = /*                   */ 0b0000010000000;
-export const Snapshot = /*              */ 0b0000100000000;
-export const Passive = /*               */ 0b0001000000000;
-export const Hydrating = /*             */ 0b0010000000000;
-export const HydratingAndUpdate = /*    */ 0b0010000000100;
+export const Placement = /*             */ 0b00000000000010;
+export const Update = /*                */ 0b00000000000100;
+export const PlacementAndUpdate = /*    */ 0b00000000000110;
+export const Deletion = /*              */ 0b00000000001000;
+export const ContentReset = /*          */ 0b00000000010000;
+export const Callback = /*              */ 0b00000000100000;
+export const DidCapture = /*            */ 0b00000001000000;
+export const Ref = /*                   */ 0b00000010000000;
+export const Snapshot = /*              */ 0b00000100000000;
+export const Passive = /*               */ 0b00001000000000;
+export const PassiveUnmountPending = /* */ 0b10000000000000;
+export const Hydrating = /*             */ 0b00010000000000;
+export const HydratingAndUpdate = /*    */ 0b00010000000100;
 
 // Passive & Update & Callback & Ref & Snapshot
-export const LifecycleEffectMask = /*   */ 0b0001110100100;
+export const LifecycleEffectMask = /*   */ 0b00001110100100;
 
 // Union of all host effects
-export const HostEffectMask = /*        */ 0b0011111111111;
+export const HostEffectMask = /*        */ 0b00011111111111;
 
-export const Incomplete = /*            */ 0b0100000000000;
-export const ShouldCapture = /*         */ 0b1000000000000;
+export const Incomplete = /*            */ 0b00100000000000;
+export const ShouldCapture = /*         */ 0b01000000000000;


### PR DESCRIPTION
There was a recent report within Facebook of an invalid "_can't perform a React state update on an unmounted component_" warning that was eventually reduced to the fact that the Fiber being warned about was not tracked in the `pendingPassiveHookEffectsUnmount` array, but it's alternate **was**.

Unfortunately, because we detach fibers (which nulls the `.alternate` field) when we commit a deletion, any state updates scheduled between that point and the eventual passive effects flush won't have a way to check if there is a pending passive unmount effect scheduled for the alternate *unless we also explicitly track the alternates*.

~~This fix feels heavy handed and gross to me. Is there a better solution that I'm overlooking?~~ Rather than tracking both sets of Fibers, this PR uses a new DEV-only effect that indicates if the Fiber has a pending passive unmount effect scheduled.

Relates to PR #18096