### PR TITLE
ADD: disableRemotePlayback attribute for HTML5 videos

### DIFF
--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -449,6 +449,11 @@ const attributes = [
   },
   {name: 'disabled', tagName: 'input'},
   {
+    name: 'disableRemotePlayback',
+    tagName: 'video',
+    read: getProperty('disableremoteplayback'),
+  },
+  {
     name: 'disablePictureInPicture',
     tagName: 'video',
     read: getProperty('disablepictureinpicture'),

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -449,14 +449,14 @@ const attributes = [
   },
   {name: 'disabled', tagName: 'input'},
   {
-    name: 'disableRemotePlayback',
-    tagName: 'video',
-    read: getProperty('disableremoteplayback'),
-  },
-  {
     name: 'disablePictureInPicture',
     tagName: 'video',
     read: getProperty('disablepictureinpicture'),
+  },
+  {
+    name: 'disableRemotePlayback',
+    tagName: 'video',
+    read: getProperty('disableremoteplayback'),
   },
   {
     name: 'display',

--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -336,6 +336,7 @@ reservedProps.forEach(name => {
   'defer',
   'disabled',
   'disablePictureInPicture',
+  'disableRemotePlayback',
   'formNoValidate',
   'hidden',
   'loop',

--- a/packages/react-dom/src/shared/possibleStandardNames.js
+++ b/packages/react-dom/src/shared/possibleStandardNames.js
@@ -55,6 +55,7 @@ const possibleStandardNames = {
   dir: 'dir',
   disabled: 'disabled',
   disablepictureinpicture: 'disablePictureInPicture',
+  disableremoteplayback: 'disableRemotePlayback',
   download: 'download',
   draggable: 'draggable',
   enctype: 'encType',


### PR DESCRIPTION
This is a fix for issue #18618.

Given this has a wide browser support, I think this should be available.