### PR TITLE
feat(react-dom): Add enterKeyHint

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -3223,6 +3223,31 @@
 | `end=(null)`| (initial)| `<null>` |
 | `end=(undefined)`| (initial)| `<null>` |
 
+## `enterKeyHint` (on `<input>` inside `<div>`)
+| Test Case | Flags | Result |
+| --- | --- | --- |
+| `enterKeyHint=(string)`| (initial)| `<empty string>` |
+| `enterKeyHint=(empty string)`| (initial)| `<empty string>` |
+| `enterKeyHint=(array with string)`| (initial)| `<empty string>` |
+| `enterKeyHint=(empty array)`| (initial)| `<empty string>` |
+| `enterKeyHint=(object)`| (initial)| `<empty string>` |
+| `enterKeyHint=(numeric string)`| (initial)| `<empty string>` |
+| `enterKeyHint=(-1)`| (initial)| `<empty string>` |
+| `enterKeyHint=(0)`| (initial)| `<empty string>` |
+| `enterKeyHint=(integer)`| (initial)| `<empty string>` |
+| `enterKeyHint=(NaN)`| (initial, warning)| `<empty string>` |
+| `enterKeyHint=(float)`| (initial)| `<empty string>` |
+| `enterKeyHint=(true)`| (initial, warning)| `<empty string>` |
+| `enterKeyHint=(false)`| (initial, warning)| `<empty string>` |
+| `enterKeyHint=(string 'true')`| (initial)| `<empty string>` |
+| `enterKeyHint=(string 'false')`| (initial)| `<empty string>` |
+| `enterKeyHint=(string 'on')`| (initial)| `<empty string>` |
+| `enterKeyHint=(string 'off')`| (initial)| `<empty string>` |
+| `enterKeyHint=(symbol)`| (initial, warning)| `<empty string>` |
+| `enterKeyHint=(function)`| (initial, warning)| `<empty string>` |
+| `enterKeyHint=(null)`| (initial)| `<empty string>` |
+| `enterKeyHint=(undefined)`| (initial)| `<empty string>` |
+
 ## `exponent` (on `<feFuncA>` inside `<svg>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |

--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -557,6 +557,11 @@ const attributes = [
     read: getSVGAttribute('end'),
   },
   {
+    name: 'enterKeyHint',
+    tagName: 'input',
+    read: getProperty('enterKeyHint'),
+  },
+  {
     name: 'exponent',
     read: getSVGProperty('exponent'),
     containerTagName: 'svg',

--- a/packages/react-dom/src/shared/possibleStandardNames.js
+++ b/packages/react-dom/src/shared/possibleStandardNames.js
@@ -59,6 +59,7 @@ const possibleStandardNames = {
   download: 'download',
   draggable: 'draggable',
   enctype: 'encType',
+  enterkeyhint: 'enterKeyHint',
   for: 'htmlFor',
   form: 'form',
   formmethod: 'formMethod',


### PR DESCRIPTION
## Summary

```diff
-<input enterkeyhint="search" />
+<input enterKeyHint="search" />
```

- [WHATWG spec](https://html.spec.whatwg.org/multipage/interaction.html#attr-enterkeyhint)
- [Chrome Platform Status](https://www.chromestatus.com/feature/5654529808793600)
- supported in chrome 77, safari 13.1, [firefox intents to implement it](https://bugzilla.mozilla.org/show_bug.cgi?id=1490661)
## Test Plan

Ran /fixtures/attribute-behavior locally. Results available under https://drive.google.com/open?id=1j5PJgc-NcKXsGZh8GqBfHXHfdEwd9ii_.

Note: Should I update the fixture for `inputMode` as well? It is still reading from the attribute but the property is [supported as of chrome 66](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode). 

https://github.com/facebook/react/blob/8c75389319d479dc5b2f2cf4b2c7084549913084/fixtures/attribute-behavior/src/attributes.js#L955

Codesandbox using this PR: https://codesandbox.io/s/enterkeyhint-6l5t3