### PR TITLE
Fix a ping preventing a root with Idle work from being rescheduled

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -94,6 +94,7 @@ export function isRootSuspendedAtTime(
 export function markRootSuspendedAtTime(
   root: FiberRoot,
   expirationTime: ExpirationTime,
+  isRendering: boolean,
 ): void {
   const firstSuspendedTime = root.firstSuspendedTime;
   const lastSuspendedTime = root.lastSuspendedTime;
@@ -104,7 +105,11 @@ export function markRootSuspendedAtTime(
     root.lastSuspendedTime = expirationTime;
   }
 
-  if (expirationTime <= root.lastPingedTime) {
+  if (!isRendering && expirationTime <= root.lastPingedTime) {
+    // This function is sometimes called during rendering, but we can
+    // only set this field outside of the render work loop. Otherwise,
+    // we may drop updates because we wouldn't know there's more work to do.
+    // https://github.com/facebook/react/issues/18644
     root.lastPingedTime = NoWork;
   }
 

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -94,6 +94,7 @@ export function isRootSuspendedAtTime(
 export function markRootSuspendedAtTime(
   root: FiberRoot,
   expirationTime: ExpirationTime,
+  isRendering: boolean,
 ): void {
   const firstSuspendedTime = root.firstSuspendedTime;
   const lastSuspendedTime = root.lastSuspendedTime;
@@ -104,7 +105,11 @@ export function markRootSuspendedAtTime(
     root.lastSuspendedTime = expirationTime;
   }
 
-  if (expirationTime <= root.lastPingedTime) {
+  if (!isRendering && expirationTime <= root.lastPingedTime) {
+    // This function is sometimes called during rendering, but we can
+    // only set this field outside of the render work loop. Otherwise,
+    // we may drop updates because we wouldn't know there's more work to do.
+    // https://github.com/facebook/react/issues/18644
     root.lastPingedTime = NoWork;
   }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -543,7 +543,7 @@ function markUpdateTimeFromFiberToRoot(fiber, expirationTime) {
         // scheduled before the root started rendering. Need to track the next
         // pending expiration time (perhaps by backtracking the return path) and
         // then trigger a restart in the `renderDidSuspendDelayIfPossible` path.
-        markRootSuspendedAtTime(root, renderExpirationTime);
+        markRootSuspendedAtTime(root, renderExpirationTime, false);
       }
     }
     // Mark that the root has a pending update.
@@ -717,7 +717,7 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
     if (exitStatus === RootFatalErrored) {
       const fatalError = workInProgressRootFatalError;
       prepareFreshStack(root, expirationTime);
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       ensureRootIsScheduled(root);
       throw fatalError;
     }
@@ -761,7 +761,7 @@ function finishConcurrentRender(
       break;
     }
     case RootSuspended: {
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       const lastSuspendedTime = root.lastSuspendedTime;
 
       // We have an acceptable loading state. We need to figure out if we
@@ -829,7 +829,7 @@ function finishConcurrentRender(
       break;
     }
     case RootSuspendedWithDelay: {
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       const lastSuspendedTime = root.lastSuspendedTime;
 
       if (
@@ -920,7 +920,7 @@ function finishConcurrentRender(
           workInProgressRootCanSuspendUsingConfig,
         );
         if (msUntilTimeout > 10) {
-          markRootSuspendedAtTime(root, expirationTime);
+          markRootSuspendedAtTime(root, expirationTime, false);
           root.timeoutHandle = scheduleTimeout(
             commitRoot.bind(null, root),
             msUntilTimeout,
@@ -985,7 +985,7 @@ function performSyncWorkOnRoot(root) {
   if (exitStatus === RootFatalErrored) {
     const fatalError = workInProgressRootFatalError;
     prepareFreshStack(root, expirationTime);
-    markRootSuspendedAtTime(root, expirationTime);
+    markRootSuspendedAtTime(root, expirationTime, false);
     ensureRootIsScheduled(root);
     throw fatalError;
   }
@@ -1385,7 +1385,7 @@ export function renderDidSuspendDelayIfPossible(): void {
     // pending update.
     // TODO: This should immediately interrupt the current render, instead
     // of waiting until the next time we yield.
-    markRootSuspendedAtTime(workInProgressRoot, renderExpirationTime);
+    markRootSuspendedAtTime(workInProgressRoot, renderExpirationTime, true);
     markRootUpdatedAtTime(
       workInProgressRoot,
       workInProgressRootNextUnprocessedUpdateTime,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -536,7 +536,7 @@ function markUpdateTimeFromFiberToRoot(fiber, expirationTime) {
         // scheduled before the root started rendering. Need to track the next
         // pending expiration time (perhaps by backtracking the return path) and
         // then trigger a restart in the `renderDidSuspendDelayIfPossible` path.
-        markRootSuspendedAtTime(root, renderExpirationTime);
+        markRootSuspendedAtTime(root, renderExpirationTime, false);
       }
     }
     // Mark that the root has a pending update.
@@ -710,7 +710,7 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
     if (exitStatus === RootFatalErrored) {
       const fatalError = workInProgressRootFatalError;
       prepareFreshStack(root, expirationTime);
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       ensureRootIsScheduled(root);
       throw fatalError;
     }
@@ -754,7 +754,7 @@ function finishConcurrentRender(
       break;
     }
     case RootSuspended: {
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       const lastSuspendedTime = root.lastSuspendedTime;
 
       // We have an acceptable loading state. We need to figure out if we
@@ -822,7 +822,7 @@ function finishConcurrentRender(
       break;
     }
     case RootSuspendedWithDelay: {
-      markRootSuspendedAtTime(root, expirationTime);
+      markRootSuspendedAtTime(root, expirationTime, false);
       const lastSuspendedTime = root.lastSuspendedTime;
 
       if (
@@ -928,7 +928,7 @@ function finishConcurrentRender(
           workInProgressRootCanSuspendUsingConfig,
         );
         if (msUntilTimeout > 10) {
-          markRootSuspendedAtTime(root, expirationTime);
+          markRootSuspendedAtTime(root, expirationTime, false);
           root.timeoutHandle = scheduleTimeout(
             commitRoot.bind(null, root),
             msUntilTimeout,
@@ -993,7 +993,7 @@ function performSyncWorkOnRoot(root) {
   if (exitStatus === RootFatalErrored) {
     const fatalError = workInProgressRootFatalError;
     prepareFreshStack(root, expirationTime);
-    markRootSuspendedAtTime(root, expirationTime);
+    markRootSuspendedAtTime(root, expirationTime, false);
     ensureRootIsScheduled(root);
     throw fatalError;
   }
@@ -1383,7 +1383,7 @@ export function renderDidSuspendDelayIfPossible(): void {
     // pending update.
     // TODO: This should immediately interrupt the current render, instead
     // of waiting until the next time we yield.
-    markRootSuspendedAtTime(workInProgressRoot, renderExpirationTime);
+    markRootSuspendedAtTime(workInProgressRoot, renderExpirationTime, true);
     markRootUpdatedAtTime(
       workInProgressRoot,
       workInProgressRootNextUnprocessedUpdateTime,


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/18644.

I don't know if this is the correct fix model-wise. But it does fix both the sandbox and the product issue we found, and it doesn't fail any of our tests.

---

Here's the gist of the repro case:

<details>

We schedule a UB and Idle updates together. We start working on UB, and then also get a Normal update. For now we keep working on UB. Then we commit UB.

Now we start working on our Normal update. It has a fallback inside, so we're waiting for JND. We set a short timeout to commit Normal update. We mark Idle as the next pending level cause we didn't get to it yet. We also set workInProgressRoot to null because it's complete.

Then we get a ping! So we try Normal again. Because workInProgressRoot is null, we think we need to prepare a fresh stack. By preparing the fresh stack, we nuked the timeout. Well, who cares, we're retrying anyway, right?

This time we're gonna yield because we unlocked more CPU intensive components. The second time we're yielding, we're gonna look if it's okay to bail out because nextKnownPendingLevel is still 2 (Idle) from our first Normal attempt.

</details>

---

## Why This Fix?

I've noticed that the bailout respects `lastPingedTime` when it's set:

https://github.com/facebook/react/blob/f8b084276dc2595b19d021c73664d9aab3fc9f7e/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L567-L577

So if it was set, we wouldn't bail out. But in our particular case, a Suspense that doesn't want to get hidden calls `markRootSuspendedAtTime` **during render**:

https://github.com/facebook/react/blob/f8b084276dc2595b19d021c73664d9aab3fc9f7e/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L1382-L1386

And `markRootSuspendedAtTime` clears `lastPingedTime`. So by the time we decide whether to schedule the next callback or not, we think only Idle work is left. And we give up.

I've noticed then that `markRootSuspendedAtTime` gets called in two kinds of circumstances. During commits and elsewhere. I have a hunch (but might be wrong) that it's not legit to reset `lastPingedTime` until that commit is actually ready. Since we may still want to keep working on it. That's the fix.

I couldn't figure out a test case. My last attempt is in https://github.com/facebook/react/pull/18646. There's probably something simpler underneath if you just rely on information in this PR. Assuming this fix makes sense.