### PR TITLE
Revise isFiberInsideHiddenOrRemovedTree

### DIFF
--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -346,10 +346,15 @@ export function isFiberSuspenseAndTimedOut(fiber: Fiber): boolean {
 // It should not be used anywhere else. See PR #18609 for details.
 export function isFiberInsideHiddenOrRemovedTree(fiber: Fiber): boolean {
   let node = fiber;
+  let lastChild = null;
   while (node !== null) {
-    if (node.effectTag & Deletion || isFiberSuspenseAndTimedOut(node)) {
+    if (
+      node.effectTag & Deletion ||
+      (isFiberSuspenseAndTimedOut(node) && node.child === lastChild)
+    ) {
       return true;
     }
+    lastChild = node;
     node = node.return;
   }
   return false;


### PR DESCRIPTION
We can validate the `child` of the Suspense Component to see what branch the active element is in. Note: this is not a thorough fix, as it doesn't take into account the fact that the active element might be in both branches due to a lower-pri update.