### PR TITLE
Refine the heuristics around beforeblur/afterblur

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -306,6 +306,7 @@ export function getPublicInstance(instance) {
 
 export function prepareForCommit() {
   // Noop
+  return null;
 }
 
 export function prepareUpdate(domElement, type, oldProps, newProps) {

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -507,3 +507,11 @@ export function unmountEventListener(listener: any) {
 export function validateEventListenerTarget(target: any, listener: any) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeActiveInstanceBlur() {
+  // noop
+}
+
+export function afterActiveInstanceBlur() {
+  // noop
+}

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -242,10 +242,10 @@ export function getPublicInstance(instance: Instance): * {
   return instance;
 }
 
-export function prepareForCommit(containerInfo: Container): Object | void {
+export function prepareForCommit(containerInfo: Container): Object | null {
   eventsEnabled = ReactBrowserEventEmitterIsEnabled();
   selectionInformation = getSelectionInformation();
-  let activeInstance;
+  let activeInstance = null;
   if (enableDeprecatedFlareAPI || enableUseEventAPI) {
     const focusedElem = selectionInformation.focusedElem;
     if (focusedElem !== null) {

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -91,10 +91,6 @@ import {
 import {getListenerMapForElement} from '../events/DOMEventListenerMap';
 import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
 
-// TODO: This is an exposed internal, we should move this around
-// so this isn't the case.
-import {isFiberInsideHiddenOrRemovedTree} from 'react-reconciler/src/ReactFiberTreeReflection';
-
 export type ReactListenerEvent = ReactDOMListenerEvent;
 export type ReactListenerMap = ReactDOMListenerMap;
 export type ReactListener = ReactDOMListener;
@@ -159,7 +155,6 @@ export opaque type OpaqueIDType =
     };
 
 type SelectionInformation = {|
-  activeElementDetached: null | HTMLElement,
   focusedElem: null | HTMLElement,
   selectionRange: mixed,
 |};
@@ -247,32 +242,40 @@ export function getPublicInstance(instance: Instance): * {
   return instance;
 }
 
-export function prepareForCommit(containerInfo: Container): void {
+export function prepareForCommit(containerInfo: Container): Object | void {
   eventsEnabled = ReactBrowserEventEmitterIsEnabled();
   selectionInformation = getSelectionInformation();
+  let activeInstance;
   if (enableDeprecatedFlareAPI || enableUseEventAPI) {
     const focusedElem = selectionInformation.focusedElem;
     if (focusedElem !== null) {
-      const instance = getClosestInstanceFromNode(focusedElem);
-      if (instance !== null && isFiberInsideHiddenOrRemovedTree(instance)) {
-        dispatchBeforeDetachedBlur(focusedElem);
-      }
+      activeInstance = getClosestInstanceFromNode(focusedElem);
     }
   }
   ReactBrowserEventEmitterSetEnabled(false);
+  return activeInstance;
+}
+
+export function beforeActiveInstanceBlur(): void {
+  if (enableDeprecatedFlareAPI || enableUseEventAPI) {
+    ReactBrowserEventEmitterSetEnabled(true);
+    dispatchBeforeDetachedBlur((selectionInformation: any).focusedElem);
+    ReactBrowserEventEmitterSetEnabled(false);
+  }
+}
+
+export function afterActiveInstanceBlur(): void {
+  if (enableDeprecatedFlareAPI || enableUseEventAPI) {
+    ReactBrowserEventEmitterSetEnabled(true);
+    dispatchAfterDetachedBlur((selectionInformation: any).focusedElem);
+    ReactBrowserEventEmitterSetEnabled(false);
+  }
 }
 
 export function resetAfterCommit(containerInfo: Container): void {
   restoreSelection(selectionInformation);
   ReactBrowserEventEmitterSetEnabled(eventsEnabled);
   eventsEnabled = null;
-  if (enableDeprecatedFlareAPI || enableUseEventAPI) {
-    const activeElementDetached = (selectionInformation: any)
-      .activeElementDetached;
-    if (activeElementDetached !== null) {
-      dispatchAfterDetachedBlur(activeElementDetached);
-    }
-  }
   selectionInformation = null;
 }
 
@@ -525,8 +528,6 @@ function createEvent(type: TopLevelType): Event {
 }
 
 function dispatchBeforeDetachedBlur(target: HTMLElement): void {
-  ((selectionInformation: any): SelectionInformation).activeElementDetached = target;
-
   if (enableDeprecatedFlareAPI || enableUseEventAPI) {
     const event = createEvent(TOP_BEFORE_BLUR);
     // Dispatch "beforeblur" directly on the target,

--- a/packages/react-dom/src/client/ReactInputSelection.js
+++ b/packages/react-dom/src/client/ReactInputSelection.js
@@ -100,8 +100,6 @@ export function hasSelectionCapabilities(elem) {
 export function getSelectionInformation() {
   const focusedElem = getActiveElementDeep();
   return {
-    // Used by Flare
-    activeElementDetached: null,
     focusedElem: focusedElem,
     selectionRange: hasSelectionCapabilities(focusedElem)
       ? getSelection(focusedElem)

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -45,17 +45,22 @@ const table = [[forcePointerEvents], [!forcePointerEvents]];
 
 describe.each(table)('FocusWithin responder', hasPointerEvents => {
   let container;
+  let container2;
 
   beforeEach(() => {
     initializeModules();
     container = document.createElement('div');
     document.body.appendChild(container);
+    container2 = document.createElement('div');
+    document.body.appendChild(container2);
   });
 
   afterEach(() => {
     ReactDOM.render(null, container);
     document.body.removeChild(container);
+    document.body.removeChild(container2);
     container = null;
+    container2 = null;
   });
 
   describe('disabled', () => {
@@ -466,9 +471,6 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
         );
       };
 
-      const container2 = document.createElement('div');
-      document.body.appendChild(container2);
-
       const root = ReactDOM.createRoot(container2);
       act(() => {
         root.render(<Component />);
@@ -494,8 +496,6 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
       resolve();
-
-      document.body.removeChild(container2);
     });
 
     // @gate experimental
@@ -528,9 +528,6 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
           </div>
         );
       };
-
-      const container2 = document.createElement('div');
-      document.body.appendChild(container2);
 
       const root = ReactDOM.createRoot(container2);
 
@@ -567,8 +564,6 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
 
       resolve();
-
-      document.body.removeChild(container2);
     });
   });
 

--- a/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/FocusWithin-test.internal.js
@@ -367,6 +367,40 @@ describe.each(table)('FocusWithin responder', hasPointerEvents => {
     });
 
     // @gate experimental
+    it('is called after many elements are unmounted', () => {
+      const buttonRef = React.createRef();
+      const inputRef = React.createRef();
+
+      const Component = ({show}) => {
+        const listener = useFocusWithin({
+          onBeforeBlurWithin,
+          onBlurWithin,
+        });
+        return (
+          <div ref={ref} DEPRECATED_flareListeners={listener}>
+            {show && <button>Press me!</button>}
+            {show && <button>Press me!</button>}
+            {show && <input ref={inputRef} />}
+            {show && <button>Press me!</button>}
+            {!show && <button ref={buttonRef}>Press me!</button>}
+            {show && <button>Press me!</button>}
+            <button>Press me!</button>
+            <button>Press me!</button>
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+
+      inputRef.current.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onBlurWithin).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onBlurWithin).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate experimental
     it('is called after a nested focused element is unmounted (with scope query)', () => {
       const TestScope = React.unstable_createScope();
       const testScopeQuery = (type, props) => true;

--- a/packages/react-interactions/events/src/dom/use-event/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/use-event/__tests__/useFocusWithin-test.internal.js
@@ -42,17 +42,22 @@ const table = [[forcePointerEvents], [!forcePointerEvents]];
 
 describe.each(table)(`useFocus`, hasPointerEvents => {
   let container;
+  let container2;
 
   beforeEach(() => {
     initializeModules(hasPointerEvents);
     container = document.createElement('div');
     document.body.appendChild(container);
+    container2 = document.createElement('div');
+    document.body.appendChild(container2);
   });
 
   afterEach(() => {
     ReactDOM.render(null, container);
     document.body.removeChild(container);
+    document.body.removeChild(container2);
     container = null;
+    container2 = null;
   });
 
   describe('disabled', () => {
@@ -465,9 +470,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
         );
       };
 
-      const container2 = document.createElement('div');
-      document.body.appendChild(container2);
-
       const root = ReactDOM.createRoot(container2);
 
       act(() => {
@@ -494,8 +496,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
       resolve();
-
-      document.body.removeChild(container2);
     });
 
     // @gate experimental
@@ -528,9 +528,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
           </div>
         );
       };
-
-      const container2 = document.createElement('div');
-      document.body.appendChild(container2);
 
       const root = ReactDOM.createRoot(container2);
 
@@ -567,8 +564,6 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
 
       resolve();
-
-      document.body.removeChild(container2);
     });
   });
 });

--- a/packages/react-interactions/events/src/dom/use-event/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/use-event/__tests__/useFocusWithin-test.internal.js
@@ -368,6 +368,40 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
 
     // @gate experimental
+    it('is called after many elements are unmounted', () => {
+      const buttonRef = React.createRef();
+      const inputRef = React.createRef();
+
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+        return (
+          <div ref={ref}>
+            {show && <button>Press me!</button>}
+            {show && <button>Press me!</button>}
+            {show && <input ref={inputRef} />}
+            {show && <button>Press me!</button>}
+            {!show && <button ref={buttonRef}>Press me!</button>}
+            {show && <button>Press me!</button>}
+            <button>Press me!</button>
+            <button>Press me!</button>
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+
+      inputRef.current.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate experimental
     it('is called after a nested focused element is unmounted (with scope query)', () => {
       const TestScope = React.unstable_createScope();
       const testScopeQuery = (type, props) => true;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -524,3 +524,11 @@ export function unmountEventListener(listener: any) {
 export function validateEventListenerTarget(target: any, listener: any) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeActiveInstanceBlur() {
+  // noop
+}
+
+export function afterActiveInstanceBlur() {
+  // noop
+}

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -304,8 +304,9 @@ export function getPublicInstance(instance: Instance): * {
   return instance.canonical;
 }
 
-export function prepareForCommit(containerInfo: Container): void {
+export function prepareForCommit(containerInfo: Container): null | Object {
   // Noop
+  return null;
 }
 
 export function prepareUpdate(

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -573,3 +573,11 @@ export function unmountEventListener(listener: any) {
 export function validateEventListenerTarget(target: any, listener: any) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeActiveInstanceBlur() {
+  // noop
+}
+
+export function afterActiveInstanceBlur() {
+  // noop
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -223,8 +223,9 @@ export function getPublicInstance(instance: Instance): * {
   return instance;
 }
 
-export function prepareForCommit(containerInfo: Container): void {
+export function prepareForCommit(containerInfo: Container): null | Object {
   // Noop
+  return null;
 }
 
 export function prepareUpdate(

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -439,6 +439,14 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     beforeRemoveInstance(instance: any): void {
       // NO-OP
     },
+
+    beforeActiveInstanceBlur() {
+      // NO-OP
+    },
+
+    afterActiveInstanceBlur() {
+      // NO-OP
+    },
   };
 
   const hostConfig = useMutation

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -363,7 +363,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     cancelTimeout: clearTimeout,
     noTimeout: -1,
 
-    prepareForCommit(): void {},
+    prepareForCommit(): null | Object {
+      return null;
+    },
 
     resetAfterCommit(): void {},
 

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -354,22 +354,16 @@ function doesFiberContain(parentFiber: Fiber, childFiber: Fiber): boolean {
   return false;
 }
 
-function isFiberInHiddenTreeThatsContainsTargetFiber(
+function isFiberTimedOutSuspenseThatContainsTargetFiber(
   fiber: Fiber,
   targetFiber: Fiber,
 ): boolean {
-  let node = fiber;
-  while (node !== null) {
-    if (isFiberSuspenseAndTimedOut(node)) {
-      const child = node.child;
-      if (child !== null) {
-        return doesFiberContain(child, targetFiber);
-      }
-      return false;
-    }
-    node = node.return;
-  }
-  return false;
+  const child = fiber.child;
+  return (
+    isFiberSuspenseAndTimedOut(fiber) &&
+    child !== null &&
+    doesFiberContain(child, targetFiber)
+  );
 }
 
 function isFiberDeletedAndContainsTargetFiber(
@@ -387,6 +381,6 @@ export function isFiberHiddenOrDeletedAndContains(
 ): boolean {
   return (
     isFiberDeletedAndContainsTargetFiber(parentFiber, childFiber) ||
-    isFiberInHiddenTreeThatsContainsTargetFiber(parentFiber, childFiber)
+    isFiberTimedOutSuspenseThatContainsTargetFiber(parentFiber, childFiber)
   );
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -301,8 +301,8 @@ let currentEventTime: ExpirationTime = NoWork;
 // We warn about state updates for unmounted components differently in this case.
 let isFlushingPassiveEffects = false;
 
-let activeInstanceFiber = null;
-let shouldFireAfterActiveInstanceBlur = null;
+let focusedInstanceHandle: null | Fiber = null;
+let shouldFireAfterActiveInstanceBlur: boolean = false;
 
 export function getWorkInProgressRoot(): FiberRoot | null {
   return workInProgressRoot;
@@ -1908,7 +1908,7 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    activeInstanceFiber = prepareForCommit(root.containerInfo);
+    focusedInstanceHandle = prepareForCommit(root.containerInfo);
     shouldFireAfterActiveInstanceBlur = false;
 
     nextEffect = firstEffect;
@@ -1933,7 +1933,7 @@ function commitRootImpl(root, renderPriorityLevel) {
     } while (nextEffect !== null);
 
     // We no longer need to track the active instance fiber
-    activeInstanceFiber = null;
+    focusedInstanceHandle = null;
 
     if (enableProfilerTimer) {
       // Mark the current commit time to be shared by all Profilers in this
@@ -2141,8 +2141,8 @@ function commitBeforeMutationEffects() {
   while (nextEffect !== null) {
     if (
       !shouldFireAfterActiveInstanceBlur &&
-      activeInstanceFiber != null &&
-      isFiberHiddenOrDeletedAndContains(nextEffect, activeInstanceFiber)
+      focusedInstanceHandle !== null &&
+      isFiberHiddenOrDeletedAndContains(nextEffect, focusedInstanceHandle)
     ) {
       shouldFireAfterActiveInstanceBlur = true;
       beforeActiveInstanceBlur();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -72,6 +72,8 @@ import {
   cancelTimeout,
   noTimeout,
   warnsIfNotActing,
+  beforeActiveInstanceBlur,
+  afterActiveInstanceBlur,
 } from './ReactFiberHostConfig';
 
 import {
@@ -193,6 +195,7 @@ import {onCommitRoot} from './ReactFiberDevToolsHook.new';
 
 // Used by `act`
 import enqueueTask from 'shared/enqueueTask';
+import {isFiberHiddenOrDeletedAndContains} from './ReactFiberTreeReflection';
 
 const ceil = Math.ceil;
 
@@ -297,6 +300,9 @@ let currentEventTime: ExpirationTime = NoWork;
 // Dev only flag that tracks if passive effects are currently being flushed.
 // We warn about state updates for unmounted components differently in this case.
 let isFlushingPassiveEffects = false;
+
+let activeInstanceFiber = null;
+let shouldFireAfterActiveInstanceBlur = null;
 
 export function getWorkInProgressRoot(): FiberRoot | null {
   return workInProgressRoot;
@@ -1902,7 +1908,9 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    prepareForCommit(root.containerInfo);
+    activeInstanceFiber = prepareForCommit(root.containerInfo);
+    shouldFireAfterActiveInstanceBlur = false;
+
     nextEffect = firstEffect;
     do {
       if (__DEV__) {
@@ -1923,6 +1931,9 @@ function commitRootImpl(root, renderPriorityLevel) {
         }
       }
     } while (nextEffect !== null);
+
+    // We no longer need to track the active instance fiber
+    activeInstanceFiber = null;
 
     if (enableProfilerTimer) {
       // Mark the current commit time to be shared by all Profilers in this
@@ -1957,6 +1968,10 @@ function commitRootImpl(root, renderPriorityLevel) {
         }
       }
     } while (nextEffect !== null);
+
+    if (shouldFireAfterActiveInstanceBlur) {
+      afterActiveInstanceBlur();
+    }
     resetAfterCommit(root.containerInfo);
 
     // The work-in-progress tree is now the current tree. This must come after
@@ -2124,6 +2139,14 @@ function commitRootImpl(root, renderPriorityLevel) {
 
 function commitBeforeMutationEffects() {
   while (nextEffect !== null) {
+    if (
+      !shouldFireAfterActiveInstanceBlur &&
+      activeInstanceFiber != null &&
+      isFiberHiddenOrDeletedAndContains(nextEffect, activeInstanceFiber)
+    ) {
+      shouldFireAfterActiveInstanceBlur = true;
+      beforeActiveInstanceBlur();
+    }
     const effectTag = nextEffect.effectTag;
     if ((effectTag & Snapshot) !== NoEffect) {
       setCurrentDebugFiberInDEV(nextEffect);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -299,8 +299,8 @@ let currentEventTime: ExpirationTime = NoWork;
 // We warn about state updates for unmounted components differently in this case.
 let isFlushingPassiveEffects = false;
 
-let activeInstanceFiber = null;
-let shouldFireAfterActiveInstanceBlur = null;
+let focusedInstanceHandle: null | Fiber = null;
+let shouldFireAfterActiveInstanceBlur: boolean = false;
 
 export function getWorkInProgressRoot(): FiberRoot | null {
   return workInProgressRoot;
@@ -1927,7 +1927,7 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    activeInstanceFiber = prepareForCommit(root.containerInfo);
+    focusedInstanceHandle = prepareForCommit(root.containerInfo);
     shouldFireAfterActiveInstanceBlur = false;
 
     nextEffect = firstEffect;
@@ -1952,7 +1952,7 @@ function commitRootImpl(root, renderPriorityLevel) {
     } while (nextEffect !== null);
 
     // We no longer need to track the active instance fiber
-    activeInstanceFiber = null;
+    focusedInstanceHandle = null;
 
     if (enableProfilerTimer) {
       // Mark the current commit time to be shared by all Profilers in this
@@ -2160,8 +2160,8 @@ function commitBeforeMutationEffects() {
   while (nextEffect !== null) {
     if (
       !shouldFireAfterActiveInstanceBlur &&
-      activeInstanceFiber != null &&
-      isFiberHiddenOrDeletedAndContains(nextEffect, activeInstanceFiber)
+      focusedInstanceHandle !== null &&
+      isFiberHiddenOrDeletedAndContains(nextEffect, focusedInstanceHandle)
     ) {
       shouldFireAfterActiveInstanceBlur = true;
       beforeActiveInstanceBlur();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -72,6 +72,8 @@ import {
   cancelTimeout,
   noTimeout,
   warnsIfNotActing,
+  beforeActiveInstanceBlur,
+  afterActiveInstanceBlur,
 } from './ReactFiberHostConfig';
 
 import {
@@ -191,6 +193,7 @@ import {onCommitRoot} from './ReactFiberDevToolsHook.old';
 
 // Used by `act`
 import enqueueTask from 'shared/enqueueTask';
+import {isFiberHiddenOrDeletedAndContains} from './ReactFiberTreeReflection';
 
 const ceil = Math.ceil;
 
@@ -295,6 +298,9 @@ let currentEventTime: ExpirationTime = NoWork;
 // Dev only flag that tracks if passive effects are currently being flushed.
 // We warn about state updates for unmounted components differently in this case.
 let isFlushingPassiveEffects = false;
+
+let activeInstanceFiber = null;
+let shouldFireAfterActiveInstanceBlur = null;
 
 export function getWorkInProgressRoot(): FiberRoot | null {
   return workInProgressRoot;
@@ -1921,7 +1927,9 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    prepareForCommit(root.containerInfo);
+    activeInstanceFiber = prepareForCommit(root.containerInfo);
+    shouldFireAfterActiveInstanceBlur = false;
+
     nextEffect = firstEffect;
     do {
       if (__DEV__) {
@@ -1942,6 +1950,9 @@ function commitRootImpl(root, renderPriorityLevel) {
         }
       }
     } while (nextEffect !== null);
+
+    // We no longer need to track the active instance fiber
+    activeInstanceFiber = null;
 
     if (enableProfilerTimer) {
       // Mark the current commit time to be shared by all Profilers in this
@@ -1976,6 +1987,10 @@ function commitRootImpl(root, renderPriorityLevel) {
         }
       }
     } while (nextEffect !== null);
+
+    if (shouldFireAfterActiveInstanceBlur) {
+      afterActiveInstanceBlur();
+    }
     resetAfterCommit(root.containerInfo);
 
     // The work-in-progress tree is now the current tree. This must come after
@@ -2143,6 +2158,14 @@ function commitRootImpl(root, renderPriorityLevel) {
 
 function commitBeforeMutationEffects() {
   while (nextEffect !== null) {
+    if (
+      !shouldFireAfterActiveInstanceBlur &&
+      activeInstanceFiber != null &&
+      isFiberHiddenOrDeletedAndContains(nextEffect, activeInstanceFiber)
+    ) {
+      shouldFireAfterActiveInstanceBlur = true;
+      beforeActiveInstanceBlur();
+    }
     const effectTag = nextEffect.effectTag;
     if ((effectTag & Snapshot) !== NoEffect) {
       setCurrentDebugFiberInDEV(nextEffect);

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -25,7 +25,9 @@ describe('ReactFiberHostContext', () => {
   it('works with null host context', () => {
     let creates = 0;
     const Renderer = ReactFiberReconciler({
-      prepareForCommit: function() {},
+      prepareForCommit: function() {
+        return null;
+      },
       resetAfterCommit: function() {},
       getRootHostContext: function() {
         return null;
@@ -76,6 +78,7 @@ describe('ReactFiberHostContext', () => {
     const Renderer = ReactFiberReconciler({
       prepareForCommit: function(hostContext) {
         expect(hostContext).toBe(rootContext);
+        return null;
       },
       resetAfterCommit: function(hostContext) {
         expect(hostContext).toBe(rootContext);

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -89,6 +89,8 @@ export const makeOpaqueHydratingObject =
 export const makeClientId = $$$hostConfig.makeClientId;
 export const makeClientIdInDEV = $$$hostConfig.makeClientIdInDEV;
 export const makeServerId = $$$hostConfig.makeServerId;
+export const beforeActiveInstanceBlur = $$$hostConfig.beforeActiveInstanceBlur;
+export const afterActiveInstanceBlur = $$$hostConfig.afterActiveInstanceBlur;
 
 // -------------------
 //      Mutation

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -445,3 +445,11 @@ export function unmountEventListener(listener: any) {
 export function validateEventListenerTarget(target: any, listener: any) {
   throw new Error('Not yet implemented.');
 }
+
+export function beforeActiveInstanceBlur() {
+  // noop
+}
+
+export function afterActiveInstanceBlur() {
+  // noop
+}

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -143,8 +143,9 @@ export function getChildHostContext(
   return NO_CONTEXT;
 }
 
-export function prepareForCommit(containerInfo: Container): void {
+export function prepareForCommit(containerInfo: Container): null | Object {
   // noop
+  return null;
 }
 
 export function resetAfterCommit(containerInfo: Container): void {


### PR DESCRIPTION
This is a follow up to https://github.com/facebook/react/pull/18662. Notably, that PR was a temporary fix, which turned out to still have issues when testing locally on FB.

I listened to the advice from @sebmarkbage and we now handle the logic for determining if an active element fiber is in a hidden or deleted sub-tree in the "before mutation" phase. I also took the opportunity to break apart the logic into separate host config methods which match the intent nicely, without needing to leak fiber details to the host configs: so now we expost to new methods called `beforeActiveInstanceBlur` and `afterActiveInstanceBlur`.

We can always improve and optimize this logic once the refactor for creating fast-paths comes in. I also thought about using an array to contain all the fibers, but this turned out quite large in practice. Internally this array can be extremely larger in some cases, so we'd probably want to use a `Set`.

I went with an implementation that works: it seems to completely fix the issue internally and all tests relating to this now pass everytime (unlike before, where they'd sometimes fail).

I also added a bunch of regression tests to prevent this issue from occuring in the future.