### PR TITLE
Repro bug for Google Closure Compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "webpack": "^4.41.2"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x || 11.x || 12.x || 13.x"
+    "node": "*"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -263,6 +263,7 @@ export function prepareForCommit(containerInfo: Container): void {
     }
   }
   ReactBrowserEventEmitterSetEnabled(false);
+  return null;
 }
 
 export function resetAfterCommit(containerInfo: Container): void {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1920,7 +1920,7 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The first phase a "before mutation" phase. We use this phase to read the
     // state of the host tree right before we mutate it. This is where
     // getSnapshotBeforeUpdate is called.
-    prepareForCommit(root.containerInfo);
+    prepareForCommit(root.containerInfo) || null;
     nextEffect = firstEffect;
     do {
       if (__DEV__) {

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -31,7 +31,11 @@ moduleNameMapper[
 ] = `<rootDir>/packages/shared/forks/ReactFeatureFlags.readonly`;
 
 // Map packages to bundles
-packages.forEach(name => {
+[
+  'react',
+  'react-dom',
+  'scheduler'
+].forEach(name => {
   // Root entry point
   moduleNameMapper[`^${name}$`] = `<rootDir>/build/node_modules/${name}`;
   // Named entry points


### PR DESCRIPTION
This strange set of changes causes our ReactDOM Prod bundle to have broken JS. 

Run these commands to see the error:

`yarn build --type=NODE_PROD`

`yarn test-prod-build ReactDOMServerIntegrationTextarea`

You'll see this error:

`TypeError: Cannot read property 'focusedElem' of null`

It seems to be related to `JSCompiler_inline_result`. Which incorrectly gets re-used from a `null` value.

Issue reported:  google/closure-compiler#3588