### PR TITLE
Migrate ReactSuspense fuzz tests to Property Based Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-no-for-of-loops": "^1.0.0",
     "eslint-plugin-react": "^6.7.1",
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
+    "fast-check": "^1.24.1",
     "fbjs-scripts": "0.8.3",
     "filesize": "^6.0.1",
     "flow-bin": "0.97",

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const fc = require('fast-check');
 const util = require('util');
 const shouldIgnoreConsoleError = require('./shouldIgnoreConsoleError');
 const {getTestFlags} = require('./TestFlags');
@@ -313,3 +314,10 @@ if (process.env.REACT_CLASS_EQUIVALENCE_TEST) {
 
   require('jasmine-check').install();
 }
+
+// Configure fuzzer based on environment variables if any
+// Do not require fast-check in beforeEach if you want to benefit from this configuration
+fc.configureGlobal({
+  numRuns: 500, // default is 100
+  seed: +process.env.FUZZ_TEST_SEED || undefined,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5158,6 +5158,7 @@ eslint-plugin-no-unsafe-innerhtml@1.0.16:
 
 "eslint-plugin-react-internal@link:./scripts/eslint-rules":
   version "0.0.0"
+  uid ""
 
 eslint-plugin-react@^6.7.1:
   version "6.10.3"
@@ -5700,6 +5701,14 @@ fancy-log@^1.3.2:
     ansi-gray "^0.1.1"
     color-support "^1.1.3"
     time-stamp "^1.0.0"
+
+fast-check@^1.24.1:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-1.24.1.tgz#42a153e664122b1a2defdaea4e9b8311635fa7e7"
+  integrity sha512-ECF5LDbt4F8sJyTDI62fRLn0BdHDAdBacxlEsxaYbtqwbsdWofoYZUSaUp9tJrLsqCQ8jG28SkNvPZpDfNo3tw==
+  dependencies:
+    pure-rand "^2.0.0"
+    tslib "^1.10.0"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -10745,6 +10754,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pure-rand@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-2.0.0.tgz#3324633545207907fe964c2f0ebf05d8e9a7f129"
+  integrity sha512-mk98aayyd00xbfHgE3uEmAUGzz3jCdm8Mkf5DUXUhc7egmOaGG2D7qhVlynGenNe9VaNJZvzO9hkc8myuTkDgw==
 
 qs@6.7.0:
   version "6.7.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

As discussed with @gaearon in #14147 and in the context of #18669, here is a Pull Request to move some of the tests using home-made fuzzing to property based testing solutions.

The advantage of switching to a property based testing approach instead of manually generated random values is that property based testing frameworks come with shrinking capabilities by default. It means that anytime such framework detects an issue in a test (also referred as property) it will try to produce simpler values producing the error too.

As of today, there are mainly 3 leading libraries for property based testing: [fast-check](https://github.com/dubzzz/fast-check), [jsverify](https://github.com/jsverify/jsverify) or [testcheck-js](https://github.com/leebyron/testcheck-js). _fast-check_ is the choice added by this PR as it comes with features that would be pretty useful in the future: built-in helpers to detect race-conditions.

Depending on how much time it takes me to migrate `ReactNewContext-test.js` to _fast-check_, I might add this test to the patch too.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Move to property based testing for ReactSuspense fuzz tests.
