### PR TITLE
Add repro for select event inconsistency

### DIFF
--- a/packages/react-dom/src/events/plugins/__tests__/LegacySelectEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/LegacySelectEventPlugin-test.js
@@ -142,4 +142,23 @@ describe('SelectEventPlugin', () => {
     node.dispatchEvent(nativeEvent);
     expect(select).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle selectionchange events', function() {
+    const onSelect = jest.fn();
+    const node = ReactDOM.render(
+      <input type="text" onSelect={onSelect} />,
+      container,
+    );
+    node.focus();
+
+    // Make sure the event was not called before we emit the selection change event
+    expect(onSelect).toHaveBeenCalledTimes(0);
+
+    // This is dispatched e.g. when using CMD+a on macOS
+    document.dispatchEvent(
+      new Event('selectionchange', {bubbles: false, cancelable: false}),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.internal.js
@@ -145,4 +145,23 @@ describe('SelectEventPlugin', () => {
     node.dispatchEvent(nativeEvent);
     expect(select).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle selectionchange events', function() {
+    const onSelect = jest.fn();
+    const node = ReactDOM.render(
+      <input type="text" onSelect={onSelect} />,
+      container,
+    );
+    node.focus();
+
+    // Make sure the event was not called before we emit the selection change event
+    expect(onSelect).toHaveBeenCalledTimes(0);
+
+    // This is dispatched e.g. when using CMD+a on macOS
+    document.dispatchEvent(
+      new Event('selectionchange', {bubbles: false, cancelable: false}),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
We have an issue in the modern select event plugin that is now no longer emitting `onSelect` when using CMD+a to select text on macOS.

The issue is that the `selectionchange` event is only emitted at the document and targets the document so without document level listeners, the modern event system doesn’t know it happens.

@trueadm asked me to make a repro 🙂 