### PR TITLE
chore: Build react-dom/server in codesandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,scheduler/index,scheduler/tracing",
+  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/server,scheduler/index,scheduler/tracing",
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom",


### PR DESCRIPTION
## Summary

For codesandboxes using PR deploys `react-dom/server` will be unavailable. This would've been helpful for e.g. #18676

## Test Plan

Check if https://codesandbox.io/s/dangerouslysetinnerhtml-undefined-dhs8i?file=/src/index.js works with a build from this PR
Edit: works https://codesandbox.io/s/dangerouslysetinnerhtml-undefined-wxhn5?file=/package.json