### PR TITLE
Modern event system: fix selectionchange bug

### DIFF
--- a/packages/react-dom/src/events/DOMEventListenerMap.js
+++ b/packages/react-dom/src/events/DOMEventListenerMap.js
@@ -43,14 +43,28 @@ export function isListeningToAllDependencies(
   registrationName: string,
   mountAt: Document | Element,
 ): boolean {
-  const listenerMap = getListenerMapForElement(mountAt);
   const dependencies = registrationNameDependencies[registrationName];
+  return isListeningToEvents(dependencies, mountAt);
+}
 
-  for (let i = 0; i < dependencies.length; i++) {
-    const dependency = dependencies[i];
-    if (!listenerMap.has(dependency)) {
+export function isListeningToEvents(
+  events: Array<string>,
+  mountAt: Document | Element,
+): boolean {
+  const listenerMap = getListenerMapForElement(mountAt);
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (!listenerMap.has(event)) {
       return false;
     }
   }
   return true;
+}
+
+export function isListeningToEvent(
+  registrationName: string,
+  mountAt: Document | Element,
+): boolean {
+  const listenerMap = getListenerMapForElement(mountAt);
+  return listenerMap.has(registrationName);
 }

--- a/packages/react-dom/src/events/plugins/__tests__/LegacySelectEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/LegacySelectEventPlugin-test.js
@@ -142,4 +142,23 @@ describe('SelectEventPlugin', () => {
     node.dispatchEvent(nativeEvent);
     expect(select).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle selectionchange events', function() {
+    const onSelect = jest.fn();
+    const node = ReactDOM.render(
+      <input type="text" onSelect={onSelect} />,
+      container,
+    );
+    node.focus();
+
+    // Make sure the event was not called before we emit the selection change event
+    expect(onSelect).toHaveBeenCalledTimes(0);
+
+    // This is dispatched e.g. when using CMD+a on macOS
+    document.dispatchEvent(
+      new Event('selectionchange', {bubbles: false, cancelable: false}),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-dom/src/events/plugins/__tests__/ModernBeforeInputEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernBeforeInputEventPlugin-test.internal.js
@@ -21,6 +21,8 @@ describe('BeforeInputEventPlugin', () => {
     if (envSimulator) {
       envSimulator();
     }
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableModernEventSystem = true;
     return require('react-dom');
   }
 
@@ -78,8 +80,6 @@ describe('BeforeInputEventPlugin', () => {
   }
 
   beforeEach(() => {
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.enableModernEventSystem = true;
     React = require('react');
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.internal.js
@@ -145,4 +145,23 @@ describe('SelectEventPlugin', () => {
     node.dispatchEvent(nativeEvent);
     expect(select).toHaveBeenCalledTimes(1);
   });
+
+  it('should handle selectionchange events', function() {
+    const onSelect = jest.fn();
+    const node = ReactDOM.render(
+      <input type="text" onSelect={onSelect} />,
+      container,
+    );
+    node.focus();
+
+    // Make sure the event was not called before we emit the selection change event
+    expect(onSelect).toHaveBeenCalledTimes(0);
+
+    // This is dispatched e.g. when using CMD+a on macOS
+    document.dispatchEvent(
+      new Event('selectionchange', {bubbles: false, cancelable: false}),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
This fixes the issue found in https://github.com/facebook/react/pull/18678.

Notably, `TOP_SELECTION_CHANGE` or the native event `selectionchange` should always be attached to the `document` when setting up the listener. We cannot attach to the React root – which is why we were seeing issues internally with the `SelectPlugin`.