### PR TITLE
Remove null sibling

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1116,6 +1116,9 @@ function detachFiber(fiber: Fiber) {
   // get GC:ed but we don't know which for sure which parent is the current
   // one so we'll settle for GC:ing the subtree of this child. This child
   // itself will be GC:ed when the parent updates the next time.
+  // Note: we cannot null out sibling here, otherwise it can cause issues
+  // with findDOMNode and how it requires the sibling field to carry out
+  // traversal in a later effect. See PR #16820.
   fiber.alternate = null;
   fiber.child = null;
   fiber.dependencies = null;
@@ -1125,7 +1128,6 @@ function detachFiber(fiber: Fiber) {
   fiber.memoizedState = null;
   fiber.pendingProps = null;
   fiber.return = null;
-  fiber.sibling = null;
   fiber.stateNode = null;
   fiber.updateQueue = null;
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1116,6 +1116,9 @@ function detachFiber(fiber: Fiber) {
   // get GC:ed but we don't know which for sure which parent is the current
   // one so we'll settle for GC:ing the subtree of this child. This child
   // itself will be GC:ed when the parent updates the next time.
+  // Note: we cannot null out sibling here, otherwise it can cause issues
+  // with findDOMNode and how it requires the sibling field to carry out
+  // traversal in a later effect. See PR #16820.
   fiber.alternate = null;
   fiber.child = null;
   fiber.dependencies = null;
@@ -1125,7 +1128,6 @@ function detachFiber(fiber: Fiber) {
   fiber.memoizedState = null;
   fiber.pendingProps = null;
   fiber.return = null;
-  fiber.sibling = null;
   fiber.stateNode = null;
   fiber.updateQueue = null;
   if (__DEV__) {


### PR DESCRIPTION
The issue that affected us in https://github.com/facebook/react/pull/16820 is still a problem today it seems. This PR removes the logic where we `null` the `sibling` field, which is unfortunate as this was causing a leak. I added a comment for future reading, in case we forget this again.

I'll look at making a repro case later today.