### PR TITLE
Clear fiber field from host instance on unmount

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -40,6 +40,12 @@ export function precacheFiberNode(
   (node: any)[internalInstanceKey] = hostInst;
 }
 
+export function clearFiberNode(
+  node: Instance | TextInstance | SuspenseInstance,
+): void {
+  (node: any)[internalInstanceKey] = null;
+}
+
 export function markContainerAsRoot(hostRoot: Fiber, node: Container): void {
   node[internalContainerInstanceKey] = hostRoot;
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -19,6 +19,7 @@ import {
   precacheFiberNode,
   updateFiberProps,
   getClosestInstanceFromNode,
+  clearFiberNode,
 } from './ReactDOMComponentTree';
 import {
   createElement,
@@ -522,8 +523,10 @@ function dispatchAfterDetachedBlur(target: HTMLElement): void {
 
 export function beforeRemoveInstance(
   instance: Instance | TextInstance | SuspenseInstance,
-) {
-  // TODO for ReactDOM.createEventInstance
+): void {
+  // Clear the fiber off the instance, to help GC
+  clearFiberNode(instance);
+  // TODO handle ReactDOM.createEventInstance
 }
 
 export function removeChild(


### PR DESCRIPTION
Given we're still seeing memory leaks internally and that we already traverse each host component when we detach its fiber – let's also clear the fiber field from the host instance. I did some quick checks and didn't notice any performance runtime implications, in fact I noticed that overall memory consumed was lower from this change (testing internally)!