### PR TITLE
Don't dedupe using the stack

### DIFF
--- a/packages/react-dom/src/__tests__/ReactComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactComponent-test.js
@@ -16,6 +16,8 @@ let ReactTestUtils;
 
 describe('ReactComponent', () => {
   beforeEach(() => {
+    jest.resetModules();
+
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1689,26 +1689,12 @@ describe('ReactDOMComponent', () => {
             <tr />
           </div>,
         );
-      }).toErrorDev(
-        ReactFeatureFlags.enableComponentStackLocations
-          ? [
-              // This warning dedupes since they're in the same component.
-              'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-                '<div>.' +
-                '\n    in tr (at **)' +
-                '\n    in div (at **)',
-            ]
-          : [
-              'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-                '<div>.' +
-                '\n    in tr (at **)' +
-                '\n    in div (at **)',
-              'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
-                '<div>.' +
-                '\n    in tr (at **)' +
-                '\n    in div (at **)',
-            ],
-      );
+      }).toErrorDev([
+        'Warning: validateDOMNesting(...): <tr> cannot appear as a child of ' +
+          '<div>.' +
+          '\n    in tr (at **)' +
+          '\n    in div (at **)',
+      ]);
     });
 
     it('warns on invalid nesting at root', () => {
@@ -1777,18 +1763,6 @@ describe('ReactDOMComponent', () => {
         return <Row />;
       }
 
-      class Table extends React.Component {
-        render() {
-          return <table>{this.props.children}</table>;
-        }
-      }
-
-      class FancyTable extends React.Component {
-        render() {
-          return <Table>{this.props.children}</Table>;
-        }
-      }
-
       function Viz1() {
         return (
           <table>
@@ -1806,6 +1780,27 @@ describe('ReactDOMComponent', () => {
           '\n    in table (at **)' +
           '\n    in Viz1 (at **)',
       );
+    });
+
+    it('gives useful context in warnings 2', () => {
+      function Row() {
+        return <tr />;
+      }
+      function FancyRow() {
+        return <Row />;
+      }
+
+      class Table extends React.Component {
+        render() {
+          return <table>{this.props.children}</table>;
+        }
+      }
+
+      class FancyTable extends React.Component {
+        render() {
+          return <Table>{this.props.children}</Table>;
+        }
+      }
 
       function Viz2() {
         return (
@@ -1826,7 +1821,27 @@ describe('ReactDOMComponent', () => {
           '\n    in FancyTable (at **)' +
           '\n    in Viz2 (at **)',
       );
+    });
 
+    it('gives useful context in warnings 3', () => {
+      function Row() {
+        return <tr />;
+      }
+      function FancyRow() {
+        return <Row />;
+      }
+
+      class Table extends React.Component {
+        render() {
+          return <table>{this.props.children}</table>;
+        }
+      }
+
+      class FancyTable extends React.Component {
+        render() {
+          return <Table>{this.props.children}</Table>;
+        }
+      }
       expect(() => {
         ReactTestUtils.renderIntoDocument(
           <FancyTable>
@@ -1841,6 +1856,15 @@ describe('ReactDOMComponent', () => {
           '\n    in Table (at **)' +
           '\n    in FancyTable (at **)',
       );
+    });
+
+    it('gives useful context in warnings 4', () => {
+      function Row() {
+        return <tr />;
+      }
+      function FancyRow() {
+        return <Row />;
+      }
 
       expect(() => {
         ReactTestUtils.renderIntoDocument(
@@ -1854,6 +1878,20 @@ describe('ReactDOMComponent', () => {
           '\n    in FancyRow (at **)' +
           '\n    in table (at **)',
       );
+    });
+
+    it('gives useful context in warnings 5', () => {
+      class Table extends React.Component {
+        render() {
+          return <table>{this.props.children}</table>;
+        }
+      }
+
+      class FancyTable extends React.Component {
+        render() {
+          return <Table>{this.props.children}</Table>;
+        }
+      }
 
       expect(() => {
         ReactTestUtils.renderIntoDocument(

--- a/packages/react-dom/src/client/validateDOMNesting.js
+++ b/packages/react-dom/src/client/validateDOMNesting.js
@@ -5,9 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// TODO: direct imports like some-package/src/* are bad. Fix me.
-import {getCurrentFiberStackInDev} from 'react-reconciler/src/ReactCurrentFiber';
-
 let validateDOMNesting = () => {};
 let updatedAncestorInfo = () => {};
 
@@ -430,10 +427,8 @@ if (__DEV__) {
     }
 
     const ancestorTag = invalidParentOrAncestor.tag;
-    const addendum = getCurrentFiberStackInDev();
 
-    const warnKey =
-      !!invalidParent + '|' + childTag + '|' + ancestorTag + '|' + addendum;
+    const warnKey = !!invalidParent + '|' + childTag + '|' + ancestorTag;
     if (didWarn[warnKey]) {
       return;
     }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -44,7 +44,6 @@ import {
   createFiberFromPortal,
 } from './ReactFiber.old';
 import {emptyRefsObject} from './ReactFiberClassComponent.old';
-import {getCurrentFiberStackInDev} from './ReactCurrentFiber';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.old';
 import {StrictMode} from './ReactTypeOfMode';
 
@@ -53,7 +52,7 @@ let didWarnAboutGenerators;
 let didWarnAboutStringRefs;
 let ownerHasKeyUseWarning;
 let ownerHasFunctionTypeWarning;
-let warnForMissingKey = (child: mixed) => {};
+let warnForMissingKey = (child: mixed, returnFiber: Fiber) => {};
 
 if (__DEV__) {
   didWarnAboutMaps = false;
@@ -68,7 +67,7 @@ if (__DEV__) {
   ownerHasKeyUseWarning = {};
   ownerHasFunctionTypeWarning = {};
 
-  warnForMissingKey = (child: mixed) => {
+  warnForMissingKey = (child: mixed, returnFiber: Fiber) => {
     if (child === null || typeof child !== 'object') {
       return;
     }
@@ -82,15 +81,12 @@ if (__DEV__) {
     );
     child._store.validated = true;
 
-    const currentComponentErrorInfo =
-      'Each child in a list should have a unique ' +
-      '"key" prop. See https://fb.me/react-warning-keys for ' +
-      'more information.' +
-      getCurrentFiberStackInDev();
-    if (ownerHasKeyUseWarning[currentComponentErrorInfo]) {
+    const componentName = getComponentName(returnFiber.type) || 'Component';
+
+    if (ownerHasKeyUseWarning[componentName]) {
       return;
     }
-    ownerHasKeyUseWarning[currentComponentErrorInfo] = true;
+    ownerHasKeyUseWarning[componentName] = true;
 
     console.error(
       'Each child in a list should have a unique ' +
@@ -231,18 +227,13 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
   }
 }
 
-function warnOnFunctionType() {
+function warnOnFunctionType(returnFiber: Fiber) {
   if (__DEV__) {
-    const currentComponentErrorInfo =
-      'Functions are not valid as a React child. This may happen if ' +
-      'you return a Component instead of <Component /> from render. ' +
-      'Or maybe you meant to call this function rather than return it.' +
-      getCurrentFiberStackInDev();
-
-    if (ownerHasFunctionTypeWarning[currentComponentErrorInfo]) {
+    const componentName = getComponentName(returnFiber.type) || 'Component';
+    if (ownerHasFunctionTypeWarning[componentName]) {
       return;
     }
-    ownerHasFunctionTypeWarning[currentComponentErrorInfo] = true;
+    ownerHasFunctionTypeWarning[componentName] = true;
 
     console.error(
       'Functions are not valid as a React child. This may happen if ' +
@@ -569,7 +560,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     if (__DEV__) {
       if (typeof newChild === 'function') {
-        warnOnFunctionType();
+        warnOnFunctionType(returnFiber);
       }
     }
 
@@ -657,7 +648,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     if (__DEV__) {
       if (typeof newChild === 'function') {
-        warnOnFunctionType();
+        warnOnFunctionType(returnFiber);
       }
     }
 
@@ -736,7 +727,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     if (__DEV__) {
       if (typeof newChild === 'function') {
-        warnOnFunctionType();
+        warnOnFunctionType(returnFiber);
       }
     }
 
@@ -749,6 +740,7 @@ function ChildReconciler(shouldTrackSideEffects) {
   function warnOnInvalidKey(
     child: mixed,
     knownKeys: Set<string> | null,
+    returnFiber: Fiber,
   ): Set<string> | null {
     if (__DEV__) {
       if (typeof child !== 'object' || child === null) {
@@ -757,7 +749,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       switch (child.$$typeof) {
         case REACT_ELEMENT_TYPE:
         case REACT_PORTAL_TYPE:
-          warnForMissingKey(child);
+          warnForMissingKey(child, returnFiber);
           const key = child.key;
           if (typeof key !== 'string') {
             break;
@@ -817,7 +809,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       let knownKeys = null;
       for (let i = 0; i < newChildren.length; i++) {
         const child = newChildren[i];
-        knownKeys = warnOnInvalidKey(child, knownKeys);
+        knownKeys = warnOnInvalidKey(child, knownKeys, returnFiber);
       }
     }
 
@@ -1001,7 +993,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         let step = newChildren.next();
         for (; !step.done; step = newChildren.next()) {
           const child = step.value;
-          knownKeys = warnOnInvalidKey(child, knownKeys);
+          knownKeys = warnOnInvalidKey(child, knownKeys, returnFiber);
         }
       }
     }
@@ -1395,7 +1387,7 @@ function ChildReconciler(shouldTrackSideEffects) {
 
     if (__DEV__) {
       if (typeof newChild === 'function') {
-        warnOnFunctionType();
+        warnOnFunctionType(returnFiber);
       }
     }
     if (typeof newChild === 'undefined' && !isUnkeyedTopLevelFragment) {

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -31,7 +31,7 @@ export function getCurrentFiberOwnerNameInDevOrNull(): string | null {
   return null;
 }
 
-export function getCurrentFiberStackInDev(): string {
+function getCurrentFiberStackInDev(): string {
   if (__DEV__) {
     if (current === null) {
       return '';

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 let React;
-let ReactFeatureFlags;
 let ReactNoop;
 let Scheduler;
 
@@ -19,7 +18,6 @@ describe('ReactFragment', () => {
     jest.resetModules();
 
     React = require('react');
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
   });
@@ -902,27 +900,15 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={false} />);
-    if (ReactFeatureFlags.enableComponentStackLocations) {
-      // The key warning gets deduped because it's in the same component.
-      expect(Scheduler).toFlushWithoutYielding();
-    } else {
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-        'Each child in a list should have a unique "key" prop.',
-      );
-    }
+    // The key warning gets deduped because it's in the same component.
+    expect(Scheduler).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([span(), div()]);
 
     ReactNoop.render(<Foo condition={true} />);
-    if (ReactFeatureFlags.enableComponentStackLocations) {
-      // The key warning gets deduped because it's in the same component.
-      expect(Scheduler).toFlushWithoutYielding();
-    } else {
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-        'Each child in a list should have a unique "key" prop.',
-      );
-    }
+    // The key warning gets deduped because it's in the same component.
+    expect(Scheduler).toFlushWithoutYielding();
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop.getChildren()).toEqual([span(), div()]);

--- a/packages/shared/__tests__/describeComponentFrame-test.js
+++ b/packages/shared/__tests__/describeComponentFrame-test.js
@@ -89,6 +89,7 @@ describe('Component stack trace displaying', () => {
       'C:\\funny long (path)/index.jsx': 'funny long (path)/index.jsx',
     };
     Object.keys(fileNames).forEach((fileName, i) => {
+      Component.displayName = 'Component ' + i;
       ReactDOM.render(
         <Component __source={{fileName, lineNumber: i}} />,
         container,


### PR DESCRIPTION
We currently use the stack to dedupe warnings in a couple of places. This is a very heavy weight way of computing that a warning doesn't need to be fired.

This uses parent component name as a heuristic for deduping. It's not perfect but as soon as you fix one you'll uncover the next. It might be a little annoying but having many logs is also annoying.

We now have no special cases for stacks. The only thing that uses stacks in dev is the console.error transform and dev tools. This means that we could externalize this completely to an console.error patching module and drop it from being built-in to react. Or alternatively always patch the console in the renderer but have the isomorphic one just call console.error without needing to expose any details.

The only prod/dev behavior is the one we pass to error boundaries or the error we throw if you don't have an error boundary.
