### PR TITLE
Nit: add suffix _TIMEOUT consistently in scheduler

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -53,11 +53,11 @@ var maxSigned31BitInt = 1073741823;
 // Times out immediately
 var IMMEDIATE_PRIORITY_TIMEOUT = -1;
 // Eventually times out
-var USER_BLOCKING_PRIORITY = 250;
+var USER_BLOCKING_PRIORITY_TIMEOUT = 250;
 var NORMAL_PRIORITY_TIMEOUT = 5000;
 var LOW_PRIORITY_TIMEOUT = 10000;
 // Never times out
-var IDLE_PRIORITY = maxSigned31BitInt;
+var IDLE_PRIORITY_TIMEOUT = maxSigned31BitInt;
 
 // Tasks are stored on a min heap
 var taskQueue = [];
@@ -281,9 +281,9 @@ function timeoutForPriorityLevel(priorityLevel) {
     case ImmediatePriority:
       return IMMEDIATE_PRIORITY_TIMEOUT;
     case UserBlockingPriority:
-      return USER_BLOCKING_PRIORITY;
+      return USER_BLOCKING_PRIORITY_TIMEOUT;
     case IdlePriority:
-      return IDLE_PRIORITY;
+      return IDLE_PRIORITY_TIMEOUT;
     case LowPriority:
       return LOW_PRIORITY_TIMEOUT;
     case NormalPriority:


### PR DESCRIPTION
This is just a naming thing to avoid confusing it with the levels.