### PR TITLE
Temporarily Remove DebugTracing from the New Reconciler

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -10,14 +10,12 @@
 import type {Fiber} from './ReactInternalTypes';
 import type {ExpirationTime} from './ReactFiberExpirationTime.new';
 import type {UpdateQueue} from './ReactUpdateQueue.new';
-import type {ReactPriorityLevel} from './ReactInternalTypes';
 
 import * as React from 'react';
 import {Update, Snapshot} from './ReactSideEffectTags';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
-  enableDebugTracing,
   warnAboutDeprecatedLifecycles,
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings.new';
@@ -29,7 +27,7 @@ import invariant from 'shared/invariant';
 import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.new';
-import {DebugTracingMode, StrictMode} from './ReactTypeOfMode';
+import {StrictMode} from './ReactTypeOfMode';
 
 import {
   enqueueUpdate,
@@ -55,10 +53,8 @@ import {
   requestCurrentTimeForUpdate,
   computeExpirationForFiber,
   scheduleUpdateOnFiber,
-  priorityLevelToLabel,
 } from './ReactFiberWorkLoop.new';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
-import {logForceUpdateScheduled, logStateUpdateScheduled} from './DebugTracing';
 
 import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
@@ -211,18 +207,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, expirationTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const label = priorityLevelToLabel(
-            ((update.priority: any): ReactPriorityLevel),
-          );
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logStateUpdateScheduled(name, label, payload);
-        }
-      }
-    }
   },
   enqueueReplaceState(inst, payload, callback) {
     const fiber = getInstance(inst);
@@ -247,18 +231,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, expirationTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const label = priorityLevelToLabel(
-            ((update.priority: any): ReactPriorityLevel),
-          );
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logStateUpdateScheduled(name, label, payload);
-        }
-      }
-    }
   },
   enqueueForceUpdate(inst, callback) {
     const fiber = getInstance(inst);
@@ -282,18 +254,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, expirationTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const label = priorityLevelToLabel(
-            ((update.priority: any): ReactPriorityLevel),
-          );
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logForceUpdateScheduled(name, label);
-        }
-      }
-    }
   },
 };
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -24,15 +24,10 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {enableDebugTracing} from 'shared/ReactFeatureFlags';
 
 import {markRootExpiredAtTime} from './ReactFiberRoot.new';
-import {
-  inferPriorityFromExpirationTime,
-  NoWork,
-  Sync,
-} from './ReactFiberExpirationTime.new';
-import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
+import {NoWork, Sync} from './ReactFiberExpirationTime.new';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {readContext} from './ReactFiberNewContext.new';
 import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.new';
 import {
@@ -82,7 +77,6 @@ import {
   warnAboutMultipleRenderersDEV,
 } from './ReactMutableSource.new';
 import {getIsRendering} from './ReactCurrentFiber';
-import {logStateUpdateScheduled} from './DebugTracing';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -1723,16 +1717,6 @@ function dispatchAction<S, A>(
       }
     }
     scheduleUpdateOnFiber(fiber, expirationTime);
-  }
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      if (fiber.mode & DebugTracingMode) {
-        const label = 'Unknown';
-        const name = getComponentName(fiber.type) || 'Unknown';
-        logStateUpdateScheduled(name, label, action);
-      }
-    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -54,7 +54,6 @@ import {
   warnIfNotScopedWithMatchingAct,
   markRenderEventTimeAndConfig,
   markUnprocessedUpdateTime,
-  priorityLevelToLabel,
 } from './ReactFiberWorkLoop.new';
 
 import invariant from 'shared/invariant';
@@ -1655,10 +1654,6 @@ function dispatchAction<S, A>(
     next: (null: any),
   };
 
-  if (__DEV__) {
-    update.priority = getCurrentPriorityLevel();
-  }
-
   // Append the update to the end of the list.
   const pending = queue.pending;
   if (pending === null) {
@@ -1733,11 +1728,7 @@ function dispatchAction<S, A>(
   if (__DEV__) {
     if (enableDebugTracing) {
       if (fiber.mode & DebugTracingMode) {
-        const priorityLevel = inferPriorityFromExpirationTime(
-          currentTime,
-          expirationTime,
-        );
-        const label = priorityLevelToLabel(priorityLevel);
+        const label = 'Unknown';
         const name = getComponentName(fiber.type) || 'Unknown';
         logStateUpdateScheduled(name, label, action);
       }

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -30,8 +30,7 @@ import {
   LifecycleEffectMask,
 } from './ReactSideEffectTags';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent.new';
-import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
-import {enableDebugTracing} from 'shared/ReactFeatureFlags';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
   enqueueCapturedUpdate,
@@ -55,7 +54,6 @@ import {
   pingSuspendedRoot,
 } from './ReactFiberWorkLoop.new';
 import {logCapturedError} from './ReactFiberErrorLogger';
-import {logComponentSuspended} from './DebugTracing';
 
 import {Sync, NoWork} from './ReactFiberExpirationTime.new';
 
@@ -194,15 +192,6 @@ function throwException(
   ) {
     // This is a wakeable.
     const wakeable: Wakeable = (value: any);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (sourceFiber.mode & DebugTracingMode) {
-          const name = getComponentName(sourceFiber.type) || 'Unknown';
-          logComponentSuspended(name, wakeable);
-        }
-      }
-    }
 
     if ((sourceFiber.mode & BlockingMode) === NoMode) {
       // Reset the memoizedState to what it was before we attempted

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -27,7 +27,6 @@ import {
   enableSchedulerTracing,
   warnAboutUnmockedScheduler,
   disableSchedulerTimeoutBasedOnReactExpirationTime,
-  enableDebugTracing,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
@@ -49,16 +48,6 @@ import {
   flushSyncCallbackQueue,
   scheduleSyncCallback,
 } from './SchedulerWithReactIntegration.new';
-import {
-  logCommitStarted,
-  logCommitStopped,
-  logLayoutEffectsStarted,
-  logLayoutEffectsStopped,
-  logPassiveEffectsStarted,
-  logPassiveEffectsStopped,
-  logRenderStarted,
-  logRenderStopped,
-} from './DebugTracing';
 
 // The scheduler is imported here *only* to detect whether it's been mocked
 import * as Scheduler from 'scheduler';
@@ -1405,14 +1394,6 @@ function renderRootSync(root, expirationTime) {
 
   const prevInteractions = pushInteractions(root);
 
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      const priorityLevel = getCurrentPriorityLevel();
-      const label = 'Unknown';
-      logRenderStarted(label);
-    }
-  }
-
   do {
     try {
       workLoopSync();
@@ -1436,12 +1417,6 @@ function renderRootSync(root, expirationTime) {
       'Cannot commit an incomplete root. This error is likely caused by a ' +
         'bug in React. Please file an issue.',
     );
-  }
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      logRenderStopped();
-    }
   }
 
   // Set this to null to indicate there's no in-progress render.
@@ -1473,13 +1448,6 @@ function renderRootConcurrent(root, expirationTime) {
 
   const prevInteractions = pushInteractions(root);
 
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      const label = 'Unknown';
-      logRenderStarted(label);
-    }
-  }
-
   do {
     try {
       workLoopConcurrent();
@@ -1495,12 +1463,6 @@ function renderRootConcurrent(root, expirationTime) {
 
   popDispatcher(prevDispatcher);
   executionContext = prevExecutionContext;
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      logRenderStopped();
-    }
-  }
 
   // Check if the tree has completed.
   if (workInProgress !== null) {
@@ -1769,12 +1731,6 @@ function commitRoot(root) {
 }
 
 function commitRootImpl(root, renderPriorityLevel) {
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      const label = 'Unknown';
-      logCommitStarted(label);
-    }
-  }
   do {
     // `flushPassiveEffects` will call `flushSyncUpdateQueue` at the end, which
     // means `flushPassiveEffects` will sometimes result in additional
@@ -1794,11 +1750,6 @@ function commitRootImpl(root, renderPriorityLevel) {
   const finishedWork = root.finishedWork;
   const expirationTime = root.finishedExpirationTime;
   if (finishedWork === null) {
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        logCommitStopped();
-      }
-    }
     return null;
   }
   root.finishedWork = null;
@@ -2088,12 +2039,6 @@ function commitRootImpl(root, renderPriorityLevel) {
   }
 
   if ((executionContext & LegacyUnbatchedContext) !== NoContext) {
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        logCommitStopped();
-      }
-    }
-
     // This is a legacy edge case. We just committed the initial mount of
     // a ReactDOM.render-ed root inside of batchedUpdates. The commit fired
     // synchronously, but layout updates should be deferred until the end
@@ -2103,12 +2048,6 @@ function commitRootImpl(root, renderPriorityLevel) {
 
   // If layout work was scheduled, flush it now.
   flushSyncCallbackQueue();
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      logCommitStopped();
-    }
-  }
 
   return null;
 }
@@ -2225,13 +2164,6 @@ function commitLayoutEffects(
   root: FiberRoot,
   committedExpirationTime: ExpirationTime,
 ) {
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      const label = 'Unknown';
-      logLayoutEffectsStarted(label);
-    }
-  }
-
   // TODO: Should probably move the bulk of this function to commitWork.
   while (nextEffect !== null) {
     setCurrentDebugFiberInDEV(nextEffect);
@@ -2254,12 +2186,6 @@ function commitLayoutEffects(
 
     resetCurrentDebugFiberInDEV();
     nextEffect = nextEffect.nextEffect;
-  }
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      logLayoutEffectsStopped();
-    }
   }
 }
 
@@ -2347,13 +2273,6 @@ function flushPassiveEffectsImpl() {
     (executionContext & (RenderContext | CommitContext)) === NoContext,
     'Cannot flush passive effects while already rendering.',
   );
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      const label = 'Unknown';
-      logPassiveEffectsStarted(label);
-    }
-  }
 
   if (__DEV__) {
     isFlushingPassiveEffects = true;
@@ -2531,12 +2450,6 @@ function flushPassiveEffectsImpl() {
 
   if (__DEV__) {
     isFlushingPassiveEffects = false;
-  }
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      logPassiveEffectsStopped();
-    }
   }
 
   executionContext = prevExecutionContext;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -396,29 +396,6 @@ export function computeExpirationForFiber(
   return expirationTime;
 }
 
-export function priorityLevelToLabel(
-  priorityLevel: ReactPriorityLevel,
-): string {
-  if (__DEV__ && enableDebugTracing) {
-    switch (priorityLevel) {
-      case ImmediatePriority:
-        return 'immediate';
-      case UserBlockingPriority:
-        return 'user-blocking';
-      case NormalPriority:
-        return 'normal';
-      case LowPriority:
-        return 'low';
-      case IdlePriority:
-        return 'idle';
-      default:
-        return 'other';
-    }
-  } else {
-    return '';
-  }
-}
-
 export function scheduleUpdateOnFiber(
   fiber: Fiber,
   expirationTime: ExpirationTime,
@@ -1431,7 +1408,7 @@ function renderRootSync(root, expirationTime) {
   if (__DEV__) {
     if (enableDebugTracing) {
       const priorityLevel = getCurrentPriorityLevel();
-      const label = priorityLevelToLabel(priorityLevel);
+      const label = 'Unknown';
       logRenderStarted(label);
     }
   }
@@ -1498,8 +1475,7 @@ function renderRootConcurrent(root, expirationTime) {
 
   if (__DEV__) {
     if (enableDebugTracing) {
-      const priorityLevel = getCurrentPriorityLevel();
-      const label = priorityLevelToLabel(priorityLevel);
+      const label = 'Unknown';
       logRenderStarted(label);
     }
   }
@@ -1795,7 +1771,7 @@ function commitRoot(root) {
 function commitRootImpl(root, renderPriorityLevel) {
   if (__DEV__) {
     if (enableDebugTracing) {
-      const label = priorityLevelToLabel(renderPriorityLevel);
+      const label = 'Unknown';
       logCommitStarted(label);
     }
   }
@@ -2251,8 +2227,7 @@ function commitLayoutEffects(
 ) {
   if (__DEV__) {
     if (enableDebugTracing) {
-      const priorityLevel = getCurrentPriorityLevel();
-      const label = priorityLevelToLabel(priorityLevel);
+      const label = 'Unknown';
       logLayoutEffectsStarted(label);
     }
   }
@@ -2375,8 +2350,7 @@ function flushPassiveEffectsImpl() {
 
   if (__DEV__) {
     if (enableDebugTracing) {
-      const priorityLevel = getCurrentPriorityLevel();
-      const label = priorityLevelToLabel(priorityLevel);
+      const label = 'Unknown';
       logPassiveEffectsStarted(label);
     }
   }

--- a/packages/react-reconciler/src/ReactUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.new.js
@@ -121,9 +121,6 @@ export type Update<State> = {|
   callback: (() => mixed) | null,
 
   next: Update<State> | null,
-
-  // DEV only
-  priority?: ReactPriorityLevel,
 |};
 
 type SharedQueue<State> = {|
@@ -207,9 +204,6 @@ export function createUpdate(
 
     next: null,
   };
-  if (__DEV__) {
-    update.priority = getCurrentPriorityLevel();
-  }
   return update;
 }
 

--- a/packages/react-reconciler/src/ReactUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.new.js
@@ -87,7 +87,6 @@
 import type {Fiber} from './ReactInternalTypes';
 import type {ExpirationTime} from './ReactFiberExpirationTime.new';
 import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
-import type {ReactPriorityLevel} from './ReactInternalTypes';
 
 import {NoWork, Sync} from './ReactFiberExpirationTime.new';
 import {
@@ -105,7 +104,6 @@ import {
 } from './ReactFiberWorkLoop.new';
 
 import invariant from 'shared/invariant';
-import {getCurrentPriorityLevel} from './SchedulerWithReactIntegration.new';
 
 import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,7 +19,7 @@ export const disableInputAttributeSyncing = __VARIANT__;
 export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableModernEventSystem = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
-export const enableDebugTracing = __VARIANT__;
+export const enableDebugTracing = !__VARIANT__;
 
 // These are already tested in both modes using the build type dimension,
 // so we don't need to use __VARIANT__ to get extra coverage.


### PR DESCRIPTION
Sorry @bvaughn and @gaearon. 😢We can add it back.

Some of the concepts are changing. E.g. getting the current priority level isn't as obviously going to be in the same place. Priority field on update isn't useful anymore since the lanes convey more info. This code is also in all the places moving around. It'll be easier to just add this back than to try to keep them each time they move.
