### PR TITLE
Remove unnecessary stack

### DIFF
--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -39,7 +39,6 @@ import {
   ForceUpdate,
   enqueueUpdate,
 } from './ReactUpdateQueue.new';
-import {getStackByFiberInDevAndProd} from './ReactFiberComponentStack';
 import {markFailedErrorBoundaryForHotReloading} from './ReactFiberHotReloading.new';
 import {
   suspenseStackCursor,
@@ -333,8 +332,7 @@ function throwException(
         ' suspended while rendering, but no fallback UI was specified.\n' +
         '\n' +
         'Add a <Suspense fallback=...> component higher in the tree to ' +
-        'provide a loading indicator or placeholder to display.' +
-        getStackByFiberInDevAndProd(sourceFiber),
+        'provide a loading indicator or placeholder to display.',
     );
   }
 

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -40,7 +40,6 @@ import {
   ForceUpdate,
   enqueueUpdate,
 } from './ReactUpdateQueue.old';
-import {getStackByFiberInDevAndProd} from './ReactFiberComponentStack';
 import {markFailedErrorBoundaryForHotReloading} from './ReactFiberHotReloading.old';
 import {
   suspenseStackCursor,
@@ -344,8 +343,7 @@ function throwException(
         ' suspended while rendering, but no fallback UI was specified.\n' +
         '\n' +
         'Add a <Suspense fallback=...> component higher in the tree to ' +
-        'provide a loading indicator or placeholder to display.' +
-        getStackByFiberInDevAndProd(sourceFiber),
+        'provide a loading indicator or placeholder to display.',
     );
   }
 


### PR DESCRIPTION
Same rationale as https://github.com/facebook/react/pull/18685/commits/3aca0a08b47a3abc54207b143cddd64021f51fc2

We already append stacks in the "above error" log and to error boundaries so this provide superfluous information.