### PR TITLE
ReactDOMEventListener: clean up module

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -10,7 +10,11 @@
 import {registrationNameModules} from 'legacy-events/EventPluginRegistry';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import invariant from 'shared/invariant';
-import {setListenToResponderEventTypes} from '../events/DeprecatedDOMEventResponderSystem';
+import {
+  setListenToResponderEventTypes,
+  addResponderEventSystemEvent,
+  removeTrappedEventListener,
+} from '../events/DeprecatedDOMEventResponderSystem';
 
 import {
   getValueForAttribute,
@@ -56,10 +60,6 @@ import {
   TOP_TOGGLE,
 } from '../events/DOMTopLevelEventTypes';
 import {getListenerMapForElement} from '../events/DOMEventListenerMap';
-import {
-  addResponderEventSystemEvent,
-  removeTrappedEventListener,
-} from '../events/ReactDOMEventListener.js';
 import {mediaEventTypes} from '../events/DOMTopLevelEventTypes';
 import {
   createDangerousStringForStyles,

--- a/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
+++ b/packages/react-dom/src/events/DOMLegacyEventPluginSystem.js
@@ -44,9 +44,10 @@ import {
   getRawEventName,
   mediaEventTypes,
 } from './DOMTopLevelEventTypes';
-import {addTrappedEventListener} from './ReactDOMEventListener';
+import {createEventListenerWrapperWithPriority} from './ReactDOMEventListener';
 import {batchedEventUpdates} from './ReactDOMUpdateBatching';
 import getListener from './getListener';
+import {addEventCaptureListener, addEventBubbleListener} from './EventListener';
 
 /**
  * Summary of `DOMEventPluginSystem` event handling:
@@ -397,6 +398,24 @@ export function legacyTrapCapturedEvent(
     true,
   );
   listenerMap.set(topLevelType, {passive: undefined, listener});
+}
+
+function addTrappedEventListener(
+  targetContainer: EventTarget,
+  topLevelType: DOMTopLevelEventType,
+  eventSystemFlags: EventSystemFlags,
+  capture: boolean,
+): any => void {
+  const rawEventName = getRawEventName(topLevelType);
+  const listener = createEventListenerWrapperWithPriority(
+    targetContainer,
+    topLevelType,
+    eventSystemFlags,
+  );
+  const unsubscribeListener = capture
+    ? addEventCaptureListener(targetContainer, rawEventName, listener)
+    : addEventBubbleListener(targetContainer, rawEventName, listener);
+  return unsubscribeListener;
 }
 
 function getParent(inst: Object | null): Object | null {

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -30,10 +30,7 @@ import {
   getContainerFromFiber,
   getSuspenseInstanceFromFiber,
 } from 'react-reconciler/src/ReactFiberTreeReflection';
-import {
-  attemptToDispatchEvent,
-  addResponderEventSystemEvent,
-} from './ReactDOMEventListener';
+import {attemptToDispatchEvent} from './ReactDOMEventListener';
 import {getListenerMapForElement} from './DOMEventListenerMap';
 import {
   getInstanceFromNode,
@@ -121,6 +118,7 @@ import {
 import {IS_REPLAYED, PLUGIN_EVENT_SYSTEM} from './EventSystemFlags';
 import {legacyListenToTopLevelEvent} from './DOMLegacyEventPluginSystem';
 import {listenToTopLevelEvent} from './DOMModernPluginEventSystem';
+import {addResponderEventSystemEvent} from './DeprecatedDOMEventResponderSystem';
 
 type QueuedReplayableEvent = {|
   blockedOn: null | Container | SuspenseInstance,

--- a/packages/react-dom/src/events/plugins/__tests__/ModernChangeEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernChangeEventPlugin-test.internal.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-let React = require('react');
-let ReactDOM = require('react-dom');
-let TestUtils = require('react-dom/test-utils');
+let React;
+let ReactDOM;
+let TestUtils;
 let ReactFeatureFlags;
 let Scheduler;
 
@@ -34,6 +34,7 @@ describe('ChangeEventPlugin', () => {
   let container;
 
   beforeEach(() => {
+    jest.resetModules();
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     // TODO pull this into helper method, reduce repetition.
     // mock the browser APIs which are used in schedule:
@@ -53,7 +54,11 @@ describe('ChangeEventPlugin', () => {
         postMessageCallback(postMessageEvent);
       }
     };
-    jest.resetModules();
+    ReactFeatureFlags.enableModernEventSystem = true;
+    React = require('react');
+    ReactDOM = require('react-dom');
+    TestUtils = require('react-dom/test-utils');
+    Scheduler = require('scheduler');
     container = document.createElement('div');
     document.body.appendChild(container);
   });
@@ -467,17 +472,6 @@ describe('ChangeEventPlugin', () => {
   });
 
   describe('concurrent mode', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      ReactFeatureFlags = require('shared/ReactFeatureFlags');
-      ReactFeatureFlags.enableModernEventSystem = true;
-
-      React = require('react');
-      ReactDOM = require('react-dom');
-      TestUtils = require('react-dom/test-utils');
-      Scheduler = require('scheduler');
-    });
-
     // @gate experimental
     it('text input', () => {
       const root = ReactDOM.createRoot(container);
@@ -719,14 +713,6 @@ describe('ChangeEventPlugin', () => {
 
     // @gate experimental
     it('mouse enter/leave should be user-blocking but not discrete', async () => {
-      // This is currently behind a feature flag
-      jest.resetModules();
-      ReactFeatureFlags.enableModernEventSystem = true;
-      React = require('react');
-      ReactDOM = require('react-dom');
-      TestUtils = require('react-dom/test-utils');
-      Scheduler = require('scheduler');
-
       const {act} = TestUtils;
       const {useState} = React;
 

--- a/packages/react-dom/src/events/plugins/__tests__/ModernSimpleEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernSimpleEventPlugin-test.internal.js
@@ -234,7 +234,8 @@ describe('SimpleEventPlugin', function() {
   describe('interactive events, in concurrent mode', () => {
     beforeEach(() => {
       jest.resetModules();
-
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      ReactFeatureFlags.enableModernEventSystem = true;
       ReactDOM = require('react-dom');
       Scheduler = require('scheduler');
     });


### PR DESCRIPTION
This PR tidies up `ReactDOMEventListener` and moves the different event listener approaches into their respective modules. This makes it easier to remove event systems in the future without breaking something else. Along the way, I noticed that we weren't applying the modern event system flag in the plugin tests properly, so this fixes that too.