### PR TITLE
[ESLint] Extend isHook to recognize those under PascalCase's namespace

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -380,6 +380,8 @@ const tests = {
     },
     {
       code: `
+        // This is a false positive (it's valid) that unfortunately 
+        // we cannot avoid. Prefer to rename it to not start with "use"
         class Foo extends Component {
           render() {
             if (cond) {
@@ -401,17 +403,6 @@ const tests = {
         }
       `,
       errors: [conditionalError('Namespace.useConditionalHook')],
-    },
-    {
-      code: `
-        // Extending the isHook check to [A-Z].*\.use
-        // to not let it be called on top level
-        const History = require('history-2.1.2');
-        const browserHistory = History.useBasename(History.createHistory)({
-          basename: '/',
-        });
-      `,
-      errors: [topLevelError('History.useBasename')],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -311,6 +311,7 @@ const tests = {
         if (c) {} else {}
         if (c) {} else {}
         if (c) {} else {}
+        
         // 10 hooks
         useHook();
         useHook();

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -206,6 +206,8 @@ const tests = {
       _use();
       _useState();
       use_hook();
+      // also valid because it's not matching the PascalCase namespace
+      jest.useFakeTimer()
     `,
     `
       // Regression test for some internal code.

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -311,7 +311,7 @@ const tests = {
         if (c) {} else {}
         if (c) {} else {}
         if (c) {} else {}
-        
+
         // 10 hooks
         useHook();
         useHook();

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -106,6 +106,7 @@ const tests = {
       ({useHook() { useState(); }});
       const {useHook3 = () => { useState(); }} = {};
       ({useHook = () => { useState(); }} = {});
+      Namespace.useHook = () => { useState(); };
     `,
     `
       // Valid because hooks can call hooks.
@@ -192,45 +193,11 @@ const tests = {
       }
     `,
     `
-      // Currently valid.
-      // We *could* make this invalid if we want, but it creates false positives
-      // (see the FooStore case).
-      class C {
-        m() {
-          This.useHook();
-          Super.useHook();
-        }
-      }
-    `,
-    `
-      // Valid although we *could* consider these invalid.
-      // But it doesn't bring much benefit since it's an immediate runtime error anyway.
-      // So might as well allow it.
-      Hook.use();
-      Hook._use();
-      Hook.useState();
-      Hook._useState();
-      Hook.use42();
-      Hook.useHook();
-      Hook.use_hook();
-    `,
-    `
       // Valid -- this is a regression test.
       jest.useFakeTimers();
       beforeEach(() => {
         jest.useRealTimers();
       })
-    `,
-    `
-      // Valid because that's a false positive we've seen quite a bit.
-      // This is a regression test.
-      class Foo extends Component {
-        render() {
-          if (cond) {
-            FooStore.useFeatureFlag();
-          }
-        }
-      }
     `,
     `
       // Valid because they're not matching use[A-Z].
@@ -239,16 +206,6 @@ const tests = {
       _use();
       _useState();
       use_hook();
-    `,
-    `
-      // This is grey area.
-      // Currently it's valid (although React.useCallback would fail here).
-      // We could also get stricter and disallow it, just like we did
-      // with non-namespace use*() top-level calls.
-      const History = require('history-2.1.2');
-      const browserHistory = History.useBasename(History.createHistory)({
-        basename: '/',
-      });
     `,
     `
       // Regression test for some internal code.
@@ -352,7 +309,6 @@ const tests = {
         if (c) {} else {}
         if (c) {} else {}
         if (c) {} else {}
-
         // 10 hooks
         useHook();
         useHook();
@@ -391,6 +347,68 @@ const tests = {
         }
       `,
       errors: [conditionalError('useConditionalHook')],
+    },
+    {
+      code: `
+        Hook.use();
+        Hook._use();
+        Hook.useState();
+        Hook._useState();
+        Hook.use42();
+        Hook.useHook();
+        Hook.use_hook();
+      `,
+      errors: [
+        topLevelError('Hook.useState'),
+        topLevelError('Hook.use42'),
+        topLevelError('Hook.useHook'),
+      ],
+    },
+    {
+      code: `
+        class C {
+          m() {
+            This.useHook();
+            Super.useHook();
+          }
+        }
+      `,
+      errors: [classError('This.useHook'), classError('Super.useHook')],
+    },
+    {
+      code: `
+        class Foo extends Component {
+          render() {
+            if (cond) {
+              FooStore.useFeatureFlag();
+            }
+          }
+        }
+      `,
+      errors: [classError('FooStore.useFeatureFlag')],
+    },
+    {
+      code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+        function ComponentWithConditionalHook() {
+          if (cond) {
+            Namespace.useConditionalHook();
+          }
+        }
+      `,
+      errors: [conditionalError('Namespace.useConditionalHook')],
+    },
+    {
+      code: `
+        // Extending the isHook check to [A-Z].*\.use
+        // to not let it be called on top level
+        const History = require('history-2.1.2');
+        const browserHistory = History.useBasename(History.createHistory)({
+          basename: '/',
+        });
+      `,
+      errors: [topLevelError('History.useBasename')],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -31,10 +31,9 @@ function isHook(node) {
     !node.computed &&
     isHook(node.property)
   ) {
-    // Only consider React.useFoo() to be namespace hooks for now to avoid false positives.
-    // We can expand this check later.
     const obj = node.object;
-    return obj.type === 'Identifier' && obj.name === 'React';
+    const isPascalCaseNameSpace = /^[A-Z].*/;
+    return obj.type === 'Identifier' && isPascalCaseNameSpace.test(obj.name);
   } else {
     return false;
   }


### PR DESCRIPTION
## Summary

Context and discussion: https://fburl.com/ppb00y2s

TLDR: A few teams have the convention to put hooks under a namespace and the current implementation doesn't catch hooks that are written this way.

```
// is hook
useSomething();

// is not hook => doesn't recognize
Foo.useSomething();
```

This prevented us from catching the true positives and started to cause issues, like T65929958. We want to extend the definition of `isHook` so that we can safely catch those that are used:

- on top level / not in React component or other hooks
- called in class component
- being conditionally called

We intentionally don't include the namespace that are named in "camelCase" because there're a lot of false positive, eg:

```
jest.useFakeTimers
```

This change requires us to move a few test cases that are used to be regression tests and _were_ valid to invalid.

## Test Plan

```
# under react
> yarn test ESLintRulesOfHooks-test.js
```
