### PR TITLE
Move hide/unhide logic to new Offscreen fiber type

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -20,6 +20,7 @@ import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {ExpirationTimeOpaque} from './ReactFiberExpirationTime.new';
 import type {SuspenseInstance} from './ReactFiberHostConfig';
+import type {OffscreenProps} from './ReactFiberOffscreenComponent';
 
 import invariant from 'shared/invariant';
 import {
@@ -738,7 +739,7 @@ export function createFiberFromSuspenseList(
 }
 
 export function createFiberFromOffscreen(
-  pendingProps: any,
+  pendingProps: OffscreenProps,
   mode: TypeOfMode,
   expirationTime: ExpirationTimeOpaque,
   key: null | string,

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -54,6 +54,7 @@ import {
   FundamentalComponent,
   ScopeComponent,
   Block,
+  OffscreenComponent,
 } from './ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 
@@ -87,6 +88,7 @@ import {
   REACT_FUNDAMENTAL_TYPE,
   REACT_SCOPE_TYPE,
   REACT_BLOCK_TYPE,
+  REACT_OFFSCREEN_TYPE,
 } from 'shared/ReactSymbols';
 
 export type {Fiber};
@@ -511,6 +513,13 @@ export function createFiberFromTypeAndProps(
           expirationTime,
           key,
         );
+      case REACT_OFFSCREEN_TYPE:
+        return createFiberFromOffscreen(
+          pendingProps,
+          mode,
+          expirationTime,
+          key,
+        );
       default: {
         if (typeof type === 'object' && type !== null) {
           switch (type.$$typeof) {
@@ -724,6 +733,24 @@ export function createFiberFromSuspenseList(
     fiber.type = REACT_SUSPENSE_LIST_TYPE;
   }
   fiber.elementType = REACT_SUSPENSE_LIST_TYPE;
+  fiber.expirationTime_opaque = expirationTime;
+  return fiber;
+}
+
+export function createFiberFromOffscreen(
+  pendingProps: any,
+  mode: TypeOfMode,
+  expirationTime: ExpirationTimeOpaque,
+  key: null | string,
+) {
+  const fiber = createFiber(OffscreenComponent, pendingProps, key, mode);
+  // TODO: The OffscreenComponent fiber shouldn't have a type. It has a tag.
+  // This needs to be fixed in getComponentName so that it relies on the tag
+  // instead.
+  if (__DEV__) {
+    fiber.type = REACT_OFFSCREEN_TYPE;
+  }
+  fiber.elementType = REACT_OFFSCREEN_TYPE;
   fiber.expirationTime_opaque = expirationTime;
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -172,6 +172,7 @@ import {
   resolveLazyComponentTag,
   createFiberFromTypeAndProps,
   createFiberFromFragment,
+  createFiberFromOffscreen,
   createWorkInProgress,
   isSimpleFunctionComponent,
 } from './ReactFiber.new';
@@ -1995,7 +1996,7 @@ function mountSuspensePrimaryChildren(
   renderExpirationTime,
 ) {
   const mode = workInProgress.mode;
-  const primaryChildFragment = createFiberFromFragment(
+  const primaryChildFragment = createFiberFromOffscreen(
     primaryChildren,
     mode,
     renderExpirationTime,
@@ -2041,7 +2042,7 @@ function mountSuspenseFallbackChildren(
       null,
     );
   } else {
-    primaryChildFragment = createFiberFromFragment(null, mode, NoWork, null);
+    primaryChildFragment = createFiberFromOffscreen(null, mode, NoWork, null);
     fallbackChildFragment = createFiberFromFragment(
       fallbackChildren,
       mode,
@@ -2202,7 +2203,7 @@ function mountSuspenseFallbackAfterRetryWithoutHydrating(
   renderExpirationTime,
 ) {
   const mode = workInProgress.mode;
-  const primaryChildFragment = createFiberFromFragment(
+  const primaryChildFragment = createFiberFromOffscreen(
     null,
     mode,
     NoWork,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -45,6 +45,7 @@ import {
   FundamentalComponent,
   ScopeComponent,
   Block,
+  OffscreenComponent,
 } from './ReactWorkTags';
 import {
   NoEffect,
@@ -553,6 +554,21 @@ function updateSimpleMemoComponent(
     nextProps,
     renderExpirationTime,
   );
+}
+
+function updateOffscreenComponent(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderExpirationTime: ExpirationTimeOpaque,
+) {
+  const nextChildren = workInProgress.pendingProps;
+  reconcileChildren(
+    current,
+    workInProgress,
+    nextChildren,
+    renderExpirationTime,
+  );
+  return workInProgress.child;
 }
 
 function updateFragment(
@@ -3445,6 +3461,13 @@ function beginWork(
         type,
         resolvedProps,
         updateExpirationTime,
+        renderExpirationTime,
+      );
+    }
+    case OffscreenComponent: {
+      return updateOffscreenComponent(
+        current,
+        workInProgress,
         renderExpirationTime,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -26,6 +26,8 @@ import type {
   SuspenseListRenderState,
 } from './ReactFiberSuspenseComponent.new';
 import type {SuspenseContext} from './ReactFiberSuspenseContext.new';
+import type {OffscreenState} from './ReactFiberOffscreenComponent';
+
 import {resetWorkInProgressVersions as resetMutableSourceWorkInProgressVersions} from './ReactMutableSource.new';
 
 import {now} from './SchedulerWithReactIntegration.new';
@@ -1288,8 +1290,19 @@ function completeWork(
         return null;
       }
       break;
-    case OffscreenComponent:
+    case OffscreenComponent: {
+      if (current !== null) {
+        const nextState: OffscreenState | null = workInProgress.memoizedState;
+        const prevState: OffscreenState | null = current.memoizedState;
+
+        const prevIsHidden = prevState !== null;
+        const nextIsHidden = nextState !== null;
+        if (prevIsHidden !== nextIsHidden) {
+          workInProgress.effectTag |= Update;
+        }
+      }
       return null;
+    }
   }
   invariant(
     false,

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -53,6 +53,7 @@ import {
   FundamentalComponent,
   ScopeComponent,
   Block,
+  OffscreenComponent,
 } from './ReactWorkTags';
 import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {Ref, Update, NoEffect, DidCapture} from './ReactSideEffectTags';
@@ -1287,6 +1288,8 @@ function completeWork(
         return null;
       }
       break;
+    case OffscreenComponent:
+      return null;
   }
   invariant(
     false,

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+import type {ExpirationTimeOpaque} from './ReactFiberExpirationTime.new';
+
+export type OffscreenProps = {|
+  // TODO: Pick an API before exposing the Offscreen type. I've chosen an enum
+  // for now, since we might have multiple variants. For example, hiding the
+  // content without changing the layout.
+  //
+  // Default mode is visible. Kind of a weird default for a component
+  // called "Offscreen." Possible alt: <Visibility />?
+  mode?: 'hidden' | 'visible' | null | void,
+  children?: ReactNodeList,
+|};
+
+// We use the existence of the state object as an indicator that the component
+// is hidden.
+export type OffscreenState = {|
+  // TODO: This doesn't do anything, yet. It's always NoWork. But eventually it
+  // will represent the pending work that must be included in the render in
+  // order to unhide the component.
+  baseTime: ExpirationTimeOpaque,
+|};

--- a/packages/react-reconciler/src/ReactWorkTags.js
+++ b/packages/react-reconciler/src/ReactWorkTags.js
@@ -30,7 +30,8 @@ export type WorkTag =
   | 19
   | 20
   | 21
-  | 22;
+  | 22
+  | 23;
 
 export const FunctionComponent = 0;
 export const ClassComponent = 1;
@@ -55,3 +56,4 @@ export const SuspenseListComponent = 19;
 export const FundamentalComponent = 20;
 export const ScopeComponent = 21;
 export const Block = 22;
+export const OffscreenComponent = 23;

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -32,6 +32,7 @@ export let REACT_RESPONDER_TYPE = 0xead6;
 export let REACT_SCOPE_TYPE = 0xead7;
 export let REACT_OPAQUE_ID_TYPE = 0xeae0;
 export let REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
+export let REACT_OFFSCREEN_TYPE = 0xeae2;
 
 if (typeof Symbol === 'function' && Symbol.for) {
   const symbolFor = Symbol.for;
@@ -54,6 +55,7 @@ if (typeof Symbol === 'function' && Symbol.for) {
   REACT_SCOPE_TYPE = symbolFor('react.scope');
   REACT_OPAQUE_ID_TYPE = symbolFor('react.opaque.id');
   REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
+  REACT_OFFSCREEN_TYPE = symbolFor('react.offscreen');
 }
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;


### PR DESCRIPTION
This adds a new internal Fiber type, Offscreen, and uses it in the Suspense implementation to hide/unhide children when switching between the primary and fallback trees. Most of the logic for hiding/unhiding already existed, so this PR mostly just moves it to the new type. Eventually, the idea is we'll expose an `<Offscreen />` component type (name TBD) that uses the same implementation. I have not added the public type yet.