### PR TITLE
Unhide Suspense trees without entanglement

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -131,6 +131,7 @@ import {
   renderDidSuspend,
   renderDidSuspendDelayIfPossible,
   renderHasNotSuspendedYet,
+  popRenderExpirationTime,
 } from './ReactFiberWorkLoop.new';
 import {createFundamentalStateInstance} from './ReactFiberFundamental.new';
 import {Never, isSameOrHigherPriority} from './ReactFiberExpirationTime.new';
@@ -1312,6 +1313,7 @@ function completeWork(
       }
       break;
     case OffscreenComponent: {
+      popRenderExpirationTime(workInProgress);
       if (current !== null) {
         const nextState: OffscreenState | null = workInProgress.memoizedState;
         const prevState: OffscreenState | null = current.memoizedState;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -55,7 +55,7 @@ import {
   didNotFindHydratableSuspenseInstance,
 } from './ReactFiberHostConfig';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
-import {Never, NoWork} from './ReactFiberExpirationTime.new';
+import {Never} from './ReactFiberExpirationTime.new';
 
 // The deepest Fiber on the stack involved in a hydration context.
 // This may have been an insertion or a hydration.
@@ -231,7 +231,6 @@ function tryHydrate(fiber, nextInstance) {
         if (suspenseInstance !== null) {
           const suspenseState: SuspenseState = {
             dehydrated: suspenseInstance,
-            baseTime: NoWork,
             retryTime: Never,
           };
           fiber.memoizedState = suspenseState;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
@@ -29,10 +29,6 @@ export type SuspenseState = {|
   // here to indicate that it is dehydrated (flag) and for quick access
   // to check things like isSuspenseInstancePending.
   dehydrated: null | SuspenseInstance,
-  // Represents the work that was deprioritized when we committed the fallback.
-  // The work outside the boundary already committed at this level, so we cannot
-  // unhide the content without including it.
-  baseTime: ExpirationTimeOpaque,
   // Represents the earliest expiration time we should attempt to hydrate
   // a dehydrated boundary at.
   // Never is the default for dehydrated boundaries.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -20,6 +20,7 @@ import {
   ContextProvider,
   SuspenseComponent,
   SuspenseListComponent,
+  OffscreenComponent,
 } from './ReactWorkTags';
 import {DidCapture, NoEffect, ShouldCapture} from './ReactSideEffectTags';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
@@ -33,6 +34,7 @@ import {
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext.new';
 import {popProvider} from './ReactFiberNewContext.new';
+import {popRenderExpirationTime} from './ReactFiberWorkLoop.new';
 
 import invariant from 'shared/invariant';
 
@@ -105,6 +107,9 @@ function unwindWork(
     case ContextProvider:
       popProvider(workInProgress);
       return null;
+    case OffscreenComponent:
+      popRenderExpirationTime(workInProgress);
+      return null;
     default:
       return null;
   }
@@ -140,6 +145,9 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
       break;
     case ContextProvider:
       popProvider(interruptedWork);
+      break;
+    case OffscreenComponent:
+      popRenderExpirationTime(interruptedWork);
       break;
     default:
       break;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -3180,18 +3180,49 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         });
         setFallbackText('Still loading...');
 
-        expect(Scheduler).toFlushAndYield([
-          // First try to render the high pri update. We won't try to re-render
-          // the suspended tree during this pass, because it still has unfinished
-          // updates at a lower priority.
-          'Loading...',
+        expect(Scheduler).toFlushAndYield(
+          gate(flags =>
+            flags.new
+              ? [
+                  // First try to render the high pri update. Still suspended.
+                  'Suspend! [C]',
+                  'Loading...',
 
-          // Now try the suspended update again. It's still suspended.
-          'Suspend! [C]',
+                  // In the expiration times model, once the high pri update
+                  // suspends, we can't be sure if there's additional work at a
+                  // lower priority that might unblock the tree. We do know that
+                  // there's a lower priority update *somehwere* in the entire
+                  // root, though (the update to the fallback). So we try
+                  // rendering one more time, just in case.
+                  // TODO: We shouldn't need to do this with lanes, because we
+                  // always know exactly which lanes have pending work in
+                  // each tree.
+                  'Suspend! [C]',
 
-          // Then complete the update to the fallback.
-          'Still loading...',
-        ]);
+                  // Then complete the update to the fallback.
+                  'Still loading...',
+                ]
+              : [
+                  // In the old reconciler, we don't attempt to unhdie the
+                  // Suspense boundary at high priority. Instead, we bailout,
+                  // then try again at the original priority that the component
+                  // suspended. This is mostly an implementation compromise,
+                  // though there are some advantages to this behavior, because
+                  // attempt to unhide could slow down the rest of the update.
+                  //
+                  // Render that only includes the fallback, since we bailed
+                  // out on the primary tree.
+                  'Loading...',
+
+                  // Now try the suspended update again at the original
+                  // priority. It's still suspended.
+                  'Suspend! [C]',
+
+                  // Then complete the update to the fallback.
+                  'Still loading...',
+                ],
+          ),
+        );
         expect(root).toMatchRenderedOutput(
           <>
             <span hidden={true} prop="A" />
@@ -3466,17 +3497,34 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           root.render(<Parent step={1} />);
         });
       });
+
       // Only the outer part can update. The inner part should still show a
       // fallback because we haven't finished loading B yet. Otherwise, the
       // inner text would be inconsistent with the outer text.
-      expect(Scheduler).toHaveYielded([
-        'Outer text: B',
-        'Outer step: 1',
-        'Loading...',
-
-        'Suspend! [Inner text: B]',
-        'Inner step: 1',
-      ]);
+      expect(Scheduler).toHaveYielded(
+        gate(flags =>
+          flags.new
+            ? [
+                'Outer text: B',
+                'Outer step: 1',
+                'Suspend! [Inner text: B]',
+                'Inner step: 1',
+                'Loading...',
+              ]
+            : [
+                // In the old reconciler, we first complete the outside of the
+                // Suspense boundary, then attempt to unhide it in a separate
+                // render at the original priority at which it suspended.
+                // First render:
+                'Outer text: B',
+                'Outer step: 1',
+                'Loading...',
+                // Second render:
+                'Suspend! [Inner text: B]',
+                'Inner step: 1',
+              ],
+        ),
+      );
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="Outer text: B" />
@@ -3595,15 +3643,23 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
     });
 
-    expect(Scheduler).toHaveYielded([
-      // First the outer part of the tree updates, at high pri.
-      'Outer: B1',
-      'Loading...',
-
-      // Then we retry the boundary.
-      'Inner: B1',
-      'Commit Child',
-    ]);
+    expect(Scheduler).toHaveYielded(
+      gate(flags =>
+        flags.new
+          ? ['Outer: B1', 'Inner: B1', 'Commit Child']
+          : [
+              // In the old reconciler, we first complete the outside of the
+              // Suspense boundary, then attempt to unhide it in a separate
+              // render at the original priority at which it suspended.
+              // First render:
+              'Outer: B1',
+              'Loading...',
+              // Second render:
+              'Inner: B1',
+              'Commit Child',
+            ],
+      ),
+    );
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: B1" />


### PR DESCRIPTION
When a Suspense boundary is in its fallback state, you cannot switch back to the main content without also finishing any updates inside the tree that might have been skipped. That would be a form of tearing.

Before we fixed this in #18411, the way this bug manifested was that a boundary was suspended by an update that originated from a child component (as opposed to props from a parent). While the fallback was showing, it received another update, this time at high priority. React would render the high priority update without also including the original update. That would cause the fallback to switch back to the main content, since the update that caused the tree to suspend was no longer part of the render. But then, React would immediately try to render the original update, which would again suspend and show the fallback, leading to a momentary flicker in the UI.

The approach added in #18411 is, when receiving a high priority update to a Suspense tree that's in its fallback state is to bail out, keep showing the fallback and finish the update in the rest of the tree. After that commits, render again at the original priority. Because low priority expiration times are inclusive of higher priority expiration times, this ensures that all the updates are committed together.

The new approach in this commit is to turn `renderExpirationTime` into a context-like value that lives on the stack. Then, when unhiding the Suspense boundary, we can push a new `renderExpirationTime` that is inclusive of both the high pri update and the original update that suspended. Then the boundary can be unblocked in a single render pass.

An advantage of the old approach is that by deferring the work of unhiding, there's less work to do in the high priority update.

The key advantage of the new approach is that it solves the consistency problem without having to entangle the entire root.