### PR TITLE
Devtools: Show inspectedElement `key` in right pane

### DIFF
--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -731,7 +731,7 @@ export function attach(
       return null;
     }
 
-    const {displayName} = getData(internalInstance);
+    const {displayName, key} = getData(internalInstance);
     const type = getElementType(internalInstance);
 
     let context = null;
@@ -788,6 +788,8 @@ export function attach(
       displayName: displayName,
 
       type: type,
+
+      key: key != null ? key : null,
 
       // Inspectable properties.
       context,

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2143,6 +2143,7 @@ export function attach(
       _debugOwner,
       _debugSource,
       stateNode,
+      key,
       memoizedProps,
       memoizedState,
       tag,
@@ -2299,6 +2300,8 @@ export function attach(
 
       // Does the component have legacy context attached to it.
       hasLegacyContext,
+
+      key: key != null ? key : null,
 
       displayName: getDisplayNameForFiber(fiber),
       type: elementType,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -202,6 +202,7 @@ export type InspectedElement = {|
   hooks: Object | null,
   props: Object | null,
   state: Object | null,
+  key: number | string | null,
 
   // List of owners
   owners: Array<Owner> | null,

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -243,7 +243,6 @@ function InspectedElementContextController({children}: Props) {
             hooks: hydrateHelper(hooks),
             props: hydrateHelper(props),
             state: hydrateHelper(state),
-            key: hydrateHelper(key),
           };
 
           element = store.getElementByID(id);

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -209,6 +209,7 @@ function InspectedElementContextController({children}: Props) {
             hooks,
             props,
             state,
+            key,
           } = ((data.value: any): InspectedElementBackend);
 
           const inspectedElement: InspectedElementFrontend = {
@@ -241,6 +242,7 @@ function InspectedElementContextController({children}: Props) {
             hooks: hydrateHelper(hooks),
             props: hydrateHelper(props),
             state: hydrateHelper(state),
+            key: hydrateHelper(key),
           };
 
           element = store.getElementByID(id);

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -219,6 +219,7 @@ function InspectedElementContextController({children}: Props) {
             canViewSource,
             hasLegacyContext,
             id,
+            key,
             source,
             type,
             owners:

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -77,14 +77,16 @@ export default function InspectedElementTree({
   } else {
     return (
       <div className={styles.InspectedElementTree}>
-        <div className={styles.HeaderRow}>
-          {label && <div className={styles.Header}>{label}</div>}
-          {!isEmpty && (
-            <Button onClick={handleCopy} title="Copy to clipboard">
-              <ButtonIcon type="copy" />
-            </Button>
-          )}
-        </div>
+        {label && (
+          <div className={styles.HeaderRow}>
+            <div className={styles.Header}>{label}</div>
+            {!isEmpty && (
+              <Button onClick={handleCopy} title="Copy to clipboard">
+                <ButtonIcon type="copy" />
+              </Button>
+            )}
+          </div>
+        )}
         {isEmpty && !canAddEntries && <div className={styles.Empty}>None</div>}
         {!isEmpty &&
           (entries: any).map(([name, value]) => (

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -77,16 +77,14 @@ export default function InspectedElementTree({
   } else {
     return (
       <div className={styles.InspectedElementTree}>
-        {label && (
-          <div className={styles.HeaderRow}>
-            <div className={styles.Header}>{label}</div>
-            {!isEmpty && (
-              <Button onClick={handleCopy} title="Copy to clipboard">
-                <ButtonIcon type="copy" />
-              </Button>
-            )}
-          </div>
-        )}
+        <div className={styles.HeaderRow}>
+          <div className={styles.Header}>{label}</div>
+          {!isEmpty && (
+            <Button onClick={handleCopy} title="Copy to clipboard">
+              <ButtonIcon type="copy" />
+            </Button>
+          )}
+        </div>
         {isEmpty && !canAddEntries && <div className={styles.Empty}>None</div>}
         {!isEmpty &&
           (entries: any).map(([name, value]) => (

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementTree.js
@@ -78,7 +78,7 @@ export default function InspectedElementTree({
     return (
       <div className={styles.InspectedElementTree}>
         <div className={styles.HeaderRow}>
-          <div className={styles.Header}>{label}</div>
+          {label && <div className={styles.Header}>{label}</div>}
           {!isEmpty && (
             <Button onClick={handleCopy} title="Copy to clipboard">
               <ButtonIcon type="copy" />

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.css
@@ -16,10 +16,37 @@
   padding: 0.5rem;
 }
 
+.Key {
+  flex: 0 1 auto;
+  padding-left: 0.25rem;
+  padding-right: 0.125rem;
+  line-height: 1rem;
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+  display: inline-block;
+  background-color: var(--color-component-badge-background);
+  color: var(--color-text);
+  font-family: var(--font-family-monospace);
+  font-size: var(--font-size-monospace-small);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.KeyArrow {
+  height: 1rem;
+  width: 1rem;
+  margin-right: -0.25rem;
+  border: 0.5rem solid transparent;
+  border-left: 0.5rem solid var(--color-component-badge-background);
+}
+
 .SelectedComponentName {
   flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: normal;
 }
 
 .Owners {

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -376,6 +376,14 @@ function InspectedElementView({
     <Fragment>
       <div className={styles.InspectedElement}>
         <HocBadges element={element} />
+        {key && (
+          <InspectedElementTree
+            label=""
+            data={{key: key}}
+            inspectPath={inspectKeyPath}
+            pathRoot="key"
+          />
+        )}
         <InspectedElementTree
           label="props"
           data={props}
@@ -384,12 +392,6 @@ function InspectedElementView({
           pathRoot="props"
           showWhenEmpty={true}
           canAddEntries={typeof overridePropsFn === 'function'}
-        />
-        <InspectedElementTree
-          label=""
-          data={{key: key}}
-          inspectPath={inspectKeyPath}
-          pathRoot="key"
         />
         {type === ElementTypeSuspense ? (
           <InspectedElementTree

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -284,6 +284,7 @@ function InspectedElementView({
     props,
     source,
     state,
+    key,
   } = inspectedElement;
 
   const {ownerID} = useContext(TreeStateContext);
@@ -298,6 +299,12 @@ function InspectedElementView({
   const inspectContextPath = useCallback(
     (path: Array<string | number>) => {
       getInspectedElementPath(id, ['context', ...path]);
+    },
+    [getInspectedElementPath, id],
+  );
+  const inspectKeyPath = useCallback(
+    (path: Array<string | number>) => {
+      getInspectedElementPath(id, ['key', ...path]);
     },
     [getInspectedElementPath, id],
   );
@@ -377,6 +384,12 @@ function InspectedElementView({
           pathRoot="props"
           showWhenEmpty={true}
           canAddEntries={typeof overridePropsFn === 'function'}
+        />
+        <InspectedElementTree
+          label=""
+          data={{key: key}}
+          inspectPath={inspectKeyPath}
+          pathRoot="key"
         />
         {type === ElementTypeSuspense ? (
           <InspectedElementTree

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedElement.js
@@ -190,6 +190,15 @@ export default function SelectedElement(_: Props) {
   return (
     <div className={styles.SelectedElement}>
       <div className={styles.TitleRow}>
+        {element.key && (
+          <>
+            <div className={styles.Key} title={`key "${element.key}"`}>
+              {element.key}
+            </div>
+            <div className={styles.KeyArrow} />
+          </>
+        )}
+
         <div className={styles.SelectedComponentName}>
           <div className={styles.Component} title={element.displayName}>
             {element.displayName}
@@ -284,7 +293,6 @@ function InspectedElementView({
     props,
     source,
     state,
-    key,
   } = inspectedElement;
 
   const {ownerID} = useContext(TreeStateContext);
@@ -299,12 +307,6 @@ function InspectedElementView({
   const inspectContextPath = useCallback(
     (path: Array<string | number>) => {
       getInspectedElementPath(id, ['context', ...path]);
-    },
-    [getInspectedElementPath, id],
-  );
-  const inspectKeyPath = useCallback(
-    (path: Array<string | number>) => {
-      getInspectedElementPath(id, ['key', ...path]);
     },
     [getInspectedElementPath, id],
   );
@@ -376,14 +378,6 @@ function InspectedElementView({
     <Fragment>
       <div className={styles.InspectedElement}>
         <HocBadges element={element} />
-        {key && (
-          <InspectedElementTree
-            label=""
-            data={{key: key}}
-            inspectPath={inspectKeyPath}
-            pathRoot="key"
-          />
-        )}
         <InspectedElementTree
           label="props"
           data={props}

--- a/packages/react-devtools-shared/src/devtools/views/Components/types.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/types.js
@@ -79,6 +79,7 @@ export type InspectedElement = {|
   hooks: Object | null,
   props: Object | null,
   state: Object | null,
+  key: number | string | null,
 
   // List of owners
   owners: Array<Owner> | null,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Initial MVP for showing `key` in `InspectedElementView`

Wasn't able to get the tooling for Flow and the development server set up quickly, so I have skipped that for now.

Just want to check if this approach has any fundamental problems before investing further time.

Closes #18702

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

TBD