### PR TITLE
SuspenseList: Reschedule continuation at same priority

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -127,11 +127,7 @@ import {
   renderHasNotSuspendedYet,
 } from './ReactFiberWorkLoop.new';
 import {createFundamentalStateInstance} from './ReactFiberFundamental.new';
-import {
-  Never,
-  isSameOrHigherPriority,
-  bumpPriorityLower,
-} from './ReactFiberExpirationTime.new';
+import {Never, isSameOrHigherPriority} from './ReactFiberExpirationTime.new';
 import {resetChildFibers} from './ReactChildFiber.new';
 import {updateDeprecatedEventListeners} from './ReactFiberDeprecatedEvents.new';
 import {createScopeMethods} from './ReactFiberScope.new';
@@ -1118,11 +1114,9 @@ function completeWork(
             // them, then they really have the same priority as this render.
             // So we'll pick it back up the very next render pass once we've had
             // an opportunity to yield for paint.
-
-            const nextPriority = bumpPriorityLower(renderExpirationTime);
-            workInProgress.expirationTime_opaque = workInProgress.childExpirationTime_opaque = nextPriority;
+            workInProgress.expirationTime_opaque = renderExpirationTime;
             if (enableSchedulerTracing) {
-              markSpawnedWork(nextPriority);
+              markSpawnedWork(renderExpirationTime);
             }
           }
         }


### PR DESCRIPTION
SuspenseList progressively renders items even if the list is CPU bound, i.e. it isn't waiting for missing data. It does this by showing a fallback for the remaining items, committing the items in that have already finished, then starting a new render to continue working on the rest.

When it schedules that subsequent render, it uses a slightly lower priority than the current render: `renderExpirationTime - 1`.

This commit changes it to reschedule at `renderExpirationTime` instead.

I don't know what the original motivation was for bumping the expiration time slightly lower. The comment says that the priorities of the two renders are the same (which makes sense to me) so I imagine it was motivated by some implementation detail. I don't think it's necessary anymore, though perhaps it was when it was originally written. If it is still necessary, we should write a test case that illustrates why.