### PR TITLE
Add experimental ReactDOM.createEventHandle

### DIFF
--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -36,4 +36,5 @@ export {
   unstable_scheduleHydration,
   unstable_renderSubtreeIntoContainer,
   unstable_createPortal,
+  unstable_createEventHandle,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -27,4 +27,5 @@ export {
   unstable_scheduleHydration,
   unstable_renderSubtreeIntoContainer,
   unstable_createPortal,
+  unstable_createEventHandle,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -19,4 +19,5 @@ export {
   createBlockingRoot as unstable_createBlockingRoot,
   unstable_flushControlled,
   unstable_scheduleHydration,
+  unstable_createEventHandle,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -20,6 +20,7 @@ import {
   unmountComponentAtNode,
 } from './ReactDOMLegacy';
 import {createRoot, createBlockingRoot, isValidContainer} from './ReactDOMRoot';
+import {createEventHandle} from './ReactDOMEventHandle';
 
 import {
   batchedEventUpdates,
@@ -208,6 +209,8 @@ export {
   // Temporary alias since we already shipped React 16 RC with it.
   // TODO: remove in React 17.
   unstable_createPortal,
+  // enableCreateEventHandleAPI
+  createEventHandle as unstable_createEventHandle,
 };
 
 const foundDevTools = injectIntoDevTools({

--- a/packages/react-dom/src/client/ReactDOMEventHandle.js
+++ b/packages/react-dom/src/client/ReactDOMEventHandle.js
@@ -1,0 +1,247 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {DOMTopLevelEventType} from 'legacy-events/TopLevelEventTypes';
+import type {EventPriority, ReactScopeInstance} from 'shared/ReactTypes';
+import type {
+  ReactDOMEventHandle,
+  ReactDOMEventHandleListener,
+} from '../shared/ReactDOMTypes';
+
+import {getEventPriorityForListenerSystem} from '../events/DOMEventProperties';
+import {
+  getClosestInstanceFromNode,
+  getEventHandlerListeners,
+  setEventHandlerListeners,
+  getEventListenerMap,
+  getFiberFromScopeInstance,
+} from './ReactDOMComponentTree';
+import {ELEMENT_NODE} from '../shared/HTMLNodeType';
+import {
+  listenToTopLevelEvent,
+  addEventTypeToDispatchConfig,
+} from '../events/DOMModernPluginEventSystem';
+
+import {HostRoot, HostPortal} from 'react-reconciler/src/ReactWorkTags';
+import {
+  PLUGIN_EVENT_SYSTEM,
+  IS_TARGET_PHASE_ONLY,
+} from '../events/EventSystemFlags';
+
+import {
+  enableScopeAPI,
+  enableCreateEventHandleAPI,
+} from 'shared/ReactFeatureFlags';
+import invariant from 'shared/invariant';
+
+type EventHandleOptions = {|
+  capture?: boolean,
+  passive?: boolean,
+  priority?: EventPriority,
+|};
+
+function getNearestRootOrPortalContainer(node: Fiber): null | Element {
+  while (node !== null) {
+    const tag = node.tag;
+    // Once we encounter a host container or root container
+    // we can return their DOM instance.
+    if (tag === HostRoot || tag === HostPortal) {
+      return node.stateNode.containerInfo;
+    }
+    node = node.return;
+  }
+  return null;
+}
+
+function isValidEventTarget(target: EventTarget | ReactScopeInstance): boolean {
+  return typeof (target: Object).addEventListener === 'function';
+}
+
+function isReactScope(target: EventTarget | ReactScopeInstance): boolean {
+  return typeof (target: Object).getChildContextValues === 'function';
+}
+
+function createEventHandleListener(
+  type: DOMTopLevelEventType,
+  capture: boolean,
+  callback: (SyntheticEvent<EventTarget>) => void,
+  destroy: (target: EventTarget | ReactScopeInstance) => void,
+): ReactDOMEventHandleListener {
+  return {
+    callback,
+    capture,
+    destroy,
+    type,
+  };
+}
+
+function registerEventOnNearestTargetContainer(
+  targetFiber: Fiber,
+  topLevelType: DOMTopLevelEventType,
+  passive: boolean | void,
+  priority: EventPriority | void,
+): void {
+  // If it is, find the nearest root or portal and make it
+  // our event handle target container.
+  const targetContainer = getNearestRootOrPortalContainer(targetFiber);
+  if (targetContainer === null) {
+    invariant(
+      false,
+      'ReactDOM.createEventHandle: setListener called on an target ' +
+        'that did not have a corresponding root. This is likely a bug in React.',
+    );
+  }
+  const listenerMap = getEventListenerMap(targetContainer);
+  listenToTopLevelEvent(
+    topLevelType,
+    targetContainer,
+    listenerMap,
+    PLUGIN_EVENT_SYSTEM,
+    passive,
+    priority,
+  );
+}
+
+export function createEventHandle(
+  type: string,
+  options?: EventHandleOptions,
+): ReactDOMEventHandle {
+  if (enableCreateEventHandleAPI) {
+    const topLevelType = ((type: any): DOMTopLevelEventType);
+    let capture = false;
+    let passive = undefined; // Undefined means to use the browser default
+    let priority;
+
+    if (options != null) {
+      const optionsCapture = options.capture;
+      const optionsPassive = options.passive;
+      const optionsPriority = options.priority;
+
+      if (typeof optionsCapture === 'boolean') {
+        capture = optionsCapture;
+      }
+      if (typeof optionsPassive === 'boolean') {
+        passive = optionsPassive;
+      }
+      if (typeof optionsPriority === 'number') {
+        priority = optionsPriority;
+      }
+    }
+    if (priority === undefined) {
+      priority = getEventPriorityForListenerSystem(topLevelType);
+    }
+
+    const listeners = new Map();
+
+    const destroy = (target: EventTarget | ReactScopeInstance): void => {
+      const listener = listeners.get(target);
+      if (listener !== undefined) {
+        listeners.delete(target);
+        const targetListeners = getEventHandlerListeners(target);
+        if (targetListeners !== null) {
+          targetListeners.delete(listener);
+        }
+      }
+    };
+
+    const clear = (): void => {
+      const eventTargetsArr = Array.from(listeners.keys());
+      for (let i = 0; i < eventTargetsArr.length; i++) {
+        destroy(eventTargetsArr[i]);
+      }
+    };
+
+    return {
+      setListener(
+        target: EventTarget | ReactScopeInstance,
+        callback: null | ((SyntheticEvent<EventTarget>) => void),
+      ): void {
+        // Check if the target is a DOM element.
+        if ((target: any).nodeType === ELEMENT_NODE) {
+          const targetElement = ((target: any): Element);
+          // Check if the DOM element is managed by React.
+          const targetFiber = getClosestInstanceFromNode(targetElement);
+          if (targetFiber === null) {
+            invariant(
+              false,
+              'ReactDOM.createEventHandle: setListener called on an element ' +
+                'target that is not managed by React. Ensure React rendered the DOM element.',
+            );
+          }
+          registerEventOnNearestTargetContainer(
+            targetFiber,
+            topLevelType,
+            passive,
+            priority,
+          );
+        } else if (enableScopeAPI && isReactScope(target)) {
+          const scopeTarget = ((target: any): ReactScopeInstance);
+          const targetFiber = getFiberFromScopeInstance(scopeTarget);
+          if (targetFiber === null) {
+            // Scope is unmounted, do not proceed.
+            return;
+          }
+          registerEventOnNearestTargetContainer(
+            targetFiber,
+            topLevelType,
+            passive,
+            priority,
+          );
+        } else if (isValidEventTarget(target)) {
+          const eventTarget = ((target: any): EventTarget);
+          const listenerMap = getEventListenerMap(eventTarget);
+          listenToTopLevelEvent(
+            topLevelType,
+            eventTarget,
+            listenerMap,
+            PLUGIN_EVENT_SYSTEM | IS_TARGET_PHASE_ONLY,
+            passive,
+            priority,
+            capture,
+          );
+        } else {
+          invariant(
+            false,
+            'ReactDOM.createEventHandle: setListener called on an invalid ' +
+              'target. Provide a vaid EventTarget or an element managed by React.',
+          );
+        }
+        let listener = listeners.get(target);
+        if (listener === undefined) {
+          if (callback === null) {
+            return;
+          }
+          listener = createEventHandleListener(
+            topLevelType,
+            capture,
+            callback,
+            destroy,
+          );
+          listeners.set(target, listener);
+
+          let targetListeners = getEventHandlerListeners(target);
+          if (targetListeners === null) {
+            targetListeners = new Set();
+            setEventHandlerListeners(target, targetListeners);
+          }
+          targetListeners.add(listener);
+          // Finally, add the event to our known event types list.
+          addEventTypeToDispatchConfig(topLevelType);
+        } else if (callback !== null) {
+          listener.callback = callback;
+        } else {
+          // Remove listener
+          destroy(target);
+        }
+      },
+      clear,
+    };
+  }
+  return (null: any);
+}

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -76,12 +76,15 @@ import {
   enableDeprecatedFlareAPI,
   enableFundamentalAPI,
   enableModernEventSystem,
-  enableScopeAPI,
   enableCreateEventHandleAPI,
+  enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
 import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
-import {listenToEvent} from '../events/DOMModernPluginEventSystem';
+import {
+  listenToEvent,
+  clearEventHandleListenersForTarget,
+} from '../events/DOMModernPluginEventSystem';
 
 export type Type = string;
 export type Props = {
@@ -539,7 +542,9 @@ function dispatchAfterDetachedBlur(target: HTMLElement): void {
 export function removeInstanceEventHandles(
   instance: Instance | TextInstance | SuspenseInstance,
 ) {
-  // TODO for ReactDOM.createEventInstance
+  if (enableCreateEventHandleAPI) {
+    clearEventHandleListenersForTarget(instance);
+  }
 }
 
 export function removeChild(
@@ -1136,8 +1141,12 @@ export function prepareScopeUpdate(
   }
 }
 
-export function removeScopeEventHandles(scopeInstance: Object): void {
-  // TODO when we add createEventHandle
+export function removeScopeEventHandles(
+  scopeInstance: ReactScopeInstance,
+): void {
+  if (enableScopeAPI && enableCreateEventHandleAPI) {
+    clearEventHandleListenersForTarget(scopeInstance);
+  }
 }
 
 export function getInstanceFromScope(

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -9,11 +9,14 @@
 
 'use strict';
 
+import {createEventTarget} from 'dom-event-testing-library';
+
 let React;
 let ReactFeatureFlags;
 let ReactDOM;
 let ReactDOMServer;
 let Scheduler;
+let ReactTestUtils;
 
 function dispatchEvent(element, type) {
   const event = document.createEvent('Event');
@@ -1166,6 +1169,1585 @@ describe('DOMModernPluginEventSystem', () => {
               'bubble root',
             ]);
           }
+        });
+
+        describe('ReactDOM.createEventHandle', () => {
+          beforeEach(() => {
+            jest.resetModules();
+            ReactFeatureFlags = require('shared/ReactFeatureFlags');
+            ReactFeatureFlags.enableLegacyFBSupport = enableLegacyFBSupport;
+            ReactFeatureFlags.enableModernEventSystem = true;
+            ReactFeatureFlags.enableCreateEventHandleAPI = true;
+
+            React = require('react');
+            ReactDOM = require('react-dom');
+            Scheduler = require('scheduler');
+            ReactDOMServer = require('react-dom/server');
+            ReactTestUtils = require('react-dom/test-utils');
+          });
+
+          // @gate experimental
+          it('can render correctly with the ReactDOMServer', () => {
+            const clickEvent = jest.fn();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              const divRef = React.useRef(null);
+
+              React.useEffect(() => {
+                click.setListener(divRef.current, clickEvent);
+              });
+
+              return <div ref={divRef}>Hello world</div>;
+            }
+            const output = ReactDOMServer.renderToString(<Test />);
+            expect(output).toBe(`<div data-reactroot="">Hello world</div>`);
+          });
+
+          // @gate experimental
+          it('can render correctly with the ReactDOMServer hydration', () => {
+            const clickEvent = jest.fn();
+            const spanRef = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(spanRef.current, clickEvent);
+              });
+
+              return (
+                <div>
+                  <span ref={spanRef}>Hello world</span>
+                </div>
+              );
+            }
+            const output = ReactDOMServer.renderToString(<Test />);
+            expect(output).toBe(
+              `<div data-reactroot=""><span>Hello world</span></div>`,
+            );
+            container.innerHTML = output;
+            ReactDOM.hydrate(<Test />, container);
+            Scheduler.unstable_flushAll();
+            dispatchClickEvent(spanRef.current);
+            expect(clickEvent).toHaveBeenCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('should correctly work for a basic "click" listener', () => {
+            let log = [];
+            const clickEvent = jest.fn(event => {
+              log.push({
+                eventPhase: event.eventPhase,
+                type: event.type,
+                currentTarget: event.currentTarget,
+                target: event.target,
+              });
+            });
+            const divRef = React.createRef();
+            const buttonRef = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(buttonRef.current, clickEvent);
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(container.innerHTML).toBe(
+              '<button><div>Click me!</div></button>',
+            );
+
+            // Clicking the button should trigger the event callback
+            let divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(log).toEqual([
+              {
+                eventPhase: 3,
+                type: 'click',
+                currentTarget: buttonRef.current,
+                target: divRef.current,
+              },
+            ]);
+            expect(clickEvent).toBeCalledTimes(1);
+
+            // Unmounting the container and clicking should not work
+            ReactDOM.render(null, container);
+            Scheduler.unstable_flushAll();
+
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(1);
+
+            // Re-rendering the container and clicking should work
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(2);
+
+            log = [];
+
+            // Clicking the button should also work
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(log).toEqual([
+              {
+                eventPhase: 3,
+                type: 'click',
+                currentTarget: buttonRef.current,
+                target: buttonRef.current,
+              },
+            ]);
+
+            const click2 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test2({clickEvent2}) {
+              React.useEffect(() => {
+                click2.setListener(buttonRef.current, clickEvent2);
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            let clickEvent2 = jest.fn();
+            ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+            Scheduler.unstable_flushAll();
+
+            divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent2).toBeCalledTimes(1);
+
+            // Reset the function we pass in, so it's different
+            clickEvent2 = jest.fn();
+            ReactDOM.render(<Test2 clickEvent2={clickEvent2} />, container);
+            Scheduler.unstable_flushAll();
+
+            divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent2).toBeCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('should correctly work for setting and clearing a basic "click" listener', () => {
+            const clickEvent = jest.fn();
+            const divRef = React.createRef();
+            const buttonRef = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test({off}) {
+              React.useEffect(() => {
+                click.setListener(buttonRef.current, clickEvent);
+              });
+
+              React.useEffect(() => {
+                if (off) {
+                  click.setListener(buttonRef.current, null);
+                }
+              }, [off]);
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test off={false} />, container);
+            Scheduler.unstable_flushAll();
+
+            let divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(1);
+
+            // The listener should get unmounted in the second effect
+            ReactDOM.render(<Test off={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            clickEvent.mockClear();
+
+            divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(0);
+          });
+
+          // @gate experimental
+          it('should handle the target being a text node', () => {
+            const clickEvent = jest.fn();
+            const buttonRef = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(buttonRef.current, clickEvent);
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const textNode = buttonRef.current.firstChild;
+            dispatchClickEvent(textNode);
+            expect(clickEvent).toBeCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('handle propagation of click events', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const log = [];
+            const onClick = jest.fn(e => log.push(['bubble', e.currentTarget]));
+            const onClickCapture = jest.fn(e =>
+              log.push(['capture', e.currentTarget]),
+            );
+            const click = ReactDOM.unstable_createEventHandle('click');
+            const clickCapture = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(buttonRef.current, onClick);
+                clickCapture.setListener(buttonRef.current, onClickCapture);
+                click.setListener(divRef.current, onClick);
+                clickCapture.setListener(divRef.current, onClickCapture);
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(onClick).toHaveBeenCalledTimes(1);
+            expect(onClickCapture).toHaveBeenCalledTimes(1);
+            expect(log[0]).toEqual(['capture', buttonElement]);
+            expect(log[1]).toEqual(['bubble', buttonElement]);
+
+            log.length = 0;
+            onClick.mockClear();
+            onClickCapture.mockClear();
+
+            const divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(onClick).toHaveBeenCalledTimes(2);
+            expect(onClickCapture).toHaveBeenCalledTimes(2);
+            expect(log[0]).toEqual(['capture', buttonElement]);
+            expect(log[1]).toEqual(['capture', divElement]);
+            expect(log[2]).toEqual(['bubble', divElement]);
+            expect(log[3]).toEqual(['bubble', buttonElement]);
+          });
+
+          // @gate experimental
+          it('handle propagation of click events mixed with onClick events', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const log = [];
+            const onClick = jest.fn(e => log.push(['bubble', e.currentTarget]));
+            const onClickCapture = jest.fn(e =>
+              log.push(['capture', e.currentTarget]),
+            );
+            const click = ReactDOM.unstable_createEventHandle('click');
+            const clickCapture = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(buttonRef.current, onClick);
+                clickCapture.setListener(buttonRef.current, onClickCapture);
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div
+                    ref={divRef}
+                    onClick={onClick}
+                    onClickCapture={onClickCapture}>
+                    Click me!
+                  </div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(onClick).toHaveBeenCalledTimes(1);
+            expect(onClickCapture).toHaveBeenCalledTimes(1);
+            expect(log[0]).toEqual(['capture', buttonElement]);
+            expect(log[1]).toEqual(['bubble', buttonElement]);
+
+            const divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(onClick).toHaveBeenCalledTimes(3);
+            expect(onClickCapture).toHaveBeenCalledTimes(3);
+            expect(log[2]).toEqual(['capture', buttonElement]);
+            expect(log[3]).toEqual(['capture', divElement]);
+            expect(log[4]).toEqual(['bubble', divElement]);
+            expect(log[5]).toEqual(['bubble', buttonElement]);
+          });
+
+          // @gate experimental
+          it('should correctly work for a basic "click" listener on the outer target', () => {
+            const log = [];
+            const clickEvent = jest.fn(event => {
+              log.push({
+                eventPhase: event.eventPhase,
+                type: event.type,
+                currentTarget: event.currentTarget,
+                target: event.target,
+              });
+            });
+            const divRef = React.createRef();
+            const buttonRef = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(divRef.current, clickEvent);
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(container.innerHTML).toBe(
+              '<button><div>Click me!</div></button>',
+            );
+
+            // Clicking the button should trigger the event callback
+            let divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(log).toEqual([
+              {
+                eventPhase: 3,
+                type: 'click',
+                currentTarget: divRef.current,
+                target: divRef.current,
+              },
+            ]);
+
+            // Unmounting the container and clicking should not work
+            ReactDOM.render(null, container);
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(1);
+
+            // Re-rendering the container and clicking should work
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toBeCalledTimes(2);
+
+            // Clicking the button should not work
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(clickEvent).toBeCalledTimes(2);
+          });
+
+          // @gate experimental
+          it('should correctly handle many nested target listeners', () => {
+            const buttonRef = React.createRef();
+            const targetListener1 = jest.fn();
+            const targetListener2 = jest.fn();
+            const targetListener3 = jest.fn();
+            const targetListener4 = jest.fn();
+            let click1 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            let click2 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            let click3 = ReactDOM.unstable_createEventHandle('click');
+            let click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(buttonRef.current, targetListener1);
+                click2.setListener(buttonRef.current, targetListener2);
+                click3.setListener(buttonRef.current, targetListener3);
+                click4.setListener(buttonRef.current, targetListener4);
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            let buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+
+            expect(targetListener1).toHaveBeenCalledTimes(1);
+            expect(targetListener2).toHaveBeenCalledTimes(1);
+            expect(targetListener3).toHaveBeenCalledTimes(1);
+            expect(targetListener4).toHaveBeenCalledTimes(1);
+
+            click1 = ReactDOM.unstable_createEventHandle('click');
+            click2 = ReactDOM.unstable_createEventHandle('click');
+            click3 = ReactDOM.unstable_createEventHandle('click');
+            click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test2() {
+              React.useEffect(() => {
+                click1.setListener(buttonRef.current, targetListener1);
+                click2.setListener(buttonRef.current, targetListener2);
+                click3.setListener(buttonRef.current, targetListener3);
+                click4.setListener(buttonRef.current, targetListener4);
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test2 />, container);
+            Scheduler.unstable_flushAll();
+
+            buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(targetListener1).toHaveBeenCalledTimes(2);
+            expect(targetListener2).toHaveBeenCalledTimes(2);
+            expect(targetListener3).toHaveBeenCalledTimes(2);
+            expect(targetListener4).toHaveBeenCalledTimes(2);
+          });
+
+          // @gate experimental
+          it('should correctly handle stopPropagation corrrectly for target events', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const clickEvent = jest.fn();
+            const click1 = ReactDOM.unstable_createEventHandle('click', {
+              bind: buttonRef,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(buttonRef.current, clickEvent);
+                click2.setListener(divRef.current, e => {
+                  e.stopPropagation();
+                });
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(clickEvent).toHaveBeenCalledTimes(0);
+          });
+
+          // @gate experimental
+          it('should correctly handle stopPropagation corrrectly for many target events', () => {
+            const buttonRef = React.createRef();
+            const targetListerner1 = jest.fn(e => e.stopPropagation());
+            const targetListerner2 = jest.fn(e => e.stopPropagation());
+            const targetListerner3 = jest.fn(e => e.stopPropagation());
+            const targetListerner4 = jest.fn(e => e.stopPropagation());
+            const click1 = ReactDOM.unstable_createEventHandle('click');
+            const click2 = ReactDOM.unstable_createEventHandle('click');
+            const click3 = ReactDOM.unstable_createEventHandle('click');
+            const click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(buttonRef.current, targetListerner1);
+                click2.setListener(buttonRef.current, targetListerner2);
+                click3.setListener(buttonRef.current, targetListerner3);
+                click4.setListener(buttonRef.current, targetListerner4);
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(targetListerner1).toHaveBeenCalledTimes(1);
+            expect(targetListerner2).toHaveBeenCalledTimes(1);
+            expect(targetListerner3).toHaveBeenCalledTimes(1);
+            expect(targetListerner4).toHaveBeenCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('should correctly handle stopPropagation for mixed capture/bubbling target listeners', () => {
+            const buttonRef = React.createRef();
+            const targetListerner1 = jest.fn(e => e.stopPropagation());
+            const targetListerner2 = jest.fn(e => e.stopPropagation());
+            const targetListerner3 = jest.fn(e => e.stopPropagation());
+            const targetListerner4 = jest.fn(e => e.stopPropagation());
+            const click1 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click3 = ReactDOM.unstable_createEventHandle('click');
+            const click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(buttonRef.current, targetListerner1);
+                click2.setListener(buttonRef.current, targetListerner2);
+                click3.setListener(buttonRef.current, targetListerner3);
+                click4.setListener(buttonRef.current, targetListerner4);
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(targetListerner1).toHaveBeenCalledTimes(1);
+            expect(targetListerner2).toHaveBeenCalledTimes(1);
+            expect(targetListerner3).toHaveBeenCalledTimes(0);
+            expect(targetListerner4).toHaveBeenCalledTimes(0);
+          });
+
+          // @gate experimental
+          it('should work with concurrent mode updates', async () => {
+            const log = [];
+            const ref = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test({counter}) {
+              React.useLayoutEffect(() => {
+                click.setListener(ref.current, () => {
+                  log.push({counter});
+                });
+              });
+
+              Scheduler.unstable_yieldValue('Test');
+              return <button ref={ref}>Press me</button>;
+            }
+
+            const root = ReactDOM.createRoot(container);
+            root.render(<Test counter={0} />);
+
+            expect(Scheduler).toFlushAndYield(['Test']);
+
+            // Click the button
+            dispatchClickEvent(ref.current);
+            expect(log).toEqual([{counter: 0}]);
+
+            // Clear log
+            log.length = 0;
+
+            // Increase counter
+            root.render(<Test counter={1} />);
+            // Yield before committing
+            expect(Scheduler).toFlushAndYieldThrough(['Test']);
+
+            // Click the button again
+            dispatchClickEvent(ref.current);
+            expect(log).toEqual([{counter: 0}]);
+
+            // Clear log
+            log.length = 0;
+
+            // Commit
+            expect(Scheduler).toFlushAndYield([]);
+            dispatchClickEvent(ref.current);
+            expect(log).toEqual([{counter: 1}]);
+          });
+
+          // @gate experimental
+          it('should correctly work for a basic "click" listener that upgrades', () => {
+            const clickEvent = jest.fn();
+            const buttonRef = React.createRef();
+            const button2Ref = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click', {
+              passive: false,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click', {
+              passive: true,
+            });
+
+            function Test2() {
+              React.useEffect(() => {
+                click.setListener(button2Ref.current, clickEvent);
+              });
+
+              return <button ref={button2Ref}>Click me!</button>;
+            }
+
+            function Test({extra}) {
+              React.useEffect(() => {
+                click2.setListener(buttonRef.current, clickEvent);
+              });
+
+              return (
+                <>
+                  <button ref={buttonRef}>Click me!</button>
+                  {extra && <Test2 />}
+                </>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            let button = buttonRef.current;
+            dispatchClickEvent(button);
+            expect(clickEvent).toHaveBeenCalledTimes(1);
+
+            ReactDOM.render(<Test extra={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            clickEvent.mockClear();
+
+            button = button2Ref.current;
+            dispatchClickEvent(button);
+            expect(clickEvent).toHaveBeenCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('should correctly work for a basic "click" listener that upgrades #2', () => {
+            const clickEvent = jest.fn();
+            const buttonRef = React.createRef();
+            const button2Ref = React.createRef();
+            const click = ReactDOM.unstable_createEventHandle('click', {
+              passive: false,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click', {
+              passive: undefined,
+            });
+
+            function Test2() {
+              React.useEffect(() => {
+                click.setListener(button2Ref.current, clickEvent);
+              });
+
+              return <button ref={button2Ref}>Click me!</button>;
+            }
+
+            function Test({extra}) {
+              React.useEffect(() => {
+                click2.setListener(buttonRef.current, clickEvent);
+              });
+
+              return (
+                <>
+                  <button ref={buttonRef}>Click me!</button>
+                  {extra && <Test2 />}
+                </>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            let button = buttonRef.current;
+            dispatchClickEvent(button);
+            expect(clickEvent).toHaveBeenCalledTimes(1);
+
+            ReactDOM.render(<Test extra={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            clickEvent.mockClear();
+
+            button = button2Ref.current;
+            dispatchClickEvent(button);
+            expect(clickEvent).toHaveBeenCalledTimes(1);
+          });
+
+          // @gate experimental
+          it('should correctly work for a basic "click" window listener', () => {
+            const log = [];
+            const clickEvent = jest.fn(event => {
+              log.push({
+                eventPhase: event.eventPhase,
+                type: event.type,
+                currentTarget: event.currentTarget,
+                target: event.target,
+              });
+            });
+            const click = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(window, clickEvent);
+
+                return () => {
+                  click.setListener(window, null);
+                };
+              });
+
+              return <button>Click anything!</button>;
+            }
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(container.innerHTML).toBe(
+              '<button>Click anything!</button>',
+            );
+
+            // Clicking outside the button should trigger the event callback
+            dispatchClickEvent(document.body);
+            expect(log[0]).toEqual({
+              eventPhase: 3,
+              type: 'click',
+              currentTarget: window,
+              target: document.body,
+            });
+
+            // Unmounting the container and clicking should not work
+            ReactDOM.render(null, container);
+            Scheduler.unstable_flushAll();
+
+            dispatchClickEvent(document.body);
+            expect(clickEvent).toBeCalledTimes(1);
+
+            // Re-rendering and clicking the body should work again
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            dispatchClickEvent(document.body);
+            expect(clickEvent).toBeCalledTimes(2);
+          });
+
+          // @gate experimental
+          it('handle propagation of click events on the window', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const log = [];
+            const onClick = jest.fn(e => log.push(['bubble', e.currentTarget]));
+            const onClickCapture = jest.fn(e =>
+              log.push(['capture', e.currentTarget]),
+            );
+            const click = ReactDOM.unstable_createEventHandle('click');
+            const clickCapture = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(window, onClick);
+                clickCapture.setListener(window, onClickCapture);
+                click.setListener(buttonRef.current, onClick);
+                clickCapture.setListener(buttonRef.current, onClickCapture);
+                click.setListener(divRef.current, onClick);
+                clickCapture.setListener(divRef.current, onClickCapture);
+
+                return () => {
+                  click.setListener(window, null);
+                  clickCapture.setListener(window, null);
+                };
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(onClick).toHaveBeenCalledTimes(2);
+            expect(onClickCapture).toHaveBeenCalledTimes(2);
+            expect(log[0]).toEqual(['capture', window]);
+            expect(log[1]).toEqual(['capture', buttonElement]);
+            expect(log[2]).toEqual(['bubble', buttonElement]);
+            expect(log[3]).toEqual(['bubble', window]);
+
+            log.length = 0;
+            onClick.mockClear();
+            onClickCapture.mockClear();
+
+            const divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(onClick).toHaveBeenCalledTimes(3);
+            expect(onClickCapture).toHaveBeenCalledTimes(3);
+            expect(log[0]).toEqual(['capture', window]);
+            expect(log[1]).toEqual(['capture', buttonElement]);
+            expect(log[2]).toEqual(['capture', divElement]);
+            expect(log[3]).toEqual(['bubble', divElement]);
+            expect(log[4]).toEqual(['bubble', buttonElement]);
+            expect(log[5]).toEqual(['bubble', window]);
+          });
+
+          // @gate experimental
+          it('should correctly handle stopPropagation for mixed listeners', () => {
+            const buttonRef = React.createRef();
+            const rootListerner1 = jest.fn(e => e.stopPropagation());
+            const rootListerner2 = jest.fn();
+            const targetListerner1 = jest.fn();
+            const targetListerner2 = jest.fn();
+            const click1 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click3 = ReactDOM.unstable_createEventHandle('click');
+            const click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(window, rootListerner1);
+                click2.setListener(buttonRef.current, targetListerner1);
+                click3.setListener(window, rootListerner2);
+                click4.setListener(buttonRef.current, targetListerner2);
+
+                return () => {
+                  click1.setListener(window, null);
+                  click3.setListener(window, null);
+                };
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(rootListerner1).toHaveBeenCalledTimes(1);
+            expect(targetListerner1).toHaveBeenCalledTimes(0);
+            expect(targetListerner2).toHaveBeenCalledTimes(0);
+            expect(rootListerner2).toHaveBeenCalledTimes(0);
+          });
+
+          // @gate experimental
+          it('should correctly handle stopPropagation for delegated listeners', () => {
+            const buttonRef = React.createRef();
+            const rootListerner1 = jest.fn(e => e.stopPropagation());
+            const rootListerner2 = jest.fn();
+            const rootListerner3 = jest.fn(e => e.stopPropagation());
+            const rootListerner4 = jest.fn();
+            const click1 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click2 = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+            const click3 = ReactDOM.unstable_createEventHandle('click');
+            const click4 = ReactDOM.unstable_createEventHandle('click');
+
+            function Test() {
+              React.useEffect(() => {
+                click1.setListener(window, rootListerner1);
+                click2.setListener(window, rootListerner2);
+                click3.setListener(window, rootListerner3);
+                click4.setListener(window, rootListerner4);
+
+                return () => {
+                  click1.setListener(window, null);
+                  click2.setListener(window, null);
+                  click3.setListener(window, null);
+                  click4.setListener(window, null);
+                };
+              });
+
+              return <button ref={buttonRef}>Click me!</button>;
+            }
+
+            ReactDOM.render(<Test />, container);
+
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(rootListerner1).toHaveBeenCalledTimes(1);
+            expect(rootListerner2).toHaveBeenCalledTimes(1);
+            expect(rootListerner3).toHaveBeenCalledTimes(0);
+            expect(rootListerner4).toHaveBeenCalledTimes(0);
+          });
+
+          // @gate experimental
+          it('handle propagation of click events on the window and document', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const log = [];
+            const onClick = jest.fn(e => log.push(['bubble', e.currentTarget]));
+            const onClickCapture = jest.fn(e =>
+              log.push(['capture', e.currentTarget]),
+            );
+            const click = ReactDOM.unstable_createEventHandle('click');
+            const clickCapture = ReactDOM.unstable_createEventHandle('click', {
+              capture: true,
+            });
+
+            function Test() {
+              React.useEffect(() => {
+                click.setListener(window, onClick);
+                clickCapture.setListener(window, onClickCapture);
+                click.setListener(document, onClick);
+                clickCapture.setListener(document, onClickCapture);
+                click.setListener(buttonRef.current, onClick);
+                clickCapture.setListener(buttonRef.current, onClickCapture);
+                click.setListener(divRef.current, onClick);
+                clickCapture.setListener(divRef.current, onClickCapture);
+
+                return () => {
+                  click.setListener(window, null);
+                  clickCapture.setListener(window, null);
+                  click.setListener(document, null);
+                  clickCapture.setListener(document, null);
+                };
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchClickEvent(buttonElement);
+            expect(onClick).toHaveBeenCalledTimes(3);
+            expect(onClickCapture).toHaveBeenCalledTimes(3);
+
+            if (enableLegacyFBSupport) {
+              expect(log[0]).toEqual(['capture', window]);
+              expect(log[1]).toEqual(['capture', document]);
+              expect(log[2]).toEqual(['bubble', document]);
+              expect(log[3]).toEqual(['capture', buttonElement]);
+              expect(log[4]).toEqual(['bubble', buttonElement]);
+              expect(log[5]).toEqual(['bubble', window]);
+            } else {
+              expect(log[0]).toEqual(['capture', window]);
+              expect(log[1]).toEqual(['capture', document]);
+              expect(log[2]).toEqual(['capture', buttonElement]);
+              expect(log[3]).toEqual(['bubble', buttonElement]);
+              expect(log[4]).toEqual(['bubble', document]);
+              expect(log[5]).toEqual(['bubble', window]);
+            }
+
+            log.length = 0;
+            onClick.mockClear();
+            onClickCapture.mockClear();
+
+            const divElement = divRef.current;
+            dispatchClickEvent(divElement);
+            expect(onClick).toHaveBeenCalledTimes(4);
+            expect(onClickCapture).toHaveBeenCalledTimes(4);
+
+            if (enableLegacyFBSupport) {
+              expect(log[0]).toEqual(['capture', window]);
+              expect(log[1]).toEqual(['capture', document]);
+              expect(log[2]).toEqual(['bubble', document]);
+              expect(log[3]).toEqual(['capture', buttonElement]);
+              expect(log[4]).toEqual(['capture', divElement]);
+              expect(log[5]).toEqual(['bubble', divElement]);
+              expect(log[6]).toEqual(['bubble', buttonElement]);
+              expect(log[7]).toEqual(['bubble', window]);
+            } else {
+              expect(log[0]).toEqual(['capture', window]);
+              expect(log[1]).toEqual(['capture', document]);
+              expect(log[2]).toEqual(['capture', buttonElement]);
+              expect(log[3]).toEqual(['capture', divElement]);
+              expect(log[4]).toEqual(['bubble', divElement]);
+              expect(log[5]).toEqual(['bubble', buttonElement]);
+              expect(log[6]).toEqual(['bubble', document]);
+              expect(log[7]).toEqual(['bubble', window]);
+            }
+          });
+
+          // @gate experimental
+          it('handles propagation of custom user events', () => {
+            const buttonRef = React.createRef();
+            const divRef = React.createRef();
+            const log = [];
+            const onCustomEvent = jest.fn(e =>
+              log.push(['bubble', e.currentTarget]),
+            );
+            const onCustomEventCapture = jest.fn(e =>
+              log.push(['capture', e.currentTarget]),
+            );
+
+            let customEventHandle;
+
+            // Test that we get a warning when we don't provide an explicit priortiy
+            expect(() => {
+              customEventHandle = ReactDOM.unstable_createEventHandle(
+                'custom-event',
+              );
+            }).toWarnDev(
+              'Warning: The event "type" provided to createEventHandle() does not have a known priority type. ' +
+                'It is recommended to provide a "priority" option to specify a priority.',
+              {withoutStack: true},
+            );
+
+            customEventHandle = ReactDOM.unstable_createEventHandle(
+              'custom-event',
+              {
+                priority: 0, // Discrete
+              },
+            );
+
+            const customCaptureHandle = ReactDOM.unstable_createEventHandle(
+              'custom-event',
+              {
+                capture: true,
+                priority: 0, // Discrete
+              },
+            );
+
+            function Test() {
+              React.useEffect(() => {
+                customEventHandle.setListener(buttonRef.current, onCustomEvent);
+                customCaptureHandle.setListener(
+                  buttonRef.current,
+                  onCustomEventCapture,
+                );
+                customEventHandle.setListener(divRef.current, onCustomEvent);
+                customCaptureHandle.setListener(
+                  divRef.current,
+                  onCustomEventCapture,
+                );
+              });
+
+              return (
+                <button ref={buttonRef}>
+                  <div ref={divRef}>Click me!</div>
+                </button>
+              );
+            }
+
+            ReactDOM.render(<Test />, container);
+            Scheduler.unstable_flushAll();
+
+            const buttonElement = buttonRef.current;
+            dispatchEvent(buttonElement, 'custom-event');
+            expect(onCustomEvent).toHaveBeenCalledTimes(1);
+            expect(onCustomEventCapture).toHaveBeenCalledTimes(1);
+            expect(log[0]).toEqual(['capture', buttonElement]);
+            expect(log[1]).toEqual(['bubble', buttonElement]);
+
+            const divElement = divRef.current;
+            dispatchEvent(divElement, 'custom-event');
+            expect(onCustomEvent).toHaveBeenCalledTimes(3);
+            expect(onCustomEventCapture).toHaveBeenCalledTimes(3);
+            expect(log[2]).toEqual(['capture', buttonElement]);
+            expect(log[3]).toEqual(['capture', divElement]);
+            expect(log[4]).toEqual(['bubble', divElement]);
+            expect(log[5]).toEqual(['bubble', buttonElement]);
+          });
+
+          // @gate experimental
+          it('beforeblur and afterblur are called after a focused element is unmounted', () => {
+            const log = [];
+            // We have to persist here because we want to read relatedTarget later.
+            const onAfterBlur = jest.fn(e => {
+              e.persist();
+              log.push(e.type);
+            });
+            const onBeforeBlur = jest.fn(e => log.push(e.type));
+            const innerRef = React.createRef();
+            const innerRef2 = React.createRef();
+            const afterBlurHandle = ReactDOM.unstable_createEventHandle(
+              'afterblur',
+            );
+            const beforeBlurHandle = ReactDOM.unstable_createEventHandle(
+              'beforeblur',
+            );
+
+            const Component = ({show}) => {
+              const ref = React.useRef(null);
+
+              React.useEffect(() => {
+                afterBlurHandle.setListener(document, onAfterBlur);
+                beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+              });
+
+              return (
+                <div ref={ref}>
+                  {show && <input ref={innerRef} />}
+                  <div ref={innerRef2} />
+                </div>
+              );
+            };
+
+            ReactDOM.render(<Component show={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            const inner = innerRef.current;
+            const target = createEventTarget(inner);
+            target.focus();
+            expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+            expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+            ReactDOM.render(<Component show={false} />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledWith(
+              expect.objectContaining({relatedTarget: inner}),
+            );
+            expect(log).toEqual(['beforeblur', 'afterblur']);
+          });
+
+          // @gate experimental
+          it('beforeblur and afterblur are called after a nested focused element is unmounted', () => {
+            const log = [];
+            // We have to persist here because we want to read relatedTarget later.
+            const onAfterBlur = jest.fn(e => {
+              e.persist();
+              log.push(e.type);
+            });
+            const onBeforeBlur = jest.fn(e => log.push(e.type));
+            const innerRef = React.createRef();
+            const innerRef2 = React.createRef();
+            const afterBlurHandle = ReactDOM.unstable_createEventHandle(
+              'afterblur',
+            );
+            const beforeBlurHandle = ReactDOM.unstable_createEventHandle(
+              'beforeblur',
+            );
+
+            const Component = ({show}) => {
+              const ref = React.useRef(null);
+
+              React.useEffect(() => {
+                afterBlurHandle.setListener(document, onAfterBlur);
+                beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+              });
+
+              return (
+                <div ref={ref}>
+                  {show && (
+                    <div>
+                      <input ref={innerRef} />
+                    </div>
+                  )}
+                  <div ref={innerRef2} />
+                </div>
+              );
+            };
+
+            ReactDOM.render(<Component show={true} />, container);
+            Scheduler.unstable_flushAll();
+
+            const inner = innerRef.current;
+            const target = createEventTarget(inner);
+            target.focus();
+            expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+            expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+            ReactDOM.render(<Component show={false} />, container);
+            Scheduler.unstable_flushAll();
+
+            expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledWith(
+              expect.objectContaining({relatedTarget: inner}),
+            );
+            expect(log).toEqual(['beforeblur', 'afterblur']);
+          });
+
+          // @gate experimental
+          it('beforeblur and afterblur are called after a focused element is suspended', () => {
+            const log = [];
+            // We have to persist here because we want to read relatedTarget later.
+            const onAfterBlur = jest.fn(e => {
+              e.persist();
+              log.push(e.type);
+            });
+            const onBeforeBlur = jest.fn(e => log.push(e.type));
+            const innerRef = React.createRef();
+            const Suspense = React.Suspense;
+            let suspend = false;
+            let resolve;
+            const promise = new Promise(
+              resolvePromise => (resolve = resolvePromise),
+            );
+            const afterBlurHandle = ReactDOM.unstable_createEventHandle(
+              'afterblur',
+            );
+            const beforeBlurHandle = ReactDOM.unstable_createEventHandle(
+              'beforeblur',
+            );
+
+            function Child() {
+              if (suspend) {
+                throw promise;
+              } else {
+                return <input ref={innerRef} />;
+              }
+            }
+
+            const Component = () => {
+              const ref = React.useRef(null);
+
+              React.useEffect(() => {
+                afterBlurHandle.setListener(document, onAfterBlur);
+                beforeBlurHandle.setListener(ref.current, onBeforeBlur);
+              });
+
+              return (
+                <div ref={ref}>
+                  <Suspense fallback="Loading...">
+                    <Child />
+                  </Suspense>
+                </div>
+              );
+            };
+
+            const container2 = document.createElement('div');
+            document.body.appendChild(container2);
+
+            const root = ReactDOM.createRoot(container2);
+
+            ReactTestUtils.act(() => {
+              root.render(<Component />);
+            });
+            jest.runAllTimers();
+
+            const inner = innerRef.current;
+            const target = createEventTarget(inner);
+            target.focus();
+            expect(onBeforeBlur).toHaveBeenCalledTimes(0);
+            expect(onAfterBlur).toHaveBeenCalledTimes(0);
+
+            suspend = true;
+            ReactTestUtils.act(() => {
+              root.render(<Component />);
+            });
+            jest.runAllTimers();
+
+            expect(onBeforeBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledTimes(1);
+            expect(onAfterBlur).toHaveBeenCalledWith(
+              expect.objectContaining({relatedTarget: inner}),
+            );
+            resolve();
+            expect(log).toEqual(['beforeblur', 'afterblur']);
+
+            document.body.removeChild(container2);
+          });
+
+          describe('Compatibility with Scopes API', () => {
+            beforeEach(() => {
+              jest.resetModules();
+              ReactFeatureFlags = require('shared/ReactFeatureFlags');
+              ReactFeatureFlags.enableModernEventSystem = true;
+              ReactFeatureFlags.enableCreateEventHandleAPI = true;
+              ReactFeatureFlags.enableScopeAPI = true;
+
+              React = require('react');
+              ReactDOM = require('react-dom');
+              Scheduler = require('scheduler');
+              ReactDOMServer = require('react-dom/server');
+            });
+
+            // @gate experimental
+            it('handle propagation of click events on a scope', () => {
+              const buttonRef = React.createRef();
+              const log = [];
+              const onClick = jest.fn(e =>
+                log.push(['bubble', e.currentTarget]),
+              );
+              const onClickCapture = jest.fn(e =>
+                log.push(['capture', e.currentTarget]),
+              );
+              const TestScope = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+              const clickCapture = ReactDOM.unstable_createEventHandle(
+                'click',
+                {
+                  capture: true,
+                },
+              );
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, onClick);
+                  clickCapture.setListener(scopeRef.current, onClickCapture);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <button ref={buttonRef} />
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(onClick).toHaveBeenCalledTimes(1);
+              expect(onClickCapture).toHaveBeenCalledTimes(1);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+            });
+
+            // @gate experimental
+            it('handle mixed propagation of click events on a scope', () => {
+              const buttonRef = React.createRef();
+              const divRef = React.createRef();
+              const log = [];
+              const onClick = jest.fn(e =>
+                log.push(['bubble', e.currentTarget]),
+              );
+              const onClickCapture = jest.fn(e =>
+                log.push(['capture', e.currentTarget]),
+              );
+              const TestScope = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+              const clickCapture = ReactDOM.unstable_createEventHandle(
+                'click',
+                {
+                  capture: true,
+                },
+              );
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, onClick);
+                  clickCapture.setListener(scopeRef.current, onClickCapture);
+                  click.setListener(buttonRef.current, onClick);
+                  clickCapture.setListener(buttonRef.current, onClickCapture);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <button ref={buttonRef}>
+                      <div
+                        ref={divRef}
+                        onClick={onClick}
+                        onClickCapture={onClickCapture}>
+                        Click me!
+                      </div>
+                    </button>
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(onClick).toHaveBeenCalledTimes(2);
+              expect(onClickCapture).toHaveBeenCalledTimes(2);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['capture', buttonElement],
+                ['bubble', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+
+              log.length = 0;
+              onClick.mockClear();
+              onClickCapture.mockClear();
+
+              const divElement = divRef.current;
+              dispatchClickEvent(divElement);
+
+              expect(onClick).toHaveBeenCalledTimes(3);
+              expect(onClickCapture).toHaveBeenCalledTimes(3);
+              expect(log).toEqual([
+                ['capture', buttonElement],
+                ['capture', buttonElement],
+                ['capture', divElement],
+                ['bubble', divElement],
+                ['bubble', buttonElement],
+                ['bubble', buttonElement],
+              ]);
+            });
+
+            // @gate experimental
+            it('should not handle the target being a dangling text node within a scope', () => {
+              const clickEvent = jest.fn();
+              const buttonRef = React.createRef();
+              const TestScope = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, clickEvent);
+                });
+
+                return (
+                  <button ref={buttonRef}>
+                    <TestScope ref={scopeRef}>Click me!</TestScope>
+                  </button>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const textNode = buttonRef.current.firstChild;
+              dispatchClickEvent(textNode);
+              // This should not work, as the target instance will be the
+              // <button>, which is actually outside the scope.
+              expect(clickEvent).toBeCalledTimes(0);
+            });
+
+            // @gate experimental
+            it('handle stopPropagation (inner) correctly between scopes', () => {
+              const buttonRef = React.createRef();
+              const outerOnClick = jest.fn();
+              const innerOnClick = jest.fn(e => e.stopPropagation());
+              const TestScope = React.unstable_createScope();
+              const TestScope2 = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+                const scope2Ref = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, outerOnClick);
+                  click.setListener(scope2Ref.current, innerOnClick);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <TestScope2 ref={scope2Ref}>
+                      <button ref={buttonRef} />
+                    </TestScope2>
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(innerOnClick).toHaveBeenCalledTimes(1);
+              expect(outerOnClick).toHaveBeenCalledTimes(0);
+            });
+
+            // @gate experimental
+            it('handle stopPropagation (outer) correctly between scopes', () => {
+              const buttonRef = React.createRef();
+              const outerOnClick = jest.fn(e => e.stopPropagation());
+              const innerOnClick = jest.fn();
+              const TestScope = React.unstable_createScope();
+              const TestScope2 = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+                const scope2Ref = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, outerOnClick);
+                  click.setListener(scope2Ref.current, innerOnClick);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <TestScope2 ref={scope2Ref}>
+                      <button ref={buttonRef} />
+                    </TestScope2>
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(innerOnClick).toHaveBeenCalledTimes(1);
+              expect(outerOnClick).toHaveBeenCalledTimes(1);
+            });
+
+            // @gate experimental
+            it('handle stopPropagation (inner and outer) correctly between scopes', () => {
+              const buttonRef = React.createRef();
+              const onClick = jest.fn(e => e.stopPropagation());
+              const TestScope = React.unstable_createScope();
+              const TestScope2 = React.unstable_createScope();
+              const click = ReactDOM.unstable_createEventHandle('click');
+
+              function Test() {
+                const scopeRef = React.useRef(null);
+                const scope2Ref = React.useRef(null);
+
+                React.useEffect(() => {
+                  click.setListener(scopeRef.current, onClick);
+                  click.setListener(scope2Ref.current, onClick);
+                });
+
+                return (
+                  <TestScope ref={scopeRef}>
+                    <TestScope2 ref={scope2Ref}>
+                      <button ref={buttonRef} />
+                    </TestScope2>
+                  </TestScope>
+                );
+              }
+
+              ReactDOM.render(<Test />, container);
+              Scheduler.unstable_flushAll();
+
+              const buttonElement = buttonRef.current;
+              dispatchClickEvent(buttonElement);
+
+              expect(onClick).toHaveBeenCalledTimes(1);
+            });
+          });
         });
       },
     );

--- a/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
@@ -25,7 +25,10 @@ import {
   topLevelEventsToDispatchConfig,
   simpleEventPluginEventTypes,
 } from '../DOMEventProperties';
-import {accumulateTwoPhaseListeners} from '../DOMModernPluginEventSystem';
+import {
+  accumulateTwoPhaseListeners,
+  accumulateEventTargetListeners,
+} from '../DOMModernPluginEventSystem';
 import {IS_TARGET_PHASE_ONLY} from '../EventSystemFlags';
 
 import SyntheticAnimationEvent from '../SyntheticAnimationEvent';
@@ -210,10 +213,11 @@ const SimpleEventPlugin: ModernPluginModule<MouseEvent> = {
       eventSystemFlags & IS_TARGET_PHASE_ONLY &&
       targetContainer != null
     ) {
-      // TODO: accumulateEventTargetListeners
+      accumulateEventTargetListeners(dispatchQueue, event, targetContainer);
     } else {
-      accumulateTwoPhaseListeners(targetInst, dispatchQueue, event);
+      accumulateTwoPhaseListeners(targetInst, dispatchQueue, event, true);
     }
+    return event;
   },
 };
 

--- a/packages/react-interactions/events/focus.js
+++ b/packages/react-interactions/events/focus.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/dom/create-event-handle/Focus';

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -1,0 +1,439 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import useEvent from './useEvent';
+
+const {useEffect, useRef} = React;
+
+type UseFocusOptions = {|
+  disabled?: boolean,
+  onBlur?: (SyntheticEvent<EventTarget>) => void,
+  onFocus?: (SyntheticEvent<EventTarget>) => void,
+  onFocusChange?: boolean => void,
+  onFocusVisibleChange?: boolean => void,
+|};
+
+type UseFocusWithinOptions = {|
+  disabled?: boolean,
+  onAfterBlurWithin?: (SyntheticEvent<EventTarget>) => void,
+  onBeforeBlurWithin?: (SyntheticEvent<EventTarget>) => void,
+  onBlurWithin?: (SyntheticEvent<EventTarget>) => void,
+  onFocusWithin?: (SyntheticEvent<EventTarget>) => void,
+  onFocusWithinChange?: boolean => void,
+  onFocusWithinVisibleChange?: boolean => void,
+|};
+
+const isMac =
+  typeof window !== 'undefined' && window.navigator != null
+    ? /^Mac/.test(window.navigator.platform)
+    : false;
+
+const canUseDOM: boolean = !!(
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+);
+
+let passiveBrowserEventsSupported = false;
+
+// Check if browser support events with passive listeners
+// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
+if (canUseDOM) {
+  try {
+    const options = {};
+    // $FlowFixMe: Ignore Flow complaining about needing a value
+    Object.defineProperty(options, 'passive', {
+      get: function() {
+        passiveBrowserEventsSupported = true;
+      },
+    });
+    window.addEventListener('test', options, options);
+    window.removeEventListener('test', options, options);
+  } catch (e) {
+    passiveBrowserEventsSupported = false;
+  }
+}
+
+const hasPointerEvents =
+  typeof window !== 'undefined' && window.PointerEvent != null;
+
+const globalFocusVisibleEvents = hasPointerEvents
+  ? ['keydown', 'pointermove', 'pointerdown', 'pointerup']
+  : ['keydown', 'mousedown', 'touchmove', 'touchstart', 'touchend'];
+
+// Global state for tracking focus visible and emulation of mouse
+let isGlobalFocusVisible = true;
+let hasTrackedGlobalFocusVisible = false;
+let isEmulatingMouseEvents = false;
+
+function trackGlobalFocusVisible() {
+  globalFocusVisibleEvents.forEach(type => {
+    window.addEventListener(
+      type,
+      handleGlobalFocusVisibleEvent,
+      passiveBrowserEventsSupported ? {capture: true, passive: true} : true,
+    );
+  });
+}
+
+function handleGlobalFocusVisibleEvent(
+  nativeEvent: MouseEvent | TouchEvent | KeyboardEvent,
+): void {
+  const {type} = nativeEvent;
+
+  switch (type) {
+    case 'pointermove':
+    case 'pointerdown':
+    case 'pointerup': {
+      isGlobalFocusVisible = false;
+      break;
+    }
+
+    case 'keydown': {
+      const {metaKey, altKey, ctrlKey} = nativeEvent;
+      const validKey = !(metaKey || (!isMac && altKey) || ctrlKey);
+
+      if (validKey) {
+        isGlobalFocusVisible = true;
+      }
+      break;
+    }
+
+    // fallbacks for no PointerEvent support
+    case 'touchmove':
+    case 'touchstart':
+    case 'touchend': {
+      isEmulatingMouseEvents = true;
+      isGlobalFocusVisible = false;
+      break;
+    }
+    case 'mousedown': {
+      if (!isEmulatingMouseEvents) {
+        isGlobalFocusVisible = false;
+      } else {
+        isEmulatingMouseEvents = false;
+      }
+      break;
+    }
+  }
+}
+
+const passiveObject = {passive: true};
+
+function handleFocusVisibleTargetEvent(
+  type: string,
+  focusTarget: EventTarget,
+  callback: boolean => void,
+): void {
+  isGlobalFocusVisible = false;
+
+  // Focus should stop being visible if a pointer is used on the element
+  // after it was focused using a keyboard.
+  if (
+    focusTarget !== null &&
+    (type === 'mousedown' || type === 'touchstart' || type === 'pointerdown')
+  ) {
+    callback(false);
+  }
+}
+
+function handleFocusVisibleTargetEvents(
+  event: SyntheticEvent<EventTarget>,
+  focusTarget,
+  callback,
+): void {
+  const {type} = event;
+
+  switch (type) {
+    case 'pointermove':
+    case 'pointerdown':
+    case 'pointerup': {
+      handleFocusVisibleTargetEvent(type, focusTarget, callback);
+      break;
+    }
+
+    case 'keydown':
+    case 'keyup': {
+      const {metaKey, altKey, ctrlKey} = (event: any);
+      const validKey = !(metaKey || (!isMac && altKey) || ctrlKey);
+
+      if (validKey) {
+        if (focusTarget !== null) {
+          callback(true);
+        }
+      }
+      break;
+    }
+
+    // fallbacks for no PointerEvent support
+    case 'touchmove':
+    case 'touchstart':
+    case 'touchend': {
+      handleFocusVisibleTargetEvent(type, focusTarget, callback);
+      break;
+    }
+    case 'mousedown': {
+      if (!isEmulatingMouseEvents) {
+        handleFocusVisibleTargetEvent(type, focusTarget, callback);
+      }
+      break;
+    }
+  }
+}
+
+function isRelatedTargetWithin(
+  focusWithinTarget: Node,
+  relatedTarget: null | Node,
+): boolean {
+  if (relatedTarget == null) {
+    return false;
+  }
+  // To support experimental scopes, which can be the target:
+  const containsNode = (focusWithinTarget: any).containsNode;
+  if (typeof containsNode === 'function') {
+    return containsNode(relatedTarget);
+  }
+  return focusWithinTarget.contains(relatedTarget);
+}
+
+function setFocusVisibleListeners(focusVisibleHandles, focusTarget, callback) {
+  focusVisibleHandles.forEach(focusVisibleHandle => {
+    focusVisibleHandle.setListener(focusTarget, event =>
+      handleFocusVisibleTargetEvents(event, focusTarget, callback),
+    );
+  });
+}
+
+function useFocusVisibleInputHandles() {
+  return [
+    useEvent('mousedown', passiveObject),
+    useEvent(hasPointerEvents ? 'pointerdown' : 'touchstart', passiveObject),
+    useEvent(hasPointerEvents ? 'pointermove' : 'touchmove', passiveObject),
+    useEvent(hasPointerEvents ? 'pointerup' : 'touchend', passiveObject),
+    useEvent('keydown', passiveObject),
+  ];
+}
+
+function useFocusLifecycles(stateRef) {
+  useEffect(() => {
+    if (!hasTrackedGlobalFocusVisible) {
+      hasTrackedGlobalFocusVisible = true;
+      trackGlobalFocusVisible();
+    }
+  }, []);
+}
+
+export function useFocus(
+  focusTargetRef: {current: null | Node},
+  {
+    disabled,
+    onBlur,
+    onFocus,
+    onFocusChange,
+    onFocusVisibleChange,
+  }: UseFocusOptions,
+): void {
+  // Setup controlled state for this useFocus hook
+  const stateRef = useRef({isFocused: false, isFocusVisible: false});
+  const focusHandle = useEvent('focus', passiveObject);
+  const blurHandle = useEvent('blur', passiveObject);
+  const focusVisibleHandles = useFocusVisibleInputHandles();
+
+  useEffect(() => {
+    const focusTarget = focusTargetRef.current;
+    const state = stateRef.current;
+
+    if (focusTarget !== null && state !== null) {
+      // Handle focus visible
+      setFocusVisibleListeners(
+        focusVisibleHandles,
+        focusTarget,
+        isFocusVisible => {
+          if (state.isFocused && state.isFocusVisible !== isFocusVisible) {
+            state.isFocusVisible = isFocusVisible;
+            if (onFocusVisibleChange) {
+              onFocusVisibleChange(isFocusVisible);
+            }
+          }
+        },
+      );
+
+      // Handle focus
+      focusHandle.setListener(focusTarget, event => {
+        if (disabled) {
+          return;
+        }
+        // Limit focus events to the direct child of the event component.
+        // Browser focus is not expected to bubble.
+        if (!state.isFocused && focusTarget === event.target) {
+          state.isFocused = true;
+          state.isFocusVisible = isGlobalFocusVisible;
+          if (onFocus) {
+            onFocus(event);
+          }
+          if (onFocusChange) {
+            onFocusChange(true);
+          }
+          if (state.isFocusVisible && onFocusVisibleChange) {
+            onFocusVisibleChange(true);
+          }
+          isEmulatingMouseEvents = false;
+        }
+      });
+
+      // Handle blur
+      blurHandle.setListener(focusTarget, event => {
+        if (disabled) {
+          return;
+        }
+        if (state.isFocused) {
+          state.isFocused = false;
+          state.isFocusVisible = isGlobalFocusVisible;
+          if (onBlur) {
+            onBlur(event);
+          }
+          if (onFocusChange) {
+            onFocusChange(false);
+          }
+          if (state.isFocusVisible && onFocusVisibleChange) {
+            onFocusVisibleChange(false);
+          }
+        }
+        isEmulatingMouseEvents = false;
+      });
+    }
+  }, [disabled, onBlur, onFocus, onFocusChange, onFocusVisibleChange]);
+
+  // Mount/Unmount logic
+  useFocusLifecycles(stateRef);
+}
+
+export function useFocusWithin(
+  focusWithinTargetRef: {current: null | Node},
+  {
+    disabled,
+    onAfterBlurWithin,
+    onBeforeBlurWithin,
+    onBlurWithin,
+    onFocusWithin,
+    onFocusWithinChange,
+    onFocusWithinVisibleChange,
+  }: UseFocusWithinOptions,
+) {
+  // Setup controlled state for this useFocus hook
+  const stateRef = useRef({isFocused: false, isFocusVisible: false});
+  const focusHandle = useEvent('focus', passiveObject);
+  const blurHandle = useEvent('blur', passiveObject);
+  const afterBlurHandle = useEvent('afterblur', passiveObject);
+  const beforeBlurHandle = useEvent('beforeblur', passiveObject);
+  const focusVisibleHandles = useFocusVisibleInputHandles();
+
+  useEffect(() => {
+    const focusWithinTarget = focusWithinTargetRef.current;
+    const state = stateRef.current;
+
+    if (focusWithinTarget !== null && state !== null) {
+      // Handle focus visible
+      setFocusVisibleListeners(
+        focusVisibleHandles,
+        focusWithinTarget,
+        isFocusVisible => {
+          if (state.isFocused && state.isFocusVisible !== isFocusVisible) {
+            state.isFocusVisible = isFocusVisible;
+            if (onFocusWithinVisibleChange) {
+              onFocusWithinVisibleChange(isFocusVisible);
+            }
+          }
+        },
+      );
+
+      // Handle focus
+      focusHandle.setListener(focusWithinTarget, event => {
+        if (disabled) {
+          return;
+        }
+        if (!state.isFocused) {
+          state.isFocused = true;
+          state.isFocusVisible = isGlobalFocusVisible;
+          if (onFocusWithinChange) {
+            onFocusWithinChange(true);
+          }
+          if (state.isFocusVisible && onFocusWithinVisibleChange) {
+            onFocusWithinVisibleChange(true);
+          }
+        }
+        if (!state.isFocusVisible && isGlobalFocusVisible) {
+          state.isFocusVisible = isGlobalFocusVisible;
+          if (onFocusWithinVisibleChange) {
+            onFocusWithinVisibleChange(true);
+          }
+        }
+        if (onFocusWithin) {
+          onFocusWithin(event);
+        }
+        isEmulatingMouseEvents = false;
+      });
+
+      // Handle blur
+      blurHandle.setListener(focusWithinTarget, event => {
+        if (disabled) {
+          return;
+        }
+        const {relatedTarget} = (event: any);
+
+        if (
+          state.isFocused &&
+          !isRelatedTargetWithin(focusWithinTarget, relatedTarget)
+        ) {
+          state.isFocused = false;
+          if (onFocusWithinChange) {
+            onFocusWithinChange(false);
+          }
+          if (state.isFocusVisible && onFocusWithinVisibleChange) {
+            onFocusWithinVisibleChange(false);
+          }
+          if (onBlurWithin) {
+            onBlurWithin(event);
+          }
+        }
+        isEmulatingMouseEvents = false;
+      });
+
+      // Handle before blur. This is a special
+      // React provided event.
+      beforeBlurHandle.setListener(focusWithinTarget, event => {
+        if (disabled) {
+          return;
+        }
+        if (onBeforeBlurWithin) {
+          onBeforeBlurWithin(event);
+          // Add an "afterblur" listener on document. This is a special
+          // React provided event.
+          afterBlurHandle.setListener(document, afterBlurEvent => {
+            if (onAfterBlurWithin) {
+              onAfterBlurWithin(afterBlurEvent);
+            }
+            // Clear listener on document
+            afterBlurHandle.setListener(document, null);
+          });
+        }
+      });
+    }
+  }, [
+    disabled,
+    onBlurWithin,
+    onFocusWithin,
+    onFocusWithinChange,
+    onFocusWithinVisibleChange,
+  ]);
+
+  // Mount/Unmount logic
+  useFocusLifecycles(stateRef);
+}

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
@@ -1,0 +1,327 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {createEventTarget, setPointerEvent} from 'dom-event-testing-library';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let useFocus;
+let Scheduler;
+
+function initializeModules(hasPointerEvents) {
+  setPointerEvent(hasPointerEvents);
+  jest.resetModules();
+  ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.enableModernEventSystem = true;
+  ReactFeatureFlags.enableCreateEventHandleAPI = true;
+  React = require('react');
+  ReactDOM = require('react-dom');
+  Scheduler = require('scheduler');
+
+  // TODO: This import throws outside of experimental mode. Figure out better
+  // strategy for gated imports.
+  if (__EXPERIMENTAL__) {
+    useFocus = require('react-interactions/events/focus').useFocus;
+  }
+}
+
+const forcePointerEvents = true;
+const table = [[forcePointerEvents], [!forcePointerEvents]];
+
+describe.each(table)(`useFocus`, hasPointerEvents => {
+  let container;
+
+  beforeEach(() => {
+    initializeModules(hasPointerEvents);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    ReactDOM.render(null, container);
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  describe('disabled', () => {
+    let onBlur, onFocus, ref;
+
+    const componentInit = () => {
+      onBlur = jest.fn();
+      onFocus = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useFocus(ref, {
+          disabled: true,
+          onBlur,
+          onFocus,
+        });
+        return <div ref={ref} />;
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('does not call callbacks', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      target.blur();
+      expect(onFocus).not.toBeCalled();
+      expect(onBlur).not.toBeCalled();
+    });
+  });
+
+  describe('onBlur', () => {
+    let onBlur, ref;
+
+    const componentInit = () => {
+      onBlur = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useFocus(ref, {
+          onBlur,
+        });
+        return <div ref={ref} />;
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "blur" event', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      target.blur();
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onFocus', () => {
+    let onFocus, ref, innerRef;
+
+    const componentInit = () => {
+      onFocus = jest.fn();
+      ref = React.createRef();
+      innerRef = React.createRef();
+      const Component = () => {
+        useFocus(ref, {
+          onFocus,
+        });
+        return (
+          <div ref={ref}>
+            <a ref={innerRef} />
+          </div>
+        );
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "focus" event', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate experimental
+    it('is not called if descendants of target receive focus', () => {
+      componentInit();
+      const target = createEventTarget(innerRef.current);
+      target.focus();
+      expect(onFocus).not.toBeCalled();
+    });
+  });
+
+  describe('onFocusChange', () => {
+    let onFocusChange, ref, innerRef;
+
+    const componentInit = () => {
+      onFocusChange = jest.fn();
+      ref = React.createRef();
+      innerRef = React.createRef();
+      const Component = () => {
+        useFocus(ref, {
+          onFocusChange,
+        });
+        return (
+          <div ref={ref}>
+            <div ref={innerRef} />
+          </div>
+        );
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "blur" and "focus" events', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      expect(onFocusChange).toHaveBeenCalledTimes(1);
+      expect(onFocusChange).toHaveBeenCalledWith(true);
+      target.blur();
+      expect(onFocusChange).toHaveBeenCalledTimes(2);
+      expect(onFocusChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is not called after "blur" and "focus" events on descendants', () => {
+      componentInit();
+      const target = createEventTarget(innerRef.current);
+      target.focus();
+      expect(onFocusChange).toHaveBeenCalledTimes(0);
+      target.blur();
+      expect(onFocusChange).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('onFocusVisibleChange', () => {
+    let onFocusVisibleChange, ref, innerRef;
+
+    const componentInit = () => {
+      onFocusVisibleChange = jest.fn();
+      ref = React.createRef();
+      innerRef = React.createRef();
+      const Component = () => {
+        useFocus(ref, {
+          onFocusVisibleChange,
+        });
+        return (
+          <div ref={ref}>
+            <div ref={innerRef} />
+          </div>
+        );
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "focus" and "blur" if keyboard navigation is active', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      const containerTarget = createEventTarget(container);
+      // use keyboard first
+      containerTarget.keydown({key: 'Tab'});
+      target.focus();
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusVisibleChange).toHaveBeenCalledWith(true);
+      target.blur({relatedTarget: container});
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusVisibleChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      const containerTarget = createEventTarget(container);
+      // use keyboard first
+      containerTarget.keydown({key: 'Tab'});
+      target.focus();
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusVisibleChange).toHaveBeenCalledWith(true);
+      // then use pointer on the target, focus should no longer be visible
+      target.pointerdown();
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusVisibleChange).toHaveBeenCalledWith(false);
+      // onFocusVisibleChange should not be called again
+      target.blur({relatedTarget: container});
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(2);
+    });
+
+    // @gate experimental
+    it('is not called after "focus" and "blur" events without keyboard', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      const containerTarget = createEventTarget(container);
+      target.pointerdown();
+      target.pointerup();
+      containerTarget.pointerdown();
+      target.blur({relatedTarget: container});
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(0);
+    });
+
+    // @gate experimental
+    it('is not called after "blur" and "focus" events on descendants', () => {
+      componentInit();
+      const innerTarget = createEventTarget(innerRef.current);
+      const containerTarget = createEventTarget(container);
+      containerTarget.keydown({key: 'Tab'});
+      innerTarget.focus();
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(0);
+      innerTarget.blur({relatedTarget: container});
+      expect(onFocusVisibleChange).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('nested Focus components', () => {
+    // @gate experimental
+    it('propagates events in the correct order', () => {
+      const events = [];
+      const innerRef = React.createRef();
+      const outerRef = React.createRef();
+      const createEventHandler = msg => () => {
+        events.push(msg);
+      };
+
+      const Inner = () => {
+        useFocus(innerRef, {
+          onBlur: createEventHandler('inner: onBlur'),
+          onFocus: createEventHandler('inner: onFocus'),
+          onFocusChange: createEventHandler('inner: onFocusChange'),
+        });
+        return <div ref={innerRef} />;
+      };
+
+      const Outer = () => {
+        useFocus(outerRef, {
+          onBlur: createEventHandler('outer: onBlur'),
+          onFocus: createEventHandler('outer: onFocus'),
+          onFocusChange: createEventHandler('outer: onFocusChange'),
+        });
+        return (
+          <div ref={outerRef}>
+            <Inner />
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Outer />, container);
+      Scheduler.unstable_flushAll();
+
+      const innerTarget = createEventTarget(innerRef.current);
+      const outerTarget = createEventTarget(outerRef.current);
+
+      outerTarget.focus();
+      outerTarget.blur();
+      innerTarget.focus();
+      innerTarget.blur();
+      expect(events).toEqual([
+        'outer: onFocus',
+        'outer: onFocusChange',
+        'outer: onBlur',
+        'outer: onFocusChange',
+        'inner: onFocus',
+        'inner: onFocusChange',
+        'inner: onBlur',
+        'inner: onFocusChange',
+      ]);
+    });
+  });
+});

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
@@ -1,0 +1,579 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+import {createEventTarget, setPointerEvent} from 'dom-event-testing-library';
+
+let React;
+let ReactFeatureFlags;
+let ReactDOM;
+let useFocusWithin;
+let ReactTestRenderer;
+let act;
+let Scheduler;
+
+function initializeModules(hasPointerEvents) {
+  setPointerEvent(hasPointerEvents);
+  jest.resetModules();
+  ReactFeatureFlags = require('shared/ReactFeatureFlags');
+  ReactFeatureFlags.enableScopeAPI = true;
+  ReactFeatureFlags.enableModernEventSystem = true;
+  ReactFeatureFlags.enableCreateEventHandleAPI = true;
+  React = require('react');
+  ReactDOM = require('react-dom');
+  ReactTestRenderer = require('react-test-renderer');
+  Scheduler = require('scheduler');
+  act = ReactTestRenderer.act;
+
+  // TODO: This import throws outside of experimental mode. Figure out better
+  // strategy for gated imports.
+  if (__EXPERIMENTAL__) {
+    useFocusWithin = require('react-interactions/events/focus').useFocusWithin;
+  }
+}
+
+const forcePointerEvents = true;
+const table = [[forcePointerEvents], [!forcePointerEvents]];
+
+describe.each(table)(`useFocus`, hasPointerEvents => {
+  let container;
+  let container2;
+
+  beforeEach(() => {
+    initializeModules(hasPointerEvents);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    container2 = document.createElement('div');
+    document.body.appendChild(container2);
+  });
+
+  afterEach(() => {
+    ReactDOM.render(null, container);
+    document.body.removeChild(container);
+    document.body.removeChild(container2);
+    container = null;
+    container2 = null;
+  });
+
+  describe('disabled', () => {
+    let onFocusWithinChange, onFocusWithinVisibleChange, ref;
+
+    const componentInit = () => {
+      onFocusWithinChange = jest.fn();
+      onFocusWithinVisibleChange = jest.fn();
+      ref = React.createRef();
+      const Component = () => {
+        useFocusWithin(ref, {
+          disabled: true,
+          onFocusWithinChange,
+          onFocusWithinVisibleChange,
+        });
+        return <div ref={ref} />;
+      };
+      ReactDOM.render(<Component />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('prevents custom events being dispatched', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      target.blur();
+      expect(onFocusWithinChange).not.toBeCalled();
+      expect(onFocusWithinVisibleChange).not.toBeCalled();
+    });
+  });
+
+  describe('onFocusWithinChange', () => {
+    let onFocusWithinChange, ref, innerRef, innerRef2;
+
+    const Component = ({show}) => {
+      useFocusWithin(ref, {
+        onFocusWithinChange,
+      });
+      return (
+        <div ref={ref}>
+          {show && <input ref={innerRef} />}
+          <div ref={innerRef2} />
+        </div>
+      );
+    };
+
+    const componentInit = () => {
+      onFocusWithinChange = jest.fn();
+      ref = React.createRef();
+      innerRef = React.createRef();
+      innerRef2 = React.createRef();
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "blur" and "focus" events on focus target', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      target.focus();
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(true);
+      target.blur({relatedTarget: container});
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is called after "blur" and "focus" events on descendants', () => {
+      componentInit();
+      const target = createEventTarget(innerRef.current);
+      target.focus();
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(true);
+      target.blur({relatedTarget: container});
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is only called once when focus moves within and outside the subtree', () => {
+      componentInit();
+      const node = ref.current;
+      const innerNode1 = innerRef.current;
+      const innerNode2 = innerRef.current;
+      const target = createEventTarget(node);
+      const innerTarget1 = createEventTarget(innerNode1);
+      const innerTarget2 = createEventTarget(innerNode2);
+
+      // focus shifts into subtree
+      innerTarget1.focus();
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(true);
+      // focus moves around subtree
+      innerTarget1.blur({relatedTarget: innerNode2});
+      innerTarget2.focus();
+      innerTarget2.blur({relatedTarget: node});
+      target.focus();
+      target.blur({relatedTarget: innerNode1});
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(1);
+      // focus shifts outside subtree
+      innerTarget1.blur({relatedTarget: container});
+      expect(onFocusWithinChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('onFocusWithinVisibleChange', () => {
+    let onFocusWithinVisibleChange, ref, innerRef, innerRef2;
+
+    const Component = ({show}) => {
+      useFocusWithin(ref, {
+        onFocusWithinVisibleChange,
+      });
+      return (
+        <div ref={ref}>
+          {show && <input ref={innerRef} />}
+          <div ref={innerRef2} />
+        </div>
+      );
+    };
+
+    const componentInit = () => {
+      onFocusWithinVisibleChange = jest.fn();
+      ref = React.createRef();
+      innerRef = React.createRef();
+      innerRef2 = React.createRef();
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+    };
+
+    // @gate experimental
+    it('is called after "focus" and "blur" on focus target if keyboard was used', () => {
+      componentInit();
+      const target = createEventTarget(ref.current);
+      const containerTarget = createEventTarget(container);
+      // use keyboard first
+      containerTarget.keydown({key: 'Tab'});
+      target.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      target.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is called after "focus" and "blur" on descendants if keyboard was used', () => {
+      componentInit();
+      const innerTarget = createEventTarget(innerRef.current);
+      const containerTarget = createEventTarget(container);
+      // use keyboard first
+      containerTarget.keydown({key: 'Tab'});
+      innerTarget.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      innerTarget.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+    });
+
+    // @gate experimental
+    it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
+      componentInit();
+      const node = ref.current;
+      const innerNode1 = innerRef.current;
+      const innerNode2 = innerRef2.current;
+
+      const target = createEventTarget(node);
+      const innerTarget1 = createEventTarget(innerNode1);
+      const innerTarget2 = createEventTarget(innerNode2);
+      // use keyboard first
+      target.focus();
+      target.keydown({key: 'Tab'});
+      target.blur({relatedTarget: innerNode1});
+      innerTarget1.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      // then use pointer on the next target, focus should no longer be visible
+      innerTarget2.pointerdown();
+      innerTarget1.blur({relatedTarget: innerNode2});
+      innerTarget2.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+      // then use keyboard again
+      innerTarget2.keydown({key: 'Tab', shiftKey: true});
+      innerTarget2.blur({relatedTarget: innerNode1});
+      innerTarget1.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(3);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      // then use pointer on the target, focus should no longer be visible
+      innerTarget1.pointerdown();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(4);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+      // onFocusVisibleChange should not be called again
+      innerTarget1.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(4);
+    });
+
+    // @gate experimental
+    it('is not called after "focus" and "blur" events without keyboard', () => {
+      componentInit();
+      const innerTarget = createEventTarget(innerRef.current);
+      innerTarget.pointerdown();
+      innerTarget.pointerup();
+      innerTarget.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(0);
+    });
+
+    // @gate experimental
+    it('is only called once when focus moves within and outside the subtree', () => {
+      componentInit();
+      const node = ref.current;
+      const innerNode1 = innerRef.current;
+      const innerNode2 = innerRef2.current;
+      const target = createEventTarget(node);
+      const innerTarget1 = createEventTarget(innerNode1);
+      const innerTarget2 = createEventTarget(innerNode2);
+
+      // focus shifts into subtree
+      innerTarget1.focus();
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(true);
+      // focus moves around subtree
+      innerTarget1.blur({relatedTarget: innerNode2});
+      innerTarget2.focus();
+      innerTarget2.blur({relatedTarget: node});
+      target.focus();
+      target.blur({relatedTarget: innerNode1});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(1);
+      // focus shifts outside subtree
+      innerTarget1.blur({relatedTarget: container});
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(2);
+      expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('onBeforeBlurWithin', () => {
+    let onBeforeBlurWithin, onAfterBlurWithin, ref, innerRef, innerRef2;
+
+    beforeEach(() => {
+      onBeforeBlurWithin = jest.fn();
+      onAfterBlurWithin = jest.fn(e => {
+        e.persist();
+      });
+      ref = React.createRef();
+      innerRef = React.createRef();
+      innerRef2 = React.createRef();
+    });
+
+    // @gate experimental
+    it('is called after a focused element is unmounted', () => {
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+        return (
+          <div ref={ref}>
+            {show && <input ref={innerRef} />}
+            <div ref={innerRef2} />
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledWith(
+        expect.objectContaining({relatedTarget: inner}),
+      );
+    });
+
+    // @gate experimental
+    it('is called after a nested focused element is unmounted', () => {
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+        return (
+          <div ref={ref}>
+            {show && (
+              <div>
+                <input ref={innerRef} />
+              </div>
+            )}
+            <div ref={innerRef2} />
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledWith(
+        expect.objectContaining({relatedTarget: inner}),
+      );
+    });
+
+    // @gate experimental
+    it('is called after many elements are unmounted', () => {
+      const buttonRef = React.createRef();
+      const inputRef = React.createRef();
+
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+        return (
+          <div ref={ref}>
+            {show && <button>Press me!</button>}
+            {show && <button>Press me!</button>}
+            {show && <input ref={inputRef} />}
+            {show && <button>Press me!</button>}
+            {!show && <button ref={buttonRef}>Press me!</button>}
+            {show && <button>Press me!</button>}
+            <button>Press me!</button>
+            <button>Press me!</button>
+          </div>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      inputRef.current.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+      ReactDOM.render(<Component show={false} />, container);
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+    });
+
+    // @gate experimental
+    it('is called after a nested focused element is unmounted (with scope query)', () => {
+      const TestScope = React.unstable_createScope();
+      const testScopeQuery = (type, props) => true;
+      let targetNodes;
+      let targetNode;
+
+      const Component = ({show}) => {
+        const scopeRef = React.useRef(null);
+        useFocusWithin(scopeRef, {
+          onBeforeBlurWithin(event) {
+            const scope = scopeRef.current;
+            targetNode = innerRef.current;
+            targetNodes = scope.DO_NOT_USE_queryAllNodes(testScopeQuery);
+          },
+        });
+
+        return (
+          <TestScope ref={scopeRef}>
+            {show && <input ref={innerRef} />}
+          </TestScope>
+        );
+      };
+
+      ReactDOM.render(<Component show={true} />, container);
+      Scheduler.unstable_flushAll();
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      ReactDOM.render(<Component show={false} />, container);
+      Scheduler.unstable_flushAll();
+      expect(targetNodes).toEqual([targetNode]);
+    });
+
+    // @gate experimental
+    it('is called after a focused suspended element is hidden', () => {
+      const Suspense = React.Suspense;
+      let suspend = false;
+      let resolve;
+      const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+
+      function Child() {
+        if (suspend) {
+          throw promise;
+        } else {
+          return <input ref={innerRef} />;
+        }
+      }
+
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+
+        return (
+          <div ref={ref}>
+            <Suspense fallback="Loading...">
+              <Child />
+            </Suspense>
+          </div>
+        );
+      };
+
+      const root = ReactDOM.createRoot(container2);
+
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+      expect(container2.innerHTML).toBe('<div><input></div>');
+
+      const inner = innerRef.current;
+      const target = createEventTarget(inner);
+      target.keydown({key: 'Tab'});
+      target.focus();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+
+      suspend = true;
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+      expect(container2.innerHTML).toBe(
+        '<div><input style="display: none;">Loading...</div>',
+      );
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+      resolve();
+    });
+
+    // @gate experimental
+    it('is called after a focused suspended element is hidden then shown', () => {
+      const Suspense = React.Suspense;
+      let suspend = false;
+      let resolve;
+      const promise = new Promise(resolvePromise => (resolve = resolvePromise));
+      const buttonRef = React.createRef();
+
+      function Child() {
+        if (suspend) {
+          throw promise;
+        } else {
+          return <input ref={innerRef} />;
+        }
+      }
+
+      const Component = ({show}) => {
+        useFocusWithin(ref, {
+          onBeforeBlurWithin,
+          onAfterBlurWithin,
+        });
+
+        return (
+          <div ref={ref}>
+            <Suspense fallback={<button ref={buttonRef}>Loading...</button>}>
+              <Child />
+            </Suspense>
+          </div>
+        );
+      };
+
+      const root = ReactDOM.createRoot(container2);
+
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+
+      suspend = true;
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(0);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(0);
+
+      buttonRef.current.focus();
+      suspend = false;
+      act(() => {
+        root.render(<Component />);
+      });
+      jest.runAllTimers();
+      expect(onBeforeBlurWithin).toHaveBeenCalledTimes(1);
+      expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
+
+      resolve();
+    });
+  });
+});

--- a/packages/react-interactions/events/src/dom/create-event-handle/useEvent.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/useEvent.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+const {useEffect, useRef} = React;
+const {unstable_createEventHandle: createEventHandle} = ReactDOM;
+
+type UseEventHandle = {|
+  setListener: (
+    target: EventTarget,
+    null | ((SyntheticEvent<EventTarget>) => void),
+  ) => void,
+  clear: () => void,
+|};
+
+export default function useEvent(
+  event: string,
+  options?: {|
+    capture?: boolean,
+    passive?: boolean,
+    priority?: 0 | 1 | 2,
+  |},
+): UseEventHandle {
+  const handleRef = useRef(null);
+
+  if (handleRef.current == null) {
+    handleRef.current = createEventHandle(event, options);
+  }
+
+  useEffect(() => {
+    const handle = handleRef.current;
+    return () => {
+      if (handle !== null) {
+        handle.clear();
+      }
+      handleRef.current = null;
+    };
+  }, []);
+
+  return ((handleRef.current: any): UseEventHandle);
+}

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -58,7 +58,7 @@ export const disableModulePatternComponents = true;
 
 export const enableDeprecatedFlareAPI = true;
 
-export const enableCreateEventHandleAPI = false;
+export const enableCreateEventHandleAPI = true;
 
 export const enableFundamentalAPI = false;
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -363,5 +363,8 @@
   "362": "Could not find React container within specified host subtree.",
   "363": "Test selector API is not supported by this renderer.",
   "364": "Invalid host root specified. Should be either a React container or a node with a testname attribute.",
-  "365": "Invalid selector type %s specified."
+  "365": "Invalid selector type %s specified.",
+  "366": "ReactDOM.createEventHandle: setListener called on an target that did not have a corresponding root. This is likely a bug in React.",
+  "367": "ReactDOM.createEventHandle: setListener called on an element target that is not managed by React. Ensure React rendered the DOM element.",
+  "368": "ReactDOM.createEventHandle: setListener called on an invalid target. Provide a vaid EventTarget or an element managed by React."
 }


### PR DESCRIPTION
This PR adds the experimental `ReactDOM.createEventHandle` API. This works similar to how the recently removed `ReactDOM.useEvent` works, and provides an event handle object that can be use to set and clear listeners.

```jsx
const clickHandle = ReactDOM.createEventHandle('click')

function Component() {
  const ref = useRef(null);

  useEffect(() => {
    clickHandle.setListener(ref.current, () => {
      console.log('click!');
    });
  });

  return <button ref={ref}>Click me</button>
}
```

The key difference is that we no longer need to do this as a hook. I've added an implementation of how you can do `useEvent` with this API, and that is actually used in the `useFocus` and `useFocusWithin` surfaces.

I know this is a large PR, but most of the code is being brought back, and is largely unchanged from how `useEvent` worked before (all the tests are basically the same, as is the implementation for handling events). Some codepaths have been unified, to avoid code duplication and improve the fast paths compared to before.

Why is this API better than the hook version? Well we found there to be lots of cases where you want to use `addEventListener` in an application, either in a React effect or in some other external system that connects to React. Given this API is meant to replace usages of `addEventListener`, as a form of "wrapper", we wanted an API that can be used as such. Having it limited to a hook means that it can only be used during the render phase of a component, which doesn't cover many cases we want to be able to provide cover for.