### PR TITLE
Refine ReactDOM "Container" type

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -100,9 +100,7 @@ export type EventTargetChildElement = {
   },
   ...
 };
-export type Container =
-  | (Element & {_reactRootContainer?: RootType, ...})
-  | (Document & {_reactRootContainer?: RootType, ...});
+export type Container = Element & {_reactRootContainer?: RootType, ...};
 export type Instance = Element;
 export type TextInstance = Text;
 export type SuspenseInstance = Comment & {_reactRetry?: () => void, ...};


### PR DESCRIPTION
The `Container` is never a `document` (anymore at least), so let's refine the type better.