### PR TITLE
[DevTools] enable Electron interactions on Linux & auto copy script tags

### DIFF
--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -30,6 +30,10 @@
         margin: 0;
       }
 
+      .input-container {
+        position: relative;
+      }
+
       .input {
         display: block;
         font-weight: 100;
@@ -37,6 +41,18 @@
         border: 1px solid #aaa;
         background-color: #fff;
         color: #666;
+        position: relative;
+        left: -8px;
+      }
+
+      .copy-btn {
+        position: absolute;
+        cursor: pointer;
+        top: 0px;
+        right: -10px;
+      }
+      .copy-btn:active {
+        opacity: 0.5;
       }
 
       .link {
@@ -116,8 +132,14 @@
           <div class="box-header">React DOM</div>
           <div class="box-content">
             Add one of the following:
-            <span class="input" contenteditable="true" id="localhost"></span>
-            <span class="input" contenteditable="true" id="byip"></span>
+            <div class="input-container">
+              <span class="input" contenteditable="true" id="localhost"></span>
+              <span class="copy-btn" id="copy-localhost" title="copy">&#x1f4cb;</span>
+            </div>
+            <div class="input-container">
+              <span class="input" contenteditable="true" id="byip"></span>
+              <span class="copy-btn" id="copy-byip" title="copy">&#x1f4cb;</span>
+            </div>
             to the top of the page you want to debug,
             <br />
             <strong>before</strong> importing React DOM.
@@ -127,6 +149,7 @@
       </div>
     </div>
     <script>
+      const {clipboard} = require('electron');
       const port = process.env.PORT || 8097;
       const localIp = require("ip").address();
       const $ = document.querySelector.bind(document);
@@ -134,7 +157,7 @@
       function selectAll(event) {
         const element = event.target;
         if (window.getSelection) {
-          const selection = window.getSelection();        
+          const selection = window.getSelection();
           const range = document.createRange();
           range.selectNodeContents(element);
           selection.removeAllRanges();
@@ -157,6 +180,16 @@
       $byIp.innerText = `<script src="http://${localIp}:${port}"></` + 'script>';
       $byIp.addEventListener('click', selectAll);
       $byIp.addEventListener('focus', selectAll);
+
+      function copyPreviousElementText(event) {
+        const prevElemSibling = event.target.previousElementSibling;
+        clipboard.writeText(prevElemSibling.textContent);
+      }
+
+      const $copyLocalhost = $("#copy-localhost");
+      $copyLocalhost.addEventListener('click', copyPreviousElementText);
+      const $copyByIp = $("#copy-byip");
+      $copyByIp.addEventListener('click', copyPreviousElementText);
 
       let devtools;
       try {

--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -30,10 +30,6 @@
         margin: 0;
       }
 
-      .input-container {
-        position: relative;
-      }
-
       .input {
         display: block;
         font-weight: 100;
@@ -41,18 +37,6 @@
         border: 1px solid #aaa;
         background-color: #fff;
         color: #666;
-        position: relative;
-        left: -8px;
-      }
-
-      .copy-btn {
-        position: absolute;
-        cursor: pointer;
-        top: 0px;
-        right: -10px;
-      }
-      .copy-btn:active {
-        opacity: 0.5;
       }
 
       .link {
@@ -131,15 +115,11 @@
         <div class="box">
           <div class="box-header">React DOM</div>
           <div class="box-content">
-            Add one of the following:
-            <div class="input-container">
-              <span class="input" contenteditable="true" id="localhost"></span>
-              <span class="copy-btn" id="copy-localhost" title="copy">&#x1f4cb;</span>
+            <div id="box-content-status">
+              Add one of the following (click to copy):
             </div>
-            <div class="input-container">
-              <span class="input" contenteditable="true" id="byip"></span>
-              <span class="copy-btn" id="copy-byip" title="copy">&#x1f4cb;</span>
-            </div>
+            <span class="input" contenteditable="true" id="localhost"></span>
+            <span class="input" contenteditable="true" id="byip"></span>
             to the top of the page you want to debug,
             <br />
             <strong>before</strong> importing React DOM.
@@ -149,12 +129,14 @@
       </div>
     </div>
     <script>
-      const {clipboard} = require('electron');
+      const {clipboard} = require("electron");
       const port = process.env.PORT || 8097;
       const localIp = require("ip").address();
       const $ = document.querySelector.bind(document);
+      const boxContentInitialStatus = $("#box-content-status").textContent;
+      let boxContentStatusID;
 
-      function selectAll(event) {
+      function selectAllAndCopy(event) {
         const element = event.target;
         if (window.getSelection) {
           const selection = window.getSelection();
@@ -162,6 +144,13 @@
           range.selectNodeContents(element);
           selection.removeAllRanges();
           selection.addRange(range);
+          clipboard.writeText(event.target.textContent);
+          const $boxContentStatus = $("#box-content-status");
+          $boxContentStatus.textContent = "Copied to clipboard";
+          if (boxContentStatusID) clearTimeout(boxContentStatusID);
+          boxContentStatusID = setTimeout(() => {
+            $boxContentStatus.textContent = boxContentInitialStatus;
+          }, 1000);
         }
       }
 
@@ -173,23 +162,13 @@
 
       const $localhost = $("#localhost");
       $localhost.innerText = `<script src="http://localhost:${port}"></` + 'script>';
-      $localhost.addEventListener('click', selectAll);
-      $localhost.addEventListener('focus', selectAll);
+      $localhost.addEventListener('click', selectAllAndCopy);
+      $localhost.addEventListener('focus', selectAllAndCopy);
 
       const $byIp = $("#byip");
       $byIp.innerText = `<script src="http://${localIp}:${port}"></` + 'script>';
-      $byIp.addEventListener('click', selectAll);
-      $byIp.addEventListener('focus', selectAll);
-
-      function copyPreviousElementText(event) {
-        const prevElemSibling = event.target.previousElementSibling;
-        clipboard.writeText(prevElemSibling.textContent);
-      }
-
-      const $copyLocalhost = $("#copy-localhost");
-      $copyLocalhost.addEventListener('click', copyPreviousElementText);
-      const $copyByIp = $("#copy-byip");
-      $copyByIp.addEventListener('click', copyPreviousElementText);
+      $byIp.addEventListener('click', selectAllAndCopy);
+      $byIp.addEventListener('focus', selectAllAndCopy);
 
       let devtools;
       try {

--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -95,6 +95,19 @@
         text-align: center;
         margin-top: 1rem;
       }
+
+      .prompt,
+      .confirmation {
+        margin-bottom: 0.25rem;
+      }
+
+      .confirmation {
+        font-style: italic;
+      }
+
+      .hidden {
+        display: none;
+      }
     </style>
   </head>
   <body>
@@ -115,8 +128,11 @@
         <div class="box">
           <div class="box-header">React DOM</div>
           <div class="box-content">
-            <div id="box-content-status">
+            <div id="box-content-prompt" class="prompt">
               Add one of the following (click to copy):
+            </div>
+            <div id="box-content-confirmation" class="confirmation hidden">
+              Copied to clipboard.
             </div>
             <span class="input" contenteditable="true" id="localhost"></span>
             <span class="input" contenteditable="true" id="byip"></span>
@@ -133,9 +149,9 @@
       const port = process.env.PORT || 8097;
       const localIp = require("ip").address();
       const $ = document.querySelector.bind(document);
-      const $boxContentStatus = $("#box-content-status");
-      const boxContentInitialStatus = $boxContentStatus.textContent;
-      let boxContentStatusID;
+      const $promptDiv = $("#box-content-prompt");
+      const $confirmationDiv = $("#box-content-confirmation");
+      let timeoutID;
 
       function selectAllAndCopy(event) {
         const element = event.target;
@@ -146,10 +162,17 @@
           selection.removeAllRanges();
           selection.addRange(range);
           clipboard.writeText(event.target.textContent);
-          $boxContentStatus.textContent = "Copied to clipboard";
-          if (boxContentStatusID) clearTimeout(boxContentStatusID);
-          boxContentStatusID = setTimeout(() => {
-            $boxContentStatus.textContent = boxContentInitialStatus;
+
+          $promptDiv.classList.add('hidden');
+          $confirmationDiv.classList.remove('hidden');
+
+          if (timeoutID) {
+            clearTimeout(timeoutID);
+          }
+
+          timeoutID = setTimeout(() => {
+            $promptDiv.classList.remove('hidden');
+            $confirmationDiv.classList.add('hidden');
           }, 1000);
         }
       }

--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -100,7 +100,7 @@
   <body>
     <div id="container" class="container" style="-webkit-user-select: none; -webkit-app-region: drag;">
       <div class="waiting-header">Waiting for React to connect…</div>
-      <div class="boxes">
+      <div class="boxes" style="-webkit-app-region: none;">
         <div class="box">
           <div class="box-header">React Native</div>
           <div class="box-content">
@@ -133,7 +133,8 @@
       const port = process.env.PORT || 8097;
       const localIp = require("ip").address();
       const $ = document.querySelector.bind(document);
-      const boxContentInitialStatus = $("#box-content-status").textContent;
+      const $boxContentStatus = $("#box-content-status");
+      const boxContentInitialStatus = $boxContentStatus.textContent;
       let boxContentStatusID;
 
       function selectAllAndCopy(event) {
@@ -145,7 +146,6 @@
           selection.removeAllRanges();
           selection.addRange(range);
           clipboard.writeText(event.target.textContent);
-          const $boxContentStatus = $("#box-content-status");
           $boxContentStatus.textContent = "Copied to clipboard";
           if (boxContentStatusID) clearTimeout(boxContentStatusID);
           boxContentStatusID = setTimeout(() => {

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -25,7 +25,7 @@ app.on('ready', function() {
     width: 800,
     height: 600,
     icon: join(__dirname, 'icons/icon128.png'),
-    frame: process.platform === 'linux' ? true : false,
+    frame: false,
     //titleBarStyle: 'customButtonsOnHover',
     webPreferences: {
       nodeIntegration: true,

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -25,7 +25,7 @@ app.on('ready', function() {
     width: 800,
     height: 600,
     icon: join(__dirname, 'icons/icon128.png'),
-    frame: false,
+    frame: process.platform === 'linux' ? true : false,
     //titleBarStyle: 'customButtonsOnHover',
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
When `react-devtools` is runned on Linux, the user cannot interact with Electron window. Also it may be convenient to have button to copy script tag immediately instead of manually copying it.

![Peek 2020-04-29 1](https://user-images.githubusercontent.com/16987322/80543108-b0724f00-89c7-11ea-87fe-4d2ac00f16f2.gif)
