### PR TITLE
Refine experimental Scopes API

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -508,3 +508,18 @@ export function afterActiveInstanceBlur() {
 export function preparePortalMount(portalInstance: any): void {
   // noop
 }
+
+export function prepareScopeUpdate(
+  scopeInstance: Object,
+  internalInstanceHandle: Object,
+): void {
+  // noop
+}
+
+export function prepareScopeUnmount(scopeInstance: Object): void {
+  // noop
+}
+
+export function getInstanceFromScope(scopeInstance: Object): null | Object {
+  return null;
+}

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -243,6 +243,7 @@ function applyTextProps(instance, props, prevProps = {}) {
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 
 export function appendInitialChild(parentInstance, child) {
   if (typeof child === 'string') {
@@ -507,19 +508,4 @@ export function afterActiveInstanceBlur() {
 
 export function preparePortalMount(portalInstance: any): void {
   // noop
-}
-
-export function prepareScopeUpdate(
-  scopeInstance: Object,
-  internalInstanceHandle: Object,
-): void {
-  // noop
-}
-
-export function prepareScopeUnmount(scopeInstance: Object): void {
-  // noop
-}
-
-export function getInstanceFromScope(scopeInstance: Object): null | Object {
-  return null;
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -8,6 +8,7 @@
  */
 
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {ReactScopeInstance} from 'shared/ReactTypes';
 import type {
   Container,
   TextInstance,
@@ -47,7 +48,7 @@ export type ElementListenerMapEntry = {
 
 export function precacheFiberNode(
   hostInst: Fiber,
-  node: Instance | TextInstance | SuspenseInstance,
+  node: Instance | TextInstance | SuspenseInstance | ReactScopeInstance,
 ): void {
   (node: any)[internalInstanceKey] = hostInst;
 }
@@ -204,4 +205,10 @@ export function getEventListenerMap(node: EventTarget): ElementListenerMap {
     elementListenerMap = (node: any)[internalEventHandlersKey] = new Map();
   }
   return elementListenerMap;
+}
+
+export function getFiberFromScopeInstance(
+  scope: ReactScopeInstance,
+): null | Fiber {
+  return (scope: any)[internalInstanceKey] || null;
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -24,9 +24,11 @@ import {
   HostRoot,
   SuspenseComponent,
 } from 'react-reconciler/src/ReactWorkTags';
-import invariant from 'shared/invariant';
 
 import {getParentSuspenseInstance} from './ReactDOMHostConfig';
+
+import invariant from 'shared/invariant';
+import {enableScopeAPI} from 'shared/ReactFeatureFlags';
 
 const randomKey = Math.random()
   .toString(36)
@@ -210,5 +212,8 @@ export function getEventListenerMap(node: EventTarget): ElementListenerMap {
 export function getFiberFromScopeInstance(
   scope: ReactScopeInstance,
 ): null | Fiber {
-  return (scope: any)[internalInstanceKey] || null;
+  if (enableScopeAPI) {
+    return (scope: any)[internalInstanceKey] || null;
+  }
+  return null;
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -9,6 +9,7 @@
 
 import type {TopLevelType} from 'legacy-events/TopLevelEventTypes';
 import type {RootType} from './ReactDOMRoot';
+import type {ReactScopeInstance} from 'shared/ReactTypes';
 import type {
   ReactDOMEventResponder,
   ReactDOMEventResponderInstance,
@@ -19,6 +20,7 @@ import {
   precacheFiberNode,
   updateFiberProps,
   getClosestInstanceFromNode,
+  getFiberFromScopeInstance,
 } from './ReactDOMComponentTree';
 import {
   createElement,
@@ -65,6 +67,7 @@ import {
   enableDeprecatedFlareAPI,
   enableFundamentalAPI,
   enableModernEventSystem,
+  enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
 import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
 import {listenToEvent} from '../events/DOMModernPluginEventSystem';
@@ -1116,4 +1119,26 @@ export function preparePortalMount(portalInstance: Instance): void {
   if (enableModernEventSystem) {
     listenToEvent('onMouseEnter', portalInstance);
   }
+}
+
+export function prepareScopeUpdate(
+  scopeInstance: ReactScopeInstance,
+  internalInstanceHandle: Object,
+): void {
+  if (enableScopeAPI) {
+    precacheFiberNode(internalInstanceHandle, scopeInstance);
+  }
+}
+
+export function prepareScopeUnmount(scopeInstance: Object): void {
+  // TODO when we add createEventHandle
+}
+
+export function getInstanceFromScope(
+  scopeInstance: ReactScopeInstance,
+): null | Object {
+  if (enableScopeAPI) {
+    return getFiberFromScopeInstance(scopeInstance);
+  }
+  return null;
 }

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -14,7 +14,7 @@ import type {
   ElementListenerMapEntry,
 } from '../client/ReactDOMComponentTree';
 import type {EventSystemFlags} from './EventSystemFlags';
-import type {EventPriority, ReactScopeMethods} from 'shared/ReactTypes';
+import type {EventPriority} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {PluginModule} from 'legacy-events/PluginModuleType';
 import type {ReactSyntheticEvent} from 'legacy-events/ReactSyntheticEventType';
@@ -379,22 +379,6 @@ function isMatchingRootContainer(
     (grandContainer.nodeType === COMMENT_NODE &&
       grandContainer.parentNode === targetContainer)
   );
-}
-
-export function isManagedDOMElement(
-  target: EventTarget | ReactScopeMethods,
-): boolean {
-  return getClosestInstanceFromNode(((target: any): Node)) !== null;
-}
-
-export function isValidEventTarget(
-  target: EventTarget | ReactScopeMethods,
-): boolean {
-  return typeof (target: Object).addEventListener === 'function';
-}
-
-export function isReactScope(target: EventTarget | ReactScopeMethods): boolean {
-  return typeof (target: Object).getChildContextValues === 'function';
 }
 
 export function dispatchEventForPluginEventSystem(

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -183,6 +183,7 @@ class ReactFabricHostComponent {
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMutation';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 
 export function appendInitialChild(
   parentInstance: Instance,
@@ -517,19 +518,4 @@ export function afterActiveInstanceBlur() {
 
 export function preparePortalMount(portalInstance: Instance): void {
   // noop
-}
-
-export function prepareScopeUpdate(
-  scopeInstance: Object,
-  internalInstanceHandle: Object,
-): void {
-  // noop
-}
-
-export function prepareScopeUnmount(scopeInstance: Object): void {
-  // noop
-}
-
-export function getInstanceFromScope(scopeInstance: Object): null | Object {
-  return null;
 }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -518,3 +518,18 @@ export function afterActiveInstanceBlur() {
 export function preparePortalMount(portalInstance: Instance): void {
   // noop
 }
+
+export function prepareScopeUpdate(
+  scopeInstance: Object,
+  internalInstanceHandle: Object,
+): void {
+  // noop
+}
+
+export function prepareScopeUnmount(scopeInstance: Object): void {
+  // noop
+}
+
+export function getInstanceFromScope(scopeInstance: Object): null | Object {
+  return null;
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -571,3 +571,18 @@ export function afterActiveInstanceBlur() {
 export function preparePortalMount(portalInstance: Instance): void {
   // noop
 }
+
+export function prepareScopeUpdate(
+  scopeInstance: Object,
+  internalInstanceHandle: Object,
+): void {
+  // noop
+}
+
+export function prepareScopeUnmount(scopeInstance: Object): void {
+  // noop
+}
+
+export function getInstanceFromScope(scopeInstance: Object): null | Object {
+  return null;
+}

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -87,6 +87,7 @@ function recursivelyUncacheFiberNode(node: Instance | TextInstance) {
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 
 export function appendInitialChild(
   parentInstance: Instance,
@@ -570,19 +571,4 @@ export function afterActiveInstanceBlur() {
 
 export function preparePortalMount(portalInstance: Instance): void {
   // noop
-}
-
-export function prepareScopeUpdate(
-  scopeInstance: Object,
-  internalInstanceHandle: Object,
-): void {
-  // noop
-}
-
-export function prepareScopeUnmount(scopeInstance: Object): void {
-  // noop
-}
-
-export function getInstanceFromScope(scopeInstance: Object): null | Object {
-  return null;
 }

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -457,6 +457,14 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     preparePortalMount() {
       // NO-OP
     },
+
+    prepareScopeUpdate() {},
+
+    prepareScopeUnmount() {},
+
+    getInstanceFromScope() {
+      throw new Error('Not yet implemented.');
+    },
   };
 
   const hostConfig = useMutation

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -86,6 +86,7 @@ import {
   cloneFundamentalInstance,
   shouldUpdateFundamentalComponent,
   preparePortalMount,
+  prepareScopeUpdate,
 } from './ReactFiberHostConfig';
 import {
   getRootHostContainer,
@@ -136,7 +137,7 @@ import {createFundamentalStateInstance} from './ReactFiberFundamental.new';
 import {Never, isSameOrHigherPriority} from './ReactFiberExpirationTime.new';
 import {resetChildFibers} from './ReactChildFiber.new';
 import {updateDeprecatedEventListeners} from './ReactFiberDeprecatedEvents.new';
-import {createScopeMethods} from './ReactFiberScope.new';
+import {createScopeInstance} from './ReactFiberScope.new';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -1247,13 +1248,8 @@ function completeWork(
     case ScopeComponent: {
       if (enableScopeAPI) {
         if (current === null) {
-          const type = workInProgress.type;
-          const scopeInstance: ReactScopeInstance = {
-            fiber: workInProgress,
-            methods: null,
-          };
+          const scopeInstance: ReactScopeInstance = createScopeInstance();
           workInProgress.stateNode = scopeInstance;
-          scopeInstance.methods = createScopeMethods(type, scopeInstance);
           if (enableDeprecatedFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
@@ -1265,6 +1261,7 @@ function completeWork(
               );
             }
           }
+          prepareScopeUpdate(scopeInstance, workInProgress);
           if (workInProgress.ref !== null) {
             markRef(workInProgress);
             markUpdate(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -84,6 +84,7 @@ import {
   cloneFundamentalInstance,
   shouldUpdateFundamentalComponent,
   preparePortalMount,
+  prepareScopeUpdate,
 } from './ReactFiberHostConfig';
 import {
   getRootHostContainer,
@@ -134,7 +135,7 @@ import {createFundamentalStateInstance} from './ReactFiberFundamental.old';
 import {Never} from './ReactFiberExpirationTime.old';
 import {resetChildFibers} from './ReactChildFiber.old';
 import {updateDeprecatedEventListeners} from './ReactFiberDeprecatedEvents.old';
-import {createScopeMethods} from './ReactFiberScope.old';
+import {createScopeInstance} from './ReactFiberScope.old';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -1264,13 +1265,8 @@ function completeWork(
     case ScopeComponent: {
       if (enableScopeAPI) {
         if (current === null) {
-          const type = workInProgress.type;
-          const scopeInstance: ReactScopeInstance = {
-            fiber: workInProgress,
-            methods: null,
-          };
+          const scopeInstance: ReactScopeInstance = createScopeInstance();
           workInProgress.stateNode = scopeInstance;
-          scopeInstance.methods = createScopeMethods(type, scopeInstance);
           if (enableDeprecatedFlareAPI) {
             const listeners = newProps.DEPRECATED_flareListeners;
             if (listeners != null) {
@@ -1282,6 +1278,7 @@ function completeWork(
               );
             }
           }
+          prepareScopeUpdate(scopeInstance, workInProgress);
           if (workInProgress.ref !== null) {
             markRef(workInProgress);
             markUpdate(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoScopes.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoScopes.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from 'shared/invariant';
+
+// Renderers that don't support React Scopes
+// can re-export everything from this module.
+
+function shim(...args: any) {
+  invariant(
+    false,
+    'The current renderer does not support React Scopes. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
+}
+
+// React Scopes (when unsupported)
+export const prepareScopeUpdate = shim;
+export const prepareScopeUnmount = shim;
+export const getInstanceFromScope = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -84,6 +84,9 @@ export const makeServerId = $$$hostConfig.makeServerId;
 export const beforeActiveInstanceBlur = $$$hostConfig.beforeActiveInstanceBlur;
 export const afterActiveInstanceBlur = $$$hostConfig.afterActiveInstanceBlur;
 export const preparePortalMount = $$$hostConfig.preparePortalMount;
+export const prepareScopeUpdate = $$$hostConfig.preparePortalMount;
+export const prepareScopeUnmount = $$$hostConfig.prepareScopeUnmount;
+export const getInstanceFromScope = $$$hostConfig.getInstanceFromScope;
 
 // -------------------
 //      Mutation

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -443,3 +443,15 @@ export function afterActiveInstanceBlur() {
 export function preparePortalMount(portalInstance: Instance): void {
   // noop
 }
+
+export function prepareScopeUpdate(scopeInstance: Object, inst: Object): void {
+  nodeToInstanceMap.set(scopeInstance, inst);
+}
+
+export function prepareScopeUnmount(scopeInstance: Object): void {
+  nodeToInstanceMap.delete(scopeInstance);
+}
+
+export function getInstanceFromScope(scopeInstance: Object): null | Object {
+  return nodeToInstanceMap.get(scopeInstance) || null;
+}

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -179,16 +179,11 @@ export type ReactScopeQuery = (
   instance: mixed,
 ) => boolean;
 
-export type ReactScopeMethods = {|
+export type ReactScopeInstance = {|
   DO_NOT_USE_queryAllNodes(ReactScopeQuery): null | Array<Object>,
   DO_NOT_USE_queryFirstNode(ReactScopeQuery): null | Object,
   containsNode(Object): boolean,
   getChildContextValues: <T>(context: ReactContext<T>) => Array<T>,
-|};
-
-export type ReactScopeInstance = {|
-  fiber: Object,
-  methods: null | ReactScopeMethods,
 |};
 
 // Mutable source version can be anything (e.g. number, string, immutable data structure)

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -353,5 +353,6 @@
   "353": "A server block should never encode any other slots. This is a bug in React.",
   "354": "getInspectorDataForViewAtPoint() is not available in production.",
   "355": "The object passed back from useOpaqueIdentifier is meant to be passed through to attributes only. Do not read the value directly.",
-  "356": "Could not read the cache."
+  "356": "Could not read the cache.",
+  "357": "The current renderer does not support React Scopes. This error is likely caused by a bug in React. Please file an issue."
 }


### PR DESCRIPTION
This PR cleans up some of the types around the experimental Scopes API and simplies the data structure around how they're created. The main goal here is to cleanup the API for integration with `createEventHandle`.

With this PR, rather than create a `ScopeMethods` object, we create only a `ScopeInstance` object, which has the methods on – but attached from static functions rather than generated inline. In order for the methods to work with this change, it uses itself (the `ScopeInstance`) as a key to ask the renderer for it's associated fiber so it can carry out traversal.