### PR TITLE
Handle legacy root contains in clearContainer

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -427,7 +427,7 @@ export function unhideTextInstance(textInstance, text): void {
   // Noop
 }
 
-export function clearContainer(container) {
+export function clearContainer(container, scope) {
   // TODO Implement this
 }
 

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -634,13 +634,21 @@ export function unhideTextInstance(
   textInstance.nodeValue = text;
 }
 
-export function clearContainer(container: Container): void {
-  if (container.nodeType === ELEMENT_NODE) {
-    ((container: any): Element).textContent = '';
-  } else if (container.nodeType === DOCUMENT_NODE) {
-    const body = ((container: any): Document).body;
-    if (body != null) {
-      body.textContent = '';
+export function clearContainer(container: Container, root: RootType): void {
+  const legacyRootContainer = container._reactRootContainer;
+  // If there is a legacy root container, check to see if the root
+  // matches the root's container that we want to clear.
+  if (
+    legacyRootContainer == null ||
+    legacyRootContainer._internalRoot === root
+  ) {
+    if (container.nodeType === ELEMENT_NODE) {
+      ((container: any): Element).textContent = '';
+    } else if (container.nodeType === DOCUMENT_NODE) {
+      const body = ((container: any): Document).body;
+      if (body != null) {
+        body.textContent = '';
+      }
     }
   }
 }

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -482,7 +482,7 @@ export function unhideInstance(instance: Instance, props: Props): void {
   );
 }
 
-export function clearContainer(container: Container): void {
+export function clearContainer(container: Container, scope: Object): void {
   // TODO Implement this for React Native
   // UIManager does not expose a "remove all" type method.
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -300,7 +300,7 @@ function commitBeforeMutationLifeCycles(
       if (supportsMutation) {
         if (finishedWork.effectTag & Snapshot) {
           const root = finishedWork.stateNode;
-          clearContainer(root.containerInfo);
+          clearContainer(root.containerInfo, root);
         }
       }
       return;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -298,7 +298,7 @@ function commitBeforeMutationLifeCycles(
       if (supportsMutation) {
         if (finishedWork.effectTag & Snapshot) {
           const root = finishedWork.stateNode;
-          clearContainer(root.containerInfo);
+          clearContainer(root.containerInfo, root);
         }
       }
       return;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -679,7 +679,7 @@ function completeWork(
           // If we hydrated, then we'll need to schedule an update for
           // the commit side-effects on the root.
           markUpdate(workInProgress);
-        } else if (!fiberRoot.hydrate) {
+        } else if (!fiberRoot.hydrate && workInProgress.child !== null) {
           // Schedule an effect to clear this container at the start of the next commit.
           // This handles the case of React rendering into a container with previous children.
           // It's also safe to do for updates too, because current.child would only be null

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -679,7 +679,7 @@ function completeWork(
           // If we hydrated, then we'll need to schedule an update for
           // the commit side-effects on the root.
           markUpdate(workInProgress);
-        } else if (!fiberRoot.hydrate && workInProgress.child !== null) {
+        } else if (!fiberRoot.hydrate) {
           // Schedule an effect to clear this container at the start of the next commit.
           // This handles the case of React rendering into a container with previous children.
           // It's also safe to do for updates too, because current.child would only be null

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -126,7 +126,7 @@ export function removeChild(
   parentInstance.children.splice(index, 1);
 }
 
-export function clearContainer(container: Container): void {
+export function clearContainer(container: Container, root: Object): void {
   container.children.splice(0);
 }
 


### PR DESCRIPTION
When debugging an internal issue, I noticed that we have an issue where we clear down a root that has existing content. This particular fix checks in `clearContainer` if the container we're trying to clear has a legacy container and if it does, checks to see if it matches the root we expected.