### PR TITLE
Move legacy hidden API to new internal Fiber type

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -56,6 +56,7 @@ import {
   ScopeComponent,
   Block,
   OffscreenComponent,
+  LegacyHiddenComponent,
 } from './ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 
@@ -90,6 +91,7 @@ import {
   REACT_SCOPE_TYPE,
   REACT_BLOCK_TYPE,
   REACT_OFFSCREEN_TYPE,
+  REACT_LEGACY_HIDDEN_TYPE,
 } from 'shared/ReactSymbols';
 
 export type {Fiber};
@@ -521,6 +523,13 @@ export function createFiberFromTypeAndProps(
           expirationTime,
           key,
         );
+      case REACT_LEGACY_HIDDEN_TYPE:
+        return createFiberFromLegacyHidden(
+          pendingProps,
+          mode,
+          expirationTime,
+          key,
+        );
       default: {
         if (typeof type === 'object' && type !== null) {
           switch (type.$$typeof) {
@@ -752,6 +761,24 @@ export function createFiberFromOffscreen(
     fiber.type = REACT_OFFSCREEN_TYPE;
   }
   fiber.elementType = REACT_OFFSCREEN_TYPE;
+  fiber.expirationTime_opaque = expirationTime;
+  return fiber;
+}
+
+export function createFiberFromLegacyHidden(
+  pendingProps: OffscreenProps,
+  mode: TypeOfMode,
+  expirationTime: ExpirationTimeOpaque,
+  key: null | string,
+) {
+  const fiber = createFiber(LegacyHiddenComponent, pendingProps, key, mode);
+  // TODO: The LegacyHidden fiber shouldn't have a type. It has a tag.
+  // This needs to be fixed in getComponentName so that it relies on the tag
+  // instead.
+  if (__DEV__) {
+    fiber.type = REACT_LEGACY_HIDDEN_TYPE;
+  }
+  fiber.elementType = REACT_LEGACY_HIDDEN_TYPE;
   fiber.expirationTime_opaque = expirationTime;
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -57,6 +57,7 @@ import {
   ScopeComponent,
   Block,
   OffscreenComponent,
+  LegacyHiddenComponent,
 } from './ReactWorkTags';
 import {
   invokeGuardedCallback,
@@ -817,6 +818,7 @@ function commitLifeCycles(
     case FundamentalComponent:
     case ScopeComponent:
     case OffscreenComponent:
+    case LegacyHiddenComponent:
       return;
   }
   invariant(
@@ -847,7 +849,8 @@ function hideOrUnhideAllChildren(finishedWork, isHidden) {
           unhideTextInstance(instance, node.memoizedProps);
         }
       } else if (
-        node.tag === OffscreenComponent &&
+        (node.tag === OffscreenComponent ||
+          node.tag === LegacyHiddenComponent) &&
         (node.memoizedState: OffscreenState) !== null &&
         node !== finishedWork
       ) {
@@ -1592,7 +1595,8 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         }
         break;
       }
-      case OffscreenComponent: {
+      case OffscreenComponent:
+      case LegacyHiddenComponent: {
         return;
       }
     }
@@ -1731,7 +1735,8 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
       }
       break;
     }
-    case OffscreenComponent: {
+    case OffscreenComponent:
+    case LegacyHiddenComponent: {
       const newState: OffscreenState | null = finishedWork.memoizedState;
       const isHidden = newState !== null;
       hideOrUnhideAllChildren(finishedWork, isHidden);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -56,6 +56,7 @@ import {
   ScopeComponent,
   Block,
   OffscreenComponent,
+  LegacyHiddenComponent,
 } from './ReactWorkTags';
 import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {
@@ -1312,7 +1313,8 @@ function completeWork(
         return null;
       }
       break;
-    case OffscreenComponent: {
+    case OffscreenComponent:
+    case LegacyHiddenComponent: {
       popRenderExpirationTime(workInProgress);
       if (current !== null) {
         const nextState: OffscreenState | null = workInProgress.memoizedState;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -131,6 +131,7 @@ import {
   renderDidSuspend,
   renderDidSuspendDelayIfPossible,
   renderHasNotSuspendedYet,
+  popRenderExpirationTime,
 } from './ReactFiberWorkLoop.new';
 import {createFundamentalStateInstance} from './ReactFiberFundamental.new';
 import {Never, isSameOrHigherPriority} from './ReactFiberExpirationTime.new';
@@ -1312,6 +1313,7 @@ function completeWork(
       }
       break;
     case OffscreenComponent: {
+      popRenderExpirationTime(workInProgress);
       if (current !== null) {
         const nextState: OffscreenState | null = workInProgress.memoizedState;
         const prevState: OffscreenState | null = current.memoizedState;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -55,7 +55,7 @@ import {
   didNotFindHydratableSuspenseInstance,
 } from './ReactFiberHostConfig';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
-import {Never, NoWork} from './ReactFiberExpirationTime.new';
+import {Never} from './ReactFiberExpirationTime.new';
 
 // The deepest Fiber on the stack involved in a hydration context.
 // This may have been an insertion or a hydration.
@@ -231,7 +231,6 @@ function tryHydrate(fiber, nextInstance) {
         if (suspenseInstance !== null) {
           const suspenseState: SuspenseState = {
             dehydrated: suspenseInstance,
-            baseTime: NoWork,
             retryTime: Never,
           };
           fiber.memoizedState = suspenseState;

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
@@ -29,10 +29,6 @@ export type SuspenseState = {|
   // here to indicate that it is dehydrated (flag) and for quick access
   // to check things like isSuspenseInstancePending.
   dehydrated: null | SuspenseInstance,
-  // Represents the work that was deprioritized when we committed the fallback.
-  // The work outside the boundary already committed at this level, so we cannot
-  // unhide the content without including it.
-  baseTime: ExpirationTimeOpaque,
   // Represents the earliest expiration time we should attempt to hydrate
   // a dehydrated boundary at.
   // Never is the default for dehydrated boundaries.

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -21,6 +21,7 @@ import {
   SuspenseComponent,
   SuspenseListComponent,
   OffscreenComponent,
+  LegacyHiddenComponent,
 } from './ReactWorkTags';
 import {DidCapture, NoEffect, ShouldCapture} from './ReactSideEffectTags';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
@@ -108,6 +109,7 @@ function unwindWork(
       popProvider(workInProgress);
       return null;
     case OffscreenComponent:
+    case LegacyHiddenComponent:
       popRenderExpirationTime(workInProgress);
       return null;
     default:
@@ -147,6 +149,7 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
       popProvider(interruptedWork);
       break;
     case OffscreenComponent:
+    case LegacyHiddenComponent:
       popRenderExpirationTime(interruptedWork);
       break;
     default:

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -20,6 +20,7 @@ import {
   ContextProvider,
   SuspenseComponent,
   SuspenseListComponent,
+  OffscreenComponent,
 } from './ReactWorkTags';
 import {DidCapture, NoEffect, ShouldCapture} from './ReactSideEffectTags';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
@@ -33,6 +34,7 @@ import {
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext.new';
 import {popProvider} from './ReactFiberNewContext.new';
+import {popRenderExpirationTime} from './ReactFiberWorkLoop.new';
 
 import invariant from 'shared/invariant';
 
@@ -105,6 +107,9 @@ function unwindWork(
     case ContextProvider:
       popProvider(workInProgress);
       return null;
+    case OffscreenComponent:
+      popRenderExpirationTime(workInProgress);
+      return null;
     default:
       return null;
   }
@@ -140,6 +145,9 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
       break;
     case ContextProvider:
       popProvider(interruptedWork);
+      break;
+    case OffscreenComponent:
+      popRenderExpirationTime(interruptedWork);
       break;
     default:
       break;

--- a/packages/react-reconciler/src/ReactWorkTags.js
+++ b/packages/react-reconciler/src/ReactWorkTags.js
@@ -31,7 +31,8 @@ export type WorkTag =
   | 20
   | 21
   | 22
-  | 23;
+  | 23
+  | 24;
 
 export const FunctionComponent = 0;
 export const ClassComponent = 1;
@@ -57,3 +58,4 @@ export const FundamentalComponent = 20;
 export const ScopeComponent = 21;
 export const Block = 22;
 export const OffscreenComponent = 23;
+export const LegacyHiddenComponent = 24;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -3180,18 +3180,49 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         });
         setFallbackText('Still loading...');
 
-        expect(Scheduler).toFlushAndYield([
-          // First try to render the high pri update. We won't try to re-render
-          // the suspended tree during this pass, because it still has unfinished
-          // updates at a lower priority.
-          'Loading...',
+        expect(Scheduler).toFlushAndYield(
+          gate(flags =>
+            flags.new
+              ? [
+                  // First try to render the high pri update. Still suspended.
+                  'Suspend! [C]',
+                  'Loading...',
 
-          // Now try the suspended update again. It's still suspended.
-          'Suspend! [C]',
+                  // In the expiration times model, once the high pri update
+                  // suspends, we can't be sure if there's additional work at a
+                  // lower priority that might unblock the tree. We do know that
+                  // there's a lower priority update *somehwere* in the entire
+                  // root, though (the update to the fallback). So we try
+                  // rendering one more time, just in case.
+                  // TODO: We shouldn't need to do this with lanes, because we
+                  // always know exactly which lanes have pending work in
+                  // each tree.
+                  'Suspend! [C]',
 
-          // Then complete the update to the fallback.
-          'Still loading...',
-        ]);
+                  // Then complete the update to the fallback.
+                  'Still loading...',
+                ]
+              : [
+                  // In the old reconciler, we don't attempt to unhdie the
+                  // Suspense boundary at high priority. Instead, we bailout,
+                  // then try again at the original priority that the component
+                  // suspended. This is mostly an implementation compromise,
+                  // though there are some advantages to this behavior, because
+                  // attempt to unhide could slow down the rest of the update.
+                  //
+                  // Render that only includes the fallback, since we bailed
+                  // out on the primary tree.
+                  'Loading...',
+
+                  // Now try the suspended update again at the original
+                  // priority. It's still suspended.
+                  'Suspend! [C]',
+
+                  // Then complete the update to the fallback.
+                  'Still loading...',
+                ],
+          ),
+        );
         expect(root).toMatchRenderedOutput(
           <>
             <span hidden={true} prop="A" />
@@ -3466,17 +3497,34 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           root.render(<Parent step={1} />);
         });
       });
+
       // Only the outer part can update. The inner part should still show a
       // fallback because we haven't finished loading B yet. Otherwise, the
       // inner text would be inconsistent with the outer text.
-      expect(Scheduler).toHaveYielded([
-        'Outer text: B',
-        'Outer step: 1',
-        'Loading...',
-
-        'Suspend! [Inner text: B]',
-        'Inner step: 1',
-      ]);
+      expect(Scheduler).toHaveYielded(
+        gate(flags =>
+          flags.new
+            ? [
+                'Outer text: B',
+                'Outer step: 1',
+                'Suspend! [Inner text: B]',
+                'Inner step: 1',
+                'Loading...',
+              ]
+            : [
+                // In the old reconciler, we first complete the outside of the
+                // Suspense boundary, then attempt to unhide it in a separate
+                // render at the original priority at which it suspended.
+                // First render:
+                'Outer text: B',
+                'Outer step: 1',
+                'Loading...',
+                // Second render:
+                'Suspend! [Inner text: B]',
+                'Inner step: 1',
+              ],
+        ),
+      );
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="Outer text: B" />
@@ -3595,15 +3643,23 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
     });
 
-    expect(Scheduler).toHaveYielded([
-      // First the outer part of the tree updates, at high pri.
-      'Outer: B1',
-      'Loading...',
-
-      // Then we retry the boundary.
-      'Inner: B1',
-      'Commit Child',
-    ]);
+    expect(Scheduler).toHaveYielded(
+      gate(flags =>
+        flags.new
+          ? ['Outer: B1', 'Inner: B1', 'Commit Child']
+          : [
+              // In the old reconciler, we first complete the outside of the
+              // Suspense boundary, then attempt to unhide it in a separate
+              // render at the original priority at which it suspended.
+              // First render:
+              'Outer: B1',
+              'Loading...',
+              // Second render:
+              'Inner: B1',
+              'Commit Child',
+            ],
+      ),
+    );
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: B1" />

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -33,6 +33,7 @@ export let REACT_SCOPE_TYPE = 0xead7;
 export let REACT_OPAQUE_ID_TYPE = 0xeae0;
 export let REACT_DEBUG_TRACING_MODE_TYPE = 0xeae1;
 export let REACT_OFFSCREEN_TYPE = 0xeae2;
+export let REACT_LEGACY_HIDDEN_TYPE = 0xeae3;
 
 if (typeof Symbol === 'function' && Symbol.for) {
   const symbolFor = Symbol.for;
@@ -56,6 +57,7 @@ if (typeof Symbol === 'function' && Symbol.for) {
   REACT_OPAQUE_ID_TYPE = symbolFor('react.opaque.id');
   REACT_DEBUG_TRACING_MODE_TYPE = symbolFor('react.debug_trace_mode');
   REACT_OFFSCREEN_TYPE = symbolFor('react.offscreen');
+  REACT_LEGACY_HIDDEN_TYPE = symbolFor('react.legacy_hidden');
 }
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;


### PR DESCRIPTION
## Based on #18733 

[**Diff compared to previous PR in stack**](https://github.com/acdlite/react/compare/unhide-suspense-trees-without...legacy-hidden)

Adds a new LegacyHidden fiber type.

This only exists so we can clean up the internal implementation of `<div hidden={isHidden} />`, which is not a stable feature. The goal is to move everything to the new Offscreen type instead. However, Offscreen has different semantics, so before we can remove the legacy API, we have to migrate our internal usage at Facebook. So we'll need to maintain both temporarily.

If a host component receives a `hidden` prop, we wrap its children in an LegacyHidden fiber. This is similar to what we do for Suspense children.

The LegacyHidden type happens to share the same implementation as the new Offscreen type, for now, but using separate types allows us to fork the behavior later when we implement our planned changes to the Offscreen API.

There are two subtle semantic changes here. One is that the children of the host component wil have their visibility toggled using the same mechanism we use for Offscreen and Suspense: find the nearest host node children and give them a style of `display: none`. We didn't used to do this in the old API, because the `hidden` DOM attribute on the parent already hides them. So with this change, we're actually "overhiding" the children. I considered addressing this, but I figure I'll leave it as-is in case we want to expose the LegacyHidden component type temporarily to ease migration of Facebook's internal callers to the Offscreen type.

The other subtle semantic change is that, because of the extra fiber that wraps around the children, this pattern will cause the children to lose state:

```js
return isHidden ? <div hidden={true} /> : <div />;
```

The reason is that I didn't want to wrap every single host component in an extra fiber. So I only wrap them if a `hidden` prop exists. In the above example, that means the children are conditionally wrapped in an extra fiber, so they don't line up during reconciliation, so they get remounted every time `isHidden` changes.

The fix is to rewrite to:

```js
return <div hidden={isHidden} />;
```

I don't anticipate this will be a problem at Facebook, especially since we're only supposed to use `hidden` via a userspace wrapper component. (And since the bad pattern isn't very React-y, anyway.)

Again, the eventual goal is to delete this completely and replace it with Offscreen.