### PR TITLE
[Blocks] Use native fetch

### DIFF
--- a/fixtures/blocks/src/Comments.js
+++ b/fixtures/blocks/src/Comments.js
@@ -10,9 +10,7 @@ import {fetch} from 'react-data/fetch';
 
 function load(postId) {
   return {
-    comments: JSON.parse(
-      fetch('http://localhost:3001/comments?postId=' + postId)
-    ),
+    comments: fetch('http://localhost:3001/comments?postId=' + postId).json(),
   };
 }
 

--- a/fixtures/blocks/src/Post.js
+++ b/fixtures/blocks/src/Post.js
@@ -11,8 +11,10 @@ import {fetch} from 'react-data/fetch';
 import loadComments from './Comments';
 
 function load(params) {
+  const postResponse = fetch('http://localhost:3001/posts/' + params.id);
   return {
-    post: JSON.parse(fetch('http://localhost:3001/posts/' + params.id)),
+    post: postResponse.json(),
+    meta: postResponse.status + ' ' + postResponse.statusText,
     Comments: loadComments(params.id),
   };
 }
@@ -23,6 +25,7 @@ function Post(props, data) {
       <h1>Post {data.post.id}</h1>
       <h4>{data.post.title}</h4>
       <p>{data.post.body}</p>
+      <pre>{data.meta}</pre>
       <hr />
       <Suspense fallback={<p>Loading comments...</p>}>
         <data.Comments />

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -94,34 +94,38 @@ function Response(nativeResponse) {
 Response.prototype = {
   constructor: Response,
   arrayBuffer() {
-    let entry = this._entries.get('arrayBuffer');
+    const entries = this._entries;
+    let entry = entries.get('arrayBuffer');
     if (!entry) {
       entry = createFromThenable(this._response.arrayBuffer());
-      this._entries.set('arrayBuffer', entry);
+      entries.set('arrayBuffer', entry);
     }
     return readResult(entry);
   },
   blob() {
-    let entry = this._entries.get('blob');
+    const entries = this._entries;
+    let entry = entries.get('blob');
     if (!entry) {
       entry = createFromThenable(this._response.blob());
-      this._entries.set('blob', entry);
+      entries.set('blob', entry);
     }
     return readResult(entry);
   },
   json() {
-    let entry = this._entries.get('json');
+    const entries = this._entries;
+    let entry = entries.get('json');
     if (!entry) {
       entry = createFromThenable(this._response.json());
-      this._entries.set('json', entry);
+      entries.set('json', entry);
     }
     return readResult(entry);
   },
   text() {
-    let entry = this._entries.get('text');
+    const entries = this._entries;
+    let entry = entries.get('text');
     if (!entry) {
       entry = createFromThenable(this._response.text());
-      this._entries.set('text', entry);
+      entries.set('text', entry);
     }
     return readResult(entry);
   },

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -49,9 +49,9 @@ function readResultMap(): Map<string, Result> {
 function toResult(thenable): Result {
   const result: Result = {
     status: Pending,
-    value: (null: any),
+    value: thenable,
   };
-  result.value = thenable.then(
+  thenable.then(
     value => {
       if (result.status === Pending) {
         const resolvedResult = ((result: any): ResolvedResult);

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -46,7 +46,7 @@ function readResultMap(): Map<string, Result> {
   return map;
 }
 
-function createFromThenable(thenable, wrapValue): Result {
+function createFromThenable(thenable): Result {
   const result: Result = {
     status: Pending,
     value: (null: any),

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -109,6 +109,7 @@ function Response(nativeResponse) {
 }
 
 Response.prototype = {
+  constructor: Response,
   arrayBuffer() {
     return this._read('arrayBuffer', getArrayBuffer);
   },

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -87,50 +87,41 @@ function Response(nativeResponse) {
   this.type = nativeResponse.type;
   this.url = nativeResponse.url;
 
-  this._entry = null;
-  this._format = null;
+  this._entries = new Map();
   this._response = nativeResponse;
-}
-
-function getConsumed(response, format) {
-  const consumedFormat = response._format;
-  if (consumedFormat != null && format !== consumedFormat) {
-    throw new Error('Already read.');
-  }
-  const entry = response._entry;
-  if (entry == null) {
-    response._format = format;
-  }
-  return entry;
 }
 
 Response.prototype = {
   constructor: Response,
   arrayBuffer() {
-    let entry = getConsumed(this, 'arrayBuffer');
-    if (entry == null) {
-      this._entry = entry = createFromThenable(this._response.arrayBuffer());
+    let entry = this._entries.get('arrayBuffer');
+    if (!entry) {
+      entry = createFromThenable(this._response.arrayBuffer());
+      this._entries.set('arrayBuffer', entry);
     }
     return readResult(entry);
   },
   blob() {
-    let entry = getConsumed(this, 'blob');
-    if (entry == null) {
-      this._entry = entry = createFromThenable(this._response.blob());
+    let entry = this._entries.get('blob');
+    if (!entry) {
+      entry = createFromThenable(this._response.blob());
+      this._entries.set('blob', entry);
     }
     return readResult(entry);
   },
   json() {
-    let entry = getConsumed(this, 'json');
-    if (entry == null) {
-      this._entry = entry = createFromThenable(this._response.json());
+    let entry = this._entries.get('json');
+    if (!entry) {
+      entry = createFromThenable(this._response.json());
+      this._entries.set('json', entry);
     }
     return readResult(entry);
   },
   text() {
-    let entry = getConsumed(this, 'text');
-    if (entry == null) {
-      this._entry = entry = createFromThenable(this._response.text());
+    let entry = this._entries.get('text');
+    if (!entry) {
+      entry = createFromThenable(this._response.text());
+      this._entries.set('text', entry);
     }
     return readResult(entry);
   },
@@ -139,7 +130,7 @@ Response.prototype = {
 export function fetch(url: string, options: mixed): Object {
   const map = readResultMap();
   let entry = map.get(url);
-  if (entry == null) {
+  if (!entry) {
     if (options) {
       if (options.method || options.body || options.signal) {
         // TODO: wire up our own cancellation mechanism.

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -46,7 +46,7 @@ function readResultMap(): Map<string, Result> {
   return map;
 }
 
-function createFromThenable(thenable): Result {
+function toResult(thenable): Result {
   const result: Result = {
     status: Pending,
     value: (null: any),
@@ -87,47 +87,35 @@ function Response(nativeResponse) {
   this.type = nativeResponse.type;
   this.url = nativeResponse.url;
 
-  this._entries = new Map();
   this._response = nativeResponse;
+  this._arrayBuffer = null;
+  this._blob = null;
+  this._json = null;
+  this._text = null;
 }
 
 Response.prototype = {
   constructor: Response,
   arrayBuffer() {
-    const entries = this._entries;
-    let entry = entries.get('arrayBuffer');
-    if (!entry) {
-      entry = createFromThenable(this._response.arrayBuffer());
-      entries.set('arrayBuffer', entry);
-    }
-    return readResult(entry);
+    return readResult(
+      this._arrayBuffer ||
+        (this._arrayBuffer = toResult(this._response.arrayBuffer())),
+    );
   },
   blob() {
-    const entries = this._entries;
-    let entry = entries.get('blob');
-    if (!entry) {
-      entry = createFromThenable(this._response.blob());
-      entries.set('blob', entry);
-    }
-    return readResult(entry);
+    return readResult(
+      this._blob || (this._blob = toResult(this._response.blob())),
+    );
   },
   json() {
-    const entries = this._entries;
-    let entry = entries.get('json');
-    if (!entry) {
-      entry = createFromThenable(this._response.json());
-      entries.set('json', entry);
-    }
-    return readResult(entry);
+    return readResult(
+      this._json || (this._json = toResult(this._response.json())),
+    );
   },
   text() {
-    const entries = this._entries;
-    let entry = entries.get('text');
-    if (!entry) {
-      entry = createFromThenable(this._response.text());
-      entries.set('text', entry);
-    }
-    return readResult(entry);
+    return readResult(
+      this._text || (this._text = toResult(this._response.text())),
+    );
   },
 };
 
@@ -143,7 +131,7 @@ export function fetch(url: string, options: mixed): Object {
       }
     }
     const thenable = nativeFetch(url, options);
-    entry = createFromThenable(thenable);
+    entry = toResult(thenable);
     map.set(url, entry);
   }
   const nativeResponse = (readResult(entry): any);

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -56,7 +56,7 @@ function createFromThenable(thenable, wrapValue): Result {
       if (result.status === Pending) {
         const resolvedResult = ((result: any): ResolvedResult);
         resolvedResult.status = Resolved;
-        resolvedResult.value = wrapValue ? wrapValue(value) : value;
+        resolvedResult.value = value;
       }
     },
     err => {
@@ -148,11 +148,13 @@ export function fetch(url: string, options: mixed): Object {
       }
     }
     const thenable = nativeFetch(url, options);
-    entry = createFromThenable(
-      thenable,
-      nativeResponse => new Response(nativeResponse),
-    );
+    entry = createFromThenable(thenable);
     map.set(url, entry);
   }
-  return readResult(entry);
+  const nativeResponse = (readResult(entry): any);
+  if (nativeResponse._reactResponse) {
+    return nativeResponse._reactResponse;
+  } else {
+    return (nativeResponse._reactResponse = new Response(nativeResponse));
+  }
 }

--- a/packages/react-data/src/fetch/ReactDataFetch.js
+++ b/packages/react-data/src/fetch/ReactDataFetch.js
@@ -78,6 +78,14 @@ function readResult(result: Result) {
   }
 }
 
+function getArrayBuffer(nativeResponse) {
+  return nativeResponse.arrayBuffer();
+}
+
+function getBlob(nativeResponse) {
+  return nativeResponse.blob();
+}
+
 function getJson(nativeResponse) {
   return nativeResponse.json();
 }
@@ -101,6 +109,12 @@ function Response(nativeResponse) {
 }
 
 Response.prototype = {
+  arrayBuffer() {
+    return this._read('arrayBuffer', getArrayBuffer);
+  },
+  blob() {
+    return this._read('blob', getBlob);
+  },
   json() {
     return this._read('json', getJson);
   },


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/18774.
Rewrites from XHR to just using native fetch.

- Fetch now returns a Response object, a thin wrapper over native Response.
- New Response methods: `arrayBuffer()`, `blob()`, `text()`, `json()`.
  - I didn't add `formData()` because I'm not sure why it's useful for GETs.
  - <s>Note I currently forbid reading different types from the same URL. Could be fixable but let's wait until someone actually has a use case.</s> Delegating to the browser here so if it throws, it throws.
- New Response fields: `headers`, `ok`, `redirected`, `status`, `statusText`, `type`, `url`.
  - Maybe we could just expose the native object as a property.
- Fetch now passes the options through.
  - But it errors on a few that don't make sense:
    - `signal`: We're going to control this ourselves.
    - `body` and `method`: We haven't decided what to do with POST.