### PR TITLE
Don't "schedule" discrete work if we're scheduling sync work

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -686,22 +686,7 @@ function completeWork(
           // This handles the case of React rendering into a container with previous children.
           // It's also safe to do for updates too, because current.child would only be null
           // if the previous render was null (so the the container would already be empty).
-          //
-          // The additional root.hydrate check above is required for hydration in legacy mode with no fallback.
-          //
-          // The root container check below also avoids a potential legacy mode problem
-          // where unmounting from a container then rendering into it again
-          // can sometimes cause the container to be cleared after the new render.
-          const containerInfo = fiberRoot.containerInfo;
-          const legacyRootContainer =
-            containerInfo == null ? null : containerInfo._reactRootContainer;
-          if (
-            legacyRootContainer == null ||
-            legacyRootContainer._internalRoot == null ||
-            legacyRootContainer._internalRoot === fiberRoot
-          ) {
-            workInProgress.effectTag |= Snapshot;
-          }
+          workInProgress.effectTag |= Snapshot;
         }
       }
       updateHostContainer(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -684,22 +684,7 @@ function completeWork(
           // This handles the case of React rendering into a container with previous children.
           // It's also safe to do for updates too, because current.child would only be null
           // if the previous render was null (so the the container would already be empty).
-          //
-          // The additional root.hydrate check above is required for hydration in legacy mode with no fallback.
-          //
-          // The root container check below also avoids a potential legacy mode problem
-          // where unmounting from a container then rendering into it again
-          // can sometimes cause the container to be cleared after the new render.
-          const containerInfo = fiberRoot.containerInfo;
-          const legacyRootContainer =
-            containerInfo == null ? null : containerInfo._reactRootContainer;
-          if (
-            legacyRootContainer == null ||
-            legacyRootContainer._internalRoot == null ||
-            legacyRootContainer._internalRoot === fiberRoot
-          ) {
-            workInProgress.effectTag |= Snapshot;
-          }
+          workInProgress.effectTag |= Snapshot;
         }
       }
       updateHostContainer(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -474,30 +474,31 @@ export function scheduleUpdateOnFiber(
       }
     }
   } else {
-    ensureRootIsScheduled(root);
-    schedulePendingInteractions(root, expirationTime);
-  }
-
-  if (
-    (executionContext & DiscreteEventContext) !== NoContext &&
-    // Only updates at user-blocking priority or greater are considered
-    // discrete, even inside a discrete event.
-    (priorityLevel === UserBlockingSchedulerPriority ||
-      priorityLevel === ImmediateSchedulerPriority)
-  ) {
-    // This is the result of a discrete event. Track the lowest priority
-    // discrete update per root so we can flush them early, if needed.
-    if (rootsWithPendingDiscreteUpdates === null) {
-      rootsWithPendingDiscreteUpdates = new Map([[root, expirationTime]]);
-    } else {
-      const lastDiscreteTime = rootsWithPendingDiscreteUpdates.get(root);
-      if (
-        lastDiscreteTime === undefined ||
-        !isSameOrHigherPriority(expirationTime, lastDiscreteTime)
-      ) {
-        rootsWithPendingDiscreteUpdates.set(root, expirationTime);
+    // Schedule a discrete update but only if it's not Sync.
+    if (
+      (executionContext & DiscreteEventContext) !== NoContext &&
+      // Only updates at user-blocking priority or greater are considered
+      // discrete, even inside a discrete event.
+      (priorityLevel === UserBlockingSchedulerPriority ||
+        priorityLevel === ImmediateSchedulerPriority)
+    ) {
+      // This is the result of a discrete event. Track the lowest priority
+      // discrete update per root so we can flush them early, if needed.
+      if (rootsWithPendingDiscreteUpdates === null) {
+        rootsWithPendingDiscreteUpdates = new Map([[root, expirationTime]]);
+      } else {
+        const lastDiscreteTime = rootsWithPendingDiscreteUpdates.get(root);
+        if (
+          lastDiscreteTime === undefined ||
+          !isSameOrHigherPriority(expirationTime, lastDiscreteTime)
+        ) {
+          rootsWithPendingDiscreteUpdates.set(root, expirationTime);
+        }
       }
     }
+    // Schedule other updates after in case the callback is sync.
+    ensureRootIsScheduled(root);
+    schedulePendingInteractions(root, expirationTime);
   }
 }
 
@@ -1155,9 +1156,9 @@ function flushPendingDiscreteUpdates() {
       markRootExpiredAtTime(root, expirationTime);
       ensureRootIsScheduled(root);
     });
-    // Now flush the immediate queue.
-    flushSyncCallbackQueue();
   }
+  // Now flush the immediate queue.
+  flushSyncCallbackQueue();
 }
 
 export function batchedUpdates<A, R>(fn: A => R, a: A): R {


### PR DESCRIPTION
_This is an alternative fix to #18792. This is a convoluted bug. Settle in._

The problem is that we're adding discrete work during an unmount:

https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L463-L480

Normally this is fine because once we complete the unmount we'll clear it here:

https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L1879-L1887

That ensures that we never have any work scheduled on a root after it unmounts.

However in non-batched legacy mode the work that completes and clears it can be done synchronously here:

https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberWorkLoop.old.js#L445

That's before we add it. So once it's done, we end up adding the discrete work after we've already unmounted. Leaving work remaining that later flushes and clears the container again.

So one bug is that we should be doing this before we run the sync work. Sync work or scheduling should always come at the end of a function to avoid bugs like this.

However, the other bug is that we're scheduling this for Sync work at all. We don't need to. So I moved it to only schedule discrete for non-Sync work.

That revealed another bug. We currently flush discrete work before controlled components which is before the batched updates wrapper in events. That also flushes sync work implicitly. However, it only does that if there's discrete work scheduled. We relied on this to actually make controlled components work. So when we no longer schedule discrete work, this no longer implicitly flushes.

So I make flushing discrete always flush sync too.