### PR TITLE
Update bundle configs to not build some packages

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -579,17 +579,12 @@ const bundles = [
 
   /******* React Cache (experimental, old) *******/
   {
-    bundleTypes: [
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      NODE_DEV,
-      NODE_PROD,
-      UMD_DEV,
-      UMD_PROD,
-    ],
+    // This is only used by our own tests.
+    // We can delete it later.
+    bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-cache',
-    global: 'ReactCache',
+    global: 'ReactCacheOld',
     externals: ['react', 'scheduler'],
   },
 

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -82,9 +82,7 @@ const bundles = [
       NODE_DEV,
       NODE_PROD,
       NODE_PROFILING,
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      FB_WWW_PROFILING,
+      // TODO: use on WWW.
     ],
     moduleType: ISOMORPHIC,
     entry: 'react/jsx-runtime',
@@ -110,14 +108,7 @@ const bundles = [
 
   /******* React Cache (experimental, new) *******/
   {
-    bundleTypes: [
-      NODE_DEV,
-      NODE_PROD,
-      NODE_PROFILING,
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      FB_WWW_PROFILING,
-    ],
+    bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING],
     moduleType: ISOMORPHIC,
     entry: 'react/unstable-cache',
     global: 'ReactCache',
@@ -197,7 +188,7 @@ const bundles = [
   /******* React DOM - www - Testing *******/
   {
     moduleType: RENDERER,
-    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
+    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD],
     entry: 'react-dom/testing',
     global: 'ReactDOMTesting',
     externals: ['react'],
@@ -318,7 +309,7 @@ const bundles = [
     ],
   },
   {
-    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD],
+    bundleTypes: [], // TODO: FB_WWW_DEV, FB_WWW_PROD
     moduleType: RENDERER,
     entry: 'react-flight-dom-relay/server-runtime',
     global: 'ReactFlightDOMRelayServerRuntime',


### PR DESCRIPTION
Removes old ReactCache from FB builds. (D21349384 checks in a frozen copy.)

Also removes all bundles that are currently unused on WWW (including new cache) so we stop getting automatic codemod diffs trying to remove them. Let's add them back when we need them.