### PR TITLE
[Blocks] Failing test for nested load

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -258,8 +258,9 @@ describe('ReactBlocks', () => {
     );
   });
 
+  // Regression test.
   // @gate experimental
-  it('can load a nested block after an update', async () => {
+  it('does not render stale data after ping', async () => {
     function Child() {
       return <span>Name: {readString('Sebastian')}</span>;
     }
@@ -289,11 +290,54 @@ describe('ReactBlocks', () => {
     await ReactNoop.act(async () => {
       ReactNoop.render(<App Page={loadParent('Sebastian')} />);
     });
-
     await ReactNoop.act(async () => {
       jest.advanceTimersByTime(1000);
     });
-
     expect(ReactNoop).toMatchRenderedOutput(<span>Name: Sebastian</span>);
+  });
+
+  // Regression test.
+  // @gate experimental
+  it('does not render stale data after ping and setState', async () => {
+    function Child() {
+      return <span>Name: {readString('Sebastian')}</span>;
+    }
+
+    let _setSuspend;
+    const loadParent = block(
+      function Parent(props, data) {
+        const [suspend, setSuspend] = useState(true);
+        _setSuspend = setSuspend;
+        if (!suspend) {
+          return <span>{data.name}</span>;
+        }
+        return (
+          <Suspense fallback="Loading...">
+            {data.name ? <Child /> : <span>Empty</span>}
+          </Suspense>
+        );
+      },
+      function load(name) {
+        return {name};
+      },
+    );
+
+    function App({Page}) {
+      return <Page />;
+    }
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App Page={loadParent(null)} />);
+    });
+    expect(ReactNoop).toMatchRenderedOutput(<span>Empty</span>);
+
+    await ReactNoop.act(async () => {
+      ReactNoop.render(<App Page={loadParent('Sebastian')} />);
+    });
+    await ReactNoop.act(async () => {
+      _setSuspend(false);
+      jest.advanceTimersByTime(1000);
+    });
+    expect(ReactNoop).toMatchRenderedOutput(<span>Sebastian</span>);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -260,29 +260,20 @@ describe('ReactBlocks', () => {
 
   // @gate experimental
   it('can load a nested block after an update', async () => {
-    const loadChild = block(
-      function Child(props, data) {
-        return <span>Name: {data.name}</span>;
-      },
-      function load(name) {
-        return {
-          name: readString(name),
-        };
-      },
-    );
+    function Child() {
+      return <span>Name: {readString('Sebastian')}</span>;
+    }
 
     const loadParent = block(
       function Parent(props, data) {
         return (
           <Suspense fallback="Loading...">
-            {data.Child ? <data.Child /> : <span>Empty</span>}
+            {data.name ? <Child /> : <span>Empty</span>}
           </Suspense>
         );
       },
       function load(name) {
-        return {
-          Child: name !== null ? loadChild(name) : null,
-        };
+        return {name};
       },
     );
 


### PR DESCRIPTION
Extracted from https://github.com/facebook/react/pull/18803. I think this is a bug.

The symptom is that we keep seeing the old screen after it unsuspends.
Hosting `<Suspense>` from `Parent` into `App` "fixes" it.