### PR TITLE
[Memory Leaks] Detach Fibers from nodes with refs

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -322,6 +322,10 @@ export function resetTextContent(domElement) {
   // Noop
 }
 
+export function clearInstanceHandle(instance) {
+  // Noop
+}
+
 export function shouldDeprioritizeSubtree(type, props) {
   return false;
 }

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -55,6 +55,12 @@ export function precacheFiberNode(
   (node: any)[internalInstanceKey] = hostInst;
 }
 
+export function uncacheFiberNode(
+  node: Instance | TextInstance | SuspenseInstance | ReactScopeInstance,
+): void {
+  (node: any)[internalInstanceKey] = null;
+}
+
 export function markContainerAsRoot(hostRoot: Fiber, node: Container): void {
   node[internalContainerInstanceKey] = hostRoot;
 }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -18,6 +18,7 @@ import type {
 
 import {
   precacheFiberNode,
+  uncacheFiberNode,
   updateFiberProps,
   getClosestInstanceFromNode,
   getFiberFromScopeInstance,
@@ -646,6 +647,10 @@ export function clearContainer(container: Container): void {
       body.textContent = '';
     }
   }
+}
+
+export function clearInstanceHandle(instance: Instance) {
+  uncacheFiberNode(instance);
 }
 
 // -------------------

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -342,6 +342,10 @@ export function shouldSetTextContent(type: string, props: Props): boolean {
   return false;
 }
 
+export function clearInstanceHandle(instance: Instance) {
+  instance.canonical._internalInstanceHandle = null;
+}
+
 // The Fabric renderer is secondary to the existing React Native renderer.
 export const isPrimaryRenderer = false;
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -488,6 +488,10 @@ export function clearContainer(container: Container): void {
   // UIManager does not expose a "remove all" type method.
 }
 
+export function clearInstanceHandle(instance: Instance) {
+  uncacheFiberNode(instance);
+}
+
 export function unhideTextInstance(
   textInstance: TextInstance,
   text: string,

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -363,6 +363,10 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return inst;
     },
 
+    clearInstanceHandle() {
+      // NO-OP
+    },
+
     scheduleTimeout: setTimeout,
     cancelTimeout: clearTimeout,
     noTimeout: -1,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -101,6 +101,7 @@ import {
   insertInContainerBefore,
   removeChild,
   removeChildFromContainer,
+  clearInstanceHandle,
   clearSuspenseBoundary,
   clearSuspenseBoundaryFromContainer,
   replaceContainerChildren,
@@ -191,27 +192,29 @@ function safelyCallComponentWillUnmount(current, instance) {
   }
 }
 
-function safelyDetachRef(current: Fiber) {
+function safelyDetachRef(current: Fiber): boolean {
   const ref = current.ref;
-  if (ref !== null) {
-    if (typeof ref === 'function') {
-      if (__DEV__) {
-        invokeGuardedCallback(null, ref, null, null);
-        if (hasCaughtError()) {
-          const refError = clearCaughtError();
-          captureCommitPhaseError(current, refError);
-        }
-      } else {
-        try {
-          ref(null);
-        } catch (refError) {
-          captureCommitPhaseError(current, refError);
-        }
+  if (ref === null) {
+    return false;
+  }
+  if (typeof ref === 'function') {
+    if (__DEV__) {
+      invokeGuardedCallback(null, ref, null, null);
+      if (hasCaughtError()) {
+        const refError = clearCaughtError();
+        captureCommitPhaseError(current, refError);
       }
     } else {
-      ref.current = null;
+      try {
+        ref(null);
+      } catch (refError) {
+        captureCommitPhaseError(current, refError);
+      }
     }
+  } else {
+    ref.current = null;
   }
+  return true;
 }
 
 function safelyCallDestroy(current, destroy) {
@@ -1030,7 +1033,13 @@ function commitUnmount(
         unmountDeprecatedResponderListeners(current);
       }
       beforeRemoveInstance(current.stateNode);
-      safelyDetachRef(current);
+      const instance = current.stateNode;
+      beforeRemoveInstance(instance);
+      if (safelyDetachRef(current)) {
+        // To reduce the impact of userspace memory leaks,
+        // detach Fibers from nodes that have refs.
+        clearInstanceHandle(instance);
+      }
       return;
     }
     case HostPortal: {

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -74,6 +74,7 @@ export const mountFundamentalComponent =
 export const shouldUpdateFundamentalComponent =
   $$$hostConfig.shouldUpdateFundamentalComponent;
 export const getInstanceFromNode = $$$hostConfig.getInstanceFromNode;
+export const clearInstanceHandle = $$$hostConfig.clearInstanceHandle;
 export const beforeRemoveInstance = $$$hostConfig.beforeRemoveInstance;
 export const isOpaqueHydratingObject = $$$hostConfig.isOpaqueHydratingObject;
 export const makeOpaqueHydratingObject =

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -153,7 +153,7 @@ export function resetAfterCommit(containerInfo: Container): void {
   // noop
 }
 
-export function clearInstanceHandle() {
+export function clearInstanceHandle(instance: Instance) {
   // noop
 }
 

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -153,6 +153,10 @@ export function resetAfterCommit(containerInfo: Container): void {
   // noop
 }
 
+export function clearInstanceHandle() {
+  // noop
+}
+
 export function createInstance(
   type: string,
   props: Props,


### PR DESCRIPTION
A more restrained alternative to https://github.com/facebook/react/pull/18690.
Addresses @sebmarkbage's proposal in https://github.com/facebook/react/issues/16087:

> If a handle on a DOM node is leaked, it takes the React tree with it. This is a fairly easy mistake to make and the effect is pretty high. What we would do here is special case DOM nodes with refs on them, and always detach their back pointer to the React Fiber, if it was ever fully mounted. We currently traverse these trees anyway when they get deleted. We want to stop doing this for most things but for nodes with a ref it seems minor to special case since they typically need to be invoked with null anyway.

Note: this does not fix any memory leak **in React**; it just makes the impact of **userland** memory leaks less severe.

**[View without whitespace](https://github.com/facebook/react/compare/master...gaearon:detach-ref?w=1)**

I checked that this works manually:

<img width="602" alt="Screenshot 2020-05-04 at 15 37 12" src="https://user-images.githubusercontent.com/810438/80978901-90ef8200-8e1e-11ea-9200-e88f81c62ee7.png">
