### PR TITLE
chore: remove usage of deprecated Jest functions

### DIFF
--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -57,9 +57,7 @@ describe('unmocked scheduler', () => {
 describe('mocked scheduler', () => {
   beforeEach(() => {
     jest.resetModules();
-    jest.mock('scheduler', () =>
-      jest.requireActual('scheduler/unstable_mock')
-    );
+    jest.mock('scheduler', () => jest.requireActual('scheduler/unstable_mock'));
     React = require('react');
     DOMAct = require('react-dom/test-utils').act;
     TestRenderer = require('react-test-renderer');

--- a/fixtures/dom/src/__tests__/nested-act-test.js
+++ b/fixtures/dom/src/__tests__/nested-act-test.js
@@ -58,7 +58,7 @@ describe('mocked scheduler', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.mock('scheduler', () =>
-      require.requireActual('scheduler/unstable_mock')
+      jest.requireActual('scheduler/unstable_mock')
     );
     React = require('react');
     DOMAct = require('react-dom/test-utils').act;

--- a/packages/legacy-events/__tests__/EventPluginRegistry-test.internal.js
+++ b/packages/legacy-events/__tests__/EventPluginRegistry-test.internal.js
@@ -14,7 +14,7 @@ describe('EventPluginRegistry', () => {
   let createPlugin;
 
   beforeEach(() => {
-    jest.resetModuleRegistry();
+    jest.resetModules();
     // These tests are intentionally testing the private injection interface.
     // The public API surface of this is covered by other tests so
     // if `EventPluginRegistry` is ever deleted, these tests should be

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -18,7 +18,7 @@ let ReactDOMServer;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationBasic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationBasic-test.js
@@ -20,7 +20,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationCheckbox-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationCheckbox-test.js
@@ -20,7 +20,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationClassContextType-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationClassContextType-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -19,7 +19,7 @@ let ReactDOMServer;
 let ReactTestUtils;
 
 function initModules() {
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationFragment-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -36,7 +36,7 @@ let clearYields;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
 
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationInput-test.js
@@ -20,7 +20,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContext-test.js
@@ -19,7 +19,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   PropTypes = require('prop-types');
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -19,7 +19,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationModes-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationNewContext-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationReconnecting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationReconnecting-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
 
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationRefs-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSelect-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationSpecialTypes-test.js
@@ -23,7 +23,7 @@ let clearYields;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationTextarea-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUntrustedURL-test.internal.js
@@ -149,7 +149,7 @@ function runTests(itRenders, itRejectsRendering, expectToReject) {
 
 describe('ReactDOMServerIntegration - Untrusted URLs', () => {
   function initModules() {
-    jest.resetModuleRegistry();
+    jest.resetModules();
     React = require('react');
     ReactDOM = require('react-dom');
     ReactDOMServer = require('react-dom/server');
@@ -181,7 +181,7 @@ describe('ReactDOMServerIntegration - Untrusted URLs', () => {
 
 describe('ReactDOMServerIntegration - Untrusted URLs - disableJavaScriptURLs', () => {
   function initModules() {
-    jest.resetModuleRegistry();
+    jest.resetModules();
     const ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.disableJavaScriptURLs = true;
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUserInteraction-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationUserInteraction-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerLifecycles-test.js
@@ -16,7 +16,7 @@ let ReactDOMServer;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOMServer = require('react-dom/server');
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -72,7 +72,7 @@ function dispatchMouseEvent(to, from) {
 
 describe('ReactDOMServerPartialHydration', () => {
   beforeEach(() => {
-    jest.resetModuleRegistry();
+    jest.resetModules();
 
     ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableSuspenseCallback = true;

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -93,7 +93,7 @@ function dispatchClickEvent(target) {
 
 describe('ReactDOMServerSelectiveHydration', () => {
   beforeEach(() => {
-    jest.resetModuleRegistry();
+    jest.resetModules();
 
     const ReactFeatureFlags = require('shared/ReactFeatureFlags');
     ReactFeatureFlags.enableDeprecatedFlareAPI = true;

--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
 
   React = require('react');
   ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactDOMserverIntegrationProgress-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMserverIntegrationProgress-test.js
@@ -18,7 +18,7 @@ let ReactTestUtils;
 
 function initModules() {
   // Reset warning cache.
-  jest.resetModuleRegistry();
+  jest.resetModules();
   React = require('react');
   ReactDOM = require('react-dom');
   ReactDOMServer = require('react-dom/server');

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -20,7 +20,7 @@ function FunctionComponent(props) {
 
 describe('ReactFunctionComponent', () => {
   beforeEach(() => {
-    jest.resetModuleRegistry();
+    jest.resetModules();
     PropTypes = require('prop-types');
     React = require('react');
     ReactDOM = require('react-dom');

--- a/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
@@ -20,7 +20,7 @@ describe('ReactServerRenderingBrowser', () => {
     React = require('react');
     ReactDOMServer = require('react-dom/server');
     // For extra isolation between what would be two bundles on npm
-    jest.resetModuleRegistry();
+    jest.resetModules();
     ReactDOMServerBrowser = require('react-dom/server.browser');
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -16,7 +16,7 @@ let Scheduler;
 
 describe('ReactIncrementalUpdates', () => {
   beforeEach(() => {
-    jest.resetModuleRegistry();
+    jest.resetModules();
 
     React = require('react');
     ReactNoop = require('react-noop-renderer');

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -417,7 +417,7 @@ describe(
       jest.resetModules();
 
       jest.mock('scheduler', () => {
-        const actual = require.requireActual('scheduler/unstable_mock');
+        const actual = jest.requireActual('scheduler/unstable_mock');
         return {
           ...actual,
           unstable_shouldYield() {
@@ -438,7 +438,7 @@ describe(
 
     afterEach(() => {
       jest.mock('scheduler', () =>
-        require.requireActual('scheduler/unstable_mock'),
+        jest.requireActual('scheduler/unstable_mock'),
       );
     });
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -265,7 +265,7 @@ describe('Profiler', () => {
           // Mock the Scheduler module so we can track how many times the current
           // time is read
           jest.mock('scheduler', obj => {
-            const ActualScheduler = require.requireActual(
+            const ActualScheduler = jest.requireActual(
               'scheduler/unstable_mock',
             );
             return {
@@ -305,7 +305,7 @@ describe('Profiler', () => {
 
           // Restore original mock
           jest.mock('scheduler', () =>
-            require.requireActual('scheduler/unstable_mock'),
+            jest.requireActual('scheduler/unstable_mock'),
           );
         });
 

--- a/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
@@ -34,9 +34,9 @@ describe('SchedulerBrowser', () => {
     jest.resetModules();
 
     // Un-mock scheduler
-    jest.mock('scheduler', () => require.requireActual('scheduler'));
+    jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      require.requireActual(
+      jest.requireActual(
         'scheduler/src/forks/SchedulerHostConfig.default.js',
       ),
     );

--- a/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
@@ -36,9 +36,7 @@ describe('SchedulerBrowser', () => {
     // Un-mock scheduler
     jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      jest.requireActual(
-        'scheduler/src/forks/SchedulerHostConfig.default.js',
-      ),
+      jest.requireActual('scheduler/src/forks/SchedulerHostConfig.default.js'),
     );
 
     runtime = installMockBrowserRuntime();

--- a/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
@@ -24,9 +24,9 @@ describe('SchedulerNoDOM', () => {
     jest.useFakeTimers();
 
     // Un-mock scheduler
-    jest.mock('scheduler', () => require.requireActual('scheduler'));
+    jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      require.requireActual(
+      jest.requireActual(
         'scheduler/src/forks/SchedulerHostConfig.default.js',
       ),
     );

--- a/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerNoDOM-test.js
@@ -26,9 +26,7 @@ describe('SchedulerNoDOM', () => {
     // Un-mock scheduler
     jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      jest.requireActual(
-        'scheduler/src/forks/SchedulerHostConfig.default.js',
-      ),
+      jest.requireActual('scheduler/src/forks/SchedulerHostConfig.default.js'),
     );
 
     Scheduler = require('scheduler');

--- a/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
@@ -17,9 +17,7 @@ describe('Scheduling UMD bundle', () => {
 
     jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      jest.requireActual(
-        'scheduler/src/forks/SchedulerHostConfig.default.js',
-      ),
+      jest.requireActual('scheduler/src/forks/SchedulerHostConfig.default.js'),
     );
   });
 

--- a/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
+++ b/packages/scheduler/src/__tests__/SchedulerUMDBundle-test.internal.js
@@ -15,9 +15,9 @@ describe('Scheduling UMD bundle', () => {
 
     jest.resetModules();
 
-    jest.mock('scheduler', () => require.requireActual('scheduler'));
+    jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      require.requireActual(
+      jest.requireActual(
         'scheduler/src/forks/SchedulerHostConfig.default.js',
       ),
     );

--- a/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -14,9 +14,9 @@ describe('ReactDOMFrameScheduling', () => {
     jest.resetModules();
 
     // Un-mock scheduler
-    jest.mock('scheduler', () => require.requireActual('scheduler'));
+    jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      require.requireActual(
+      jest.requireActual(
         'scheduler/src/forks/SchedulerHostConfig.default.js',
       ),
     );

--- a/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
+++ b/packages/shared/__tests__/ReactDOMFrameScheduling-test.js
@@ -16,9 +16,7 @@ describe('ReactDOMFrameScheduling', () => {
     // Un-mock scheduler
     jest.mock('scheduler', () => jest.requireActual('scheduler'));
     jest.mock('scheduler/src/SchedulerHostConfig', () =>
-      jest.requireActual(
-        'scheduler/src/forks/SchedulerHostConfig.default.js',
-      ),
+      jest.requireActual('scheduler/src/forks/SchedulerHostConfig.default.js'),
     );
   });
 

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -3,7 +3,7 @@
 const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
 
 jest.mock('react-reconciler/src/ReactFiberReconciler', () => {
-  return require.requireActual(
+  return jest.requireActual(
     __VARIANT__
       ? 'react-reconciler/src/ReactFiberReconciler.new'
       : 'react-reconciler/src/ReactFiberReconciler.old'
@@ -16,7 +16,7 @@ const shimHostConfigPath = 'react-reconciler/src/ReactFiberHostConfig';
 jest.mock('react-reconciler', () => {
   return config => {
     jest.mock(shimHostConfigPath, () => config);
-    return require.requireActual('react-reconciler');
+    return jest.requireActual('react-reconciler');
   };
 });
 const shimServerStreamConfigPath = 'react-server/src/ReactServerStreamConfig';
@@ -26,7 +26,7 @@ jest.mock('react-server', () => {
   return config => {
     jest.mock(shimServerStreamConfigPath, () => config);
     jest.mock(shimServerFormatConfigPath, () => config);
-    return require.requireActual('react-server');
+    return jest.requireActual('react-server');
   };
 });
 jest.mock('react-server/flight', () => {
@@ -37,11 +37,11 @@ jest.mock('react-server/flight', () => {
       resolveModuleMetaData: config.resolveModuleMetaData,
     }));
     jest.mock(shimFlightServerConfigPath, () =>
-      require.requireActual(
+      jest.requireActual(
         'react-server/src/forks/ReactFlightServerConfig.custom'
       )
     );
-    return require.requireActual('react-server/flight');
+    return jest.requireActual('react-server/flight');
   };
 });
 const shimFlightClientHostConfigPath =
@@ -49,7 +49,7 @@ const shimFlightClientHostConfigPath =
 jest.mock('react-client/flight', () => {
   return config => {
     jest.mock(shimFlightClientHostConfigPath, () => config);
-    return require.requireActual('react-client/flight');
+    return jest.requireActual('react-client/flight');
   };
 });
 
@@ -67,7 +67,7 @@ function mockAllConfigs(rendererInfo) {
     jest.mock(path, () => {
       let idx = path.lastIndexOf('/');
       let forkPath = path.substr(0, idx) + '/forks' + path.substr(idx);
-      return require.requireActual(`${forkPath}.${rendererInfo.shortName}.js`);
+      return jest.requireActual(`${forkPath}.${rendererInfo.shortName}.js`);
     });
   });
 }
@@ -83,7 +83,7 @@ inlinedHostConfigs.forEach(rendererInfo => {
   rendererInfo.entryPoints.forEach(entryPoint => {
     jest.mock(entryPoint, () => {
       mockAllConfigs(rendererInfo);
-      return require.requireActual(entryPoint);
+      return jest.requireActual(entryPoint);
     });
   });
 });
@@ -91,10 +91,10 @@ inlinedHostConfigs.forEach(rendererInfo => {
 // Make it possible to import this module inside
 // the React package itself.
 jest.mock('shared/ReactSharedInternals', () =>
-  require.requireActual('react/src/ReactSharedInternals')
+  jest.requireActual('react/src/ReactSharedInternals')
 );
 
-jest.mock('scheduler', () => require.requireActual('scheduler/unstable_mock'));
+jest.mock('scheduler', () => jest.requireActual('scheduler/unstable_mock'));
 jest.mock('scheduler/src/SchedulerHostConfig', () =>
-  require.requireActual('scheduler/src/forks/SchedulerHostConfig.mock.js')
+  jest.requireActual('scheduler/src/forks/SchedulerHostConfig.mock.js')
 );

--- a/scripts/jest/setupTests.build.js
+++ b/scripts/jest/setupTests.build.js
@@ -1,6 +1,6 @@
 'use strict';
 
-jest.mock('scheduler', () => require.requireActual('scheduler/unstable_mock'));
+jest.mock('scheduler', () => jest.requireActual('scheduler/unstable_mock'));
 jest.mock('scheduler/src/SchedulerHostConfig', () =>
-  require.requireActual('scheduler/src/forks/SchedulerHostConfig.mock.js')
+  jest.requireActual('scheduler/src/forks/SchedulerHostConfig.mock.js')
 );

--- a/scripts/jest/setupTests.persistent.js
+++ b/scripts/jest/setupTests.persistent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 jest.mock('react-noop-renderer', () =>
-  require.requireActual('react-noop-renderer/persistent')
+  jest.requireActual('react-noop-renderer/persistent')
 );
 
 global.__PERSISTENT__ = true;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Jest 26 is coming today or tomorrow, and we've removed `require.requireActual`. I just ran the lint rule `jest/no-deprecated-functions` on the code base, which also fixes a couple of removals scheduled for Jest 27. Doesn't hurt to be prepared 🙂 

## Test Plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
