### PR TITLE
Modern Event System: fix EnterLeave plugin logic

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -9,6 +9,7 @@
 
 import {registrationNameModules} from 'legacy-events/EventPluginRegistry';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
+import invariant from 'shared/invariant';
 import {
   setListenToResponderEventTypes,
   addResponderEventSystemEvent,
@@ -282,12 +283,13 @@ export function ensureListeningTo(
     // Containers should only ever be element nodes. We do not
     // want to register events to document fragments or documents
     // with the modern plugin event system.
-    if (
+    invariant(
       rootContainerElement != null &&
-      rootContainerElement.nodeType === ELEMENT_NODE
-    ) {
-      listenToEvent(registrationName, ((rootContainerElement: any): Element));
-    }
+        rootContainerElement.nodeType === ELEMENT_NODE,
+      'ensureListeningTo(): received a container that was not an element node. ' +
+        'This is likely a bug in React.',
+    );
+    listenToEvent(registrationName, ((rootContainerElement: any): Element));
   } else {
     // Legacy plugin event system path
     const isDocumentOrFragment =

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -9,7 +9,6 @@
 
 import {registrationNameModules} from 'legacy-events/EventPluginRegistry';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import invariant from 'shared/invariant';
 import {
   setListenToResponderEventTypes,
   addResponderEventSystemEvent,
@@ -269,7 +268,7 @@ if (__DEV__) {
   };
 }
 
-function ensureListeningTo(
+export function ensureListeningTo(
   rootContainerInstance: Element | Node,
   registrationName: string,
 ): void {
@@ -280,16 +279,15 @@ function ensureListeningTo(
       rootContainerInstance.nodeType === COMMENT_NODE
         ? rootContainerInstance.parentNode
         : rootContainerInstance;
-    // Containers can only ever be element nodes. We do not
+    // Containers should only ever be element nodes. We do not
     // want to register events to document fragments or documents
     // with the modern plugin event system.
-    invariant(
+    if (
       rootContainerElement != null &&
-        rootContainerElement.nodeType === ELEMENT_NODE,
-      'ensureListeningTo(): received a container that was not an element node. ' +
-        'This is likely a bug in React.',
-    );
-    listenToEvent(registrationName, ((rootContainerElement: any): Element));
+      rootContainerElement.nodeType === ELEMENT_NODE
+    ) {
+      listenToEvent(registrationName, ((rootContainerElement: any): Element));
+    }
   } else {
     // Legacy plugin event system path
     const isDocumentOrFragment =

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -126,15 +126,21 @@ function createRootImpl(
     (options != null && options.hydrationOptions) || null;
   const root = createContainer(container, tag, hydrate, hydrationCallbacks);
   markContainerAsRoot(root.current, container);
+  const containerNodeType = container.nodeType;
+
   if (hydrate && tag !== LegacyRoot) {
     const doc =
-      container.nodeType === DOCUMENT_NODE
-        ? container
-        : container.ownerDocument;
-    eagerlyTrapReplayableEvents(container, doc);
-  } else if (enableModernEventSystem) {
-    // We use ensureListeningTo because the container might
-    // be a COMMENT_NODE.
+      containerNodeType === DOCUMENT_NODE ? container : container.ownerDocument;
+    // We need to cast this because Flow doesn't work
+    // with the hoisted containerNodeType. If we inline
+    // it, then Flow doesn't complain. We intentionally
+    // hoist it to reduce code-size.
+    eagerlyTrapReplayableEvents(container, ((doc: any): Document));
+  } else if (
+    enableModernEventSystem &&
+    containerNodeType !== DOCUMENT_FRAGMENT_NODE &&
+    containerNodeType !== DOCUMENT_NODE
+  ) {
     ensureListeningTo(container, 'onMouseEnter');
   }
   return root;

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -42,6 +42,7 @@ import {
   DOCUMENT_NODE,
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
+import {ensureListeningTo} from './ReactDOMComponent';
 
 import {
   createContainer,
@@ -53,6 +54,8 @@ import {
   ConcurrentRoot,
   LegacyRoot,
 } from 'react-reconciler/src/ReactRootTags';
+
+import {enableModernEventSystem} from 'shared/ReactFeatureFlags';
 
 function ReactDOMRoot(container: Container, options: void | RootOptions) {
   this._internalRoot = createRootImpl(container, ConcurrentRoot, options);
@@ -129,6 +132,10 @@ function createRootImpl(
         ? container
         : container.ownerDocument;
     eagerlyTrapReplayableEvents(container, doc);
+  } else if (enableModernEventSystem) {
+    // We use ensureListeningTo because the container might
+    // be a COMMENT_NODE.
+    ensureListeningTo(container, 'onMouseEnter');
   }
   return root;
 }

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -677,7 +677,7 @@ function accumulateEnterLeaveListenersForEvent(
 export function accumulateEnterLeaveListeners(
   dispatchQueue: DispatchQueue,
   leaveEvent: ReactSyntheticEvent,
-  enterEvent: ReactSyntheticEvent,
+  enterEvent: null | ReactSyntheticEvent,
   from: Fiber | null,
   to: Fiber | null,
 ): void {
@@ -692,7 +692,7 @@ export function accumulateEnterLeaveListeners(
       false,
     );
   }
-  if (to !== null) {
+  if (to !== null && enterEvent !== null) {
     accumulateEnterLeaveListenersForEvent(
       dispatchQueue,
       enterEvent,

--- a/packages/react-dom/src/events/plugins/__tests__/ModernEnterLeaveEventPlugin-test.internal.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernEnterLeaveEventPlugin-test.internal.js
@@ -240,7 +240,7 @@ describe('EnterLeaveEventPlugin', () => {
     ReactDOM.render(<Parent />, container);
   });
 
-  it('should work with portals outside of the root', () => {
+  it('should work with portals outside of the root that has onMouseLeave', () => {
     const divRef = React.createRef();
     const onMouseLeave = jest.fn();
 
@@ -264,5 +264,35 @@ describe('EnterLeaveEventPlugin', () => {
     );
 
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('should work with portals that have onMouseEnter outside of the root ', () => {
+    const divRef = React.createRef();
+    const otherDivRef = React.createRef();
+    const onMouseEnter = jest.fn();
+
+    function Component() {
+      return (
+        <div ref={divRef}>
+          {ReactDOM.createPortal(
+            <div ref={otherDivRef} onMouseEnter={onMouseEnter} />,
+            document.body,
+          )}
+        </div>
+      );
+    }
+
+    ReactDOM.render(<Component />, container);
+
+    // Leave from the portal div
+    divRef.current.dispatchEvent(
+      new MouseEvent('mouseout', {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: otherDivRef.current,
+      }),
+    );
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Today we found an internal issue with the modern event system and the EnterLeave plugin. Specifically, we didn't track `mouseout` on the container, only in the portal. That's because the portal had a child contained `onMouseEnter`. This bug is actually very similar to that of the recent fix to https://github.com/facebook/react/pull/18720.

Making this change, so that we now register this plugin on each root container fixed that issue, but also brought about another issue. This was great though, as we had already solved this in the legacy EnterLeave plugin (I commented on it below). Taking that logic and bringing it to the modern event system fixed the failing issues and aligned the modern event system with the legacy one.