### PR TITLE
[WIP] SuspenseList should do a second pass if all children are dehydrated

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -193,6 +193,7 @@ import {
   markSpawnedWork,
   retryDehydratedSuspenseBoundary,
   scheduleUpdateOnFiber,
+  renderDidSuspend,
   renderDidSuspendDelayIfPossible,
   markSkippedUpdateLanes,
   getWorkInProgressRoot,
@@ -2231,6 +2232,11 @@ function mountDehydratedSuspenseComponent(
     // wrong priority associated with it and will prevent hydration of parent path.
     // Instead, we'll leave work left on it to render it in a separate commit.
 
+    // Mark this render as suspended. Not because we want it to actually suspend,
+    // but just so that SuspenseList knows that this render might have something
+    // suspended in it.
+    renderDidSuspend();
+
     // TODO This time should be the time at which the server rendered response that is
     // a parent to this boundary was displayed. However, since we currently don't have
     // a protocol to transfer that time, we'll just estimate it by using the current
@@ -2242,6 +2248,13 @@ function mountDehydratedSuspenseComponent(
     }
     workInProgress.lanes = laneToLanes(DefaultHydrationLane);
   } else {
+    if (isSuspenseInstancePending(suspenseInstance)) {
+      // Mark this render as suspended. Not because we want it to actually suspend,
+      // but just so that SuspenseList knows that this render might have something
+      // suspended in it.
+      renderDidSuspend();
+    }
+
     // We'll continue hydrating the rest at offscreen priority since we'll already
     // be showing the right content coming from the server, it is no rush.
     workInProgress.lanes = laneToLanes(OffscreenLane);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -169,6 +169,7 @@ import {
   enterHydrationState,
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,
+  snapshotHydrationState,
   tryToClaimNextHydratableInstance,
   warnIfHydrating,
 } from './ReactFiberHydrationContext.new';
@@ -2618,6 +2619,7 @@ function initSuspenseListRenderState(
       tailExpiration: 0,
       tailMode: tailMode,
       lastEffect: lastEffectBeforeRendering,
+      hydrationState: snapshotHydrationState(),
     }: SuspenseListRenderState);
   } else {
     // We can reuse the existing object from previous renders.
@@ -2629,6 +2631,7 @@ function initSuspenseListRenderState(
     renderState.tailExpiration = 0;
     renderState.tailMode = tailMode;
     renderState.lastEffect = lastEffectBeforeRendering;
+    renderState.hydrationState = snapshotHydrationState();
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -152,6 +152,7 @@ import {
   enterHydrationState,
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,
+  snapshotHydrationState,
   tryToClaimNextHydratableInstance,
   warnIfHydrating,
 } from './ReactFiberHydrationContext.old';
@@ -2597,6 +2598,7 @@ function initSuspenseListRenderState(
       tailExpiration: 0,
       tailMode: tailMode,
       lastEffect: lastEffectBeforeRendering,
+      hydrationState: snapshotHydrationState(),
     }: SuspenseListRenderState);
   } else {
     // We can reuse the existing object from previous renders.
@@ -2608,6 +2610,7 @@ function initSuspenseListRenderState(
     renderState.tailExpiration = 0;
     renderState.tailMode = tailMode;
     renderState.lastEffect = lastEffectBeforeRendering;
+    renderState.hydrationState = snapshotHydrationState();
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -176,6 +176,7 @@ import {
   requestCurrentTimeForUpdate,
   retryDehydratedSuspenseBoundary,
   scheduleUpdateOnFiber,
+  renderDidSuspend,
   renderDidSuspendDelayIfPossible,
   markUnprocessedUpdateTime,
   getWorkInProgressRoot,
@@ -2205,6 +2206,11 @@ function mountDehydratedSuspenseComponent(
     // wrong priority associated with it and will prevent hydration of parent path.
     // Instead, we'll leave work left on it to render it in a separate commit.
 
+    // Mark this render as suspended. Not because we want it to actually suspend,
+    // but just so that SuspenseList knows that this render might have something
+    // suspended in it.
+    renderDidSuspend();
+
     // TODO This time should be the time at which the server rendered response that is
     // a parent to this boundary was displayed. However, since we currently don't have
     // a protocol to transfer that time, we'll just estimate it by using the current
@@ -2218,6 +2224,12 @@ function mountDehydratedSuspenseComponent(
     }
     workInProgress.expirationTime = newExpirationTime;
   } else {
+    if (isSuspenseInstancePending(suspenseInstance)) {
+      // Mark this render as suspended. Not because we want it to actually suspend,
+      // but just so that SuspenseList knows that this render might have something
+      // suspended in it.
+      renderDidSuspend();
+    }
     // We'll continue hydrating the rest at offscreen priority since we'll already
     // be showing the right content coming from the server, it is no rush.
     workInProgress.expirationTime = Never;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -118,6 +118,7 @@ import {
   prepareToHydrateHostSuspenseInstance,
   popHydrationState,
   resetHydrationState,
+  getIsHydrating,
 } from './ReactFiberHydrationContext.new';
 import {
   enableSchedulerTracing,
@@ -579,6 +580,11 @@ function cutOffTailIfNeeded(
   renderState: SuspenseListRenderState,
   hasRenderedATailFallback: boolean,
 ) {
+  if (getIsHydrating()) {
+    // If we're hydrating, we should consume as many items as we can
+    // so we don't leave any behind.
+    return;
+  }
   switch (renderState.tailMode) {
     case 'hidden': {
       // Any insertions at the end of the tail list after this point

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -119,6 +119,7 @@ import {
   popHydrationState,
   resetHydrationState,
   getIsHydrating,
+  restoreHydrationState,
 } from './ReactFiberHydrationContext.new';
 import {
   enableSchedulerTracing,
@@ -1056,6 +1057,10 @@ function completeWork(
                   workInProgress.firstEffect = null;
                 }
                 workInProgress.lastEffect = renderState.lastEffect;
+
+                // Restore hydration state to where we were in the beginning of the list.
+                restoreHydrationState(renderState.hydrationState);
+
                 // Reset the child fibers to their original state.
                 resetChildFibers(workInProgress, renderLanes);
 

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -115,6 +115,7 @@ import {
   prepareToHydrateHostSuspenseInstance,
   popHydrationState,
   resetHydrationState,
+  getIsHydrating,
 } from './ReactFiberHydrationContext.old';
 import {
   enableSchedulerTracing,
@@ -575,6 +576,11 @@ function cutOffTailIfNeeded(
   renderState: SuspenseListRenderState,
   hasRenderedATailFallback: boolean,
 ) {
+  if (getIsHydrating()) {
+    // If we're hydrating, we should consume as many items as we can
+    // so we don't leave any behind.
+    return;
+  }
   switch (renderState.tailMode) {
     case 'hidden': {
       // Any insertions at the end of the tail list after this point

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -116,6 +116,7 @@ import {
   popHydrationState,
   resetHydrationState,
   getIsHydrating,
+  restoreHydrationState,
 } from './ReactFiberHydrationContext.old';
 import {
   enableSchedulerTracing,
@@ -1072,6 +1073,10 @@ function completeWork(
                   workInProgress.firstEffect = null;
                 }
                 workInProgress.lastEffect = renderState.lastEffect;
+
+                // Restore hydration state to where we were in the beginning of the list.
+                restoreHydrationState(renderState.hydrationState);
+
                 // Reset the child fibers to their original state.
                 resetChildFibers(workInProgress, renderExpirationTime);
 
@@ -1125,6 +1130,7 @@ function completeWork(
               if (lastEffect !== null) {
                 lastEffect.nextEffect = null;
               }
+
               // We're done.
               return null;
             }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -85,6 +85,14 @@ function enterHydrationState(fiber: Fiber): boolean {
   return true;
 }
 
+function snapshotHydrationState(): null | HydratableInstance {
+  return nextHydratableInstance;
+}
+
+function restoreHydrationState(snapshot: null | HydratableInstance) {
+  nextHydratableInstance = snapshot;
+}
+
 function reenterHydrationStateFromDehydratedSuspenseInstance(
   fiber: Fiber,
   suspenseInstance: SuspenseInstance,
@@ -491,6 +499,8 @@ function getIsHydrating(): boolean {
 export {
   warnIfHydrating,
   enterHydrationState,
+  snapshotHydrationState,
+  restoreHydrationState,
   getIsHydrating,
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -85,6 +85,14 @@ function enterHydrationState(fiber: Fiber): boolean {
   return true;
 }
 
+function snapshotHydrationState(): null | HydratableInstance {
+  return nextHydratableInstance;
+}
+
+function restoreHydrationState(snapshot: null | HydratableInstance) {
+  nextHydratableInstance = snapshot;
+}
+
 function reenterHydrationStateFromDehydratedSuspenseInstance(
   fiber: Fiber,
   suspenseInstance: SuspenseInstance,
@@ -492,6 +500,8 @@ function getIsHydrating(): boolean {
 export {
   warnIfHydrating,
   enterHydrationState,
+  snapshotHydrationState,
+  restoreHydrationState,
   getIsHydrating,
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.new.js
@@ -8,7 +8,10 @@
  */
 
 import type {Fiber} from './ReactInternalTypes';
-import type {SuspenseInstance} from './ReactFiberHostConfig';
+import type {
+  SuspenseInstance,
+  HydratableInstance,
+} from './ReactFiberHostConfig';
 import type {Lane} from './ReactFiberLane';
 import {SuspenseComponent, SuspenseListComponent} from './ReactWorkTags';
 import {NoEffect, DidCapture} from './ReactSideEffectTags';
@@ -54,6 +57,8 @@ export type SuspenseListRenderState = {|
   // Last Effect before we rendered the "rendering" item.
   // Used to remove new effects added by the rendered item.
   lastEffect: null | Fiber,
+  // The hydratable instance before we entered the SuspenseList.
+  hydrationState: null | HydratableInstance,
 |};
 
 export function shouldCaptureSuspense(

--- a/packages/react-reconciler/src/ReactFiberSuspenseComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseComponent.old.js
@@ -8,7 +8,10 @@
  */
 
 import type {Fiber} from './ReactInternalTypes';
-import type {SuspenseInstance} from './ReactFiberHostConfig';
+import type {
+  SuspenseInstance,
+  HydratableInstance,
+} from './ReactFiberHostConfig';
 import type {ExpirationTime} from './ReactFiberExpirationTime.old';
 import {SuspenseComponent, SuspenseListComponent} from './ReactWorkTags';
 import {NoEffect, DidCapture} from './ReactSideEffectTags';
@@ -59,6 +62,8 @@ export type SuspenseListRenderState = {|
   // Last Effect before we rendered the "rendering" item.
   // Used to remove new effects added by the rendered item.
   lastEffect: null | Fiber,
+  // The hydratable instance before we entered the SuspenseList.
+  hydrationState: null | HydratableInstance,
 |};
 
 export function shouldCaptureSuspense(


### PR DESCRIPTION
SuspenseList doesn't trigger the "together" mode when all children are client rendered.

The issue here is that we have an optimization to figure out if the list might be suspended:
https://github.com/facebook/react/blob/master/packages/react-reconciler/src/ReactFiberCompleteWork.old.js#L1033

This doesn't trigger when we're hitting client-rendered boundaries that are still in fallback states because we leave them behind so they don't "suspend" this pass.

One fix could be triggering renderDidSuspend in this case. It might not be the right fix because there's no need to suspend *this* commit really. Maybe it could be a different flag. It also causes a second pass over the list which delays actually getting to the client rendering.

This fix reveals three other bugs that are already observable in other scenarios:

- [ ] Doing a second pass over the list causes hydration state to get confused so we forget about the content we already hydrated and never delete them. Leaving us with duplicate loading states, forever.
- [ ] In the old reconciler, this causes an infinite loop because suspending means that we try the scheduled work for the dehydrated boundary to unblock, which schedules more work etc.
- [x] ~In the new reconciler, this causes the real content to never commit. It just stays at the fallback for some reason. Not sure why.~ This is not a bug. The test error reflects a behavior change, that we probably don't want.