### PR TITLE
Modern Event System: fix bug in EnterLeave

### DIFF
--- a/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
@@ -65,16 +65,18 @@ const EnterLeaveEventPlugin = {
       topLevelType === TOP_MOUSE_OVER || topLevelType === TOP_POINTER_OVER;
     const isOutEvent =
       topLevelType === TOP_MOUSE_OUT || topLevelType === TOP_POINTER_OUT;
-    const related = nativeEvent.relatedTarget || nativeEvent.fromElement;
 
-    if (isOverEvent && (eventSystemFlags & IS_REPLAYED) === 0 && related) {
-      // Due to the fact we don't add listeners to the document with the
-      // modern event system and instead attach listeners to roots, we
-      // need to handle the over event case. To ensure this, we just need to
-      // make sure the node that we're coming from is managed by React.
-      const inst = getClosestInstanceFromNode(related);
-      if (inst !== null) {
-        return;
+    if (isOverEvent && (eventSystemFlags & IS_REPLAYED) === 0) {
+      const related = nativeEvent.relatedTarget || nativeEvent.fromElement;
+      if (related) {
+        // Due to the fact we don't add listeners to the document with the
+        // modern event system and instead attach listeners to roots, we
+        // need to handle the over event case. To ensure this, we just need to
+        // make sure the node that we're coming from is managed by React.
+        const inst = getClosestInstanceFromNode(related);
+        if (inst !== null) {
+          return;
+        }
       }
     }
 
@@ -100,6 +102,7 @@ const EnterLeaveEventPlugin = {
     let from;
     let to;
     if (isOutEvent) {
+      const related = nativeEvent.relatedTarget || nativeEvent.toElement;
       from = targetInst;
       to = related ? getClosestInstanceFromNode(related) : null;
       if (to !== null) {


### PR DESCRIPTION
This fixes a bug I accidently introduced in https://github.com/facebook/react/pull/18830.

Notably, I hoisted out the `related` const, but only today noticed they were two different related constants. One was `nativeEvent.relatedTarget || nativeEvent.fromElement;` and the other was `nativeEvent.relatedTarget || nativeEvent.toElement;` and for some reason I read them as the same thing! :/

So I've reverted that change, fixing the issue we're seeing internally. I'll follow up with a regression test at some point.