### PR TITLE
Put render phase update change behind a flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -1686,7 +1686,9 @@ describe('ReactDOMServerHooks', () => {
           <App />,
         );
 
-        if (gate(flags => flags.new)) {
+        if (
+          gate(flags => flags.new && flags.deferRenderPhaseUpdateToNextBatch)
+        ) {
           expect(() => Scheduler.unstable_flushAll()).toErrorDev([
             'The object passed back from useOpaqueIdentifier is meant to be passed through to attributes only. ' +
               'Do not read the value directly.',
@@ -1730,7 +1732,9 @@ describe('ReactDOMServerHooks', () => {
           <App />,
         );
 
-        if (gate(flags => flags.new)) {
+        if (
+          gate(flags => flags.new && flags.deferRenderPhaseUpdateToNextBatch)
+        ) {
           expect(() => Scheduler.unstable_flushAll()).toErrorDev([
             'The object passed back from useOpaqueIdentifier is meant to be passed through to attributes only. ' +
               'Do not read the value directly.',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -394,7 +394,7 @@ describe('ReactIncrementalUpdates', () => {
     expect(() =>
       expect(Scheduler).toFlushAndYield(
         gate(flags =>
-          flags.new
+          flags.new && flags.deferRenderPhaseUpdateToNextBatch
             ? [
                 'setState updater',
                 // In the new reconciler, updates inside the render phase are
@@ -427,7 +427,7 @@ describe('ReactIncrementalUpdates', () => {
     });
     expect(Scheduler).toFlushAndYield(
       gate(flags =>
-        flags.new
+        flags.new && flags.deferRenderPhaseUpdateToNextBatch
           ? // In the new reconciler, updates inside the render phase are
             // treated as if they came from an event, so the update gets shifted
             // to a subsequent render.

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -127,3 +127,11 @@ export const enableModernEventSystem = false;
 
 // Support legacy Primer support on internal FB www
 export const enableLegacyFBSupport = false;
+
+// Updates that occur in the render phase are not officially supported. But when
+// they do occur, in the new reconciler, we defer them to a subsequent render by
+// picking a lane that's not currently rendering. We treat them the same as if
+// they came from an interleaved event. In the old reconciler, we use whatever
+// expiration time is currently rendering. Remove this flag once we have
+// migrated to the new behavior.
+export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -46,6 +46,7 @@ export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -45,6 +45,7 @@ export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -45,6 +45,7 @@ export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -45,6 +45,7 @@ export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -45,6 +45,7 @@ export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -45,6 +45,7 @@ export const enableLegacyFBSupport = !__EXPERIMENTAL__;
 export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -21,6 +21,16 @@ export const enableModernEventSystem = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const enableDebugTracing = !__VARIANT__;
 
+// This only has an effect in the new reconciler. But also, the new reconciler
+// is only enabled when __VARIANT__ is true. So this is set to the opposite of
+// __VARIANT__ so that it's `false` when running against the new reconciler.
+// Ideally we would test both against the new reconciler, but until then, we
+// should test the value that is used in www. Which is `false`.
+//
+// Once Lanes has landed in both reconciler forks, we'll get coverage of
+// both branches.
+export const deferRenderPhaseUpdateToNextBatch = !__VARIANT__;
+
 // These are already tested in both modes using the build type dimension,
 // so we don't need to use __VARIANT__ to get extra coverage.
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,6 +26,7 @@ export const {
   enableFilterEmptyStringAttributesDOM,
   enableLegacyFBSupport,
   enableDebugTracing,
+  deferRenderPhaseUpdateToNextBatch,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
In the new reconciler, I made a change to how render phase updates work. (By render phase updates, I mean when a component updates another component during its render phase. Or when a class component updates itself during the render phase. It does not include when a hook updates its own component during the render phase. Those have their own semantics. So really I mean anything triggers the "`setState` in render" warning.)

The old behavior is to give the update the same "thread" (expiration time) as whatever is currently rendering. So if you call `setState` on a component that happens later in the same render, it will flush during that render. Ideally, we want to remove the special case and treat them as if they came from an interleaved event.

Regardless, this pattern is not officially supported. This behavior is only a fallback. The flag only exists until we can roll out the `setState` warning, since existing code might accidentally rely on the current behavior.

Wrapping in a flag lets me decouple this change from the rest of the lanes refactor.