### PR TITLE
rough implementation of direct context updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -27,6 +27,7 @@ import {
   enableFundamentalAPI,
   enableScopeAPI,
   enableBlocksAPI,
+  enableDirectContextPropagation,
 } from 'shared/ReactFeatureFlags';
 import {NoEffect, Placement} from './ReactSideEffectTags';
 import {ConcurrentRoot, BlockingRoot} from './ReactRootTags';
@@ -317,6 +318,18 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
           firstContext: currentDependencies.firstContext,
           responders: currentDependencies.responders,
         };
+
+  if (enableDirectContextPropagation) {
+    if (currentDependencies !== null) {
+      // we need to clone danglingReaders because it may fill up during a render
+      // and if that render restarts the dangling readers will be cleaned up
+      // before the render is committed.
+      workInProgress.dependencies_old.danglingReaders =
+        currentDependencies.danglingReaders === null
+          ? null
+          : Array.from(currentDependencies.danglingReaders);
+    }
+  }
 
   // These will be overridden during the parent's reconciliation
   workInProgress.sibling = current.sibling;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -36,6 +36,7 @@ import {
   enableSuspenseCallback,
   enableScopeAPI,
   runAllPassiveEffectDestroysBeforeCreates,
+  enableDirectContextPropagation,
 } from 'shared/ReactFeatureFlags';
 import {
   FunctionComponent,
@@ -83,6 +84,7 @@ import {
 } from './ReactProfilerTimer.old';
 import {ProfileMode} from './ReactTypeOfMode';
 import {commitUpdateQueue} from './ReactUpdateQueue.old';
+import {cleanupReadersOnUnmount} from './ReactFiberNewContext.old';
 import {
   getPublicInstance,
   supportsMutation,
@@ -937,6 +939,9 @@ function commitUnmount(
     case MemoComponent:
     case SimpleMemoComponent:
     case Block: {
+      if (enableDirectContextPropagation) {
+        cleanupReadersOnUnmount(current);
+      }
       const updateQueue: FunctionComponentUpdateQueue | null = (current.updateQueue: any);
       if (updateQueue !== null) {
         const lastEffect = updateQueue.lastEffect;
@@ -1016,6 +1021,9 @@ function commitUnmount(
       return;
     }
     case ClassComponent: {
+      if (enableDirectContextPropagation) {
+        cleanupReadersOnUnmount(current);
+      }
       safelyDetachRef(current);
       const instance = current.stateNode;
       if (typeof instance.componentWillUnmount === 'function') {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -124,6 +124,7 @@ import {
   enableFundamentalAPI,
   enableScopeAPI,
   enableBlocksAPI,
+  enableDirectContextPropagation,
 } from 'shared/ReactFeatureFlags';
 import {
   markSpawnedWork,
@@ -987,6 +988,10 @@ function completeWork(
       }
       return null;
     case ContextProvider:
+      if (enableDirectContextPropagation) {
+        workInProgress.memoizedState =
+          workInProgress.type._context._currentReaders;
+      }
       // Pop provider fiber
       popProvider(workInProgress);
       return null;

--- a/packages/react-reconciler/src/ReactFiberDeprecatedEvents.old.js
+++ b/packages/react-reconciler/src/ReactFiberDeprecatedEvents.old.js
@@ -25,6 +25,7 @@ import {REACT_RESPONDER_TYPE} from 'shared/ReactSymbols';
 
 import invariant from 'shared/invariant';
 import {HostComponent, HostRoot} from './ReactWorkTags';
+import {enableDirectContextPropagation} from 'shared/ReactFeatureFlags';
 
 const emptyObject = {};
 const isArray = Array.isArray;
@@ -158,6 +159,9 @@ export function updateDeprecatedEventListeners(
         firstContext: null,
         responders: new Map(),
       };
+    }
+    if (enableDirectContextPropagation) {
+      dependencies.danglingReaders = null;
     }
     let respondersMap = dependencies.responders;
     if (respondersMap === null) {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -127,3 +127,6 @@ export const enableModernEventSystem = false;
 
 // Support legacy Primer support on internal FB www
 export const enableLegacyFBSupport = false;
+
+// enable new direct reader context propagation
+export const enableDirectContextPropagation = true;


### PR DESCRIPTION
This is an early implementation of an alternative method of propagating context updates which avoids walking the Provider's sub-tree

Will update description with more detail soon but high level

## Implementation
- when creating a context dependency (a read) if no `reader` yet exists, attach one.
- readers provide Providers a list of fibers that have read from them
- on propagation, readers are evaluated for updates just like all fibers are today during the walk
- on render a fiber will copy readers into new context dependencies if the context item matches in the same "slot"
- If there is a discrepancy (rare) we stuff the old reader in a lazily created danglingReaders array and worry about cleaning up if this WIP fiber is committed and then renders again
- If during a render there are danglingReaders they are cleaned up in the prepareToReadContext phase
- on unmount all readers are cleaned up


## Pros:
* Providers hold reference to specific fibers that read from them, can jump straight to them rather than walk entire sub-tree. Perf scales at `O(# of readers)` instead of `O(size of tree)`
* Still maintains lightweight mount/unmount overhead

## Perf Impact
* holds reference to the first fiber that read from Provider so unknown whether that fiber or alternate are part of the current tree. need to examine both's dependency list which can in common cases lead to double evaluations (relatively minor given offsets in not walking tree) and in rare cases unnecessary renders (if context reads change from render to render then effectively the past two renders contexts can trigger an update)
* extra object allocation to set up the reader. paid once on mount typically
* small cleanup work on unmount. it shouldn't have major impacts on perf but it's commit phase so I know there is sensitivity here

## Notes
* a lot of the complexity comes from `readContext` since this is the only way you can read from a variable list of contexts on each render
* my new tests were mostly used to observe internal implementations working looking at now removed log statements. They probably shouldn't stick around since they don't test new functionality alone. not sure if it's worth writing tests to assert that for instance readers get cleaned up appropriately but if it is how do I don that and still just test the public api?
* the change to Depdendency_old type should be made explicit, i sorta shortcutted a bit but if this PR is interesting I can certainly refine it