### PR TITLE
Disable Profiler commit filtering

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -1500,7 +1500,17 @@ Object {
 
 exports[`ProfilingCache should collect data for each root (including ones added or mounted after profiling started): Data for root Parent 3`] = `
 Object {
-  "commitData": Array [],
+  "commitData": Array [
+    Object {
+      "changeDescriptions": Map {},
+      "duration": 0,
+      "fiberActualDurations": Map {},
+      "fiberSelfDurations": Map {},
+      "interactionIDs": Array [],
+      "priorityLevel": "Immediate",
+      "timestamp": 34,
+    },
+  ],
   "displayName": "Parent",
   "initialTreeBaseDurations": Map {
     6 => 11,
@@ -1510,7 +1520,19 @@ Object {
   },
   "interactionCommits": Map {},
   "interactions": Map {},
-  "operations": Array [],
+  "operations": Array [
+    Array [
+      1,
+      6,
+      0,
+      2,
+      4,
+      9,
+      8,
+      7,
+      6,
+    ],
+  ],
   "rootID": 6,
   "snapshots": Map {
     6 => Object {
@@ -2044,7 +2066,17 @@ Object {
       "snapshots": Array [],
     },
     Object {
-      "commitData": Array [],
+      "commitData": Array [
+        Object {
+          "changeDescriptions": Array [],
+          "duration": 0,
+          "fiberActualDurations": Array [],
+          "fiberSelfDurations": Array [],
+          "interactionIDs": Array [],
+          "priorityLevel": "Immediate",
+          "timestamp": 34,
+        },
+      ],
       "displayName": "Parent",
       "initialTreeBaseDurations": Array [
         Array [
@@ -2066,7 +2098,19 @@ Object {
       ],
       "interactionCommits": Array [],
       "interactions": Array [],
-      "operations": Array [],
+      "operations": Array [
+        Array [
+          1,
+          6,
+          0,
+          2,
+          4,
+          9,
+          8,
+          7,
+          6,
+        ],
+      ],
       "rootID": 6,
       "snapshots": Array [
         Array [


### PR DESCRIPTION
We used to filter "empty" DevTools commits, but it was error prone (see #18798). A commit may appear to be empty (no actual durations) because of component filters, but filtering these empty commits causes interaction commit indices to be off by N. This not only corrupts the resulting data, but also potentially causes runtime errors.

For that matter, hiding "empty" commits might cause confusion too. A commit *did happen* even if none of the components the Profiler is showing were involved.

---

See this comment for more context: https://github.com/facebook/react/pull/18806#issuecomment-625511231

Resolves #18798, #18786, and #18044. Alternative for PR #18806.