### PR TITLE
Add Mounting/Unmounting Effects/Refs to Offscreen Component

### DIFF
--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -19,6 +19,7 @@ export type OffscreenProps = {|
   // called "Offscreen." Possible alt: <Visibility />?
   mode?: 'hidden' | 'visible' | null | void,
   children?: ReactNodeList,
+  cleanupPassiveEffects?: boolean,
 |};
 
 // We use the existence of the state object as an indicator that the component

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -1,0 +1,632 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+'use strict';
+
+let React;
+let ReactNoop;
+let Scheduler;
+
+describe('ReactOffscreen', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+  });
+
+  function createChild(name) {
+    return ({children}) => {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue(`${name} passive effect`);
+        return () => {
+          Scheduler.unstable_yieldValue(`${name} passive destroy`);
+        };
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue(`${name} layout effect`);
+        return () => {
+          Scheduler.unstable_yieldValue(`${name} layout destroy`);
+        };
+      }, []);
+
+      Scheduler.unstable_yieldValue(`${name}`);
+      return (
+        <>
+          <span
+            ref={element => {
+              Scheduler.unstable_yieldValue(
+                element === null
+                  ? `${name} Ref null`
+                  : `${name} Ref ${element.type}`,
+              );
+            }}>
+            {name}
+          </span>
+          {children}
+        </>
+      );
+    };
+  }
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('should show subtrees/mount effects/attachRefs if shown and hide subtrees/unmount effects/detachRefs if hidden', async () => {
+    const ChildOne = createChild('ChildOne');
+    const ChildTwo = createChild('ChildTwo');
+    const ChildThree = createChild('ChildThree');
+    let _setMode;
+    let _setText;
+    function App() {
+      const [mode, setMode] = React.useState('visible');
+      const [text, setText] = React.useState('Child');
+      _setMode = setMode;
+      _setText = setText;
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('App passive effect');
+        return () => {
+          Scheduler.unstable_yieldValue('App passive destroy');
+        };
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('App layout effect');
+        return () => {
+          Scheduler.unstable_yieldValue('App layout destroy');
+        };
+      });
+
+      Scheduler.unstable_yieldValue('App');
+      return (
+        <>
+          <div>Always Visible</div>
+          <React.unstable_Offscreen mode={mode}>
+            <ChildOne text={text}>
+              <ChildTwo text={text} />
+            </ChildOne>
+            <ChildThree text={text} />
+          </React.unstable_Offscreen>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne',
+      'ChildTwo',
+      'ChildThree',
+      'ChildOne Ref span',
+      'ChildTwo Ref span',
+      'ChildTwo layout effect',
+      'ChildOne layout effect',
+      'ChildThree Ref span',
+      'ChildThree layout effect',
+      'App layout effect',
+      'ChildTwo passive effect',
+      'ChildOne passive effect',
+      'ChildThree passive effect',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span>ChildOne</span>
+        <span>ChildTwo</span>
+        <span>ChildThree</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setMode('hidden'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne layout destroy',
+      'ChildOne Ref null',
+      'ChildTwo layout destroy',
+      'ChildTwo Ref null',
+      'ChildThree layout destroy',
+      'ChildThree Ref null',
+      'App layout destroy',
+      'App layout effect',
+      'App passive destroy',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span hidden={true}>ChildOne</span>
+        <span hidden={true}>ChildTwo</span>
+        <span hidden={true}>ChildThree</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setText('New Text'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'App layout destroy',
+      'App layout effect',
+      'App passive destroy',
+      'App passive effect',
+    ]);
+
+    ReactNoop.act(() => _setMode('visible'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne',
+      'ChildTwo',
+      'ChildThree',
+      'ChildOne Ref null',
+      'ChildTwo Ref null',
+      'ChildThree Ref null',
+      'App layout destroy',
+      'ChildOne Ref span',
+      'ChildTwo Ref span',
+      'ChildTwo layout effect',
+      'ChildOne layout effect',
+      'ChildThree Ref span',
+      'ChildThree layout effect',
+      'App layout effect',
+      'ChildTwo passive destroy',
+      'ChildOne passive destroy',
+      'ChildThree passive destroy',
+      'App passive destroy',
+      'ChildTwo passive effect',
+      'ChildOne passive effect',
+      'ChildThree passive effect',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span>ChildOne</span>
+        <span>ChildTwo</span>
+        <span>ChildThree</span>
+      </React.Fragment>,
+    );
+  });
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('should unmount all layout effects as well as passive effects when cleanupPassiveEffects is true', async () => {
+    const ChildOne = createChild('ChildOne');
+    let _setMode;
+    let _setText;
+    function App() {
+      const [mode, setMode] = React.useState('visible');
+      const [text, setText] = React.useState('Child');
+      _setMode = setMode;
+      _setText = setText;
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('App passive effect');
+        return () => {
+          Scheduler.unstable_yieldValue('App passive destroy');
+        };
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('App layout effect');
+        return () => {
+          Scheduler.unstable_yieldValue('App layout destroy');
+        };
+      });
+
+      Scheduler.unstable_yieldValue('App');
+      return (
+        <>
+          <div>Always Visible</div>
+          <React.unstable_Offscreen mode={mode} cleanupPassiveEffects={true}>
+            <ChildOne text={text} />
+          </React.unstable_Offscreen>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne',
+      'ChildOne Ref span',
+      'ChildOne layout effect',
+      'App layout effect',
+      'ChildOne passive effect',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span>ChildOne</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setMode('hidden'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne layout destroy',
+      'ChildOne Ref null',
+
+      'App layout destroy',
+      'App layout effect',
+      'ChildOne passive destroy',
+      'App passive destroy',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span hidden={true}>ChildOne</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setText('New Text'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'App layout destroy',
+      'App layout effect',
+      'App passive destroy',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span hidden={true}>ChildOne</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setMode('visible'));
+    expect(Scheduler).toHaveYielded([
+      'App',
+      'ChildOne',
+      'ChildOne Ref null',
+      'App layout destroy',
+      'ChildOne Ref span',
+      'ChildOne layout effect',
+      'App layout effect',
+      'App passive destroy',
+      'ChildOne passive effect',
+      'App passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <div>Always Visible</div>
+        <span>ChildOne</span>
+      </React.Fragment>,
+    );
+  });
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('Nested Offscreen components behave properly', async () => {
+    const ChildOne = createChild('ChildOne');
+    const ChildTwo = createChild('ChildTwo');
+    let _setMode;
+    let _setNestedMode;
+    function App() {
+      const [mode, setMode] = React.useState('visible');
+      const [nestedMode, setNestedMode] = React.useState('visible');
+      _setMode = setMode;
+      _setNestedMode = setNestedMode;
+      return (
+        <React.unstable_Offscreen mode={mode}>
+          <ChildOne />
+          <React.unstable_Offscreen mode={nestedMode}>
+            <ChildTwo />
+          </React.unstable_Offscreen>
+        </React.unstable_Offscreen>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(Scheduler).toHaveYielded([
+      'ChildOne',
+      'ChildTwo',
+      'ChildOne Ref span',
+      'ChildOne layout effect',
+      'ChildTwo Ref span',
+      'ChildTwo layout effect',
+      'ChildOne passive effect',
+      'ChildTwo passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <span>ChildOne</span>
+        <span>ChildTwo</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setNestedMode('hidden'));
+    expect(Scheduler).toHaveYielded([
+      'ChildOne',
+      'ChildOne Ref null',
+      'ChildTwo layout destroy',
+      'ChildTwo Ref null',
+      'ChildOne Ref span',
+      'ChildOne passive destroy',
+      'ChildOne passive effect',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <span>ChildOne</span>
+        <span hidden={true}>ChildTwo</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setMode('hidden'));
+    expect(Scheduler).toHaveYielded([
+      'ChildOne layout destroy',
+      'ChildOne Ref null',
+    ]);
+
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <span hidden={true}>ChildOne</span>
+        <span hidden={true}>ChildTwo</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setNestedMode('visible'));
+    expect(Scheduler).toHaveYielded([]);
+
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <span hidden={true}>ChildOne</span>
+        <span hidden={true}>ChildTwo</span>
+      </React.Fragment>,
+    );
+
+    ReactNoop.act(() => _setMode('visible'));
+    expect(Scheduler).toHaveYielded([
+      'ChildOne',
+      'ChildTwo',
+      'ChildOne Ref null',
+      'ChildTwo Ref null',
+      'ChildOne Ref span',
+      'ChildOne layout effect',
+      'ChildTwo Ref span',
+      'ChildTwo layout effect',
+      'ChildOne passive destroy',
+      'ChildTwo passive destroy',
+      'ChildOne passive effect',
+      'ChildTwo passive effect',
+    ]);
+
+    expect(root).toMatchRenderedOutput(
+      <React.Fragment>
+        <span>ChildOne</span>
+        <span>ChildTwo</span>
+      </React.Fragment>,
+    );
+  });
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('should show/hide subtrees and mount/unmount refs for Class Components', async () => {
+    class ChildOne extends React.Component {
+      componentDidMount() {
+        Scheduler.unstable_yieldValue('ChildOne componentDidMount');
+      }
+
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue('ChildOne componentWillUnmount');
+      }
+
+      render() {
+        Scheduler.unstable_yieldValue('ChildOne render');
+        return (
+          <span
+            ref={element =>
+              Scheduler.unstable_yieldValue(
+                element === null ? 'span Ref null' : `span Ref ${element.type}`,
+              )
+            }>
+            ChildOne
+          </span>
+        );
+      }
+    }
+
+    let AppInstance;
+    class App extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          mode: false,
+        };
+        AppInstance = this;
+      }
+
+      componentDidMount() {
+        Scheduler.unstable_yieldValue('App componentDidMount');
+      }
+
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue('App componentWillUnmount');
+      }
+
+      render() {
+        Scheduler.unstable_yieldValue('App render');
+        return (
+          <React.unstable_Offscreen mode={this.state.mode}>
+            <ChildOne
+              ref={element => {
+                Scheduler.unstable_yieldValue(
+                  element === null
+                    ? 'ChildOne Ref null'
+                    : `ChildOne Ref ${element.constructor.name}`,
+                );
+              }}
+            />
+          </React.unstable_Offscreen>
+        );
+      }
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(Scheduler).toHaveYielded([
+      'App render',
+      'ChildOne render',
+      'span Ref span',
+      'ChildOne componentDidMount',
+      'ChildOne Ref ChildOne',
+      'App componentDidMount',
+    ]);
+    expect(root).toMatchRenderedOutput(<span>ChildOne</span>);
+
+    ReactNoop.act(() => AppInstance.setState({mode: 'hidden'}));
+    expect(Scheduler).toHaveYielded([
+      'App render',
+      'ChildOne Ref null',
+      'ChildOne componentWillUnmount',
+      'span Ref null',
+    ]);
+    expect(root).toMatchRenderedOutput(<span hidden={true}>ChildOne</span>);
+
+    ReactNoop.act(() => AppInstance.setState({mode: 'visible'}));
+    expect(Scheduler).toHaveYielded([
+      'App render',
+      'ChildOne render',
+      'span Ref null',
+      'ChildOne Ref null',
+      'span Ref span',
+      'ChildOne componentDidMount',
+      'ChildOne Ref ChildOne',
+    ]);
+    expect(root).toMatchRenderedOutput(<span>ChildOne</span>);
+  });
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('Forward refs are mounted/unmounted when hidden/visible', async () => {
+    const Child = React.forwardRef((props, ref) => <span ref={ref} />);
+
+    let _ref;
+    let _setMode;
+    function App() {
+      const ref = React.useRef();
+      const [mode, setMode] = React.useState('visible');
+      _ref = ref;
+      _setMode = setMode;
+      return (
+        <React.unstable_Offscreen mode={mode}>
+          <Child ref={ref} />
+        </React.unstable_Offscreen>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(_ref.current.type).toEqual('span');
+
+    ReactNoop.act(() => _setMode('hidden'));
+    expect(_ref.current).toBe(null);
+
+    ReactNoop.act(() => _setMode('visible'));
+    expect(_ref.current.type).toEqual('span');
+  });
+
+  // @gate enableHiddenAPI && runAllPassiveEffectDestroysBeforeCreates
+  it('Portals are hidden in hidden subtrees and shown in visible ones', async () => {
+    const portalContainer = ReactNoop.getOrCreateRootContainer(
+      'portalContainer',
+    );
+    function Modal({portalRef, mode}) {
+      React.useLayoutEffect(() => {
+        portalContainer.hidden = true;
+        return () => {
+          portalContainer.hidden = false;
+        };
+      });
+      return ReactNoop.createPortal(
+        <span ref={portalRef}>
+          <div>Child</div>
+          {mode}
+        </span>,
+        portalContainer,
+      );
+    }
+
+    let _setMode;
+    function App() {
+      const ref = React.useRef();
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue(
+          `Portal Child Ref ${
+            ref.current === null || ref.current.hidden ? 'hidden' : 'visible'
+          }`,
+        );
+      });
+
+      const [mode, setMode] = React.useState('visible');
+      _setMode = setMode;
+      return (
+        <React.unstable_Offscreen mode={mode}>
+          <div>
+            <div>
+              <Modal mode={mode} portalRef={ref} />
+            </div>
+          </div>
+        </React.unstable_Offscreen>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(Scheduler).toHaveYielded(['Portal Child Ref visible']);
+    expect(root).toMatchRenderedOutput(
+      <div>
+        <div />
+      </div>,
+    );
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <span>
+        <div>Child</div>
+        visible
+      </span>,
+    );
+    ReactNoop.act(() => _setMode('hidden'));
+    expect(Scheduler).toHaveYielded(['Portal Child Ref hidden']);
+    expect(root).toMatchRenderedOutput(
+      <div hidden={true}>
+        <div />
+      </div>,
+    );
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <span hidden={true}>
+        <div>Child</div>
+        visible
+      </span>,
+    );
+
+    ReactNoop.act(() => _setMode('visible'));
+    expect(Scheduler).toHaveYielded(['Portal Child Ref visible']);
+    expect(root).toMatchRenderedOutput(
+      <div>
+        <div />
+      </div>,
+    );
+    expect(ReactNoop.getChildrenAsJSX('portalContainer')).toEqual(
+      <span>
+        <div>Child</div>
+        visible
+      </span>,
+    );
+  });
+});

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -82,4 +82,5 @@ export {
   unstable_createFundamental,
   unstable_createScope,
   unstable_useOpaqueIdentifier,
+  unstable_Offscreen,
 } from './src/React';

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -15,6 +15,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
+  REACT_OFFSCREEN_TYPE,
 } from 'shared/ReactSymbols';
 
 import {Component, PureComponent} from './ReactBaseClasses';
@@ -99,6 +100,8 @@ export {
   REACT_STRICT_MODE_TYPE as StrictMode,
   REACT_DEBUG_TRACING_MODE_TYPE as unstable_DebugTracingMode,
   REACT_SUSPENSE_TYPE as Suspense,
+  // enableHiddenAPI
+  REACT_OFFSCREEN_TYPE as unstable_Offscreen,
   createElement,
   cloneElement,
   isValidElement,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -102,6 +102,8 @@ export const enableComponentStackLocations = __EXPERIMENTAL__;
 
 export const enableNewReconciler = false;
 
+export const enableHiddenAPI = false;
+
 // --------------------------
 // Future APIs to be deprecated
 // --------------------------

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -48,6 +48,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -47,6 +47,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -47,6 +47,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -47,6 +47,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -47,6 +47,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -47,6 +47,8 @@ export const enableFilterEmptyStringAttributesDOM = false;
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 
+export const enableHiddenAPI = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -36,6 +36,8 @@ export const deferRenderPhaseUpdateToNextBatch = !__VARIANT__;
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 
+export const enableHiddenAPI = __VARIANT__ && __DEV__;
+
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these
 // to __VARIANT__.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -27,6 +27,7 @@ export const {
   enableLegacyFBSupport,
   enableDebugTracing,
   deferRenderPhaseUpdateToNextBatch,
+  enableHiddenAPI,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -22,6 +22,7 @@ import {
   REACT_SUSPENSE_LIST_TYPE,
   REACT_LAZY_TYPE,
   REACT_BLOCK_TYPE,
+  REACT_OFFSCREEN_TYPE,
 } from 'shared/ReactSymbols';
 import type {ReactContext, ReactProviderType} from 'shared/ReactTypes';
 
@@ -73,6 +74,8 @@ function getComponentName(type: mixed): string | null {
       return 'Suspense';
     case REACT_SUSPENSE_LIST_TYPE:
       return 'SuspenseList';
+    case REACT_OFFSCREEN_TYPE:
+      return 'Offscreen';
   }
   if (typeof type === 'object') {
     switch (type.$$typeof) {

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -24,6 +24,7 @@ import {
   REACT_SCOPE_TYPE,
   REACT_BLOCK_TYPE,
   REACT_SERVER_BLOCK_TYPE,
+  REACT_OFFSCREEN_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -37,6 +38,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_STRICT_MODE_TYPE ||
     type === REACT_SUSPENSE_TYPE ||
     type === REACT_SUSPENSE_LIST_TYPE ||
+    type === REACT_OFFSCREEN_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
       (type.$$typeof === REACT_LAZY_TYPE ||


### PR DESCRIPTION
This PR expands on #18729 by introducing an `Offscreen` component. This component will eventually be used to hide or unhide children and mount/unmount all effects in the Offscreen subtree. This PR also changes the behavior of effects and refs in the Offscreen component when components are hidden. Previously, when a component is hidden, its effects and refs do not unmount. This PR changes this so that whenever a component is hidden, its effects and ref do unmount. Layout effects and refs will always be unmounted on hide. Passive effects currently do not unmount by default (though there is a mode in which they do unmount), but we are still deciding what the default behavior should be. 

Note: This PR does yet not modify behavior for the current Suspense implementation. This will be added in a subsequent PR.