### PR TITLE
Expose LegacyHidden type and disable <div hidden /> API in new fork

### DIFF
--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -25,6 +25,25 @@ describe('ReactUpdates', () => {
     Scheduler = require('scheduler');
   });
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('should batch state when updating state twice', () => {
     let updateCount = 0;
 
@@ -1288,6 +1307,7 @@ describe('ReactUpdates', () => {
   });
 
   // @gate experimental
+  // @gate enableLegacyHiddenType
   it('delays sync updates inside hidden subtrees in Concurrent Mode', () => {
     const container = document.createElement('div');
 
@@ -1311,9 +1331,9 @@ describe('ReactUpdates', () => {
       });
       return (
         <div>
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Bar />
-          </div>
+          </LegacyHiddenDiv>
           <Baz />
         </div>
       );

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -75,6 +75,7 @@ import {
   warnAboutDefaultPropsOnFunctionComponents,
   enableScopeAPI,
   enableBlocksAPI,
+  warnAboutDOMHiddenAttribute,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
 import shallowEqual from 'shared/shallowEqual';
@@ -1123,6 +1124,21 @@ function updateHostComponent(
   }
 
   markRef(current, workInProgress);
+
+  if (__DEV__) {
+    if (
+      warnAboutDOMHiddenAttribute &&
+      (workInProgress.mode & ConcurrentMode) !== NoMode &&
+      nextProps.hasOwnProperty('hidden')
+    ) {
+      // This warning will not be user visible. Only exists so React Core team
+      // can find existing callers and migrate them to the new API.
+      console.error(
+        'Detected use of DOM `hidden` attribute. Should migrate to new API. ' +
+          '(owner: React Core)',
+      );
+    }
+  }
 
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -80,12 +80,7 @@ import invariant from 'shared/invariant';
 import shallowEqual from 'shared/shallowEqual';
 import getComponentName from 'shared/getComponentName';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings.new';
-import {
-  REACT_ELEMENT_TYPE,
-  REACT_LAZY_TYPE,
-  REACT_LEGACY_HIDDEN_TYPE,
-  getIteratorFn,
-} from 'shared/ReactSymbols';
+import {REACT_LAZY_TYPE, getIteratorFn} from 'shared/ReactSymbols';
 import {
   getCurrentFiberOwnerNameInDevOrNull,
   setIsRendering,
@@ -128,7 +123,6 @@ import {
 } from './ReactTypeOfMode';
 import {
   shouldSetTextContent,
-  shouldDeprioritizeSubtree,
   isSuspenseInstancePending,
   isSuspenseInstanceFallback,
   registerSuspenseInstanceRetry,
@@ -572,7 +566,15 @@ function updateOffscreenComponent(
     current !== null ? current.memoizedState : null;
 
   if (nextProps.mode === 'hidden') {
-    if (!includesSomeLane(renderLanes, (OffscreenLane: Lane))) {
+    if ((workInProgress.mode & ConcurrentMode) === NoMode) {
+      // In legacy sync mode, don't defer the subtree. Render it now.
+      // TODO: Figure out what we should do in Blocking mode.
+      const nextState: OffscreenState = {
+        baseLanes: NoLanes,
+      };
+      workInProgress.memoizedState = nextState;
+      pushRenderLanes(workInProgress, renderLanes);
+    } else if (!includesSomeLane(renderLanes, (OffscreenLane: Lane))) {
       let nextBaseLanes;
       if (prevState !== null) {
         const prevBaseLanes = prevState.baseLanes;
@@ -1121,25 +1123,6 @@ function updateHostComponent(
   }
 
   markRef(current, workInProgress);
-
-  if (
-    (workInProgress.mode & ConcurrentMode) !== NoMode &&
-    nextProps.hasOwnProperty('hidden')
-  ) {
-    const wrappedChildren = {
-      $$typeof: REACT_ELEMENT_TYPE,
-      type: REACT_LEGACY_HIDDEN_TYPE,
-      key: null,
-      ref: null,
-      props: {
-        children: nextChildren,
-        // Check the host config to see if the children are offscreen/hidden.
-        mode: shouldDeprioritizeSubtree(type, nextProps) ? 'hidden' : 'visible',
-      },
-      _owner: __DEV__ ? {} : null,
-    };
-    nextChildren = wrappedChildren;
-  }
 
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -69,6 +69,7 @@ import {
   warnAboutDefaultPropsOnFunctionComponents,
   enableScopeAPI,
   enableBlocksAPI,
+  warnAboutDOMHiddenAttribute,
 } from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
 import shallowEqual from 'shared/shallowEqual';
@@ -1098,6 +1099,21 @@ function updateHostComponent(current, workInProgress, renderExpirationTime) {
   }
 
   markRef(current, workInProgress);
+
+  if (__DEV__) {
+    if (
+      warnAboutDOMHiddenAttribute &&
+      (workInProgress.mode & ConcurrentMode) !== NoMode &&
+      nextProps.hasOwnProperty('hidden')
+    ) {
+      // This warning will not be user visible. Only exists so React Core team
+      // can find existing callers and migrate them to the new API.
+      console.error(
+        'Detected use of DOM `hidden` attribute. Should migrate to new API. ' +
+          '(owner: React Core)',
+      );
+    }
+  }
 
   // Check the host config to see if the children are offscreen/hidden.
   if (

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -24,6 +24,25 @@ describe('ReactIncremental', () => {
     PropTypes = require('prop-types');
   });
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('should render a simple component', () => {
     function Bar() {
       return <div>Hello World</div>;
@@ -210,6 +229,7 @@ describe('ReactIncremental', () => {
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
+  // @gate enableLegacyHiddenType
   it('can deprioritize unfinished work and resume it later', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -226,13 +246,13 @@ describe('ReactIncremental', () => {
       return (
         <div>
           <Bar>{props.text}</Bar>
-          <section hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Middle>{props.text}</Middle>
-          </section>
+          </LegacyHiddenDiv>
           <Bar>{props.text}</Bar>
-          <footer hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Middle>Footer</Middle>
-          </footer>
+          </LegacyHiddenDiv>
         </div>
       );
     }
@@ -255,6 +275,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['Middle', 'Middle']);
   });
 
+  // @gate enableLegacyHiddenType
   it('can deprioritize a tree from without dropping work', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -271,13 +292,13 @@ describe('ReactIncremental', () => {
       return (
         <div>
           <Bar>{props.text}</Bar>
-          <section hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Middle>{props.text}</Middle>
-          </section>
+          </LegacyHiddenDiv>
           <Bar>{props.text}</Bar>
-          <footer hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Middle>Footer</Middle>
-          </footer>
+          </LegacyHiddenDiv>
         </div>
       );
     }
@@ -1950,6 +1971,7 @@ describe('ReactIncremental', () => {
     });
   }
 
+  // @gate enableLegacyHiddenType
   it('provides context when reusing work', () => {
     class Intl extends React.Component {
       static childContextTypes = {
@@ -1981,12 +2003,12 @@ describe('ReactIncremental', () => {
     ReactNoop.render(
       <Intl locale="fr">
         <ShowLocale />
-        <div hidden="true">
+        <LegacyHiddenDiv hidden="true">
           <ShowLocale />
           <Intl locale="ru">
             <ShowLocale />
           </Intl>
-        </div>
+        </LegacyHiddenDiv>
         <ShowLocale />
       </Intl>,
     );

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -45,6 +45,25 @@ describe('ReactIncrementalErrorHandling', () => {
     );
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('recovers from errors asynchronously', () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
@@ -270,6 +289,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Everything is fine.')]);
   });
 
+  // @gate enableLegacyHiddenType
   it('does not include offscreen work when retrying after an error', () => {
     function App(props) {
       if (props.isBroken) {
@@ -280,9 +300,9 @@ describe('ReactIncrementalErrorHandling', () => {
       return (
         <>
           Everything is fine
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <div>Offscreen content</div>
-          </div>
+          </LegacyHiddenDiv>
         </>
       );
     }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -38,6 +38,25 @@ describe('ReactIncrementalSideEffects', () => {
     return {text: t, hidden: false};
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('can update child nodes of a host instance', () => {
     function Bar(props) {
       return <span>{props.text}</span>;
@@ -405,6 +424,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
+  // @gate enableLegacyHiddenType
   it('preserves a previously rendered node when deprioritized', () => {
     function Middle(props) {
       Scheduler.unstable_yieldValue('Middle');
@@ -415,9 +435,9 @@ describe('ReactIncrementalSideEffects', () => {
       Scheduler.unstable_yieldValue('Foo');
       return (
         <div>
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Middle>{props.text}</Middle>
-          </div>
+          </LegacyHiddenDiv>
         </div>
       );
     }
@@ -455,6 +475,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
   });
 
+  // @gate enableLegacyHiddenType
   it('can reuse side-effects after being preempted', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -471,7 +492,7 @@ describe('ReactIncrementalSideEffects', () => {
     function Foo(props) {
       Scheduler.unstable_yieldValue('Foo');
       return (
-        <div hidden={true}>
+        <LegacyHiddenDiv hidden={true}>
           {props.step === 0 ? (
             <div>
               <Bar>Hi</Bar>
@@ -480,7 +501,7 @@ describe('ReactIncrementalSideEffects', () => {
           ) : (
             middleContent
           )}
-        </div>
+        </LegacyHiddenDiv>
       );
     }
 
@@ -534,6 +555,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
   });
 
+  // @gate enableLegacyHiddenType
   it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
@@ -563,9 +585,9 @@ describe('ReactIncrementalSideEffects', () => {
     function Foo(props) {
       Scheduler.unstable_yieldValue('Foo');
       return (
-        <div hidden={true}>
+        <LegacyHiddenDiv hidden={true}>
           <Content step={props.step} text={props.text} />
-        </div>
+        </LegacyHiddenDiv>
       );
     }
 
@@ -649,12 +671,13 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={3} />);
   });
 
+  // @gate enableLegacyHiddenType
   it('updates a child even though the old props is empty', () => {
     function Foo(props) {
       return (
-        <div hidden={true}>
+        <LegacyHiddenDiv hidden={true}>
           <span prop={1} />
-        </div>
+        </LegacyHiddenDiv>
       );
     }
 
@@ -888,6 +911,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Bar', 'Baz', 'Bar', 'Bar']);
   });
 
+  // @gate enableLegacyHiddenType
   it('deprioritizes setStates that happens within a deprioritized tree', () => {
     const barInstances = [];
 
@@ -910,11 +934,11 @@ describe('ReactIncrementalSideEffects', () => {
       return (
         <div>
           <span prop={props.tick} />
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Bar idx={props.idx} />
             <Bar idx={props.idx} />
             <Bar idx={props.idx} />
-          </div>
+          </LegacyHiddenDiv>
         </div>
       );
     }

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -42,6 +42,25 @@ describe('ReactNewContext', () => {
     return dispatcher.readContext(Context, observedBits);
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   // We have several ways of reading from context. sharedContextTests runs
   // a suite of tests for a given context consumer implementation.
   sharedContextTests('Context.Consumer', Context => Context.Consumer);
@@ -903,6 +922,7 @@ describe('ReactNewContext', () => {
         expect(ReactNoop.getChildren()).toEqual([span(2), span(2)]);
       });
 
+      // @gate enableLegacyHiddenType
       it("context consumer doesn't bail out inside hidden subtree", () => {
         const Context = React.createContext('dark');
         const Consumer = getConsumer(Context);
@@ -910,9 +930,9 @@ describe('ReactNewContext', () => {
         function App({theme}) {
           return (
             <Context.Provider value={theme}>
-              <div hidden={true}>
+              <LegacyHiddenDiv hidden={true}>
                 <Consumer>{value => <Text text={value} />}</Consumer>
-              </div>
+              </LegacyHiddenDiv>
             </Context.Provider>
           );
         }

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -53,6 +53,25 @@ describe('ReactSchedulerIntegration', () => {
     }
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('flush sync has correct priority', () => {
     function ReadPriority() {
       Scheduler.unstable_yieldValue(
@@ -351,6 +370,7 @@ describe('ReactSchedulerIntegration', () => {
     expect(Scheduler).toHaveYielded(['A', 'B', 'C']);
   });
 
+  // @gate enableLegacyHiddenType
   it('idle updates are not blocked by offscreen work', async () => {
     function Text({text}) {
       Scheduler.unstable_yieldValue(text);
@@ -361,9 +381,9 @@ describe('ReactSchedulerIntegration', () => {
       return (
         <>
           <Text text={`Visible: ` + label} />
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Text text={`Hidden: ` + label} />
-          </div>
+          </LegacyHiddenDiv>
         </>
       );
     }

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -142,6 +142,25 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('does not restart rendering for initial render', async () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -2891,6 +2910,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   // @gate experimental
+  // @gate enableLegacyHiddenType
   it('should not render hidden content while suspended on higher pri', async () => {
     function Offscreen() {
       Scheduler.unstable_yieldValue('Offscreen');
@@ -2902,9 +2922,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
       return (
         <>
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <Offscreen />
-          </div>
+          </LegacyHiddenDiv>
           <Suspense fallback={<Text text="Loading..." />}>
             {showContent ? <AsyncText text="A" ms={2000} /> : null}
           </Suspense>
@@ -2946,6 +2966,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   // @gate experimental
+  // @gate enableLegacyHiddenType
   it('should be able to unblock higher pri content before suspended hidden', async () => {
     function Offscreen() {
       Scheduler.unstable_yieldValue('Offscreen');
@@ -2957,10 +2978,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
       return (
         <Suspense fallback={<Text text="Loading..." />}>
-          <div hidden={true}>
+          <LegacyHiddenDiv hidden={true}>
             <AsyncText text="A" ms={2000} />
             <Offscreen />
-          </div>
+          </LegacyHiddenDiv>
           {showContent ? <AsyncText text="A" ms={2000} /> : null}
         </Suspense>
       );

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -75,6 +75,25 @@ describe('ReactFresh', () => {
     return type;
   }
 
+  // TODO: Delete this once new API exists in both forks
+  function LegacyHiddenDiv({hidden, children, ...props}) {
+    if (gate(flags => flags.new)) {
+      return (
+        <div hidden={hidden} {...props}>
+          <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+            {children}
+          </React.unstable_LegacyHidden>
+        </div>
+      );
+    } else {
+      return (
+        <div hidden={hidden} {...props}>
+          {children}
+        </div>
+      );
+    }
+  }
+
   it('can preserve state for compatible types', () => {
     if (__DEV__) {
       const HelloV1 = render(() => {
@@ -2417,9 +2436,9 @@ describe('ReactFresh', () => {
             Scheduler.unstable_yieldValue('App#layout');
           });
           return (
-            <div hidden={offscreen}>
+            <LegacyHiddenDiv hidden={offscreen}>
               <Hello />
-            </div>
+            </LegacyHiddenDiv>
           );
         };
       });

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -32,6 +32,7 @@ export {
   Profiler,
   StrictMode,
   Suspense,
+  unstable_LegacyHidden,
   createElement,
   cloneElement,
   isValidElement,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -32,6 +32,7 @@ export {
   Profiler,
   StrictMode,
   Suspense,
+  unstable_LegacyHidden,
   createElement,
   cloneElement,
   isValidElement,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -77,6 +77,7 @@ export {
   unstable_withSuspenseConfig,
   block,
   block as unstable_block,
+  unstable_LegacyHidden,
   DEPRECATED_useResponder,
   DEPRECATED_createResponder,
   unstable_createFundamental,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -32,6 +32,7 @@ export {
   Profiler,
   StrictMode,
   Suspense,
+  unstable_LegacyHidden,
   createElement,
   cloneElement,
   isValidElement,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -15,6 +15,7 @@ import {
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
   REACT_SUSPENSE_LIST_TYPE,
+  REACT_LEGACY_HIDDEN_TYPE,
 } from 'shared/ReactSymbols';
 
 import {Component, PureComponent} from './ReactBaseClasses';
@@ -110,6 +111,7 @@ export {
   useTransition,
   useDeferredValue,
   REACT_SUSPENSE_LIST_TYPE as SuspenseList,
+  REACT_LEGACY_HIDDEN_TYPE as unstable_LegacyHidden,
   withSuspenseConfig as unstable_withSuspenseConfig,
   // enableBlocksAPI
   block,

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -55,6 +55,25 @@ function loadModules() {
   });
 }
 
+// TODO: Delete this once new API exists in both forks
+function LegacyHiddenDiv({hidden, children, ...props}) {
+  if (gate(flags => flags.new)) {
+    return (
+      <div hidden={hidden} {...props}>
+        <React.unstable_LegacyHidden mode={hidden ? 'hidden' : 'visible'}>
+          {children}
+        </React.unstable_LegacyHidden>
+      </div>
+    );
+  } else {
+    return (
+      <div hidden={hidden} {...props}>
+        {children}
+      </div>
+    );
+  }
+}
+
 describe('ReactDOMTracing', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -65,6 +84,7 @@ describe('ReactDOMTracing', () => {
   describe('interaction tracing', () => {
     describe('hidden', () => {
       // @gate experimental
+      // @gate enableLegacyHiddenType
       it('traces interaction through hidden subtree', () => {
         const Child = () => {
           const [didMount, setDidMount] = React.useState(false);
@@ -86,9 +106,9 @@ describe('ReactDOMTracing', () => {
             Scheduler.unstable_yieldValue('App:mount');
           }, []);
           return (
-            <div hidden={true}>
+            <LegacyHiddenDiv hidden={true}>
               <Child />
-            </div>
+            </LegacyHiddenDiv>
           );
         };
 
@@ -142,6 +162,7 @@ describe('ReactDOMTracing', () => {
       });
 
       // @gate experimental
+      // @gate enableLegacyHiddenType
       it('traces interaction through hidden subtree when there is other pending traced work', () => {
         const Child = () => {
           Scheduler.unstable_yieldValue('Child');
@@ -157,9 +178,9 @@ describe('ReactDOMTracing', () => {
             Scheduler.unstable_yieldValue('App:mount');
           }, []);
           return (
-            <div hidden={true}>
+            <LegacyHiddenDiv hidden={true}>
               <Child />
-            </div>
+            </LegacyHiddenDiv>
           );
         };
 
@@ -210,6 +231,7 @@ describe('ReactDOMTracing', () => {
       });
 
       // @gate experimental
+      // @gate enableLegacyHiddenType
       it('traces interaction through hidden subtree that schedules more idle/never work', () => {
         const Child = () => {
           const [didMount, setDidMount] = React.useState(false);
@@ -234,9 +256,9 @@ describe('ReactDOMTracing', () => {
             Scheduler.unstable_yieldValue('App:mount');
           }, []);
           return (
-            <div hidden={true}>
+            <LegacyHiddenDiv hidden={true}>
               <Child />
-            </div>
+            </LegacyHiddenDiv>
           );
         };
 
@@ -293,6 +315,7 @@ describe('ReactDOMTracing', () => {
       });
 
       // @gate experimental
+      // @gate enableLegacyHiddenType
       it('does not continue interactions across pre-existing idle work', () => {
         const Child = () => {
           Scheduler.unstable_yieldValue('Child');
@@ -304,9 +327,9 @@ describe('ReactDOMTracing', () => {
         const WithHiddenWork = () => {
           Scheduler.unstable_yieldValue('WithHiddenWork');
           return (
-            <div hidden={true}>
+            <LegacyHiddenDiv hidden={true}>
               <Child />
-            </div>
+            </LegacyHiddenDiv>
           );
         };
 
@@ -394,6 +417,7 @@ describe('ReactDOMTracing', () => {
       });
 
       // @gate experimental
+      // @gate enableLegacyHiddenType
       it('should properly trace interactions when there is work of interleaved priorities', () => {
         const Child = () => {
           Scheduler.unstable_yieldValue('Child');
@@ -411,9 +435,9 @@ describe('ReactDOMTracing', () => {
             Scheduler.unstable_yieldValue('MaybeHiddenWork:effect');
           });
           return flag ? (
-            <div hidden={true}>
+            <LegacyHiddenDiv hidden={true}>
               <Child />
-            </div>
+            </LegacyHiddenDiv>
           ) : null;
         };
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -135,3 +135,6 @@ export const enableLegacyFBSupport = false;
 // expiration time is currently rendering. Remove this flag once we have
 // migrated to the new behavior.
 export const deferRenderPhaseUpdateToNextBatch = true;
+
+// Flag used by www build so we can log occurrences of legacy hidden API
+export const warnAboutDOMHiddenAttribute = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -47,6 +47,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -46,6 +46,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -46,6 +46,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -46,6 +46,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -46,6 +46,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -46,6 +46,7 @@ export const enableFilterEmptyStringAttributesDOM = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
+export const warnAboutDOMHiddenAttribute = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -36,6 +36,13 @@ export const deferRenderPhaseUpdateToNextBatch = !__VARIANT__;
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 
+// Do not add the corresponding warning to the warning filter! Only exists so we
+// can detect callers and migrate them to the new API. Should not visible to
+// anyone outside React Core team.
+//
+// Disabled in our tests, but we'll enable in www.
+export const warnAboutDOMHiddenAttribute = false;
+
 // TODO: These flags are hard-coded to the default values used in open source.
 // Update the tests so that they pass in either mode, then set these
 // to __VARIANT__.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -27,6 +27,7 @@ export const {
   enableLegacyFBSupport,
   enableDebugTracing,
   deferRenderPhaseUpdateToNextBatch,
+  warnAboutDOMHiddenAttribute,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -24,6 +24,7 @@ import {
   REACT_SCOPE_TYPE,
   REACT_BLOCK_TYPE,
   REACT_SERVER_BLOCK_TYPE,
+  REACT_LEGACY_HIDDEN_TYPE,
 } from 'shared/ReactSymbols';
 
 export default function isValidElementType(type: mixed) {
@@ -37,6 +38,7 @@ export default function isValidElementType(type: mixed) {
     type === REACT_STRICT_MODE_TYPE ||
     type === REACT_SUSPENSE_TYPE ||
     type === REACT_SUSPENSE_LIST_TYPE ||
+    type === REACT_LEGACY_HIDDEN_TYPE ||
     (typeof type === 'object' &&
       type !== null &&
       (type.$$typeof === REACT_LAZY_TYPE ||

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -73,6 +73,10 @@ function getTestFlags() {
       classic: releaseChannel === 'classic',
       www,
 
+      // Using this more specific flag so it's easier to clean up later
+      enableLegacyHiddenType:
+        featureFlags.enableNewReconciler === false || __EXPERIMENTAL__,
+
       ...featureFlags,
       ...environmentFlags,
     },


### PR DESCRIPTION
I will use this internally at Facebook to migrate away from `<div hidden />`. The end goal is to migrate to the Offscreen type, but that has different semantics. This is an incremental step.

I disabled `<div hidden />` in the new fork and updated the tests to use an indirection that picks the correct API. I will remove this once the LegacyHidden (and/or Offscreen) type has landed in both implementations.