### PR TITLE
React Flare: fix PressLegacy preventDefault issue

### DIFF
--- a/packages/react-interactions/events/src/dom/PressLegacy.js
+++ b/packages/react-interactions/events/src/dom/PressLegacy.js
@@ -586,7 +586,11 @@ const pressResponderImpl = {
                 !ctrlKey &&
                 !altKey
               ) {
-                nativeEvent.preventDefault();
+                // Prevent spacebar press from scrolling the window
+                const key = nativeEvent.key;
+                if (key === ' ' || key === 'Spacebar') {
+                  nativeEvent.preventDefault();
+                }
                 state.shouldPreventClick = true;
               }
             } else {
@@ -637,7 +641,11 @@ const pressResponderImpl = {
           addRootEventTypes(context, state);
         } else {
           // Prevent spacebar press from scrolling the window
-          if (isValidKeyboardEvent(nativeEvent) && nativeEvent.key === ' ') {
+          const key = nativeEvent.key;
+          if (
+            isValidKeyboardEvent(nativeEvent) &&
+            (key === ' ' || key === 'Spacebar')
+          ) {
             nativeEvent.preventDefault();
           }
         }

--- a/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
+++ b/packages/react-interactions/events/src/dom/__tests__/PressLegacy-test.internal.js
@@ -1054,8 +1054,9 @@ describe.each(environmentTable)('Press responder', hasPointerEvents => {
       ReactDOM.render(<Component />, container);
 
       const target = createEventTarget(ref.current);
-      target.keydown({key: 'Enter', preventDefault});
+      target.keydown({key: 'Enter'});
       target.keyup({key: 'Enter'});
+      target.click({preventDefault});
       expect(preventDefault).toBeCalled();
       expect(onPress).toHaveBeenCalledWith(
         expect.objectContaining({defaultPrevented: true}),


### PR DESCRIPTION
We recently uncovered a bug in the PressLegacy responder in React Flare. @necolas found a bug that occurs because we call `preventDefault` for `Enter` key presses. We should have only been doing this for `Space` key presses, otherwise it means we never get a corresponding `click` fire, because calling `preventDefault` in the key press phase cancels out the click. This PR fixes that, and also fixes the test that had the wrong semantics.