### PR TITLE
[eslint-plugin-react-hooks] useWithoutEffectSuffix fix (#18902)

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -415,6 +415,15 @@ const tests = {
       `,
     },
     {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          return renderHelperConfusedWithEffect(() => {
+            console.log(props.foo);
+          }, []);
+        }
+      `,
+    },
+    {
       // Valid because we don't care about hooks outside of components.
       code: normalizeIndent`
         const local = {};

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -406,6 +406,15 @@ const tests = {
       `,
     },
     {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useWithoutEffectSuffix(() => {
+            console.log(props.foo);
+          }, []);
+        }
+      `,
+    },
+    {
       // Valid because we don't care about hooks outside of components.
       code: normalizeIndent`
         const local = {};

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1510,7 +1510,7 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
       // useImperativeHandle(ref, fn)
       return 1;
     default:
-      if (node === calleeNode && node.name.match(/use.+Effect/)) {
+      if (node === calleeNode && node.name.match(/use.+Effect$/)) {
         return 0;
       } else if (node === calleeNode && options && options.additionalHooks) {
         // Allow the user to provide a regular expression which enables the lint to

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1510,7 +1510,7 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
       // useImperativeHandle(ref, fn)
       return 1;
     default:
-      if (node === calleeNode && node.name.match(/use.+Effect$/)) {
+      if (node === calleeNode && node.name.match(/^use.+Effect$/)) {
         return 0;
       } else if (node === calleeNode && options && options.additionalHooks) {
         // Allow the user to provide a regular expression which enables the lint to


### PR DESCRIPTION
##  Summary

Due to [a bug](https://github.com/facebook/react/issues/18902) `react-hooks/exhaustive-deps` currently warns whenever name contains `-Effect-` (even if it does NOT contain it as a suffix).

Since we only reserve `-Effect` suffix, react-hooks/exhaustive-deps is
expected to succeed without warning on a custom hook which contains `-Effect-` in
the middle of it's name (but does NOT contain it as a suffix).


## Test Plan

Added a testcase that fails when fix isn't present:
```
$ yarn test ExhaustiveDeps
yarn run v1.22.4
$ cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js ExhaustiveDeps
 FAIL  packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
  react-hooks
    valid
      ✕ 
function MyComponent(props) {
  useWithoutEffectSuffix(() => {
    console.log(props.foo);
  }, []);
}
 (282ms)

  ● react-hooks › valid › 
function MyComponent(props) {
  useWithoutEffectSuffix(() => {
    console.log(props.foo);
  }, []);
}


    assert.strictEqual(received, expected)

    Expected value to strictly be equal to:
      0
    Received:
      1
    
    Message:
      Should have no errors but had 1: [
      {
        ruleId: 'react-hooks',
        severity: 1,
        message: "React Hook useWithoutEffectSuffix has a missing dependency: 'props.foo'. Either include it or remove the dependency array.",
        line: 5,
        column: 6,
        nodeType: 'ArrayExpression',
        endLine: 5,
        endColumn: 8,
        suggestions: [ [Object] ]
      }
    ]

      at testValidTemplate (node_modules/eslint/lib/rule-tester/rule-tester.js:460:20)
      at Object.<anonymous> (node_modules/eslint/lib/rule-tester/rule-tester.js:662:25)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        2.13s, estimated 3s
Ran all test suites matching /ExhaustiveDeps/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Once fix is added test succeeds:
```
$ yarn test ExhaustiveDeps
yarn run v1.22.4
$ cross-env NODE_ENV=development jest --config ./scripts/jest/config.source.js ExhaustiveDeps
 PASS  packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
  react-hooks
    valid
      ✓ 
function MyComponent(props) {
  useWithoutEffectSuffix(() => {
    console.log(props.foo);
  }, []);
}
 (229ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.839s, estimated 9s
Ran all test suites matching /ExhaustiveDeps/i.
Done in 4.30s.
```