### PR TITLE
Fix useMutableSource tearing bug

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -997,14 +997,11 @@ function useMutableSource<Source, Snapshot>(
         const suspenseConfig = requestCurrentSuspenseConfig();
         const lane = requestUpdateLane(fiber, suspenseConfig);
         markRootMutableRead(root, lane);
-
-        // If the source mutated between render and now,
-        // there may be state updates already scheduled from the old source.
-        // Entangle the updates so that they render in the same batch.
-        // TODO: I think we need to entangle even if the snapshot matches,
-        // because there could have been an update to a different hook.
-        markRootEntangled(root, root.mutableReadLanes);
       }
+      // If the source mutated between render and now,
+      // there may be state updates already scheduled from the old source.
+      // Entangle the updates so that they render in the same batch.
+      markRootEntangled(root, root.mutableReadLanes);
     }
   }, [getSnapshot, source, subscribe]);
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -986,15 +986,14 @@ function useMutableSource<Source, Snapshot>(
           suspenseConfig,
         );
         setPendingExpirationTime(root, expirationTime);
-
-        // If the source mutated between render and now,
-        // there may be state updates already scheduled from the old getSnapshot.
-        // Those updates should not commit without this value.
-        // There is no mechanism currently to associate these updates though,
-        // so for now we fall back to synchronously flushing all pending updates.
-        // TODO: Improve this later.
-        markRootExpiredAtTime(root, getLastPendingExpirationTime(root));
       }
+      // If the source mutated between render and now,
+      // there may be state updates already scheduled from the old getSnapshot.
+      // Those updates should not commit without this value.
+      // There is no mechanism currently to associate these updates though,
+      // so for now we fall back to synchronously flushing all pending updates.
+      // TODO: Improve this later.
+      markRootExpiredAtTime(root, getLastPendingExpirationTime(root));
     }
   }, [getSnapshot, source, subscribe]);
 


### PR DESCRIPTION
If a source is mutated after initial read but before subscription is set up, it should still entangle all pending mutations even if snapshot of new subscription happens to match.

Test case illustrates how not doing this can lead to tearing.

The fix is to move the entanglement call outside of the block that checks if the snapshot has changed.