### PR TITLE
Add expando prop to disabledLog function

### DIFF
--- a/packages/shared/ConsolePatchingDev.js
+++ b/packages/shared/ConsolePatchingDev.js
@@ -19,6 +19,7 @@ let prevWarn;
 let prevError;
 
 function disabledLog() {}
+disabledLog.__reactDisabledLog = true;
 
 export function disableLogs(): void {
   if (__DEV__) {


### PR DESCRIPTION
This will enable it to be identified by Facebook infra even if the function name is mangled during DevTools build process.