### PR TITLE
Simplify logic for mutable workInProgressSources

### DIFF
--- a/packages/react-reconciler/src/ReactMutableSource.new.js
+++ b/packages/react-reconciler/src/ReactMutableSource.new.js
@@ -14,8 +14,7 @@ import {isPrimaryRenderer} from './ReactFiberHostConfig';
 // Work in progress version numbers only apply to a single render,
 // and should be reset before starting a new render.
 // This tracks which mutable sources need to be reset after a render.
-const workInProgressPrimarySources: Array<MutableSource<any>> = [];
-const workInProgressSecondarySources: Array<MutableSource<any>> = [];
+const workInProgressSources: Array<MutableSource<any>> = [];
 
 let rendererSigil;
 if (__DEV__) {
@@ -24,27 +23,19 @@ if (__DEV__) {
 }
 
 export function markSourceAsDirty(mutableSource: MutableSource<any>): void {
-  if (isPrimaryRenderer) {
-    workInProgressPrimarySources.push(mutableSource);
-  } else {
-    workInProgressSecondarySources.push(mutableSource);
-  }
+  workInProgressSources.push(mutableSource);
 }
 
 export function resetWorkInProgressVersions(): void {
-  if (isPrimaryRenderer) {
-    for (let i = 0; i < workInProgressPrimarySources.length; i++) {
-      const mutableSource = workInProgressPrimarySources[i];
+  for (let i = 0; i < workInProgressSources.length; i++) {
+    const mutableSource = workInProgressSources[i];
+    if (isPrimaryRenderer) {
       mutableSource._workInProgressVersionPrimary = null;
-    }
-    workInProgressPrimarySources.length = 0;
-  } else {
-    for (let i = 0; i < workInProgressSecondarySources.length; i++) {
-      const mutableSource = workInProgressSecondarySources[i];
+    } else {
       mutableSource._workInProgressVersionSecondary = null;
     }
-    workInProgressSecondarySources.length = 0;
   }
+  workInProgressSources.length = 0;
 }
 
 export function getWorkInProgressVersion(
@@ -63,11 +54,10 @@ export function setWorkInProgressVersion(
 ): void {
   if (isPrimaryRenderer) {
     mutableSource._workInProgressVersionPrimary = version;
-    workInProgressPrimarySources.push(mutableSource);
   } else {
     mutableSource._workInProgressVersionSecondary = version;
-    workInProgressSecondarySources.push(mutableSource);
   }
+  workInProgressSources.push(mutableSource);
 }
 
 export function warnAboutMultipleRenderersDEV(

--- a/packages/react-reconciler/src/ReactMutableSource.old.js
+++ b/packages/react-reconciler/src/ReactMutableSource.old.js
@@ -17,8 +17,7 @@ import {NoWork} from './ReactFiberExpirationTime.old';
 // Work in progress version numbers only apply to a single render,
 // and should be reset before starting a new render.
 // This tracks which mutable sources need to be reset after a render.
-const workInProgressPrimarySources: Array<MutableSource<any>> = [];
-const workInProgressSecondarySources: Array<MutableSource<any>> = [];
+const workInProgressSources: Array<MutableSource<any>> = [];
 
 let rendererSigil;
 if (__DEV__) {
@@ -55,27 +54,19 @@ export function setPendingExpirationTime(
 }
 
 export function markSourceAsDirty(mutableSource: MutableSource<any>): void {
-  if (isPrimaryRenderer) {
-    workInProgressPrimarySources.push(mutableSource);
-  } else {
-    workInProgressSecondarySources.push(mutableSource);
-  }
+  workInProgressSources.push(mutableSource);
 }
 
 export function resetWorkInProgressVersions(): void {
-  if (isPrimaryRenderer) {
-    for (let i = 0; i < workInProgressPrimarySources.length; i++) {
-      const mutableSource = workInProgressPrimarySources[i];
+  for (let i = 0; i < workInProgressSources.length; i++) {
+    const mutableSource = workInProgressSources[i];
+    if (isPrimaryRenderer) {
       mutableSource._workInProgressVersionPrimary = null;
-    }
-    workInProgressPrimarySources.length = 0;
-  } else {
-    for (let i = 0; i < workInProgressSecondarySources.length; i++) {
-      const mutableSource = workInProgressSecondarySources[i];
+    } else {
       mutableSource._workInProgressVersionSecondary = null;
     }
-    workInProgressSecondarySources.length = 0;
   }
+  workInProgressSources.length = 0;
 }
 
 export function getWorkInProgressVersion(
@@ -94,11 +85,10 @@ export function setWorkInProgressVersion(
 ): void {
   if (isPrimaryRenderer) {
     mutableSource._workInProgressVersionPrimary = version;
-    workInProgressPrimarySources.push(mutableSource);
   } else {
     mutableSource._workInProgressVersionSecondary = version;
-    workInProgressSecondarySources.push(mutableSource);
   }
+  workInProgressSources.push(mutableSource);
 }
 
 export function warnAboutMultipleRenderersDEV(


### PR DESCRIPTION
isPrimaryRenderer is always constant for a given React build, so these two arrays do nothing.
