### PR TITLE
useMutableSource: Allow returning function from getSnapshot

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1012,7 +1012,8 @@ function useMutableSource<Source, Snapshot>(
       const latestSetSnapshot = refs.setSnapshot;
 
       try {
-        latestSetSnapshot(latestGetSnapshot(source._source));
+        const value = latestGetSnapshot(source._source);
+        latestSetSnapshot(() => value);
 
         // Record a pending mutable source update with the same expiration time.
         const suspenseConfig = requestCurrentSuspenseConfig();

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1004,7 +1004,8 @@ function useMutableSource<Source, Snapshot>(
       const latestSetSnapshot = refs.setSnapshot;
 
       try {
-        latestSetSnapshot(latestGetSnapshot(source._source));
+        const value = latestGetSnapshot(source._source);
+        latestSetSnapshot(() => value);
 
         // Record a pending mutable source update with the same expiration time.
         const currentTime = requestCurrentTimeForUpdate();


### PR DESCRIPTION
basicStateReducer strikes again.