### PR TITLE
Add test for displayName on React.memo components

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -502,16 +502,30 @@ describe('memo', () => {
       const MemoComponent = React.memo(function Component(props) {
         return <div {...props} />;
       });
-
       MemoComponent.displayName = 'Foo';
-
       MemoComponent.propTypes = {
-        optional: PropTypes.string,
         required: PropTypes.string.isRequired,
       };
 
-      MemoComponent.defaultProps = {
-        optional: 'default',
+      expect(() =>
+        ReactNoop.render(<MemoComponent optional="foo" />),
+      ).toErrorDev(
+        'Warning: Failed prop type: The prop `required` is marked as required in ' +
+          '`Foo`, but its value is `undefined`.\n' +
+          '    in Foo (at **)',
+      );
+    });
+
+    it('should honor a inner displayName if set on the wrapped function', () => {
+      function Component(props) {
+        return <div {...props} />;
+      }
+      Component.displayName = 'Foo';
+
+      const MemoComponent = React.memo(Component);
+      MemoComponent.displayName = 'Bar';
+      MemoComponent.propTypes = {
+        required: PropTypes.string.isRequired,
       };
 
       expect(() =>

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -497,5 +497,30 @@ describe('memo', () => {
         expect(root).toMatchRenderedOutput('1');
       });
     });
+
+    it('should honor a displayName if set on the memo wrapper in warnings', () => {
+      const MemoComponent = React.memo(function Component(props) {
+        return <div {...props} />;
+      });
+
+      MemoComponent.displayName = 'Foo';
+
+      MemoComponent.propTypes = {
+        optional: PropTypes.string,
+        required: PropTypes.string.isRequired,
+      };
+
+      MemoComponent.defaultProps = {
+        optional: 'default',
+      };
+
+      expect(() =>
+        ReactNoop.render(<MemoComponent optional="foo" />),
+      ).toErrorDev(
+        'Warning: Failed prop type: The prop `required` is marked as required in ' +
+          '`Foo`, but its value is `undefined`.\n' +
+          '    in Foo (at **)',
+      );
+    });
   }
 });


### PR DESCRIPTION
## Summary

Adds a test for display name behavior of
```js
const MemoComponent = React.memo(() => {});
MemoComponent.displayName = "SomeName";
```

The behavior was implemented in https://github.com/facebook/react/pull/18495/files#diff-ad60306adf3e53077dba1bbeabd57b19R30-R45<sup>1</sup> but untested. Commenting out the linked lines does not break any test on `master`.

<sup>1</sup> Might need to scroll a bit when opening a link since the highlighted lines are collapsed initially.

## Test Plan

n/a
