### PR TITLE
Add MIT license to use-subscription package

### DIFF
--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -14,6 +14,7 @@
     "index.js",
     "cjs/"
   ],
+  "license": "MIT",
   "dependencies": {
     "object-assign": "^4.1.1"
   },


### PR DESCRIPTION
## Summary
This package is missing the license attribute (or a license file).

Being a sub-package of React, it should get the same license, however, none was specified.
A scan with `license_checker` would recognize this as `UNKNOWN`.

## Test Plan
_none_