### PR TITLE
Update inaccurate mapChildren comment

### DIFF
--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -212,7 +212,7 @@ type MapFunc = (child: ?React$Node) => ?ReactNodeList;
  *
  * See https://reactjs.org/docs/react-api.html#reactchildrenmap
  *
- * The provided mapFunction(child, key, index) will be called for each
+ * The provided mapFunction(child, index) will be called for each
  * leaf child.
  *
  * @param {?*} children Children tree container.


### PR DESCRIPTION
The function you provide will only be passed a child and an index. It will not be passed a key. This is confirmed in the source, the Flow types, and the jsdoc comments.

## Summary

I was actually looking for a child map api that would expose keys and noticed this comment. It gave me the wrong impression and took a few minutes to re-affirm my understanding of React.Children and how it works. Removing this inaccuracy to hopefully prevent a similar misunderstanding in the future.

## Test Plan

I ran absolutely no tests. This is a non-jsdoc comment-only change.
