### PR TITLE
Proof-of-concept: Express render phase in terms of generator functions

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
+import type {ReactContext} from 'shared/ReactTypes';
 import type {BlockComponent} from 'react/src/ReactBlock';
 import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
 import type {Fiber} from './ReactInternalTypes';
@@ -142,11 +142,8 @@ import {
 } from './ReactFiberSuspenseContext.new';
 import {findFirstSuspended} from './ReactFiberSuspenseComponent.new';
 import {
-  pushProvider,
-  propagateContextChange,
   readContext,
   prepareToReadContext,
-  calculateChangedBits,
   scheduleWorkOnParentPath,
 } from './ReactFiberNewContext.new';
 import {renderWithHooks, bailoutHooks} from './ReactFiberHooks.new';
@@ -194,6 +191,8 @@ import {
   getWorkInProgressRoot,
   pushRenderLanes,
 } from './ReactFiberWorkLoop.new';
+import {renderContextProvider} from './ReactFiberRenderWork.new';
+import {beginGeneratorComponent} from './ReactFiberGeneratorComponent.new';
 import {unstable_wrap as Schedule_tracing_wrap} from 'scheduler/tracing';
 
 import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
@@ -2771,56 +2770,6 @@ function updatePortalComponent(
   return workInProgress.child;
 }
 
-function updateContextProvider(
-  current: Fiber | null,
-  workInProgress: Fiber,
-  renderLanes: Lanes,
-) {
-  const providerType: ReactProviderType<any> = workInProgress.type;
-  const context: ReactContext<any> = providerType._context;
-
-  const newProps = workInProgress.pendingProps;
-  const oldProps = workInProgress.memoizedProps;
-
-  const newValue = newProps.value;
-
-  if (__DEV__) {
-    const providerPropTypes = workInProgress.type.propTypes;
-
-    if (providerPropTypes) {
-      checkPropTypes(providerPropTypes, newProps, 'prop', 'Context.Provider');
-    }
-  }
-
-  pushProvider(workInProgress, newValue);
-
-  if (oldProps !== null) {
-    const oldValue = oldProps.value;
-    const changedBits = calculateChangedBits(context, newValue, oldValue);
-    if (changedBits === 0) {
-      // No change. Bailout early if children are the same.
-      if (
-        oldProps.children === newProps.children &&
-        !hasLegacyContextChanged()
-      ) {
-        return bailoutOnAlreadyFinishedWork(
-          current,
-          workInProgress,
-          renderLanes,
-        );
-      }
-    } else {
-      // The context value changed. Search for matching consumers and schedule
-      // them to update.
-      propagateContextChange(workInProgress, context, changedBits, renderLanes);
-    }
-  }
-
-  const newChildren = newProps.children;
-  reconcileChildren(current, workInProgress, newChildren, renderLanes);
-  return workInProgress.child;
-}
-
 let hasWarnedAboutUsingContextAsConsumer = false;
 
 function updateContextConsumer(
@@ -3042,190 +2991,203 @@ function beginWork(
       // If props or context changed, mark the fiber as having performed work.
       // This may be unset if the props are determined to be equal later (memo).
       didReceiveUpdate = true;
-    } else if (!includesSomeLane(renderLanes, updateLanes)) {
-      didReceiveUpdate = false;
-      // This fiber does not have any pending work. Bailout without entering
-      // the begin phase. There's still some bookkeeping we that needs to be done
-      // in this optimized path, mostly pushing stuff onto the stack.
-      switch (workInProgress.tag) {
-        case HostRoot:
-          pushHostRootContext(workInProgress);
-          resetHydrationState();
-          break;
-        case HostComponent:
-          pushHostContext(workInProgress);
-          break;
-        case ClassComponent: {
-          const Component = workInProgress.type;
-          if (isLegacyContextProvider(Component)) {
-            pushLegacyContextProvider(workInProgress);
-          }
-          break;
-        }
-        case HostPortal:
-          pushHostContainer(
-            workInProgress,
-            workInProgress.stateNode.containerInfo,
-          );
-          break;
-        case ContextProvider: {
-          const newValue = workInProgress.memoizedProps.value;
-          pushProvider(workInProgress, newValue);
-          break;
-        }
-        case Profiler:
-          if (enableProfilerTimer) {
-            // Profiler should only call onRender when one of its descendants actually rendered.
-            const hasChildWork = includesSomeLane(
-              renderLanes,
-              workInProgress.childLanes,
-            );
-            if (hasChildWork) {
-              workInProgress.effectTag |= Update;
-            }
 
-            // Reset effect durations for the next eventual effect phase.
-            // These are reset during render to allow the DevTools commit hook a chance to read them,
-            const stateNode = workInProgress.stateNode;
-            stateNode.effectDuration = 0;
-            stateNode.passiveEffectDuration = 0;
+      // TODO: Extract the bailout path to its own special phase
+      /* eslint-disable no-labels  */
+    } else
+      bailoutWork: if (!includesSomeLane(renderLanes, updateLanes)) {
+        didReceiveUpdate = false;
+        // This fiber does not have any pending work. Bailout without entering
+        // the begin phase. There's still some bookkeeping we that needs to be done
+        // in this optimized path, mostly pushing stuff onto the stack.
+        switch (workInProgress.tag) {
+          case HostRoot:
+            pushHostRootContext(workInProgress);
+            resetHydrationState();
+            break;
+          case HostComponent:
+            pushHostContext(workInProgress);
+            break;
+          case ClassComponent: {
+            const Component = workInProgress.type;
+            if (isLegacyContextProvider(Component)) {
+              pushLegacyContextProvider(workInProgress);
+            }
+            break;
           }
-          break;
-        case SuspenseComponent: {
-          const state: SuspenseState | null = workInProgress.memoizedState;
-          if (state !== null) {
-            if (enableSuspenseServerRenderer) {
-              if (state.dehydrated !== null) {
+          case HostPortal:
+            pushHostContainer(
+              workInProgress,
+              workInProgress.stateNode.containerInfo,
+            );
+            break;
+          case ContextProvider: {
+            break bailoutWork;
+          }
+          case Profiler:
+            if (enableProfilerTimer) {
+              // Profiler should only call onRender when one of its descendants actually rendered.
+              const hasChildWork = includesSomeLane(
+                renderLanes,
+                workInProgress.childLanes,
+              );
+              if (hasChildWork) {
+                workInProgress.effectTag |= Update;
+              }
+
+              // Reset effect durations for the next eventual effect phase.
+              // These are reset during render to allow the DevTools commit hook a chance to read them,
+              const stateNode = workInProgress.stateNode;
+              stateNode.effectDuration = 0;
+              stateNode.passiveEffectDuration = 0;
+            }
+            break;
+          case SuspenseComponent: {
+            const state: SuspenseState | null = workInProgress.memoizedState;
+            if (state !== null) {
+              if (enableSuspenseServerRenderer) {
+                if (state.dehydrated !== null) {
+                  pushSuspenseContext(
+                    workInProgress,
+                    setDefaultShallowSuspenseContext(
+                      suspenseStackCursor.current,
+                    ),
+                  );
+                  // We know that this component will suspend again because if it has
+                  // been unsuspended it has committed as a resolved Suspense component.
+                  // If it needs to be retried, it should have work scheduled on it.
+                  workInProgress.effectTag |= DidCapture;
+                  // We should never render the children of a dehydrated boundary until we
+                  // upgrade it. We return null instead of bailoutOnAlreadyFinishedWork.
+                  return null;
+                }
+              }
+
+              // If this boundary is currently timed out, we need to decide
+              // whether to retry the primary children, or to skip over it and
+              // go straight to the fallback. Check the priority of the primary
+              // child fragment.
+              const primaryChildFragment: Fiber = (workInProgress.child: any);
+              const primaryChildLanes = primaryChildFragment.childLanes;
+              if (includesSomeLane(renderLanes, primaryChildLanes)) {
+                // The primary children have pending work. Use the normal path
+                // to attempt to render the primary children again.
+                return updateSuspenseComponent(
+                  current,
+                  workInProgress,
+                  renderLanes,
+                );
+              } else {
+                // The primary child fragment does not have pending work marked
+                // on it
                 pushSuspenseContext(
                   workInProgress,
                   setDefaultShallowSuspenseContext(suspenseStackCursor.current),
                 );
-                // We know that this component will suspend again because if it has
-                // been unsuspended it has committed as a resolved Suspense component.
-                // If it needs to be retried, it should have work scheduled on it.
-                workInProgress.effectTag |= DidCapture;
-                // We should never render the children of a dehydrated boundary until we
-                // upgrade it. We return null instead of bailoutOnAlreadyFinishedWork.
-                return null;
+                // The primary children do not have pending work with sufficient
+                // priority. Bailout.
+                const child = bailoutOnAlreadyFinishedWork(
+                  current,
+                  workInProgress,
+                  renderLanes,
+                );
+                if (child !== null) {
+                  // The fallback children have pending work. Skip over the
+                  // primary children and work on the fallback.
+                  return child.sibling;
+                } else {
+                  return null;
+                }
               }
-            }
-
-            // If this boundary is currently timed out, we need to decide
-            // whether to retry the primary children, or to skip over it and
-            // go straight to the fallback. Check the priority of the primary
-            // child fragment.
-            const primaryChildFragment: Fiber = (workInProgress.child: any);
-            const primaryChildLanes = primaryChildFragment.childLanes;
-            if (includesSomeLane(renderLanes, primaryChildLanes)) {
-              // The primary children have pending work. Use the normal path
-              // to attempt to render the primary children again.
-              return updateSuspenseComponent(
-                current,
-                workInProgress,
-                renderLanes,
-              );
             } else {
-              // The primary child fragment does not have pending work marked
-              // on it
               pushSuspenseContext(
                 workInProgress,
                 setDefaultShallowSuspenseContext(suspenseStackCursor.current),
               );
-              // The primary children do not have pending work with sufficient
-              // priority. Bailout.
-              const child = bailoutOnAlreadyFinishedWork(
-                current,
-                workInProgress,
-                renderLanes,
-              );
-              if (child !== null) {
-                // The fallback children have pending work. Skip over the
-                // primary children and work on the fallback.
-                return child.sibling;
-              } else {
-                return null;
-              }
             }
-          } else {
-            pushSuspenseContext(
+            break;
+          }
+          case SuspenseListComponent: {
+            const didSuspendBefore =
+              (current.effectTag & DidCapture) !== NoEffect;
+
+            const hasChildWork = includesSomeLane(
+              renderLanes,
+              workInProgress.childLanes,
+            );
+
+            if (didSuspendBefore) {
+              if (hasChildWork) {
+                // If something was in fallback state last time, and we have all the
+                // same children then we're still in progressive loading state.
+                // Something might get unblocked by state updates or retries in the
+                // tree which will affect the tail. So we need to use the normal
+                // path to compute the correct tail.
+                return updateSuspenseListComponent(
+                  current,
+                  workInProgress,
+                  renderLanes,
+                );
+              }
+              // If none of the children had any work, that means that none of
+              // them got retried so they'll still be blocked in the same way
+              // as before. We can fast bail out.
+              workInProgress.effectTag |= DidCapture;
+            }
+
+            // If nothing suspended before and we're rendering the same children,
+            // then the tail doesn't matter. Anything new that suspends will work
+            // in the "together" mode, so we can continue from the state we had.
+            const renderState = workInProgress.memoizedState;
+            if (renderState !== null) {
+              // Reset to the "together" mode in case we've started a different
+              // update in the past but didn't complete it.
+              renderState.rendering = null;
+              renderState.tail = null;
+              renderState.lastEffect = null;
+            }
+            pushSuspenseContext(workInProgress, suspenseStackCursor.current);
+
+            if (hasChildWork) {
+              break;
+            } else {
+              // If none of the children had any work, that means that none of
+              // them got retried so they'll still be blocked in the same way
+              // as before. We can fast bail out.
+              return null;
+            }
+          }
+          case OffscreenComponent:
+          case LegacyHiddenComponent: {
+            // Need to check if the tree still needs to be deferred. This is
+            // almost identical to the logic used in the normal update path,
+            // so we'll just enter that. The only difference is we'll bail out
+            // at the next level instead of this one, because the child props
+            // have not changed. Which is fine.
+            // TODO: Probably should refactor `beginWork` to split the bailout
+            // path from the normal path. I'm tempted to do a labeled break here
+            // but I won't :)
+            workInProgress.lanes = NoLanes;
+            return updateOffscreenComponent(
+              current,
               workInProgress,
-              setDefaultShallowSuspenseContext(suspenseStackCursor.current),
+              renderLanes,
             );
           }
-          break;
         }
-        case SuspenseListComponent: {
-          const didSuspendBefore =
-            (current.effectTag & DidCapture) !== NoEffect;
-
-          const hasChildWork = includesSomeLane(
-            renderLanes,
-            workInProgress.childLanes,
-          );
-
-          if (didSuspendBefore) {
-            if (hasChildWork) {
-              // If something was in fallback state last time, and we have all the
-              // same children then we're still in progressive loading state.
-              // Something might get unblocked by state updates or retries in the
-              // tree which will affect the tail. So we need to use the normal
-              // path to compute the correct tail.
-              return updateSuspenseListComponent(
-                current,
-                workInProgress,
-                renderLanes,
-              );
-            }
-            // If none of the children had any work, that means that none of
-            // them got retried so they'll still be blocked in the same way
-            // as before. We can fast bail out.
-            workInProgress.effectTag |= DidCapture;
-          }
-
-          // If nothing suspended before and we're rendering the same children,
-          // then the tail doesn't matter. Anything new that suspends will work
-          // in the "together" mode, so we can continue from the state we had.
-          const renderState = workInProgress.memoizedState;
-          if (renderState !== null) {
-            // Reset to the "together" mode in case we've started a different
-            // update in the past but didn't complete it.
-            renderState.rendering = null;
-            renderState.tail = null;
-            renderState.lastEffect = null;
-          }
-          pushSuspenseContext(workInProgress, suspenseStackCursor.current);
-
-          if (hasChildWork) {
-            break;
-          } else {
-            // If none of the children had any work, that means that none of
-            // them got retried so they'll still be blocked in the same way
-            // as before. We can fast bail out.
-            return null;
-          }
-        }
-        case OffscreenComponent:
-        case LegacyHiddenComponent: {
-          // Need to check if the tree still needs to be deferred. This is
-          // almost identical to the logic used in the normal update path,
-          // so we'll just enter that. The only difference is we'll bail out
-          // at the next level instead of this one, because the child props
-          // have not changed. Which is fine.
-          // TODO: Probably should refactor `beginWork` to split the bailout
-          // path from the normal path. I'm tempted to do a labeled break here
-          // but I won't :)
-          workInProgress.lanes = NoLanes;
-          return updateOffscreenComponent(current, workInProgress, renderLanes);
-        }
+        /* eslint-enable no-labels  */
+        return bailoutOnAlreadyFinishedWork(
+          current,
+          workInProgress,
+          renderLanes,
+        );
+      } else {
+        // An update was scheduled on this fiber, but there are no new props
+        // nor legacy context. Set this to false. If an update queue or context
+        // consumer produces a changed value, it will set this to true. Otherwise,
+        // the component will assume the children have not changed and bail out.
+        didReceiveUpdate = false;
       }
-      return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
-    } else {
-      // An update was scheduled on this fiber, but there are no new props
-      // nor legacy context. Set this to false. If an update queue or context
-      // consumer produces a changed value, it will set this to true. Otherwise,
-      // the component will assume the children have not changed and bail out.
-      didReceiveUpdate = false;
-    }
   } else {
     didReceiveUpdate = false;
   }
@@ -3317,8 +3279,14 @@ function beginWork(
       return updateMode(current, workInProgress, renderLanes);
     case Profiler:
       return updateProfiler(current, workInProgress, renderLanes);
-    case ContextProvider:
-      return updateContextProvider(current, workInProgress, renderLanes);
+    case ContextProvider: {
+      return beginGeneratorComponent(
+        renderContextProvider,
+        current,
+        workInProgress,
+        renderLanes,
+      );
+    }
     case ContextConsumer:
       return updateContextConsumer(current, workInProgress, renderLanes);
     case MemoComponent: {

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -111,7 +111,6 @@ import {
   popContext as popLegacyContext,
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext.new';
-import {popProvider} from './ReactFiberNewContext.new';
 import {
   prepareToHydrateHostInstance,
   prepareToHydrateHostTextInstance,
@@ -141,6 +140,7 @@ import {OffscreenLane} from './ReactFiberLane';
 import {resetChildFibers} from './ReactChildFiber.new';
 import {updateDeprecatedEventListeners} from './ReactFiberDeprecatedEvents.new';
 import {createScopeInstance} from './ReactFiberScope.new';
+import {completeGeneratorComponent} from './ReactFiberGeneratorComponent.new';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -977,9 +977,7 @@ function completeWork(
       }
       return null;
     case ContextProvider:
-      // Pop provider fiber
-      popProvider(workInProgress);
-      return null;
+      return completeGeneratorComponent(current, workInProgress);
     case IncompleteClassComponent: {
       // Same as class component case. I put it down here so that the tags are
       // sequential to ensure this switch is compiled to a jump table.

--- a/packages/react-reconciler/src/ReactFiberGeneratorComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberGeneratorComponent.new.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber} from './ReactInternalTypes';
+import type {Lanes} from './ReactFiberLane';
+
+import {NoEffect, GeneratorIncomplete} from './ReactSideEffectTags';
+
+export type RenderStateMachine = Generator<Fiber | null, void, void>;
+
+const stack = [];
+
+export function beginGeneratorComponent(
+  generatorFn: (
+    current: Fiber | null,
+    workInProgress: Fiber,
+    renderLanes: Lanes,
+  ) => RenderStateMachine,
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+): Fiber | null {
+  const stateMachine = generatorFn(current, workInProgress, renderLanes);
+  const state = stateMachine.next();
+  if (state.done) {
+    return null;
+  }
+  workInProgress.effectTag |= GeneratorIncomplete;
+  stack.push(stateMachine);
+  return state.value;
+}
+
+export function completeGeneratorComponent(
+  current: Fiber | null,
+  workInProgress: Fiber,
+): Fiber | null {
+  if ((workInProgress.effectTag & GeneratorIncomplete) === NoEffect) {
+    return null;
+  }
+  const stateMachine = stack.pop();
+  const state = stateMachine.next();
+  if (state.done) {
+    workInProgress.effectTag &= ~GeneratorIncomplete;
+    return null;
+  }
+  stack.push(stateMachine);
+  return state.value;
+}
+
+export function unwindGeneratorComponent(workInProgress: Fiber): Fiber | null {
+  if ((workInProgress.effectTag & GeneratorIncomplete) === NoEffect) {
+    return null;
+  }
+  const stateMachine = stack.pop();
+  try {
+    const state = stateMachine.throw(null);
+    if (state.done) {
+      workInProgress.effectTag &= ~GeneratorIncomplete;
+      return null;
+    }
+    stack.push(stateMachine);
+    return state.value;
+  } catch (error) {
+    workInProgress.effectTag &= ~GeneratorIncomplete;
+    return null;
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberRenderWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberRenderWork.new.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
+import type {Fiber} from './ReactInternalTypes';
+import type {Lanes} from './ReactFiberLane';
+import type {RenderStateMachine} from './ReactFiberGeneratorComponent.new';
+
+import {enableProfilerTimer} from 'shared/ReactFeatureFlags';
+
+import {includesSomeLane} from './ReactFiberLane';
+import {reconcileChildren} from './ReactFiberBeginWork.new';
+import {cloneChildFibers} from './ReactChildFiber.new';
+import {
+  pushProvider,
+  popProvider,
+  propagateContextChange,
+  calculateChangedBits,
+} from './ReactFiberNewContext.new';
+import {hasContextChanged as hasLegacyContextChanged} from './ReactFiberContext.new';
+import checkPropTypes from 'shared/checkPropTypes';
+import {stopProfilerTimerIfRunning} from './ReactProfilerTimer.new';
+
+export function* renderContextProvider(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+): RenderStateMachine {
+  const providerType: ReactProviderType<any> = workInProgress.type;
+  const context: ReactContext<any> = providerType._context;
+
+  const newProps = workInProgress.pendingProps;
+  const oldProps = workInProgress.memoizedProps;
+
+  if (__DEV__) {
+    const providerPropTypes = workInProgress.type.propTypes;
+
+    if (providerPropTypes) {
+      checkPropTypes(providerPropTypes, newProps, 'prop', 'Context.Provider');
+    }
+  }
+
+  const newValue = newProps.value;
+  pushProvider(workInProgress, newValue);
+
+  try {
+    if (oldProps !== null) {
+      const oldValue = oldProps.value;
+      const changedBits = calculateChangedBits(context, newValue, oldValue);
+      if (changedBits === 0) {
+        // No change. Bailout early if children are the same.
+        if (
+          oldProps.children === newProps.children &&
+          !hasLegacyContextChanged()
+        ) {
+          return yield* bailoutOnAlreadyFinishedWork(
+            current,
+            workInProgress,
+            renderLanes,
+          );
+        }
+      } else {
+        propagateContextChange(
+          workInProgress,
+          context,
+          changedBits,
+          renderLanes,
+        );
+      }
+    }
+
+    const newChildren = newProps.children;
+    reconcileChildren(current, workInProgress, newChildren, renderLanes);
+    yield workInProgress.child;
+  } finally {
+    popProvider(workInProgress);
+  }
+}
+
+function* bailoutOnAlreadyFinishedWork(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+): RenderStateMachine {
+  // Fork of function with the same name in ReactFiberBeginWork
+  //
+  // These lines aren't used by any of the components in this module
+  // if (current !== null) {
+  //   // Reuse previous dependencies
+  //   workInProgress.dependencies_new = current.dependencies_new;
+  // }
+  //
+  // markSkippedUpdateLanes(workInProgress.lanes);
+
+  if (enableProfilerTimer) {
+    // Don't update "base" render times for bailouts.
+    stopProfilerTimerIfRunning(workInProgress);
+  }
+
+  // Check if the children have any pending work.
+  if (!includesSomeLane(renderLanes, workInProgress.childLanes)) {
+    // The children don't have any work either. We can skip them.
+    // TODO: Once we add back resuming, we should check if the children are
+    // a work-in-progress set. If so, we need to transfer their effects.
+  } else {
+    // This fiber doesn't have work, but its subtree does. Clone the child
+    // fibers and continue.
+    cloneChildFibers(current, workInProgress);
+    yield workInProgress.child;
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberRenderWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberRenderWork.new.js
@@ -18,8 +18,8 @@ import {includesSomeLane} from './ReactFiberLane';
 import {reconcileChildren} from './ReactFiberBeginWork.new';
 import {cloneChildFibers} from './ReactChildFiber.new';
 import {
-  pushProvider,
-  popProvider,
+  setContextValue,
+  restoreContextValue,
   propagateContextChange,
   calculateChangedBits,
 } from './ReactFiberNewContext.new';
@@ -47,8 +47,7 @@ export function* renderContextProvider(
   }
 
   const newValue = newProps.value;
-  pushProvider(workInProgress, newValue);
-
+  const prevValueOnStack = setContextValue(context, newValue);
   try {
     if (oldProps !== null) {
       const oldValue = oldProps.value;
@@ -79,7 +78,7 @@ export function* renderContextProvider(
     reconcileChildren(current, workInProgress, newChildren, renderLanes);
     yield workInProgress.child;
   } finally {
-    popProvider(workInProgress);
+    restoreContextValue(context, prevValueOnStack);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -34,8 +34,8 @@ import {
   popContext as popLegacyContext,
   popTopLevelContextObject as popTopLevelLegacyContextObject,
 } from './ReactFiberContext.new';
-import {popProvider} from './ReactFiberNewContext.new';
 import {popRenderLanes} from './ReactFiberWorkLoop.new';
+import {unwindGeneratorComponent} from './ReactFiberGeneratorComponent.new';
 
 import invariant from 'shared/invariant';
 
@@ -103,7 +103,7 @@ function unwindWork(workInProgress: Fiber, renderLanes: Lanes) {
       popHostContainer(workInProgress);
       return null;
     case ContextProvider:
-      popProvider(workInProgress);
+      unwindGeneratorComponent(workInProgress);
       return null;
     case OffscreenComponent:
     case LegacyHiddenComponent:
@@ -143,7 +143,7 @@ function unwindInterruptedWork(interruptedWork: Fiber) {
       popSuspenseContext(interruptedWork);
       break;
     case ContextProvider:
-      popProvider(interruptedWork);
+      unwindGeneratorComponent(interruptedWork);
       break;
     case OffscreenComponent:
     case LegacyHiddenComponent:

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -36,3 +36,4 @@ export const HostEffectMask = /*           */ 0b00011111111111;
 
 export const Incomplete = /*               */ 0b00100000000000;
 export const ShouldCapture = /*            */ 0b01000000000000;
+export const GeneratorIncomplete = /*      */ 0b10000000000000;


### PR DESCRIPTION
Combines all the sub-phases of the render phase — begin, complete, and unwind — into a single generator function.

It works by pushing/popping generator objects onto a stack. This replaces the stack in ReactFiberStack.

The cursor objects used by ReactFiberStack are replaced by module level variables that are referenced via closure.

For our release builds, what we would do is compile the generator functions to normal, static functions that push/pop to the stack directly, skipping the overhead of the generator objects.

The first one I've ported is Context providers.