### PR TITLE
Profiler: Fix error on profiling stop

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js
@@ -8,7 +8,14 @@
  */
 
 import * as React from 'react';
-import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+} from 'react';
 import {unstable_batchedUpdates as batchedUpdates} from 'react-dom';
 import {useLocalStorage, useSubscription} from '../hooks';
 import {
@@ -68,6 +75,11 @@ export type Context = {|
   // Which interaction is currently selected in the Interactions graph?
   selectedInteractionID: number | null,
   selectInteraction: (id: number | null) => void,
+
+  numFilteredCommits: number,
+  setNumFilteredCommits: (value: number) => void,
+  selectedFilteredCommitIndex: number | null,
+  setSelectedFilteredCommitIndex: (value: number | null) => void,
 |};
 
 const ProfilerContext = createContext<Context>(((null: any): Context));
@@ -235,6 +247,29 @@ function ProfilerContextController({children}: Props) {
     });
   }
 
+  const [numFilteredCommits, setNumFilteredCommits] = useState<number>(0);
+  const [
+    selectedFilteredCommitIndex,
+    setSelectedFilteredCommitIndex,
+  ] = useState<number | null>(null);
+
+  // TODO (ProfilerContext) This should be managed by the context controller (reducer).
+  useEffect(() => {
+    if (selectedFilteredCommitIndex === null) {
+      if (numFilteredCommits > 0) {
+        selectCommitIndex(0);
+      } else {
+        selectCommitIndex(null);
+      }
+    } else if (selectedFilteredCommitIndex >= numFilteredCommits) {
+      if (numFilteredCommits === 0) {
+        selectCommitIndex(null);
+      } else {
+        selectCommitIndex(numFilteredCommits - 1);
+      }
+    }
+  }, [selectedFilteredCommitIndex, numFilteredCommits]);
+
   const value = useMemo(
     () => ({
       selectedTabID,
@@ -265,6 +300,11 @@ function ProfilerContextController({children}: Props) {
 
       selectedInteractionID,
       selectInteraction,
+
+      numFilteredCommits,
+      setNumFilteredCommits,
+      selectedFilteredCommitIndex,
+      setSelectedFilteredCommitIndex,
     }),
     [
       selectedTabID,
@@ -296,6 +336,11 @@ function ProfilerContextController({children}: Props) {
 
       selectedInteractionID,
       selectInteraction,
+
+      numFilteredCommits,
+      setNumFilteredCommits,
+      selectedFilteredCommitIndex,
+      setSelectedFilteredCommitIndex,
     ],
   );
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotSelector.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotSelector.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {Fragment, useCallback, useContext, useMemo} from 'react';
+import {Fragment, useCallback, useContext, useMemo, useEffect} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {ProfilerContext} from './ProfilerContext';
@@ -27,6 +27,10 @@ export default function SnapshotSelector(_: Props) {
     rootID,
     selectedCommitIndex,
     selectCommitIndex,
+    numFilteredCommits,
+    setNumFilteredCommits,
+    selectedFilteredCommitIndex,
+    setSelectedFilteredCommitIndex,
   } = useContext(ProfilerContext);
 
   const {profilerStore} = useContext(StoreContext);
@@ -53,10 +57,12 @@ export default function SnapshotSelector(_: Props) {
     [commitData, isCommitFilterEnabled, minCommitDuration],
   );
 
-  const numFilteredCommits = filteredCommitIndices.length;
+  useEffect(() => {
+    setNumFilteredCommits(filteredCommitIndices.length);
+  }, [filteredCommitIndices.length]);
 
   // Map the (unfiltered) selected commit index to an index within the filtered data.
-  const selectedFilteredCommitIndex = useMemo(() => {
+  const newSelectedFilteredCommitIndex = useMemo(() => {
     if (selectedCommitIndex !== null) {
       for (let i = 0; i < filteredCommitIndices.length; i++) {
         if (filteredCommitIndices[i] === selectedCommitIndex) {
@@ -67,18 +73,9 @@ export default function SnapshotSelector(_: Props) {
     return null;
   }, [filteredCommitIndices, selectedCommitIndex]);
 
-  // TODO (ProfilerContext) This should be managed by the context controller (reducer).
-  // It doesn't currently know about the filtered commits though (since it doesn't suspend).
-  // Maybe this component should pass filteredCommitIndices up?
-  if (selectedFilteredCommitIndex === null) {
-    if (numFilteredCommits > 0) {
-      selectCommitIndex(0);
-    } else {
-      selectCommitIndex(null);
-    }
-  } else if (selectedFilteredCommitIndex >= numFilteredCommits) {
-    selectCommitIndex(numFilteredCommits === 0 ? null : numFilteredCommits - 1);
-  }
+  useEffect(() => {
+    setSelectedFilteredCommitIndex(newSelectedFilteredCommitIndex);
+  }, [newSelectedFilteredCommitIndex]);
 
   let label = null;
   if (numFilteredCommits > 0) {


### PR DESCRIPTION
Fix browser console error which is thrown on profiling stop: `Warning: Cannot update a component ('ProfilerContextController') while rendering a different component ('SnapshotSelector')` by moving code of `SnapshotSelector` containing commit index update logic responsible for error to `ProfilerContext` (according to comment above that code)