### PR TITLE
DevTools editable props tweaks

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.css
@@ -3,7 +3,7 @@
 }
 
 .Name {
-  color: var(--color-dim);
+  color: var(--color-attribute-name-not-editable);
   flex: 0 0 auto;
   cursor: default;
 }

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -235,6 +235,11 @@ function updateThemeVariables(
   documentElements: DocumentElements,
 ): void {
   updateStyleHelper(theme, 'color-attribute-name', documentElements);
+  updateStyleHelper(
+    theme,
+    'color-attribute-name-not-editable',
+    documentElements,
+  );
   updateStyleHelper(theme, 'color-attribute-name-inverted', documentElements);
   updateStyleHelper(theme, 'color-attribute-value', documentElements);
   updateStyleHelper(theme, 'color-attribute-value-inverted', documentElements);

--- a/packages/react-devtools-shared/src/devtools/views/root.css
+++ b/packages/react-devtools-shared/src/devtools/views/root.css
@@ -5,6 +5,7 @@
 
   /* Light theme */
   --light-color-attribute-name: #ef6632;
+  --light-color-attribute-name-not-editable: #23272f;
   --light-color-attribute-name-inverted: rgba(255, 255, 255, 0.7);
   --light-color-attribute-value: #1a1aa6;
   --light-color-attribute-value-inverted: #ffffff;
@@ -77,6 +78,7 @@
 
   /* Dark theme */
   --dark-color-attribute-name: #9d87d2;
+  --dark-color-attribute-name-not-editable: #ededed;
   --dark-color-attribute-name-inverted: #282828;
   --dark-color-attribute-value: #cedae0;
   --dark-color-attribute-value-inverted: #ffffff;


### PR DESCRIPTION
1. Made non-editable prop text higher contrast (easier to read)
2. Also makes it stand out as different from dimmer placeholder text for "new prop"

## Before
#### Light mode
<img width="465" alt="Screen Shot 2020-05-19 at 9 11 05 AM" src="https://user-images.githubusercontent.com/29597/82350891-c1075b00-99b0-11ea-9c35-11f9dcd965b1.png">

#### Dark mode
<img width="461" alt="Screen Shot 2020-05-19 at 9 10 56 AM" src="https://user-images.githubusercontent.com/29597/82350906-c49ae200-99b0-11ea-99a1-cdf249019480.png">

## After
#### Light mode
<img width="466" alt="Screen Shot 2020-05-19 at 9 08 56 AM" src="https://user-images.githubusercontent.com/29597/82350923-c95f9600-99b0-11ea-9ecb-5d5fcd927a3a.png">

#### Dark mode
<img width="462" alt="Screen Shot 2020-05-19 at 9 10 20 AM" src="https://user-images.githubusercontent.com/29597/82350939-cebce080-99b0-11ea-8472-b42114f1a05d.png">
