### PR TITLE
DevTools: Improve error boundary

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.css
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.css
@@ -1,8 +1,7 @@
 .ErrorBoundary {
   height: 100%;
   width: 100%;
-  background-color: white;
-  color: red;
+  background-color: var(--color-background);
   padding: 0.5rem;
   overflow: auto;
 }
@@ -10,15 +9,46 @@
 .Header {
   font-size: var(--font-size-sans-large);
   font-weight: bold;
+  color: var(--color-error-text);
 }
 
 .Stack {
   margin-top: 0.5rem;
   white-space: pre-wrap;
   font-family: var(--font-family-monospace);
-  font-size: var(--font-size-monospace-small);
-  background-color: hsl(0, 100%, 97%);
-  border: 1px solid hsl(0, 100%, 92%);
+  font-size: var(--font-size-monospace-normal);
+  -webkit-font-smoothing: initial;
+  background-color: var(--color-error-background);
+  border: 1px solid var(--color-error-border);
+  color: var(--color-error-text);
   border-radius: 0.25rem;
   padding: 0.5rem;
+}
+
+.IconAndLinkRow {
+  display: flex;
+  align-items: center;
+  margin-top: 0.5rem;
+  color: var(--color-text);
+}
+
+.RetryIcon {
+  margin-right: 0.25rem;
+  color: var(--color-button-active);
+}
+
+.RetryButton {
+  margin-right: 0.25rem;
+  color: var(--color-text);
+}
+.RetryButton:hover {
+  color: var(--color-button-hover);
+}
+
+.ReportIcon {
+  margin-right: 0.25rem;
+}
+
+.ReportLink {
+  color: var(--color-link);
 }

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary.js
@@ -9,10 +9,16 @@
 
 import * as React from 'react';
 import {Component} from 'react';
+import Button from './Button';
+import ButtonIcon from './ButtonIcon';
+import Icon from './Icon';
 import styles from './ErrorBoundary.css';
+import Store from 'react-devtools-shared/src/devtools/store';
 
 type Props = {|
   children: React$Node,
+  onRetry?: (store: Store) => void,
+  store: Store,
 |};
 
 type State = {|
@@ -22,13 +28,15 @@ type State = {|
   hasError: boolean,
 |};
 
+const InitialState: State = {
+  callStack: null,
+  componentStack: null,
+  errorMessage: null,
+  hasError: false,
+};
+
 export default class ErrorBoundary extends Component<Props, State> {
-  state: State = {
-    callStack: null,
-    componentStack: null,
-    errorMessage: null,
-    hasError: false,
-  };
+  state: State = InitialState;
 
   componentDidCatch(error: any, {componentStack}: any) {
     const errorMessage =
@@ -85,17 +93,30 @@ export default class ErrorBoundary extends Component<Props, State> {
       return (
         <div className={styles.ErrorBoundary}>
           <div className={styles.Header}>
-            An error was thrown: "{errorMessage}"
+            Uncaught Error: {errorMessage || ''}
           </div>
-          {bugURL && (
-            <a
-              href={bugURL}
-              rel="noopener noreferrer"
-              target="_blank"
-              title="Report bug">
-              Report this issue
-            </a>
-          )}
+          <div className={styles.IconAndLinkRow}>
+            <Button
+              className={styles.RetryButton}
+              title="Retry"
+              onClick={this.handleRetry}>
+              <ButtonIcon className={styles.RetryIcon} type="reload" />
+              Retry
+            </Button>
+            {bugURL && (
+              <>
+                <Icon className={styles.ReportIcon} type="bug" />
+                <a
+                  className={styles.ReportLink}
+                  href={bugURL}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  title="Report bug">
+                  Report this issue
+                </a>
+              </>
+            )}
+          </div>
           {!!callStack && (
             <div className={styles.Stack}>
               The error was thrown {callStack.trim()}
@@ -112,4 +133,13 @@ export default class ErrorBoundary extends Component<Props, State> {
 
     return children;
   }
+
+  handleRetry = () => {
+    const {onRetry, store} = this.props;
+    if (typeof onRetry === 'function') {
+      onRetry(store);
+    }
+
+    this.setState(InitialState);
+  };
 }

--- a/packages/react-devtools-shared/src/devtools/views/Icon.js
+++ b/packages/react-devtools-shared/src/devtools/views/Icon.js
@@ -12,6 +12,7 @@ import styles from './Icon.css';
 
 export type IconType =
   | 'arrow'
+  | 'bug'
   | 'code'
   | 'components'
   | 'copy'
@@ -33,6 +34,9 @@ export default function Icon({className = '', type}: Props) {
   switch (type) {
     case 'arrow':
       pathData = PATH_ARROW;
+      break;
+    case 'bug':
+      pathData = PATH_BUG;
       break;
     case 'code':
       pathData = PATH_CODE;
@@ -83,6 +87,13 @@ export default function Icon({className = '', type}: Props) {
 }
 
 const PATH_ARROW = 'M8 5v14l11-7z';
+
+const PATH_BUG = `
+  M20 8h-2.81c-.45-.78-1.07-1.45-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49
+  0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09
+  1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21
+  5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z
+`;
 
 const PATH_CODE = `
   M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -28,6 +28,7 @@ import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/Set
 import SettingsModalContextToggle from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
 import portaledContent from '../portaledContent';
+import Store from '../../store';
 
 import styles from './Profiler.css';
 
@@ -201,4 +202,10 @@ const RecordingInProgress = () => (
   </div>
 );
 
-export default portaledContent(Profiler);
+function onErrorRetry(store: Store) {
+  // If an error happened in the Profiler,
+  // we should clear data on retry (or it will just happen again).
+  store.profilerStore.profilingData = null;
+}
+
+export default portaledContent(Profiler, onErrorRetry);

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -319,7 +319,11 @@ function updateThemeVariables(
   updateStyleHelper(theme, 'color-dim', documentElements);
   updateStyleHelper(theme, 'color-dimmer', documentElements);
   updateStyleHelper(theme, 'color-dimmest', documentElements);
+  updateStyleHelper(theme, 'color-error-background', documentElements);
+  updateStyleHelper(theme, 'color-error-border', documentElements);
+  updateStyleHelper(theme, 'color-error-text', documentElements);
   updateStyleHelper(theme, 'color-expand-collapse-toggle', documentElements);
+  updateStyleHelper(theme, 'color-link', documentElements);
   updateStyleHelper(theme, 'color-modal-background', documentElements);
   updateStyleHelper(theme, 'color-record-active', documentElements);
   updateStyleHelper(theme, 'color-record-hover', documentElements);

--- a/packages/react-devtools-shared/src/devtools/views/portaledContent.js
+++ b/packages/react-devtools-shared/src/devtools/views/portaledContent.js
@@ -8,17 +8,23 @@
  */
 
 import * as React from 'react';
+import {useContext} from 'react';
 import {createPortal} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary';
+import {StoreContext} from './context';
+import Store from '../store';
 
 export type Props = {portalContainer?: Element, ...};
 
 export default function portaledContent(
   Component: React$StatelessFunctionalComponent<any>,
+  onErrorRetry?: (store: Store) => void,
 ): React$StatelessFunctionalComponent<any> {
   return function PortaledContent({portalContainer, ...rest}: Props) {
+    const store = useContext(StoreContext);
+
     const children = (
-      <ErrorBoundary>
+      <ErrorBoundary store={store} onRetry={onErrorRetry}>
         <Component {...rest} />
       </ErrorBoundary>
     );

--- a/packages/react-devtools-shared/src/devtools/views/root.css
+++ b/packages/react-devtools-shared/src/devtools/views/root.css
@@ -53,7 +53,11 @@
   --light-color-dim: #777d88;
   --light-color-dimmer: #cfd1d5;
   --light-color-dimmest: #eff0f1;
+  --light-color-error-background: hsl(0, 100%, 97%);
+  --light-color-error-border: hsl(0, 100%, 92%);
+  --light-color-error-text: #ff0000;
   --light-color-expand-collapse-toggle: #777d88;
+  --light-color-link: #0000ff;
   --light-color-modal-background: rgba(255, 255, 255, 0.75);
   --light-color-record-active: #fc3a4b;
   --light-color-record-hover: #3578e5;
@@ -126,7 +130,11 @@
   --dark-color-dim: #8f949d;
   --dark-color-dimmer: #777d88;
   --dark-color-dimmest: #4f5766;
+  --dark-color-error-background: #200;
+  --dark-color-error-border: #900;
+  --dark-color-error-text: #f55;
   --dark-color-expand-collapse-toggle: #8f949d;
+  --dark-color-link: #61dafb;
   --dark-color-modal-background: rgba(0, 0, 0, 0.75);
   --dark-color-record-active: #fc3a4b;
   --dark-color-record-hover: #a2e9fc;


### PR DESCRIPTION
1. Add support for dark mode.
2. Add retry option for case where Profiler data is corrupted.
3. Increased size and contrast of error text for readability.

Resolves #18935

## Before
<img width="641" alt="Screen Shot 2020-05-19 at 1 12 30 PM" src="https://user-images.githubusercontent.com/29597/82373508-857d8880-99d2-11ea-9409-826bf61af24c.png">

## After
<img width="640" alt="Screen Shot 2020-05-19 at 1 12 56 PM" src="https://user-images.githubusercontent.com/29597/82373550-929a7780-99d2-11ea-9d0b-49015624cb9a.png">

## Demos
### Dark mode (new!)
![retry-error-dark](https://user-images.githubusercontent.com/29597/82369817-77c50480-99cc-11ea-8b41-a677f3aa32e2.gif)

### Light mode
![reaaa](https://user-images.githubusercontent.com/29597/82373481-7bf42080-99d2-11ea-9e9c-1d277c6776b5.gif)
