### PR TITLE
Bugfix: Missing mode check in resetChildLanes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1684,7 +1684,8 @@ function resetChildLanes(completedWork: Fiber) {
     (completedWork.tag === LegacyHiddenComponent ||
       completedWork.tag === OffscreenComponent) &&
     completedWork.memoizedState !== null &&
-    !includesSomeLane(subtreeRenderLanes, (OffscreenLane: Lane))
+    !includesSomeLane(subtreeRenderLanes, (OffscreenLane: Lane)) &&
+    (completedWork.mode & ConcurrentMode) !== NoLanes
   ) {
     // The children of this component are hidden. Don't bubble their
     // expiration times.


### PR DESCRIPTION
Deferring a hidden tree is only supported in Concurrent Mode.

The missing check leads to an infinite loop when an update is scheduled inside a hidden tree, because the pending work never gets reset.

This "accidentally" worked in the old reconciler because the heurstic we used to detect offscreen trees was if `childExpirationTime` was `Never`.

In the new reconciler, we check the tag instead. Which means we also need to check the mode, like we do in the begin phase.

We should move this check out of the hot path. It shouldn't have been in the hot path of the old reconciler, either.

Probably by moving `resetChildLanes` into the switch statement in ReactFiberCompleteWork.