### PR TITLE
Remove event pooling in the modern system

### DIFF
--- a/packages/legacy-events/SyntheticEvent.js
+++ b/packages/legacy-events/SyntheticEvent.js
@@ -157,7 +157,10 @@ Object.assign(SyntheticEvent.prototype, {
    * won't be added back into the pool.
    */
   persist: function() {
-    this.isPersistent = functionThatReturnsTrue;
+    // Modern event system doesn't use pooling.
+    if (!enableModernEventSystem) {
+      this.isPersistent = functionThatReturnsTrue;
+    }
   },
 
   /**
@@ -165,65 +168,68 @@ Object.assign(SyntheticEvent.prototype, {
    *
    * @return {boolean} True if this should not be released, false otherwise.
    */
-  isPersistent: functionThatReturnsFalse,
+  isPersistent: enableModernEventSystem
+    ? functionThatReturnsTrue
+    : functionThatReturnsFalse,
 
   /**
    * `PooledClass` looks for `destructor` on each instance it releases.
    */
   destructor: function() {
-    const Interface = this.constructor.Interface;
-    for (const propName in Interface) {
+    // Modern event system doesn't use pooling.
+    if (!enableModernEventSystem) {
+      const Interface = this.constructor.Interface;
+      for (const propName in Interface) {
+        if (__DEV__) {
+          Object.defineProperty(
+            this,
+            propName,
+            getPooledWarningPropertyDefinition(propName, Interface[propName]),
+          );
+        } else {
+          this[propName] = null;
+        }
+      }
+      this.dispatchConfig = null;
+      this._targetInst = null;
+      this.nativeEvent = null;
+      this.isDefaultPrevented = functionThatReturnsFalse;
+      this.isPropagationStopped = functionThatReturnsFalse;
+      this._dispatchListeners = null;
+      this._dispatchInstances = null;
       if (__DEV__) {
         Object.defineProperty(
           this,
-          propName,
-          getPooledWarningPropertyDefinition(propName, Interface[propName]),
+          'nativeEvent',
+          getPooledWarningPropertyDefinition('nativeEvent', null),
         );
-      } else {
-        this[propName] = null;
-      }
-    }
-    this.dispatchConfig = null;
-    this._targetInst = null;
-    this.nativeEvent = null;
-    this.isDefaultPrevented = functionThatReturnsFalse;
-    this.isPropagationStopped = functionThatReturnsFalse;
-    if (!enableModernEventSystem) {
-      this._dispatchListeners = null;
-      this._dispatchInstances = null;
-    }
-    if (__DEV__) {
-      Object.defineProperty(
-        this,
-        'nativeEvent',
-        getPooledWarningPropertyDefinition('nativeEvent', null),
-      );
-      Object.defineProperty(
-        this,
-        'isDefaultPrevented',
-        getPooledWarningPropertyDefinition(
+        Object.defineProperty(
+          this,
           'isDefaultPrevented',
-          functionThatReturnsFalse,
-        ),
-      );
-      Object.defineProperty(
-        this,
-        'isPropagationStopped',
-        getPooledWarningPropertyDefinition(
+          getPooledWarningPropertyDefinition(
+            'isDefaultPrevented',
+            functionThatReturnsFalse,
+          ),
+        );
+        Object.defineProperty(
+          this,
           'isPropagationStopped',
-          functionThatReturnsFalse,
-        ),
-      );
-      Object.defineProperty(
-        this,
-        'preventDefault',
-        getPooledWarningPropertyDefinition('preventDefault', () => {}),
-      );
-      Object.defineProperty(
-        this,
-        'stopPropagation',
-        getPooledWarningPropertyDefinition('stopPropagation', () => {}),
-      );
+          getPooledWarningPropertyDefinition(
+            'isPropagationStopped',
+            functionThatReturnsFalse,
+          ),
+        );
+        Object.defineProperty(
+          this,
+          'preventDefault',
+          getPooledWarningPropertyDefinition('preventDefault', () => {}),
+        );
+        Object.defineProperty(
+          this,
+          'stopPropagation',
+          getPooledWarningPropertyDefinition('stopPropagation', () => {}),
+        );
+      }
     }
   },
 });
@@ -303,18 +309,26 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
   }
 }
 
-function getPooledEvent(dispatchConfig, targetInst, nativeEvent, nativeInst) {
+function createOrGetPooledEvent(
+  dispatchConfig,
+  targetInst,
+  nativeEvent,
+  nativeInst,
+) {
   const EventConstructor = this;
-  if (EventConstructor.eventPool.length) {
-    const instance = EventConstructor.eventPool.pop();
-    EventConstructor.call(
-      instance,
-      dispatchConfig,
-      targetInst,
-      nativeEvent,
-      nativeInst,
-    );
-    return instance;
+  // Modern event system doesn't use pooling.
+  if (!enableModernEventSystem) {
+    if (EventConstructor.eventPool.length) {
+      const instance = EventConstructor.eventPool.pop();
+      EventConstructor.call(
+        instance,
+        dispatchConfig,
+        targetInst,
+        nativeEvent,
+        nativeInst,
+      );
+      return instance;
+    }
   }
   return new EventConstructor(
     dispatchConfig,
@@ -325,21 +339,28 @@ function getPooledEvent(dispatchConfig, targetInst, nativeEvent, nativeInst) {
 }
 
 function releasePooledEvent(event) {
-  const EventConstructor = this;
-  invariant(
-    event instanceof EventConstructor,
-    'Trying to release an event instance into a pool of a different type.',
-  );
-  event.destructor();
-  if (EventConstructor.eventPool.length < EVENT_POOL_SIZE) {
-    EventConstructor.eventPool.push(event);
+  // Modern event system doesn't use pooling.
+  if (!enableModernEventSystem) {
+    const EventConstructor = this;
+    invariant(
+      event instanceof EventConstructor,
+      'Trying to release an event instance into a pool of a different type.',
+    );
+    event.destructor();
+    if (EventConstructor.eventPool.length < EVENT_POOL_SIZE) {
+      EventConstructor.eventPool.push(event);
+    }
   }
 }
 
 function addEventPoolingTo(EventConstructor) {
-  EventConstructor.eventPool = [];
-  EventConstructor.getPooled = getPooledEvent;
-  EventConstructor.release = releasePooledEvent;
+  EventConstructor.getPooled = createOrGetPooledEvent;
+
+  // Modern event system doesn't use pooling.
+  if (!enableModernEventSystem) {
+    EventConstructor.eventPool = [];
+    EventConstructor.release = releasePooledEvent;
+  }
 }
 
 export default SyntheticEvent;

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -207,10 +207,7 @@ export function dispatchEventsInBatch(dispatchQueue: DispatchQueue): void {
     const dispatchQueueItem: DispatchQueueItem = dispatchQueue[i];
     const {event, capture, bubble} = dispatchQueueItem;
     executeDispatchesInOrder(event, capture, bubble);
-    // Release the event from the pool if needed
-    if (!event.isPersistent()) {
-      event.constructor.release(event);
-    }
+    // Modern event system doesn't use pooling.
   }
   // This would be a good time to rethrow if any of the event handlers threw.
   rethrowCaughtError();

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -78,6 +78,27 @@ describe('DOMModernPluginEventSystem', () => {
           endNativeEventListenerClearDown();
         });
 
+        it('does not pool events', () => {
+          const buttonRef = React.createRef();
+          const log = [];
+          const onClick = jest.fn(e => log.push(e));
+
+          function Test() {
+            return <button ref={buttonRef} onClick={onClick} />;
+          }
+
+          ReactDOM.render(<Test />, container);
+
+          let buttonElement = buttonRef.current;
+          dispatchClickEvent(buttonElement);
+          expect(onClick).toHaveBeenCalledTimes(1);
+          dispatchClickEvent(buttonElement);
+          expect(onClick).toHaveBeenCalledTimes(2);
+          expect(log[0]).not.toBe(log[1]);
+          expect(log[0].type).toBe('click');
+          expect(log[1].type).toBe('click');
+        });
+
         it('handle propagation of click events', () => {
           const buttonRef = React.createRef();
           const divRef = React.createRef();

--- a/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticClipboardEvent-test.js
@@ -11,6 +11,7 @@
 
 let React;
 let ReactDOM;
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 describe('SyntheticClipboardEvent', () => {
   let container;
@@ -117,41 +118,43 @@ describe('SyntheticClipboardEvent', () => {
       expect(expectedCount).toBe(3);
     });
 
-    it('is able to `persist`', () => {
-      const persistentEvents = [];
-      const eventHandler = event => {
-        expect(event.isPersistent()).toBe(false);
-        event.persist();
-        expect(event.isPersistent()).toBe(true);
-        persistentEvents.push(event);
-      };
+    if (!ReactFeatureFlags.enableModernEventSystem) {
+      it('is able to `persist`', () => {
+        const persistentEvents = [];
+        const eventHandler = event => {
+          expect(event.isPersistent()).toBe(false);
+          event.persist();
+          expect(event.isPersistent()).toBe(true);
+          persistentEvents.push(event);
+        };
 
-      const div = ReactDOM.render(
-        <div
-          onCopy={eventHandler}
-          onCut={eventHandler}
-          onPaste={eventHandler}
-        />,
-        container,
-      );
+        const div = ReactDOM.render(
+          <div
+            onCopy={eventHandler}
+            onCut={eventHandler}
+            onPaste={eventHandler}
+          />,
+          container,
+        );
 
-      let event;
-      event = document.createEvent('Event');
-      event.initEvent('copy', true, true);
-      div.dispatchEvent(event);
+        let event;
+        event = document.createEvent('Event');
+        event.initEvent('copy', true, true);
+        div.dispatchEvent(event);
 
-      event = document.createEvent('Event');
-      event.initEvent('cut', true, true);
-      div.dispatchEvent(event);
+        event = document.createEvent('Event');
+        event.initEvent('cut', true, true);
+        div.dispatchEvent(event);
 
-      event = document.createEvent('Event');
-      event.initEvent('paste', true, true);
-      div.dispatchEvent(event);
+        event = document.createEvent('Event');
+        event.initEvent('paste', true, true);
+        div.dispatchEvent(event);
 
-      expect(persistentEvents.length).toBe(3);
-      expect(persistentEvents[0].type).toBe('copy');
-      expect(persistentEvents[1].type).toBe('cut');
-      expect(persistentEvents[2].type).toBe('paste');
-    });
+        expect(persistentEvents.length).toBe(3);
+        expect(persistentEvents[0].type).toBe('copy');
+        expect(persistentEvents[1].type).toBe('cut');
+        expect(persistentEvents[2].type).toBe('paste');
+      });
+    }
   });
 });

--- a/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticKeyboardEvent-test.js
@@ -11,6 +11,7 @@
 
 let React;
 let ReactDOM;
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 describe('SyntheticKeyboardEvent', () => {
   let container;
@@ -547,49 +548,51 @@ describe('SyntheticKeyboardEvent', () => {
       expect(expectedCount).toBe(3);
     });
 
-    it('is able to `persist`', () => {
-      const persistentEvents = [];
-      const eventHandler = event => {
-        expect(event.isPersistent()).toBe(false);
-        event.persist();
-        expect(event.isPersistent()).toBe(true);
-        persistentEvents.push(event);
-      };
-      const div = ReactDOM.render(
-        <div
-          onKeyDown={eventHandler}
-          onKeyUp={eventHandler}
-          onKeyPress={eventHandler}
-        />,
-        container,
-      );
+    if (!ReactFeatureFlags.enableModernEventSystem) {
+      it('is able to `persist`', () => {
+        const persistentEvents = [];
+        const eventHandler = event => {
+          expect(event.isPersistent()).toBe(false);
+          event.persist();
+          expect(event.isPersistent()).toBe(true);
+          persistentEvents.push(event);
+        };
+        const div = ReactDOM.render(
+          <div
+            onKeyDown={eventHandler}
+            onKeyUp={eventHandler}
+            onKeyPress={eventHandler}
+          />,
+          container,
+        );
 
-      div.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      div.dispatchEvent(
-        new KeyboardEvent('keyup', {
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      div.dispatchEvent(
-        new KeyboardEvent('keypress', {
-          charCode: 40,
-          keyCode: 40,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
-      expect(persistentEvents.length).toBe(3);
-      expect(persistentEvents[0].type).toBe('keydown');
-      expect(persistentEvents[1].type).toBe('keyup');
-      expect(persistentEvents[2].type).toBe('keypress');
-    });
+        div.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            keyCode: 40,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        div.dispatchEvent(
+          new KeyboardEvent('keyup', {
+            keyCode: 40,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        div.dispatchEvent(
+          new KeyboardEvent('keypress', {
+            charCode: 40,
+            keyCode: 40,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+        expect(persistentEvents.length).toBe(3);
+        expect(persistentEvents[0].type).toBe('keydown');
+        expect(persistentEvents[1].type).toBe('keyup');
+        expect(persistentEvents[2].type).toBe('keypress');
+      });
+    }
   });
 });

--- a/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
+++ b/packages/react-dom/src/events/__tests__/SyntheticWheelEvent-test.js
@@ -11,6 +11,7 @@
 
 let React;
 let ReactDOM;
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 describe('SyntheticWheelEvent', () => {
   let container;
@@ -113,23 +114,25 @@ describe('SyntheticWheelEvent', () => {
     expect(events.length).toBe(2);
   });
 
-  it('should be able to `persist`', () => {
-    const events = [];
-    const onWheel = event => {
-      expect(event.isPersistent()).toBe(false);
-      event.persist();
-      expect(event.isPersistent()).toBe(true);
-      events.push(event);
-    };
-    ReactDOM.render(<div onWheel={onWheel} />, container);
+  if (!ReactFeatureFlags.enableModernEventSystem) {
+    it('should be able to `persist`', () => {
+      const events = [];
+      const onWheel = event => {
+        expect(event.isPersistent()).toBe(false);
+        event.persist();
+        expect(event.isPersistent()).toBe(true);
+        events.push(event);
+      };
+      ReactDOM.render(<div onWheel={onWheel} />, container);
 
-    container.firstChild.dispatchEvent(
-      new MouseEvent('wheel', {
-        bubbles: true,
-      }),
-    );
+      container.firstChild.dispatchEvent(
+        new MouseEvent('wheel', {
+          bubbles: true,
+        }),
+      );
 
-    expect(events.length).toBe(1);
-    expect(events[0].type).toBe('wheel');
-  });
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe('wheel');
+    });
+  }
 });


### PR DESCRIPTION
This PR is a follow up to https://github.com/facebook/react/pull/18216, and re-applies much of the same logic and also keeps consistency with that PR's summary. After a bunch of internal discussions, we decided we want to go ahead with this change and bring it into the modern event system.

The main difference is that now we have a proper fork of the different event systems, we don't need to apply the gated logic around a bunch of places (other than the `SyntheticEvent` module). I also had to fork a bunch of tests that expect persistance when we run the modern event system. Once we remove the feature flags, we can tidy up a load of code relating to pooling (by removing it all).