### PR TITLE
Clear fiber.sibling field when clearing nextEffect

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1124,7 +1124,7 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(fiber: Fiber) {
+function detachFiberMutation(fiber: Fiber) {
   // Cut off the return pointers to disconnect it from the tree. Ideally, we
   // should clear the child pointer of the parent alternate to let this
   // get GC:ed but we don't know which for sure which parent is the current
@@ -1132,7 +1132,8 @@ function detachFiber(fiber: Fiber) {
   // itself will be GC:ed when the parent updates the next time.
   // Note: we cannot null out sibling here, otherwise it can cause issues
   // with findDOMNode and how it requires the sibling field to carry out
-  // traversal in a later effect. See PR #16820.
+  // traversal in a later effect. See PR #16820. We now clear the sibling
+  // field after effects, see: detachFiberAfterEffects.
   fiber.alternate = null;
   fiber.child = null;
   fiber.dependencies_new = null;
@@ -1543,9 +1544,9 @@ function commitDeletion(
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
   }
   const alternate = current.alternate;
-  detachFiber(current);
+  detachFiberMutation(current);
   if (alternate !== null) {
-    detachFiber(alternate);
+    detachFiberMutation(alternate);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1122,7 +1122,7 @@ function commitNestedUnmounts(
   }
 }
 
-function detachFiber(fiber: Fiber) {
+function detachFiberMutation(fiber: Fiber) {
   // Cut off the return pointers to disconnect it from the tree. Ideally, we
   // should clear the child pointer of the parent alternate to let this
   // get GC:ed but we don't know which for sure which parent is the current
@@ -1130,7 +1130,8 @@ function detachFiber(fiber: Fiber) {
   // itself will be GC:ed when the parent updates the next time.
   // Note: we cannot null out sibling here, otherwise it can cause issues
   // with findDOMNode and how it requires the sibling field to carry out
-  // traversal in a later effect. See PR #16820.
+  // traversal in a later effect. See PR #16820. We now clear the sibling
+  // field after effects, see: detachFiberAfterEffects.
   fiber.alternate = null;
   fiber.child = null;
   fiber.dependencies_old = null;
@@ -1541,9 +1542,9 @@ function commitDeletion(
     commitNestedUnmounts(finishedRoot, current, renderPriorityLevel);
   }
   const alternate = current.alternate;
-  detachFiber(current);
+  detachFiberMutation(current);
   if (alternate !== null) {
-    detachFiber(alternate);
+    detachFiberMutation(alternate);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1994,7 +1994,7 @@ function commitRootImpl(root, renderPriorityLevel) {
       const nextNextEffect = nextEffect.nextEffect;
       nextEffect.nextEffect = null;
       if (nextEffect.effectTag & Deletion) {
-        nextEffect.sibling = null;
+        detachFiberAfterEffects(nextEffect);
       }
       nextEffect = nextNextEffect;
     }
@@ -2451,7 +2451,7 @@ function flushPassiveEffectsImpl() {
     // Remove nextEffect pointer to assist GC
     effect.nextEffect = null;
     if (effect.effectTag & Deletion) {
-      effect.sibling = null;
+      detachFiberAfterEffects(effect);
     }
     effect = nextNextEffect;
   }
@@ -3554,4 +3554,8 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
       },
     };
   }
+}
+
+function detachFiberAfterEffects(fiber: Fiber): void {
+  fiber.sibling = null;
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1993,6 +1993,9 @@ function commitRootImpl(root, renderPriorityLevel) {
     while (nextEffect !== null) {
       const nextNextEffect = nextEffect.nextEffect;
       nextEffect.nextEffect = null;
+      if (nextEffect.effectTag & Deletion) {
+        nextEffect.sibling = null;
+      }
       nextEffect = nextNextEffect;
     }
   }
@@ -2447,6 +2450,9 @@ function flushPassiveEffectsImpl() {
     const nextNextEffect = effect.nextEffect;
     // Remove nextEffect pointer to assist GC
     effect.nextEffect = null;
+    if (effect.effectTag & Deletion) {
+      effect.sibling = null;
+    }
     effect = nextNextEffect;
   }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2101,6 +2101,9 @@ function commitRootImpl(root, renderPriorityLevel) {
     while (nextEffect !== null) {
       const nextNextEffect = nextEffect.nextEffect;
       nextEffect.nextEffect = null;
+      if (nextEffect.effectTag & Deletion) {
+        nextEffect.sibling = null;
+      }
       nextEffect = nextNextEffect;
     }
   }
@@ -2595,6 +2598,9 @@ function flushPassiveEffectsImpl() {
     const nextNextEffect = effect.nextEffect;
     // Remove nextEffect pointer to assist GC
     effect.nextEffect = null;
+    if (effect.effectTag & Deletion) {
+      effect.sibling = null;
+    }
     effect = nextNextEffect;
   }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2102,7 +2102,7 @@ function commitRootImpl(root, renderPriorityLevel) {
       const nextNextEffect = nextEffect.nextEffect;
       nextEffect.nextEffect = null;
       if (nextEffect.effectTag & Deletion) {
-        nextEffect.sibling = null;
+        detachFiberAfterEffects(nextEffect);
       }
       nextEffect = nextNextEffect;
     }
@@ -2599,7 +2599,7 @@ function flushPassiveEffectsImpl() {
     // Remove nextEffect pointer to assist GC
     effect.nextEffect = null;
     if (effect.effectTag & Deletion) {
-      effect.sibling = null;
+      detachFiberAfterEffects(effect);
     }
     effect = nextNextEffect;
   }
@@ -3717,4 +3717,8 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
       },
     };
   }
+}
+
+function detachFiberAfterEffects(fiber: Fiber): void {
+  fiber.sibling = null;
 }


### PR DESCRIPTION
In order to help an internal issue with leaking memory from fibers, we should clear the `sibling` field when we mark a fiber for deletion. We previously did this in #16820 but this caused internal errors because there are subtle use cases with the deprecated `findDOMNode` when we need the `sibling` for traversal.

Instead of clearing the `sibling` field at this point, we could also maybe clear it when we also clear the `nextEffect`. This should happen at a later time, after the `findDOMNode` logic has run, allowing the field to properly be cleared and the retained fiber to be GC'd.