### PR TITLE
DevTools: Fix highlight updates Canvas side problem

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/canvas.js
@@ -35,8 +35,8 @@ export function draw(nodeToData: Map<NativeType, Data>): void {
   }
 
   const canvasFlow: HTMLCanvasElement = ((canvas: any): HTMLCanvasElement);
-  canvasFlow.width = window.screen.availWidth;
-  canvasFlow.height = window.screen.availHeight;
+  canvasFlow.width = window.innerWidth;
+  canvasFlow.height = window.innerHeight;
 
   const context = canvasFlow.getContext('2d');
   context.clearRect(0, 0, canvasFlow.width, canvasFlow.height);


### PR DESCRIPTION
Previously we were setting the width/height of the canvas to the screen's available width and height, but the CSS size to the viewport size. This former is generally smaller than the latter, and on some websites (e.g. [everycode.store](https://everycode.store/)) this caused the drawn dimensions to be compressed and look bad.

The reason this behavior was particularly broken for the site above [is because of a CSS rule](https://twitter.com/marvinhagemeist/status/1263506164144316416):
![image](https://user-images.githubusercontent.com/29597/82582375-cf877b00-9b46-11ea-82b2-5705d98cf895.png)

So to be fair, an alternate fix would be to override this rule with our inline style.

Resolves #17432