### PR TITLE
Add `unstable_isNewReconciler` export to FB builds

### DIFF
--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -37,4 +37,5 @@ export {
   unstable_renderSubtreeIntoContainer,
   unstable_createPortal,
   unstable_createEventHandle,
+  unstable_isNewReconciler,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -28,4 +28,5 @@ export {
   unstable_renderSubtreeIntoContainer,
   unstable_createPortal,
   unstable_createEventHandle,
+  unstable_isNewReconciler,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -20,4 +20,5 @@ export {
   unstable_flushControlled,
   unstable_scheduleHydration,
   unstable_createEventHandle,
+  unstable_isNewReconciler,
 } from './src/client/ReactDOM';

--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -45,7 +45,10 @@ import {
 } from 'legacy-events/EventPluginRegistry';
 import ReactVersion from 'shared/ReactVersion';
 import invariant from 'shared/invariant';
-import {warnUnstableRenderSubtreeIntoContainer} from 'shared/ReactFeatureFlags';
+import {
+  warnUnstableRenderSubtreeIntoContainer,
+  enableNewReconciler,
+} from 'shared/ReactFeatureFlags';
 
 import {
   getInstanceFromNode,
@@ -246,3 +249,5 @@ if (__DEV__) {
     }
   }
 }
+
+export const unstable_isNewReconciler = enableNewReconciler;


### PR DESCRIPTION
Should check this at runtime instead of the GK