### PR TITLE
Separate _owner from _debugOwner

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -235,6 +235,12 @@ function createElement(type, key, props): React$Element<any> {
       writable: false,
       value: null,
     });
+    Object.defineProperty(element, '_debugOwner', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: null,
+    });
   }
   return element;
 }

--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -158,16 +158,12 @@ describe('ReactFunctionComponent', () => {
     expect(function() {
       ReactTestUtils.renderIntoDocument(<Child test="test" />);
     }).toThrowError(
-      __DEV__
-        ? 'Function components cannot have string refs. We recommend using useRef() instead.'
-        : // It happens because we don't save _owner in production for
-          // function components.
-          'Element ref was specified as a string (me) but no owner was set. This could happen for one of' +
-            ' the following reasons:\n' +
-            '1. You may be adding a ref to a function component\n' +
-            "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
-            '3. You have multiple copies of React loaded\n' +
-            'See https://fb.me/react-refs-must-have-owner for more information.',
+      'Element ref was specified as a string (me) but no owner was set. This could happen for one of' +
+        ' the following reasons:\n' +
+        '1. You may be adding a ref to a function component\n' +
+        "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
+        '3. You have multiple copies of React loaded\n' +
+        'See https://fb.me/react-refs-must-have-owner for more information.',
     );
   });
 

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -25,6 +25,7 @@ import {
   injectIntoDevTools,
   getPublicRootInstance,
 } from 'react-reconciler/src/ReactFiberReconciler';
+import {isRendering as ReactCurrentFiberIsRendering} from 'react-reconciler/src/ReactCurrentFiber';
 
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {setBatchingImplementation} from 'legacy-events/ReactGenericBatching';
@@ -42,26 +43,33 @@ import {LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 
-const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+let ReactDebugCurrentFrame;
+if (__DEV__) {
+  ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+}
 
 function findHostInstance_DEPRECATED(
   componentOrHandle: any,
 ): ?ElementRef<HostComponent<mixed>> {
   if (__DEV__) {
-    const owner = ReactCurrentOwner.current;
-    if (owner !== null && owner.stateNode !== null) {
-      if (!owner.stateNode._warnedAboutRefsInRender) {
+    const debugOwner = ReactDebugCurrentFrame.debugOwner;
+    if (
+      ReactCurrentFiberIsRendering &&
+      debugOwner !== null &&
+      debugOwner.stateNode !== null
+    ) {
+      if (!debugOwner.stateNode._warnedAboutRefsInRender) {
         console.error(
           '%s is accessing findNodeHandle inside its render(). ' +
             'render() should be a pure function of props and state. It should ' +
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(debugOwner.type) || 'A component',
         );
       }
 
-      owner.stateNode._warnedAboutRefsInRender = true;
+      debugOwner.stateNode._warnedAboutRefsInRender = true;
     }
   }
   if (componentOrHandle == null) {
@@ -95,20 +103,24 @@ function findHostInstance_DEPRECATED(
 
 function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
-    const owner = ReactCurrentOwner.current;
-    if (owner !== null && owner.stateNode !== null) {
-      if (!owner.stateNode._warnedAboutRefsInRender) {
+    const debugOwner = ReactDebugCurrentFrame.debugOwner;
+    if (
+      ReactCurrentFiberIsRendering &&
+      debugOwner !== null &&
+      debugOwner.stateNode !== null
+    ) {
+      if (!debugOwner.stateNode._warnedAboutRefsInRender) {
         console.error(
           '%s is accessing findNodeHandle inside its render(). ' +
             'render() should be a pure function of props and state. It should ' +
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(debugOwner.type) || 'A component',
         );
       }
 
-      owner.stateNode._warnedAboutRefsInRender = true;
+      debugOwner.stateNode._warnedAboutRefsInRender = true;
     }
   }
   if (componentOrHandle == null) {

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -24,6 +24,7 @@ import {
   injectIntoDevTools,
   getPublicRootInstance,
 } from 'react-reconciler/src/ReactFiberReconciler';
+import {isRendering as ReactCurrentFiberIsRendering} from 'react-reconciler/src/ReactCurrentFiber';
 // TODO: direct imports like some-package/src/* are bad. Fix me.
 import {getStackByFiberInDevAndProd} from 'react-reconciler/src/ReactFiberComponentStack';
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
@@ -44,26 +45,33 @@ import {LegacyRoot} from 'react-reconciler/src/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentName from 'shared/getComponentName';
 
-const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+let ReactDebugCurrentFrame;
+if (__DEV__) {
+  ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+}
 
 function findHostInstance_DEPRECATED(
   componentOrHandle: any,
 ): ?React$ElementRef<HostComponent<mixed>> {
   if (__DEV__) {
-    const owner = ReactCurrentOwner.current;
-    if (owner !== null && owner.stateNode !== null) {
-      if (!owner.stateNode._warnedAboutRefsInRender) {
+    const debugOwner = ReactDebugCurrentFrame.debugOwner;
+    if (
+      ReactCurrentFiberIsRendering &&
+      debugOwner !== null &&
+      debugOwner.stateNode !== null
+    ) {
+      if (!debugOwner.stateNode._warnedAboutRefsInRender) {
         console.error(
           '%s is accessing findNodeHandle inside its render(). ' +
             'render() should be a pure function of props and state. It should ' +
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(debugOwner.type) || 'A component',
         );
       }
 
-      owner.stateNode._warnedAboutRefsInRender = true;
+      debugOwner.stateNode._warnedAboutRefsInRender = true;
     }
   }
   if (componentOrHandle == null) {
@@ -97,20 +105,24 @@ function findHostInstance_DEPRECATED(
 
 function findNodeHandle(componentOrHandle: any): ?number {
   if (__DEV__) {
-    const owner = ReactCurrentOwner.current;
-    if (owner !== null && owner.stateNode !== null) {
-      if (!owner.stateNode._warnedAboutRefsInRender) {
+    const debugOwner = ReactDebugCurrentFrame.debugOwner;
+    if (
+      ReactCurrentFiberIsRendering &&
+      debugOwner !== null &&
+      debugOwner.stateNode !== null
+    ) {
+      if (!debugOwner.stateNode._warnedAboutRefsInRender) {
         console.error(
           '%s is accessing findNodeHandle inside its render(). ' +
             'render() should be a pure function of props and state. It should ' +
             'never access something that requires stale data from the previous ' +
             'render, such as refs. Move this logic to componentDidMount and ' +
             'componentDidUpdate instead.',
-          getComponentName(owner.type) || 'A component',
+          getComponentName(debugOwner.type) || 'A component',
         );
       }
 
-      owner.stateNode._warnedAboutRefsInRender = true;
+      debugOwner.stateNode._warnedAboutRefsInRender = true;
     }
   }
   if (componentOrHandle == null) {

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -410,7 +410,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         existing.return = returnFiber;
         if (__DEV__) {
           existing._debugSource = element._source;
-          existing._debugOwner = element._owner;
+          existing._debugOwner = element._debugOwner;
         }
         return existing;
       } else if (enableBlocksAPI && current.tag === Block) {
@@ -431,7 +431,7 @@ function ChildReconciler(shouldTrackSideEffects) {
           existing.type = type;
           if (__DEV__) {
             existing._debugSource = element._source;
-            existing._debugOwner = element._owner;
+            existing._debugOwner = element._debugOwner;
           }
           return existing;
         }
@@ -1111,7 +1111,7 @@ function ChildReconciler(shouldTrackSideEffects) {
               existing.return = returnFiber;
               if (__DEV__) {
                 existing._debugSource = element._source;
-                existing._debugOwner = element._owner;
+                existing._debugOwner = element._debugOwner;
               }
               return existing;
             }
@@ -1136,7 +1136,7 @@ function ChildReconciler(shouldTrackSideEffects) {
                   existing.return = returnFiber;
                   if (__DEV__) {
                     existing._debugSource = element._source;
-                    existing._debugOwner = element._owner;
+                    existing._debugOwner = element._debugOwner;
                   }
                   return existing;
                 }
@@ -1158,7 +1158,7 @@ function ChildReconciler(shouldTrackSideEffects) {
               existing.return = returnFiber;
               if (__DEV__) {
                 existing._debugSource = element._source;
-                existing._debugOwner = element._owner;
+                existing._debugOwner = element._debugOwner;
               }
               return existing;
             }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -412,7 +412,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         existing.return = returnFiber;
         if (__DEV__) {
           existing._debugSource = element._source;
-          existing._debugOwner = element._owner;
+          existing._debugOwner = element._debugOwner;
         }
         return existing;
       } else if (enableBlocksAPI && current.tag === Block) {
@@ -433,7 +433,7 @@ function ChildReconciler(shouldTrackSideEffects) {
           existing.type = type;
           if (__DEV__) {
             existing._debugSource = element._source;
-            existing._debugOwner = element._owner;
+            existing._debugOwner = element._debugOwner;
           }
           return existing;
         }
@@ -1176,7 +1176,7 @@ function ChildReconciler(shouldTrackSideEffects) {
               existing.return = returnFiber;
               if (__DEV__) {
                 existing._debugSource = element._source;
-                existing._debugOwner = element._owner;
+                existing._debugOwner = element._debugOwner;
               }
               return existing;
             }
@@ -1201,7 +1201,7 @@ function ChildReconciler(shouldTrackSideEffects) {
                   existing.return = returnFiber;
                   if (__DEV__) {
                     existing._debugSource = element._source;
-                    existing._debugOwner = element._owner;
+                    existing._debugOwner = element._debugOwner;
                   }
                   return existing;
                 }
@@ -1223,7 +1223,7 @@ function ChildReconciler(shouldTrackSideEffects) {
               existing.return = returnFiber;
               if (__DEV__) {
                 existing._debugSource = element._source;
-                existing._debugOwner = element._owner;
+                existing._debugOwner = element._debugOwner;
               }
               return existing;
             }

--- a/packages/react-reconciler/src/ReactCurrentFiber.js
+++ b/packages/react-reconciler/src/ReactCurrentFiber.js
@@ -46,6 +46,7 @@ function getCurrentFiberStackInDev(): string {
 export function resetCurrentFiber() {
   if (__DEV__) {
     ReactDebugCurrentFrame.getCurrentStack = null;
+    ReactDebugCurrentFrame.debugOwner = null;
     current = null;
     isRendering = false;
   }
@@ -54,6 +55,7 @@ export function resetCurrentFiber() {
 export function setCurrentFiber(fiber: Fiber) {
   if (__DEV__) {
     ReactDebugCurrentFrame.getCurrentStack = getCurrentFiberStackInDev;
+    ReactDebugCurrentFrame.debugOwner = fiber;
     current = fiber;
     isRendering = false;
   }

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -606,7 +606,7 @@ export function createFiberFromElement(
   );
   if (__DEV__) {
     fiber._debugSource = element._source;
-    fiber._debugOwner = element._owner;
+    fiber._debugOwner = element._debugOwner;
   }
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -454,7 +454,7 @@ export function createFiberFromTypeAndProps(
   type: any, // React$ElementType
   key: null | string,
   pendingProps: any,
-  owner: null | Fiber,
+  debugOwner: null | Fiber,
   mode: TypeOfMode,
   lanes: Lanes,
 ): Fiber {
@@ -559,7 +559,9 @@ export function createFiberFromTypeAndProps(
               "it's defined in, or you might have mixed up default and " +
               'named imports.';
           }
-          const ownerName = owner ? getComponentName(owner.type) : null;
+          const ownerName = debugOwner
+            ? getComponentName(debugOwner.type)
+            : null;
           if (ownerName) {
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }
@@ -580,7 +582,9 @@ export function createFiberFromTypeAndProps(
   fiber.elementType = type;
   fiber.type = resolvedType;
   fiber.lanes = lanes;
-
+  if (__DEV__) {
+    fiber._debugOwner = debugOwner;
+  }
   return fiber;
 }
 
@@ -589,9 +593,9 @@ export function createFiberFromElement(
   mode: TypeOfMode,
   lanes: Lanes,
 ): Fiber {
-  let owner = null;
+  let debugOwner = null;
   if (__DEV__) {
-    owner = element._owner;
+    debugOwner = element._debugOwner;
   }
   const type = element.type;
   const key = element.key;
@@ -600,13 +604,12 @@ export function createFiberFromElement(
     type,
     key,
     pendingProps,
-    owner,
+    debugOwner,
     mode,
     lanes,
   );
   if (__DEV__) {
     fiber._debugSource = element._source;
-    fiber._debugOwner = element._debugOwner;
   }
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -452,7 +452,7 @@ export function createFiberFromTypeAndProps(
   type: any, // React$ElementType
   key: null | string,
   pendingProps: any,
-  owner: null | Fiber,
+  debugOwner: null | Fiber,
   mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
@@ -562,7 +562,9 @@ export function createFiberFromTypeAndProps(
               "it's defined in, or you might have mixed up default and " +
               'named imports.';
           }
-          const ownerName = owner ? getComponentName(owner.type) : null;
+          const ownerName = debugOwner
+            ? getComponentName(debugOwner.type)
+            : null;
           if (ownerName) {
             info += '\n\nCheck the render method of `' + ownerName + '`.';
           }
@@ -583,7 +585,9 @@ export function createFiberFromTypeAndProps(
   fiber.elementType = type;
   fiber.type = resolvedType;
   fiber.expirationTime = expirationTime;
-
+  if (__DEV__) {
+    fiber._debugOwner = debugOwner;
+  }
   return fiber;
 }
 
@@ -592,9 +596,9 @@ export function createFiberFromElement(
   mode: TypeOfMode,
   expirationTime: ExpirationTime,
 ): Fiber {
-  let owner = null;
+  let debugOwner = null;
   if (__DEV__) {
-    owner = element._owner;
+    debugOwner = element._debugOwner;
   }
   const type = element.type;
   const key = element.key;
@@ -603,13 +607,12 @@ export function createFiberFromElement(
     type,
     key,
     pendingProps,
-    owner,
+    debugOwner,
     mode,
     expirationTime,
   );
   if (__DEV__) {
     fiber._debugSource = element._source;
-    fiber._debugOwner = element._debugOwner;
   }
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -609,7 +609,7 @@ export function createFiberFromElement(
   );
   if (__DEV__) {
     fiber._debugSource = element._source;
-    fiber._debugOwner = element._owner;
+    fiber._debugOwner = element._debugOwner;
   }
   return fiber;
 }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -323,7 +323,6 @@ function updateForwardRef(
   let nextChildren;
   prepareToReadContext(workInProgress, renderLanes);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -726,7 +725,6 @@ function updateFunctionComponent(
   let nextChildren;
   prepareToReadContext(workInProgress, renderLanes);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -795,7 +793,6 @@ function updateBlock<Props, Data>(
   let nextChildren;
   prepareToReadContext(workInProgress, renderLanes);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -1384,7 +1381,6 @@ function mountIndeterminateComponent(
     }
 
     setIsRendering(true);
-    ReactCurrentOwner.current = workInProgress;
     value = renderWithHooks(
       null,
       workInProgress,
@@ -2875,7 +2871,6 @@ function updateContextConsumer(
   const newValue = readContext(context, newProps.unstable_observedBits);
   let newChildren;
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     newChildren = render(newValue);
     setIsRendering(false);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -309,7 +309,6 @@ function updateForwardRef(
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -652,7 +651,6 @@ function updateFunctionComponent(
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -730,7 +728,6 @@ function updateBlock<Props, Data>(
   let nextChildren;
   prepareToReadContext(workInProgress, renderExpirationTime);
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     nextChildren = renderWithHooks(
       current,
@@ -1376,7 +1373,6 @@ function mountIndeterminateComponent(
     }
 
     setIsRendering(true);
-    ReactCurrentOwner.current = workInProgress;
     value = renderWithHooks(
       null,
       workInProgress,
@@ -2870,7 +2866,6 @@ function updateContextConsumer(
   const newValue = readContext(context, newProps.unstable_observedBits);
   let newChildren;
   if (__DEV__) {
-    ReactCurrentOwner.current = workInProgress;
     setIsRendering(true);
     newChildren = render(newValue);
     setIsRendering(false);

--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -25,6 +25,7 @@ if (__DEV__) {
   };
   // Stack implementation injected by the current renderer.
   ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
+  ReactDebugCurrentFrame.debugOwner = null;
 
   ReactDebugCurrentFrame.getStackAddendum = function(): string {
     let stack = '';

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -159,6 +159,8 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
+    element._debugOwner = owner;
+
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.
     // This can be replaced with a WeakMap once they are implemented in

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -7,9 +7,15 @@
 
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 import ReactCurrentOwner from './ReactCurrentOwner';
+
+let ReactDebugCurrentFrame;
+if (__DEV__) {
+  ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+}
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -159,7 +165,7 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
-    element._debugOwner = owner;
+    element._debugOwner = ReactDebugCurrentFrame.debugOwner;
 
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -165,8 +165,6 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
-    element._debugOwner = ReactDebugCurrentFrame.debugOwner;
-
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.
     // This can be replaced with a WeakMap once they are implemented in
@@ -197,6 +195,12 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
       enumerable: false,
       writable: false,
       value: source,
+    });
+    Object.defineProperty(element, '_debugOwner', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: ReactDebugCurrentFrame.debugOwner,
     });
     if (Object.freeze) {
       Object.freeze(element.props);

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -24,24 +24,25 @@ import {
 import {warnAboutSpreadingKeyToJSX} from 'shared/ReactFeatureFlags';
 import checkPropTypes from 'shared/checkPropTypes';
 
-import ReactCurrentOwner from './ReactCurrentOwner';
 import {
   isValidElement,
   createElement,
   cloneElement,
   jsxDEV,
 } from './ReactElement';
-import {setExtraStackFrame} from './ReactDebugCurrentFrame';
+import ReactDebugCurrentFrame, {
+  setExtraStackFrame,
+} from './ReactDebugCurrentFrame';
 import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFrame';
 
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {
     if (element) {
-      const owner = element._owner;
+      const debugOwner = element._debugOwner;
       const stack = describeUnknownElementTypeFrameInDEV(
         element.type,
         element._source,
-        owner ? owner.type : null,
+        debugOwner ? debugOwner.type : null,
       );
       setExtraStackFrame(stack);
     } else {
@@ -59,8 +60,8 @@ if (__DEV__) {
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 function getDeclarationErrorAddendum() {
-  if (ReactCurrentOwner.current) {
-    const name = getComponentName(ReactCurrentOwner.current.type);
+  if (ReactDebugCurrentFrame.debugOwner) {
+    const name = getComponentName(ReactDebugCurrentFrame.debugOwner.type);
     if (name) {
       return '\n\nCheck the render method of `' + name + '`.';
     }
@@ -135,12 +136,12 @@ function validateExplicitKey(element, parentType) {
   let childOwner = '';
   if (
     element &&
-    element._owner &&
-    element._owner !== ReactCurrentOwner.current
+    element._debugOwner &&
+    element._debugOwner !== ReactDebugCurrentFrame.debugOwner
   ) {
     // Give the component that originally created this child.
     childOwner = ` It was passed a child from ${getComponentName(
-      element._owner.type,
+      element._debugOwner.type,
     )}.`;
   }
 

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -164,8 +164,6 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
-    element._debugOwner = ReactDebugCurrentFrame.debugOwner;
-
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.
     // This can be replaced with a WeakMap once they are implemented in
@@ -196,6 +194,12 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
       enumerable: false,
       writable: false,
       value: source,
+    });
+    Object.defineProperty(element, '_debugOwner', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: ReactDebugCurrentFrame.debugOwner,
     });
     if (Object.freeze) {
       Object.freeze(element.props);

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -11,6 +11,10 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+let ReactDebugCurrentFrame;
+if (__DEV__) {
+  ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
+}
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -160,7 +164,7 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
-    element._debugOwner = owner;
+    element._debugOwner = ReactDebugCurrentFrame.debugOwner;
 
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -160,6 +160,8 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
   };
 
   if (__DEV__) {
+    element._debugOwner = owner;
+
     // The validation flag is currently mutative. We put it on
     // an external backing store so that we can freeze the whole object.
     // This can be replaced with a WeakMap once they are implemented in

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -29,17 +29,16 @@ import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFr
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {
     if (element) {
-      const owner = element._owner;
+      const debugOwner = element._debugOwner;
       const stack = describeUnknownElementTypeFrameInDEV(
         element.type,
         element._source,
-        owner ? owner.type : null,
+        debugOwner ? debugOwner.type : null,
       );
       ReactDebugCurrentFrame.setExtraStackFrame(stack);
     } else {
@@ -75,8 +74,8 @@ export function isValidElement(object) {
 
 function getDeclarationErrorAddendum() {
   if (__DEV__) {
-    if (ReactCurrentOwner.current) {
-      const name = getComponentName(ReactCurrentOwner.current.type);
+    if (ReactDebugCurrentFrame.debugOwner) {
+      const name = getComponentName(ReactDebugCurrentFrame.debugOwner.type);
       if (name) {
         return '\n\nCheck the render method of `' + name + '`.';
       }
@@ -150,12 +149,12 @@ function validateExplicitKey(element, parentType) {
     let childOwner = '';
     if (
       element &&
-      element._owner &&
-      element._owner !== ReactCurrentOwner.current
+      element._debugOwner &&
+      element._debugOwner !== ReactDebugCurrentFrame.debugOwner
     ) {
       // Give the component that originally created this child.
       childOwner = ` It was passed a child from ${getComponentName(
-        element._owner.type,
+        element._debugOwner.type,
       )}.`;
     }
 

--- a/packages/shared/ReactElementType.js
+++ b/packages/shared/ReactElementType.js
@@ -22,6 +22,7 @@ export type ReactElement = {|
   _owner: any,
 
   // __DEV__
+  _debugOwner: any,
   _store: {validated: boolean, ...},
   _self: React$Element<any>,
   _shadowChildren: any,


### PR DESCRIPTION
We rely on the element owner for two different behaviors:

1. Semantic meaning: If an element is created in a class render method, that instance becomes its String Ref Owner.
2. Debugging info: If an element gets created while rendering an arbitrary fiber, we want to "remember" that for DevTools and some warning messages.

These purposes are currently conflated because we only have `element._owner`. This field is set inconsistently, e.g. it's set in production only for classes, but in development it's set while rendering function components too. This makes it hard to remove in the future when we remove String Refs.

In this PR, we split these two purposes into `element._owner` (populated from `ReactCurrentOwner.current`) and `element._debugOwner` (populated from `ReactDebugCurrentFrame.debugOwner`).

Only String Refs now rely on `element._owner`, so in this PR we no longer set `ReactCurrentOwner.current` for other Fiber types. The DEV-only cases rely on `element._debugOwner`.

TODO:

- [ ] Possibly revert the MountInderterminateComponent case. We may need this if refs worked for Factory Components before.
- [ ] Change DevTools to rely on `_debugOwner` for "rendered by" breadcrumbs.
  - [ ] Perhaps, this means we need to flip it, add a PROD `_refOwner` field, and then keep `_owner` as the DEV-only one? Then we won't need to change DevTools.
- [ ] Maybe, put `isRendering` onto `ReactDebugCurrentFrame`.