### PR TITLE
Resolve an edge case where ref.node can be falsy

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -171,6 +171,7 @@ export default function(babel, opts = {}) {
         for (let i = 0; i < referencePaths.length; i++) {
           const ref = referencePaths[i];
           if (
+            ref.node &&
             ref.node.type !== 'JSXIdentifier' &&
             ref.node.type !== 'Identifier'
           ) {


### PR DESCRIPTION
## Summary

Discovered an edge case on a Next.js project where `ref.node` can be falsy. This causes the development server to become unable to compile correctly, and subsequently fails.

## Test Plan

Apologies, the project in question is proprietary, I cannot use it to demonstrate this case, it's also not the easier thing to replicate. 

I'm hoping the simplicity of the change in question will be enough to allow it to be merged
