### PR TITLE
Fix: bug (styles/lastProp).hasOwnProperty is not a function

### DIFF
--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -271,7 +271,7 @@ describe('CSSPropertyOperations', () => {
     class Comp extends React.Component {
       render() {
         const style = {
-          __proto__: { hasOwnProperty: '' }
+          __proto__: {hasOwnProperty: ''},
         };
         return <div style={style} />;
       }

--- a/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/CSSPropertyOperations-test.js
@@ -254,4 +254,30 @@ describe('CSSPropertyOperations', () => {
 
     expect(root.children[0].style.getPropertyValue('--foo')).toEqual('5');
   });
+
+  it('should render when style object has `null` prototype', () => {
+    class Comp extends React.Component {
+      render() {
+        const style = Object.create(null);
+        return <div style={style} />;
+      }
+    }
+
+    const root = document.createElement('div');
+    ReactDOM.render(<Comp />, root);
+  });
+
+  it('should render when style object has `__proto__`', () => {
+    class Comp extends React.Component {
+      render() {
+        const style = {
+          __proto__: { hasOwnProperty: '' }
+        };
+        return <div style={style} />;
+      }
+    }
+
+    const root = document.createElement('div');
+    ReactDOM.render(<Comp />, root);
+  });
 });

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -110,6 +110,7 @@ const HTML = '__html';
 const DEPRECATED_flareListeners = 'DEPRECATED_flareListeners';
 
 const {html: HTML_NAMESPACE} = Namespaces;
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 let warnedUnknownTags;
 let suppressHydrationWarning;
@@ -731,7 +732,7 @@ export function diffProperties(
     if (propKey === STYLE) {
       const lastStyle = lastProps[propKey];
       for (styleName in lastStyle) {
-        if (lastStyle.hasOwnProperty(styleName)) {
+        if (hasOwnProperty.call(lastStyle, styleName)) {
           if (!styleUpdates) {
             styleUpdates = {};
           }
@@ -783,8 +784,8 @@ export function diffProperties(
         // Unset styles on `lastProp` but not on `nextProp`.
         for (styleName in lastProp) {
           if (
-            lastProp.hasOwnProperty(styleName) &&
-            (!nextProp || !nextProp.hasOwnProperty(styleName))
+            hasOwnProperty.call(lastProp, styleName) &&
+            (!nextProp || !hasOwnProperty.call(nextProp, styleName))
           ) {
             if (!styleUpdates) {
               styleUpdates = {};
@@ -795,7 +796,7 @@ export function diffProperties(
         // Update styles that changed since `lastProp`.
         for (styleName in nextProp) {
           if (
-            nextProp.hasOwnProperty(styleName) &&
+            hasOwnProperty.call(nextProp, styleName) &&
             lastProp[styleName] !== nextProp[styleName]
           ) {
             if (!styleUpdates) {

--- a/packages/react-dom/src/shared/CSSPropertyOperations.js
+++ b/packages/react-dom/src/shared/CSSPropertyOperations.js
@@ -11,6 +11,8 @@ import dangerousStyleValue from './dangerousStyleValue';
 import hyphenateStyleName from './hyphenateStyleName';
 import warnValidStyle from './warnValidStyle';
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
 /**
  * Operations for dealing with CSS properties.
  */
@@ -26,7 +28,7 @@ export function createDangerousStringForStyles(styles) {
     let serialized = '';
     let delimiter = '';
     for (const styleName in styles) {
-      if (!styles.hasOwnProperty(styleName)) {
+      if (!hasOwnProperty.call(styles, styleName)) {
         continue;
       }
       const styleValue = styles[styleName];
@@ -59,7 +61,7 @@ export function createDangerousStringForStyles(styles) {
 export function setValueForStyles(node, styles) {
   const style = node.style;
   for (let styleName in styles) {
-    if (!styles.hasOwnProperty(styleName)) {
+    if (!hasOwnProperty.call(styles, styleName)) {
       continue;
     }
     const isCustomProperty = styleName.indexOf('--') === 0;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I've found a strange issue when using style objects with prototype `null` or that override `__proto__` which causes React to crash with:

```
[First props] Uncaught TypeError: styles.hasOwnProperty is not a function
[Diff props] Uncaught TypeError: lastProp.hasOwnProperty is not a function
```

## Test Plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I added two tests that check this behavior. It basically happens in these cases:

1. Style object has prototype of `null`:
```js
const styles = Object.create(null)
return <span style={styles}>Hey</span>
```
This is because React does:
```js
styles.hasOwnProperty(styleName)
```
However, objects with prototype `null` don't have `hasOwnProperty` method.

2. Style object has `__proto__` that overrides `hasOwnProperty`
```js
const styles = { __proto__: { hasOwnProperty: '' } }
return <span style={styles}>Hey</span>
```
This is similar to the previous in that the prototype overrides `hasOwnProperty` method. In this case to something that is not a `function`.

These are probably edge cases but it doesn't seem safe to rely on `hasOwnProperty` method from the provided `style` prop. In my case, it was a port of a styled system that created objects with prototype `null`.

From what I understand, this doesn't or shouldn't affects `lastProps/nextProps` because create React elements method does already use `Object.prototype.hasOwnProperty` to create a shallow copy of props.

As a suggestion, maybe React could export `Object.prototype.hasOwnProperty` to a shared module as `has` or `hasOwn` method and use it everywhere in order to avoid this type of issues.