### PR TITLE
Make LegacyHidden match semantics of old fork

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -1020,18 +1020,14 @@ class ReactDOMServerRenderer {
       }
 
       switch (elementType) {
-        case REACT_LEGACY_HIDDEN_TYPE: {
-          if (!enableSuspenseServerRenderer) {
-            break;
-          }
-          if (((nextChild: any): ReactElement).props.mode === 'hidden') {
-            // In hidden mode, render nothing.
-            return '';
-          }
-          // Otherwise the tree is visible, so act like a fragment.
-        }
-        // Intentional fall through
-        // eslint-disable-next-line no-fallthrough
+        // TODO: LegacyHidden acts the same as a fragment. This only works
+        // because we currently assume that every instance of LegacyHidden is
+        // accompanied by a host component wrapper. In the hidden mode, the host
+        // component is given a `hidden` attribute, which ensures that the
+        // initial HTML is not visible. To support the use of LegacyHidden as a
+        // true fragment, without an extra DOM node, we would have to hide the
+        // initial HTML in some other way.
+        case REACT_LEGACY_HIDDEN_TYPE:
         case REACT_DEBUG_TRACING_MODE_TYPE:
         case REACT_STRICT_MODE_TYPE:
         case REACT_PROFILER_TYPE:

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -165,7 +165,6 @@ import {
   reenterHydrationStateFromDehydratedSuspenseInstance,
   resetHydrationState,
   tryToClaimNextHydratableInstance,
-  getIsHydrating,
   warnIfHydrating,
 } from './ReactFiberHydrationContext.new';
 import {
@@ -578,13 +577,7 @@ function updateOffscreenComponent(
       };
       workInProgress.memoizedState = nextState;
       pushRenderLanes(workInProgress, renderLanes);
-    } else if (
-      !includesSomeLane(renderLanes, (OffscreenLane: Lane)) ||
-      // Server renderer does not render hidden subtrees, so if we're hydrating
-      // we should always bail out and schedule a subsequent render pass, to
-      // force a client render. Even if we're already at Offscreen priority.
-      (current === null && getIsHydrating())
-    ) {
+    } else if (!includesSomeLane(renderLanes, (OffscreenLane: Lane))) {
       let nextBaseLanes;
       if (prevState !== null) {
         const prevBaseLanes = prevState.baseLanes;

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -41,6 +41,9 @@ const environmentFlags = {
   experimental: __EXPERIMENTAL__,
   // Similarly, should stable imply "classic"?
   stable: !__EXPERIMENTAL__,
+
+  // Use this for tests that are known to be broken.
+  FIXME: false,
 };
 
 function getTestFlags() {


### PR DESCRIPTION
Facebook currently relies on being able to hydrate hidden HTML. So skipping those trees is a regression.

We don't have a proper solution for this in the new API yet. So I'm reverting it to match the old behavior.

Now the server renderer will treat LegacyHidden the same as a fragment, with no other special behavior. We can only get away with this because we assume that every instance of LegacyHidden is accompanied by a host component wrapper. In the hidden mode, the host component is given a `hidden` attribute, which ensures that the initial HTML is not visible. To support the use of LegacyHidden as a true fragment, without an extra DOM node, we will have to hide the initial HTML in some other way.