### PR TITLE
fix(eslint-plugin-react-hooks): Support nullish coalescing and optional chaining of dependencies

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -251,6 +251,44 @@ const tests = {
         }
       `,
     },
+    // Nullish coalescing and optional chaining
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo?.bar?.baz ?? null);
+          }, [props.foo]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo?.bar);
+          }, [props.foo?.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo);
+            console.log(props.foo?.bar);
+          }, [props.foo]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo?.toString());
+          }, [props.foo]);
+        }
+      `,
+    },
     {
       code: normalizeIndent`
         function MyComponent() {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1238,7 +1238,7 @@ function collectRecommendations({
     const keys = path.split('.');
     let node = rootNode;
     for (const key of keys) {
-      let child = node.children.get(key);
+      let child = getChildByKey(node, key);
       if (!child) {
         child = createDepTree();
         node.children.set(key, child);
@@ -1251,13 +1251,28 @@ function collectRecommendations({
     const keys = path.split('.');
     let node = rootNode;
     for (const key of keys) {
-      const child = node.children.get(key);
+      const child = getChildByKey(node, key);
       if (!child) {
         return;
       }
       fn(child);
       node = child;
     }
+  }
+
+  /**
+   * Match key with optional chaining
+   * key -> key
+   * key? -> key
+   * key -> key?
+   * Otherwise undefined.
+   */
+  function getChildByKey(node, key) {
+    return (
+      node.children.get(key) ||
+      node.children.get(key.split('?')[0]) ||
+      node.children.get(key + '?')
+    );
   }
 
   // Now we can learn which dependencies are missing or necessary.


### PR DESCRIPTION
Relates to #18985

## Summary

In conditions where optional chaining is used inside the `useEffect` hook, the `react-hooks/exhaustive-deps` rule falsely flags missing dependencies. This change adds some logic to the linting rules to also match dependencies with optional chaining.

## Test Plan

Have added tests to cover the following valid scenarios that were previously failing:

```javascript
// Nullish coalescing
function MyComponent(props) {
  useEffect(() => {
    console.log(props.foo?.bar?.baz ?? null);
  }, [props.foo]);
}
```

```javascript
// Optional chaining
function MyComponent(props) {
  useEffect(() => {
    console.log(props.foo?.bar);
  }, [props.foo?.bar]);
}
```

```javascript
// Normal and optional chaining
function MyComponent(props) {
  useEffect(() => {
    console.log(props.foo);
    console.log(props.foo?.bar);
  }, [props.foo]);
}
```

```javascript
// Optional chaining with prototype method
function MyComponent(props) {
  useEffect(() => {
    console.log(props.foo?.toString());
  }, [props.foo]);
}
```