### PR TITLE
Support Babel's envName option in React Refresh plugin

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -8,7 +8,7 @@
 'use strict';
 
 export default function(babel, opts = {}) {
-  if (typeof babel.getEnv === 'function') {
+  if (typeof babel.env === 'function') {
     // Only available in Babel 7.
     const env = babel.env();
     if (env !== 'development' && !opts.skipEnvCheck) {

--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -10,7 +10,7 @@
 export default function(babel, opts = {}) {
   if (typeof babel.getEnv === 'function') {
     // Only available in Babel 7.
-    const env = babel.getEnv();
+    const env = babel.env();
     if (env !== 'development' && !opts.skipEnvCheck) {
       throw new Error(
         'React Refresh Babel transform should only be enabled in development environment. ' +

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -16,13 +16,15 @@ function transform(input, options = {}) {
     babel.transform(input, {
       babelrc: false,
       configFile: false,
+      envName: options.envName,
       plugins: [
         '@babel/syntax-jsx',
         '@babel/syntax-dynamic-import',
         [
           freshPlugin,
           {
-            skipEnvCheck: true,
+            skipEnvCheck:
+              options.skipEnvCheck === undefined ? true : options.skipEnvCheck,
             // To simplify debugging tests:
             emitFullSignatures: true,
             ...options.freshOptions,
@@ -497,5 +499,20 @@ describe('ReactFreshBabelPlugin', () => {
         },
       ),
     ).toMatchSnapshot();
+  });
+
+  it("respects Babel's envName option", () => {
+    const envName = 'random';
+    expect(() =>
+      transform(`export default function BabelEnv () { return null };`, {
+        envName,
+        skipEnvCheck: false,
+      }),
+    ).toThrowError(
+      'React Refresh Babel transform should only be enabled in development environment. ' +
+        'Instead, the environment is: "' +
+        envName +
+        '". If you want to override this check, pass {skipEnvCheck: true} as plugin options.',
+    );
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

[`babel.getEnv()`](https://github.com/babel/babel/blob/f6c7bf36cec81baaba8c37e572985bb59ca334b1/packages/babel-core/src/config/helpers/environment.js) ignores Babel's [`envName`](https://babeljs.io/docs/en/options#envname) option that can be used, for example, when calling `transformFromAst` from `@babel/core` directly. This can throw an error if `skipEnvCheck == false` and `process.env.BABEL_ENV !== 'development'`.

Using [`babel.env()`](https://babeljs.io/docs/en/config-files#apienv) prioritizes `envName` over `process.env.<x>` values and resolves the issue.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Added a test. If I change `babel.env()` back to `babel.getEnv()`, the test fails.