### PR TITLE
Bug: Spawning hydration in response to Idle update

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -208,6 +208,7 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
       return_updateRangeEnd = IdleUpdateRangeStart;
       return IdleHydrationLane;
     } else {
+      return_highestLanePriority = IdleLanePriority;
       return_updateRangeEnd = IdleUpdateRangeEnd;
       return idleLanes;
     }
@@ -527,7 +528,7 @@ export function findUpdateLane(
       // Should be handled by findTransitionLane instead
       break;
     case IdleLanePriority:
-      let lane = findLane(IdleUpdateRangeStart, IdleUpdateRangeEnd, IdleLanes);
+      let lane = findLane(IdleUpdateRangeStart, IdleUpdateRangeEnd, wipLanes);
       if (lane === NoLane) {
         lane = IdleHydrationLane;
       }


### PR DESCRIPTION
Fixes a bug in the new fork when hydrating in response to an idle priority update.

The root cause isn't super interesting. Just silly mistakes that I made while iterating on the Lanes module, and that weren't caught by any of our tests.

There's a lot of duplication in the Lanes module right now. It's also not super stable as we continue to refine our heuristics. Hopefully the final state is simpler and harder to mess up.