### PR TITLE
Only prepare extra stack frames if needed

### DIFF
--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -227,9 +227,7 @@ function validatePropTypes(element) {
       return;
     }
     if (propTypes) {
-      setCurrentlyValidatingElement(element);
-      checkPropTypes(propTypes, element.props, 'prop', name);
-      setCurrentlyValidatingElement(null);
+      checkPropTypes(propTypes, element.props, 'prop', name, element);
     } else if (type.PropTypes !== undefined && !propTypesMisspellWarningShown) {
       propTypesMisspellWarningShown = true;
       console.error(
@@ -255,26 +253,26 @@ function validatePropTypes(element) {
  */
 function validateFragmentProps(fragment) {
   if (__DEV__) {
-    setCurrentlyValidatingElement(fragment);
-
     const keys = Object.keys(fragment.props);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       if (key !== 'children' && key !== 'key') {
+        setCurrentlyValidatingElement(fragment);
         console.error(
           'Invalid prop `%s` supplied to `React.Fragment`. ' +
             'React.Fragment can only have `key` and `children` props.',
           key,
         );
+        setCurrentlyValidatingElement(null);
         break;
       }
     }
 
     if (fragment.ref !== null) {
+      setCurrentlyValidatingElement(fragment);
       console.error('Invalid attribute `ref` supplied to `React.Fragment`.');
+      setCurrentlyValidatingElement(null);
     }
-
-    setCurrentlyValidatingElement(null);
   }
 }
 

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -243,9 +243,7 @@ function validatePropTypes(element) {
       return;
     }
     if (propTypes) {
-      setCurrentlyValidatingElement(element);
-      checkPropTypes(propTypes, element.props, 'prop', name);
-      setCurrentlyValidatingElement(null);
+      checkPropTypes(propTypes, element.props, 'prop', name, element);
     } else if (type.PropTypes !== undefined && !propTypesMisspellWarningShown) {
       propTypesMisspellWarningShown = true;
       console.error(
@@ -271,26 +269,26 @@ function validatePropTypes(element) {
  */
 function validateFragmentProps(fragment) {
   if (__DEV__) {
-    setCurrentlyValidatingElement(fragment);
-
     const keys = Object.keys(fragment.props);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       if (key !== 'children' && key !== 'key') {
+        setCurrentlyValidatingElement(fragment);
         console.error(
           'Invalid prop `%s` supplied to `React.Fragment`. ' +
             'React.Fragment can only have `key` and `children` props.',
           key,
         );
+        setCurrentlyValidatingElement(null);
         break;
       }
     }
 
     if (fragment.ref !== null) {
+      setCurrentlyValidatingElement(fragment);
       console.error('Invalid attribute `ref` supplied to `React.Fragment`.');
+      setCurrentlyValidatingElement(null);
     }
-
-    setCurrentlyValidatingElement(null);
   }
 }
 


### PR DESCRIPTION
We currently prepare an extra stack frame before they're needed. Particularly for propTypes. This causes problems as they can have side-effects with the new component stacks and it's slow.

This moves it to be lazy.

I stopped short of just deleting propTypes support but I think we should do it. I've literally spent weeks debugging propTypes issues this year. The opportunity cost is too high.