### PR TITLE
Don't build unstable entry point for STABLE

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -516,6 +516,10 @@ function shouldSkipBundle(bundle, bundleType) {
       return true;
     }
   }
+  if (!__EXPERIMENTAL__ && bundle.entry.indexOf('unstable') !== -1) {
+    // Don't build unstable entry point bundles for the stable release channel.
+    return true;
+  }
   return false;
 }
 


### PR DESCRIPTION
Let's see what breaks?

This just excludes bundles from the build. The entry points would still be there. Maybe that's a reasonable protection. I don't know if any tools try to crawl the entry points preemptively and if shipping intentionally missing ones could cause any issues. As a layer above, we could also exclude the entry points themselves but that adds more moving parts and not sure if worth the complexity.