### PR TITLE
Revert "Fix mistyped script arbitrary code execution vulnerability"

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -430,13 +430,11 @@ export function createElement(
     namespaceURI = getIntrinsicNamespace(type);
   }
   if (namespaceURI === HTML_NAMESPACE) {
-    const lowerCaseType = type.toLowerCase();
-
     if (__DEV__) {
       isCustomComponentTag = isCustomComponent(type, props);
       // Should this check be gated by parent namespace? Not sure we want to
       // allow <SVG> or <mATH>.
-      if (!isCustomComponentTag && type !== lowerCaseType) {
+      if (!isCustomComponentTag && type !== type.toLowerCase()) {
         console.error(
           '<%s /> is using incorrect casing. ' +
             'Use PascalCase for React components, ' +
@@ -446,7 +444,7 @@ export function createElement(
       }
     }
 
-    if (lowerCaseType === 'script') {
+    if (type === 'script') {
       // Create the script via .innerHTML so its "parser-inserted" flag is
       // set to true and it does not execute
       const div = ownerDocument.createElement('div');

--- a/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
+++ b/packages/react-dom/src/client/__tests__/trustedTypes-test.internal.js
@@ -242,20 +242,4 @@ describe('when Trusted Types are available in global object', () => {
     // check that the warning is printed only once
     ReactDOM.render(<script>alert("I am not executed")</script>, container);
   });
-
-  it('should warn twice when rendering scRipt tag and prevent code execution on mistyped tag', () => {
-    expect(() => {
-      ReactDOM.render(<scRipt>alert("I am not executed")</scRipt>, container);
-    }).toErrorDev([
-      'Warning: <scRipt /> is using incorrect casing. ' +
-        'Use PascalCase for React components, ' +
-        'or lowercase for HTML elements.\n' +
-        '    in scRipt (at **)',
-      'Warning: Encountered a script tag while rendering React component. ' +
-        'Scripts inside React components are never executed when rendering ' +
-        'on the client. Consider using template tag instead ' +
-        '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).\n' +
-        '    in scRipt (at **)',
-    ]);
-  });
 });


### PR DESCRIPTION
Reverts facebook/react#18660

This is not a "vulnerability".

If the attacker controls the tag name, then they can just give you `<script>` instead. So this is not protecting from any actual attack.

We have a warning if you try to use non-lowercase characters in the type. This is not supported. So the semantics there are undefined. They don't have to be consistent. You're on your own if you ignore warnings.

Moreover, even a regular `<script>` will execute if you do SSR. So generally, if you don't want them to execute, you shouldn't be putting `<script>` in your components.

The motivation of the revert is to remove otherwise-unnecessary `toLowerCase` from the production path for every element.