### PR TITLE
Add ES2015 Node Build Config without ESM nor PROD/DEV

### DIFF
--- a/packages/react-transport-dom-webpack/npm/plugin.js
+++ b/packages/react-transport-dom-webpack/npm/plugin.js
@@ -1,7 +1,3 @@
 'use strict';
 
-if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-transport-dom-webpack-plugin.production.min.js');
-} else {
-  module.exports = require('./cjs/react-transport-dom-webpack-plugin.development.js');
-}
+module.exports = require('./cjs/react-transport-dom-webpack-plugin.js');

--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -45,6 +45,7 @@ process.on('unhandledRejection', err => {
 });
 
 const {
+  NODE_ES2015,
   UMD_DEV,
   UMD_PROD,
   UMD_PROFILING,
@@ -244,6 +245,7 @@ function getFormat(bundleType) {
     case UMD_PROD:
     case UMD_PROFILING:
       return `umd`;
+    case NODE_ES2015:
     case NODE_DEV:
     case NODE_PROD:
     case NODE_PROFILING:
@@ -262,6 +264,7 @@ function getFormat(bundleType) {
 
 function isProductionBundleType(bundleType) {
   switch (bundleType) {
+    case NODE_ES2015:
     case UMD_DEV:
     case NODE_DEV:
     case FB_WWW_DEV:
@@ -286,6 +289,7 @@ function isProductionBundleType(bundleType) {
 
 function isProfilingBundleType(bundleType) {
   switch (bundleType) {
+    case NODE_ES2015:
     case FB_WWW_DEV:
     case FB_WWW_PROD:
     case NODE_DEV:
@@ -725,6 +729,7 @@ async function buildEverything() {
   // eslint-disable-next-line no-for-of-loops/no-for-of-loops
   for (const bundle of Bundles.bundles) {
     bundles.push(
+      [bundle, NODE_ES2015],
       [bundle, UMD_DEV],
       [bundle, UMD_PROD],
       [bundle, UMD_PROFILING],

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -8,6 +8,7 @@ const __EXPERIMENTAL__ =
     : true;
 
 const bundleTypes = {
+  NODE_ES2015: 'NODE_ES2015',
   UMD_DEV: 'UMD_DEV',
   UMD_PROD: 'UMD_PROD',
   UMD_PROFILING: 'UMD_PROFILING',
@@ -26,6 +27,7 @@ const bundleTypes = {
 };
 
 const {
+  NODE_ES2015,
   UMD_DEV,
   UMD_PROD,
   UMD_PROFILING,
@@ -280,22 +282,11 @@ const bundles = [
 
   /******* React Transport DOM Webpack Plugin *******/
   {
-    bundleTypes: [NODE_DEV, NODE_PROD],
+    bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
     entry: 'react-transport-dom-webpack/plugin',
     global: 'ReactFlightWebpackPlugin',
     externals: [],
-    babel: opts =>
-      Object.assign({}, opts, {
-        // Include JSX
-        presets: opts.presets.concat([
-          require.resolve('@babel/preset-react'),
-          require.resolve('@babel/preset-flow'),
-        ]),
-        plugins: opts.plugins.concat([
-          [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
-        ]),
-      }),
   },
 
   /******* React Transport DOM Server Relay *******/
@@ -803,6 +794,8 @@ function getFilename(bundle, bundleType) {
   // we do this to replace / to -, for react-dom/server
   name = name.replace('/index.', '.').replace('/', '-');
   switch (bundleType) {
+    case NODE_ES2015:
+      return `${name}.js`;
     case UMD_DEV:
       return `${name}.development.js`;
     case UMD_PROD:

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -16,6 +16,7 @@ const {
 } = require('./utils');
 
 const {
+  NODE_ES2015,
   UMD_DEV,
   UMD_PROD,
   UMD_PROFILING,
@@ -42,6 +43,8 @@ function getPackageName(name) {
 
 function getBundleOutputPath(bundleType, filename, packageName) {
   switch (bundleType) {
+    case NODE_ES2015:
+      return `build/node_modules/${packageName}/cjs/${filename}`;
     case NODE_DEV:
     case NODE_PROD:
     case NODE_PROFILING:

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = {
+  env: {
+    commonjs: true,
+    browser: true,
+  },
+  globals: {
+    // ES 6
+    Map: true,
+    Set: true,
+    Proxy: true,
+    Symbol: true,
+    WeakMap: true,
+    WeakSet: true,
+    Uint16Array: true,
+    Reflect: true,
+    // Vendor specific
+    MSApp: true,
+    __REACT_DEVTOOLS_GLOBAL_HOOK__: true,
+    // CommonJS / Node
+    process: true,
+    setImmediate: true,
+    Buffer: true,
+    // Trusted Types
+    trustedTypes: true,
+
+    // Scheduler profiling
+    SharedArrayBuffer: true,
+    Int32Array: true,
+    ArrayBuffer: true,
+
+    // Flight
+    Uint8Array: true,
+    Promise: true,
+
+    // Flight Webpack
+    __webpack_chunk_load__: true,
+    __webpack_require__: true,
+
+    // jest
+    expect: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2015,
+    sourceType: 'script',
+  },
+  rules: {
+    'no-undef': 'error',
+    'no-shadow-restricted-names': 'error',
+  },
+
+  // These plugins aren't used, but eslint complains if an eslint-ignore comment
+  // references unused plugins. An alternate approach could be to strip
+  // eslint-ignore comments as part of the build.
+  plugins: ['jest', 'no-for-of-loops', 'react', 'react-internal'],
+};

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -8,6 +8,7 @@ const {bundles, getFilename, bundleTypes} = require('../bundles');
 const Packaging = require('../packaging');
 
 const {
+  NODE_ES2015,
   UMD_DEV,
   UMD_PROD,
   UMD_PROFILING,
@@ -31,6 +32,8 @@ function getFormat(bundleType) {
     case UMD_PROD:
     case UMD_PROFILING:
       return 'umd';
+    case NODE_ES2015:
+      return 'cjs2015';
     case NODE_DEV:
     case NODE_PROD:
     case NODE_PROFILING:
@@ -60,6 +63,7 @@ function getESLintInstance(format) {
 
 const esLints = {
   cjs: getESLintInstance('cjs'),
+  cjs2015: getESLintInstance('cjs2015'),
   rn: getESLintInstance('rn'),
   fb: getESLintInstance('fb'),
   umd: getESLintInstance('umd'),

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -4,6 +4,7 @@ const {bundleTypes, moduleTypes} = require('./bundles');
 const reactVersion = require('../../package.json').version;
 
 const {
+  NODE_ES2015,
   UMD_DEV,
   UMD_PROD,
   UMD_PROFILING,
@@ -29,6 +30,19 @@ const license = ` * Copyright (c) Facebook, Inc. and its affiliates.
  * LICENSE file in the root directory of this source tree.`;
 
 const wrappers = {
+  /***************** NODE_ES2015 *****************/
+  [NODE_ES2015](source, globalName, filename, moduleType) {
+    return `/** @license React v${reactVersion}
+ * ${filename}
+ *
+${license}
+ */
+
+'use strict';
+
+${source}`;
+  },
+
   /***************** UMD_DEV *****************/
   [UMD_DEV](source, globalName, filename, moduleType) {
     return `/** @license React v${reactVersion}


### PR DESCRIPTION
I've had this pending in a branch for a while so I figured I'd just get it in.

The webpack plugin doesn't really need a separate prod and dev build. It also needs to be ES2015 otherwise we can't extend native classes.

Notably, unlike other build variants we'll add for ESM, this compiles to CommonJS. This is basically the current idiomatic output for Node.js script builds.

We could probably use this for other Node scripts as well like eslint-plugin-react-hooks.