### PR TITLE
Lint classic www build

### DIFF
--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -69,13 +69,10 @@ const bundles = [
       `./build/node_modules/*/cjs/*.js`,
     ],
   },
-];
-
-if (process.env.RELEASE_CHANNEL === 'experimental') {
-  bundles.push({
+  {
     format: 'fb',
     filePatterns: [`./build/facebook-www/*.js`],
-  });
-}
+  },
+];
 
 bundles.map(checkFilesExist).map(lint);


### PR DESCRIPTION
We don't currently lint the build that we actually use. I think this was probably an oversight when we enabled modern www builds.