### PR TITLE
Remove ReactComponentTreeHook from internals

### DIFF
--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -22,13 +22,7 @@ const ReactSharedInternals = {
 };
 
 if (__DEV__) {
-  Object.assign(ReactSharedInternals, {
-    // These should not be included in production.
-    ReactDebugCurrentFrame,
-    // Shim for React DOM 16.0.0 which still destructured (but not used) this.
-    // TODO: remove in React 17.0.
-    ReactComponentTreeHook: {},
-  });
+  ReactSharedInternals.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
 }
 
 export default ReactSharedInternals;

--- a/packages/react/src/forks/ReactSharedInternals.umd.js
+++ b/packages/react/src/forks/ReactSharedInternals.umd.js
@@ -21,26 +21,18 @@ const ReactSharedInternals = {
   ReactCurrentBatchConfig,
   // Used by renderers to avoid bundling object-assign twice in UMD bundles:
   assign,
+
+  // Re-export the schedule API(s) for UMD bundles.
+  // This avoids introducing a dependency on a new UMD global in a minor update,
+  // Since that would be a breaking change (e.g. for all existing CodeSandboxes).
+  // This re-export is only required for UMD bundles;
+  // CJS bundles use the shared NPM package.
+  Scheduler,
+  SchedulerTracing,
 };
 
 if (__DEV__) {
-  Object.assign(ReactSharedInternals, {
-    // These should not be included in production.
-    ReactDebugCurrentFrame,
-    // Shim for React DOM 16.0.0 which still destructured (but not used) this.
-    // TODO: remove in React 17.0.
-    ReactComponentTreeHook: {},
-  });
+  ReactSharedInternals.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
 }
-
-// Re-export the schedule API(s) for UMD bundles.
-// This avoids introducing a dependency on a new UMD global in a minor update,
-// Since that would be a breaking change (e.g. for all existing CodeSandboxes).
-// This re-export is only required for UMD bundles;
-// CJS bundles use the shared NPM package.
-Object.assign(ReactSharedInternals, {
-  Scheduler,
-  SchedulerTracing,
-});
 
 export default ReactSharedInternals;


### PR DESCRIPTION
We don't really support mixing minor versions anymore anyway. But seems safe to remove in 17.
