### PR TITLE
Exploration: find why we leak fibers in new reconciler

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -859,6 +859,8 @@ function hideOrUnhideAllChildren(finishedWork, isHidden) {
       ) {
         // Found a nested Offscreen component that is hidden. Don't search
         // any deeper. This tree should remain hidden.
+        const fallbackChildFragment: Fiber = (node.child: any).sibling;
+        fallbackChildFragment.return = node;
       } else if (node.child !== null) {
         node.child.return = node;
         node = node.child;


### PR DESCRIPTION
Note: this is more of an exploration PR for finding why we leak fibers internally with the new reconciler when we didn't with the older one. I don't expect us to merge it.

After speaking to Andrew recently, he mentioned that there might be a place that we don't properly set the return pointer on a fragment fiber. I checked between the old and new reconcilers for all return pointers that we mutate and this was the only difference between the two. I'm not 100% sure if it's still applicable here, but I'll put this up for now anyway.