### PR TITLE
Remove www builds of fetch

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -124,14 +124,7 @@ const bundles = [
 
   /******* React Fetch Browser (experimental, new) *******/
   {
-    bundleTypes: [
-      NODE_DEV,
-      NODE_PROD,
-      NODE_PROFILING,
-      FB_WWW_DEV,
-      FB_WWW_PROD,
-      FB_WWW_PROFILING,
-    ],
+    bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: ISOMORPHIC,
     entry: 'react-fetch/index.browser',
     global: 'ReactFetch',


### PR DESCRIPTION
I don't think we'll ever use this just because we have such a unique set up for network delivery so we'll use something custom for this case.

Also, we don't need a profiling build for this since it doesn't have an entry point.
