### PR TITLE
Revert autofix lint

### DIFF
--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -68,11 +68,10 @@ function runESLint({onlyChanged}) {
   if (typeof onlyChanged !== 'boolean') {
     throw new Error('Pass options.onlyChanged as a boolean.');
   }
-  const {
-    errorCount,
-    warningCount,
-    output,
-  } = runESLintOnFilesWithOptions(allPaths, onlyChanged, {fix: true});
+  const {errorCount, warningCount, output} = runESLintOnFilesWithOptions(
+    allPaths,
+    onlyChanged
+  );
   console.log(output);
   return errorCount === 0 && warningCount === 0;
 }


### PR DESCRIPTION
I accidentally committed this since I had it on locally so I didn't have to manually convert things to const.

However, this causes things to always pass lint since CI also runs this which fixes the lint violations in CI without committing it.

We should probably add this as an option to the command line tool. Ideally all the eslint options should be passable.
