### PR TITLE
Remove unnecessary throw catch

### DIFF
--- a/packages/shared/consoleWithStackDev.js
+++ b/packages/shared/consoleWithStackDev.js
@@ -43,15 +43,5 @@ function printWarning(level, format, args) {
     // breaks IE9: https://github.com/facebook/react/issues/13610
     // eslint-disable-next-line react-internal/no-production-logging
     Function.prototype.apply.call(console[level], console, argsWithFormat);
-
-    try {
-      // --- Welcome to debugging React ---
-      // This error was thrown as a convenience so that you can use this stack
-      // to find the callsite that caused this warning to fire.
-      let argIndex = 0;
-      const message =
-        'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
-      throw new Error(message);
-    } catch (x) {}
   }
 }


### PR DESCRIPTION
This was originally added so you could use "break on caught exceptions" but that feature is pretty useless these days since it's used for feature detection and Suspense.

The better pattern is to use the stack trace, jump to source and set a break point here.

Since DevTools injects its own console.error, we could inject a "debugger" statement in there. Conditionally. E.g. React DevTools could have a flag to toggle "break on warnings".