### PR TITLE
Enable component stack locations in www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -20,7 +20,6 @@ export const {
   enableTrustedTypesIntegration,
   disableSchedulerTimeoutBasedOnReactExpirationTime,
   warnAboutSpreadingKeyToJSX,
-  enableComponentStackLocations,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   enableModernEventSystem,
   enableFilterEmptyStringAttributesDOM,
@@ -67,6 +66,8 @@ export const enableScopeAPI = true;
 export const warnAboutUnmockedScheduler = true;
 
 export const enableSuspenseCallback = true;
+
+export const enableComponentStackLocations = true;
 
 export const disableTextareaChildren = __EXPERIMENTAL__;
 


### PR DESCRIPTION
I'd like to enable this everywhere but haven't tested it in RN yet and enabling it isomorphic would affect RN.