### PR TITLE
Added warning to <Context.Provider> in case no value prop is provided

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2814,7 +2814,9 @@ function updateContextProvider(
     if (!('value' in newProps)) {
       if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
         hasWarnedAboutUsingNoValuePropOnContextProvider = true;
-        console.error('<Context.Provider> must have a value prop');
+        console.error(
+          'The prop `value` is required in `Context.Provider`, have you misspelled it',
+        );
       }
     }
     const providerPropTypes = workInProgress.type.propTypes;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2795,6 +2795,8 @@ function updatePortalComponent(
   return workInProgress.child;
 }
 
+let hasWarnedAboutUsingNoValuePropOnContextProvider = false;
+
 function updateContextProvider(
   current: Fiber | null,
   workInProgress: Fiber,
@@ -2809,6 +2811,12 @@ function updateContextProvider(
   const newValue = newProps.value;
 
   if (__DEV__) {
+    if (!('value' in newProps)) {
+      if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
+        hasWarnedAboutUsingNoValuePropOnContextProvider = true;
+        console.error('<Context.Provider> must have a value prop');
+      }
+    }
     const providerPropTypes = workInProgress.type.propTypes;
 
     if (providerPropTypes) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2815,7 +2815,7 @@ function updateContextProvider(
       if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
         hasWarnedAboutUsingNoValuePropOnContextProvider = true;
         console.error(
-          'The prop `value` is required in `Context.Provider`, have you misspelled it',
+          'The `value` prop is required for the `<Context.Provider>`. Did you misspell it or forget to pass it?',
         );
       }
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2792,6 +2792,8 @@ function updatePortalComponent(
   return workInProgress.child;
 }
 
+let hasWarnedAboutUsingNoValuePropOnContextProvider = false;
+
 function updateContextProvider(
   current: Fiber | null,
   workInProgress: Fiber,
@@ -2806,6 +2808,12 @@ function updateContextProvider(
   const newValue = newProps.value;
 
   if (__DEV__) {
+    if (!('value' in newProps)) {
+      if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
+        hasWarnedAboutUsingNoValuePropOnContextProvider = true;
+        console.error('<Context.Provider> must have a value prop');
+      }
+    }
     const providerPropTypes = workInProgress.type.propTypes;
 
     if (providerPropTypes) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2811,7 +2811,9 @@ function updateContextProvider(
     if (!('value' in newProps)) {
       if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
         hasWarnedAboutUsingNoValuePropOnContextProvider = true;
-        console.error('<Context.Provider> must have a value prop');
+        console.error(
+          'The prop `value` is required in `Context.Provider`, have you misspelled it',
+        );
       }
     }
     const providerPropTypes = workInProgress.type.propTypes;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2812,7 +2812,7 @@ function updateContextProvider(
       if (!hasWarnedAboutUsingNoValuePropOnContextProvider) {
         hasWarnedAboutUsingNoValuePropOnContextProvider = true;
         console.error(
-          'The prop `value` is required in `Context.Provider`, have you misspelled it',
+          'The `value` prop is required for the `<Context.Provider>`. Did you misspell it or forget to pass it?',
         );
       }
     }

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1097,7 +1097,7 @@ describe('ReactNewContext', () => {
       );
 
       expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-        '<Context.Provider> must have a value prop',
+        'The prop `value` is required in `Context.Provider`, have you misspelled it',
         {
           withoutStack: true,
         },

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1089,6 +1089,21 @@ describe('ReactNewContext', () => {
       );
     });
 
+    it('warns if no value prop provided', () => {
+      const Context = React.createContext();
+
+      ReactNoop.render(
+        <Context.Provider anyPropNameOtherThanValue="value could be anything" />,
+      );
+
+      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+        '<Context.Provider> must have a value prop',
+        {
+          withoutStack: true,
+        },
+      );
+    });
+
     it('warns if multiple renderers concurrently render the same context', () => {
       spyOnDev(console, 'error');
       const Context = React.createContext(0);
@@ -1617,7 +1632,7 @@ describe('ReactNewContext', () => {
     // caused by unwinding the context from wrong point.
     ReactNoop.render(
       <errorInCompletePhase>
-        <Context.Provider />
+        <Context.Provider value={null} />
       </errorInCompletePhase>,
     );
     expect(Scheduler).toFlushAndThrow('Error in host config.');

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -1097,7 +1097,7 @@ describe('ReactNewContext', () => {
       );
 
       expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-        'The prop `value` is required in `Context.Provider`, have you misspelled it',
+        'The `value` prop is required for the `<Context.Provider>`. Did you misspell it or forget to pass it?',
         {
           withoutStack: true,
         },

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -1012,7 +1012,7 @@ describe('ReactTestRenderer', () => {
     const Context = React.createContext(null);
     const Indirection = React.Fragment;
     const App = () => (
-      <Context.Provider>
+      <Context.Provider value={null}>
         <Indirection>
           <Context.Consumer>{() => null}</Context.Consumer>
         </Indirection>

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -236,7 +236,7 @@ describe('ReactTestRendererTraversal', () => {
     ).toBe(2);
     expect(
       ReactTestRenderer.create(
-        <Context.Provider>
+        <Context.Provider value={null}>
           <div />
           <div />
         </Context.Provider>,

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -263,13 +263,13 @@ describe('ReactContextValidator', () => {
 
     class Component extends React.Component {
       render() {
-        return <TestContext.Provider value={null} />;
+        return <TestContext.Provider value={undefined} />;
       }
     }
 
     expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
-        '`Context.Provider`, but its value is `null`.\n' +
+        '`Context.Provider`, but its value is `undefined`.\n' +
         '    in Component (at **)',
     );
   });

--- a/packages/react/src/__tests__/ReactContextValidator-test.js
+++ b/packages/react/src/__tests__/ReactContextValidator-test.js
@@ -263,13 +263,13 @@ describe('ReactContextValidator', () => {
 
     class Component extends React.Component {
       render() {
-        return <TestContext.Provider />;
+        return <TestContext.Provider value={null} />;
       }
     }
 
     expect(() => ReactTestUtils.renderIntoDocument(<Component />)).toErrorDev(
       'Warning: Failed prop type: The prop `value` is marked as required in ' +
-        '`Context.Provider`, but its value is `undefined`.\n' +
+        '`Context.Provider`, but its value is `null`.\n' +
         '    in Component (at **)',
     );
   });


### PR DESCRIPTION
## Summary
This PR aims to add a fix for #19020 

1. There is a duplication in what I have done in files
    - `packages/react-reconciler/src/ReactFiberBeginWork.new.js`
    - `packages/react-reconciler/src/ReactFiberBeginWork.old.js`

In feature flag saw `const enableNewReconciler = false` but still cannot jump to any solid conclusions hence added in both.

Test Added
`packages/react-reconciler/src/__tests__/ReactNewContext-test.js` test to detect warning.

Tests Updated Reason
As now `<Context.Provider>` now throws a warning if value prop is not given, and hence updated the ones which were not having value prop to have `null` now.

Points to be discussed
1. What should be the warning message, (not really good with this) 😅 
2. Should this be included in both old and new, or I have added in the totally wrong place.
    - if correct, out of curiosity why there are 2 files, seems almost identical, and only these but a whole lot files are in the same format. (please ignore if very long explanation and out of the scope of this PR)
3. Should any more test cases to be added in this?

cc @brunogonzales @heath-freenome 