### PR TITLE
fix(eslint-plugin-react-hooks): Support optional chaining when accessing prototype method inside useCallback and useMemo #19061

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1254,7 +1254,8 @@ const tests = {
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [props.foo?.toString]',
+              desc:
+                'Update the dependencies array to be: [props.foo?.toString]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -291,6 +291,24 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(props) {
+          useMemo(() => {
+            console.log(props.foo?.toString());
+          }, [props.foo]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.toString());
+          }, [props.foo]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const myEffect = () => {
             // Doesn't use anything
@@ -1221,6 +1239,34 @@ const tests = {
     },
   ],
   invalid: [
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.toString());
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useCallback has a missing dependency: 'props.foo?.toString'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo?.toString]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCallback(() => {
+                    console.log(props.foo?.toString());
+                  }, [props.foo?.toString]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
     {
       code: normalizeIndent`
         function MyComponent() {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1287,12 +1287,13 @@ function collectRecommendations({
   function scanTreeRecursively(node, missingPaths, satisfyingPaths, keyToPath) {
     node.children.forEach((child, key) => {
       const path = keyToPath(key);
+      // For analyzing dependencies, we want the "normalized" path, without any optional chaining ("?.") operator
+      // foo?.bar -> foo.bar
+      const normalizedPath = path.replace(/\?$/, '');
       if (child.isSatisfiedRecursively) {
         if (child.hasRequiredNodesBelow) {
           // Remember this dep actually satisfied something.
-          // Here we only want to compare the "normalized" path, without any optional chaining ("?.") operator
-          // foo?.bar -> foo.bar
-          satisfyingPaths.add(path.replace(/\?$/, ''));
+          satisfyingPaths.add(normalizedPath);
         }
         // It doesn't matter if there's something deeper.
         // It would be transitively satisfied since we assume immutability.
@@ -1301,7 +1302,7 @@ function collectRecommendations({
       }
       if (child.isRequired) {
         // Remember that no declared deps satisfied this node.
-        missingPaths.add(path);
+        missingPaths.add(normalizedPath);
         // If we got here, nothing in its subtree was satisfied.
         // No need to search further.
         return;

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1290,7 +1290,9 @@ function collectRecommendations({
       if (child.isSatisfiedRecursively) {
         if (child.hasRequiredNodesBelow) {
           // Remember this dep actually satisfied something.
-          satisfyingPaths.add(path);
+          // Here we only want to compare the "normalized" path, without any optional chaining ("?.") operator
+          // foo?.bar -> foo.bar
+          satisfyingPaths.add(path.replace(/\?$/, ''));
         }
         // It doesn't matter if there's something deeper.
         // It would be transitively satisfied since we assume immutability.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->
Relates to #19061
## Summary

This fix ensures that optional chaining can be used to access a prototype method of an object, inside a `useCallback` or `useEffect` hook. 

For example, assume we use optional chaining to call the `toString()` method of an object:
```
foo?.toString();
```

In such a case, `foo`, **not** `foo?.toString`, should be added to the dependencies array of the `useCallback` or `useMemo` hooks. However, doing so currently throws a false "unnecessary dependencies" warning.

## Test Plan

Additional tests were added to cover using the optional chaining operator in the `useCallback` and `useMemo` hooks, when only a prefix of the object path is provided (as it would be if a prototype method is being referenced in the callback.)
