### PR TITLE
Add ESLint Rule for Safe Ref Usage

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintSafeRefMutations-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintSafeRefMutations-test.js
@@ -233,8 +233,7 @@ const tests = {
       }
     `,
     // When ref mutations occur in callbacks
-    {
-      code: normalizeIndent`
+    normalizeIndent`
       const ComponentWithRef = () => {
         const someRef = useRef();
 
@@ -245,10 +244,19 @@ const tests = {
         return <div onClick={someCallback}>some child</div>;
       };
     `,
-    },
-    // TODO: Scenarios where React is no in play at all
+    // Scenarios where React is not in play at all
     normalizeIndent`
       myObject.current = 'some value';
+    `,
+    normalizeIndent`
+      function someNonComponentFunction() {
+        someObject.current = 'some value';
+      }
+    `,
+    normalizeIndent`
+      const someNonComponentFunction = () => {
+        someObject.current = 'some value';
+      }
     `,
   ],
   invalid: [
@@ -354,6 +362,43 @@ const tests = {
         },
       ],
     },
+    // TODO: handle assignments to variables
+    // {
+    //   code: normalizeIndent`
+    //     function ComponentWithRef({ someProp }) {
+    //       const someRef = useRef();
+
+    //       someRef.current = someProp;
+    //     }
+    //   `,
+    //   errors: [
+    //     {
+    //       message: errorMessage,
+    //       suggestions: [
+    //         {
+    //           desc: 'Place the ref mutation in a useEffect',
+    //           output: normalizeIndent`
+    //             function ComponentWithRef({ someProp }) {
+    //               const someRef = useRef();
+
+    //               useEffect(() => { someRef.current = 'some value'; }, [someProp]);
+    //             }
+    //           `,
+    //         },
+    //         {
+    //           desc: 'Place the ref mutation in a useLayoutEffect',
+    //           output: normalizeIndent`
+    //             function ComponentWithRef({ someProp }) {
+    //               const someRef = useRef();
+
+    //               useLayoutEffect(() => { someRef.current = 'some value'; }, [someProp]);
+    //             }
+    //           `,
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // },
   ],
 };
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintSafeRefMutations-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintSafeRefMutations-test.js
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const ESLintTester = require('eslint').RuleTester;
+const ReactHooksESLintPlugin = require('eslint-plugin-react-hooks');
+const ReactHooksESLintRule = ReactHooksESLintPlugin.rules['safe-ref-mutations'];
+
+ESLintTester.setDefaultConfig({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+function normalizeIndent(strings) {
+  const codeLines = strings[0].split('\n');
+  const leftPadding = codeLines[1].match(/\s+/)[0];
+  return codeLines.map(line => line.substr(leftPadding.length)).join('\n');
+}
+
+const errorMessage =
+  'Ref mutations should either be in useEffect or useLayoutEffect calls or inside callbacks.';
+
+const tests = {
+  valid: [
+    // Simple safe ref assignments
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      }
+    `,
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      }
+    `,
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        React.useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      }
+    `,
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        React.useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      }
+    `,
+    normalizeIndent`
+      const ComponentWithRef = () => {
+        const someRef = useRef();
+
+        useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      };
+    `,
+    normalizeIndent`
+      const ComponentWithRef = () => {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      };
+    `,
+    normalizeIndent`
+      const ComponentWithRef = () => {
+        const someRef = useRef();
+
+        React.useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      };
+    `,
+    normalizeIndent`
+      const ComponentWithRef = () => {
+        const someRef = useRef();
+
+        React.useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      };
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.memo(() => {
+        const someRef = useRef();
+
+        useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.memo(() => {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.memo(() => {
+        const someRef = useRef();
+
+        React.useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.memo(() => {
+        const someRef = useRef();
+
+        React.useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.forwardRef(() => {
+        const someRef = useRef();
+
+        useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.forwardRef(() => {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.forwardRef(() => {
+        const someRef = useRef();
+
+        React.useEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    normalizeIndent`
+      const ComponentWithRef = React.forwardRef(() => {
+        const someRef = useRef();
+
+        React.useLayoutEffect(() => {
+          someRef.current = 'some value';
+        }, []);
+      });
+    `,
+    // Scenarios where the ref mutation is in an effect, but not top-level
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        useEffect(() => {
+          const someFunction = () => {
+            someRef.current = 'some value';
+          }
+        }, []);
+      }
+    `,
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          const someFunction = () => {
+            someRef.current = 'some value';
+          }
+        }, []);
+      }
+    `,
+    normalizeIndent`
+    function ComponentWithRef() {
+      const someRef = useRef();
+
+      useEffect(() => {
+        const someFunction = () => {
+          const yetAnotherFunction = () => {
+            const andYetAnotherFunction = () => {
+              const andOneMoreFunctionForGoodMeasure = () => {
+                someRef.current = 'some value';
+              }
+            }
+          }
+        }
+      }, []);
+    }
+  `,
+    normalizeIndent`
+      function ComponentWithRef() {
+        const someRef = useRef();
+
+        useLayoutEffect(() => {
+          const someFunction = () => {
+            const yetAnotherFunction = () => {
+              const andYetAnotherFunction = () => {
+                const andOneMoreFunctionForGoodMeasure = () => {
+                  someRef.current = 'some value';
+                }
+              }
+            }
+          }
+        }, []);
+      }
+    `,
+    // When ref mutations occur in callbacks
+    {
+      code: normalizeIndent`
+      const ComponentWithRef = () => {
+        const someRef = useRef();
+
+        const someCallback = () => {
+          someRef.current = 'some value';
+        };
+
+        return <div onClick={someCallback}>some child</div>;
+      };
+    `,
+    },
+    // TODO: Scenarios where React is no in play at all
+    normalizeIndent`
+      myObject.current = 'some value';
+    `,
+  ],
+  invalid: [
+    {
+      code: normalizeIndent`
+        function ComponentWithRef() {
+          const someRef = useRef();
+
+          someRef.current = 'some value';
+        }
+      `,
+      errors: [
+        {
+          message: errorMessage,
+          suggestions: [
+            {
+              desc: 'Place the ref mutation in a useEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  useEffect(() => { someRef.current = 'some value'; }, []);
+                }
+              `,
+            },
+            {
+              desc: 'Place the ref mutation in a useLayoutEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  useLayoutEffect(() => { someRef.current = 'some value'; }, []);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function ComponentWithRef() {
+          const someRef = useRef();
+
+          someRef.current = 'some value';
+          someRef.current = 'some other value';
+        }
+      `,
+      errors: [
+        {
+          message: errorMessage,
+          suggestions: [
+            {
+              desc: 'Place the ref mutation in a useEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  useEffect(() => { someRef.current = 'some value'; }, []);
+                  someRef.current = 'some other value';
+                }
+              `,
+            },
+            {
+              desc: 'Place the ref mutation in a useLayoutEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  useLayoutEffect(() => { someRef.current = 'some value'; }, []);
+                  someRef.current = 'some other value';
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message: errorMessage,
+          suggestions: [
+            {
+              desc: 'Place the ref mutation in a useEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  someRef.current = 'some value';
+                  useEffect(() => { someRef.current = 'some other value'; }, []);
+                }
+              `,
+            },
+            {
+              desc: 'Place the ref mutation in a useLayoutEffect',
+              output: normalizeIndent`
+                function ComponentWithRef() {
+                  const someRef = useRef();
+
+                  someRef.current = 'some value';
+                  useLayoutEffect(() => { someRef.current = 'some other value'; }, []);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// For easier local testing
+if (!process.env.CI) {
+  let only = [];
+  let skipped = [];
+  [...tests.valid, ...tests.invalid].forEach(t => {
+    if (t.skip) {
+      delete t.skip;
+      skipped.push(t);
+    }
+    if (t.only) {
+      delete t.only;
+      only.push(t);
+    }
+  });
+  const predicate = t => {
+    if (only.length > 0) {
+      return only.indexOf(t) !== -1;
+    }
+    if (skipped.length > 0) {
+      return skipped.indexOf(t) === -1;
+    }
+    return true;
+  };
+  tests.valid = tests.valid.filter(predicate);
+  tests.invalid = tests.invalid.filter(predicate);
+}
+
+const eslintTester = new ESLintTester();
+eslintTester.run('safe-ref-mutations', ReactHooksESLintRule, tests);

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -9,100 +9,14 @@
 
 'use strict';
 
-/**
- * Catch all identifiers that begin with "use" followed by an uppercase Latin
- * character to exclude identifiers like "user".
- */
-
-function isHookName(s) {
-  return /^use[A-Z0-9].*$/.test(s);
-}
-
-/**
- * We consider hooks to be a hook name identifier or a member expression
- * containing a hook name.
- */
-
-function isHook(node) {
-  if (node.type === 'Identifier') {
-    return isHookName(node.name);
-  } else if (
-    node.type === 'MemberExpression' &&
-    !node.computed &&
-    isHook(node.property)
-  ) {
-    const obj = node.object;
-    const isPascalCaseNameSpace = /^[A-Z].*/;
-    return obj.type === 'Identifier' && isPascalCaseNameSpace.test(obj.name);
-  } else {
-    return false;
-  }
-}
-
-/**
- * Checks if the node is a React component name. React component names must
- * always start with a non-lowercase letter. So `MyComponent` or `_MyComponent`
- * are valid component names for instance.
- */
-
-function isComponentName(node) {
-  if (node.type === 'Identifier') {
-    return !/^[a-z]/.test(node.name);
-  } else {
-    return false;
-  }
-}
-
-function isReactFunction(node, functionName) {
-  return (
-    node.name === functionName ||
-    (node.type === 'MemberExpression' &&
-      node.object.name === 'React' &&
-      node.property.name === functionName)
-  );
-}
-
-/**
- * Checks if the node is a callback argument of forwardRef. This render function
- * should follow the rules of hooks.
- */
-
-function isForwardRefCallback(node) {
-  return !!(
-    node.parent &&
-    node.parent.callee &&
-    isReactFunction(node.parent.callee, 'forwardRef')
-  );
-}
-
-/**
- * Checks if the node is a callback argument of React.memo. This anonymous
- * functional component should follow the rules of hooks.
- */
-
-function isMemoCallback(node) {
-  return !!(
-    node.parent &&
-    node.parent.callee &&
-    isReactFunction(node.parent.callee, 'memo')
-  );
-}
-
-function isInsideComponentOrHook(node) {
-  while (node) {
-    const functionName = getFunctionName(node);
-    if (functionName) {
-      if (isComponentName(functionName) || isHook(functionName)) {
-        return true;
-      }
-    }
-    if (isForwardRefCallback(node) || isMemoCallback(node)) {
-      return true;
-    }
-    node = node.parent;
-  }
-  return false;
-}
+import {
+  getFunctionName,
+  isComponentName,
+  isForwardRefCallback,
+  isHook,
+  isInsideComponentOrHook,
+  isMemoCallback,
+} from './utils';
 
 export default {
   meta: {
@@ -530,76 +444,6 @@ export default {
     };
   },
 };
-
-/**
- * Gets the static name of a function AST node. For function declarations it is
- * easy. For anonymous function expressions it is much harder. If you search for
- * `IsAnonymousFunctionDefinition()` in the ECMAScript spec you'll find places
- * where JS gives anonymous function expressions names. We roughly detect the
- * same AST nodes with some exceptions to better fit our usecase.
- */
-
-function getFunctionName(node) {
-  if (
-    node.type === 'FunctionDeclaration' ||
-    (node.type === 'FunctionExpression' && node.id)
-  ) {
-    // function useHook() {}
-    // const whatever = function useHook() {};
-    //
-    // Function declaration or function expression names win over any
-    // assignment statements or other renames.
-    return node.id;
-  } else if (
-    node.type === 'FunctionExpression' ||
-    node.type === 'ArrowFunctionExpression'
-  ) {
-    if (
-      node.parent.type === 'VariableDeclarator' &&
-      node.parent.init === node
-    ) {
-      // const useHook = () => {};
-      return node.parent.id;
-    } else if (
-      node.parent.type === 'AssignmentExpression' &&
-      node.parent.right === node &&
-      node.parent.operator === '='
-    ) {
-      // useHook = () => {};
-      return node.parent.left;
-    } else if (
-      node.parent.type === 'Property' &&
-      node.parent.value === node &&
-      !node.parent.computed
-    ) {
-      // {useHook: () => {}}
-      // {useHook() {}}
-      return node.parent.key;
-
-      // NOTE: We could also support `ClassProperty` and `MethodDefinition`
-      // here to be pedantic. However, hooks in a class are an anti-pattern. So
-      // we don't allow it to error early.
-      //
-      // class {useHook = () => {}}
-      // class {useHook() {}}
-    } else if (
-      node.parent.type === 'AssignmentPattern' &&
-      node.parent.right === node &&
-      !node.parent.computed
-    ) {
-      // const {useHook = () => {}} = {};
-      // ({useHook = () => {}} = {});
-      //
-      // Kinda clowny, but we'd said we'd follow spec convention for
-      // `IsAnonymousFunctionDefinition()` usage.
-      return node.parent.left;
-    } else {
-      return undefined;
-    }
-  } else {
-    return undefined;
-  }
-}
 
 /**
  * Convenience function for peeking the last item in a stack.

--- a/packages/eslint-plugin-react-hooks/src/SafeRefMutations.js
+++ b/packages/eslint-plugin-react-hooks/src/SafeRefMutations.js
@@ -1,0 +1,364 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Catch all identifiers that begin with "use" followed by an uppercase Latin
+ * character to exclude identifiers like "user".
+ */
+
+function getFunctionName(node) {
+  if (
+    node.type === 'FunctionDeclaration' ||
+    (node.type === 'FunctionExpression' && node.id)
+  ) {
+    // function useHook() {}
+    // const whatever = function useHook() {};
+    //
+    // Function declaration or function expression names win over any
+    // assignment statements or other renames.
+    return node.id;
+  } else if (
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  ) {
+    if (
+      node.parent.type === 'VariableDeclarator' &&
+      node.parent.init === node
+    ) {
+      // const useHook = () => {};
+      return node.parent.id;
+    } else if (
+      node.parent.type === 'AssignmentExpression' &&
+      node.parent.right === node &&
+      node.parent.operator === '='
+    ) {
+      // useHook = () => {};
+      return node.parent.left;
+    } else if (
+      node.parent.type === 'Property' &&
+      node.parent.value === node &&
+      !node.parent.computed
+    ) {
+      // {useHook: () => {}}
+      // {useHook() {}}
+      return node.parent.key;
+
+      // NOTE: We could also support `ClassProperty` and `MethodDefinition`
+      // here to be pedantic. However, hooks in a class are an anti-pattern. So
+      // we don't allow it to error early.
+      //
+      // class {useHook = () => {}}
+      // class {useHook() {}}
+    } else if (
+      node.parent.type === 'AssignmentPattern' &&
+      node.parent.right === node &&
+      !node.parent.computed
+    ) {
+      // const {useHook = () => {}} = {};
+      // ({useHook = () => {}} = {});
+      //
+      // Kinda clowny, but we'd said we'd follow spec convention for
+      // `IsAnonymousFunctionDefinition()` usage.
+      return node.parent.left;
+    } else {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+}
+
+function isHookName(s) {
+  return /^use[A-Z0-9].*$/.test(s);
+}
+
+/**
+ * We consider hooks to be a hook name identifier or a member expression
+ * containing a hook name.
+ */
+
+function isHook(node) {
+  if (node.type === 'Identifier') {
+    return isHookName(node.name);
+  } else if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    isHook(node.property)
+  ) {
+    const obj = node.object;
+    const isPascalCaseNameSpace = /^[A-Z].*/;
+    return obj.type === 'Identifier' && isPascalCaseNameSpace.test(obj.name);
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Checks if the node is a React component name. React component names must
+ * always start with a non-lowercase letter. So `MyComponent` or `_MyComponent`
+ * are valid component names for instance.
+ */
+
+function isComponentName(node) {
+  if (node.type === 'Identifier') {
+    return !/^[a-z]/.test(node.name);
+  } else {
+    return false;
+  }
+}
+
+function isReactFunction(node, functionName) {
+  return (
+    node.name === functionName ||
+    (node.type === 'MemberExpression' &&
+      node.object.name === 'React' &&
+      node.property.name === functionName)
+  );
+}
+
+/**
+ * Checks if the node is a callback argument of forwardRef. This render function
+ * should follow the rules of hooks.
+ */
+
+function isForwardRefCallback(node) {
+  return !!(
+    node.parent &&
+    node.parent.callee &&
+    isReactFunction(node.parent.callee, 'forwardRef')
+  );
+}
+
+/**
+ * Checks if the node is a callback argument of React.memo. This anonymous
+ * functional component should follow the rules of hooks.
+ */
+
+function isMemoCallback(node) {
+  return !!(
+    node.parent &&
+    node.parent.callee &&
+    isReactFunction(node.parent.callee, 'memo')
+  );
+}
+
+function getComponentOrHookScopeBlock(node) {
+  let currentNode = node;
+
+  while (!isProgram(currentNode)) {
+    const functionName = getFunctionName(currentNode);
+    if (functionName) {
+      if (isComponentName(functionName) || isHook(functionName)) {
+        return currentNode;
+      }
+    }
+    if (isForwardRefCallback(currentNode) || isMemoCallback(currentNode)) {
+      return currentNode;
+    }
+    currentNode = currentNode.parent;
+  }
+
+  return;
+}
+
+function getNearestFunctionScopeBlock(node) {
+  let currentNode = node;
+
+  while (!isProgram(currentNode)) {
+    if (isFunction(currentNode)) {
+      return currentNode.body;
+    }
+
+    currentNode = currentNode.parent;
+  }
+
+  return;
+}
+
+function isFunction(node) {
+  return (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'ArrowFunctionExpression'
+  );
+}
+
+function isAssignmentExpression(node) {
+  return node.type === 'AssignmentExpression';
+}
+
+function isMemberExpression(node) {
+  return node.type === 'MemberExpression';
+}
+
+function isIdentifier(node) {
+  return node.type === 'Identifier';
+}
+
+function isCallExpression(node) {
+  return node.type === 'CallExpression';
+}
+
+function isProgram(node) {
+  return node.type === 'Program';
+}
+
+function isAssignmentToCurrent(node) {
+  if (!isMemberExpression(node.left)) return false;
+  if (!isIdentifier(node.left.property)) return false;
+  return node.left.property.name === 'current';
+}
+
+function isRefAssignmentLike(expressionStatementNode) {
+  // Returns true if it looks something like this:
+  //
+  // .current = x
+  //
+  const assignmentNode = expressionStatementNode.expression;
+  if (!isAssignmentExpression(assignmentNode)) return false;
+
+  return isAssignmentToCurrent(assignmentNode);
+}
+
+function isUseRefCall(node) {
+  // Returns true if it is either:
+  //
+  // useRef(...)
+  //
+  // or
+  //
+  // React.useRef(...)
+  //
+  return (
+    isCallExpression(node) &&
+    ((isIdentifier(node.callee) && node.callee.name === 'useRef') ||
+      isReactFunction(node.callee, 'useRef'))
+  );
+}
+
+function isRefAssignment(assignmentExpressionNode, scope) {
+  const assignmentMemberObject = assignmentExpressionNode.left.object;
+  if (!isIdentifier(assignmentMemberObject)) return false;
+
+  const {name} = assignmentMemberObject;
+
+  // TODO: Generate a map and re-use it across calls when possible. Possibly
+  // memoize.
+  const reference = scope.references.find(
+    scopeReference =>
+      scopeReference.resolved.name && scopeReference.resolved.name === name,
+  );
+
+  // TODO: Handle more involved scenarios like:
+  //
+  // let myRef;
+  // myRef = useRef(...);
+  //
+  // or
+  //
+  // const myRef = useRef(...);
+  // const myTransitiveRef = myRef;
+  //
+  const definition = reference.resolved.defs[0].node;
+  return isUseRefCall(definition.init);
+}
+
+function createSuggestionForEffectWrapper(effectWrapperString) {
+  function createSuggestion(expressionStatementNode) {
+    return {
+      desc: `Place the ref mutation in a ${effectWrapperString}`,
+      fix(fixer) {
+        // TODO:
+        // We need to handle the deps array in the case that the ref is assigned
+        // to a variable of any kind.
+        return [
+          fixer.insertTextBefore(
+            expressionStatementNode,
+            `${effectWrapperString}(() => { `,
+          ),
+          fixer.insertTextAfter(expressionStatementNode, ' }, []);'),
+        ];
+      },
+    };
+  }
+
+  return createSuggestion;
+}
+
+const EFFECT_WRAPPERS = [
+  createSuggestionForEffectWrapper('useEffect'),
+  createSuggestionForEffectWrapper('useLayoutEffect'),
+];
+
+function createSuggestions(expressionStatementNode) {
+  return EFFECT_WRAPPERS.map(createSuggestion =>
+    createSuggestion(expressionStatementNode),
+  );
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'ensures ref.current assignments only ever occur in either useEffect or useLayoutEffect call expressions',
+      category: 'Possible Errors',
+      recommended: false,
+      suggestion: true,
+    },
+  },
+  create(context) {
+    // This is where the overarching logic resides.
+    function isUnsafeRefMutation(expressionStatementNode) {
+      // First, let's check if it's an assignment to an object's current
+      // property. This is low cost and likely to short-circuit often.
+      if (!isRefAssignmentLike(expressionStatementNode)) return false;
+      // Next, let's only move forward if we're inside a component or hook.
+      const componentOrHookScopeBlock = getComponentOrHookScopeBlock(
+        expressionStatementNode,
+      );
+      const isInsideComponentOrHook = !!componentOrHookScopeBlock;
+      if (!isInsideComponentOrHook) return false;
+      // Next, let's verify that the assignment was really taking place on a
+      // ref.
+      const scope = context.getScope();
+      const assignmentNode = expressionStatementNode.expression;
+      if (!isRefAssignment(assignmentNode, scope)) return false;
+      // At this point, we know that we have a ref mutation inside of a
+      // component. We can now check to see if assignment is occurring at the
+      // top-level of a component or hook by looking up the expression's nearest
+      // function block. If it is the same, then we know that we have a
+      // top-level assignment.
+      const nearestFunctionScopeBlock = getNearestFunctionScopeBlock(
+        expressionStatementNode,
+      );
+      const isTopLevelRefMutation =
+        nearestFunctionScopeBlock === componentOrHookScopeBlock.body;
+
+      if (isTopLevelRefMutation) return true;
+
+      // TODO:
+      // If it's not a top-level ref assignment, that doesn't mean we're in the
+      // clear. Now we need to check if the ref assignment isn't occurring in
+      // a function that is immediately called as a consequence of the render or
+      // hook call.
+      return false;
+    }
+
+    return {
+      ExpressionStatement(node) {
+        if (isUnsafeRefMutation(node)) {
+          context.report({
+            message:
+              'Ref mutations should either be in useEffect or useLayoutEffect calls or inside callbacks.',
+            node,
+            suggest: createSuggestions(node),
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-react-hooks/src/index.js
+++ b/packages/eslint-plugin-react-hooks/src/index.js
@@ -9,6 +9,7 @@
 
 import RulesOfHooks from './RulesOfHooks';
 import ExhaustiveDeps from './ExhaustiveDeps';
+import SafeRefMutations from './SafeRefMutations';
 
 export const configs = {
   recommended: {
@@ -23,4 +24,5 @@ export const configs = {
 export const rules = {
   'rules-of-hooks': RulesOfHooks,
   'exhaustive-deps': ExhaustiveDeps,
+  'safe-ref-mutations': SafeRefMutations,
 };

--- a/packages/eslint-plugin-react-hooks/src/utils.js
+++ b/packages/eslint-plugin-react-hooks/src/utils.js
@@ -1,0 +1,164 @@
+/**
+ * Catch all identifiers that begin with "use" followed by an uppercase Latin
+ * character to exclude identifiers like "user".
+ */
+
+export function isHookName(s) {
+  return /^use[A-Z0-9].*$/.test(s);
+}
+
+/**
+ * We consider hooks to be a hook name identifier or a member expression
+ * containing a hook name.
+ */
+
+export function isHook(node) {
+  if (node.type === 'Identifier') {
+    return isHookName(node.name);
+  } else if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    isHook(node.property)
+  ) {
+    const obj = node.object;
+    const isPascalCaseNameSpace = /^[A-Z].*/;
+    return obj.type === 'Identifier' && isPascalCaseNameSpace.test(obj.name);
+  } else {
+    return false;
+  }
+}
+
+/**
+ * Checks if the node is a React component name. React component names must
+ * always start with a non-lowercase letter. So `MyComponent` or `_MyComponent`
+ * are valid component names for instance.
+ */
+
+export function isComponentName(node) {
+  if (node.type === 'Identifier') {
+    return !/^[a-z]/.test(node.name);
+  } else {
+    return false;
+  }
+}
+
+export function isReactFunction(node, functionName) {
+  return (
+    node.name === functionName ||
+    (node.type === 'MemberExpression' &&
+      node.object.name === 'React' &&
+      node.property.name === functionName)
+  );
+}
+
+/**
+ * Checks if the node is a callback argument of forwardRef. This render function
+ * should follow the rules of hooks.
+ */
+
+export function isForwardRefCallback(node) {
+  return !!(
+    node.parent &&
+    node.parent.callee &&
+    isReactFunction(node.parent.callee, 'forwardRef')
+  );
+}
+
+/**
+ * Checks if the node is a callback argument of React.memo. This anonymous
+ * functional component should follow the rules of hooks.
+ */
+
+export function isMemoCallback(node) {
+  return !!(
+    node.parent &&
+    node.parent.callee &&
+    isReactFunction(node.parent.callee, 'memo')
+  );
+}
+
+export function isInsideComponentOrHook(node) {
+  while (node) {
+    const functionName = getFunctionName(node);
+    if (functionName) {
+      if (isComponentName(functionName) || isHook(functionName)) {
+        return true;
+      }
+    }
+    if (isForwardRefCallback(node) || isMemoCallback(node)) {
+      return true;
+    }
+    node = node.parent;
+  }
+  return false;
+}
+
+/**
+ * Gets the static name of a function AST node. For function declarations it is
+ * easy. For anonymous function expressions it is much harder. If you search for
+ * `IsAnonymousFunctionDefinition()` in the ECMAScript spec you'll find places
+ * where JS gives anonymous function expressions names. We roughly detect the
+ * same AST nodes with some exceptions to better fit our usecase.
+ */
+
+export function getFunctionName(node) {
+  if (
+    node.type === 'FunctionDeclaration' ||
+    (node.type === 'FunctionExpression' && node.id)
+  ) {
+    // function useHook() {}
+    // const whatever = function useHook() {};
+    //
+    // Function declaration or function expression names win over any
+    // assignment statements or other renames.
+    return node.id;
+  } else if (
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  ) {
+    if (
+      node.parent.type === 'VariableDeclarator' &&
+      node.parent.init === node
+    ) {
+      // const useHook = () => {};
+      return node.parent.id;
+    } else if (
+      node.parent.type === 'AssignmentExpression' &&
+      node.parent.right === node &&
+      node.parent.operator === '='
+    ) {
+      // useHook = () => {};
+      return node.parent.left;
+    } else if (
+      node.parent.type === 'Property' &&
+      node.parent.value === node &&
+      !node.parent.computed
+    ) {
+      // {useHook: () => {}}
+      // {useHook() {}}
+      return node.parent.key;
+
+      // NOTE: We could also support `ClassProperty` and `MethodDefinition`
+      // here to be pedantic. However, hooks in a class are an anti-pattern. So
+      // we don't allow it to error early.
+      //
+      // class {useHook = () => {}}
+      // class {useHook() {}}
+    } else if (
+      node.parent.type === 'AssignmentPattern' &&
+      node.parent.right === node &&
+      !node.parent.computed
+    ) {
+      // const {useHook = () => {}} = {};
+      // ({useHook = () => {}} = {});
+      //
+      // Kinda clowny, but we'd said we'd follow spec convention for
+      // `IsAnonymousFunctionDefinition()` usage.
+      return node.parent.left;
+    } else {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Mutating a given ref's `current` property as the result of a render or hook call is not safe in concurrent mode. The reason for this is described [here](https://github.com/facebook/react/issues/14099#issuecomment-440794435).

As an example, this is not safe:

```js
const MyComponent = React.memo({ someProp }) => {
  const myRef = useRef();

  myRef.current = someProp;

  // ...
});
```

This also wouldn't be safe:

```js
const useMyCustomHook = () => {
  const [someState, setSomeState] = useState('');
  const myRef = useRef();

  myRef.current = someState;

  // ...
};
```

There currently isn't a guard rail in place to prevent applications not written for concurrent mode first to easily identify this problem before the application is opted-in to concurrent mode. Without a guard rail, applications that move from non-concurrent mode to concurrent mode are at some point are at a serious risk of experiencing cumbersome regressions as a result of the move.

So, I'm proposing an ESLint rule that fails in the case that any top-level ref mutations are found and suggests that they be moved into either `useEffect` or `useLayoutEffect` hook calls so that way the mutation only occurs in the case that a commit to render has happened.

At the time that this PR is opened, the rule is called `safe-ref-mutations`. It is initially not marked as recommended because I'd like to get some core React contributor guidance first.

This rule didn't seem to fit in with either `rules-of-hooks` or `exhaustive-deps`, so I wrote it as its own rule. If there's a preference to move it into one or the other, I'm happy to do so. But in general, I wonder if there are more rules that React should have in place for safe concurrency mode usage. Maybe some kind of `safe-concurrency` rule would be better?

As part of this PR, I needed some functions that accomplished the same as those in `RulesOfHooks.js`, so I've extracted them into a `utils.js` for re-use.

If there's a preference that I open an issue for this, I'm happy to do so.

## Test Plan

The ESLint rule will be heavily tested if this is the route that is chosen.
