### PR TITLE
feat(ReactDOMServer): add renderToBrowserStream

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "through2": "^3.0.1",
     "tmp": "^0.1.0",
     "typescript": "^3.7.5",
+    "web-streams-polyfill": "^2.1.1",
     "webpack": "^4.41.2"
   },
   "devEngines": {

--- a/packages/react-dom/server.browser.js
+++ b/packages/react-dom/server.browser.js
@@ -12,5 +12,7 @@ export {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToBrowserStream,
+  renderToStaticBrowserStream,
   version,
 } from './src/server/ReactDOMServerBrowser';

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -13,5 +13,7 @@ export {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToBrowserStream,
+  renderToStaticBrowserStream,
   version,
 } from './src/server/ReactDOMServerNode';

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -621,6 +621,16 @@ describe('ReactDOMServer', () => {
       });
     });
   });
+  it('throws meaningfully for browser-only APIs', () => {
+    expect(() => ReactDOMServer.renderToBrowserStream(<div />)).toThrow(
+      'ReactDOMServer.renderToBrowserStream(): This streaming API is not available ' +
+        'in Node environement. Use ReactDOMServer.renderToNodeStream() instead.',
+    );
+    expect(() => ReactDOMServer.renderToStaticBrowserStream(<div />)).toThrow(
+      'ReactDOMServer.renderToStaticBrowserStream(): This streaming API is not available ' +
+        'in Node environement. Use ReactDOMServer.renderToStaticNodeStream() instead.',
+    );
+  });
 
   it('warns with a no-op when an async setState is triggered', () => {
     class Foo extends React.Component {

--- a/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingBrowser-test.js
@@ -54,14 +54,14 @@ describe('ReactServerRenderingBrowser', () => {
 
   it('throws meaningfully for server-only APIs', () => {
     expect(() => ReactDOMServerBrowser.renderToNodeStream(<div />)).toThrow(
-      'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
-        'in the browser. Use ReactDOMServer.renderToString() instead.',
+      'ReactDOMServer.renderToNodeStream(): This streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToBrowserStream() instead.',
     );
     expect(() =>
       ReactDOMServerBrowser.renderToStaticNodeStream(<div />),
     ).toThrow(
-      'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
-        'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
+      'ReactDOMServer.renderToStaticNodeStream(): This streaming API is not available ' +
+        'in the browser. Use ReactDOMServer.renderToStaticBrowserStream() instead.',
     );
   });
 });

--- a/packages/react-dom/src/server/ReactDOMBrowserStreamRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMBrowserStreamRenderer.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type {ServerOptions} from './ReactPartialRenderer';
+
+import ReactPartialRenderer from './ReactPartialRenderer';
+
+// This is a ReadableStream which wraps the ReactDOMPartialRenderer.
+function ReactMarkupReadableStream(element, makeStaticMarkup, options) {
+  const partialRenderer = new ReactPartialRenderer(
+    element,
+    makeStaticMarkup,
+    options,
+  );
+  return new ReadableStream({
+    // Calls the ReadableStream(options). Consider exposing built-in
+    // features like highWaterMark in the future.
+    pull(controller) {
+      try {
+        const chunk = partialRenderer.read(controller.desiredSize);
+        if (chunk === null) controller.close();
+        controller.enqueue(chunk);
+      } catch (e) {
+        partialRenderer.destroy(e);
+        controller.error(e);
+      }
+    },
+    cancel(reason) {
+      partialRenderer.destroy(reason);
+    },
+  });
+}
+
+/**
+ * Render a ReactElement to its initial HTML.
+ * See https://reactjs.org/docs/react-dom-server.html#rendertonodestream
+ */
+export function renderToBrowserStream(element, options?: ServerOptions) {
+  return new ReactMarkupReadableStream(element, false, options);
+}
+
+/**
+ * Similar to renderToStream, except this doesn't create extra DOM attributes
+ * such as data-react-id that React uses internally.
+ * See https://reactjs.org/docs/react-dom-server.html#rendertostaticnodestream
+ */
+export function renderToStaticBrowserStream(element, options?: ServerOptions) {
+  return new ReactMarkupReadableStream(element, true, options);
+}

--- a/packages/react-dom/src/server/ReactDOMBrowserStreamRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMBrowserStreamRenderer.js
@@ -10,14 +10,17 @@ import ReactPartialRenderer from './ReactPartialRenderer';
 
 // This is a ReadableStream which wraps the ReactDOMPartialRenderer.
 function ReactMarkupReadableStream(element, makeStaticMarkup, options) {
-  const partialRenderer = new ReactPartialRenderer(
-    element,
-    makeStaticMarkup,
-    options,
-  );
+  let partialRenderer;
   return new ReadableStream({
     // Calls the ReadableStream(options). Consider exposing built-in
     // features like highWaterMark in the future.
+    start() {
+      partialRenderer = new ReactPartialRenderer(
+        element,
+        makeStaticMarkup,
+        options,
+      );
+    },
     pull(controller) {
       try {
         const chunk = partialRenderer.read(controller.desiredSize);

--- a/packages/react-dom/src/server/ReactDOMServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMServerBrowser.js
@@ -9,20 +9,24 @@ import ReactVersion from 'shared/ReactVersion';
 import invariant from 'shared/invariant';
 
 import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
+import {
+  renderToBrowserStream,
+  renderToStaticBrowserStream,
+} from './ReactDOMBrowserStreamRenderer';
 
 function renderToNodeStream() {
   invariant(
     false,
-    'ReactDOMServer.renderToNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToString() instead.',
+    'ReactDOMServer.renderToNodeStream(): This streaming API is not available ' +
+      'in the browser. Use ReactDOMServer.renderToBrowserStream() instead.',
   );
 }
 
 function renderToStaticNodeStream() {
   invariant(
     false,
-    'ReactDOMServer.renderToStaticNodeStream(): The streaming API is not available ' +
-      'in the browser. Use ReactDOMServer.renderToStaticMarkup() instead.',
+    'ReactDOMServer.renderToStaticNodeStream(): This streaming API is not available ' +
+      'in the browser. Use ReactDOMServer.renderToStaticBrowserStream() instead.',
   );
 }
 
@@ -31,5 +35,7 @@ export {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToBrowserStream,
+  renderToStaticBrowserStream,
   ReactVersion as version,
 };

--- a/packages/react-dom/src/server/ReactDOMServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMServerNode.js
@@ -6,6 +6,7 @@
  */
 
 import ReactVersion from 'shared/ReactVersion';
+import invariant from 'shared/invariant';
 
 import {renderToString, renderToStaticMarkup} from './ReactDOMStringRenderer';
 import {
@@ -13,10 +14,28 @@ import {
   renderToStaticNodeStream,
 } from './ReactDOMNodeStreamRenderer';
 
+function renderToBrowserStream() {
+  invariant(
+    false,
+    'ReactDOMServer.renderToBrowserStream(): This streaming API is not available ' +
+      'in Node environement. Use ReactDOMServer.renderToNodeStream() instead.',
+  );
+}
+
+function renderToStaticBrowserStream() {
+  invariant(
+    false,
+    'ReactDOMServer.renderToStaticBrowserStream(): This streaming API is not available ' +
+      'in Node environement. Use ReactDOMServer.renderToStaticNodeStream() instead.',
+  );
+}
+
 export {
   renderToString,
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
+  renderToBrowserStream,
+  renderToStaticBrowserStream,
   ReactVersion as version,
 };

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -1,4 +1,3 @@
-
 {
   "0": "React.addons.createFragment(...): Encountered an invalid child; DOM elements are not valid children of React components.",
   "1": "update(): expected target of %s to be an array; got %s.",
@@ -366,5 +365,9 @@
   "365": "Invalid selector type %s specified.",
   "366": "ReactDOM.createEventHandle: setListener called on an target that did not have a corresponding root. This is likely a bug in React.",
   "367": "ReactDOM.createEventHandle: setListener called on an element target that is not managed by React. Ensure React rendered the DOM element.",
-  "368": "ReactDOM.createEventHandle: setListener called on an invalid target. Provide a vaid EventTarget or an element managed by React."
+  "368": "ReactDOM.createEventHandle: setListener called on an invalid target. Provide a vaid EventTarget or an element managed by React.",
+  "369": "ReactDOMServer.renderToNodeStream(): This streaming API is not available in the browser. Use ReactDOMServer.renderToBrowserStream() instead.",
+  "370": "ReactDOMServer.renderToStaticNodeStream(): This streaming API is not available in the browser. Use ReactDOMServer.renderToStaticBrowserStream() instead.",
+  "371": "ReactDOMServer.renderToBrowserStream(): This streaming API is not available in Node environement. Use ReactDOMServer.renderToNodeStream() instead.",
+  "372": "ReactDOMServer.renderToStaticBrowserStream(): This streaming API is not available in Node environement. Use ReactDOMServer.renderToStaticNodeStream() instead."
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13685,6 +13685,11 @@ web-ext@^3.0.0:
     yargs "13.2.4"
     zip-dir "1.0.2"
 
+web-streams-polyfill@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.1.1.tgz#2c82b6193849ccb9efaa267772c28260ef68d6d2"
+  integrity sha512-dlNpL2aab3g8CKfGz6rl8FNmGaRWLLn2g/DtSc9IjB30mEdE6XxzPfPSig5BwGSzI+oLxHyETrQGKjrVVhbLCg==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
And renderToStaticBrowserStream. Using ReadableStream browser API

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) typechecks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Hello :)
This PR add possibility to use `ReactDOM.renderToNodeStream()` inside the **browser** or in **Deno.land** with `ReactDOM.renderToBrowserStream()` & `ReactDOM.renderToStaticBrowserStream()`method.

It use browser API [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)

If you don't want this feature, can we have access to ReactPartialRenderer to be able to do that ?
It's my first PR. Sorry if I waste your time here !

Thank you !

## Test Plan
I tried to do some tests, but I don't know how to run browser api test in node Environment.
I'm motivate to do that but, I need a little help here :)
**EDIT** : I figured out how handle this issue
```javascript
  describe('renderToStaticBrowserStream', () => {
    it('should generate simple markup', async () => {
      const SuccessfulElement = React.createElement(() => <img />);
      const stream = ReactDOMServerBrowser.renderToStaticBrowserStream(
        SuccessfulElement,
      );
      const reader = stream.getReader();
      const string = (await reader.read()).value;
      expect(string).toMatch(new RegExp('<img' + '/>'));
    });

    it('should handle errors correctly', () => {
      const FailingElement = React.createElement(() => {
        throw new Error('An Error');
      });
      const stream = ReactDOMServerBrowser.renderToStaticBrowserStream(
        FailingElement,
      );
      const response = stream.getReader();
      let handleError = false;
      response
        .read()
        .catch(e => {
          handleError = true;
        })
        .finally(() => {
          expect(handleError).toBeTruthy();
        });
    });
  });
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
