### PR TITLE
Remove React Flare discrete timeStamp flushing heuristic

### DIFF
--- a/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
+++ b/packages/react-dom/src/events/DeprecatedDOMEventResponderSystem.js
@@ -94,7 +94,7 @@ const eventResponderContext: ReactDOMResponderContext = {
     validateEventValue(eventValue);
     switch (eventPriority) {
       case DiscreteEvent: {
-        flushDiscreteUpdatesIfNeeded(currentTimeStamp);
+        flushDiscreteUpdatesIfNeeded();
         discreteUpdates(() =>
           executeUserEventHandler(eventListener, eventValue),
         );

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -131,7 +131,7 @@ function dispatchDiscreteEvent(
     // flushed for this event and we don't need to do it again.
     (eventSystemFlags & LEGACY_FB_SUPPORT) === 0
   ) {
-    flushDiscreteUpdatesIfNeeded(nativeEvent.timeStamp);
+    flushDiscreteUpdatesIfNeeded();
   }
   discreteUpdates(
     dispatchEvent,

--- a/packages/react-dom/src/events/ReactDOMUpdateBatching.js
+++ b/packages/react-dom/src/events/ReactDOMUpdateBatching.js
@@ -10,7 +10,6 @@ import {
   restoreStateIfNeeded,
 } from './ReactDOMControlledComponent';
 
-import {enableDeprecatedFlareAPI} from 'shared/ReactFeatureFlags';
 import {invokeGuardedCallbackAndCatchFirstError} from 'shared/ReactErrorUtils';
 
 // Used as a way to call batchedUpdates when we don't have a reference to
@@ -102,27 +101,8 @@ export function discreteUpdates(fn, a, b, c, d) {
   }
 }
 
-let lastFlushedEventTimeStamp = 0;
-export function flushDiscreteUpdatesIfNeeded(timeStamp: number) {
-  // event.timeStamp isn't overly reliable due to inconsistencies in
-  // how different browsers have historically provided the time stamp.
-  // Some browsers provide high-resolution time stamps for all events,
-  // some provide low-resolution time stamps for all events. FF < 52
-  // even mixes both time stamps together. Some browsers even report
-  // negative time stamps or time stamps that are 0 (iOS9) in some cases.
-  // Given we are only comparing two time stamps with equality (!==),
-  // we are safe from the resolution differences. If the time stamp is 0
-  // we bail-out of preventing the flush, which can affect semantics,
-  // such as if an earlier flush removes or adds event listeners that
-  // are fired in the subsequent flush. However, this is the same
-  // behaviour as we had before this change, so the risks are low.
-  if (
-    !isInsideEventHandler &&
-    (!enableDeprecatedFlareAPI ||
-      timeStamp === 0 ||
-      lastFlushedEventTimeStamp !== timeStamp)
-  ) {
-    lastFlushedEventTimeStamp = timeStamp;
+export function flushDiscreteUpdatesIfNeeded() {
+  if (!isInsideEventHandler) {
     flushDiscreteUpdatesImpl();
   }
 }


### PR DESCRIPTION
This PR removes a heuristic we introduced with React Flare. Given we're in the process of gradually removing React Flare, we should also remove this heuristic as it causes a lack of flushing when dealing with discrete events that do not come from Flare (i.e. using the new `createEventHandle` primitive).

The reason for this is because Flare controlled the flushing itself, whilst the normal React event workflow is to flush when encountering a native event that is discrete. Flare introduced the timeStamp logic to prevent too many flushes, but now we're seeing that it actually causes issues with normal React (under-flushing). This is most evident when dealing with a11y use-cases, like `focus` and `blur`.