### PR TITLE
Revert "Re-enabled DebugTracing feature for old reconciler fork (#191…

### DIFF
--- a/packages/react-reconciler/src/DebugTracing.js
+++ b/packages/react-reconciler/src/DebugTracing.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {Lane, Lanes} from './ReactFiberLane';
 import type {Wakeable} from 'shared/ReactTypes';
 
 import {enableDebugTracing} from 'shared/ReactFeatureFlags';
@@ -17,10 +16,6 @@ let nativeConsoleLog: null | Function = null;
 
 const pendingGroupArgs: Array<any> = [];
 let printedGroupIndex: number = -1;
-
-function formatLanes(laneOrLanes: Lane | Lanes): string {
-  return '0b' + (laneOrLanes: any).toString(2).padStart(31, '0');
-}
 
 function group(...groupArgs): void {
   pendingGroupArgs.push(groupArgs);
@@ -62,11 +57,11 @@ function log(...logArgs): void {
 const REACT_LOGO_STYLE =
   'background-color: #20232a; color: #61dafb; padding: 0 2px;';
 
-export function logCommitStarted(lanes: Lanes): void {
+export function logCommitStarted(priorityLabel: string): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       group(
-        `%c⚛️%c commit%c (${formatLanes(lanes)})`,
+        `%c⚛️%c commit%c (priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         '',
         'font-weight: normal;',
@@ -133,11 +128,11 @@ export function logComponentSuspended(
   }
 }
 
-export function logLayoutEffectsStarted(lanes: Lanes): void {
+export function logLayoutEffectsStarted(priorityLabel: string): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       group(
-        `%c⚛️%c layout effects%c (${formatLanes(lanes)})`,
+        `%c⚛️%c layout effects%c (priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         '',
         'font-weight: normal;',
@@ -154,11 +149,11 @@ export function logLayoutEffectsStopped(): void {
   }
 }
 
-export function logPassiveEffectsStarted(lanes: Lanes): void {
+export function logPassiveEffectsStarted(priorityLabel: string): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       group(
-        `%c⚛️%c passive effects%c (${formatLanes(lanes)})`,
+        `%c⚛️%c passive effects%c (priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         '',
         'font-weight: normal;',
@@ -175,11 +170,11 @@ export function logPassiveEffectsStopped(): void {
   }
 }
 
-export function logRenderStarted(lanes: Lanes): void {
+export function logRenderStarted(priorityLabel: string): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       group(
-        `%c⚛️%c render%c (${formatLanes(lanes)})`,
+        `%c⚛️%c render%c (priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         '',
         'font-weight: normal;',
@@ -198,12 +193,12 @@ export function logRenderStopped(): void {
 
 export function logForceUpdateScheduled(
   componentName: string,
-  lane: Lane,
+  priorityLabel: string,
 ): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       log(
-        `%c⚛️%c ${componentName} forced update %c(${formatLanes(lane)})`,
+        `%c⚛️%c ${componentName} forced update %c(priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         'color: #db2e1f; font-weight: bold;',
         '',
@@ -214,13 +209,13 @@ export function logForceUpdateScheduled(
 
 export function logStateUpdateScheduled(
   componentName: string,
-  lane: Lane,
+  priorityLabel: string,
   payloadOrAction: any,
 ): void {
   if (__DEV__) {
     if (enableDebugTracing) {
       log(
-        `%c⚛️%c ${componentName} updated state %c(${formatLanes(lane)})`,
+        `%c⚛️%c ${componentName} updated state %c(priority: ${priorityLabel})`,
         REACT_LOGO_STYLE,
         'color: #01a252; font-weight: bold;',
         '',

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -16,7 +16,6 @@ import {Update, Snapshot} from './ReactSideEffectTags';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
-  enableDebugTracing,
   warnAboutDeprecatedLifecycles,
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings.old';
@@ -28,7 +27,7 @@ import invariant from 'shared/invariant';
 import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
-import {DebugTracingMode, StrictMode} from './ReactTypeOfMode';
+import {StrictMode} from './ReactTypeOfMode';
 
 import {
   enqueueUpdate,
@@ -56,7 +55,6 @@ import {
   scheduleUpdateOnFiber,
 } from './ReactFiberWorkLoop.old';
 import {requestCurrentSuspenseConfig} from './ReactFiberSuspenseConfig';
-import {logForceUpdateScheduled, logStateUpdateScheduled} from './DebugTracing';
 
 import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
@@ -205,15 +203,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logStateUpdateScheduled(name, lane, payload);
-        }
-      }
-    }
   },
   enqueueReplaceState(inst, payload, callback) {
     const fiber = getInstance(inst);
@@ -234,15 +223,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logStateUpdateScheduled(name, lane, payload);
-        }
-      }
-    }
   },
   enqueueForceUpdate(inst, callback) {
     const fiber = getInstance(inst);
@@ -262,15 +242,6 @@ const classComponentUpdater = {
 
     enqueueUpdate(fiber, update);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (fiber.mode & DebugTracingMode) {
-          const name = getComponentName(fiber.type) || 'Unknown';
-          logForceUpdateScheduled(name, lane);
-        }
-      }
-    }
   },
 };
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -24,12 +24,9 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {
-  enableDebugTracing,
-  enableNewReconciler,
-} from 'shared/ReactFeatureFlags';
+import {enableNewReconciler} from 'shared/ReactFeatureFlags';
 
-import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {
   NoLane,
   NoLanes,
@@ -86,7 +83,6 @@ import {
   warnAboutMultipleRenderersDEV,
 } from './ReactMutableSource.old';
 import {getIsRendering} from './ReactCurrentFiber';
-import {logStateUpdateScheduled} from './DebugTracing';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -1740,15 +1736,6 @@ function dispatchAction<S, A>(
       }
     }
     scheduleUpdateOnFiber(fiber, lane, eventTime);
-  }
-
-  if (__DEV__) {
-    if (enableDebugTracing) {
-      if (fiber.mode & DebugTracingMode) {
-        const name = getComponentName(fiber.type) || 'Unknown';
-        logStateUpdateScheduled(name, lane, action);
-      }
-    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -30,8 +30,7 @@ import {
   LifecycleEffectMask,
 } from './ReactSideEffectTags';
 import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent.old';
-import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
-import {enableDebugTracing} from 'shared/ReactFeatureFlags';
+import {NoMode, BlockingMode} from './ReactTypeOfMode';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
   enqueueCapturedUpdate,
@@ -54,7 +53,6 @@ import {
   pingSuspendedRoot,
 } from './ReactFiberWorkLoop.old';
 import {logCapturedError} from './ReactFiberErrorLogger';
-import {logComponentSuspended} from './DebugTracing';
 
 import {
   SyncLane,
@@ -190,15 +188,6 @@ function throwException(
   ) {
     // This is a wakeable.
     const wakeable: Wakeable = (value: any);
-
-    if (__DEV__) {
-      if (enableDebugTracing) {
-        if (sourceFiber.mode & DebugTracingMode) {
-          const name = getComponentName(sourceFiber.type) || 'Unknown';
-          logComponentSuspended(name, wakeable);
-        }
-      }
-    }
 
     if ((sourceFiber.mode & BlockingMode) === NoMode) {
       // Reset the memoizedState to what it was before we attempted

--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -85,9 +85,9 @@ describe('DebugTracing', () => {
     );
 
     expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000000000000001)',
+      'group: ⚛️ render (priority: immediate)',
       'log: ⚛️ Example suspended',
-      'groupEnd: ⚛️ render (0b0000000000000000000000000000001)',
+      'groupEnd: ⚛️ render (priority: immediate)',
     ]);
 
     logs.splice(0);
@@ -119,9 +119,9 @@ describe('DebugTracing', () => {
     expect(Scheduler).toFlushUntilNextPaint([]);
 
     expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
+      'group: ⚛️ render (priority: normal)',
       'log: ⚛️ Example suspended',
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+      'groupEnd: ⚛️ render (priority: normal)',
     ]);
 
     logs.splice(0);
@@ -156,11 +156,11 @@ describe('DebugTracing', () => {
     expect(Scheduler).toFlushUntilNextPaint([]);
 
     expect(logs).toEqual([
-      'group: ⚛️ commit (0b0000000000000000000001000000000)',
-      'group: ⚛️ layout effects (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000000000000001)',
-      'groupEnd: ⚛️ layout effects (0b0000000000000000000001000000000)',
-      'groupEnd: ⚛️ commit (0b0000000000000000000001000000000)',
+      'group: ⚛️ commit (priority: normal)',
+      'group: ⚛️ layout effects (priority: immediate)',
+      'log: ⚛️ Example updated state (priority: immediate)',
+      'groupEnd: ⚛️ layout effects (priority: immediate)',
+      'groupEnd: ⚛️ commit (priority: normal)',
     ]);
   });
 
@@ -192,10 +192,10 @@ describe('DebugTracing', () => {
     }).toErrorDev('Cannot update during an existing state transition');
 
     expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+      'group: ⚛️ render (priority: normal)',
+      'log: ⚛️ Example updated state (priority: normal)',
+      'log: ⚛️ Example updated state (priority: normal)',
+      'groupEnd: ⚛️ render (priority: normal)',
     ]);
   });
 
@@ -223,11 +223,11 @@ describe('DebugTracing', () => {
     expect(Scheduler).toFlushUntilNextPaint([]);
 
     expect(logs).toEqual([
-      'group: ⚛️ commit (0b0000000000000000000001000000000)',
-      'group: ⚛️ layout effects (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000000000000001)',
-      'groupEnd: ⚛️ layout effects (0b0000000000000000000001000000000)',
-      'groupEnd: ⚛️ commit (0b0000000000000000000001000000000)',
+      'group: ⚛️ commit (priority: normal)',
+      'group: ⚛️ layout effects (priority: immediate)',
+      'log: ⚛️ Example updated state (priority: immediate)',
+      'groupEnd: ⚛️ layout effects (priority: immediate)',
+      'groupEnd: ⚛️ commit (priority: normal)',
     ]);
   });
 
@@ -250,9 +250,9 @@ describe('DebugTracing', () => {
       );
     });
     expect(logs).toEqual([
-      'group: ⚛️ passive effects (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'groupEnd: ⚛️ passive effects (0b0000000000000000000001000000000)',
+      'group: ⚛️ passive effects (priority: normal)',
+      'log: ⚛️ Example updated state (priority: normal)',
+      'groupEnd: ⚛️ passive effects (priority: normal)',
     ]);
   });
 
@@ -275,10 +275,10 @@ describe('DebugTracing', () => {
       );
     });
     expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)', // debugRenderPhaseSideEffectsForStrictMode
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+      'group: ⚛️ render (priority: normal)',
+      'log: ⚛️ Example updated state (priority: normal)',
+      'log: ⚛️ Example updated state (priority: normal)', // debugRenderPhaseSideEffectsForStrictMode
+      'groupEnd: ⚛️ render (priority: normal)',
     ]);
   });
 
@@ -303,9 +303,9 @@ describe('DebugTracing', () => {
     expect(Scheduler).toFlushUntilNextPaint([]);
 
     expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
+      'group: ⚛️ render (priority: normal)',
       'log: Hello from user code',
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+      'groupEnd: ⚛️ render (priority: normal)',
     ]);
   });
 

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -78,8 +78,8 @@ export const enableModernEventSystem = true;
 // to the correct value.
 export const enableNewReconciler = __VARIANT__;
 
-// TODO: This does not currently exist in the new reconciler fork.
-export const enableDebugTracing = !__VARIANT__;
+// TODO: This does not currently exist in the Lanes implementation.
+export const enableDebugTracing = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
This reverts commit cc7c1aece46a6b69b41958d731e0fd27c94bfc6c.

This PR introduced a bug [here](https://github.com/facebook/react/commit/cc7c1aece46a6b69b41958d731e0fd27c94bfc6c#r40015023). `root.finishedLanes` is potentially different before and after we call `flushPassiveEffects`. This PR moved `var lanes = root.finishedLanes` before the `flushPassiveEffects` call, which caused a bug in FBR. Once I can reproduce the bug in FBR I will add a unit test and fix forward.