### PR TITLE
[eslint-plugin-react-hooks]: enable linting default exported function

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -380,7 +380,7 @@ const tests = {
     },
     {
       code: `
-        // This is a false positive (it's valid) that unfortunately 
+        // This is a false positive (it's valid) that unfortunately
         // we cannot avoid. Prefer to rename it to not start with "use"
         class Foo extends Component {
           render() {
@@ -505,6 +505,39 @@ const tests = {
         });
       `,
       errors: [genericError('useHookInsideCallback')],
+    },
+    {
+      code: `
+        export const Foo = () => {
+          const cb = useCallback(() => {
+            useHook()
+          }, [])
+          return <button onClick={cb}></button>
+        }
+      `,
+      errors: [genericError('useHook')],
+    },
+    {
+      code: `
+        export default () => {
+          const cb = useCallback(() => {
+            useHook()
+          }, [])
+          return <button onClick={cb}></button>
+        }
+      `,
+      errors: [
+        functionError(
+          'useCallback',
+          `export default () => {
+          const cb = useCallback(() => {
+            useHook()
+          }, [])
+          return <button onClick={cb}></button>
+        }`
+        ),
+        genericError('useHook'),
+      ],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -39,6 +39,10 @@ function isHook(node) {
   }
 }
 
+function isDefaultExport(node) {
+  return node.type === 'ExportDefaultDeclaration';
+}
+
 /**
  * Checks if the node is a React component name. React component names must
  * always start with a non-lowercase letter. So `MyComponent` or `_MyComponent`
@@ -92,7 +96,11 @@ function isInsideComponentOrHook(node) {
   while (node) {
     const functionName = getFunctionName(node);
     if (functionName) {
-      if (isComponentName(functionName) || isHook(functionName)) {
+      if (
+        isComponentName(functionName) ||
+        isHook(functionName) ||
+        isDefaultExport(functionName)
+      ) {
         return true;
       }
     }
@@ -593,6 +601,8 @@ function getFunctionName(node) {
       // Kinda clowny, but we'd said we'd follow spec convention for
       // `IsAnonymousFunctionDefinition()` usage.
       return node.parent.left;
+    } else if (node.parent.type === 'ExportDefaultDeclaration') {
+      return node.parent;
     } else {
       return undefined;
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
Relates to #19155 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

So, basically I came across a situation where `eslint-plugin-react-hooks` does not throw any error on a default exported function.

As I've read through the code and found out that the root cause for this was around the `getFunctionName` function:

https://github.com/facebook/react/blob/6ba25b96df5d4179bf8aba3c3fe1ace3dce28234/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L339-L345

where it gets the function name from the given AST and (currently)  returns `undefined` for a default exported anonymous function.

So, this PR aims to handle that specific case, by

1. **not** letting `getFunctionName` return `undefined`
1. letting `isInsideComponentOrHook` return `true`
1. letting `isSomewhereInsideComponentOrHook` to be `true`
1. letting print the generic error message


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

#### Named Export
This throws a `genericError` as it is supposed to. (a testcase to make sure it works for named exports as well)
```javascript
export const Foo = () => {
  const cb = useCallback(() => {
    useHook()
  }, [])
  return <button onClick={cb}></button>
}
```

#### Default Export
This **now** throws a `genericError` and a `functionError`.
```javascript
export default () => {
  const cb = useCallback(() => {
    useHook()
  }, [])
  return <button onClick={cb}></button>
}
```
