### PR TITLE
Adds React.unstable_useSnapshotBeforeCommit

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -333,6 +333,18 @@ function useOpaqueIdentifier(): OpaqueIDType | void {
   return value;
 }
 
+function useSnapshotBeforeCommit(
+  create: () => void,
+  inputs: Array<mixed> | void | null,
+): void {
+  nextHook();
+  hookLog.push({
+    primitive: 'SnapshotBeforeCommit',
+    stackError: new Error(),
+    value: create,
+  });
+}
+
 const Dispatcher: DispatcherType = {
   readContext,
   useCallback,
@@ -350,6 +362,7 @@ const Dispatcher: DispatcherType = {
   useMutableSource,
   useDeferredValue,
   useOpaqueIdentifier,
+  useSnapshotBeforeCommit,
 };
 
 // Inspect

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -33,6 +33,7 @@ let forwardRef;
 let yieldedValues;
 let yieldValue;
 let clearYields;
+let useSnapshotBeforeCommit;
 
 function initModules() {
   // Reset warning cache.
@@ -55,6 +56,7 @@ function initModules() {
   useLayoutEffect = React.useLayoutEffect;
   useOpaqueIdentifier = React.unstable_useOpaqueIdentifier;
   forwardRef = React.forwardRef;
+  useSnapshotBeforeCommit = React.unstable_useSnapshotBeforeCommit;
 
   yieldedValues = [];
   yieldValue = value => {
@@ -633,6 +635,23 @@ describe('ReactDOMServerHooks', () => {
       const domNode = await serverRender(
         <Counter label="Count" ref={counter} />,
       );
+      expect(clearYields()).toEqual(['Count: 0']);
+      expect(domNode.tagName).toEqual('SPAN');
+      expect(domNode.textContent).toEqual('Count: 0');
+    });
+  });
+
+  describe('useSnapshotBeforeCommit', () => {
+    // @gate experimental
+    it('should not be invoked on the server', async () => {
+      function Counter() {
+        useSnapshotBeforeCommit(() => {
+          throw new Error('should not be invoked');
+        });
+
+        return <Text text="Count: 0" />;
+      }
+      const domNode = await serverRender(<Counter />);
       expect(clearYields()).toEqual(['Count: 0']);
       expect(domNode.tagName).toEqual('SPAN');
       expect(domNode.textContent).toEqual('Count: 0');

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -529,4 +529,5 @@ export const Dispatcher: DispatcherType = {
   useOpaqueIdentifier,
   // Subscriptions are not setup in a server environment.
   useMutableSource,
+  useSnapshotBeforeCommit: noop,
 };

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -127,6 +127,7 @@ import {
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
+  Snapshot as HookSnapshot,
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork.new';
 import {
@@ -231,6 +232,7 @@ function commitBeforeMutationLifeCycles(
     case ForwardRef:
     case SimpleMemoComponent:
     case Block: {
+      commitSnapshotHookEffectList(finishedWork);
       return;
     }
     case ClassComponent: {
@@ -375,6 +377,33 @@ function commitHookEffectListMount(tag: number, finishedWork: Fiber) {
               'An effect function must not return anything besides a function, ' +
                 'which is used for clean-up.%s',
               addendum,
+            );
+          }
+        }
+      }
+      effect = effect.next;
+    } while (effect !== firstEffect);
+  }
+}
+
+function commitSnapshotHookEffectList(finishedWork: Fiber) {
+  const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
+  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+  if (lastEffect !== null) {
+    const firstEffect = lastEffect.next;
+    let effect = firstEffect;
+    do {
+      if ((effect.tag & HookSnapshot) === HookSnapshot) {
+        // Run snapshot effect
+        const create = effect.create;
+        // There shouldn't be a return
+        const possibleBadValue = create();
+
+        if (__DEV__) {
+          if (typeof possibleBadValue === 'function') {
+            console.error(
+              "useSnapshotBeforeCommit's function must not return anything. Use an effect " +
+                'for when you want to return a function that handles clean-up.',
             );
           }
         }

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -41,11 +41,13 @@ import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.ne
 import {
   Update as UpdateEffect,
   Passive as PassiveEffect,
+  Snapshot as SnapshotEffect,
 } from './ReactSideEffectTags';
 import {
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
+  Snapshot as HookSnapshot,
 } from './ReactHookEffectTags';
 import {
   getWorkInProgressRoot,
@@ -121,7 +123,8 @@ export type HookType =
   | 'useDeferredValue'
   | 'useTransition'
   | 'useMutableSource'
-  | 'useOpaqueIdentifier';
+  | 'useOpaqueIdentifier'
+  | 'useSnapshotBeforeCommit';
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;
@@ -1298,6 +1301,20 @@ function updateLayoutEffect(
   return updateEffectImpl(UpdateEffect, HookLayout, create, deps);
 }
 
+function mountSnapshotBeforeCommit(
+  create: () => void,
+  deps: Array<mixed> | void | null,
+): void {
+  return mountEffectImpl(SnapshotEffect, HookSnapshot, create, deps);
+}
+
+function updateSnapshotBeforeCommit(
+  create: () => void,
+  deps: Array<mixed> | void | null,
+): void {
+  return updateEffectImpl(SnapshotEffect, HookSnapshot, create, deps);
+}
+
 function imperativeHandleEffect<T>(
   create: () => T,
   ref: {|current: T | null|} | ((inst: T | null) => mixed) | null | void,
@@ -1757,6 +1774,7 @@ export const ContextOnlyDispatcher: Dispatcher = {
   useTransition: throwInvalidHookError,
   useMutableSource: throwInvalidHookError,
   useOpaqueIdentifier: throwInvalidHookError,
+  useSnapshotBeforeCommit: throwInvalidHookError,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1779,6 +1797,7 @@ const HooksDispatcherOnMount: Dispatcher = {
   useTransition: mountTransition,
   useMutableSource: mountMutableSource,
   useOpaqueIdentifier: mountOpaqueIdentifier,
+  useSnapshotBeforeCommit: mountSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1801,6 +1820,7 @@ const HooksDispatcherOnUpdate: Dispatcher = {
   useTransition: updateTransition,
   useMutableSource: updateMutableSource,
   useOpaqueIdentifier: updateOpaqueIdentifier,
+  useSnapshotBeforeCommit: updateSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1823,6 +1843,7 @@ const HooksDispatcherOnRerender: Dispatcher = {
   useTransition: rerenderTransition,
   useMutableSource: updateMutableSource,
   useOpaqueIdentifier: rerenderOpaqueIdentifier,
+  useSnapshotBeforeCommit: updateSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1987,6 +2008,15 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      mountHookTypesDev();
+      checkDepsAreArrayDev(deps);
+      return mountSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2118,6 +2148,14 @@ if (__DEV__) {
       currentHookNameInDev = 'useOpaqueIdentifier';
       updateHookTypesDev();
       return mountOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return mountSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2251,6 +2289,14 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2383,6 +2429,14 @@ if (__DEV__) {
       currentHookNameInDev = 'useOpaqueIdentifier';
       updateHookTypesDev();
       return rerenderOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2532,6 +2586,15 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      mountHookTypesDev();
+      return mountSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2679,6 +2742,15 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return updateOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2828,6 +2900,15 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return rerenderOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -44,11 +44,13 @@ import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.ol
 import {
   Update as UpdateEffect,
   Passive as PassiveEffect,
+  Snapshot as SnapshotEffect,
 } from './ReactSideEffectTags';
 import {
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
+  Snapshot as HookSnapshot,
 } from './ReactHookEffectTags';
 import {
   getWorkInProgressRoot,
@@ -125,7 +127,8 @@ export type HookType =
   | 'useDeferredValue'
   | 'useTransition'
   | 'useMutableSource'
-  | 'useOpaqueIdentifier';
+  | 'useOpaqueIdentifier'
+  | 'useSnapshotBeforeCommit';
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;
@@ -1302,6 +1305,20 @@ function updateLayoutEffect(
   return updateEffectImpl(UpdateEffect, HookLayout, create, deps);
 }
 
+function mountSnapshotBeforeCommit(
+  create: () => void,
+  deps: Array<mixed> | void | null,
+): void {
+  return mountEffectImpl(SnapshotEffect, HookSnapshot, create, deps);
+}
+
+function updateSnapshotBeforeCommit(
+  create: () => void,
+  deps: Array<mixed> | void | null,
+): void {
+  return updateEffectImpl(SnapshotEffect, HookSnapshot, create, deps);
+}
+
 function imperativeHandleEffect<T>(
   create: () => T,
   ref: {|current: T | null|} | ((inst: T | null) => mixed) | null | void,
@@ -1770,6 +1787,7 @@ export const ContextOnlyDispatcher: Dispatcher = {
   useTransition: throwInvalidHookError,
   useMutableSource: throwInvalidHookError,
   useOpaqueIdentifier: throwInvalidHookError,
+  useSnapshotBeforeCommit: throwInvalidHookError,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1792,6 +1810,7 @@ const HooksDispatcherOnMount: Dispatcher = {
   useTransition: mountTransition,
   useMutableSource: mountMutableSource,
   useOpaqueIdentifier: mountOpaqueIdentifier,
+  useSnapshotBeforeCommit: mountSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1814,6 +1833,7 @@ const HooksDispatcherOnUpdate: Dispatcher = {
   useTransition: updateTransition,
   useMutableSource: updateMutableSource,
   useOpaqueIdentifier: updateOpaqueIdentifier,
+  useSnapshotBeforeCommit: updateSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -1836,6 +1856,7 @@ const HooksDispatcherOnRerender: Dispatcher = {
   useTransition: rerenderTransition,
   useMutableSource: updateMutableSource,
   useOpaqueIdentifier: rerenderOpaqueIdentifier,
+  useSnapshotBeforeCommit: updateSnapshotBeforeCommit,
 
   unstable_isNewReconciler: enableNewReconciler,
 };
@@ -2000,6 +2021,15 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      mountHookTypesDev();
+      checkDepsAreArrayDev(deps);
+      return mountSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2131,6 +2161,14 @@ if (__DEV__) {
       currentHookNameInDev = 'useOpaqueIdentifier';
       updateHookTypesDev();
       return mountOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return mountSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2264,6 +2302,14 @@ if (__DEV__) {
       updateHookTypesDev();
       return updateOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2396,6 +2442,14 @@ if (__DEV__) {
       currentHookNameInDev = 'useOpaqueIdentifier';
       updateHookTypesDev();
       return rerenderOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2545,6 +2599,15 @@ if (__DEV__) {
       mountHookTypesDev();
       return mountOpaqueIdentifier();
     },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      mountHookTypesDev();
+      return mountSnapshotBeforeCommit(create, deps);
+    },
 
     unstable_isNewReconciler: enableNewReconciler,
   };
@@ -2692,6 +2755,15 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return updateOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,
@@ -2841,6 +2913,15 @@ if (__DEV__) {
       warnInvalidHookAccess();
       updateHookTypesDev();
       return rerenderOpaqueIdentifier();
+    },
+    useSnapshotBeforeCommit(
+      create: () => void,
+      deps: Array<mixed> | void | null,
+    ): void {
+      currentHookNameInDev = 'useSnapshotBeforeCommit';
+      warnInvalidHookAccess();
+      updateHookTypesDev();
+      return updateSnapshotBeforeCommit(create, deps);
     },
 
     unstable_isNewReconciler: enableNewReconciler,

--- a/packages/react-reconciler/src/ReactHookEffectTags.js
+++ b/packages/react-reconciler/src/ReactHookEffectTags.js
@@ -9,11 +9,12 @@
 
 export type HookEffectTag = number;
 
-export const NoEffect = /*  */ 0b000;
+export const NoEffect = /*  */ 0b0000;
 
 // Represents whether effect should fire.
-export const HasEffect = /* */ 0b001;
+export const HasEffect = /* */ 0b0001;
 
 // Represents the phase in which the effect (not the clean-up) fires.
-export const Layout = /*    */ 0b010;
-export const Passive = /*   */ 0b100;
+export const Layout = /*    */ 0b0010;
+export const Passive = /*   */ 0b0100;
+export const Snapshot = /*  */ 0b1000;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -310,6 +310,10 @@ export type Dispatcher = {|
     subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
   ): Snapshot,
   useOpaqueIdentifier(): any,
+  useSnapshotBeforeCommit(
+    create: () => void,
+    deps: Array<mixed> | void | null,
+  ): void,
 
   unstable_isNewReconciler?: boolean,
 |};

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1992,4 +1992,21 @@ describe('ReactHooks', () => {
     act(() => setShouldThrow(true));
     expect(root).toMatchRenderedOutput('Error!');
   });
+
+  // @gate experimental
+  it('useSnapshotBeforeCommit should warn if a destroy function is returned', () => {
+    const {unstable_useSnapshotBeforeCommit: useSnapshotBeforeCommit} = React;
+    function Component() {
+      useSnapshotBeforeCommit(() => {
+        return () => {};
+      });
+      return null;
+    }
+
+    const root = ReactTestRenderer.create(null);
+    expect(() => root.update(<Component />)).toErrorDev([
+      "Warning: useSnapshotBeforeCommit's function must not return anything." +
+        ' Use an effect for when you want to return a function that handles clean-up.',
+    ]);
+  });
 });

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -58,5 +58,6 @@ export {
   unstable_useOpaqueIdentifier,
   // enableDebugTracing
   unstable_DebugTracingMode,
+  unstable_useSnapshotBeforeCommit,
 } from './src/React';
 export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -49,4 +49,5 @@ export {
   unstable_useOpaqueIdentifier,
   // enableDebugTracing
   unstable_DebugTracingMode,
+  unstable_useSnapshotBeforeCommit,
 } from './src/React';

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -83,4 +83,5 @@ export {
   unstable_createFundamental,
   unstable_createScope,
   unstable_useOpaqueIdentifier,
+  unstable_useSnapshotBeforeCommit,
 } from './src/React';

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -57,5 +57,6 @@ export {
   unstable_useOpaqueIdentifier,
   // enableDebugTracing
   unstable_DebugTracingMode,
+  unstable_useSnapshotBeforeCommit,
 } from './src/React';
 export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -48,6 +48,7 @@ import {
   useTransition,
   useDeferredValue,
   useOpaqueIdentifier,
+  useSnapshotBeforeCommit,
 } from './ReactHooks';
 import {withSuspenseConfig} from './ReactBatchConfig';
 import {
@@ -123,4 +124,5 @@ export {
   // enableScopeAPI
   createScope as unstable_createScope,
   useOpaqueIdentifier as unstable_useOpaqueIdentifier,
+  useSnapshotBeforeCommit as unstable_useSnapshotBeforeCommit,
 };

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -196,3 +196,11 @@ export function useMutableSource<Source, Snapshot>(
   const dispatcher = resolveDispatcher();
   return dispatcher.useMutableSource(source, getSnapshot, subscribe);
 }
+
+export function useSnapshotBeforeCommit(
+  create: () => void,
+  deps: Array<mixed> | void | null,
+): void {
+  const dispatcher = resolveDispatcher();
+  return dispatcher.useSnapshotBeforeCommit(create, deps);
+}


### PR DESCRIPTION
## Overview

This PR adds a new hook cakked `React.unstable_useSnapshotBeforeCommit`.

This new hook triggers a callback before we commit a fiber tree:

```jsx
// The order of console.logs should be:
// useSnapshotBeforeCommit
// useLayoutEffect

function MyComponent() {
  unstable_useSnapshotBeforeCommit(() -> {
    console.log('useSnapshotBeforeCommit fired');
  });
  useLayoutEffect(() => {
  console.log('useLayoutEffect fired');
  });

  return null;
}
```

## More details:
- `React.unstable_useSnapshotBeforeCommit` does __not__ allow for a cleardown function to be returned. (@sebmarkbage was this was you expect too?)
- It does allow taking a second argument to take dependencies as an array, like other hooks.
