### PR TITLE
Fix react-runtime `main` field

### DIFF
--- a/packages/react-refresh/package.json
+++ b/packages/react-refresh/package.json
@@ -17,7 +17,7 @@
     "cjs/",
     "umd/"
   ],
-  "main": "index.js",
+  "main": "runtime.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",


### PR DESCRIPTION
The "main" field in this package points to a non-existent file. This fixes it.