### PR TITLE
[DevTools] Remove unnecessary tag end from CommitRanked view

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
@@ -167,7 +167,6 @@ function CommitRanked({chartData, commitTree, height, width}: Props) {
         width={width}>
         {CommitRankedListItem}
       </FixedSizeList>
-      >
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary

I've noticed that visual defect in the devtools during optimizing my app

<img width="300" alt="Screen Shot 2020-06-25 at 16 54 40" src="https://user-images.githubusercontent.com/4924283/85734024-5b239700-b705-11ea-8413-e0862fd17ddf.png">

## Test Plan

It looks fine after the change

<img width="309" alt="Screen Shot 2020-06-25 at 17 03 44" src="https://user-images.githubusercontent.com/4924283/85734647-d7b67580-b705-11ea-9d4b-d0f96c3ac898.png">
