### PR TITLE
Move TOP_BEFORE_BLUR to bubble phase

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -508,15 +508,15 @@ export function insertInContainerBefore(
   }
 }
 
-function createEvent(type: TopLevelType): Event {
+function createEvent(type: TopLevelType, bubbles: boolean): Event {
   const event = document.createEvent('Event');
-  event.initEvent(((type: any): string), false, false);
+  event.initEvent(((type: any): string), bubbles, false);
   return event;
 }
 
 function dispatchBeforeDetachedBlur(target: HTMLElement): void {
   if (enableDeprecatedFlareAPI || enableCreateEventHandleAPI) {
-    const event = createEvent(TOP_BEFORE_BLUR);
+    const event = createEvent(TOP_BEFORE_BLUR, true);
     // Dispatch "beforeblur" directly on the target,
     // so it gets picked up by the event system and
     // can propagate through the React internal tree.
@@ -526,7 +526,7 @@ function dispatchBeforeDetachedBlur(target: HTMLElement): void {
 
 function dispatchAfterDetachedBlur(target: HTMLElement): void {
   if (enableDeprecatedFlareAPI || enableCreateEventHandleAPI) {
-    const event = createEvent(TOP_AFTER_BLUR);
+    const event = createEvent(TOP_AFTER_BLUR, false);
     // So we know what was detached, make the relatedTarget the
     // detached target on the "afterblur" event.
     (event: any).relatedTarget = target;

--- a/packages/react-dom/src/events/DOMModernPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMModernPluginEventSystem.js
@@ -81,7 +81,6 @@ import {
   TOP_PLAYING,
   TOP_CLICK,
   TOP_SELECTION_CHANGE,
-  TOP_BEFORE_BLUR,
   TOP_AFTER_BLUR,
   getRawEventName,
 } from './DOMTopLevelEventTypes';
@@ -152,7 +151,6 @@ export const capturePhaseEvents: Set<DOMTopLevelEventType> = new Set([
 ]);
 
 if (enableCreateEventHandleAPI) {
-  capturePhaseEvents.add(TOP_BEFORE_BLUR);
   capturePhaseEvents.add(TOP_AFTER_BLUR);
 }
 


### PR DESCRIPTION
I've been meaning to do this for a while now. This makes `beforeblur` bubble, so that we correctly capture it in DOM propagation order, rather than having it in the capture phase. That way the ordering of propagation is more reliable.