### PR TITLE
Fixed test script handling of unknown/additional args

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -258,7 +258,7 @@ function getCommandArgs() {
 
   // Push the remaining args onto the command.
   // This will send args like `--watch` to Jest.
-  args.push(argv._);
+  args.push(...argv._);
 
   return args;
 }


### PR DESCRIPTION
Using multiple pass-through args (e.g. a test filter and a `--watch` flag) like so:
```
yarn test ReactHooksWithNoopRenderer --watch
```
Was being incorrect handled like so:
```
$ node ./scripts/jest/jest-cli.js ReactHooksWithNoopRenderer --watch
$ NODE_ENV=development RELEASE_CHANNEL=experimental node ./scripts/jest/jest.js --config ./scripts/jest/config.source.js ReactHooksWithNoopRenderer,--watch

Running tests for default (experimental)...
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /Users/bvaughn/Documents/git/react
  1116 files checked.
  roots: /Users/bvaughn/Documents/git/react/packages, /Users/bvaughn/Documents/git/react/scripts - 1116 matches
  testMatch:  - 0 matches
  testPathIgnorePatterns: /node_modules/ - 1116 matches
  testRegex: /__tests__/[^/]*(\.js|\.coffee|[^d]\.ts)$ - 260 matches
Pattern: ReactHooksWithNoopRenderer,--watch - 0 matches
```

This PR fixes that.