### PR TITLE
Fix state leaking when a function component throws on server render

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -889,20 +889,16 @@ describe('ReactDOMServerHooks', () => {
       return <div>{count}</div>;
     }
 
-    const container = document.createElement('div');
-
     // First, render a component that will throw an error during a re-render triggered
     // by a dispatch call.
-    try {
-      container.innerHTML = ReactDOMServer.renderToString(
-        <ThrowingComponent />,
-      );
-    } catch (e) {}
-    expect(container.children.length).toEqual(0);
+    expect(() => ReactDOMServer.renderToString(<ThrowingComponent />)).toThrow(
+      'Error from ThrowingComponent',
+    );
 
     // Next, assert that we can render a function component using hooks immediately
     // after an error occurred, which indictates the internal hooks state has been
     // reset.
+    const container = document.createElement('div');
     container.innerHTML = ReactDOMServer.renderToString(
       <NonThrowingComponent />,
     );

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -60,6 +60,7 @@ import escapeTextForBrowser from './escapeTextForBrowser';
 import {
   prepareToUseHooks,
   finishHooks,
+  resetHooksState,
   Dispatcher,
   currentPartialRenderer,
   setCurrentPartialRenderer,
@@ -955,6 +956,7 @@ class ReactDOMServerRenderer {
     } finally {
       ReactCurrentDispatcher.current = prevDispatcher;
       setCurrentPartialRenderer(prevPartialRenderer);
+      resetHooksState();
     }
   }
 

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -172,12 +172,12 @@ export function prepareToUseHooks(componentIdentity: Object): void {
     isInHookUserCodeInDev = false;
   }
 
-  // Reset the internal hooks state before rendering a component
-  didScheduleRenderPhaseUpdate = false;
-  firstWorkInProgressHook = null;
-  numberOfReRenders = 0;
-  renderPhaseUpdates = null;
-  workInProgressHook = null;
+  // The following should have already been reset
+  // didScheduleRenderPhaseUpdate = false;
+  // firstWorkInProgressHook = null;
+  // numberOfReRenders = 0;
+  // renderPhaseUpdates = null;
+  // workInProgressHook = null;
 }
 
 export function finishHooks(
@@ -202,12 +202,29 @@ export function finishHooks(
 
     children = Component(props, refOrContext);
   }
-
+  resetHooksState();
   if (__DEV__) {
     isInHookUserCodeInDev = false;
   }
 
+  // These were reset via the resetHooksState() call
+  // currentlyRenderingComponent = null;
+  // didScheduleRenderPhaseUpdate = false;
+  // firstWorkInProgressHook = null;
+  // numberOfReRenders = 0;
+  // renderPhaseUpdates = null;
+  // workInProgressHook = null;
+
   return children;
+}
+
+// Reset the internal hooks state if an error occurs while rendering a component
+export function resetHooksState(): void {
+  didScheduleRenderPhaseUpdate = false;
+  firstWorkInProgressHook = null;
+  numberOfReRenders = 0;
+  renderPhaseUpdates = null;
+  workInProgressHook = null;
 }
 
 function readContext<T>(

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -203,23 +203,15 @@ export function finishHooks(
     children = Component(props, refOrContext);
   }
   resetHooksState();
-  if (__DEV__) {
-    isInHookUserCodeInDev = false;
-  }
-
-  // These were reset via the resetHooksState() call
-  // currentlyRenderingComponent = null;
-  // didScheduleRenderPhaseUpdate = false;
-  // firstWorkInProgressHook = null;
-  // numberOfReRenders = 0;
-  // renderPhaseUpdates = null;
-  // workInProgressHook = null;
-
   return children;
 }
 
 // Reset the internal hooks state if an error occurs while rendering a component
 export function resetHooksState(): void {
+  if (__DEV__) {
+    isInHookUserCodeInDev = false;
+  }
+
   didScheduleRenderPhaseUpdate = false;
   firstWorkInProgressHook = null;
   numberOfReRenders = 0;

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -212,6 +212,7 @@ export function resetHooksState(): void {
     isInHookUserCodeInDev = false;
   }
 
+  currentlyRenderingComponent = null;
   didScheduleRenderPhaseUpdate = false;
   firstWorkInProgressHook = null;
   numberOfReRenders = 0;

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -172,12 +172,12 @@ export function prepareToUseHooks(componentIdentity: Object): void {
     isInHookUserCodeInDev = false;
   }
 
-  // The following should have already been reset
-  // didScheduleRenderPhaseUpdate = false;
-  // firstWorkInProgressHook = null;
-  // numberOfReRenders = 0;
-  // renderPhaseUpdates = null;
-  // workInProgressHook = null;
+  // Reset the internal hooks state before rendering a component
+  didScheduleRenderPhaseUpdate = false;
+  firstWorkInProgressHook = null;
+  numberOfReRenders = 0;
+  renderPhaseUpdates = null;
+  workInProgressHook = null;
 }
 
 export function finishHooks(
@@ -202,22 +202,10 @@ export function finishHooks(
 
     children = Component(props, refOrContext);
   }
-  currentlyRenderingComponent = null;
-  firstWorkInProgressHook = null;
-  numberOfReRenders = 0;
-  renderPhaseUpdates = null;
-  workInProgressHook = null;
+
   if (__DEV__) {
     isInHookUserCodeInDev = false;
   }
-
-  // These were reset above
-  // currentlyRenderingComponent = null;
-  // didScheduleRenderPhaseUpdate = false;
-  // firstWorkInProgressHook = null;
-  // numberOfReRenders = 0;
-  // renderPhaseUpdates = null;
-  // workInProgressHook = null;
 
   return children;
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
Reset the internal hooks state when preparing a component for hooks usage, rather than after a component finishes rendering.  This fixes https://github.com/facebook/react/issues/19211, where the internal hooks state is not cleared if a function component throws an error while rendering.  

## Test Plan
- ` yarn test-prod`: validated no test regressions were introduced
- Updated the repro case from https://github.com/pmaccart/react-hooks-ssr-state-leak to use the new build; validated that the example scenario successfully rendered after set
