### PR TITLE
refactor(shared/ReactTypes): remove unused getIteratorFn() function

### DIFF
--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -62,16 +62,3 @@ if (typeof Symbol === 'function' && Symbol.for) {
 
 const MAYBE_ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
-
-export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
-  if (maybeIterable === null || typeof maybeIterable !== 'object') {
-    return null;
-  }
-  const maybeIterator =
-    (MAYBE_ITERATOR_SYMBOL && maybeIterable[MAYBE_ITERATOR_SYMBOL]) ||
-    maybeIterable[FAUX_ITERATOR_SYMBOL];
-  if (typeof maybeIterator === 'function') {
-    return maybeIterator;
-  }
-  return null;
-}


### PR DESCRIPTION
## Summary

Just small housekeeping in ReactSymbols.js file. This commit removes an unused function
