### PR TITLE
Fix development mode hang when iframe is removed

### DIFF
--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -9,7 +9,7 @@
 
 import invariant from 'shared/invariant';
 
-let invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(
+function invokeGuardedCallbackProd<A, B, C, D, E, F, Context>(
   name: string | null,
   func: (a: A, b: B, c: C, d: D, e: E, f: F) => mixed,
   context: Context,
@@ -26,7 +26,9 @@ let invokeGuardedCallbackImpl = function<A, B, C, D, E, F, Context>(
   } catch (error) {
     this.onError(error);
   }
-};
+}
+
+let invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
 
 if (__DEV__) {
   // In DEV mode, we swap out invokeGuardedCallback for a special version
@@ -58,7 +60,15 @@ if (__DEV__) {
   ) {
     const fakeNode = document.createElement('react');
 
-    const invokeGuardedCallbackDev = function<A, B, C, D, E, F, Context>(
+    invokeGuardedCallbackImpl = function invokeGuardedCallbackDev<
+      A,
+      B,
+      C,
+      D,
+      E,
+      F,
+      Context,
+    >(
       name: string | null,
       func: (a: A, b: B, c: C, d: D, e: E, f: F) => mixed,
       context: Context,
@@ -85,6 +95,7 @@ if (__DEV__) {
       );
       const evt = document.createEvent('Event');
 
+      let didCall = false;
       // Keeps track of whether the user-provided callback threw an error. We
       // set this to true at the beginning, then set it to false right after
       // calling the function. If the function errors, `didError` will never be
@@ -110,6 +121,7 @@ if (__DEV__) {
       // call the user-provided callback.
       const funcArgs = Array.prototype.slice.call(arguments, 3);
       function callCallback() {
+        didCall = true;
         // We immediately remove the callback from event listeners so that
         // nested `invokeGuardedCallback` calls do not clash. Otherwise, a
         // nested call would trigger the fake event handlers of any call higher
@@ -208,9 +220,15 @@ if (__DEV__) {
 
       // Remove our event listeners
       window.removeEventListener('error', handleWindowError);
-    };
 
-    invokeGuardedCallbackImpl = invokeGuardedCallbackDev;
+      if (!didCall) {
+        // Something went really wrong, and our event was not dispatched.
+        // https://github.com/facebook/react/issues/16734
+        // https://github.com/facebook/react/issues/16585
+        // Fall back to the production implementation.
+        return invokeGuardedCallbackProd.apply(this, arguments);
+      }
+    };
   }
 }
 


### PR DESCRIPTION
Verified it fixes https://github.com/facebook/react/issues/16585.
Verified it fixes https://github.com/facebook/react/issues/16734.

Follows @sophiebits's suggestion in https://github.com/facebook/react/issues/16734#issuecomment-609923768.

This is a workaround for a [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=956832) that also exists in Safari and doesn't seem to be gaining momentum. The actual cases in which this happens may be niche but I have a hunch I've run into other manifestations of this issue so I think it's worth fixing.

The basic idea is that if our shim doesn't work, we fall back to prod behavior with a simple try/catch.