### PR TITLE
Modern Event System: make on*Capture events use capture phase

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -2714,28 +2714,23 @@ describe('ReactDOMComponent', () => {
 
       innerRef.current.click();
 
-      // The order we receive here is not ideal since it is expected that the
-      // capture listener fire before all bubble listeners. Other React apps
-      // might depend on this.
-      //
-      // @see https://github.com/facebook/react/pull/12919#issuecomment-395224674
       if (ReactFeatureFlags.enableLegacyFBSupport) {
         // The order will change here, as the legacy FB support adds
         // the event listener onto the document after the one above has.
         expect(eventOrder).toEqual([
           'document capture',
-          'document bubble',
-          'inner capture',
-          'inner bubble',
           'outer capture',
+          'inner capture',
+          'document bubble',
+          'inner bubble',
           'outer bubble',
         ]);
       } else {
         expect(eventOrder).toEqual([
           'document capture',
+          'outer capture',
           'inner capture',
           'inner bubble',
-          'outer capture',
           'outer bubble',
           'document bubble',
         ]);

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -13,6 +13,7 @@ import {
   registrationNameDependencies,
   possibleRegistrationNames,
 } from '../events/EventRegistry';
+
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import invariant from 'shared/invariant';
 import {

--- a/packages/react-dom/src/client/ReactDOMEventHandle.js
+++ b/packages/react-dom/src/client/ReactDOMEventHandle.js
@@ -26,7 +26,6 @@ import {ELEMENT_NODE} from '../shared/HTMLNodeType';
 import {
   listenToTopLevelEvent,
   addEventTypeToDispatchConfig,
-  capturePhaseEvents,
 } from '../events/DOMModernPluginEventSystem';
 
 import {HostRoot, HostPortal} from 'react-reconciler/src/ReactWorkTags';
@@ -87,6 +86,7 @@ function registerEventOnNearestTargetContainer(
   topLevelType: DOMTopLevelEventType,
   passive: boolean | void,
   priority: EventPriority | void,
+  capture: boolean,
 ): void {
   // If it is, find the nearest root or portal and make it
   // our event handle target container.
@@ -99,7 +99,6 @@ function registerEventOnNearestTargetContainer(
     );
   }
   const listenerMap = getEventListenerMap(targetContainer);
-  const capture = capturePhaseEvents.has(topLevelType);
   listenToTopLevelEvent(
     topLevelType,
     targetContainer,
@@ -135,6 +134,7 @@ function registerReactDOMEvent(
       topLevelType,
       passive,
       priority,
+      capture,
     );
   } else if (enableScopeAPI && isReactScope(target)) {
     const scopeTarget = ((target: any): ReactScopeInstance);
@@ -148,6 +148,7 @@ function registerReactDOMEvent(
       topLevelType,
       passive,
       priority,
+      capture,
     );
   } else if (isValidEventTarget(target)) {
     const eventTarget = ((target: any): EventTarget);

--- a/packages/react-dom/src/events/PluginModuleType.js
+++ b/packages/react-dom/src/events/PluginModuleType.js
@@ -26,8 +26,7 @@ export type DispatchQueueItemPhase = Array<DispatchQueueItemPhaseEntry>;
 
 export type DispatchQueueItem = {|
   event: ReactSyntheticEvent,
-  capture: DispatchQueueItemPhase,
-  bubble: DispatchQueueItemPhase,
+  phase: DispatchQueueItemPhase,
 |};
 
 export type DispatchQueue = Array<DispatchQueueItem>;

--- a/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMModernPluginEventSystem-test.internal.js
@@ -189,9 +189,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
-          expect(log[2]).toEqual(['capture', divElement]);
-          expect(log[3]).toEqual(['bubble', divElement]);
-          expect(log[4]).toEqual(['capture', buttonElement]);
+          expect(log[2]).toEqual(['capture', buttonElement]);
+          expect(log[3]).toEqual(['capture', divElement]);
+          expect(log[4]).toEqual(['bubble', divElement]);
           expect(log[5]).toEqual(['bubble', buttonElement]);
         });
 
@@ -241,9 +241,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
-          expect(log[2]).toEqual(['capture', divElement]);
-          expect(log[3]).toEqual(['bubble', divElement]);
-          expect(log[4]).toEqual(['capture', buttonElement]);
+          expect(log[2]).toEqual(['capture', buttonElement]);
+          expect(log[3]).toEqual(['capture', divElement]);
+          expect(log[4]).toEqual(['bubble', divElement]);
           expect(log[5]).toEqual(['bubble', buttonElement]);
         });
 
@@ -320,9 +320,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
-          expect(log[2]).toEqual(['capture', divElement]);
-          expect(log[3]).toEqual(['bubble', divElement]);
-          expect(log[4]).toEqual(['capture', buttonElement]);
+          expect(log[2]).toEqual(['capture', buttonElement]);
+          expect(log[3]).toEqual(['capture', divElement]);
+          expect(log[4]).toEqual(['bubble', divElement]);
           expect(log[5]).toEqual(['bubble', buttonElement]);
 
           // Inside <Parent />
@@ -330,9 +330,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(buttonElement2);
           expect(onClick).toHaveBeenCalledTimes(5);
           expect(onClickCapture).toHaveBeenCalledTimes(5);
-          expect(log[6]).toEqual(['capture', buttonElement2]);
-          expect(log[7]).toEqual(['bubble', buttonElement2]);
-          expect(log[8]).toEqual(['capture', buttonElement]);
+          expect(log[6]).toEqual(['capture', buttonElement]);
+          expect(log[7]).toEqual(['capture', buttonElement2]);
+          expect(log[8]).toEqual(['bubble', buttonElement2]);
           expect(log[9]).toEqual(['bubble', buttonElement]);
         });
 
@@ -385,9 +385,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
-          expect(log[2]).toEqual(['capture', divElement]);
-          expect(log[3]).toEqual(['bubble', divElement]);
-          expect(log[4]).toEqual(['capture', buttonElement]);
+          expect(log[2]).toEqual(['capture', buttonElement]);
+          expect(log[3]).toEqual(['capture', divElement]);
+          expect(log[4]).toEqual(['bubble', divElement]);
           expect(log[5]).toEqual(['bubble', buttonElement]);
         });
 
@@ -442,9 +442,9 @@ describe('DOMModernPluginEventSystem', () => {
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(3);
           expect(onClickCapture).toHaveBeenCalledTimes(3);
-          expect(log[2]).toEqual(['capture', divElement]);
-          expect(log[3]).toEqual(['bubble', divElement]);
-          expect(log[4]).toEqual(['capture', buttonElement]);
+          expect(log[2]).toEqual(['capture', buttonElement]);
+          expect(log[3]).toEqual(['capture', divElement]);
+          expect(log[4]).toEqual(['bubble', divElement]);
           expect(log[5]).toEqual(['bubble', buttonElement]);
         });
 
@@ -757,7 +757,7 @@ describe('DOMModernPluginEventSystem', () => {
           const divElement = divRef.current;
           dispatchClickEvent(divElement);
           expect(onClick).toHaveBeenCalledTimes(1);
-          expect(onClickCapture).toHaveBeenCalledTimes(1);
+          expect(onClickCapture).toHaveBeenCalledTimes(3);
 
           document.body.removeChild(portalElement);
         });
@@ -1179,7 +1179,7 @@ describe('DOMModernPluginEventSystem', () => {
           if (enableLegacyFBSupport) {
             // We aren't using roots with legacyFBSupport, we put clicks on the document, so we exbit the previous
             // behavior.
-            expect(log).toEqual([]);
+            expect(log).toEqual(['capture root', 'capture portal']);
           } else {
             expect(log).toEqual([
               // The events on root probably shouldn't fire if a non-React intermediated. but current behavior is that they do.
@@ -2288,8 +2288,8 @@ describe('DOMModernPluginEventSystem', () => {
             if (enableLegacyFBSupport) {
               expect(log[0]).toEqual(['capture', window]);
               expect(log[1]).toEqual(['capture', document]);
-              expect(log[2]).toEqual(['bubble', document]);
-              expect(log[3]).toEqual(['capture', buttonElement]);
+              expect(log[2]).toEqual(['capture', buttonElement]);
+              expect(log[3]).toEqual(['bubble', document]);
               expect(log[4]).toEqual(['bubble', buttonElement]);
               expect(log[5]).toEqual(['bubble', window]);
             } else {
@@ -2313,9 +2313,9 @@ describe('DOMModernPluginEventSystem', () => {
             if (enableLegacyFBSupport) {
               expect(log[0]).toEqual(['capture', window]);
               expect(log[1]).toEqual(['capture', document]);
-              expect(log[2]).toEqual(['bubble', document]);
-              expect(log[3]).toEqual(['capture', buttonElement]);
-              expect(log[4]).toEqual(['capture', divElement]);
+              expect(log[2]).toEqual(['capture', buttonElement]);
+              expect(log[3]).toEqual(['capture', divElement]);
+              expect(log[4]).toEqual(['bubble', document]);
               expect(log[5]).toEqual(['bubble', divElement]);
               expect(log[6]).toEqual(['bubble', buttonElement]);
               expect(log[7]).toEqual(['bubble', window]);

--- a/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
@@ -36,7 +36,7 @@ import {enqueueStateRestore} from '../ReactDOMControlledComponent';
 import {disableInputAttributeSyncing} from 'shared/ReactFeatureFlags';
 import {batchedUpdates} from '../ReactDOMUpdateBatching';
 import {
-  dispatchEventsInBatch,
+  processDispatchQueue,
   accumulateTwoPhaseListeners,
 } from '../DOMModernPluginEventSystem';
 
@@ -106,7 +106,7 @@ function manualDispatchChangeEvent(nativeEvent) {
 }
 
 function runEventInBatch(dispatchQueue) {
-  dispatchEventsInBatch(dispatchQueue);
+  processDispatchQueue(dispatchQueue, 0);
 }
 
 function getInstIfValueChanged(targetInst: Object) {

--- a/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
@@ -19,7 +19,7 @@ import {
   getClosestInstanceFromNode,
   getNodeFromInstance,
 } from '../../client/ReactDOMComponentTree';
-import {accumulateEnterLeaveListeners} from '../DOMModernPluginEventSystem';
+import {accumulateEnterLeaveTwoPhaseListeners} from '../DOMModernPluginEventSystem';
 
 import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {getNearestMountedFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
@@ -159,7 +159,7 @@ function extractEvents(
     enter = null;
   }
 
-  accumulateEnterLeaveListeners(dispatchQueue, leave, enter, from, to);
+  accumulateEnterLeaveTwoPhaseListeners(dispatchQueue, leave, enter, from, to);
 }
 
 export {registerEvents, extractEvents};

--- a/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
@@ -23,7 +23,7 @@ import {
   registerSimpleEvents,
 } from '../DOMEventProperties';
 import {
-  accumulateTwoPhaseListeners,
+  accumulateSinglePhaseListeners,
   accumulateEventHandleTargetListeners,
 } from '../DOMModernPluginEventSystem';
 import {IS_TARGET_PHASE_ONLY} from '../EventSystemFlags';
@@ -152,13 +152,13 @@ function extractEvents(
     nativeEventTarget,
   );
 
+  const inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
   if (
     enableCreateEventHandleAPI &&
     eventSystemFlags !== undefined &&
     eventSystemFlags & IS_TARGET_PHASE_ONLY &&
     targetContainer != null
   ) {
-    const inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
     accumulateEventHandleTargetListeners(
       dispatchQueue,
       event,
@@ -166,7 +166,13 @@ function extractEvents(
       inCapturePhase,
     );
   } else {
-    accumulateTwoPhaseListeners(targetInst, dispatchQueue, event, true);
+    // We traverse only capture or bubble phase listeners
+    accumulateSinglePhaseListeners(
+      targetInst,
+      dispatchQueue,
+      event,
+      inCapturePhase,
+    );
   }
   return event;
 }

--- a/packages/react-dom/src/events/plugins/__tests__/ModernChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernChangeEventPlugin-test.js
@@ -98,6 +98,30 @@ describe('ChangeEventPlugin', () => {
     }
   });
 
+  it('should consider initial text value to be current (capture)', () => {
+    let called = 0;
+
+    function cb(e) {
+      called++;
+      expect(e.type).toBe('change');
+    }
+
+    const node = ReactDOM.render(
+      <input type="text" onChangeCapture={cb} defaultValue="foo" />,
+      container,
+    );
+    node.dispatchEvent(new Event('input', {bubbles: true, cancelable: true}));
+    node.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+
+    if (ReactFeatureFlags.disableInputAttributeSyncing) {
+      // TODO: figure out why. This might be a bug.
+      expect(called).toBe(1);
+    } else {
+      // There should be no React change events because the value stayed the same.
+      expect(called).toBe(0);
+    }
+  });
+
   it('should consider initial checkbox checked=true to be current', () => {
     let called = 0;
 

--- a/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ModernSelectEventPlugin-test.js
@@ -108,6 +108,40 @@ describe('SelectEventPlugin', () => {
     expect(select).toHaveBeenCalledTimes(1);
   });
 
+  it('should fire `onSelectCapture` when a listener is present', () => {
+    const select = jest.fn();
+    const onSelectCapture = event => {
+      expect(typeof event).toBe('object');
+      expect(event.type).toBe('select');
+      expect(event.target).toBe(node);
+      select(event.currentTarget);
+    };
+
+    const node = ReactDOM.render(
+      <input type="text" onSelectCapture={onSelectCapture} />,
+      container,
+    );
+    node.focus();
+
+    let nativeEvent = new MouseEvent('focus', {
+      bubbles: true,
+      cancelable: true,
+    });
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(0);
+
+    nativeEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(0);
+
+    nativeEvent = new MouseEvent('mouseup', {bubbles: true, cancelable: true});
+    node.dispatchEvent(nativeEvent);
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
   // Regression test for https://github.com/facebook/react/issues/11379
   it('should not wait for `mouseup` after receiving `dragend`', () => {
     const select = jest.fn();

--- a/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
+++ b/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
@@ -45,8 +45,7 @@ export type DispatchQueueItemPhase = Array<DispatchQueueItemPhaseEntry>;
 
 export type DispatchQueueItem = {|
   event: ReactSyntheticEvent,
-  capture: DispatchQueueItemPhase,
-  bubble: DispatchQueueItemPhase,
+  phase: DispatchQueueItemPhase,
 |};
 
 export type DispatchQueue = Array<DispatchQueueItem>;


### PR DESCRIPTION
Note: this PR is rebased on https://github.com/facebook/react/pull/19244.

This PR alters the modern event system so that events that are of the format `on*Capture` (capture events) are actually put into the browser's native capture event phase when React creates the event listener. This is a deparature of the previous logic, which "virtualized" the capture and bubble phases within the native bubble event listener.

This is an important change to the modern event system, as the modern event system delegates to React roots (or portals) rather than the `document`. This means events that are setup to be capture listener, i.e. `onClickCapture` now correctly behave has expected. This also fixes some long-standing issues with how React and the browser differ in regards to how events are handled in co-ordination with native event listeners.

Lastly, we still (for now) enforce `blur` and `focus` to be capture phase listeners (so they emulate two phase propagation in the native capture phase, as we did before). We also emulate two phase propagation in the native bubble phase, as we did before, for the `ChangeEventPlugin`, `BeforeInputEventPlugin` and `SelectEventPlugin` event plugins.