### PR TITLE
Fix responder logic in ReactDOMServerSelectiveHydration-test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -349,7 +349,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
   // @gate experimental
   it('hydrates the target boundary synchronously during a click (flare)', async () => {
-    const usePress = require('react-interactions/events/press').usePress;
+    const usePress = require('react-interactions/events/press-legacy').usePress;
 
     function Child({text}) {
       Scheduler.unstable_yieldValue(text);
@@ -415,7 +415,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
   // @gate experimental
   it('hydrates at higher pri if sync did not work first time (flare)', async () => {
-    const usePress = require('react-interactions/events/press').usePress;
+    const usePress = require('react-interactions/events/press-legacy').usePress;
     let suspend = false;
     let resolve;
     const promise = new Promise(resolvePromise => (resolve = resolvePromise));
@@ -476,12 +476,10 @@ describe('ReactDOMServerSelectiveHydration', () => {
     // Nothing has been hydrated so far.
     expect(Scheduler).toHaveYielded([]);
 
-    // This click target cannot be hydrated yet because it's suspended.
-    const result = dispatchClickEvent(spanD);
+    const target = createEventTarget(spanD);
+    target.virtualclick();
 
     expect(Scheduler).toHaveYielded(['App']);
-
-    expect(result).toBe(true);
 
     // Continuing rendering will render B next.
     expect(Scheduler).toFlushAndYield(['B', 'C']);
@@ -499,7 +497,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
 
   // @gate experimental
   it('hydrates at higher pri for secondary discrete events (flare)', async () => {
-    const usePress = require('react-interactions/events/press').usePress;
+    const usePress = require('react-interactions/events/press-legacy').usePress;
     let suspend = false;
     let resolve;
     const promise = new Promise(resolvePromise => (resolve = resolvePromise));
@@ -563,9 +561,9 @@ describe('ReactDOMServerSelectiveHydration', () => {
     expect(Scheduler).toHaveYielded([]);
 
     // This click target cannot be hydrated yet because the first is Suspended.
-    dispatchClickEvent(spanA);
-    dispatchClickEvent(spanC);
-    dispatchClickEvent(spanD);
+    createEventTarget(spanA).virtualclick();
+    createEventTarget(spanC).virtualclick();
+    createEventTarget(spanD).virtualclick();
 
     expect(Scheduler).toHaveYielded(['App']);
 


### PR DESCRIPTION
This should fix master (I broke it with https://github.com/facebook/react/pull/19222). I had to change the logic of the tests to work the same as the old Press responder, which relied on `click`. Given the LegacyPress responder doesn't do this, we can instead just use the virtualclick, like done in the previous test.