### PR TITLE
Remove TestUtils dependency on event registry

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -38,7 +38,6 @@ import {
 } from 'react-reconciler/src/ReactFiberReconciler';
 import {createPortal as createPortalImpl} from 'react-reconciler/src/ReactPortal';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import {eventNameDispatchConfigs} from '../events/EventPluginRegistry';
 import ReactVersion from 'shared/ReactVersion';
 import invariant from 'shared/invariant';
 import {
@@ -175,7 +174,6 @@ const Internals = {
     getInstanceFromNode,
     getNodeFromInstance,
     getFiberCurrentPropsFromNode,
-    eventNameDispatchConfigs,
     enqueueStateRestore,
     restoreStateIfNeeded,
     flushPassiveEffects,

--- a/packages/react-dom/src/events/EventPluginRegistry.js
+++ b/packages/react-dom/src/events/EventPluginRegistry.js
@@ -13,11 +13,6 @@ import type {EventTypes} from './PluginModuleType';
 import invariant from 'shared/invariant';
 
 /**
- * Mapping from event name to dispatch config
- */
-export const eventNameDispatchConfigs = {};
-
-/**
  * Mapping from registration name to plugin module
  */
 export const registrationNames = {};
@@ -40,15 +35,7 @@ function publishEventForPlugin(
   eventTypes: EventTypes,
   eventName: string,
 ): boolean {
-  invariant(
-    !eventNameDispatchConfigs.hasOwnProperty(eventName),
-    'EventPluginRegistry: More than one plugin attempted to publish the same ' +
-      'event name, `%s`.',
-    eventName,
-  );
   const dispatchConfig = eventTypes[eventName];
-  eventNameDispatchConfigs[eventName] = dispatchConfig;
-
   const phasedRegistrationNames = dispatchConfig.phasedRegistrationNames;
   if (phasedRegistrationNames) {
     for (const phaseName in phasedRegistrationNames) {

--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -20,7 +20,6 @@ const [
   getInstanceFromNode,
   getNodeFromInstance,
   getFiberCurrentPropsFromNode,
-  eventNameDispatchConfigs,
   enqueueStateRestore,
   restoreStateIfNeeded,
   /* eslint-enable no-unused-vars */


### PR DESCRIPTION
This removes the last TestUtils link to the event system internals.

The dispatch config map was used to populate the Simulate helpers. I just took a snapshot of the list we have today, and inlined it in TestUtils. We also used the config to tell whether an event is two-phased or not. However there are only four events that don't have a capture phase so I have explicitly listed them instead.

In the future we should be able to remove more of these intermediate objects in the event system itself.