### PR TITLE
Make event config an implementation detail of each plugin

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -8,7 +8,7 @@
  */
 
 import {
-  registrationNames,
+  registrationNameDependencies,
   possibleRegistrationNames,
 } from '../events/EventPluginRegistry';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
@@ -133,7 +133,7 @@ if (__DEV__) {
     validateARIAProperties(type, props);
     validateInputProperties(type, props);
     validateUnknownProperties(type, props, {
-      registrationNames,
+      registrationNameDependencies,
       possibleRegistrationNames,
     });
   };
@@ -356,7 +356,7 @@ function setInitialDOMProperties(
       // We could have excluded it in the property list instead of
       // adding a special case here, but then it wouldn't be emitted
       // on server rendering (but we *do* want to emit it in SSR).
-    } else if (registrationNames.hasOwnProperty(propKey)) {
+    } else if (registrationNameDependencies.hasOwnProperty(propKey)) {
       if (nextProp != null) {
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);
@@ -694,7 +694,7 @@ export function diffProperties(
       // Noop
     } else if (propKey === AUTOFOCUS) {
       // Noop. It doesn't work on updates anyway.
-    } else if (registrationNames.hasOwnProperty(propKey)) {
+    } else if (registrationNameDependencies.hasOwnProperty(propKey)) {
       // This is a special case. If any listener updates we need to ensure
       // that the "current" fiber pointer gets updated so we need a commit
       // to update this element.
@@ -781,7 +781,7 @@ export function diffProperties(
       propKey === SUPPRESS_HYDRATION_WARNING
     ) {
       // Noop
-    } else if (registrationNames.hasOwnProperty(propKey)) {
+    } else if (registrationNameDependencies.hasOwnProperty(propKey)) {
       if (nextProp != null) {
         // We eagerly listen to this even though we haven't committed yet.
         if (__DEV__ && typeof nextProp !== 'function') {
@@ -978,7 +978,7 @@ export function diffHydratedProperties(
           updatePayload = [CHILDREN, '' + nextProp];
         }
       }
-    } else if (registrationNames.hasOwnProperty(propKey)) {
+    } else if (registrationNameDependencies.hasOwnProperty(propKey)) {
       if (nextProp != null) {
         if (__DEV__ && typeof nextProp !== 'function') {
           warnForInvalidEventListener(propKey, nextProp);

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -13,10 +13,6 @@ import type {
   DOMTopLevelEventType,
 } from '../events/TopLevelEventTypes';
 import type {EventTypes} from '../events/PluginModuleType';
-import type {
-  DispatchConfig,
-  CustomDispatchConfig,
-} from '../events/ReactSyntheticEventType';
 
 import * as DOMTopLevelEventTypes from './DOMTopLevelEventTypes';
 import {
@@ -35,9 +31,9 @@ import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 // update the below line.
 export const simpleEventPluginEventTypes: EventTypes = {};
 
-export const topLevelEventsToDispatchConfig: Map<
+export const topLevelEventsToReactNames: Map<
   TopLevelType,
-  DispatchConfig | CustomDispatchConfig,
+  string | null,
 > = new Map();
 
 const eventPriorities = new Map();
@@ -167,8 +163,8 @@ const continuousPairsForSimpleEventPlugin = [
  *   },
  *   ...
  * };
- * topLevelEventsToDispatchConfig = new Map([
- *   [TOP_ABORT, { sameConfig }],
+ * topLevelEventsToReactNames = new Map([
+ *   [TOP_ABORT, 'onAbort'],
  * ]);
  */
 
@@ -197,7 +193,7 @@ function processSimpleEventPluginPairsByPriority(
       eventPriority: priority,
     };
     eventPriorities.set(topEvent, priority);
-    topLevelEventsToDispatchConfig.set(topEvent, config);
+    topLevelEventsToReactNames.set(topEvent, onEvent);
     simpleEventPluginEventTypes[event] = config;
   }
 }

--- a/packages/react-dom/src/events/EventPluginRegistry.js
+++ b/packages/react-dom/src/events/EventPluginRegistry.js
@@ -10,13 +10,6 @@
 import type {TopLevelType} from './TopLevelEventTypes';
 import type {EventTypes} from './PluginModuleType';
 
-import invariant from 'shared/invariant';
-
-/**
- * Mapping from registration name to plugin module
- */
-export const registrationNames = {};
-
 /**
  * Mapping from registration name to event name
  */
@@ -62,13 +55,16 @@ function publishRegistrationName(
   registrationName: string,
   dependencies: ?Array<TopLevelType>,
 ): void {
-  invariant(
-    !registrationNames[registrationName],
-    'EventPluginRegistry: More than one plugin attempted to publish the same ' +
-      'registration name, `%s`.',
-    registrationName,
-  );
-  registrationNames[registrationName] = true;
+  if (__DEV__) {
+    if (registrationNameDependencies[registrationName]) {
+      console.error(
+        'EventPluginRegistry: More than one plugin attempted to publish the same ' +
+          'registration name, `%s`.',
+        registrationName,
+      );
+    }
+  }
+
   registrationNameDependencies[registrationName] = dependencies;
 
   if (__DEV__) {

--- a/packages/react-dom/src/events/ReactSyntheticEventType.js
+++ b/packages/react-dom/src/events/ReactSyntheticEventType.js
@@ -22,21 +22,12 @@ export type DispatchConfig = {|
   eventPriority?: EventPriority,
 |};
 
-export type CustomDispatchConfig = {|
-  phasedRegistrationNames: {|
-    bubbled: null,
-    captured: null,
-  |},
-  registrationName?: string,
-  customEvent: true,
-|};
-
 export type ReactSyntheticEvent = {|
-  dispatchConfig: DispatchConfig | CustomDispatchConfig,
   isPersistent: () => boolean,
   isPropagationStopped: () => boolean,
   _dispatchInstances?: null | Array<Fiber | null> | Fiber,
   _dispatchListeners?: null | Array<Function> | Function,
+  _reactName: string,
   _targetInst: Fiber,
   type: string,
   currentTarget: null | EventTarget,

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -48,19 +48,9 @@ function functionThatReturnsFalse() {
  * Synthetic events (and subclasses) implement the DOM Level 3 Events API by
  * normalizing browser quirks. Subclasses do not necessarily have to implement a
  * DOM interface; custom application-specific events can also subclass this.
- *
- * @param {object} dispatchConfig Configuration used to dispatch this event.
- * @param {*} targetInst Marker identifying the event target.
- * @param {object} nativeEvent Native browser event.
- * @param {DOMEventTarget} nativeEventTarget Target node.
  */
-function SyntheticEvent(
-  dispatchConfig,
-  targetInst,
-  nativeEvent,
-  nativeEventTarget,
-) {
-  this.dispatchConfig = dispatchConfig;
+function SyntheticEvent(reactName, targetInst, nativeEvent, nativeEventTarget) {
+  this._reactName = reactName;
   this._targetInst = targetInst;
   this.nativeEvent = nativeEvent;
 

--- a/packages/react-dom/src/events/plugins/ModernBeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernBeforeInputEventPlugin.js
@@ -140,11 +140,11 @@ function isKeypressCommand(nativeEvent) {
 function getCompositionEventType(topLevelType) {
   switch (topLevelType) {
     case TOP_COMPOSITION_START:
-      return eventTypes.compositionStart;
+      return 'onCompositionStart';
     case TOP_COMPOSITION_END:
-      return eventTypes.compositionEnd;
+      return 'onCompositionEnd';
     case TOP_COMPOSITION_UPDATE:
-      return eventTypes.compositionUpdate;
+      return 'onCompositionUpdate';
   }
 }
 
@@ -237,10 +237,10 @@ function extractCompositionEvent(
     eventType = getCompositionEventType(topLevelType);
   } else if (!isComposing) {
     if (isFallbackCompositionStart(topLevelType, nativeEvent)) {
-      eventType = eventTypes.compositionStart;
+      eventType = 'onCompositionStart';
     }
   } else if (isFallbackCompositionEnd(topLevelType, nativeEvent)) {
-    eventType = eventTypes.compositionEnd;
+    eventType = 'onCompositionEnd';
   }
 
   if (!eventType) {
@@ -250,9 +250,9 @@ function extractCompositionEvent(
   if (useFallbackCompositionData && !isUsingKoreanIME(nativeEvent)) {
     // The current composition is stored statically and must not be
     // overwritten while composition continues.
-    if (!isComposing && eventType === eventTypes.compositionStart) {
+    if (!isComposing && eventType === 'onCompositionStart') {
       isComposing = FallbackCompositionStateInitialize(nativeEventTarget);
-    } else if (eventType === eventTypes.compositionEnd) {
+    } else if (eventType === 'onCompositionEnd') {
       if (isComposing) {
         fallbackData = FallbackCompositionStateGetData();
       }
@@ -430,7 +430,7 @@ function extractBeforeInputEvent(
   }
 
   const event = new SyntheticInputEvent(
-    eventTypes.beforeInput,
+    'onBeforeInput',
     null,
     nativeEvent,
     nativeEventTarget,

--- a/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
@@ -64,12 +64,7 @@ function createAndAccumulateChangeEvent(
   nativeEvent,
   target,
 ) {
-  const event = new SyntheticEvent(
-    eventTypes.change,
-    null,
-    nativeEvent,
-    target,
-  );
+  const event = new SyntheticEvent('onChange', null, nativeEvent, target);
   event.type = 'change';
   // Flag this event loop as needing state restore.
   enqueueStateRestore(((target: any): Node));

--- a/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernEnterLeaveEventPlugin.js
@@ -126,16 +126,16 @@ function extractEvents(
 
   if (topLevelType === TOP_MOUSE_OUT || topLevelType === TOP_MOUSE_OVER) {
     eventInterface = SyntheticMouseEvent;
-    leaveEventType = eventTypes.mouseLeave;
-    enterEventType = eventTypes.mouseEnter;
+    leaveEventType = 'onMouseLeave';
+    enterEventType = 'onMouseEnter';
     eventTypePrefix = 'mouse';
   } else if (
     topLevelType === TOP_POINTER_OUT ||
     topLevelType === TOP_POINTER_OVER
   ) {
     eventInterface = SyntheticPointerEvent;
-    leaveEventType = eventTypes.pointerLeave;
-    enterEventType = eventTypes.pointerEnter;
+    leaveEventType = 'onPointerLeave';
+    enterEventType = 'onPointerEnter';
     eventTypePrefix = 'pointer';
   }
 

--- a/packages/react-dom/src/events/plugins/ModernSelectEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernSelectEventPlugin.js
@@ -133,7 +133,7 @@ function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
     lastSelection = currentSelection;
 
     const syntheticEvent = new SyntheticEvent(
-      eventTypes.select,
+      'onSelect',
       null,
       nativeEvent,
       nativeEventTarget,

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -43,8 +43,11 @@ if (__DEV__) {
 
     // We can't rely on the event system being injected on the server.
     if (eventRegistry != null) {
-      const {registrationNames, possibleRegistrationNames} = eventRegistry;
-      if (registrationNames.hasOwnProperty(name)) {
+      const {
+        registrationNameDependencies,
+        possibleRegistrationNames,
+      } = eventRegistry;
+      if (registrationNameDependencies.hasOwnProperty(name)) {
         return true;
       }
       const registrationName = possibleRegistrationNames.hasOwnProperty(


### PR DESCRIPTION
Each synthetic event used to have a `dispatchConfig` that contains the React names for this event. This makes the notion of event configs difficult to remove.

However, on the web there are always just two cases. Either our `dispatchConfig.registrationName` is the React event name. Or we have bubble event with that name and capture event with `Capture` prefix.

Taking advantage of this, I replaced `event.dispatchConfig` with `event._reactName` which is just a string. This will unlock removing the config metaprogramming because nothing else depends on the config format except the initial plugin registration.

Most of the work is in the second commit. The first commit just merges two variables that have the same purpose.