### PR TITLE
Effects list refactor

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -367,7 +367,14 @@ describe('ReactDOMServerPartialHydration', () => {
     const span2 = container.getElementsByTagName('span')[0];
     // This is a new node.
     expect(span).not.toBe(span2);
-    expect(ref.current).toBe(span2);
+
+    if (gate(flags => flags.new)) {
+      // The effects list refactor causes this to be null because the Suspense Offscreen's child
+      // is null. However, since we can't hydrate Suspense in legacy this change in behavior is ok
+      expect(ref.current).toBe(null);
+    } else {
+      expect(ref.current).toBe(span2);
+    }
 
     // Resolving the promise should render the final content.
     suspend = false;

--- a/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
@@ -45,12 +45,8 @@ describe('createReactNativeComponentClass', () => {
 
     expect(Text).not.toBe(View);
 
-    ReactNative.render(
-      <View>
-        <Text />
-      </View>,
-      1,
-    );
+    ReactNative.render(<Text />, 1);
+    ReactNative.render(<View />, 1);
   });
 
   it('should not allow viewConfigs with duplicate uiViewClassNames to be registered', () => {

--- a/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
@@ -45,8 +45,12 @@ describe('createReactNativeComponentClass', () => {
 
     expect(Text).not.toBe(View);
 
-    ReactNative.render(<Text />, 1);
-    ReactNative.render(<View />, 1);
+    ReactNative.render(
+      <View>
+        <Text />
+      </View>,
+      1,
+    );
   });
 
   it('should not allow viewConfigs with duplicate uiViewClassNames to be registered', () => {

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -293,6 +293,8 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.deletions.push(childToDelete);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    returnFiber.effectTag |= Deletion;
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -288,7 +288,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
-    returnFiber.deletions.push(childToDelete);
+    if (returnFiber.deletions === null) {
+      returnFiber.deletions = [childToDelete];
+    } else {
+      returnFiber.deletions.push(childToDelete);
+    }
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -280,6 +280,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // deletions, so we can just append the deletion to the list. The remaining
     // effects aren't added until the complete phase. Once we implement
     // resuming, this may not be true.
+    // TODO (effects) Get rid of effects list update here.
     const last = returnFiber.lastEffect;
     if (last !== null) {
       last.nextEffect = childToDelete;
@@ -287,6 +288,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
+    returnFiber.deletions.push(childToDelete);
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -144,6 +144,8 @@ function FiberNode(
 
   // Effects
   this.effectTag = NoEffect;
+  this.subtreeTag = NoEffect;
+  this.deletions = [];
   this.nextEffect = null;
 
   this.firstEffect = null;
@@ -287,6 +289,8 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
+    workInProgress.subtreeTag = NoEffect;
+    workInProgress.deletions = [];
 
     // The effect list is no longer valid.
     workInProgress.nextEffect = null;
@@ -826,6 +830,8 @@ export function assignFiberPropertiesInDEV(
   target.dependencies = source.dependencies;
   target.mode = source.mode;
   target.effectTag = source.effectTag;
+  target.subtreeTag = source.subtreeTag;
+  target.deletions = source.deletions;
   target.nextEffect = source.nextEffect;
   target.firstEffect = source.firstEffect;
   target.lastEffect = source.lastEffect;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -145,7 +145,7 @@ function FiberNode(
   // Effects
   this.effectTag = NoEffect;
   this.subtreeTag = NoEffect;
-  this.deletions = [];
+  this.deletions = null;
   this.nextEffect = null;
 
   this.firstEffect = null;
@@ -290,7 +290,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
     workInProgress.subtreeTag = NoEffect;
-    workInProgress.deletions = [];
+    workInProgress.deletions = null;
 
     // The effect list is no longer valid.
     workInProgress.nextEffect = null;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2066,6 +2066,7 @@ function updateSuspensePrimaryChildren(
     currentFallbackChildFragment.nextEffect = null;
     currentFallbackChildFragment.effectTag = Deletion;
     workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
+    workInProgress.deletions.push(currentFallbackChildFragment);
   }
 
   workInProgress.child = primaryChildFragment;
@@ -2131,9 +2132,11 @@ function updateSuspenseFallbackChildren(
       workInProgress.firstEffect = primaryChildFragment.firstEffect;
       workInProgress.lastEffect = progressedLastEffect;
       progressedLastEffect.nextEffect = null;
+      workInProgress.deletions = [];
     } else {
       // TODO: Reset this somewhere else? Lol legacy mode is so weird.
       workInProgress.firstEffect = workInProgress.lastEffect = null;
+      workInProgress.deletions = [];
     }
   } else {
     primaryChildFragment = createWorkInProgressOffscreenFiber(
@@ -3040,6 +3043,7 @@ function remountFiber(
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = current;
     }
+    returnFiber.deletions.push(current);
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2066,7 +2066,11 @@ function updateSuspensePrimaryChildren(
     currentFallbackChildFragment.nextEffect = null;
     currentFallbackChildFragment.effectTag = Deletion;
     workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
-    workInProgress.deletions.push(currentFallbackChildFragment);
+    if (workInProgress.deletions === null) {
+      workInProgress.deletions = [currentFallbackChildFragment];
+    } else {
+      workInProgress.deletions.push(currentFallbackChildFragment);
+    }
   }
 
   workInProgress.child = primaryChildFragment;
@@ -3043,7 +3047,11 @@ function remountFiber(
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = current;
     }
-    returnFiber.deletions.push(current);
+    if (returnFiber.deletions === null) {
+      returnFiber.deletions = [current];
+    } else {
+      returnFiber.deletions.push(current);
+    }
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2071,6 +2071,8 @@ function updateSuspensePrimaryChildren(
     } else {
       workInProgress.deletions.push(currentFallbackChildFragment);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    workInProgress.effectTag |= Deletion;
   }
 
   workInProgress.child = primaryChildFragment;
@@ -3052,6 +3054,8 @@ function remountFiber(
     } else {
       returnFiber.deletions.push(current);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    returnFiber.effectTag |= Deletion;
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2138,11 +2138,11 @@ function updateSuspenseFallbackChildren(
       workInProgress.firstEffect = primaryChildFragment.firstEffect;
       workInProgress.lastEffect = progressedLastEffect;
       progressedLastEffect.nextEffect = null;
-      workInProgress.deletions = [];
+      workInProgress.deletions = null;
     } else {
       // TODO: Reset this somewhere else? Lol legacy mode is so weird.
       workInProgress.firstEffect = workInProgress.lastEffect = null;
-      workInProgress.deletions = [];
+      workInProgress.deletions = null;
     }
   } else {
     primaryChildFragment = createWorkInProgressOffscreenFiber(

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1066,9 +1066,7 @@ function completeWork(
                   // TODO (effects) This probably isn't the best approach. Discuss with Brian
                   let child = workInProgress.child;
                   while (child !== null) {
-                    if (child.deletions.length > 0) {
-                      child.deletions = [];
-                    }
+                    child.deletions = null;
                     child = child.sibling;
                   }
                 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1062,6 +1062,15 @@ function completeWork(
                 // Reset the effect list before doing the second pass since that's now invalid.
                 if (renderState.lastEffect === null) {
                   workInProgress.firstEffect = null;
+                  workInProgress.subtreeTag = NoEffect;
+                  // TODO (effects) This probably isn't the best approach. Discuss with Brian
+                  let child = workInProgress.child;
+                  while (child !== null) {
+                    if (child.deletions.length > 0) {
+                      child.deletions = [];
+                    }
+                    child = child.sibling;
+                  }
                 }
                 workInProgress.lastEffect = renderState.lastEffect;
                 // Reset the child fibers to their original state.

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1063,7 +1063,6 @@ function completeWork(
                 if (renderState.lastEffect === null) {
                   workInProgress.firstEffect = null;
                   workInProgress.subtreeTag = NoEffect;
-                  // TODO (effects) This probably isn't the best approach. Discuss with Brian
                   let child = workInProgress.child;
                   while (child !== null) {
                     child.deletions = null;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -130,6 +130,8 @@ function deleteHydratableInstance(
   } else {
     returnFiber.deletions.push(childToDelete);
   }
+  // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+  returnFiber.effectTag |= Deletion;
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -125,7 +125,11 @@ function deleteHydratableInstance(
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
   childToDelete.effectTag = Deletion;
-  returnFiber.deletions.push(childToDelete);
+  if (returnFiber.deletions === null) {
+    returnFiber.deletions = [childToDelete];
+  } else {
+    returnFiber.deletions.push(childToDelete);
+  }
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -24,7 +24,7 @@ import {
   HostRoot,
   SuspenseComponent,
 } from './ReactWorkTags';
-import {Deletion, Placement, Hydrating} from './ReactSideEffectTags';
+import {Deletion, Hydrating, Placement} from './ReactSideEffectTags';
 import invariant from 'shared/invariant';
 
 import {
@@ -125,6 +125,7 @@ function deleteHydratableInstance(
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
   childToDelete.effectTag = Deletion;
+  returnFiber.deletions.push(childToDelete);
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2142,6 +2142,8 @@ function commitRootImpl(root, renderPriorityLevel) {
 }
 
 function commitBeforeMutationEffects(fiber: Fiber) {
+  commitBeforeMutationEffectsDeletions(fiber.deletions);
+
   if (fiber.child !== null) {
     const primarySubtreeTag =
       fiber.subtreeTag & (Deletion | Snapshot | Passive | Placement);
@@ -2176,15 +2178,6 @@ function commitBeforeMutationEffectsImpl(fiber: Fiber) {
   const effectTag = fiber.effectTag;
 
   if (!shouldFireAfterActiveInstanceBlur && focusedInstanceHandle !== null) {
-    // The "deletions" array on a Fiber holds previous children that were marked for deletion.
-    // However the overall commit sequence relies on child deletions being processed before parent's effects,
-    // so to satisfy that we also process the parent's "deletions" array (the deletion of siblings).
-    commitBeforeMutationEffectsDeletions(fiber.deletions);
-    const parent = fiber.return;
-    if (parent) {
-      commitBeforeMutationEffectsDeletions(parent.deletions);
-    }
-
     // Check to see if the focused element was inside of a hidden (Suspense) subtree.
     // TODO: Move this out of the hot path using a dedicated effect tag.
     if (
@@ -2237,6 +2230,8 @@ function commitMutationEffects(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
+  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+
   if (fiber.child !== null) {
     const primarySubtreeTag =
       fiber.subtreeTag &
@@ -2279,15 +2274,6 @@ function commitMutationEffectsImpl(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
-  // The "deletions" array on a Fiber holds previous children that were marked for deletion.
-  // However the overall commit sequence relies on child deletions being processed before parent's effects,
-  // so to satisfy that we also process the parent's "deletions" array (the deletion of siblings).
-  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
-  const parent = fiber.return;
-  if (parent) {
-    commitMutationEffectsDeletions(parent.deletions, root, renderPriorityLevel);
-  }
-
   const effectTag = fiber.effectTag;
   if (effectTag & ContentReset) {
     commitResetTextContent(fiber);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2215,6 +2215,9 @@ function commitMutationEffects(
 ) {
   if (fiber.deletions !== null) {
     commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+
+    // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
+    fiber.deletions = null;
   }
 
   if (fiber.child !== null) {
@@ -2354,9 +2357,6 @@ function commitMutationEffectsDeletions(
     }
     // Don't clear the Deletion effect yet; we also use it to know when we need to detach refs later.
   }
-
-  // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
-  deletions.splice(0);
 }
 
 function commitLayoutEffects(

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1745,7 +1745,7 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
         returnFiber.firstEffect = returnFiber.lastEffect = null;
         returnFiber.effectTag |= Incomplete;
         returnFiber.subtreeTag = NoEffect;
-        returnFiber.deletions = [];
+        returnFiber.deletions = null;
       }
     }
 
@@ -1806,7 +1806,7 @@ function resetChildLanes(completedWork: Fiber) {
 
       subtreeTag |= child.subtreeTag;
       subtreeTag |= child.effectTag & HostEffectMask;
-      if (child.deletions.length > 0) {
+      if (child.deletions !== null) {
         subtreeTag |= Deletion;
       }
 
@@ -1851,7 +1851,7 @@ function resetChildLanes(completedWork: Fiber) {
 
       subtreeTag |= child.subtreeTag;
       subtreeTag |= child.effectTag & HostEffectMask;
-      if (child.deletions.length > 0) {
+      if (child.deletions !== null) {
         subtreeTag |= Deletion;
       }
 
@@ -2142,7 +2142,9 @@ function commitRootImpl(root, renderPriorityLevel) {
 }
 
 function commitBeforeMutationEffects(fiber: Fiber) {
-  commitBeforeMutationEffectsDeletions(fiber.deletions);
+  if (fiber.deletions !== null) {
+    commitBeforeMutationEffectsDeletions(fiber.deletions);
+  }
 
   if (fiber.child !== null) {
     const primarySubtreeTag =
@@ -2230,7 +2232,9 @@ function commitMutationEffects(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
-  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+  if (fiber.deletions !== null) {
+    commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+  }
 
   if (fiber.child !== null) {
     const primarySubtreeTag =

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -127,7 +127,7 @@ export type Fiber = {|
   // Effect
   effectTag: SideEffectTag,
   subtreeTag: SideEffectTag,
-  deletions: Array<Fiber>,
+  deletions: Array<Fiber> | null,
 
   // Singly linked list fast path to the next fiber with side-effects.
   nextEffect: Fiber | null,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -126,6 +126,8 @@ export type Fiber = {|
 
   // Effect
   effectTag: SideEffectTag,
+  subtreeTag: SideEffectTag,
+  deletions: Array<Fiber>,
 
   // Singly linked list fast path to the next fiber with side-effects.
   nextEffect: Fiber | null,

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1744,15 +1744,30 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
 
-    expect(Scheduler).toFlushAndYield([
-      'B2',
-      'Destroy Layout Effect [Loading...]',
-      'Destroy Layout Effect [B]',
-      'Layout Effect [B2]',
-      'Destroy Effect [Loading...]',
-      'Destroy Effect [B]',
-      'Effect [B2]',
-    ]);
+    // Slight sequencing difference between old and new reconcilers,
+    // because walking the tree during the commit phase means processing deletions
+    // as part of processing the parent rather than the child.
+    gate(flags =>
+      flags.new
+        ? expect(Scheduler).toFlushAndYield([
+            'B2',
+            'Destroy Layout Effect [B]',
+            'Destroy Layout Effect [Loading...]',
+            'Layout Effect [B2]',
+            'Destroy Effect [Loading...]',
+            'Destroy Effect [B]',
+            'Effect [B2]',
+          ])
+        : expect(Scheduler).toFlushAndYield([
+            'B2',
+            'Destroy Layout Effect [Loading...]',
+            'Destroy Layout Effect [B]',
+            'Layout Effect [B2]',
+            'Destroy Effect [Loading...]',
+            'Destroy Effect [B]',
+            'Effect [B2]',
+          ]),
+    );
   });
 
   it('suspends for longer if something took a long (CPU bound) time to render', async () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1743,31 +1743,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await resolveText('B2');
 
     expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
-
-    // Slight sequencing difference between old and new reconcilers,
-    // because walking the tree during the commit phase means processing deletions
-    // as part of processing the parent rather than the child.
-    gate(flags =>
-      flags.new
-        ? expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [B]',
-            'Destroy Layout Effect [Loading...]',
-            'Layout Effect [B2]',
-            'Destroy Effect [Loading...]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ])
-        : expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [Loading...]',
-            'Destroy Layout Effect [B]',
-            'Layout Effect [B2]',
-            'Destroy Effect [Loading...]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ]),
-    );
+    expect(Scheduler).toFlushAndYield([
+      'B2',
+      'Destroy Layout Effect [Loading...]',
+      'Destroy Layout Effect [B]',
+      'Layout Effect [B2]',
+      'Destroy Effect [Loading...]',
+      'Destroy Effect [B]',
+      'Effect [B2]',
+    ]);
   });
 
   it('suspends for longer if something took a long (CPU bound) time to render', async () => {


### PR DESCRIPTION
This branch is phase one of a planned effects list refactor. It includes the following changes:
* Replace effects list usage with traversing the Fiber tree for before-mutation, mutation, and layout effects phases.
* Track pending deletions in a new `deletions` Fiber field.
* Track which effects exist below a Fiber using a new `subtreeTag` mask field to optimize traversal during commit phase.

All unit tests pass in this branch, although one or two required some slight tweaking.

This PR specifically does not include the following refactor pieces:
* Removing the effects list attributes (`firstEffect`, `lastEffect`, and `nextEffect`).
* Traversing the Fiber tree for passive effects.
* Any of the new hidden/offscreen features.
* Optimizing the new `subtreeTag` field.

Additional follow up work:
* We may be over-traversing during the commit phase now in the case where only some children are cloned. (In this case, we may end up continually traversing bailed out trees.) Maybe a better route would be to set a flag on a Fiber that explicitly marks when we bailed out (during the begin phase). Then we could just check this attribute to *know* without having to use the hacky `wasFiberCloned` heuristic.

---

Co-authored-by: Luna Ruan <luna@fb.com>