### PR TITLE
Move Scope API ref resolution to mutation phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2219,8 +2219,12 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
       if (current !== null) {
         commitDetachRef(current);
       }
-      if (enableScopeAPI && nextEffect.tag === ScopeComponent) {
-        commitAttachRef(nextEffect);
+      if (enableScopeAPI) {
+        // This is a temporary solution that allows us to transition away
+        // from React Flare on www.
+        if (nextEffect.tag === ScopeComponent) {
+          commitAttachRef(nextEffect);
+        }
       }
     }
 
@@ -2292,11 +2296,16 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
       commitLayoutEffectOnFiber(root, current, nextEffect, committedLanes);
     }
 
-    if (
-      effectTag & Ref &&
-      (!enableScopeAPI || nextEffect.tag !== ScopeComponent)
-    ) {
-      commitAttachRef(nextEffect);
+    if (enableScopeAPI) {
+      // This is a temporary solution that allows us to transition away
+      // from React Flare on www.
+      if (effectTag & Ref && nextEffect.tag !== ScopeComponent) {
+        commitAttachRef(nextEffect);
+      }
+    } else {
+      if (effectTag & Ref) {
+        commitAttachRef(nextEffect);
+      }
     }
 
     resetCurrentDebugFiberInDEV();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2220,7 +2220,7 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
         commitDetachRef(current);
       }
       if (enableScopeAPI) {
-        // This is a temporary solution that allows us to transition away
+        // TODO: This is a temporary solution that allows us to transition away
         // from React Flare on www.
         if (nextEffect.tag === ScopeComponent) {
           commitAttachRef(nextEffect);
@@ -2297,7 +2297,7 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
     }
 
     if (enableScopeAPI) {
-      // This is a temporary solution that allows us to transition away
+      // TODO: This is a temporary solution that allows us to transition away
       // from React Flare on www.
       if (effectTag & Ref && nextEffect.tag !== ScopeComponent) {
         commitAttachRef(nextEffect);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -27,6 +27,7 @@ import {
   warnAboutUnmockedScheduler,
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
+  enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
@@ -88,6 +89,7 @@ import {
   Block,
   OffscreenComponent,
   LegacyHiddenComponent,
+  ScopeComponent,
 } from './ReactWorkTags';
 import {LegacyRoot} from './ReactRootTags';
 import {
@@ -2217,6 +2219,9 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
       if (current !== null) {
         commitDetachRef(current);
       }
+      if (enableScopeAPI && nextEffect.tag === ScopeComponent) {
+        commitAttachRef(nextEffect);
+      }
     }
 
     // The following switch statement is only concerned about placement,
@@ -2287,7 +2292,10 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
       commitLayoutEffectOnFiber(root, current, nextEffect, committedLanes);
     }
 
-    if (effectTag & Ref) {
+    if (
+      effectTag & Ref &&
+      (!enableScopeAPI || nextEffect.tag !== ScopeComponent)
+    ) {
       commitAttachRef(nextEffect);
     }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2326,8 +2326,12 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
       if (current !== null) {
         commitDetachRef(current);
       }
-      if (enableScopeAPI && nextEffect.tag === ScopeComponent) {
-        commitAttachRef(nextEffect);
+      if (enableScopeAPI) {
+        // This is a temporary solution that allows us to transition away
+        // from React Flare on www.
+        if (nextEffect.tag === ScopeComponent) {
+          commitAttachRef(nextEffect);
+        }
       }
     }
 
@@ -2409,11 +2413,16 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
       commitLayoutEffectOnFiber(root, current, nextEffect, committedLanes);
     }
 
-    if (
-      effectTag & Ref &&
-      (!enableScopeAPI || nextEffect.tag !== ScopeComponent)
-    ) {
-      commitAttachRef(nextEffect);
+    if (enableScopeAPI) {
+      // This is a temporary solution that allows us to transition away
+      // from React Flare on www.
+      if (effectTag & Ref && nextEffect.tag !== ScopeComponent) {
+        commitAttachRef(nextEffect);
+      }
+    } else {
+      if (effectTag & Ref) {
+        commitAttachRef(nextEffect);
+      }
     }
 
     resetCurrentDebugFiberInDEV();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -29,6 +29,7 @@ import {
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
   enableSchedulingProfiler,
+  enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
@@ -111,6 +112,7 @@ import {
   Block,
   OffscreenComponent,
   LegacyHiddenComponent,
+  ScopeComponent,
 } from './ReactWorkTags';
 import {LegacyRoot} from './ReactRootTags';
 import {
@@ -2324,6 +2326,9 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
       if (current !== null) {
         commitDetachRef(current);
       }
+      if (enableScopeAPI && nextEffect.tag === ScopeComponent) {
+        commitAttachRef(nextEffect);
+      }
     }
 
     // The following switch statement is only concerned about placement,
@@ -2404,7 +2409,10 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
       commitLayoutEffectOnFiber(root, current, nextEffect, committedLanes);
     }
 
-    if (effectTag & Ref) {
+    if (
+      effectTag & Ref &&
+      (!enableScopeAPI || nextEffect.tag !== ScopeComponent)
+    ) {
       commitAttachRef(nextEffect);
     }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2327,7 +2327,7 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
         commitDetachRef(current);
       }
       if (enableScopeAPI) {
-        // This is a temporary solution that allows us to transition away
+        // TODO: This is a temporary solution that allows us to transition away
         // from React Flare on www.
         if (nextEffect.tag === ScopeComponent) {
           commitAttachRef(nextEffect);
@@ -2414,7 +2414,7 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
     }
 
     if (enableScopeAPI) {
-      // This is a temporary solution that allows us to transition away
+      // TODO: This is a temporary solution that allows us to transition away
       // from React Flare on www.
       if (effectTag & Ref && nextEffect.tag !== ScopeComponent) {
         commitAttachRef(nextEffect);


### PR DESCRIPTION
To unblock internal progression on replacing React Flare, let's instead move resolution of Scope API refs to the mutation phase, so we can attach event listeners to scopes before the layout phase begins.