### PR TITLE
Handle test-cli failure case for CI

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -317,7 +317,17 @@ function main() {
   }
 
   // Run Jest.
-  spawn('node', args, {stdio: 'inherit', env: {...envars, ...process.env}});
+  const jest = spawn('node', args, {
+    stdio: 'inherit',
+    env: {...envars, ...process.env},
+  });
+  // Ensure we close our process when we get a failure case.
+  jest.on('close', code => {
+    // Forward the exit code from the Jest process.
+    if (code === 1) {
+      process.exit(1);
+    }
+  });
 }
 
 main();


### PR DESCRIPTION
We should handle the failure case for the test CLI for when a process exits with a code that is `1`.