### PR TITLE
Revert "Fix ExhaustiveDeps ESLint rule throwing with optional chaining"

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6628,44 +6628,6 @@ const testsTypescript = {
         },
       ],
     },
-    {
-      // https://github.com/facebook/react/issues/19243
-      code: normalizeIndent`
-        function MyComponent() {
-          const pizza = {};
-
-          useEffect(() => ({
-            crust: pizza.crust,
-            toppings: pizza?.toppings,
-          }), []);
-        }
-      `,
-      errors: [
-        {
-          message:
-            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza.toppings'. " +
-            'Either include them or remove the dependency array.',
-          suggestions: [
-            {
-              // TODO the description and suggestions should probably also
-              // preserve the optional chaining.
-              desc:
-                'Update the dependencies array to be: [pizza.crust, pizza.toppings]',
-              output: normalizeIndent`
-                function MyComponent() {
-                  const pizza = {};
-
-                  useEffect(() => ({
-                    crust: pizza.crust,
-                    toppings: pizza?.toppings,
-                  }), [pizza.crust, pizza.toppings]);
-                }
-              `,
-            },
-          ],
-        },
-      ],
-    },
   ],
 };
 

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1016,11 +1016,11 @@ export default {
           // Is this a variable from top scope?
           const topScopeRef = componentScope.set.get(missingDep);
           const usedDep = dependencies.get(missingDep);
-          if (usedDep && usedDep.references[0].resolved !== topScopeRef) {
+          if (usedDep.references[0].resolved !== topScopeRef) {
             return;
           }
           // Is this a destructured prop?
-          const def = topScopeRef && topScopeRef.defs[0];
+          const def = topScopeRef.defs[0];
           if (def == null || def.name == null || def.type !== 'Parameter') {
             return;
           }
@@ -1062,7 +1062,7 @@ export default {
             return;
           }
           const usedDep = dependencies.get(missingDep);
-          const references = usedDep ? usedDep.references : [];
+          const references = usedDep.references;
           let id;
           let maybeCall;
           for (let i = 0; i < references.length; i++) {


### PR DESCRIPTION
Reverts facebook/react#19260

We don't have to merge this revert right now. But we shouldn't lose track of it because that PR only addressed a symptom rather than the cause. I think we'll get more confusing bugs later on if we don't fix the actual root problem.