### PR TITLE
Fix event replaying logic

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -115,7 +115,10 @@ import {
   TOP_BLUR,
 } from './DOMTopLevelEventTypes';
 import {IS_REPLAYED, PLUGIN_EVENT_SYSTEM} from './EventSystemFlags';
-import {listenToTopLevelEvent} from './DOMModernPluginEventSystem';
+import {
+  listenToTopLevelEvent,
+  capturePhaseEvents,
+} from './DOMModernPluginEventSystem';
 import {addResponderEventSystemEvent} from './DeprecatedDOMEventResponderSystem';
 
 type QueuedReplayableEvent = {|
@@ -215,12 +218,13 @@ function trapReplayableEventForContainer(
   container: Container,
   listenerMap: ElementListenerMap,
 ) {
+  const capture = capturePhaseEvents.has(topLevelType);
   listenToTopLevelEvent(
     topLevelType,
     ((container: any): Element),
     listenerMap,
     PLUGIN_EVENT_SYSTEM,
-    false,
+    capture,
   );
 }
 


### PR DESCRIPTION
We need to ensure the logic for event replaying matches the expectations for how we register events normally, so events that are capture phase only, should have their properties passed through respectfully.