### PR TITLE
[ESLint] Consistently treat optional chaining as regular chaining

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6628,6 +6628,44 @@ const testsTypescript = {
         },
       ],
     },
+    {
+      // https://github.com/facebook/react/issues/19243
+      code: normalizeIndent`
+        function MyComponent() {
+          const pizza = {};
+
+          useEffect(() => ({
+            crust: pizza.crust,
+            toppings: pizza?.toppings,
+          }), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza.toppings'. " +
+            'Either include them or remove the dependency array.',
+          suggestions: [
+            {
+              // TODO the description and suggestions should probably also
+              // preserve the optional chaining.
+              desc:
+                'Update the dependencies array to be: [pizza.crust, pizza.toppings]',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const pizza = {};
+
+                  useEffect(() => ({
+                    crust: pizza.crust,
+                    toppings: pizza?.toppings,
+                  }), [pizza.crust, pizza.toppings]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1264,17 +1264,16 @@ const tests = {
       errors: [
         {
           message:
-            "React Hook useCallback has a missing dependency: 'props.foo?.toString'. " +
+            "React Hook useCallback has a missing dependency: 'props.foo.toString'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc:
-                'Update the dependencies array to be: [props.foo?.toString]',
+              desc: 'Update the dependencies array to be: [props.foo.toString]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {
                     console.log(props.foo?.toString());
-                  }, [props.foo?.toString]);
+                  }, [props.foo.toString]);
                 }
               `,
             },
@@ -1867,18 +1866,18 @@ const tests = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'history?.foo'. " +
+            "React Hook useEffect has a missing dependency: 'history.foo'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [history?.foo]',
+              desc: 'Update the dependencies array to be: [history.foo]',
               output: normalizeIndent`
                 function MyComponent({ history }) {
                   useEffect(() => {
                     return [
                       history?.foo
                     ];
-                  }, [history?.foo]);
+                  }, [history.foo]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -274,6 +274,44 @@ const tests = {
       code: normalizeIndent`
         function MyComponent(props) {
           useEffect(() => {
+            console.log(props.foo?.bar);
+          }, [props.foo.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo.bar);
+          }, [props.foo?.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo.bar);
+            console.log(props.foo?.bar);
+          }, [props.foo?.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo.bar);
+            console.log(props.foo?.bar);
+          }, [props.foo.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
             console.log(props.foo);
             console.log(props.foo?.bar);
           }, [props.foo]);

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -347,6 +347,42 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo.bar?.toString());
+          }, [props.foo.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.bar?.toString());
+          }, [props.foo.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo.bar.toString());
+          }, [props?.foo?.bar]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.bar?.baz);
+          }, [props?.foo.bar?.baz]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const myEffect = () => {
             // Doesn't use anything
@@ -1302,16 +1338,103 @@ const tests = {
       errors: [
         {
           message:
-            "React Hook useCallback has a missing dependency: 'props.foo.toString'. " +
+            "React Hook useCallback has a missing dependency: 'props.foo'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [props.foo.toString]',
+              desc: 'Update the dependencies array to be: [props.foo]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {
                     console.log(props.foo?.toString());
-                  }, [props.foo.toString]);
+                  }, [props.foo]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.bar.baz);
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            // TODO: Ideally this would suggest props.foo?.bar.baz instead.
+            "React Hook useCallback has a missing dependency: 'props.foo.bar.baz'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo.bar.baz]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCallback(() => {
+                    console.log(props.foo?.bar.baz);
+                  }, [props.foo.bar.baz]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.bar?.baz);
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            // TODO: Ideally this would suggest props.foo?.bar?.baz instead.
+            "React Hook useCallback has a missing dependency: 'props.foo.bar.baz'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo.bar.baz]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCallback(() => {
+                    console.log(props.foo?.bar?.baz);
+                  }, [props.foo.bar.baz]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCallback(() => {
+            console.log(props.foo?.bar.toString());
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            // TODO: Ideally this would suggest props.foo?.bar instead.
+            "React Hook useCallback has a missing dependency: 'props.foo.bar'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo.bar]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCallback(() => {
+                    console.log(props.foo?.bar.toString());
+                  }, [props.foo.bar]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -771,6 +771,24 @@ const tests = {
       // ourselves. Therefore it's likely not
       // a ref managed by React.
       code: normalizeIndent`
+        function MyComponent() {
+          const myRef = useRef();
+          useEffect(() => {
+            const handleMove = () => {};
+            myRef.current = {};
+            return () => {
+              console.log(myRef?.current?.toString())
+            };
+          }, []);
+          return <div />;
+        }
+      `,
+    },
+    {
+      // Valid because we assign ref.current
+      // ourselves. Therefore it's likely not
+      // a ref managed by React.
+      code: normalizeIndent`
         function useMyThing(myRef) {
           useEffect(() => {
             const handleMove = () => {};
@@ -3641,6 +3659,47 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(props) {
+          const ref1 = useRef();
+          const ref2 = useRef();
+          useEffect(() => {
+            ref1?.current?.focus();
+            console.log(ref2?.current?.textContent);
+            alert(props.someOtherRefs.current.innerHTML);
+            fetch(props.color);
+          }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has unnecessary dependencies: 'ref1.current' and 'ref2.current'. " +
+            'Either exclude them or remove the dependency array. ' +
+            "Mutable values like 'ref1.current' aren't valid dependencies " +
+            "because mutating them doesn't re-render the component.",
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [props.someOtherRefs, props.color]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  const ref1 = useRef();
+                  const ref2 = useRef();
+                  useEffect(() => {
+                    ref1?.current?.focus();
+                    console.log(ref2?.current?.textContent);
+                    alert(props.someOtherRefs.current.innerHTML);
+                    fetch(props.color);
+                  }, [props.someOtherRefs, props.color]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const ref = useRef();
           useEffect(() => {
@@ -3834,6 +3893,42 @@ const tests = {
                   useEffect(() => {
                     if (props.onChange) {
                       props.onChange();
+                    }
+                  }, [props]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            if (props?.onChange) {
+              props?.onChange();
+            }
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props'. " +
+            'Either include it or remove the dependency array. ' +
+            `However, 'props' will change when *any* prop changes, so the ` +
+            `preferred fix is to destructure the 'props' object outside ` +
+            `of the useEffect call and refer to those specific ` +
+            `props inside useEffect.`,
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useEffect(() => {
+                    if (props?.onChange) {
+                      props?.onChange();
                     }
                   }, [props]);
                 }
@@ -4240,6 +4335,29 @@ const tests = {
           const myRef = useRef();
           useEffect(() => {
             const handleMove = () => {};
+            myRef?.current?.addEventListener('mousemove', handleMove);
+            return () => myRef?.current?.removeEventListener('mousemove', handleMove);
+          }, []);
+          return <div ref={myRef} />;
+        }
+      `,
+      errors: [
+        {
+          message:
+            `The ref value 'myRef.current' will likely have changed by the time ` +
+            `this effect cleanup function runs. If this ref points to a node ` +
+            `rendered by React, copy 'myRef.current' to a variable inside the effect, ` +
+            `and use that variable in the cleanup function.`,
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const myRef = useRef();
+          useEffect(() => {
+            const handleMove = () => {};
             myRef.current.addEventListener('mousemove', handleMove);
             return () => myRef.current.removeEventListener('mousemove', handleMove);
           });
@@ -4575,6 +4693,51 @@ const tests = {
             const fn = useCallback(() => {
               // nothing
             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+          }
+        }
+      `,
+      errors: [
+        {
+          message:
+            'React Hook useCallback has unnecessary dependencies: ' +
+            "'MutableStore.hello.world', 'global.stuff', 'props.foo', 'x', 'y', and 'z'. " +
+            'Either exclude them or remove the dependency array. ' +
+            "Outer scope values like 'MutableStore.hello.world' aren't valid dependencies " +
+            "because mutating them doesn't re-render the component.",
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: []',
+              output: normalizeIndent`
+                import MutableStore from 'store';
+                let z = {};
+
+                function MyComponent(props) {
+                  let x = props.foo;
+                  {
+                    let y = props.bar;
+                    const fn = useCallback(() => {
+                      // nothing
+                    }, []);
+                  }
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        import MutableStore from 'store';
+        let z = {};
+
+        function MyComponent(props) {
+          let x = props.foo;
+          {
+            let y = props.bar;
+            const fn = useCallback(() => {
+              // nothing
+            }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
           }
         }
       `,
@@ -6160,6 +6323,40 @@ const tests = {
                   useEffect(() => {
                     console.log(fetchPodcasts);
                     fetchPodcasts(id).then(setPodcasts);
+                  }, [fetchPodcasts, id]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Podcasts({ fetchPodcasts, id }) {
+          let [podcasts, setPodcasts] = useState(null);
+          useEffect(() => {
+            console.log(fetchPodcasts);
+            fetchPodcasts?.(id).then(setPodcasts);
+          }, [id]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            `React Hook useEffect has a missing dependency: 'fetchPodcasts'. ` +
+            `Either include it or remove the dependency array. ` +
+            `If 'fetchPodcasts' changes too often, ` +
+            `find the parent component that defines it and wrap that definition in useCallback.`,
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [fetchPodcasts, id]',
+              output: normalizeIndent`
+                function Podcasts({ fetchPodcasts, id }) {
+                  let [podcasts, setPodcasts] = useState(null);
+                  useEffect(() => {
+                    console.log(fetchPodcasts);
+                    fetchPodcasts?.(id).then(setPodcasts);
                   }, [fetchPodcasts, id]);
                 }
               `,

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6628,44 +6628,6 @@ const testsTypescript = {
         },
       ],
     },
-    {
-      // https://github.com/facebook/react/issues/19243
-      code: normalizeIndent`
-        function MyComponent() {
-          const pizza = {};
-
-          useEffect(() => ({
-            crust: pizza.crust,
-            toppings: pizza?.toppings,
-          }), []);
-        }
-      `,
-      errors: [
-        {
-          message:
-            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza.toppings'. " +
-            'Either include them or remove the dependency array.',
-          suggestions: [
-            {
-              // TODO the description and suggestions should probably also
-              // preserve the optional chaining.
-              desc:
-                'Update the dependencies array to be: [pizza.crust, pizza.toppings]',
-              output: normalizeIndent`
-                function MyComponent() {
-                  const pizza = {};
-
-                  useEffect(() => ({
-                    crust: pizza.crust,
-                    toppings: pizza?.toppings,
-                  }), [pizza.crust, pizza.toppings]);
-                }
-              `,
-            },
-          ],
-        },
-      ],
-    },
   ],
 };
 

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -588,8 +588,8 @@ export default {
             if (
               parent != null &&
               // ref.current
-              (parent.type === 'MemberExpression' ||
-                parent.type === 'OptionalMemberExpression') &&
+              // Note: no need to handle OptionalMemberExpression because it can't be LHS.
+              parent.type === 'MemberExpression' &&
               !parent.computed &&
               parent.property.type === 'Identifier' &&
               parent.property.name === 'current' &&
@@ -1452,8 +1452,8 @@ function getDependency(node) {
   ) {
     return getDependency(node.parent);
   } else if (
-    (node.type === 'MemberExpression' ||
-      node.type === 'OptionalMemberExpression') &&
+    // Note: we don't check OptionalMemberExpression because it can't be LHS.
+    node.type === 'MemberExpression' &&
     node.parent &&
     node.parent.type === 'AssignmentExpression'
   ) {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -525,7 +525,8 @@ export default {
             isEffect &&
             // ... and this look like accessing .current...
             dependencyNode.type === 'Identifier' &&
-            dependencyNode.parent.type === 'MemberExpression' &&
+            (dependencyNode.parent.type === 'MemberExpression' ||
+              dependencyNode.parent.type === 'OptionalMemberExpression') &&
             !dependencyNode.parent.computed &&
             dependencyNode.parent.property.type === 'Identifier' &&
             dependencyNode.parent.property.name === 'current' &&
@@ -587,7 +588,8 @@ export default {
             if (
               parent != null &&
               // ref.current
-              parent.type === 'MemberExpression' &&
+              (parent.type === 'MemberExpression' ||
+                parent.type === 'OptionalMemberExpression') &&
               !parent.computed &&
               parent.property.type === 'Identifier' &&
               parent.property.name === 'current' &&
@@ -790,7 +792,10 @@ export default {
           }
 
           let maybeID = declaredDependencyNode;
-          while (maybeID.type === 'MemberExpression') {
+          while (
+            maybeID.type === 'MemberExpression' ||
+            maybeID.type === 'OptionalMemberExpression'
+          ) {
             maybeID = maybeID.object;
           }
           const isDeclaredInComponent = !componentScope.through.some(
@@ -991,7 +996,10 @@ export default {
             isPropsOnlyUsedInMembers = false;
             break;
           }
-          if (parent.type !== 'MemberExpression') {
+          if (
+            parent.type !== 'MemberExpression' &&
+            parent.type !== 'OptionalMemberExpression'
+          ) {
             isPropsOnlyUsedInMembers = false;
             break;
           }
@@ -1032,7 +1040,8 @@ export default {
             if (
               id != null &&
               id.parent != null &&
-              id.parent.type === 'CallExpression' &&
+              (id.parent.type === 'CallExpression' ||
+                id.parent.type === 'OptionalCallExpression') &&
               id.parent.callee === id
             ) {
               isFunctionCall = true;
@@ -1436,13 +1445,15 @@ function getDependency(node) {
     !node.parent.computed &&
     !(
       node.parent.parent != null &&
-      node.parent.parent.type === 'CallExpression' &&
+      (node.parent.parent.type === 'CallExpression' ||
+        node.parent.parent.type === 'OptionalCallExpression') &&
       node.parent.parent.callee === node.parent
     )
   ) {
     return getDependency(node.parent);
   } else if (
-    node.type === 'MemberExpression' &&
+    (node.type === 'MemberExpression' ||
+      node.type === 'OptionalMemberExpression') &&
     node.parent &&
     node.parent.type === 'AssignmentExpression'
   ) {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1457,20 +1457,23 @@ function getDependency(node) {
  * (foo) -> 'foo'
  * foo.(bar) -> 'foo.bar'
  * foo.bar.(baz) -> 'foo.bar.baz'
- * foo?.(bar) -> 'foo?.bar'
  * Otherwise throw.
  */
 function toPropertyAccessString(node) {
   if (node.type === 'Identifier') {
     return node.name;
-  } else if (node.type === 'MemberExpression' && !node.computed) {
+  } else if (
+    (node.type === 'MemberExpression' ||
+      node.type === 'OptionalMemberExpression') &&
+    !node.computed
+  ) {
     const object = toPropertyAccessString(node.object);
     const property = toPropertyAccessString(node.property);
+    // Note: we intentionally omit ? even for optional chaining
+    // because the returned string represents a path to the node, and
+    // is used as a key in Maps where being optional doesn't matter.
+    // The result string is not being interpolated in the code output.
     return `${object}.${property}`;
-  } else if (node.type === 'OptionalMemberExpression' && !node.computed) {
-    const object = toPropertyAccessString(node.object);
-    const property = toPropertyAccessString(node.property);
-    return `${object}?.${property}`;
   } else {
     throw new Error(`Unsupported node type: ${node.type}`);
   }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1016,11 +1016,11 @@ export default {
           // Is this a variable from top scope?
           const topScopeRef = componentScope.set.get(missingDep);
           const usedDep = dependencies.get(missingDep);
-          if (usedDep && usedDep.references[0].resolved !== topScopeRef) {
+          if (usedDep.references[0].resolved !== topScopeRef) {
             return;
           }
           // Is this a destructured prop?
-          const def = topScopeRef && topScopeRef.defs[0];
+          const def = topScopeRef.defs[0];
           if (def == null || def.name == null || def.type !== 'Parameter') {
             return;
           }
@@ -1062,7 +1062,7 @@ export default {
             return;
           }
           const usedDep = dependencies.get(missingDep);
-          const references = usedDep ? usedDep.references : [];
+          const references = usedDep.references;
           let id;
           let maybeCall;
           for (let i = 0; i < references.length; i++) {


### PR DESCRIPTION
We've merged a bunch of PRs which added support for optional chaining to the ESLint rule about dependencies (https://github.com/facebook/react/pull/18820, https://github.com/facebook/react/pull/19008, https://github.com/facebook/react/pull/19062, https://github.com/facebook/react/pull/19260). However there was no single cohesive strategy behind them, and they led to crashes and edge cases because they attacked the symptoms rather than the root cause (the algorithm wasn’t designed to deal with optional chaining). There was no attempt to rethink the algorithm so the interim solutions have gradually made it broken and inconsistent. However, we did get new tests from them so they were still useful PRs. We just need to rethink our strategy.

As a first step I want to simplify this by getting back to where we were and removing the code that breaks algorithm’s assumptions. In particular, I am treating all `foo?.bar` as `foo.bar` from the dependency tracking perspective. The downside is that our error messages and fix suggestions will suggest regular chaining (but they will also be okay with optional chaining — so you can always fix them manually). The upside is that we can reason about what’s happening again because the inconsistencies are removed, and the algorithm only deals with regular property paths, just like before.

This fixes a bunch of bugs, for which I’ve added regression tests.

As a follow-up to this, I think we should be able to figure out a simple solution that will preserve optional chaining where it makes sense in the messages and suggestions. However, I think this first step is still useful to get in as a base.

**Best reviewed as individual commits**