### PR TITLE
[ESLint] Handle optional member chains

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1384,17 +1384,16 @@ const tests = {
       errors: [
         {
           message:
-            // TODO: Ideally this would suggest props.foo?.bar.baz instead.
-            "React Hook useCallback has a missing dependency: 'props.foo.bar.baz'. " +
+            "React Hook useCallback has a missing dependency: 'props.foo?.bar.baz'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [props.foo.bar.baz]',
+              desc: 'Update the dependencies array to be: [props.foo?.bar.baz]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {
                     console.log(props.foo?.bar.baz);
-                  }, [props.foo.bar.baz]);
+                  }, [props.foo?.bar.baz]);
                 }
               `,
             },
@@ -1413,17 +1412,17 @@ const tests = {
       errors: [
         {
           message:
-            // TODO: Ideally this would suggest props.foo?.bar?.baz instead.
-            "React Hook useCallback has a missing dependency: 'props.foo.bar.baz'. " +
+            "React Hook useCallback has a missing dependency: 'props.foo?.bar?.baz'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [props.foo.bar.baz]',
+              desc:
+                'Update the dependencies array to be: [props.foo?.bar?.baz]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {
                     console.log(props.foo?.bar?.baz);
-                  }, [props.foo.bar.baz]);
+                  }, [props.foo?.bar?.baz]);
                 }
               `,
             },
@@ -1442,17 +1441,16 @@ const tests = {
       errors: [
         {
           message:
-            // TODO: Ideally this would suggest props.foo?.bar instead.
-            "React Hook useCallback has a missing dependency: 'props.foo.bar'. " +
+            "React Hook useCallback has a missing dependency: 'props.foo?.bar'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [props.foo.bar]',
+              desc: 'Update the dependencies array to be: [props.foo?.bar]',
               output: normalizeIndent`
                 function MyComponent(props) {
                   useCallback(() => {
                     console.log(props.foo?.bar.toString());
-                  }, [props.foo.bar]);
+                  }, [props.foo?.bar]);
                 }
               `,
             },
@@ -2045,18 +2043,18 @@ const tests = {
       errors: [
         {
           message:
-            "React Hook useEffect has a missing dependency: 'history.foo'. " +
+            "React Hook useEffect has a missing dependency: 'history?.foo'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
-              desc: 'Update the dependencies array to be: [history.foo]',
+              desc: 'Update the dependencies array to be: [history?.foo]',
               output: normalizeIndent`
                 function MyComponent({ history }) {
                   useEffect(() => {
                     return [
                       history?.foo
                     ];
-                  }, [history.foo]);
+                  }, [history?.foo]);
                 }
               `,
             },
@@ -6986,7 +6984,6 @@ const testsTypescript = {
       ],
     },
     {
-      // https://github.com/facebook/react/issues/19243
       code: normalizeIndent`
         function MyComponent() {
           const pizza = {};
@@ -7000,14 +6997,12 @@ const testsTypescript = {
       errors: [
         {
           message:
-            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza.toppings'. " +
+            "React Hook useEffect has missing dependencies: 'pizza.crust' and 'pizza?.toppings'. " +
             'Either include them or remove the dependency array.',
           suggestions: [
             {
-              // TODO the description and suggestions should probably also
-              // preserve the optional chaining.
               desc:
-                'Update the dependencies array to be: [pizza.crust, pizza.toppings]',
+                'Update the dependencies array to be: [pizza.crust, pizza?.toppings]',
               output: normalizeIndent`
                 function MyComponent() {
                   const pizza = {};
@@ -7015,7 +7010,109 @@ const testsTypescript = {
                   useEffect(() => ({
                     crust: pizza.crust,
                     toppings: pizza?.toppings,
-                  }), [pizza.crust, pizza.toppings]);
+                  }), [pizza.crust, pizza?.toppings]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const pizza = {};
+
+          useEffect(() => ({
+            crust: pizza?.crust,
+            density: pizza.crust.density,
+          }), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [pizza.crust]',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const pizza = {};
+
+                  useEffect(() => ({
+                    crust: pizza?.crust,
+                    density: pizza.crust.density,
+                  }), [pizza.crust]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const pizza = {};
+
+          useEffect(() => ({
+            crust: pizza.crust,
+            density: pizza?.crust.density,
+          }), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'pizza.crust'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [pizza.crust]',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const pizza = {};
+
+                  useEffect(() => ({
+                    crust: pizza.crust,
+                    density: pizza?.crust.density,
+                  }), [pizza.crust]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const pizza = {};
+
+          useEffect(() => ({
+            crust: pizza?.crust,
+            density: pizza?.crust.density,
+          }), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'pizza?.crust'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [pizza?.crust]',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const pizza = {};
+
+                  useEffect(() => ({
+                    crust: pizza?.crust,
+                    density: pizza?.crust.density,
+                  }), [pizza?.crust]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -72,7 +72,7 @@ export default {
     // Should be shared between visitors.
     const setStateCallSites = new WeakMap();
     const stateVariables = new WeakSet();
-    const staticKnownValueCache = new WeakMap();
+    const stableKnownValueCache = new WeakMap();
     const functionWithoutCapturedValueCache = new WeakMap();
     function memoizeWithWeakMap(fn, map) {
       return function(arg) {
@@ -296,7 +296,7 @@ export default {
       // Next we'll define a few helpers that helps us
       // tell if some values don't have to be declared as deps.
 
-      // Some are known to be static based on Hook calls.
+      // Some are known to be stable based on Hook calls.
       // const [state, setState] = useState() / React.useState()
       //               ^^^ true for this reference
       // const [state, dispatch] = useReducer() / React.useReducer()
@@ -304,7 +304,7 @@ export default {
       // const ref = useRef()
       //       ^^^ true for this reference
       // False for everything else.
-      function isStaticKnownHookValue(resolved) {
+      function isStableKnownHookValue(resolved) {
         if (!Array.isArray(resolved.defs)) {
           return false;
         }
@@ -343,7 +343,7 @@ export default {
             typeof init.value === 'number' ||
             init.value === null)
         ) {
-          // Definitely static
+          // Definitely stable
           return true;
         }
         // Detect known Hook calls
@@ -367,10 +367,10 @@ export default {
         const id = def.node.id;
         const {name} = callee;
         if (name === 'useRef' && id.type === 'Identifier') {
-          // useRef() return value is static.
+          // useRef() return value is stable.
           return true;
         } else if (name === 'useState' || name === 'useReducer') {
-          // Only consider second value in initializing tuple static.
+          // Only consider second value in initializing tuple stable.
           if (
             id.type === 'ArrayPattern' &&
             id.elements.length === 2 &&
@@ -387,7 +387,7 @@ export default {
                   );
                 }
               }
-              // Setter is static.
+              // Setter is stable.
               return true;
             } else if (id.elements[0] === resolved.identifiers[0]) {
               if (name === 'useState') {
@@ -452,22 +452,22 @@ export default {
           }
           if (
             pureScopes.has(ref.resolved.scope) &&
-            // Static values are fine though,
+            // Stable values are fine though,
             // although we won't check functions deeper.
-            !memoizedIsStaticKnownHookValue(ref.resolved)
+            !memoizedIsStablecKnownHookValue(ref.resolved)
           ) {
             return false;
           }
         }
         // If we got here, this function doesn't capture anything
-        // from render--or everything it captures is known static.
+        // from render--or everything it captures is known stable.
         return true;
       }
 
       // Remember such values. Avoid re-running extra checks on them.
-      const memoizedIsStaticKnownHookValue = memoizeWithWeakMap(
-        isStaticKnownHookValue,
-        staticKnownValueCache,
+      const memoizedIsStablecKnownHookValue = memoizeWithWeakMap(
+        isStableKnownHookValue,
+        stableKnownValueCache,
       );
       const memoizedIsFunctionWithoutCapturedValues = memoizeWithWeakMap(
         isFunctionWithoutCapturedValues,
@@ -495,7 +495,7 @@ export default {
       }
 
       // Get dependencies from all our resolved references in pure scopes.
-      // Key is dependency string, value is whether it's static.
+      // Key is dependency string, value is whether it's stable.
       const dependencies = new Map();
       gatherDependenciesRecursively(scope);
 
@@ -556,14 +556,14 @@ export default {
           }
 
           // Add the dependency to a map so we can make sure it is referenced
-          // again in our dependencies array. Remember whether it's static.
+          // again in our dependencies array. Remember whether it's stable.
           if (!dependencies.has(dependency)) {
             const resolved = reference.resolved;
-            const isStatic =
-              memoizedIsStaticKnownHookValue(resolved) ||
+            const isStable =
+              memoizedIsStablecKnownHookValue(resolved) ||
               memoizedIsFunctionWithoutCapturedValues(resolved);
             dependencies.set(dependency, {
-              isStatic,
+              isStable,
               references: [reference],
             });
           } else {
@@ -637,11 +637,11 @@ export default {
         });
       }
 
-      // Remember which deps are optional and report bad usage first.
-      const optionalDependencies = new Set();
-      dependencies.forEach(({isStatic, references}, key) => {
-        if (isStatic) {
-          optionalDependencies.add(key);
+      // Remember which deps are stable and report bad usage first.
+      const stableDependencies = new Set();
+      dependencies.forEach(({isStable, references}, key) => {
+        if (isStable) {
+          stableDependencies.add(key);
         }
         references.forEach(reference => {
           if (reference.writeExpr) {
@@ -659,7 +659,7 @@ export default {
         // Check if there are any top-level setState() calls.
         // Those tend to lead to infinite loops.
         let setStateInsideEffectWithoutDeps = null;
-        dependencies.forEach(({isStatic, references}, key) => {
+        dependencies.forEach(({isStable, references}, key) => {
           if (setStateInsideEffectWithoutDeps) {
             return;
           }
@@ -689,7 +689,7 @@ export default {
           const {suggestedDependencies} = collectRecommendations({
             dependencies,
             declaredDependencies: [],
-            optionalDependencies,
+            stableDependencies,
             externalDependencies: new Set(),
             isEffect: true,
           });
@@ -822,7 +822,7 @@ export default {
       } = collectRecommendations({
         dependencies,
         declaredDependencies,
-        optionalDependencies,
+        stableDependencies,
         externalDependencies,
         isEffect,
       });
@@ -901,7 +901,7 @@ export default {
         suggestedDeps = collectRecommendations({
           dependencies,
           declaredDependencies: [], // Pretend we don't know
-          optionalDependencies,
+          stableDependencies,
           externalDependencies,
           isEffect,
         }).suggestedDependencies;
@@ -1198,7 +1198,7 @@ export default {
 function collectRecommendations({
   dependencies,
   declaredDependencies,
-  optionalDependencies,
+  stableDependencies,
   externalDependencies,
   isEffect,
 }) {
@@ -1214,9 +1214,9 @@ function collectRecommendations({
   const depTree = createDepTree();
   function createDepTree() {
     return {
-      isRequired: false, // True if used in code
+      isUsed: false, // True if used in code
       isSatisfiedRecursively: false, // True if specified in deps
-      hasRequiredNodesBelow: false, // True if something deeper is used by code
+      isSubtreeUsed: false, // True if something deeper is used by code
       children: new Map(), // Nodes for properties
     };
   }
@@ -1225,9 +1225,9 @@ function collectRecommendations({
   // Imagine exclamation marks next to each used deep property.
   dependencies.forEach((_, key) => {
     const node = getOrCreateNodeByPath(depTree, key);
-    node.isRequired = true;
+    node.isUsed = true;
     markAllParentsByPath(depTree, key, parent => {
-      parent.hasRequiredNodesBelow = true;
+      parent.isSubtreeUsed = true;
     });
   });
 
@@ -1237,7 +1237,7 @@ function collectRecommendations({
     const node = getOrCreateNodeByPath(depTree, key);
     node.isSatisfiedRecursively = true;
   });
-  optionalDependencies.forEach(key => {
+  stableDependencies.forEach(key => {
     const node = getOrCreateNodeByPath(depTree, key);
     node.isSatisfiedRecursively = true;
   });
@@ -1282,7 +1282,7 @@ function collectRecommendations({
     node.children.forEach((child, key) => {
       const path = keyToPath(key);
       if (child.isSatisfiedRecursively) {
-        if (child.hasRequiredNodesBelow) {
+        if (child.isSubtreeUsed) {
           // Remember this dep actually satisfied something.
           satisfyingPaths.add(path);
         }
@@ -1291,7 +1291,7 @@ function collectRecommendations({
         // `props.foo` is enough if you read `props.foo.id`.
         return;
       }
-      if (child.isRequired) {
+      if (child.isUsed) {
         // Remember that no declared deps satisfied this node.
         missingPaths.add(path);
         // If we got here, nothing in its subtree was satisfied.

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1521,7 +1521,7 @@ function analyzePropertyChain(node, optionalChains) {
       if (node.optional) {
         // We only want to consider it optional if *all* usages were optional.
         if (!optionalChains.has(result)) {
-          // Mark as optional.
+          // Mark as (maybe) optional. If there's a required usage, this will be overridden.
           optionalChains.set(result, true);
         }
       } else {


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/19273.

Our algorithm treats `a.b.c.d` as unique paths in a many places and those parts should work the same way regardless of whether these are optional or required members. So in https://github.com/facebook/react/pull/19273, I removed `?.` from the internal representation.

However, ideally we still want to print `?.` where needed **if all usages of that member in the user code used optional chaining**. For example, if we use `pizza?.crust` and `pizza?.crust.density`, then we should suggest `pizza?.crust` in deps, but if one of them didn’t have `?`, then we should suggest `pizza.crust` instead. Because then, at least one of them is required anyway. None of this should have any effects on the dependency logic — both variations, if typed by user, should satisfy the constraint.

The implementation is split in two stages.

It intentionally doesn’t interfere with the main algorithm that checks the dependencies. Instead, when we initially generate member paths, we also fill a Map. In that Map, we mark for each deep path whether it was a required or an optional one. By the time we have collected all dependencies, the Map will contain a mapping from the key path to a Boolean: `true` if all usages were optional, and `false` if some of them were required.

Finally, when we're ready to print our suggestions and/or fix the code, we will use that Map to pretty-print our paths. We will consult it to see if each segment should be concatenated using `?.` or `.`. If at least one usage was required, or if that path was not found in the code, then we will default to `.` as a default path separator. So if you don't use `?.` you won’t see it.

This adds a few tests and also fixes a bunch of existing tests to use better output.

**This is split in two commits.** The first one is just a bunch of renames because "optional" clashed with another concept we previously called the same way. Review commits individually.