### PR TITLE
Use a custom jsdom fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,5 +130,8 @@
     "version-check": "node ./scripts/tasks/version-check.js",
     "merge-fork": "node ./scripts/merge-fork/merge-fork.js",
     "replace-fork": "node ./scripts/merge-fork/replace-fork.js"
+  },
+  "resolutions": {
+    "**/jsdom": "npm:@gaearon/jsdom@15.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8012,10 +8012,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^15.2.1:
+jsdom@^15.2.1, "jsdom@npm:@gaearon/jsdom@15.2.1":
   version "15.2.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
-  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
+  resolved "https://registry.yarnpkg.com/@gaearon/jsdom/-/jsdom-15.2.1.tgz#23273b20b6c7b6ca70b54bc0b0eecdc518ae9694"
+  integrity sha512-qQc4j+gyi06zrevvopql0pehAXrgTv71wGkKMQZg8bl2VYfv2dqbdtP0hD0TpHsuI7YF1XfE7DM62Nclr13vfA==
   dependencies:
     abab "^2.0.0"
     acorn "^7.1.0"


### PR DESCRIPTION
This temporarily uses a jsdom fork, which is the version we use + https://github.com/jsdom/jsdom/commit/a52b77bf6af8a693b26be586b766f9303498214a cherry-picked. This should unblock https://github.com/facebook/react/pull/19186.

<s>This assumes that we actually need this change to unblock. I'm not confident yet because it seems like it affects only createEventHandle tests (?), and that API isn't being used anywhere. So the alternative is just to disable these tests.</s> Misunderstood, ignore me.