### PR TITLE
Fix typo in Overview doc for react-devtools

### DIFF
--- a/packages/react-devtools/OVERVIEW.md
+++ b/packages/react-devtools/OVERVIEW.md
@@ -26,8 +26,8 @@ It consists of:
 
 1. the total length of next items that belong to string table
 2. for each string in a table:
-  1. encoded size
-  2. a list of its UTF encoded codepoints
+    * encoded size
+    * a list of its UTF encoded codepoints
 
 For example, for `Foo` and `Bar` we would see:
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The Overview document in the react-devtools package had a small typo in the String table section - the 3rd and 4th point should be indented as a sub-list for the 2nd point. Fixed it by indenting the 3rd and 4th point in markdown and adding an asterisk to add bullet points.

cc @bvaughn 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->



