### PR TITLE
Refactor algorithm for determining the next Lanes to work on

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -2848,7 +2848,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       foo.setState({suspend: false});
     });
 
-    expect(Scheduler).toHaveYielded(['Foo']);
+    expect(Scheduler).toHaveYielded([
+      // First setState
+      'Foo',
+      // Second setState. This update was scheduled while we were in the
+      // middle of rendering the previous update, so it was pushed to a separate
+      // batch to avoid invalidating the work-in-progress tree.
+      'Foo',
+    ]);
     expect(root).toMatchRenderedOutput(<span prop="Foo" />);
   });
 


### PR DESCRIPTION
Some clean up to make the Lanes type easier to maintain.

I removed the "start" and "end" range markers; they don't provide any information that isn't already encoded in the bitmask for each range, and there's no computation saved compared to the `pickArbitraryLane` function.

The overall algorithm is largely the same but I did tweak some of the details. For example, if the lanes for a given priority are already being worked on, the previous algorithm would assign to the next available lane, including the dedicated hydration lanes that exist in between each priority.

The updated algorithm skips over the hydration lanes and goes to the next priority level. In the rare instance when all the non Idle update lanes are occupied, it will pick an arbitrary default lane. This will have the effect of invalidating the current work-in-progress, and indicates a starvation scenario.

Eventually, if there are too many interruptions, the expiration time mechanism will kick in and force the update to synchronously finish.