### PR TITLE
DevTools: Make break-on-warn off by default

### DIFF
--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -258,7 +258,7 @@ export function getBreakOnConsoleErrors(): boolean {
       return JSON.parse(raw);
     }
   } catch (error) {}
-  return true;
+  return false;
 }
 
 export function setBreakOnConsoleErrors(value: boolean): void {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/19308.

Changelog said https://github.com/facebook/react/pull/19048 should be off by default but it's on by default.