### PR TITLE
[ESLint] Fix a bug causing a too coarse dependency suggestion

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1343,6 +1343,39 @@ const tests = {
         }
       `,
     },
+    // Regression test.
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          useEffect(() => {
+            let topHeight = 0;
+            topHeight = props.upperViewHeight;
+          }, [props.upperViewHeight]);
+        }
+      `,
+    },
+    // Regression test.
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          useEffect(() => {
+            let topHeight = 0;
+            topHeight = props?.upperViewHeight;
+          }, [props?.upperViewHeight]);
+        }
+      `,
+    },
+    // Regression test.
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          useEffect(() => {
+            let topHeight = 0;
+            topHeight = props?.upperViewHeight;
+          }, [props]);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -7113,6 +7146,70 @@ const testsTypescript = {
                     crust: pizza?.crust,
                     density: pizza?.crust.density,
                   }), [pizza?.crust]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // Regression test.
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          useEffect(() => {
+            let topHeight = 0;
+            topHeight = props.upperViewHeight;
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props.upperViewHeight'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [props.upperViewHeight]',
+              output: normalizeIndent`
+                function Example(props) {
+                  useEffect(() => {
+                    let topHeight = 0;
+                    topHeight = props.upperViewHeight;
+                  }, [props.upperViewHeight]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // Regression test.
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          useEffect(() => {
+            let topHeight = 0;
+            topHeight = props?.upperViewHeight;
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'props?.upperViewHeight'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [props?.upperViewHeight]',
+              output: normalizeIndent`
+                function Example(props) {
+                  useEffect(() => {
+                    let topHeight = 0;
+                    topHeight = props?.upperViewHeight;
+                  }, [props?.upperViewHeight]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1478,7 +1478,8 @@ function getDependency(node) {
     // Note: we don't check OptionalMemberExpression because it can't be LHS.
     node.type === 'MemberExpression' &&
     node.parent &&
-    node.parent.type === 'AssignmentExpression'
+    node.parent.type === 'AssignmentExpression' &&
+    node.parent.left === node
   ) {
     return node.object;
   } else {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/19312.

If we use `props.something` and declare `props.something` in deps, this should not violate.

However, the existing logic for AssignmentExpressions caused it to be violating. This is because we forgot to check whether an expression is on the left or the right side. That logic should only have been active for the left side.

Added regression tests.