### PR TITLE
Extract some of the tidy up changes from 19278

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -85,7 +85,7 @@ import {
   enableDeprecatedFlareAPI,
   enableTrustedTypesIntegration,
 } from 'shared/ReactFeatureFlags';
-import {listenToReactPropEvent} from '../events/DOMModernPluginEventSystem';
+import {listenToReactEvent} from '../events/DOMModernPluginEventSystem';
 import {getEventListenerMap} from './ReactDOMComponentTree';
 
 let didWarnInvalidHydration = false;
@@ -282,10 +282,7 @@ export function ensureListeningTo(
     'ensureListeningTo(): received a container that was not an element node. ' +
       'This is likely a bug in React.',
   );
-  listenToReactPropEvent(
-    reactPropEvent,
-    ((rootContainerElement: any): Element),
-  );
+  listenToReactEvent(reactPropEvent, ((rootContainerElement: any): Element));
 }
 
 function getOwnerDocumentFromRootContainer(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -80,7 +80,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {TOP_BEFORE_BLUR, TOP_AFTER_BLUR} from '../events/DOMTopLevelEventTypes';
-import {listenToReactPropEvent} from '../events/DOMModernPluginEventSystem';
+import {listenToReactEvent} from '../events/DOMModernPluginEventSystem';
 
 export type Type = string;
 export type Props = {
@@ -1111,7 +1111,7 @@ export function makeOpaqueHydratingObject(
 }
 
 export function preparePortalMount(portalInstance: Instance): void {
-  listenToReactPropEvent('onMouseEnter', portalInstance);
+  listenToReactEvent('onMouseEnter', portalInstance);
 }
 
 export function prepareScopeUpdate(

--- a/packages/react-dom/src/events/EventSystemFlags.js
+++ b/packages/react-dom/src/events/EventSystemFlags.js
@@ -11,7 +11,7 @@ export type EventSystemFlags = number;
 
 export const PLUGIN_EVENT_SYSTEM = 1;
 export const RESPONDER_EVENT_SYSTEM = 1 << 1;
-export const IS_TARGET_PHASE_ONLY = 1 << 2;
+export const IS_EVENT_HANDLE_NON_MANAGED_NODE = 1 << 2;
 export const IS_CAPTURE_PHASE = 1 << 3;
 export const IS_PASSIVE = 1 << 4;
 export const PASSIVE_NOT_SUPPORTED = 1 << 5;

--- a/packages/react-dom/src/events/PluginModuleType.js
+++ b/packages/react-dom/src/events/PluginModuleType.js
@@ -7,26 +7,8 @@
  * @flow
  */
 
-import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
-import type {ReactSyntheticEvent} from './ReactSyntheticEventType';
-
 export type AnyNativeEvent = Event | KeyboardEvent | MouseEvent | TouchEvent;
 
 export type PluginName = string;
 
 export type EventSystemFlags = number;
-
-export type DispatchQueueItemPhaseEntry = {|
-  instance: null | Fiber,
-  listener: Function,
-  currentTarget: EventTarget,
-|};
-
-export type DispatchQueueItemPhase = Array<DispatchQueueItemPhaseEntry>;
-
-export type DispatchQueueItem = {|
-  event: ReactSyntheticEvent,
-  phase: DispatchQueueItemPhase,
-|};
-
-export type DispatchQueue = Array<DispatchQueueItem>;

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -136,7 +136,7 @@ import {
 } from './DOMTopLevelEventTypes';
 import {IS_REPLAYED, PLUGIN_EVENT_SYSTEM} from './EventSystemFlags';
 import {
-  listenToTopLevelEvent,
+  listenToNativeEvent,
   capturePhaseEvents,
 } from './DOMModernPluginEventSystem';
 import {addResponderEventSystemEvent} from './DeprecatedDOMEventResponderSystem';
@@ -240,7 +240,7 @@ function trapReplayableEventForContainer(
   listenerMap: ElementListenerMap,
 ) {
   const capture = capturePhaseEvents.has(topLevelType);
-  listenToTopLevelEvent(
+  listenToNativeEvent(
     topLevelType,
     ((container: any): Element),
     listenerMap,

--- a/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernChangeEventPlugin.js
@@ -8,7 +8,7 @@
  */
 import type {AnyNativeEvent} from '../PluginModuleType';
 import type {TopLevelType} from '../TopLevelEventTypes';
-import type {DispatchQueue} from '../PluginModuleType';
+import type {DispatchQueue} from '../DOMModernPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
 
 import {registerTwoPhaseEvent} from '../EventRegistry';

--- a/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ModernSimpleEventPlugin.js
@@ -9,10 +9,8 @@
 
 import type {TopLevelType} from '../../events/TopLevelEventTypes';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
-import type {
-  AnyNativeEvent,
-  DispatchQueue,
-} from '../../events/PluginModuleType';
+import type {AnyNativeEvent} from '../../events/PluginModuleType';
+import type {DispatchQueue} from '../DOMModernPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
 
 import SyntheticEvent from '../../events/SyntheticEvent';
@@ -24,9 +22,9 @@ import {
 } from '../DOMEventProperties';
 import {
   accumulateSinglePhaseListeners,
-  accumulateEventHandleTargetListeners,
+  accumulateEventHandleNonManagedNodeListeners,
 } from '../DOMModernPluginEventSystem';
-import {IS_TARGET_PHASE_ONLY} from '../EventSystemFlags';
+import {IS_EVENT_HANDLE_NON_MANAGED_NODE} from '../EventSystemFlags';
 import SyntheticAnimationEvent from '../SyntheticAnimationEvent';
 import SyntheticClipboardEvent from '../SyntheticClipboardEvent';
 import SyntheticFocusEvent from '../SyntheticFocusEvent';
@@ -50,7 +48,7 @@ function extractEvents(
   nativeEvent: AnyNativeEvent,
   nativeEventTarget: null | EventTarget,
   eventSystemFlags: EventSystemFlags,
-  targetContainer: null | EventTarget,
+  targetContainer: EventTarget,
 ): void {
   const reactName = topLevelEventsToReactNames.get(topLevelType);
   if (reactName === undefined) {
@@ -155,11 +153,9 @@ function extractEvents(
   const inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;
   if (
     enableCreateEventHandleAPI &&
-    eventSystemFlags !== undefined &&
-    eventSystemFlags & IS_TARGET_PHASE_ONLY &&
-    targetContainer != null
+    eventSystemFlags & IS_EVENT_HANDLE_NON_MANAGED_NODE
   ) {
-    accumulateEventHandleTargetListeners(
+    accumulateEventHandleNonManagedNodeListeners(
       dispatchQueue,
       event,
       targetContainer,

--- a/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
+++ b/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
@@ -12,15 +12,12 @@ import type {
   AnyNativeEvent,
   PluginName,
   LegacyPluginModule,
-  ModernPluginModule,
 } from './PluginModuleType';
 
 import invariant from 'shared/invariant';
 
 type NamesToPlugins = {
-  [key: PluginName]:
-    | LegacyPluginModule<AnyNativeEvent>
-    | ModernPluginModule<AnyNativeEvent>,
+  [key: PluginName]: LegacyPluginModule<AnyNativeEvent>,
   ...,
 };
 type EventPluginOrder = null | Array<PluginName>;
@@ -90,9 +87,7 @@ function recomputePluginOrdering(): void {
  */
 function publishEventForPlugin(
   dispatchConfig: DispatchConfig,
-  pluginModule:
-    | LegacyPluginModule<AnyNativeEvent>
-    | ModernPluginModule<AnyNativeEvent>,
+  pluginModule: LegacyPluginModule<AnyNativeEvent>,
   eventName: string,
 ): boolean {
   invariant(
@@ -136,9 +131,7 @@ function publishEventForPlugin(
  */
 function publishRegistrationName(
   registrationName: string,
-  pluginModule:
-    | LegacyPluginModule<AnyNativeEvent>
-    | ModernPluginModule<AnyNativeEvent>,
+  pluginModule: LegacyPluginModule<AnyNativeEvent>,
   eventName: string,
 ): void {
   invariant(
@@ -249,22 +242,5 @@ export function injectEventPluginsByName(
   }
   if (isOrderingDirty) {
     recomputePluginOrdering();
-  }
-}
-
-export function injectEventPlugins(
-  eventPlugins: [ModernPluginModule<AnyNativeEvent>],
-): void {
-  for (let i = 0; i < eventPlugins.length; i++) {
-    const pluginModule = eventPlugins[i];
-    plugins.push(pluginModule);
-    const publishedEvents = pluginModule.eventTypes;
-    for (const eventName in publishedEvents) {
-      publishEventForPlugin(
-        publishedEvents[eventName],
-        pluginModule,
-        eventName,
-      );
-    }
   }
 }

--- a/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
+++ b/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
@@ -34,31 +34,3 @@ export type LegacyPluginModule<NativeEvent> = {
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
 };
-
-export type DispatchQueueItemPhaseEntry = {|
-  instance: null | Fiber,
-  listener: Function,
-  currentTarget: EventTarget,
-|};
-
-export type DispatchQueueItemPhase = Array<DispatchQueueItemPhaseEntry>;
-
-export type DispatchQueueItem = {|
-  event: ReactSyntheticEvent,
-  phase: DispatchQueueItemPhase,
-|};
-
-export type DispatchQueue = Array<DispatchQueueItem>;
-
-export type ModernPluginModule<NativeEvent> = {
-  eventTypes: EventTypes,
-  extractEvents: (
-    dispatchQueue: DispatchQueue,
-    topLevelType: TopLevelType,
-    targetInst: null | Fiber,
-    nativeTarget: NativeEvent,
-    nativeEventTarget: null | EventTarget,
-    eventSystemFlags: number,
-    container: null | EventTarget,
-  ) => void,
-};


### PR DESCRIPTION
In order to make https://github.com/facebook/react/pull/19278 a bit smaller in terms of changes, this extracts some of the tidy up changes from that PR. https://github.com/facebook/react/pull/19278 should now only refer to the changes reflecting to moving away from capture phase events.