### PR TITLE
reference not add to dependencies if only its type is used as typeof arg

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6983,6 +6983,18 @@ const testsTypescript = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, setState] = React.useState<number>(0);
+
+          useEffect(() => {
+            const someNumber: typeof state = 2;
+            setState(prevState => prevState + someNumber);
+          }, [])
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -7212,6 +7224,76 @@ const testsTypescript = {
                   }, [props?.upperViewHeight]);
                 }
               `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, setState] = React.useState<number>(0);
+          
+          useEffect(() => {
+            const someNumber: typeof state = 2;
+            setState(prevState => prevState + someNumber + state);
+          }, [])
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'state'. " +
+            'Either include it or remove the dependency array. ' +
+            `You can also do a functional update 'setState(s => ...)' ` +
+            `if you only need 'state' in the 'setState' call.`,
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [state]',
+              output: normalizeIndent`
+              function MyComponent() {
+                const [state, setState] = React.useState<number>(0);
+                
+                useEffect(() => {
+                  const someNumber: typeof state = 2;
+                  setState(prevState => prevState + someNumber + state);
+                }, [state])
+              }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const [state, setState] = React.useState<number>(0);
+          
+          useMemo(() => {
+            const someNumber: typeof state = 2;
+            console.log(someNumber);
+          }, [state])
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has an unnecessary dependency: 'state'. " +
+            'Either exclude it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: []',
+              output: normalizeIndent`
+                function MyComponent() {
+                  const [state, setState] = React.useState<number>(0);
+                  
+                  useMemo(() => {
+                    const someNumber: typeof state = 2;
+                    console.log(someNumber);
+                  }, [])
+                }
+                `,
             },
           ],
         },

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -6995,6 +6995,18 @@ const testsTypescript = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function App() {
+          const foo = {x: 1};
+          React.useEffect(() => {
+            const bar = {x: 2};
+            const baz = bar as typeof foo;
+            console.log(baz);
+          }, []);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -7021,6 +7033,40 @@ const testsTypescript = {
                   useEffect(() => {
                     console.log(local);
                   }, [local]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function App() {
+          const foo = {x: 1};
+          const bar = {x: 2};
+          useEffect(() => {
+            const baz = bar as typeof foo;
+            console.log(baz);
+          }, []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'bar'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [bar]',
+              output: normalizeIndent`
+                function App() {
+                  const foo = {x: 1};
+                  const bar = {x: 2};
+                  useEffect(() => {
+                    const baz = bar as typeof foo;
+                    console.log(baz);
+                  }, [bar]);
                 }
               `,
             },
@@ -7233,7 +7279,7 @@ const testsTypescript = {
       code: normalizeIndent`
         function MyComponent() {
           const [state, setState] = React.useState<number>(0);
-          
+
           useEffect(() => {
             const someNumber: typeof state = 2;
             setState(prevState => prevState + someNumber + state);
@@ -7253,7 +7299,7 @@ const testsTypescript = {
               output: normalizeIndent`
               function MyComponent() {
                 const [state, setState] = React.useState<number>(0);
-                
+
                 useEffect(() => {
                   const someNumber: typeof state = 2;
                   setState(prevState => prevState + someNumber + state);
@@ -7269,7 +7315,7 @@ const testsTypescript = {
       code: normalizeIndent`
         function MyComponent() {
           const [state, setState] = React.useState<number>(0);
-          
+
           useMemo(() => {
             const someNumber: typeof state = 2;
             console.log(someNumber);
@@ -7287,7 +7333,7 @@ const testsTypescript = {
               output: normalizeIndent`
                 function MyComponent() {
                   const [state, setState] = React.useState<number>(0);
-                  
+
                   useMemo(() => {
                     const someNumber: typeof state = 2;
                     console.log(someNumber);

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -543,6 +543,10 @@ export default {
             });
           }
 
+          if (dependencyNode.parent.type === 'TSTypeQuery') {
+            continue;
+          }
+
           const def = reference.resolved.defs[0];
           if (def == null) {
             continue;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #18828 .

`react-exhaustive-deps` does not complain anymore about a missing dependency if its value is never used but its type is used as `typeof` argument.

Checking if a reference parent type has type `TSTypeQuery`, a reference is not added to dependencies.

## Test Plan


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added test to check the expected behavior and even that the dependency is required by `react-exhaustive-deps` if its type is used and its value too.