### PR TITLE
fix(act): Don't warn if an effect was not queued

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -380,6 +380,16 @@ function runActTests(label, render, unmount, rerender) {
             container,
           );
 
+          expect(Scheduler).toHaveYielded(['effect']);
+          expect(() => {
+            ReactDOM.render(
+              <React.StrictMode>
+                <Component />
+              </React.StrictMode>,
+              container,
+            );
+          }).toErrorDev([]);
+
           // Nothing scheduled so we should not have any unexpected errors regarding missing act();
           expect(Scheduler).toFlushAndYield([]);
         });

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -113,6 +113,31 @@ describe('ReactTestUtils.act()', () => {
         'An update to App ran an effect, but was not wrapped in act(...)',
       ]);
     });
+
+    // @gate experimental
+    it('does not warn on other effects', () => {
+      function Component(props) {
+        React.useLayoutEffect(() => {
+          Scheduler.unstable_yieldValue('layout');
+        });
+        React.useImperativeHandle(React.createRef(), () => {
+          Scheduler.unstable_yieldValue('imperative handle');
+        });
+        return null;
+      }
+
+      expect(() => {
+        const root = ReactDOM.unstable_createRoot(
+          document.createElement('div'),
+        );
+        root.render(<Component />);
+        // sanity check that effects were mounted
+        expect(Scheduler).toFlushAndYield(['layout', 'imperative handle']);
+        root.render(<Component />);
+        // sanity check that effects were updated
+        expect(Scheduler).toFlushAndYield(['layout', 'imperative handle']);
+      }).toErrorDev([]);
+    });
   });
 });
 

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -114,8 +114,7 @@ describe('ReactTestUtils.act()', () => {
       ]);
     });
 
-    // @gate experimental
-    it('does not warn on other effects', () => {
+    it('does not warn on other effects if root is strict', () => {
       function Component(props) {
         React.useLayoutEffect(() => {
           Scheduler.unstable_yieldValue('layout');
@@ -127,9 +126,9 @@ describe('ReactTestUtils.act()', () => {
       }
 
       expect(() => {
-        const root = ReactDOM.unstable_createRoot(
-          document.createElement('div'),
-        );
+        const root = ReactDOM.createRoot(document.createElement('div'), {
+          unstable_strictMode: true,
+        });
         root.render(<Component />);
         // confidence check that effects were mounted
         expect(Scheduler).toFlushAndYield(['layout', 'imperative handle']);
@@ -379,6 +378,7 @@ function runActTests(label, render, unmount, rerender) {
           expect(container.innerHTML).toBe('2');
         });
 
+        // @gate __DEV__
         it('does not warn on effects that were not queued', () => {
           function Component() {
             React.useEffect(() => {
@@ -387,8 +387,8 @@ function runActTests(label, render, unmount, rerender) {
             return null;
           }
 
-          ReactTestUtils.act(() => {
-            ReactDOM.render(
+          act(() => {
+            render(
               <React.StrictMode>
                 <Component />
               </React.StrictMode>,
@@ -398,16 +398,8 @@ function runActTests(label, render, unmount, rerender) {
 
           expect(Scheduler).toHaveYielded(['effect']);
 
-          ReactDOM.render(
-            <React.StrictMode>
-              <Component />
-            </React.StrictMode>,
-            container,
-          );
-
-          expect(Scheduler).toHaveYielded(['effect']);
           expect(() => {
-            ReactDOM.render(
+            rerender(
               <React.StrictMode>
                 <Component />
               </React.StrictMode>,

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -131,10 +131,10 @@ describe('ReactTestUtils.act()', () => {
           document.createElement('div'),
         );
         root.render(<Component />);
-        // sanity check that effects were mounted
+        // confidence check that effects were mounted
         expect(Scheduler).toFlushAndYield(['layout', 'imperative handle']);
         root.render(<Component />);
-        // sanity check that effects were updated
+        // confidence check that effects were updated
         expect(Scheduler).toFlushAndYield(['layout', 'imperative handle']);
       }).toErrorDev([]);
     });

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -353,6 +353,36 @@ function runActTests(label, render, unmount, rerender) {
 
           expect(container.innerHTML).toBe('2');
         });
+
+        it('does not warn on effects that were not queued', () => {
+          function Component() {
+            React.useEffect(() => {
+              Scheduler.unstable_yieldValue('effect');
+            }, []);
+            return null;
+          }
+
+          ReactTestUtils.act(() => {
+            ReactDOM.render(
+              <React.StrictMode>
+                <Component />
+              </React.StrictMode>,
+              container,
+            );
+          });
+
+          expect(Scheduler).toHaveYielded(['effect']);
+
+          ReactDOM.render(
+            <React.StrictMode>
+              <Component />
+            </React.StrictMode>,
+            container,
+          );
+
+          // Nothing scheduled so we should not have any unexpected errors regarding missing act();
+          expect(Scheduler).toFlushAndYield([]);
+        });
       });
     });
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1432,12 +1432,11 @@ function updateEffectImpl(fiberFlags, hookFlags, create, deps): void {
   }
 
   if (__DEV__) {
-    if (
-      (hookFlags & HookPassive) !== HookNoFlags &&
-      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
-      'undefined' !== typeof jest
-    ) {
-      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+    if ('undefined' !== typeof jest) {
+      if ((hookFlags & HookPassive) !== HookNoFlags) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+      }
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -71,6 +71,7 @@ import {
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
+  NoFlags as HookNoFlags,
 } from './ReactHookEffectTags';
 import {
   getWorkInProgressRoot,
@@ -1430,6 +1431,16 @@ function updateEffectImpl(fiberFlags, hookFlags, create, deps): void {
     }
   }
 
+  if (__DEV__) {
+    if (
+      (hookFlags & HookPassive) !== HookNoFlags &&
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      'undefined' !== typeof jest
+    ) {
+      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+    }
+  }
+
   currentlyRenderingFiber.flags |= fiberFlags;
 
   hook.memoizedState = pushEffect(
@@ -1475,12 +1486,6 @@ function updateEffect(
   create: () => (() => void) | void,
   deps: Array<mixed> | void | null,
 ): void {
-  if (__DEV__) {
-    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
-    if ('undefined' !== typeof jest) {
-      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
-    }
-  }
   return updateEffectImpl(PassiveEffect, HookPassive, create, deps);
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1432,12 +1432,11 @@ function updateEffectImpl(fiberFlags, hookFlags, create, deps): void {
   }
 
   if (__DEV__) {
-    if (
-      (hookFlags & HookPassive) !== HookNoFlags &&
-      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
-      'undefined' !== typeof jest
-    ) {
-      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+    if ('undefined' !== typeof jest) {
+      if ((hookFlags & HookPassive) !== HookNoFlags) {
+        warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+      }
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -71,6 +71,7 @@ import {
   HasEffect as HookHasEffect,
   Layout as HookLayout,
   Passive as HookPassive,
+  NoFlags as HookNoFlags,
 } from './ReactHookEffectTags';
 import {
   getWorkInProgressRoot,
@@ -1430,6 +1431,16 @@ function updateEffectImpl(fiberFlags, hookFlags, create, deps): void {
     }
   }
 
+  if (__DEV__) {
+    if (
+      (hookFlags & HookPassive) !== HookNoFlags &&
+      // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
+      'undefined' !== typeof jest
+    ) {
+      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
+    }
+  }
+
   currentlyRenderingFiber.flags |= fiberFlags;
 
   hook.memoizedState = pushEffect(
@@ -1475,12 +1486,6 @@ function updateEffect(
   create: () => (() => void) | void,
   deps: Array<mixed> | void | null,
 ): void {
-  if (__DEV__) {
-    // $FlowExpectedError - jest isn't a global, and isn't recognized outside of tests
-    if ('undefined' !== typeof jest) {
-      warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
-    }
-  }
   return updateEffectImpl(PassiveEffect, HookPassive, create, deps);
 }
 


### PR DESCRIPTION
## Summary

Closes #19318 

## Test Plan

- [x] build green
- [x] codesandbox in #19318 passes: https://codesandbox.io/s/missing-act-on-every-effect-forked-1iwp2?file=/src/index.test.js
- [x] use codesandbox build for an existing codebase where act warnings were enabled by setting `globalThis.jest = null`
