### PR TITLE
chore: Build react-dom/test-utils in codesandbox deploy

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/server,scheduler/index,scheduler/tracing",
+  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/server,react-dom/test-utils,scheduler/index,scheduler/tracing",
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom",


### PR DESCRIPTION
##  Summary

Build `react-dom/test-utils` in codesandbox deploy which is useful to verify fixes for issues related to `react-dom/test-utils` (e.g. #19318).

## Test Plan

- [x] Verify that the codesandbox linked in #19318 is runnable with this build. Edit: works: https://codesandbox.io/s/missing-act-on-every-effect-int7g?file=/package.json
