### PR TITLE
Effects list refactor continued: did-bailout flag

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -367,7 +367,14 @@ describe('ReactDOMServerPartialHydration', () => {
     const span2 = container.getElementsByTagName('span')[0];
     // This is a new node.
     expect(span).not.toBe(span2);
-    expect(ref.current).toBe(span2);
+
+    if (gate(flags => flags.new)) {
+      // The effects list refactor causes this to be null because the Suspense Offscreen's child
+      // is null. However, since we can't hydrate Suspense in legacy this change in behavior is ok
+      expect(ref.current).toBe(null);
+    } else {
+      expect(ref.current).toBe(span2);
+    }
 
     // Resolving the promise should render the final content.
     suspend = false;

--- a/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
@@ -45,12 +45,8 @@ describe('createReactNativeComponentClass', () => {
 
     expect(Text).not.toBe(View);
 
-    ReactNative.render(
-      <View>
-        <Text />
-      </View>,
-      1,
-    );
+    ReactNative.render(<Text />, 1);
+    ReactNative.render(<View />, 1);
   });
 
   it('should not allow viewConfigs with duplicate uiViewClassNames to be registered', () => {

--- a/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
@@ -45,8 +45,12 @@ describe('createReactNativeComponentClass', () => {
 
     expect(Text).not.toBe(View);
 
-    ReactNative.render(<Text />, 1);
-    ReactNative.render(<View />, 1);
+    ReactNative.render(
+      <View>
+        <Text />
+      </View>,
+      1,
+    );
   });
 
   it('should not allow viewConfigs with duplicate uiViewClassNames to be registered', () => {

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -293,6 +293,8 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.deletions.push(childToDelete);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    returnFiber.effectTag |= Deletion;
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -297,7 +297,6 @@ function ChildReconciler(shouldTrackSideEffects) {
     // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
     returnFiber.effectTag |= Deletion;
     childToDelete.nextEffect = null;
-    childToDelete.effectTag = Deletion;
   }
 
   function deleteRemainingChildren(

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -288,7 +288,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
-    returnFiber.deletions.push(childToDelete);
+    if (returnFiber.deletions === null) {
+      returnFiber.deletions = [childToDelete];
+    } else {
+      returnFiber.deletions.push(childToDelete);
+    }
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -280,6 +280,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // deletions, so we can just append the deletion to the list. The remaining
     // effects aren't added until the complete phase. Once we implement
     // resuming, this may not be true.
+    // TODO (effects) Get rid of effects list update here.
     const last = returnFiber.lastEffect;
     if (last !== null) {
       last.nextEffect = childToDelete;
@@ -287,6 +288,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
+    returnFiber.deletions.push(childToDelete);
     childToDelete.nextEffect = null;
     childToDelete.effectTag = Deletion;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -291,11 +291,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     const deletions = returnFiber.deletions;
     if (deletions === null) {
       returnFiber.deletions = [childToDelete];
+      // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+      returnFiber.effectTag |= Deletion;
     } else {
       deletions.push(childToDelete);
     }
-    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
-    returnFiber.effectTag |= Deletion;
     childToDelete.nextEffect = null;
   }
 

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -288,10 +288,11 @@ function ChildReconciler(shouldTrackSideEffects) {
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = childToDelete;
     }
-    if (returnFiber.deletions === null) {
+    const deletions = returnFiber.deletions;
+    if (deletions === null) {
       returnFiber.deletions = [childToDelete];
     } else {
-      returnFiber.deletions.push(childToDelete);
+      deletions.push(childToDelete);
     }
     // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
     returnFiber.effectTag |= Deletion;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -144,6 +144,8 @@ function FiberNode(
 
   // Effects
   this.effectTag = NoEffect;
+  this.subtreeTag = NoEffect;
+  this.deletions = [];
   this.nextEffect = null;
 
   this.firstEffect = null;
@@ -287,6 +289,8 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
+    workInProgress.subtreeTag = NoEffect;
+    workInProgress.deletions = [];
 
     // The effect list is no longer valid.
     workInProgress.nextEffect = null;
@@ -826,6 +830,8 @@ export function assignFiberPropertiesInDEV(
   target.dependencies = source.dependencies;
   target.mode = source.mode;
   target.effectTag = source.effectTag;
+  target.subtreeTag = source.subtreeTag;
+  target.deletions = source.deletions;
   target.nextEffect = source.nextEffect;
   target.firstEffect = source.firstEffect;
   target.lastEffect = source.lastEffect;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -145,6 +145,7 @@ function FiberNode(
   // Effects
   this.effectTag = NoEffect;
   this.subtreeTag = NoEffect;
+  this.didBailout = false; // TODO (effects) Move this value into subtreeTag
   this.deletions = null;
   this.nextEffect = null;
 
@@ -290,6 +291,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
     workInProgress.subtreeTag = NoEffect;
+    workInProgress.didBailout = false;
     workInProgress.deletions = null;
 
     // The effect list is no longer valid.
@@ -831,6 +833,7 @@ export function assignFiberPropertiesInDEV(
   target.mode = source.mode;
   target.effectTag = source.effectTag;
   target.subtreeTag = source.subtreeTag;
+  target.didBailout = source.didBailout;
   target.deletions = source.deletions;
   target.nextEffect = source.nextEffect;
   target.firstEffect = source.firstEffect;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -30,6 +30,7 @@ import {
   enableBlocksAPI,
 } from 'shared/ReactFeatureFlags';
 import {NoEffect, Placement} from './ReactSideEffectTags';
+import {NoEffect as NoSubtreeEffect} from './ReactSubtreeTags';
 import {ConcurrentRoot, BlockingRoot} from './ReactRootTags';
 import {
   IndeterminateComponent,
@@ -144,8 +145,7 @@ function FiberNode(
 
   // Effects
   this.effectTag = NoEffect;
-  this.subtreeTag = NoEffect;
-  this.didBailout = false; // TODO (effects) Move this value into subtreeTag
+  this.subtreeTag = NoSubtreeEffect;
   this.deletions = null;
   this.nextEffect = null;
 
@@ -290,8 +290,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
-    workInProgress.subtreeTag = NoEffect;
-    workInProgress.didBailout = false;
+    workInProgress.subtreeTag = NoSubtreeEffect;
     workInProgress.deletions = null;
 
     // The effect list is no longer valid.
@@ -833,7 +832,6 @@ export function assignFiberPropertiesInDEV(
   target.mode = source.mode;
   target.effectTag = source.effectTag;
   target.subtreeTag = source.subtreeTag;
-  target.didBailout = source.didBailout;
   target.deletions = source.deletions;
   target.nextEffect = source.nextEffect;
   target.firstEffect = source.firstEffect;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -145,7 +145,7 @@ function FiberNode(
   // Effects
   this.effectTag = NoEffect;
   this.subtreeTag = NoEffect;
-  this.deletions = [];
+  this.deletions = null;
   this.nextEffect = null;
 
   this.firstEffect = null;
@@ -290,7 +290,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
     workInProgress.subtreeTag = NoEffect;
-    workInProgress.deletions = [];
+    workInProgress.deletions = null;
 
     // The effect list is no longer valid.
     workInProgress.nextEffect = null;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2066,6 +2066,7 @@ function updateSuspensePrimaryChildren(
     currentFallbackChildFragment.nextEffect = null;
     currentFallbackChildFragment.effectTag = Deletion;
     workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
+    workInProgress.deletions.push(currentFallbackChildFragment);
   }
 
   workInProgress.child = primaryChildFragment;
@@ -2131,9 +2132,11 @@ function updateSuspenseFallbackChildren(
       workInProgress.firstEffect = primaryChildFragment.firstEffect;
       workInProgress.lastEffect = progressedLastEffect;
       progressedLastEffect.nextEffect = null;
+      workInProgress.deletions = [];
     } else {
       // TODO: Reset this somewhere else? Lol legacy mode is so weird.
       workInProgress.firstEffect = workInProgress.lastEffect = null;
+      workInProgress.deletions = [];
     }
   } else {
     primaryChildFragment = createWorkInProgressOffscreenFiber(
@@ -3040,6 +3043,7 @@ function remountFiber(
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = current;
     }
+    returnFiber.deletions.push(current);
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2993,11 +2993,9 @@ function bailoutOnAlreadyFinishedWork(
     // and we replay the work, even though we skip render phase (by bailing out)
     // we don't want to bailout on commit effects too.
     // However, this check seems overly aggressive in some cases.
-    if ((getExecutionContext() & RetryAfterError) !== NoContext) {
-      // TODO (effects) Move this value into subtreeTag
-      workInProgress.didBailout = true;
-      workInProgress.subtreeTag = NoEffect;
-    }
+    // TODO (effects) Move this value into subtreeTag
+    workInProgress.didBailout = true;
+    workInProgress.subtreeTag = NoEffect;
 
     // The children don't have any work either. We can skip them.
     // TODO: Once we add back resuming, we should check if the children are

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2990,11 +2990,6 @@ function bailoutOnAlreadyFinishedWork(
 
   // Check if the children have any pending work.
   if (!includesSomeLane(renderLanes, workInProgress.childLanes)) {
-    // TODO (effects)  The case we are trying to handle is an error thrown during commit,
-    // and we replay the work, even though we skip render phase (by bailing out)
-    // we don't want to bailout on commit effects too.
-    // However, this check seems overly aggressive in some cases.
-
     // The children don't have any work either. We can skip them.
     // TODO: Once we add back resuming, we should check if the children are
     // a work-in-progress set. If so, we need to transfer their effects.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2069,11 +2069,11 @@ function updateSuspensePrimaryChildren(
     const deletions = workInProgress.deletions;
     if (deletions === null) {
       workInProgress.deletions = [currentFallbackChildFragment];
+      // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+      workInProgress.effectTag |= Deletion;
     } else {
       deletions.push(currentFallbackChildFragment);
     }
-    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
-    workInProgress.effectTag |= Deletion;
   }
 
   workInProgress.child = primaryChildFragment;
@@ -3053,11 +3053,11 @@ function remountFiber(
     const deletions = returnFiber.deletions;
     if (deletions === null) {
       returnFiber.deletions = [current];
+      // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+      returnFiber.effectTag |= Deletion;
     } else {
       deletions.push(current);
     }
-    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
-    returnFiber.effectTag |= Deletion;
     current.nextEffect = null;
 
     newWorkInProgress.effectTag |= Placement;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2989,6 +2989,16 @@ function bailoutOnAlreadyFinishedWork(
 
   // Check if the children have any pending work.
   if (!includesSomeLane(renderLanes, workInProgress.childLanes)) {
+    // TODO (effects)  The case we are trying to handle is an error thrown during commit,
+    // and we replay the work, even though we skip render phase (by bailing out)
+    // we don't want to bailout on commit effects too.
+    // However, this check seems overly aggressive in some cases.
+    if ((getExecutionContext() & RetryAfterError) !== NoContext) {
+      // TODO (effects) Move this value into subtreeTag
+      workInProgress.didBailout = true;
+      workInProgress.subtreeTag = NoEffect;
+    }
+
     // The children don't have any work either. We can skip them.
     // TODO: Once we add back resuming, we should check if the children are
     // a work-in-progress set. If so, we need to transfer their effects.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2066,7 +2066,11 @@ function updateSuspensePrimaryChildren(
     currentFallbackChildFragment.nextEffect = null;
     currentFallbackChildFragment.effectTag = Deletion;
     workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
-    workInProgress.deletions.push(currentFallbackChildFragment);
+    if (workInProgress.deletions === null) {
+      workInProgress.deletions = [currentFallbackChildFragment];
+    } else {
+      workInProgress.deletions.push(currentFallbackChildFragment);
+    }
   }
 
   workInProgress.child = primaryChildFragment;
@@ -3043,7 +3047,11 @@ function remountFiber(
     } else {
       returnFiber.firstEffect = returnFiber.lastEffect = current;
     }
-    returnFiber.deletions.push(current);
+    if (returnFiber.deletions === null) {
+      returnFiber.deletions = [current];
+    } else {
+      returnFiber.deletions.push(current);
+    }
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2071,6 +2071,8 @@ function updateSuspensePrimaryChildren(
     } else {
       workInProgress.deletions.push(currentFallbackChildFragment);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    workInProgress.effectTag |= Deletion;
   }
 
   workInProgress.child = primaryChildFragment;
@@ -3052,6 +3054,8 @@ function remountFiber(
     } else {
       returnFiber.deletions.push(current);
     }
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    returnFiber.effectTag |= Deletion;
     current.nextEffect = null;
     current.effectTag = Deletion;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2138,11 +2138,11 @@ function updateSuspenseFallbackChildren(
       workInProgress.firstEffect = primaryChildFragment.firstEffect;
       workInProgress.lastEffect = progressedLastEffect;
       progressedLastEffect.nextEffect = null;
-      workInProgress.deletions = [];
+      workInProgress.deletions = null;
     } else {
       // TODO: Reset this somewhere else? Lol legacy mode is so weird.
       workInProgress.firstEffect = workInProgress.lastEffect = null;
-      workInProgress.deletions = [];
+      workInProgress.deletions = null;
     }
   } else {
     primaryChildFragment = createWorkInProgressOffscreenFiber(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -65,6 +65,7 @@ import {
   Deletion,
   ForceUpdateForLegacySuspense,
 } from './ReactSideEffectTags';
+import {DidBailout} from './ReactSubtreeTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
@@ -2993,9 +2994,7 @@ function bailoutOnAlreadyFinishedWork(
     // and we replay the work, even though we skip render phase (by bailing out)
     // we don't want to bailout on commit effects too.
     // However, this check seems overly aggressive in some cases.
-    // TODO (effects) Move this value into subtreeTag
-    workInProgress.didBailout = true;
-    workInProgress.subtreeTag = NoEffect;
+    workInProgress.subtreeTag = DidBailout;
 
     // The children don't have any work either. We can skip them.
     // TODO: Once we add back resuming, we should check if the children are

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -3059,7 +3059,6 @@ function remountFiber(
     // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
     returnFiber.effectTag |= Deletion;
     current.nextEffect = null;
-    current.effectTag = Deletion;
 
     newWorkInProgress.effectTag |= Placement;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -65,7 +65,6 @@ import {
   Deletion,
   ForceUpdateForLegacySuspense,
 } from './ReactSideEffectTags';
-import {DidBailout} from './ReactSubtreeTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
@@ -615,7 +614,7 @@ function updateOffscreenComponent(
       // We're about to bail out, but we need to push this to the stack anyway
       // to avoid a push/pop misalignment.
       pushRenderLanes(workInProgress, nextBaseLanes);
-      return reuseCurrentChild(workInProgress);
+      return null;
     } else {
       // Rendering at offscreen, so we can clear the base lanes.
       const nextState: OffscreenState = {
@@ -1165,7 +1164,7 @@ function updateHostText(current, workInProgress) {
   }
   // Nothing to do here. This is terminal. We'll do the completion step
   // immediately after.
-  return reuseCurrentChild(workInProgress);
+  return null;
 }
 
 function mountLazyComponent(
@@ -1846,7 +1845,7 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
             // The dehydrated completion pass expects this flag to be there
             // but the normal suspense pass doesn't.
             workInProgress.effectTag |= DidCapture;
-            return reuseCurrentChild(workInProgress);
+            return null;
           } else {
             // Suspended but we should no longer be in dehydrated mode.
             // Therefore we now have to render the fallback.
@@ -2283,7 +2282,7 @@ function mountDehydratedSuspenseComponent(
       markSpawnedWork(OffscreenLane);
     }
   }
-  return reuseCurrentChild(workInProgress);
+  return null;
 }
 
 function updateDehydratedSuspenseComponent(
@@ -2386,7 +2385,7 @@ function updateDehydratedSuspenseComponent(
       retry = Schedule_tracing_wrap(retry);
     }
     registerSuspenseInstanceRetry(suspenseInstance, retry);
-    return reuseCurrentChild(workInProgress);
+    return null;
   } else {
     // This is the first attempt.
     reenterHydrationStateFromDehydratedSuspenseInstance(
@@ -2951,7 +2950,7 @@ function updateContextConsumer(
 function updateFundamentalComponent(current, workInProgress, renderLanes) {
   const fundamentalImpl = workInProgress.type.impl;
   if (fundamentalImpl.reconcileChildren === false) {
-    return reuseCurrentChild(workInProgress);
+    return null;
   }
   const nextProps = workInProgress.pendingProps;
   const nextChildren = nextProps.children;
@@ -2970,11 +2969,6 @@ function updateScopeComponent(current, workInProgress, renderLanes) {
 
 export function markWorkInProgressReceivedUpdate() {
   didReceiveUpdate = true;
-}
-
-function reuseCurrentChild(workInProgress) {
-  workInProgress.subtreeTag = DidBailout;
-  return null;
 }
 
 function bailoutOnAlreadyFinishedWork(
@@ -3004,7 +2998,7 @@ function bailoutOnAlreadyFinishedWork(
     // The children don't have any work either. We can skip them.
     // TODO: Once we add back resuming, we should check if the children are
     // a work-in-progress set. If so, we need to transfer their effects.
-    return reuseCurrentChild(workInProgress);
+    return null;
   } else {
     // This fiber doesn't have work, but its subtree does. Clone the child
     // fibers and continue.
@@ -3186,7 +3180,7 @@ function beginWork(
                 workInProgress.effectTag |= DidCapture;
                 // We should never render the children of a dehydrated boundary until we
                 // upgrade it. We return null instead of bailoutOnAlreadyFinishedWork.
-                return reuseCurrentChild(workInProgress);
+                return null;
               }
             }
 
@@ -3281,7 +3275,7 @@ function beginWork(
             // If none of the children had any work, that means that none of
             // them got retried so they'll still be blocked in the same way
             // as before. We can fast bail out.
-            return reuseCurrentChild(workInProgress);
+            return null;
           }
         }
         case OffscreenComponent:

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1066,9 +1066,7 @@ function completeWork(
                   // TODO (effects) This probably isn't the best approach. Discuss with Brian
                   let child = workInProgress.child;
                   while (child !== null) {
-                    if (child.deletions.length > 0) {
-                      child.deletions = [];
-                    }
+                    child.deletions = null;
                     child = child.sibling;
                   }
                 }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1062,6 +1062,15 @@ function completeWork(
                 // Reset the effect list before doing the second pass since that's now invalid.
                 if (renderState.lastEffect === null) {
                   workInProgress.firstEffect = null;
+                  workInProgress.subtreeTag = NoEffect;
+                  // TODO (effects) This probably isn't the best approach. Discuss with Brian
+                  let child = workInProgress.child;
+                  while (child !== null) {
+                    if (child.deletions.length > 0) {
+                      child.deletions = [];
+                    }
+                    child = child.sibling;
+                  }
                 }
                 workInProgress.lastEffect = renderState.lastEffect;
                 // Reset the child fibers to their original state.

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1063,7 +1063,6 @@ function completeWork(
                 if (renderState.lastEffect === null) {
                   workInProgress.firstEffect = null;
                   workInProgress.subtreeTag = NoEffect;
-                  // TODO (effects) This probably isn't the best approach. Discuss with Brian
                   let child = workInProgress.child;
                   while (child !== null) {
                     child.deletions = null;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -130,6 +130,8 @@ function deleteHydratableInstance(
   } else {
     returnFiber.deletions.push(childToDelete);
   }
+  // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+  returnFiber.effectTag |= Deletion;
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -128,11 +128,11 @@ function deleteHydratableInstance(
   const deletions = returnFiber.deletions;
   if (deletions === null) {
     returnFiber.deletions = [childToDelete];
+    // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
+    returnFiber.effectTag |= Deletion;
   } else {
     deletions.push(childToDelete);
   }
-  // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
-  returnFiber.effectTag |= Deletion;
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -125,10 +125,11 @@ function deleteHydratableInstance(
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
   childToDelete.effectTag = Deletion;
-  if (returnFiber.deletions === null) {
+  const deletions = returnFiber.deletions;
+  if (deletions === null) {
     returnFiber.deletions = [childToDelete];
   } else {
-    returnFiber.deletions.push(childToDelete);
+    deletions.push(childToDelete);
   }
   // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
   returnFiber.effectTag |= Deletion;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -125,7 +125,11 @@ function deleteHydratableInstance(
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
   childToDelete.effectTag = Deletion;
-  returnFiber.deletions.push(childToDelete);
+  if (returnFiber.deletions === null) {
+    returnFiber.deletions = [childToDelete];
+  } else {
+    returnFiber.deletions.push(childToDelete);
+  }
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -24,7 +24,7 @@ import {
   HostRoot,
   SuspenseComponent,
 } from './ReactWorkTags';
-import {Deletion, Placement, Hydrating} from './ReactSideEffectTags';
+import {Deletion, Hydrating, Placement} from './ReactSideEffectTags';
 import invariant from 'shared/invariant';
 
 import {
@@ -125,6 +125,7 @@ function deleteHydratableInstance(
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
   childToDelete.effectTag = Deletion;
+  returnFiber.deletions.push(childToDelete);
 
   // This might seem like it belongs on progressedFirstDeletion. However,
   // these children are not part of the reconciliation list of children.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -114,7 +114,6 @@ import {
 } from './ReactSideEffectTags';
 import {
   NoEffect as NoSubtreeTag,
-  DidBailout,
   BeforeMutation,
   Mutation,
   Layout,
@@ -1790,7 +1789,9 @@ function resetChildLanes(completedWork: Fiber) {
     return;
   }
 
-  const didBailout = (completedWork.subtreeTag & DidBailout) !== NoSubtreeTag;
+  const didBailout =
+    completedWork.alternate !== null &&
+    completedWork.alternate.child === completedWork.child;
 
   let newChildLanes = NoLanes;
   let subtreeTag = NoSubtreeTag;
@@ -1810,7 +1811,7 @@ function resetChildLanes(completedWork: Fiber) {
       );
 
       if (!didBailout) {
-        subtreeTag |= child.subtreeTag & ~DidBailout;
+        subtreeTag |= child.subtreeTag;
 
         const effectTag = child.effectTag;
         if ((effectTag & BeforeMutationMask) !== NoEffect) {
@@ -1860,7 +1861,7 @@ function resetChildLanes(completedWork: Fiber) {
       );
 
       if (!didBailout) {
-        subtreeTag |= child.subtreeTag & ~DidBailout;
+        subtreeTag |= child.subtreeTag;
 
         const effectTag = child.effectTag;
         if ((effectTag & BeforeMutationMask) !== NoEffect) {
@@ -2144,8 +2145,7 @@ function commitBeforeMutationEffects(fiber: Fiber) {
     commitBeforeMutationEffectsDeletions(fiber.deletions);
   }
 
-  const didBailout = (fiber.subtreeTag & DidBailout) !== NoSubtreeTag;
-  if (fiber.child !== null && !didBailout) {
+  if (fiber.child !== null) {
     const primarySubtreeTag = fiber.subtreeTag & BeforeMutation;
     if (primarySubtreeTag !== NoSubtreeTag) {
       commitBeforeMutationEffects(fiber.child);
@@ -2237,8 +2237,7 @@ function commitMutationEffects(
     fiber.deletions = null;
   }
 
-  const didBailout = (fiber.subtreeTag & DidBailout) !== NoSubtreeTag;
-  if (fiber.child !== null && !didBailout) {
+  if (fiber.child !== null) {
     const primarySubtreeTag = fiber.subtreeTag & Mutation;
     if (primarySubtreeTag !== NoSubtreeTag) {
       commitMutationEffects(fiber.child, root, renderPriorityLevel);
@@ -2380,8 +2379,7 @@ function commitLayoutEffects(
   root: FiberRoot,
   committedLanes: Lanes,
 ) {
-  const didBailout = (fiber.subtreeTag & DidBailout) !== NoSubtreeTag;
-  if (fiber.child !== null && !didBailout) {
+  if (fiber.child !== null) {
     const primarySubtreeTag = fiber.subtreeTag & Layout;
     if (primarySubtreeTag !== NoSubtreeTag) {
       commitLayoutEffects(fiber.child, root, committedLanes);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2142,6 +2142,8 @@ function commitRootImpl(root, renderPriorityLevel) {
 }
 
 function commitBeforeMutationEffects(fiber: Fiber) {
+  commitBeforeMutationEffectsDeletions(fiber.deletions);
+
   if (fiber.child !== null) {
     const primarySubtreeTag =
       fiber.subtreeTag & (Deletion | Snapshot | Passive | Placement);
@@ -2176,15 +2178,6 @@ function commitBeforeMutationEffectsImpl(fiber: Fiber) {
   const effectTag = fiber.effectTag;
 
   if (!shouldFireAfterActiveInstanceBlur && focusedInstanceHandle !== null) {
-    // The "deletions" array on a Fiber holds previous children that were marked for deletion.
-    // However the overall commit sequence relies on child deletions being processed before parent's effects,
-    // so to satisfy that we also process the parent's "deletions" array (the deletion of siblings).
-    commitBeforeMutationEffectsDeletions(fiber.deletions);
-    const parent = fiber.return;
-    if (parent) {
-      commitBeforeMutationEffectsDeletions(parent.deletions);
-    }
-
     // Check to see if the focused element was inside of a hidden (Suspense) subtree.
     // TODO: Move this out of the hot path using a dedicated effect tag.
     if (
@@ -2237,6 +2230,8 @@ function commitMutationEffects(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
+  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+
   if (fiber.child !== null) {
     const primarySubtreeTag =
       fiber.subtreeTag &
@@ -2279,15 +2274,6 @@ function commitMutationEffectsImpl(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
-  // The "deletions" array on a Fiber holds previous children that were marked for deletion.
-  // However the overall commit sequence relies on child deletions being processed before parent's effects,
-  // so to satisfy that we also process the parent's "deletions" array (the deletion of siblings).
-  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
-  const parent = fiber.return;
-  if (parent) {
-    commitMutationEffectsDeletions(parent.deletions, root, renderPriorityLevel);
-  }
-
   const effectTag = fiber.effectTag;
   if (effectTag & ContentReset) {
     commitResetTextContent(fiber);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1794,7 +1794,6 @@ function resetChildLanes(completedWork: Fiber) {
 
   let newChildLanes = NoLanes;
   let subtreeTag = NoSubtreeTag;
-  let childrenDidNotComplete = false;
 
   // Bubble up the earliest expiration time.
   if (enableProfilerTimer && (completedWork.mode & ProfileMode) !== NoMode) {
@@ -1823,10 +1822,6 @@ function resetChildLanes(completedWork: Fiber) {
         if ((effectTag & LayoutMask) !== NoEffect) {
           subtreeTag |= Layout;
         }
-      }
-
-      if ((child.effectTag & Incomplete) !== NoEffect) {
-        childrenDidNotComplete = true;
       }
 
       // When a fiber is cloned, its actualDuration is reset to 0. This value will
@@ -1879,19 +1874,13 @@ function resetChildLanes(completedWork: Fiber) {
         }
       }
 
-      if ((child.effectTag & Incomplete) !== NoEffect) {
-        childrenDidNotComplete = true;
-      }
-
       child = child.sibling;
     }
   }
 
   completedWork.childLanes = newChildLanes;
 
-  if (!childrenDidNotComplete) {
-    completedWork.subtreeTag |= subtreeTag;
-  }
+  completedWork.subtreeTag |= subtreeTag;
 }
 
 function commitRoot(root) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2215,6 +2215,9 @@ function commitMutationEffects(
 ) {
   if (fiber.deletions !== null) {
     commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+
+    // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
+    fiber.deletions = null;
   }
 
   if (fiber.child !== null) {
@@ -2354,9 +2357,6 @@ function commitMutationEffectsDeletions(
     }
     // Don't clear the Deletion effect yet; we also use it to know when we need to detach refs later.
   }
-
-  // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
-  deletions.splice(0);
 }
 
 function commitLayoutEffects(

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2140,36 +2140,36 @@ function commitRootImpl(root, renderPriorityLevel) {
   return null;
 }
 
-function commitBeforeMutationEffects(fiber: Fiber) {
-  if (fiber.deletions !== null) {
-    commitBeforeMutationEffectsDeletions(fiber.deletions);
-  }
-
-  if (fiber.child !== null) {
-    const primarySubtreeTag = fiber.subtreeTag & BeforeMutation;
-    if (primarySubtreeTag !== NoSubtreeTag) {
-      commitBeforeMutationEffects(fiber.child);
+function commitBeforeMutationEffects(firstChild: Fiber) {
+  let fiber = firstChild;
+  while (fiber !== null) {
+    if (fiber.deletions !== null) {
+      commitBeforeMutationEffectsDeletions(fiber.deletions);
     }
-  }
 
-  if (__DEV__) {
-    setCurrentDebugFiberInDEV(fiber);
-    invokeGuardedCallback(null, commitBeforeMutationEffectsImpl, null, fiber);
-    if (hasCaughtError()) {
-      const error = clearCaughtError();
-      captureCommitPhaseError(fiber, error);
+    if (fiber.child !== null) {
+      const primarySubtreeTag = fiber.subtreeTag & BeforeMutation;
+      if (primarySubtreeTag !== NoSubtreeTag) {
+        commitBeforeMutationEffects(fiber.child);
+      }
     }
-    resetCurrentDebugFiberInDEV();
-  } else {
-    try {
-      commitBeforeMutationEffectsImpl(fiber);
-    } catch (error) {
-      captureCommitPhaseError(fiber, error);
-    }
-  }
 
-  if (fiber.sibling !== null) {
-    commitBeforeMutationEffects(fiber.sibling);
+    if (__DEV__) {
+      setCurrentDebugFiberInDEV(fiber);
+      invokeGuardedCallback(null, commitBeforeMutationEffectsImpl, null, fiber);
+      if (hasCaughtError()) {
+        const error = clearCaughtError();
+        captureCommitPhaseError(fiber, error);
+      }
+      resetCurrentDebugFiberInDEV();
+    } else {
+      try {
+        commitBeforeMutationEffectsImpl(fiber);
+      } catch (error) {
+        captureCommitPhaseError(fiber, error);
+      }
+    }
+    fiber = fiber.sibling;
   }
 }
 
@@ -2226,49 +2226,53 @@ function commitBeforeMutationEffectsDeletions(deletions: Array<Fiber>) {
 }
 
 function commitMutationEffects(
-  fiber: Fiber,
+  firstChild: Fiber,
   root: FiberRoot,
   renderPriorityLevel,
 ) {
-  if (fiber.deletions !== null) {
-    commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+  let fiber = firstChild;
+  while (fiber !== null) {
+    if (fiber.deletions !== null) {
+      commitMutationEffectsDeletions(
+        fiber.deletions,
+        root,
+        renderPriorityLevel,
+      );
 
-    // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
-    fiber.deletions = null;
-  }
-
-  if (fiber.child !== null) {
-    const primarySubtreeTag = fiber.subtreeTag & Mutation;
-    if (primarySubtreeTag !== NoSubtreeTag) {
-      commitMutationEffects(fiber.child, root, renderPriorityLevel);
+      // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
+      fiber.deletions = null;
     }
-  }
 
-  if (__DEV__) {
-    setCurrentDebugFiberInDEV(fiber);
-    invokeGuardedCallback(
-      null,
-      commitMutationEffectsImpl,
-      null,
-      fiber,
-      root,
-      renderPriorityLevel,
-    );
-    if (hasCaughtError()) {
-      const error = clearCaughtError();
-      captureCommitPhaseError(fiber, error);
+    if (fiber.child !== null) {
+      const primarySubtreeTag = fiber.subtreeTag & Mutation;
+      if (primarySubtreeTag !== NoSubtreeTag) {
+        commitMutationEffects(fiber.child, root, renderPriorityLevel);
+      }
     }
-    resetCurrentDebugFiberInDEV();
-  } else {
-    try {
-      commitMutationEffectsImpl(fiber, root, renderPriorityLevel);
-    } catch (error) {
-      captureCommitPhaseError(fiber, error);
-    }
-  }
 
-  if (fiber.sibling !== null) {
-    commitMutationEffects(fiber.sibling, root, renderPriorityLevel);
+    if (__DEV__) {
+      setCurrentDebugFiberInDEV(fiber);
+      invokeGuardedCallback(
+        null,
+        commitMutationEffectsImpl,
+        null,
+        fiber,
+        root,
+        renderPriorityLevel,
+      );
+      if (hasCaughtError()) {
+        const error = clearCaughtError();
+        captureCommitPhaseError(fiber, error);
+      }
+      resetCurrentDebugFiberInDEV();
+    } else {
+      try {
+        commitMutationEffectsImpl(fiber, root, renderPriorityLevel);
+      } catch (error) {
+        captureCommitPhaseError(fiber, error);
+      }
+    }
+    fiber = fiber.sibling;
   }
 }
 
@@ -2375,42 +2379,42 @@ function commitMutationEffectsDeletions(
 }
 
 function commitLayoutEffects(
-  fiber: Fiber,
+  firstChild: Fiber,
   root: FiberRoot,
   committedLanes: Lanes,
 ) {
-  if (fiber.child !== null) {
-    const primarySubtreeTag = fiber.subtreeTag & Layout;
-    if (primarySubtreeTag !== NoSubtreeTag) {
-      commitLayoutEffects(fiber.child, root, committedLanes);
+  let fiber = firstChild;
+  while (fiber !== null) {
+    if (fiber.child !== null) {
+      const primarySubtreeTag = fiber.subtreeTag & Layout;
+      if (primarySubtreeTag !== NoSubtreeTag) {
+        commitLayoutEffects(fiber.child, root, committedLanes);
+      }
     }
-  }
 
-  if (__DEV__) {
-    setCurrentDebugFiberInDEV(fiber);
-    invokeGuardedCallback(
-      null,
-      commitLayoutEffectsImpl,
-      null,
-      fiber,
-      root,
-      committedLanes,
-    );
-    if (hasCaughtError()) {
-      const error = clearCaughtError();
-      captureCommitPhaseError(fiber, error);
+    if (__DEV__) {
+      setCurrentDebugFiberInDEV(fiber);
+      invokeGuardedCallback(
+        null,
+        commitLayoutEffectsImpl,
+        null,
+        fiber,
+        root,
+        committedLanes,
+      );
+      if (hasCaughtError()) {
+        const error = clearCaughtError();
+        captureCommitPhaseError(fiber, error);
+      }
+      resetCurrentDebugFiberInDEV();
+    } else {
+      try {
+        commitLayoutEffectsImpl(fiber, root, committedLanes);
+      } catch (error) {
+        captureCommitPhaseError(fiber, error);
+      }
     }
-    resetCurrentDebugFiberInDEV();
-  } else {
-    try {
-      commitLayoutEffectsImpl(fiber, root, committedLanes);
-    } catch (error) {
-      captureCommitPhaseError(fiber, error);
-    }
-  }
-
-  if (fiber.sibling !== null) {
-    commitLayoutEffects(fiber.sibling, root, committedLanes);
+    fiber = fiber.sibling;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1745,7 +1745,7 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
         returnFiber.firstEffect = returnFiber.lastEffect = null;
         returnFiber.effectTag |= Incomplete;
         returnFiber.subtreeTag = NoEffect;
-        returnFiber.deletions = [];
+        returnFiber.deletions = null;
       }
     }
 
@@ -1806,7 +1806,7 @@ function resetChildLanes(completedWork: Fiber) {
 
       subtreeTag |= child.subtreeTag;
       subtreeTag |= child.effectTag & HostEffectMask;
-      if (child.deletions.length > 0) {
+      if (child.deletions !== null) {
         subtreeTag |= Deletion;
       }
 
@@ -1851,7 +1851,7 @@ function resetChildLanes(completedWork: Fiber) {
 
       subtreeTag |= child.subtreeTag;
       subtreeTag |= child.effectTag & HostEffectMask;
-      if (child.deletions.length > 0) {
+      if (child.deletions !== null) {
         subtreeTag |= Deletion;
       }
 
@@ -2142,7 +2142,9 @@ function commitRootImpl(root, renderPriorityLevel) {
 }
 
 function commitBeforeMutationEffects(fiber: Fiber) {
-  commitBeforeMutationEffectsDeletions(fiber.deletions);
+  if (fiber.deletions !== null) {
+    commitBeforeMutationEffectsDeletions(fiber.deletions);
+  }
 
   if (fiber.child !== null) {
     const primarySubtreeTag =
@@ -2230,7 +2232,9 @@ function commitMutationEffects(
   root: FiberRoot,
   renderPriorityLevel,
 ) {
-  commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+  if (fiber.deletions !== null) {
+    commitMutationEffectsDeletions(fiber.deletions, root, renderPriorityLevel);
+  }
 
   if (fiber.child !== null) {
     const primarySubtreeTag =

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -127,7 +127,7 @@ export type Fiber = {|
   // Effect
   effectTag: SideEffectTag,
   subtreeTag: SideEffectTag,
-  deletions: Array<Fiber>,
+  deletions: Array<Fiber> | null,
 
   // Singly linked list fast path to the next fiber with side-effects.
   nextEffect: Fiber | null,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -23,6 +23,7 @@ import type {SuspenseInstance} from './ReactFiberHostConfig';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {SideEffectTag} from './ReactSideEffectTags';
+import type {SubtreeTag} from './ReactSubtreeTags';
 import type {Lane, LanePriority, Lanes, LaneMap} from './ReactFiberLane';
 import type {HookType} from './ReactFiberHooks.old';
 import type {RootTag} from './ReactRootTags';
@@ -126,7 +127,7 @@ export type Fiber = {|
 
   // Effect
   effectTag: SideEffectTag,
-  subtreeTag: SideEffectTag,
+  subtreeTag: SubtreeTag,
   deletions: Array<Fiber> | null,
 
   // Singly linked list fast path to the next fiber with side-effects.

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -126,6 +126,8 @@ export type Fiber = {|
 
   // Effect
   effectTag: SideEffectTag,
+  subtreeTag: SideEffectTag,
+  deletions: Array<Fiber>,
 
   // Singly linked list fast path to the next fiber with side-effects.
   nextEffect: Fiber | null,

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -38,3 +38,8 @@ export const HostEffectMask = /*               */ 0b000011111111111;
 export const Incomplete = /*                   */ 0b000100000000000;
 export const ShouldCapture = /*                */ 0b001000000000000;
 export const ForceUpdateForLegacySuspense = /* */ 0b100000000000000;
+
+// Union of side effect groupings as pertains to subtreeTag
+export const BeforeMutationMask = /*           */ 0b000001100001010;
+export const MutationMask = /*                 */ 0b000010010011110;
+export const LayoutMask = /*                   */ 0b000000010100100;

--- a/packages/react-reconciler/src/ReactSubtreeTags.js
+++ b/packages/react-reconciler/src/ReactSubtreeTags.js
@@ -9,8 +9,7 @@
 
 export type SubtreeTag = number;
 
-export const NoEffect = /*        */ 0b0000;
-export const DidBailout = /*      */ 0b0001;
-export const BeforeMutation = /*  */ 0b0010;
-export const Mutation = /*        */ 0b0100;
-export const Layout = /*          */ 0b1000;
+export const NoEffect = /*        */ 0b000;
+export const BeforeMutation = /*  */ 0b001;
+export const Mutation = /*        */ 0b010;
+export const Layout = /*          */ 0b100;

--- a/packages/react-reconciler/src/ReactSubtreeTags.js
+++ b/packages/react-reconciler/src/ReactSubtreeTags.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type SubtreeTag = number;
+
+export const NoEffect = /*        */ 0b0000;
+export const DidBailout = /*      */ 0b0001;
+export const BeforeMutation = /*  */ 0b0010;
+export const Mutation = /*        */ 0b0100;
+export const Layout = /*          */ 0b1000;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1744,15 +1744,30 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
 
-    expect(Scheduler).toFlushAndYield([
-      'B2',
-      'Destroy Layout Effect [Loading...]',
-      'Destroy Layout Effect [B]',
-      'Layout Effect [B2]',
-      'Destroy Effect [Loading...]',
-      'Destroy Effect [B]',
-      'Effect [B2]',
-    ]);
+    // Slight sequencing difference between old and new reconcilers,
+    // because walking the tree during the commit phase means processing deletions
+    // as part of processing the parent rather than the child.
+    gate(flags =>
+      flags.new
+        ? expect(Scheduler).toFlushAndYield([
+            'B2',
+            'Destroy Layout Effect [B]',
+            'Destroy Layout Effect [Loading...]',
+            'Layout Effect [B2]',
+            'Destroy Effect [Loading...]',
+            'Destroy Effect [B]',
+            'Effect [B2]',
+          ])
+        : expect(Scheduler).toFlushAndYield([
+            'B2',
+            'Destroy Layout Effect [Loading...]',
+            'Destroy Layout Effect [B]',
+            'Layout Effect [B2]',
+            'Destroy Effect [Loading...]',
+            'Destroy Effect [B]',
+            'Effect [B2]',
+          ]),
+    );
   });
 
   it('suspends for longer if something took a long (CPU bound) time to render', async () => {

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1743,31 +1743,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await resolveText('B2');
 
     expect(Scheduler).toHaveYielded(['Promise resolved [B2]']);
-
-    // Slight sequencing difference between old and new reconcilers,
-    // because walking the tree during the commit phase means processing deletions
-    // as part of processing the parent rather than the child.
-    gate(flags =>
-      flags.new
-        ? expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [B]',
-            'Destroy Layout Effect [Loading...]',
-            'Layout Effect [B2]',
-            'Destroy Effect [Loading...]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ])
-        : expect(Scheduler).toFlushAndYield([
-            'B2',
-            'Destroy Layout Effect [Loading...]',
-            'Destroy Layout Effect [B]',
-            'Layout Effect [B2]',
-            'Destroy Effect [Loading...]',
-            'Destroy Effect [B]',
-            'Effect [B2]',
-          ]),
-    );
+    expect(Scheduler).toFlushAndYield([
+      'B2',
+      'Destroy Layout Effect [Loading...]',
+      'Destroy Layout Effect [B]',
+      'Layout Effect [B2]',
+      'Destroy Effect [Loading...]',
+      'Destroy Effect [B]',
+      'Effect [B2]',
+    ]);
   });
 
   it('suspends for longer if something took a long (CPU bound) time to render', async () => {


### PR DESCRIPTION
Builds on top of #19261

* Adds an explicit "did bailout" flag rather than checking whether or not children were cloned.
* Updates `subtreeTag` to use its own meta values rather than copying `effectTag` values.

[**View only the delta.**](https://github.com/bvaughn/react/compare/effects_list_refactor...effects_list_refactor_bailout_flag)