### PR TITLE
Scheduling profiler updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -24,9 +24,13 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {enableNewReconciler} from 'shared/ReactFeatureFlags';
+import {
+  enableDebugTracing,
+  enableSchedulingProfiler,
+  enableNewReconciler,
+} from 'shared/ReactFeatureFlags';
 
-import {NoMode, BlockingMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
 import {
   NoLane,
   NoLanes,
@@ -88,6 +92,8 @@ import {
   warnAboutMultipleRenderersDEV,
 } from './ReactMutableSource.new';
 import {getIsRendering} from './ReactCurrentFiber';
+import {logStateUpdateScheduled} from './DebugTracing';
+import {markStateUpdateScheduled} from './SchedulingProfiler';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -1750,6 +1756,19 @@ function dispatchAction<S, A>(
       }
     }
     scheduleUpdateOnFiber(fiber, lane, eventTime);
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      if (fiber.mode & DebugTracingMode) {
+        const name = getComponentName(fiber.type) || 'Unknown';
+        logStateUpdateScheduled(name, lane, action);
+      }
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markStateUpdateScheduled(fiber, lane);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -39,6 +39,7 @@ import {
 } from './ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
+import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -95,6 +96,7 @@ import {
   setRefreshHandler,
   findHostInstancesForRefresh,
 } from './ReactFiberHotReloading.new';
+import {markRenderScheduled} from './SchedulingProfiler';
 
 export {registerMutableSourceForHydration} from './ReactMutableSource.new';
 export {createPortal} from './ReactPortal';
@@ -272,6 +274,10 @@ export function updateContainer(
   }
   const suspenseConfig = requestCurrentSuspenseConfig();
   const lane = requestUpdateLane(current, suspenseConfig);
+
+  if (enableSchedulingProfiler) {
+    markRenderScheduled(lane);
+  }
 
   const context = getContextForSubtree(parentComponent);
   if (container.context === null) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -27,6 +27,8 @@ import {
   warnAboutUnmockedScheduler,
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
+  enableDebugTracing,
+  enableSchedulingProfiler,
   enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -47,6 +49,27 @@ import {
   flushSyncCallbackQueue,
   scheduleSyncCallback,
 } from './SchedulerWithReactIntegration.new';
+import {
+  logCommitStarted,
+  logCommitStopped,
+  logLayoutEffectsStarted,
+  logLayoutEffectsStopped,
+  logPassiveEffectsStarted,
+  logPassiveEffectsStopped,
+  logRenderStarted,
+  logRenderStopped,
+} from './DebugTracing';
+import {
+  markCommitStarted,
+  markCommitStopped,
+  markLayoutEffectsStarted,
+  markLayoutEffectsStopped,
+  markPassiveEffectsStarted,
+  markPassiveEffectsStopped,
+  markRenderStarted,
+  markRenderYielded,
+  markRenderStopped,
+} from './SchedulingProfiler';
 
 // The scheduler is imported here *only* to detect whether it's been mocked
 import * as Scheduler from 'scheduler';
@@ -1509,6 +1532,16 @@ function renderRootSync(root: FiberRoot, lanes: Lanes) {
 
   const prevInteractions = pushInteractions(root);
 
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logRenderStarted(lanes);
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markRenderStarted(lanes);
+  }
+
   do {
     try {
       workLoopSync();
@@ -1532,6 +1565,16 @@ function renderRootSync(root: FiberRoot, lanes: Lanes) {
       'Cannot commit an incomplete root. This error is likely caused by a ' +
         'bug in React. Please file an issue.',
     );
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logRenderStopped();
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markRenderStopped();
   }
 
   // Set this to null to indicate there's no in-progress render.
@@ -1564,6 +1607,16 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
 
   const prevInteractions = pushInteractions(root);
 
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logRenderStarted(lanes);
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markRenderStarted(lanes);
+  }
+
   do {
     try {
       workLoopConcurrent();
@@ -1580,12 +1633,25 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
   popDispatcher(prevDispatcher);
   executionContext = prevExecutionContext;
 
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logRenderStopped();
+    }
+  }
+
   // Check if the tree has completed.
   if (workInProgress !== null) {
     // Still work remaining.
+    if (enableSchedulingProfiler) {
+      markRenderYielded();
+    }
     return RootIncomplete;
   } else {
     // Completed the tree.
+    if (enableSchedulingProfiler) {
+      markRenderStopped();
+    }
+
     // Set this to null to indicate there's no in-progress render.
     workInProgressRoot = null;
     workInProgressRootRenderLanes = NoLanes;
@@ -1868,7 +1934,28 @@ function commitRootImpl(root, renderPriorityLevel) {
 
   const finishedWork = root.finishedWork;
   const lanes = root.finishedLanes;
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logCommitStarted(lanes);
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markCommitStarted(lanes);
+  }
+
   if (finishedWork === null) {
+    if (__DEV__) {
+      if (enableDebugTracing) {
+        logCommitStopped();
+      }
+    }
+
+    if (enableSchedulingProfiler) {
+      markCommitStopped();
+    }
+
     return null;
   }
   root.finishedWork = null;
@@ -2159,6 +2246,16 @@ function commitRootImpl(root, renderPriorityLevel) {
   }
 
   if ((executionContext & LegacyUnbatchedContext) !== NoContext) {
+    if (__DEV__) {
+      if (enableDebugTracing) {
+        logCommitStopped();
+      }
+    }
+
+    if (enableSchedulingProfiler) {
+      markCommitStopped();
+    }
+
     // This is a legacy edge case. We just committed the initial mount of
     // a ReactDOM.render-ed root inside of batchedUpdates. The commit fired
     // synchronously, but layout updates should be deferred until the end
@@ -2168,6 +2265,16 @@ function commitRootImpl(root, renderPriorityLevel) {
 
   // If layout work was scheduled, flush it now.
   flushSyncCallbackQueue();
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logCommitStopped();
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markCommitStopped();
+  }
 
   return null;
 }
@@ -2300,6 +2407,16 @@ function commitMutationEffects(root: FiberRoot, renderPriorityLevel) {
 }
 
 function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logLayoutEffectsStarted(committedLanes);
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markLayoutEffectsStarted(committedLanes);
+  }
+
   // TODO: Should probably move the bulk of this function to commitWork.
   while (nextEffect !== null) {
     setCurrentDebugFiberInDEV(nextEffect);
@@ -2325,6 +2442,16 @@ function commitLayoutEffects(root: FiberRoot, committedLanes: Lanes) {
 
     resetCurrentDebugFiberInDEV();
     nextEffect = nextEffect.nextEffect;
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logLayoutEffectsStopped();
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markLayoutEffectsStopped();
   }
 }
 
@@ -2414,6 +2541,16 @@ function flushPassiveEffectsImpl() {
     (executionContext & (RenderContext | CommitContext)) === NoContext,
     'Cannot flush passive effects while already rendering.',
   );
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logPassiveEffectsStarted(lanes);
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markPassiveEffectsStarted(lanes);
+  }
 
   if (__DEV__) {
     isFlushingPassiveEffects = true;
@@ -2569,6 +2706,16 @@ function flushPassiveEffectsImpl() {
 
   if (__DEV__) {
     isFlushingPassiveEffects = false;
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      logPassiveEffectsStopped();
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markPassiveEffectsStopped();
   }
 
   executionContext = prevExecutionContext;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1361,7 +1361,7 @@ function handleError(root, thrownValue): void {
         // sibling, or the parent if there are no siblings. But since the root
         // has no siblings nor a parent, we set it to null. Usually this is
         // handled by `completeUnitOfWork` or `unwindWork`, but since we're
-        // interntionally not calling those, we need set it here.
+        // intentionally not calling those, we need set it here.
         // TODO: Consider calling `unwindWork` to pop the contexts.
         workInProgress = null;
         return;

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -351,8 +351,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -378,8 +384,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -461,8 +473,14 @@ describe('SchedulingProfiler', () => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -17,7 +17,7 @@ export const enableDebugTracing = false;
 
 // Adds user timing marks for e.g. state updates, suspense, and work loop stuff,
 // for an experimental scheduling profiler tool.
-export const enableSchedulingProfiler = false;
+export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
 // reducers by double invoking them in Strict Mode.

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,9 +19,8 @@ export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 
-// TODO: These features do not currently exist in the new reconciler fork.
+// TODO: This feature does not currently exist in the new reconciler fork.
 export const enableDebugTracing = !__VARIANT__;
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,7 +26,6 @@ export const {
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
-  enableSchedulingProfiler,
   enableFormEventDelegation,
 } = dynamicFeatureFlags;
 
@@ -35,6 +34,7 @@ export const {
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
+export const enableSchedulingProfiler = __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.


### PR DESCRIPTION
* Enable `enableSchedulingProfiler` statically for experimental+profiling builds and www+profiling builds.
* Synced debug tracing and scheduling profiler code from old -> new fork.
* Update test `@gate` conditions.

To verify my manual syncing over of these features, I used diff:

### ReactFiberClassComponent
```diff
12c12
< import type {UpdateQueue} from './ReactUpdateQueue.old';
---
> import type {UpdateQueue} from './ReactUpdateQueue.new';
23c23
< import ReactStrictModeWarnings from './ReactStrictModeWarnings.old';
---
> import ReactStrictModeWarnings from './ReactStrictModeWarnings.new';
31c31
< import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
---
> import {resolveDefaultProps} from './ReactFiberLazyComponent.new';
44c44
< } from './ReactUpdateQueue.old';
---
> } from './ReactUpdateQueue.new';
52,53c52,53
< } from './ReactFiberContext.old';
< import {readContext} from './ReactFiberNewContext.old';
---
> } from './ReactFiberContext.new';
> import {readContext} from './ReactFiberNewContext.new';
58c58
< } from './ReactFiberWorkLoop.old';
---
> } from './ReactFiberWorkLoop.new';
```

### ReactFiberHooks
```diff
48,49c48,49
< import {readContext} from './ReactFiberNewContext.old';
< import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.old';
---
> import {readContext} from './ReactFiberNewContext.new';
> import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.new';
69c69
< } from './ReactFiberWorkLoop.old';
---
> } from './ReactFiberWorkLoop.new';
74c74
< import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork.old';
---
> import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork.new';
81,82c81,82
< } from './SchedulerWithReactIntegration.old';
< import {getIsHydrating} from './ReactFiberHydrationContext.old';
---
> } from './SchedulerWithReactIntegration.new';
> import {getIsHydrating} from './ReactFiberHydrationContext.new';
93c93
< } from './ReactMutableSource.old';
---
> } from './ReactMutableSource.new';
771c771
<         // its priority which is a derived and not reversible value.
---
>         // its priority which is a derived and not reverseable value.
```

### ReactFiberReconciler
```diff
27c27
< import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
---
> import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
50,52c50,52
< } from './ReactFiberContext.old';
< import {createFiberRoot} from './ReactFiberRoot.old';
< import {injectInternals, onScheduleRoot} from './ReactFiberDevToolsHook.old';
---
> } from './ReactFiberContext.new';
> import {createFiberRoot} from './ReactFiberRoot.new';
> import {injectInternals, onScheduleRoot} from './ReactFiberDevToolsHook.new';
71,72c71,72
< } from './ReactFiberWorkLoop.old';
< import {createUpdate, enqueueUpdate} from './ReactUpdateQueue.old';
---
> } from './ReactFiberWorkLoop.new';
> import {createUpdate, enqueueUpdate} from './ReactUpdateQueue.new';
98c98
< } from './ReactFiberHotReloading.old';
---
> } from './ReactFiberHotReloading.new';
```
### ReactFiberThrow
```diff
14c14
< import type {Update} from './ReactUpdateQueue.old';
---
> import type {Update} from './ReactUpdateQueue.new';
16c16
< import type {SuspenseContext} from './ReactFiberSuspenseContext.old';
---
> import type {SuspenseContext} from './ReactFiberSuspenseContext.new';
33c33
< import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent.old';
---
> import {shouldCaptureSuspense} from './ReactFiberSuspenseComponent.new';
46,47c46,47
< } from './ReactUpdateQueue.old';
< import {markFailedErrorBoundaryForHotReloading} from './ReactFiberHotReloading.old';
---
> } from './ReactUpdateQueue.new';
> import {markFailedErrorBoundaryForHotReloading} from './ReactFiberHotReloading.new';
52c52
< } from './ReactFiberSuspenseContext.old';
---
> } from './ReactFiberSuspenseContext.new';
59c59
< } from './ReactFiberWorkLoop.old';
---
> } from './ReactFiberWorkLoop.new';
```
### ReactFiberWorkLoop
```diff
16,18c16,18
< import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
< import type {Effect as HookEffect} from './ReactFiberHooks.old';
< import type {StackCursor} from './ReactFiberStack.old';
---
> import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
> import type {Effect as HookEffect} from './ReactFiberHooks.new';
> import type {StackCursor} from './ReactFiberStack.new';
51c51
< } from './SchedulerWithReactIntegration.old';
---
> } from './SchedulerWithReactIntegration.new';
94c94
< } from './ReactFiber.old';
---
> } from './ReactFiber.new';
175,177c175,177
< import {beginWork as originalBeginWork} from './ReactFiberBeginWork.old';
< import {completeWork} from './ReactFiberCompleteWork.old';
< import {unwindWork, unwindInterruptedWork} from './ReactFiberUnwindWork.old';
---
> import {beginWork as originalBeginWork} from './ReactFiberBeginWork.new';
> import {completeWork} from './ReactFiberCompleteWork.new';
> import {unwindWork, unwindInterruptedWork} from './ReactFiberUnwindWork.new';
182c182
< } from './ReactFiberThrow.old';
---
> } from './ReactFiberThrow.new';
194,196c194,196
< } from './ReactFiberCommitWork.old';
< import {enqueueUpdate} from './ReactUpdateQueue.old';
< import {resetContextDependencies} from './ReactFiberNewContext.old';
---
> } from './ReactFiberCommitWork.new';
> import {enqueueUpdate} from './ReactUpdateQueue.new';
> import {resetContextDependencies} from './ReactFiberNewContext.new';
201c201
< } from './ReactFiberHooks.old';
---
> } from './ReactFiberHooks.new';
207c207
< } from './ReactFiberStack.old';
---
> } from './ReactFiberStack.new';
215c215
< } from './ReactProfilerTimer.old';
---
> } from './ReactProfilerTimer.new';
219c219
< import ReactStrictModeWarnings from './ReactStrictModeWarnings.old';
---
> import ReactStrictModeWarnings from './ReactStrictModeWarnings.new';
231c231
< import {onCommitRoot as onCommitRootDevTools} from './ReactFiberDevToolsHook.old';
---
> import {onCommitRoot as onCommitRootDevTools} from './ReactFiberDevToolsHook.new';
```