### PR TITLE
Fix DevTools handling of empty Suspense tag for legacy renderer versions

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -2191,6 +2191,65 @@ Object {
 }
 `;
 
+exports[`ProfilingCache should handle unexpectedly shallow suspense trees: Empty Suspense node 1`] = `
+Object {
+  "commitData": Array [
+    Object {
+      "changeDescriptions": Map {},
+      "duration": 0,
+      "fiberActualDurations": Map {
+        1 => 0,
+        2 => 0,
+      },
+      "fiberSelfDurations": Map {
+        1 => 0,
+        2 => 0,
+      },
+      "interactionIDs": Array [],
+      "priorityLevel": "Normal",
+      "timestamp": 0,
+    },
+  ],
+  "displayName": "Suspense",
+  "initialTreeBaseDurations": Map {},
+  "interactionCommits": Map {},
+  "interactions": Map {},
+  "operations": Array [
+    Array [
+      1,
+      1,
+      9,
+      8,
+      83,
+      117,
+      115,
+      112,
+      101,
+      110,
+      115,
+      101,
+      1,
+      1,
+      11,
+      1,
+      1,
+      1,
+      2,
+      12,
+      1,
+      0,
+      1,
+      0,
+      4,
+      2,
+      0,
+    ],
+  ],
+  "rootID": 1,
+  "snapshots": Map {},
+}
+`;
+
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 0 1`] = `
 Object {
   "changeDescriptions": Map {

--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -696,4 +696,24 @@ describe('ProfilingCache', () => {
       ),
     );
   });
+
+  it('should handle unexpectedly shallow suspense trees', () => {
+    const container = document.createElement('div');
+
+    utils.act(() => store.profilerStore.startProfiling());
+    utils.act(() => ReactDOM.render(<React.Suspense />, container));
+    utils.act(() => store.profilerStore.stopProfiling());
+
+    function Validator({commitIndex, rootID}) {
+      const profilingDataForRoot = store.profilerStore.getDataForRoot(rootID);
+      expect(profilingDataForRoot).toMatchSnapshot('Empty Suspense node');
+      return null;
+    }
+
+    const rootID = store.roots[0];
+
+    utils.act(() => {
+      TestRenderer.create(<Validator commitIndex={0} rootID={rootID} />);
+    });
+  });
 });

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1237,11 +1237,14 @@ export function attach(
           );
         }
       } else {
+        let primaryChild: Fiber | null = null;
         const areSuspenseChildrenConditionallyWrapped =
           OffscreenComponent === -1;
-        const primaryChild: Fiber | null = areSuspenseChildrenConditionallyWrapped
-          ? fiber.child
-          : (fiber.child: any).child;
+        if (areSuspenseChildrenConditionallyWrapped) {
+          primaryChild = fiber.child;
+        } else if (fiber.child !== null) {
+          primaryChild = fiber.child.child;
+        }
         if (primaryChild !== null) {
           mountFiberRecursively(
             primaryChild,

--- a/packages/react-devtools-shell/src/app/SuspenseTree/index.js
+++ b/packages/react-devtools-shell/src/app/SuspenseTree/index.js
@@ -25,8 +25,13 @@ function SuspenseTree() {
       <PrimaryFallbackTest initialSuspend={true} />
       <NestedSuspenseTest />
       <SuspenseListTest />
+      <EmptySuspense />
     </Fragment>
   );
+}
+
+function EmptySuspense() {
+  return <Suspense />;
 }
 
 function PrimaryFallbackTest({initialSuspend}) {


### PR DESCRIPTION
Fixes #19320

This test should fail the new CI task (to run latest DevTools against all recent minor OSS releases) but that does not yet exist. I will set that up with a follow up PR.