### PR TITLE
Devtools: improve getID guard

### DIFF
--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -165,7 +165,7 @@ export function attach(
   }
 
   function getID(internalInstance: InternalInstance): number {
-    if (typeof internalInstance !== 'object') {
+    if (typeof internalInstance !== 'object' || internalInstance === null) {
       throw new Error('Invalid internal instance: ' + internalInstance);
     }
     if (!internalInstanceToIDMap.has(internalInstance)) {


### PR DESCRIPTION
Today I ran into an issue where I saw `invalid value used as weak map key` when debugging an internal issue. Unfortunately, I wasn't able to reproduce it but looking through the code. However, I did notice there was a guard in the devtools code that could be strengthened, and thus helping narrow down a codepath that leads to us setting an invalid WeakMap key.