### PR TITLE
Disable DevTools minification

### DIFF
--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -2,7 +2,6 @@
 
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
 const {GITHUB_URL, getVersionString} = require('./utils');
 
 const NODE_ENV = process.env.NODE_ENV;
@@ -41,14 +40,7 @@ module.exports = {
     },
   },
   optimization: {
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          compress: {drop_debugger: false},
-          output: {comments: true},
-        },
-      }),
-    ],
+    minimize: false,
   },
   plugins: [
     new DefinePlugin({

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -44,6 +44,9 @@ module.exports = {
       scheduler: resolve(builtModulesDir, 'scheduler'),
     },
   },
+  optimization: {
+    minimize: false,
+  },
   plugins: [
     new DefinePlugin({
       __DEV__: false,

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -1,6 +1,5 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
 const {
   GITHUB_URL,
   getVersionString,
@@ -38,14 +37,7 @@ module.exports = {
     scheduler: 'scheduler',
   },
   optimization: {
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          compress: {drop_debugger: false},
-          output: {comments: true},
-        },
-      }),
-    ],
+    minimize: false,
   },
   plugins: [
     new DefinePlugin({

--- a/packages/react-devtools-shell/webpack.config.js
+++ b/packages/react-devtools-shell/webpack.config.js
@@ -1,6 +1,5 @@
 const {resolve} = require('path');
 const {DefinePlugin} = require('webpack');
-const TerserPlugin = require('terser-webpack-plugin');
 const {
   GITHUB_URL,
   getVersionString,
@@ -41,14 +40,7 @@ const config = {
     },
   },
   optimization: {
-    minimizer: [
-      new TerserPlugin({
-        terserOptions: {
-          compress: {drop_debugger: false},
-          output: {comments: true},
-        },
-      }),
-    ],
+    minimize: false,
   },
   plugins: [
     new DefinePlugin({


### PR DESCRIPTION
For consideration.

DevTools isn't being downloaded like typical JavaScript, so bundle size concerns don't apply. Parsing is still a consideration (so I'm open for discussion here) but I think this change would provide a couple of benefits:
* People are more likely to *actually read* non-minified source code when e.g. a breakpoint is hit (whereas they don't currently, if the recent debugger statement is any indicator)
* Component stacks will be easier to parse on bug reports