### PR TITLE
Don't build shallow renderer UMD bundles

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -428,19 +428,6 @@ const bundles = [
         ]),
       }),
   },
-  {
-    bundleTypes: [UMD_DEV, UMD_PROD],
-    moduleType: NON_FIBER_RENDERER,
-    entry: 'react-test-renderer/shallow',
-    global: 'ReactShallowRenderer',
-    externals: ['react', 'scheduler', 'scheduler/unstable_mock'],
-    babel: opts =>
-      Object.assign({}, opts, {
-        plugins: opts.plugins.concat([
-          [require.resolve('@babel/plugin-transform-classes'), {loose: true}],
-        ]),
-      }),
-  },
 
   /******* React Noop Renderer (used for tests) *******/
   {


### PR DESCRIPTION
Fixes the blocker for https://github.com/facebook/react/pull/19368.

We've stopped building CJS bundles for shallow, but we're still building UMDs. They're only available in the UMD folder. I think it's reasonable to drop UMDs for the shallow renderer in our package because they can be found in https://unpkg.com/browse/react-shallow-renderer/umd/ anyway. And since master is already 17-only we can do it now.

Note this doesn't delete shallow renderer integration tests or the entry point. That keeps working.