### PR TITLE
Effects list refactor continued: passive effects traversal

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -16,7 +16,6 @@ import type {Lanes} from './ReactFiberLane';
 
 import getComponentName from 'shared/getComponentName';
 import {Deletion, Placement} from './ReactSideEffectTags';
-import {Passive as PassiveSubtreeTag} from './ReactSubtreeTags';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
@@ -294,12 +293,6 @@ function ChildReconciler(shouldTrackSideEffects) {
       returnFiber.deletions = [childToDelete];
       // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
       returnFiber.effectTag |= Deletion;
-
-      // We are deleting a subtree that may contain a passive effect.
-      // Mark the parent so we traverse this path after commit and run any unmount functions.
-      // This may cause us to traverse unnecessarily in some cases, but effects are common,
-      // and the cost of over traversing is small (just the path to the deleted node).
-      returnFiber.subtreeTag |= PassiveSubtreeTag;
     } else {
       deletions.push(childToDelete);
     }

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -30,7 +30,10 @@ import {
   enableBlocksAPI,
 } from 'shared/ReactFeatureFlags';
 import {NoEffect, Placement} from './ReactSideEffectTags';
-import {NoEffect as NoSubtreeEffect} from './ReactSubtreeTags';
+import {
+  NoEffect as NoSubtreeEffect,
+  Static as StaticSubtreeEffects,
+} from './ReactSubtreeTags';
 import {ConcurrentRoot, BlockingRoot} from './ReactRootTags';
 import {
   IndeterminateComponent,
@@ -290,7 +293,6 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // We already have an alternate.
     // Reset the effect tag.
     workInProgress.effectTag = NoEffect;
-    workInProgress.subtreeTag = NoSubtreeEffect;
     workInProgress.deletions = null;
 
     // The effect list is no longer valid.
@@ -308,6 +310,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     }
   }
 
+  workInProgress.subtreeTag = current.subtreeTag & StaticSubtreeEffects;
   workInProgress.childLanes = current.childLanes;
   workInProgress.lanes = current.lanes;
 

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -29,11 +29,8 @@ import {
   enableScopeAPI,
   enableBlocksAPI,
 } from 'shared/ReactFeatureFlags';
-import {NoEffect, Placement} from './ReactSideEffectTags';
-import {
-  NoEffect as NoSubtreeEffect,
-  Static as StaticSubtreeEffects,
-} from './ReactSubtreeTags';
+import {NoEffect, Placement, StaticMask} from './ReactSideEffectTags';
+import {NoEffect as NoSubtreeEffect} from './ReactSubtreeTags';
 import {ConcurrentRoot, BlockingRoot} from './ReactRootTags';
 import {
   IndeterminateComponent,
@@ -291,8 +288,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     workInProgress.type = current.type;
 
     // We already have an alternate.
-    // Reset the effect tag.
-    workInProgress.effectTag = NoEffect;
+    workInProgress.subtreeTag = NoSubtreeEffect;
     workInProgress.deletions = null;
 
     // The effect list is no longer valid.
@@ -310,7 +306,9 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     }
   }
 
-  workInProgress.subtreeTag = current.subtreeTag & StaticSubtreeEffects;
+  // Reset all effects except static ones.
+  // Static effects are not specific to a render.
+  workInProgress.effectTag = current.effectTag & StaticMask;
   workInProgress.childLanes = current.childLanes;
   workInProgress.lanes = current.lanes;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -64,9 +64,7 @@ import {
   Ref,
   Deletion,
   ForceUpdateForLegacySuspense,
-  StaticMask,
 } from './ReactSideEffectTags';
-import {Passive as PassiveSubtreeTag} from './ReactSubtreeTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
@@ -2066,20 +2064,12 @@ function updateSuspensePrimaryChildren(
   if (currentFallbackChildFragment !== null) {
     // Delete the fallback child fragment
     currentFallbackChildFragment.nextEffect = null;
-    currentFallbackChildFragment.effectTag =
-      (currentFallbackChildFragment.effectTag & StaticMask) | Deletion;
     workInProgress.firstEffect = workInProgress.lastEffect = currentFallbackChildFragment;
     const deletions = workInProgress.deletions;
     if (deletions === null) {
       workInProgress.deletions = [currentFallbackChildFragment];
       // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
       workInProgress.effectTag |= Deletion;
-
-      // We are deleting a subtree that may contain a passive effect.
-      // Mark the parent so we traverse this path after commit and run any unmount functions.
-      // This may cause us to traverse unnecessarily in some cases, but effects are common,
-      // and the cost of over traversing is small (just the path to the deleted node).
-      workInProgress.subtreeTag |= PassiveSubtreeTag;
     } else {
       deletions.push(currentFallbackChildFragment);
     }
@@ -3064,12 +3054,6 @@ function remountFiber(
       returnFiber.deletions = [current];
       // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
       returnFiber.effectTag |= Deletion;
-
-      // We are deleting a subtree that may contain a passive effect.
-      // Mark the parent so we traverse this path after commit and run any unmount functions.
-      // This may cause us to traverse unnecessarily in some cases, but effects are common,
-      // and the cost of over traversing is small (just the path to the deleted node).
-      returnFiber.subtreeTag |= PassiveSubtreeTag;
     } else {
       deletions.push(current);
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -69,7 +69,6 @@ import {
   Snapshot,
   Update,
   Passive,
-  PassiveUnmountPendingDev,
 } from './ReactSideEffectTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -882,17 +881,6 @@ function commitUnmount(
                 effect.tag |= HookHasEffect;
 
                 current.effectTag |= Passive;
-
-                if (__DEV__) {
-                  // This flag is used to avoid warning about an update to an unmounted component
-                  // if the component has a passive unmount scheduled.
-                  // Presumably the listener would be cleaned up by that unmount.
-                  current.effectTag |= PassiveUnmountPendingDev;
-                  const alternate = current.alternate;
-                  if (alternate !== null) {
-                    alternate.effectTag |= PassiveUnmountPendingDev;
-                  }
-                }
 
                 schedulePassiveEffectCallback();
               } else {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -881,19 +881,6 @@ function commitUnmount(
               if ((tag & HookPassive) !== NoHookEffect) {
                 effect.tag |= HookHasEffect;
 
-                // subtreeTags bubble in resetChildLanes which doens't get called for unmounted subtrees.
-                // So in the case of unmounts, we need to bubble passive effects explicitly.
-                let ancestor = current.return;
-                while (ancestor !== null) {
-                  ancestor.subtreeTag |= PassiveSubtreeTag;
-                  const alternate = ancestor.alternate;
-                  if (alternate !== null) {
-                    alternate.subtreeTag |= PassiveSubtreeTag;
-                  }
-
-                  ancestor = ancestor.return;
-                }
-
                 current.effectTag |= Passive;
 
                 if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -68,6 +68,8 @@ import {
   Placement,
   Snapshot,
   Update,
+  Passive,
+  PassiveUnmountPendingDev,
 } from './ReactSideEffectTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -115,9 +117,8 @@ import {
   captureCommitPhaseError,
   resolveRetryWakeable,
   markCommitTimeOfFallback,
-  enqueuePendingPassiveHookEffectMount,
-  enqueuePendingPassiveHookEffectUnmount,
   enqueuePendingPassiveProfilerEffect,
+  schedulePassiveEffectCallback,
 } from './ReactFiberWorkLoop.new';
 import {
   NoEffect as NoHookEffect,
@@ -130,6 +131,10 @@ import {
   updateDeprecatedEventListeners,
   unmountDeprecatedResponderListeners,
 } from './ReactFiberDeprecatedEvents.new';
+import {
+  NoEffect as NoSubtreeTag,
+  Passive as PassiveSubtreeTag,
+} from './ReactSubtreeTags';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -381,26 +386,6 @@ function commitHookEffectListMount(tag: number, finishedWork: Fiber) {
   }
 }
 
-function schedulePassiveEffects(finishedWork: Fiber) {
-  const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
-  if (lastEffect !== null) {
-    const firstEffect = lastEffect.next;
-    let effect = firstEffect;
-    do {
-      const {next, tag} = effect;
-      if (
-        (tag & HookPassive) !== NoHookEffect &&
-        (tag & HookHasEffect) !== NoHookEffect
-      ) {
-        enqueuePendingPassiveHookEffectUnmount(finishedWork, effect);
-        enqueuePendingPassiveHookEffectMount(finishedWork, effect);
-      }
-      effect = next;
-    } while (effect !== firstEffect);
-  }
-}
-
 export function commitPassiveEffectDurations(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
@@ -486,7 +471,9 @@ function commitLifeCycles(
         commitHookEffectListMount(HookLayout | HookHasEffect, finishedWork);
       }
 
-      schedulePassiveEffects(finishedWork);
+      if ((finishedWork.subtreeTag & PassiveSubtreeTag) !== NoSubtreeTag) {
+        schedulePassiveEffectCallback();
+      }
       return;
     }
     case ClassComponent: {
@@ -892,7 +879,35 @@ function commitUnmount(
             const {destroy, tag} = effect;
             if (destroy !== undefined) {
               if ((tag & HookPassive) !== NoHookEffect) {
-                enqueuePendingPassiveHookEffectUnmount(current, effect);
+                effect.tag |= HookHasEffect;
+
+                // subtreeTags bubble in resetChildLanes which doens't get called for unmounted subtrees.
+                // So in the case of unmounts, we need to bubble passive effects explicitly.
+                let ancestor = current.return;
+                while (ancestor !== null) {
+                  ancestor.subtreeTag |= PassiveSubtreeTag;
+                  const alternate = ancestor.alternate;
+                  if (alternate !== null) {
+                    alternate.subtreeTag |= PassiveSubtreeTag;
+                  }
+
+                  ancestor = ancestor.return;
+                }
+
+                current.effectTag |= Passive;
+
+                if (__DEV__) {
+                  // This flag is used to avoid warning about an update to an unmounted component
+                  // if the component has a passive unmount scheduled.
+                  // Presumably the listener would be cleaned up by that unmount.
+                  current.effectTag |= PassiveUnmountPendingDev;
+                  const alternate = current.alternate;
+                  if (alternate !== null) {
+                    alternate.effectTag |= PassiveUnmountPendingDev;
+                  }
+                }
+
+                schedulePassiveEffectCallback();
               } else {
                 if (
                   enableProfilerTimer &&
@@ -1013,8 +1028,11 @@ function commitNestedUnmounts(
 }
 
 function detachFiberMutation(fiber: Fiber) {
-  // Cut off the return pointers to disconnect it from the tree. Ideally, we
-  // should clear the child pointer of the parent alternate to let this
+  // Cut off the return pointers to disconnect it from the tree.
+  // Note that we can't clear child or sibling pointers yet,
+  // because they may be required for passive effects.
+  // These pointers will be cleared in a separate pass.
+  // Ideally, we should clear the child pointer of the parent alternate to let this
   // get GC:ed but we don't know which for sure which parent is the current
   // one so we'll settle for GC:ing the subtree of this child. This child
   // itself will be GC:ed when the parent updates the next time.
@@ -1023,7 +1041,6 @@ function detachFiberMutation(fiber: Fiber) {
   // traversal in a later effect. See PR #16820. We now clear the sibling
   // field after effects, see: detachFiberAfterEffects.
   fiber.alternate = null;
-  fiber.child = null;
   fiber.dependencies = null;
   fiber.firstEffect = null;
   fiber.lastEffect = null;
@@ -1032,7 +1049,6 @@ function detachFiberMutation(fiber: Fiber) {
   fiber.pendingProps = null;
   fiber.return = null;
   fiber.stateNode = null;
-  fiber.updateQueue = null;
   if (__DEV__) {
     fiber._debugOwner = null;
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -878,6 +878,7 @@ function commitUnmount(
             const {destroy, tag} = effect;
             if (destroy !== undefined) {
               if ((tag & HookPassive) !== NoHookEffect) {
+                // TODO: Consider if we can move this block out of the synchronous commit phase
                 effect.tag |= HookHasEffect;
 
                 current.effectTag |= Passive;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1027,6 +1027,11 @@ function detachFiberMutation(fiber: Fiber) {
   // Note that we can't clear child or sibling pointers yet.
   // They're needed for passive effects and for findDOMNode.
   // We defer those fields, and all other cleanup, to the passive phase (see detachFiberAfterEffects).
+  const alternate = fiber.alternate;
+  if (alternate !== null) {
+    alternate.return = null;
+    fiber.alternate = null;
+  }
   fiber.return = null;
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -50,6 +50,7 @@ import {createDeprecatedResponderListener} from './ReactFiberDeprecatedEvents.ne
 import {
   Update as UpdateEffect,
   Passive as PassiveEffect,
+  PassiveStatic as PassiveStaticEffect,
 } from './ReactSideEffectTags';
 import {
   HasEffect as HookHasEffect,
@@ -1270,7 +1271,7 @@ function mountEffect(
     }
   }
   return mountEffectImpl(
-    UpdateEffect | PassiveEffect,
+    UpdateEffect | PassiveEffect | PassiveStaticEffect,
     HookPassive,
     create,
     deps,
@@ -1288,7 +1289,7 @@ function updateEffect(
     }
   }
   return updateEffectImpl(
-    UpdateEffect | PassiveEffect,
+    UpdateEffect | PassiveEffect | PassiveStaticEffect,
     HookPassive,
     create,
     deps,
@@ -1631,7 +1632,8 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     const setId = mountState(id)[1];
 
     if ((currentlyRenderingFiber.mode & BlockingMode) === NoMode) {
-      currentlyRenderingFiber.effectTag |= UpdateEffect | PassiveEffect;
+      currentlyRenderingFiber.effectTag |=
+        UpdateEffect | PassiveEffect | PassiveStaticEffect;
       pushEffect(
         HookHasEffect | HookPassive,
         () => {

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1289,7 +1289,7 @@ function updateEffect(
     }
   }
   return updateEffectImpl(
-    UpdateEffect | PassiveEffect | PassiveStaticEffect,
+    UpdateEffect | PassiveEffect,
     HookPassive,
     create,
     deps,

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -124,7 +124,7 @@ function deleteHydratableInstance(
   const childToDelete = createFiberFromHostInstanceForDeletion();
   childToDelete.stateNode = instance;
   childToDelete.return = returnFiber;
-  childToDelete.effectTag = Deletion;
+
   const deletions = returnFiber.deletions;
   if (deletions === null) {
     returnFiber.deletions = [childToDelete];

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -24,17 +24,8 @@ import {
   HostRoot,
   SuspenseComponent,
 } from './ReactWorkTags';
-import {
-  Deletion,
-  Hydrating,
-  NoEffect,
-  PassiveMask,
-  Placement,
-} from './ReactSideEffectTags';
-import {
-  NoEffect as NoSubtreeTag,
-  Passive as PassiveSubtreeTag,
-} from './ReactSubtreeTags';
+import {Deletion, Hydrating, Placement} from './ReactSideEffectTags';
+import {Passive as PassiveSubtreeTag} from './ReactSubtreeTags';
 import invariant from 'shared/invariant';
 
 import {
@@ -141,13 +132,11 @@ function deleteHydratableInstance(
     // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
     returnFiber.effectTag |= Deletion;
 
-    // If we are deleting a subtree that contains a passive effect,
-    // mark the parent so that we're sure to traverse after commit and run any unmount functions.
-    const primaryEffectTag = childToDelete.effectTag & PassiveMask;
-    const primarySubtreeTag = childToDelete.subtreeTag & PassiveSubtreeTag;
-    if (primaryEffectTag !== NoEffect || primarySubtreeTag !== NoSubtreeTag) {
-      returnFiber.subtreeTag |= PassiveSubtreeTag;
-    }
+    // We are deleting a subtree that may contain a passive effect.
+    // Mark the parent so we traverse this path after commit and run any unmount functions.
+    // This may cause us to traverse unnecessarily in some cases, but effects are common,
+    // and the cost of over traversing is small (just the path to the deleted node).
+    returnFiber.subtreeTag |= PassiveSubtreeTag;
   } else {
     deletions.push(childToDelete);
   }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -25,7 +25,6 @@ import {
   SuspenseComponent,
 } from './ReactWorkTags';
 import {Deletion, Hydrating, Placement} from './ReactSideEffectTags';
-import {Passive as PassiveSubtreeTag} from './ReactSubtreeTags';
 import invariant from 'shared/invariant';
 
 import {
@@ -131,12 +130,6 @@ function deleteHydratableInstance(
     returnFiber.deletions = [childToDelete];
     // TODO (effects) Rename this to better reflect its new usage (e.g. ChildDeletions)
     returnFiber.effectTag |= Deletion;
-
-    // We are deleting a subtree that may contain a passive effect.
-    // Mark the parent so we traverse this path after commit and run any unmount functions.
-    // This may cause us to traverse unnecessarily in some cases, but effects are common,
-    // and the cost of over traversing is small (just the path to the deleted node).
-    returnFiber.subtreeTag |= PassiveSubtreeTag;
   } else {
     deletions.push(childToDelete);
   }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2560,13 +2560,6 @@ function commitMutationEffectsDeletions(
         captureCommitPhaseError(childToDelete, error);
       }
     }
-
-    // If there are no pending passive effects, it's safe to detach remaining pointers now.
-    const primarySubtreeTag = childToDelete.subtreeTag & PassiveSubtreeTag;
-    const primaryEffectTag = childToDelete.effectTag & PassiveMask;
-    if (primarySubtreeTag === NoSubtreeTag && primaryEffectTag === NoEffect) {
-      detachFiberAfterEffects(childToDelete);
-    }
   }
 }
 
@@ -4062,7 +4055,6 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
 function detachFiberAfterEffects(fiber: Fiber): void {
   // Null out fields to improve GC for references that may be lingering (e.g. DevTools).
   // Note that we already cleared the return pointer in detachFiberMutation().
-  fiber.alternate = null;
   fiber.child = null;
   fiber.dependencies = null;
   fiber.firstEffect = null;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2835,7 +2835,7 @@ function flushPassiveUnmountEffects(firstChild: Fiber): void {
       case ForwardRef:
       case SimpleMemoComponent:
       case Block: {
-        const primaryEffectTag = fiber.effectTag & PassiveMask;
+        const primaryEffectTag = fiber.effectTag & Passive;
         if (primaryEffectTag !== NoEffect) {
           flushPassiveUnmountEffectsImpl(fiber);
         }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2794,19 +2794,15 @@ function flushPassiveUnmountEffects(firstChild: Fiber): void {
       fiber.deletions = null;
     }
 
-    const didBailout =
-      fiber.alternate !== null && fiber.alternate.child === fiber.child;
-    if (!didBailout) {
-      const child = fiber.child;
-      if (child !== null) {
-        // If any children have passive effects then traverse the subtree.
-        // Note that this requires checking subtreeTag of the current Fiber,
-        // rather than the subtreeTag/effectsTag of the first child,
-        // since that would not cover passive effects in siblings.
-        const primarySubtreeTag = fiber.subtreeTag & PassiveSubtreeTag;
-        if (primarySubtreeTag !== NoSubtreeTag) {
-          flushPassiveUnmountEffects(child);
-        }
+    const child = fiber.child;
+    if (child !== null) {
+      // If any children have passive effects then traverse the subtree.
+      // Note that this requires checking subtreeTag of the current Fiber,
+      // rather than the subtreeTag/effectsTag of the first child,
+      // since that would not cover passive effects in siblings.
+      const primarySubtreeTag = fiber.subtreeTag & PassiveSubtreeTag;
+      if (primarySubtreeTag !== NoSubtreeTag) {
+        flushPassiveUnmountEffects(child);
       }
     }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -4060,7 +4060,21 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
 }
 
 function detachFiberAfterEffects(fiber: Fiber): void {
+  // Null out fields to improve GC for references that may be lingering (e.g. DevTools).
+  // Note that we already cleared the return pointer in detachFiberMutation().
+  fiber.alternate = null;
   fiber.child = null;
+  fiber.dependencies = null;
+  fiber.firstEffect = null;
+  fiber.lastEffect = null;
+  fiber.memoizedProps = null;
+  fiber.memoizedState = null;
+  fiber.pendingProps = null;
   fiber.sibling = null;
+  fiber.stateNode = null;
   fiber.updateQueue = null;
+
+  if (__DEV__) {
+    fiber._debugOwner = null;
+  }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -16,6 +16,7 @@ import type {SuspenseConfig} from './ReactFiberSuspenseConfig';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
 import type {Effect as HookEffect} from './ReactFiberHooks.new';
 import type {StackCursor} from './ReactFiberStack.new';
+import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.new';
 
 import {
   warnAboutDeprecatedLifecycles,
@@ -49,6 +50,11 @@ import {
   flushSyncCallbackQueue,
   scheduleSyncCallback,
 } from './SchedulerWithReactIntegration.new';
+import {
+  NoEffect as NoHookEffect,
+  HasEffect as HookHasEffect,
+  Passive as HookPassive,
+} from './ReactHookEffectTags';
 import {
   logCommitStarted,
   logCommitStopped,
@@ -134,12 +140,14 @@ import {
   BeforeMutationMask,
   MutationMask,
   LayoutMask,
+  PassiveMask,
 } from './ReactSideEffectTags';
 import {
   NoEffect as NoSubtreeTag,
-  BeforeMutation,
-  Mutation,
-  Layout,
+  BeforeMutation as BeforeMutationSubtreeTag,
+  Mutation as MutationSubtreeTag,
+  Layout as LayoutSubtreeTag,
+  Passive as PassiveSubtreeTag,
 } from './ReactSubtreeTags';
 import {
   NoLanePriority,
@@ -327,8 +335,6 @@ let rootDoesHavePassiveEffects: boolean = false;
 let rootWithPendingPassiveEffects: FiberRoot | null = null;
 let pendingPassiveEffectsRenderPriority: ReactPriorityLevel = NoSchedulerPriority;
 let pendingPassiveEffectsLanes: Lanes = NoLanes;
-let pendingPassiveHookEffectsMount: Array<HookEffect | Fiber> = [];
-let pendingPassiveHookEffectsUnmount: Array<HookEffect | Fiber> = [];
 let pendingPassiveProfilerEffects: Array<Fiber> = [];
 
 let rootsWithPendingDiscreteUpdates: Set<FiberRoot> | null = null;
@@ -1882,13 +1888,16 @@ function resetChildLanes(completedWork: Fiber) {
 
         const effectTag = child.effectTag;
         if ((effectTag & BeforeMutationMask) !== NoEffect) {
-          subtreeTag |= BeforeMutation;
+          subtreeTag |= BeforeMutationSubtreeTag;
         }
         if ((effectTag & MutationMask) !== NoEffect) {
-          subtreeTag |= Mutation;
+          subtreeTag |= MutationSubtreeTag;
         }
         if ((effectTag & LayoutMask) !== NoEffect) {
-          subtreeTag |= Layout;
+          subtreeTag |= LayoutSubtreeTag;
+        }
+        if ((effectTag & PassiveMask) !== NoEffect) {
+          subtreeTag |= PassiveSubtreeTag;
         }
 
         // When a fiber is cloned, its actualDuration is reset to 0. This value will
@@ -1929,13 +1938,16 @@ function resetChildLanes(completedWork: Fiber) {
 
         const effectTag = child.effectTag;
         if ((effectTag & BeforeMutationMask) !== NoEffect) {
-          subtreeTag |= BeforeMutation;
+          subtreeTag |= BeforeMutationSubtreeTag;
         }
         if ((effectTag & MutationMask) !== NoEffect) {
-          subtreeTag |= Mutation;
+          subtreeTag |= MutationSubtreeTag;
         }
         if ((effectTag & LayoutMask) !== NoEffect) {
-          subtreeTag |= Layout;
+          subtreeTag |= LayoutSubtreeTag;
+        }
+        if ((effectTag & PassiveMask) !== NoEffect) {
+          subtreeTag |= PassiveSubtreeTag;
         }
 
         child = child.sibling;
@@ -2170,6 +2182,17 @@ function commitRootImpl(root, renderPriorityLevel) {
       markLayoutEffectsStopped();
     }
 
+    // If there are pending passive effects, schedule a callback to process them.
+    if ((root.current.subtreeTag & PassiveSubtreeTag) !== NoSubtreeTag) {
+      if (!rootDoesHavePassiveEffects) {
+        rootDoesHavePassiveEffects = true;
+        scheduleCallback(NormalSchedulerPriority, () => {
+          flushPassiveEffects();
+          return null;
+        });
+      }
+    }
+
     // Tell Scheduler to yield at the end of the frame, so the browser has an
     // opportunity to paint.
     requestPaint();
@@ -2201,8 +2224,6 @@ function commitRootImpl(root, renderPriorityLevel) {
     rootWithPendingPassiveEffects = root;
     pendingPassiveEffectsLanes = lanes;
     pendingPassiveEffectsRenderPriority = renderPriorityLevel;
-  } else {
-    // TODO (effects) Detach sibling pointers for deleted Fibers
   }
 
   // Read this again, since an effect might have updated it
@@ -2312,7 +2333,7 @@ function commitBeforeMutationEffects(firstChild: Fiber) {
     }
 
     if (fiber.child !== null) {
-      const primarySubtreeTag = fiber.subtreeTag & BeforeMutation;
+      const primarySubtreeTag = fiber.subtreeTag & BeforeMutationSubtreeTag;
       if (primarySubtreeTag !== NoSubtreeTag) {
         commitBeforeMutationEffects(fiber.child);
       }
@@ -2396,19 +2417,20 @@ function commitMutationEffects(
 ) {
   let fiber = firstChild;
   while (fiber !== null) {
-    if (fiber.deletions !== null) {
-      commitMutationEffectsDeletions(
-        fiber.deletions,
-        root,
-        renderPriorityLevel,
-      );
+    const deletions = fiber.deletions;
+    if (deletions !== null) {
+      commitMutationEffectsDeletions(deletions, root, renderPriorityLevel);
 
-      // TODO (effects) Don't clear this yet; we may need to cleanup passive effects
-      fiber.deletions = null;
+      // If there are no pending passive effects, clear the deletions Array.
+      const primaryEffectTag = fiber.effectTag & PassiveMask;
+      const primarySubtreeTag = fiber.subtreeTag & PassiveSubtreeTag;
+      if (primaryEffectTag === NoEffect && primarySubtreeTag === NoSubtreeTag) {
+        fiber.deletions = null;
+      }
     }
 
     if (fiber.child !== null) {
-      const primarySubtreeTag = fiber.subtreeTag & Mutation;
+      const primarySubtreeTag = fiber.subtreeTag & MutationSubtreeTag;
       if (primarySubtreeTag !== NoSubtreeTag) {
         commitMutationEffects(fiber.child, root, renderPriorityLevel);
       }
@@ -2538,7 +2560,23 @@ function commitMutationEffectsDeletions(
         captureCommitPhaseError(childToDelete, error);
       }
     }
-    // Don't clear the Deletion effect yet; we also use it to know when we need to detach refs later.
+
+    // If there are no pending passive effects, it's safe to detach remaining pointers now.
+    const primarySubtreeTag = childToDelete.subtreeTag & PassiveSubtreeTag;
+    const primaryEffectTag = childToDelete.effectTag & PassiveMask;
+    if (primarySubtreeTag === NoSubtreeTag && primaryEffectTag === NoEffect) {
+      detachFiberAfterEffects(childToDelete);
+    }
+  }
+}
+
+export function schedulePassiveEffectCallback() {
+  if (!rootDoesHavePassiveEffects) {
+    rootDoesHavePassiveEffects = true;
+    scheduleCallback(NormalSchedulerPriority, () => {
+      flushPassiveEffects();
+      return null;
+    });
   }
 }
 
@@ -2550,7 +2588,7 @@ function commitLayoutEffects(
   let fiber = firstChild;
   while (fiber !== null) {
     if (fiber.child !== null) {
-      const primarySubtreeTag = fiber.subtreeTag & Layout;
+      const primarySubtreeTag = fiber.subtreeTag & LayoutSubtreeTag;
       if (primarySubtreeTag !== NoSubtreeTag) {
         commitLayoutEffects(fiber.child, root, committedLanes);
       }
@@ -2645,44 +2683,239 @@ export function enqueuePendingPassiveProfilerEffect(fiber: Fiber): void {
   }
 }
 
-export function enqueuePendingPassiveHookEffectMount(
-  fiber: Fiber,
-  effect: HookEffect,
-): void {
-  pendingPassiveHookEffectsMount.push(effect, fiber);
-  if (!rootDoesHavePassiveEffects) {
-    rootDoesHavePassiveEffects = true;
-    scheduleCallback(NormalSchedulerPriority, () => {
-      flushPassiveEffects();
-      return null;
-    });
-  }
-}
-
-export function enqueuePendingPassiveHookEffectUnmount(
-  fiber: Fiber,
-  effect: HookEffect,
-): void {
-  pendingPassiveHookEffectsUnmount.push(effect, fiber);
-  if (__DEV__) {
-    fiber.effectTag |= PassiveUnmountPendingDev;
-    const alternate = fiber.alternate;
-    if (alternate !== null) {
-      alternate.effectTag |= PassiveUnmountPendingDev;
-    }
-  }
-  if (!rootDoesHavePassiveEffects) {
-    rootDoesHavePassiveEffects = true;
-    scheduleCallback(NormalSchedulerPriority, () => {
-      flushPassiveEffects();
-      return null;
-    });
-  }
-}
-
 function invokePassiveEffectCreate(effect: HookEffect): void {
   const create = effect.create;
   effect.destroy = create();
+}
+
+function flushPassiveMountEffects(firstChild: Fiber): void {
+  let fiber = firstChild;
+  while (fiber !== null) {
+    const didBailout =
+      fiber.alternate !== null && fiber.alternate.child === fiber.child;
+    const primarySubtreeTag = fiber.subtreeTag & PassiveSubtreeTag;
+
+    if (
+      fiber.child !== null &&
+      !didBailout &&
+      primarySubtreeTag !== NoSubtreeTag
+    ) {
+      flushPassiveMountEffects(fiber.child);
+    }
+
+    if ((fiber.effectTag & Update) !== NoEffect) {
+      switch (fiber.tag) {
+        case FunctionComponent:
+        case ForwardRef:
+        case SimpleMemoComponent:
+        case Block: {
+          flushPassiveMountEffectsImpl(fiber);
+        }
+      }
+    }
+
+    fiber = fiber.sibling;
+  }
+}
+
+function flushPassiveMountEffectsImpl(fiber: Fiber): void {
+  const updateQueue: FunctionComponentUpdateQueue | null = (fiber.updateQueue: any);
+  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+  if (lastEffect !== null) {
+    const firstEffect = lastEffect.next;
+    let effect = firstEffect;
+    do {
+      const {next, tag} = effect;
+
+      if (
+        (tag & HookPassive) !== NoHookEffect &&
+        (tag & HookHasEffect) !== NoHookEffect
+      ) {
+        if (__DEV__) {
+          setCurrentDebugFiberInDEV(fiber);
+          if (
+            enableProfilerTimer &&
+            enableProfilerCommitHooks &&
+            fiber.mode & ProfileMode
+          ) {
+            startPassiveEffectTimer();
+            invokeGuardedCallback(
+              null,
+              invokePassiveEffectCreate,
+              null,
+              effect,
+            );
+            recordPassiveEffectDuration(fiber);
+          } else {
+            invokeGuardedCallback(
+              null,
+              invokePassiveEffectCreate,
+              null,
+              effect,
+            );
+          }
+          if (hasCaughtError()) {
+            invariant(fiber !== null, 'Should be working on an effect.');
+            const error = clearCaughtError();
+            captureCommitPhaseError(fiber, error);
+          }
+          resetCurrentDebugFiberInDEV();
+        } else {
+          try {
+            const create = effect.create;
+            if (
+              enableProfilerTimer &&
+              enableProfilerCommitHooks &&
+              fiber.mode & ProfileMode
+            ) {
+              try {
+                startPassiveEffectTimer();
+                effect.destroy = create();
+              } finally {
+                recordPassiveEffectDuration(fiber);
+              }
+            } else {
+              effect.destroy = create();
+            }
+          } catch (error) {
+            invariant(fiber !== null, 'Should be working on an effect.');
+            captureCommitPhaseError(fiber, error);
+          }
+        }
+      }
+
+      effect = next;
+    } while (effect !== firstEffect);
+  }
+}
+
+function flushPassiveUnmountEffects(firstChild: Fiber): void {
+  let fiber = firstChild;
+  while (fiber !== null) {
+    const deletions = fiber.deletions;
+    if (deletions !== null) {
+      for (let i = 0; i < deletions.length; i++) {
+        const fiberToDelete = deletions[i];
+        // If this fiber (or anything below it) has passive effects then traverse the subtree.
+        const primaryEffectTag = fiberToDelete.effectTag & PassiveMask;
+        const primarySubtreeTag = fiberToDelete.subtreeTag & PassiveSubtreeTag;
+        if (
+          primarySubtreeTag !== NoSubtreeTag ||
+          primaryEffectTag !== NoEffect
+        ) {
+          flushPassiveUnmountEffects(fiberToDelete);
+        }
+
+        // Now that passive effects have been processed, it's safe to detach lingering pointers.
+        detachFiberAfterEffects(fiberToDelete);
+      }
+
+      // Clear deletions now that passive effects have  been procssed.
+      fiber.deletions = null;
+    }
+
+    const didBailout =
+      fiber.alternate !== null && fiber.alternate.child === fiber.child;
+    if (!didBailout) {
+      const child = fiber.child;
+      if (child !== null) {
+        // If any children have passive effects then traverse the subtree.
+        // Note that this requires checking subtreeTag of the current Fiber,
+        // rather than the subtreeTag/effectsTag of the first child,
+        // since that would not cover passive effects in siblings.
+        const primarySubtreeTag = fiber.subtreeTag & PassiveSubtreeTag;
+        if (primarySubtreeTag !== NoSubtreeTag) {
+          flushPassiveUnmountEffects(child);
+        }
+      }
+    }
+
+    switch (fiber.tag) {
+      case FunctionComponent:
+      case ForwardRef:
+      case SimpleMemoComponent:
+      case Block: {
+        const primaryEffectTag = fiber.effectTag & PassiveMask;
+        if (primaryEffectTag !== NoEffect) {
+          flushPassiveUnmountEffectsImpl(fiber);
+        }
+      }
+    }
+
+    fiber = fiber.sibling;
+  }
+}
+
+function flushPassiveUnmountEffectsImpl(fiber: Fiber): void {
+  const updateQueue: FunctionComponentUpdateQueue | null = (fiber.updateQueue: any);
+  const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
+  if (lastEffect !== null) {
+    const firstEffect = lastEffect.next;
+    let effect = firstEffect;
+    do {
+      const {next, tag} = effect;
+      if (
+        (tag & HookPassive) !== NoHookEffect &&
+        (tag & HookHasEffect) !== NoHookEffect
+      ) {
+        const destroy = effect.destroy;
+        effect.destroy = undefined;
+
+        if (__DEV__) {
+          fiber.effectTag &= ~PassiveUnmountPendingDev;
+          const alternate = fiber.alternate;
+          if (alternate !== null) {
+            alternate.effectTag &= ~PassiveUnmountPendingDev;
+          }
+        }
+
+        if (typeof destroy === 'function') {
+          if (__DEV__) {
+            setCurrentDebugFiberInDEV(fiber);
+            if (
+              enableProfilerTimer &&
+              enableProfilerCommitHooks &&
+              fiber.mode & ProfileMode
+            ) {
+              startPassiveEffectTimer();
+              invokeGuardedCallback(null, destroy, null);
+              recordPassiveEffectDuration(fiber);
+            } else {
+              invokeGuardedCallback(null, destroy, null);
+            }
+            if (hasCaughtError()) {
+              invariant(fiber !== null, 'Should be working on an effect.');
+              const error = clearCaughtError();
+              captureCommitPhaseError(fiber, error);
+            }
+            resetCurrentDebugFiberInDEV();
+          } else {
+            try {
+              if (
+                enableProfilerTimer &&
+                enableProfilerCommitHooks &&
+                fiber.mode & ProfileMode
+              ) {
+                try {
+                  startPassiveEffectTimer();
+                  destroy();
+                } finally {
+                  recordPassiveEffectDuration(fiber);
+                }
+              } else {
+                destroy();
+              }
+            } catch (error) {
+              invariant(fiber !== null, 'Should be working on an effect.');
+              captureCommitPhaseError(fiber, error);
+            }
+          }
+        }
+      }
+
+      effect = next;
+    } while (effect !== firstEffect);
+  }
 }
 
 function flushPassiveEffectsImpl() {
@@ -2724,117 +2957,8 @@ function flushPassiveEffectsImpl() {
   // e.g. a destroy function in one component may unintentionally override a ref
   // value set by a create function in another component.
   // Layout effects have the same constraint.
-
-  // First pass: Destroy stale passive effects.
-  const unmountEffects = pendingPassiveHookEffectsUnmount;
-  pendingPassiveHookEffectsUnmount = [];
-  for (let i = 0; i < unmountEffects.length; i += 2) {
-    const effect = ((unmountEffects[i]: any): HookEffect);
-    const fiber = ((unmountEffects[i + 1]: any): Fiber);
-    const destroy = effect.destroy;
-    effect.destroy = undefined;
-
-    if (__DEV__) {
-      fiber.effectTag &= ~PassiveUnmountPendingDev;
-      const alternate = fiber.alternate;
-      if (alternate !== null) {
-        alternate.effectTag &= ~PassiveUnmountPendingDev;
-      }
-    }
-
-    if (typeof destroy === 'function') {
-      if (__DEV__) {
-        setCurrentDebugFiberInDEV(fiber);
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          fiber.mode & ProfileMode
-        ) {
-          startPassiveEffectTimer();
-          invokeGuardedCallback(null, destroy, null);
-          recordPassiveEffectDuration(fiber);
-        } else {
-          invokeGuardedCallback(null, destroy, null);
-        }
-        if (hasCaughtError()) {
-          invariant(fiber !== null, 'Should be working on an effect.');
-          const error = clearCaughtError();
-          captureCommitPhaseError(fiber, error);
-        }
-        resetCurrentDebugFiberInDEV();
-      } else {
-        try {
-          if (
-            enableProfilerTimer &&
-            enableProfilerCommitHooks &&
-            fiber.mode & ProfileMode
-          ) {
-            try {
-              startPassiveEffectTimer();
-              destroy();
-            } finally {
-              recordPassiveEffectDuration(fiber);
-            }
-          } else {
-            destroy();
-          }
-        } catch (error) {
-          invariant(fiber !== null, 'Should be working on an effect.');
-          captureCommitPhaseError(fiber, error);
-        }
-      }
-    }
-  }
-  // Second pass: Create new passive effects.
-  const mountEffects = pendingPassiveHookEffectsMount;
-  pendingPassiveHookEffectsMount = [];
-  for (let i = 0; i < mountEffects.length; i += 2) {
-    const effect = ((mountEffects[i]: any): HookEffect);
-    const fiber = ((mountEffects[i + 1]: any): Fiber);
-    if (__DEV__) {
-      setCurrentDebugFiberInDEV(fiber);
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        fiber.mode & ProfileMode
-      ) {
-        startPassiveEffectTimer();
-        invokeGuardedCallback(null, invokePassiveEffectCreate, null, effect);
-        recordPassiveEffectDuration(fiber);
-      } else {
-        invokeGuardedCallback(null, invokePassiveEffectCreate, null, effect);
-      }
-      if (hasCaughtError()) {
-        invariant(fiber !== null, 'Should be working on an effect.');
-        const error = clearCaughtError();
-        captureCommitPhaseError(fiber, error);
-      }
-      resetCurrentDebugFiberInDEV();
-    } else {
-      try {
-        const create = effect.create;
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          fiber.mode & ProfileMode
-        ) {
-          try {
-            startPassiveEffectTimer();
-            effect.destroy = create();
-          } finally {
-            recordPassiveEffectDuration(fiber);
-          }
-        } else {
-          effect.destroy = create();
-        }
-      } catch (error) {
-        invariant(fiber !== null, 'Should be working on an effect.');
-        captureCommitPhaseError(fiber, error);
-      }
-    }
-  }
-
-  // TODO (effects) Detach sibling pointers for deleted Fibers
+  flushPassiveUnmountEffects(root.current);
+  flushPassiveMountEffects(root.current);
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {
     const profilerEffects = pendingPassiveProfilerEffects;
@@ -3933,4 +4057,10 @@ export function act(callback: () => Thenable<mixed>): Thenable<void> {
       },
     };
   }
+}
+
+function detachFiberAfterEffects(fiber: Fiber): void {
+  fiber.child = null;
+  fiber.sibling = null;
+  fiber.updateQueue = null;
 }

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -10,37 +10,49 @@
 export type SideEffectTag = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoEffect = /*                     */ 0b000000000000000;
-export const PerformedWork = /*                */ 0b000000000000001;
+export const NoEffect = /*                     */ 0b0000000000000000;
+export const PerformedWork = /*                */ 0b0000000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*                    */ 0b000000000000010;
-export const Update = /*                       */ 0b000000000000100;
-export const PlacementAndUpdate = /*           */ 0b000000000000110;
-export const Deletion = /*                     */ 0b000000000001000;
-export const ContentReset = /*                 */ 0b000000000010000;
-export const Callback = /*                     */ 0b000000000100000;
-export const DidCapture = /*                   */ 0b000000001000000;
-export const Ref = /*                          */ 0b000000010000000;
-export const Snapshot = /*                     */ 0b000000100000000;
-export const Passive = /*                      */ 0b000001000000000;
-export const PassiveUnmountPendingDev = /*     */ 0b010000000000000;
-export const Hydrating = /*                    */ 0b000010000000000;
-export const HydratingAndUpdate = /*           */ 0b000010000000100;
+export const Placement = /*                    */ 0b0000000000000010;
+export const Update = /*                       */ 0b0000000000000100;
+export const PlacementAndUpdate = /*           */ 0b0000000000000110;
+export const Deletion = /*                     */ 0b0000000000001000;
+export const ContentReset = /*                 */ 0b0000000000010000;
+export const Callback = /*                     */ 0b0000000000100000;
+export const DidCapture = /*                   */ 0b0000000001000000;
+export const Ref = /*                          */ 0b0000000010000000;
+export const Snapshot = /*                     */ 0b0000000100000000;
+export const Passive = /*                      */ 0b0000001000000000;
+export const PassiveUnmountPendingDev = /*     */ 0b0010000000000000;
+export const Hydrating = /*                    */ 0b0000010000000000;
+export const HydratingAndUpdate = /*           */ 0b0000010000000100;
 
 // Passive & Update & Callback & Ref & Snapshot
-export const LifecycleEffectMask = /*          */ 0b000001110100100;
+export const LifecycleEffectMask = /*          */ 0b0000001110100100;
 
 // Union of all host effects
-export const HostEffectMask = /*               */ 0b000011111111111;
+export const HostEffectMask = /*               */ 0b0000011111111111;
 
 // These are not really side effects, but we still reuse this field.
-export const Incomplete = /*                   */ 0b000100000000000;
-export const ShouldCapture = /*                */ 0b001000000000000;
-export const ForceUpdateForLegacySuspense = /* */ 0b100000000000000;
+export const Incomplete = /*                   */ 0b0000100000000000;
+export const ShouldCapture = /*                */ 0b0001000000000000;
+export const ForceUpdateForLegacySuspense = /* */ 0b0100000000000000;
+
+// Static tags describe aspects of a fiber that are not specific to a render,
+// e.g. a fiber uses a passive effect (even if there are no updates on this particular render).
+// This enables us to defer more work in the unmount case,
+// since we can defer traversing the tree during layout to look for Passive effects,
+// and instead rely on the static flag as a signal that there may be cleanup work.
+export const PassiveStatic = /*                */ 0b1000000000000000;
 
 // Union of side effect groupings as pertains to subtreeTag
-export const BeforeMutationMask = /*           */ 0b000001100001010;
-export const MutationMask = /*                 */ 0b000010010011110;
-export const LayoutMask = /*                   */ 0b000000010100100;
-export const PassiveMask = /*                  */ 0b000001000000000;
+export const BeforeMutationMask = /*           */ 0b0000001100001010;
+export const MutationMask = /*                 */ 0b0000010010011110;
+export const LayoutMask = /*                   */ 0b0000000010100100;
+export const PassiveMask = /*                  */ 0b1000001000000000;
+
+// Union of tags that don't get reset on clones.
+// This allows certain concepts to persist without recalculting them,
+// e.g. whether a subtree contains passive effects or portals.
+export const StaticMask = /*                   */ 0b1000000000000000;

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -50,7 +50,7 @@ export const PassiveStatic = /*                */ 0b1000000000000000;
 export const BeforeMutationMask = /*           */ 0b0000001100001010;
 export const MutationMask = /*                 */ 0b0000010010011110;
 export const LayoutMask = /*                   */ 0b0000000010100100;
-export const PassiveMask = /*                  */ 0b1000001000000000;
+export const PassiveMask = /*                  */ 0b1000001000001000;
 
 // Union of tags that don't get reset on clones.
 // This allows certain concepts to persist without recalculting them,

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -24,6 +24,7 @@ export const DidCapture = /*                   */ 0b0000000001000000;
 export const Ref = /*                          */ 0b0000000010000000;
 export const Snapshot = /*                     */ 0b0000000100000000;
 export const Passive = /*                      */ 0b0000001000000000;
+// TODO (effects) Remove this bit once the new reconciler is synced to the old.
 export const PassiveUnmountPendingDev = /*     */ 0b0010000000000000;
 export const Hydrating = /*                    */ 0b0000010000000000;
 export const HydratingAndUpdate = /*           */ 0b0000010000000100;

--- a/packages/react-reconciler/src/ReactSideEffectTags.js
+++ b/packages/react-reconciler/src/ReactSideEffectTags.js
@@ -43,3 +43,4 @@ export const ForceUpdateForLegacySuspense = /* */ 0b100000000000000;
 export const BeforeMutationMask = /*           */ 0b000001100001010;
 export const MutationMask = /*                 */ 0b000010010011110;
 export const LayoutMask = /*                   */ 0b000000010100100;
+export const PassiveMask = /*                  */ 0b000001000000000;

--- a/packages/react-reconciler/src/ReactSubtreeTags.js
+++ b/packages/react-reconciler/src/ReactSubtreeTags.js
@@ -9,7 +9,8 @@
 
 export type SubtreeTag = number;
 
-export const NoEffect = /*        */ 0b000;
-export const BeforeMutation = /*  */ 0b001;
-export const Mutation = /*        */ 0b010;
-export const Layout = /*          */ 0b100;
+export const NoEffect = /*        */ 0b0000;
+export const BeforeMutation = /*  */ 0b0001;
+export const Mutation = /*        */ 0b0010;
+export const Layout = /*          */ 0b0100;
+export const Passive = /*         */ 0b1000;

--- a/packages/react-reconciler/src/ReactSubtreeTags.js
+++ b/packages/react-reconciler/src/ReactSubtreeTags.js
@@ -14,3 +14,8 @@ export const BeforeMutation = /*  */ 0b0001;
 export const Mutation = /*        */ 0b0010;
 export const Layout = /*          */ 0b0100;
 export const Passive = /*         */ 0b1000;
+
+// Union of tags that don't get reset on clones.
+// This allows certain concepts to persist without recalculting them,
+// e.g. whether a subtree contains passive effects or portals.
+export const Static = /*          */ 0b1000;

--- a/packages/react-reconciler/src/ReactSubtreeTags.js
+++ b/packages/react-reconciler/src/ReactSubtreeTags.js
@@ -14,8 +14,3 @@ export const BeforeMutation = /*  */ 0b0001;
 export const Mutation = /*        */ 0b0010;
 export const Layout = /*          */ 0b0100;
 export const Passive = /*         */ 0b1000;
-
-// Union of tags that don't get reset on clones.
-// This allows certain concepts to persist without recalculting them,
-// e.g. whether a subtree contains passive effects or portals.
-export const Static = /*          */ 0b1000;

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -1454,7 +1454,7 @@ describe('ReactSuspense', () => {
       ]);
     });
 
-    it('should call onInteractionScheduledWorkCompleted after suspending', done => {
+    it('should call onInteractionScheduledWorkCompleted after suspending', () => {
       const subscriber = {
         onInteractionScheduledWorkCompleted: jest.fn(),
         onInteractionTraced: jest.fn(),
@@ -1512,13 +1512,11 @@ describe('ReactSuspense', () => {
         jest.advanceTimersByTime(1000);
 
         expect(Scheduler).toHaveYielded(['Promise resolved [C]']);
-        expect(Scheduler).toFlushExpired([
+        expect(Scheduler).toFlushAndYield([
           // Even though the promise for C was thrown three times, we should only
           // re-render once.
           'C',
         ]);
-
-        done();
       });
 
       expect(

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -502,7 +502,11 @@ describe('SchedulingProfiler', () => {
       '--render-start-1024',
       '--render-stop',
       '--commit-start-1024',
+      '--layout-effects-start-1024',
+      '--layout-effects-stop',
       '--commit-stop',
+      '--passive-effects-start-1024',
+      '--passive-effects-stop',
     ]);
   });
 

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -486,28 +486,51 @@ describe('SchedulingProfiler', () => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
 
-    expect(marks.map(normalizeCodeLocInfo)).toEqual([
-      '--schedule-render-512',
-      '--render-start-512',
-      '--render-stop',
-      '--commit-start-512',
-      '--layout-effects-start-512',
-      '--layout-effects-stop',
-      '--commit-stop',
-      '--passive-effects-start-512',
-      toggleComponentStacks(
-        '--schedule-state-update-1024-Example-\n    in Example (at **)',
-      ),
-      '--passive-effects-stop',
-      '--render-start-1024',
-      '--render-stop',
-      '--commit-start-1024',
-      '--layout-effects-start-1024',
-      '--layout-effects-stop',
-      '--commit-stop',
-      '--passive-effects-start-1024',
-      '--passive-effects-stop',
-    ]);
+    gate(({old}) => {
+      if (old) {
+        expect(marks.map(normalizeCodeLocInfo)).toEqual([
+          '--schedule-render-512',
+          '--render-start-512',
+          '--render-stop',
+          '--commit-start-512',
+          '--layout-effects-start-512',
+          '--layout-effects-stop',
+          '--commit-stop',
+          '--passive-effects-start-512',
+          toggleComponentStacks(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          ),
+          '--passive-effects-stop',
+          '--render-start-1024',
+          '--render-stop',
+          '--commit-start-1024',
+          '--commit-stop',
+        ]);
+      } else {
+        expect(marks.map(normalizeCodeLocInfo)).toEqual([
+          '--schedule-render-512',
+          '--render-start-512',
+          '--render-stop',
+          '--commit-start-512',
+          '--layout-effects-start-512',
+          '--layout-effects-stop',
+          '--commit-stop',
+          '--passive-effects-start-512',
+          toggleComponentStacks(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          ),
+          '--passive-effects-stop',
+          '--render-start-1024',
+          '--render-stop',
+          '--commit-start-1024',
+          '--layout-effects-start-1024',
+          '--layout-effects-stop',
+          '--commit-stop',
+          '--passive-effects-start-1024',
+          '--passive-effects-stop',
+        ]);
+      }
+    });
   });
 
   // @gate enableSchedulingProfiler


### PR DESCRIPTION
* Adds new `Passive` subtree tag value.
* Bubbles passive flag to ancestors in the case of an unmount.
* Adds recursive traversal for passive effects (mounts and unmounts).
* Removes `pendingPassiveHookEffectsMount` and `pendingPassiveHookEffectsUnmount` arrays from work loop.
* Re-adds sibling and child pointer detaching (temporarily removed in previous PR).
* Addresses some minor TODO comments left over from previous PRs.

---

Co-authored-by: Luna Ruan <luna@fb.com>