### PR TITLE
Sync debug tracing and scheduler profiling to new fork

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -24,9 +24,13 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {enableNewReconciler} from 'shared/ReactFeatureFlags';
+import {
+  enableDebugTracing,
+  enableSchedulingProfiler,
+  enableNewReconciler,
+} from 'shared/ReactFeatureFlags';
 
-import {NoMode, BlockingMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
 import {
   NoLane,
   NoLanes,
@@ -88,6 +92,8 @@ import {
   warnAboutMultipleRenderersDEV,
 } from './ReactMutableSource.new';
 import {getIsRendering} from './ReactCurrentFiber';
+import {logStateUpdateScheduled} from './DebugTracing';
+import {markStateUpdateScheduled} from './SchedulingProfiler';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -1750,6 +1756,19 @@ function dispatchAction<S, A>(
       }
     }
     scheduleUpdateOnFiber(fiber, lane, eventTime);
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      if (fiber.mode & DebugTracingMode) {
+        const name = getComponentName(fiber.type) || 'Unknown';
+        logStateUpdateScheduled(name, lane, action);
+      }
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markStateUpdateScheduled(fiber, lane);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -39,6 +39,7 @@ import {
 } from './ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
+import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -95,6 +96,7 @@ import {
   setRefreshHandler,
   findHostInstancesForRefresh,
 } from './ReactFiberHotReloading.new';
+import {markRenderScheduled} from './SchedulingProfiler';
 
 export {registerMutableSourceForHydration} from './ReactMutableSource.new';
 export {createPortal} from './ReactPortal';
@@ -272,6 +274,10 @@ export function updateContainer(
   }
   const suspenseConfig = requestCurrentSuspenseConfig();
   const lane = requestUpdateLane(current, suspenseConfig);
+
+  if (enableSchedulingProfiler) {
+    markRenderScheduled(lane);
+  }
 
   const context = getContextForSubtree(parentComponent);
   if (container.context === null) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1361,7 +1361,7 @@ function handleError(root, thrownValue): void {
         // sibling, or the parent if there are no siblings. But since the root
         // has no siblings nor a parent, we set it to null. Usually this is
         // handled by `completeUnitOfWork` or `unwindWork`, but since we're
-        // interntionally not calling those, we need set it here.
+        // intentionally not calling those, we need set it here.
         // TODO: Consider calling `unwindWork` to pop the contexts.
         workInProgress = null;
         return;

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -351,8 +351,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -378,8 +384,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -461,8 +473,14 @@ describe('SchedulingProfiler', () => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -17,7 +17,7 @@ export const enableDebugTracing = false;
 
 // Adds user timing marks for e.g. state updates, suspense, and work loop stuff,
 // for an experimental scheduling profiler tool.
-export const enableSchedulingProfiler = false;
+export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
 // reducers by double invoking them in Strict Mode.

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,9 +19,12 @@ export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 
-// TODO: These features do not currently exist in the new reconciler fork.
-export const enableDebugTracing = !__VARIANT__;
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
+// Enable this flag to help with concurrent mode debugging.
+// It logs information to the console about React scheduling, rendering, and commit phases.
+//
+// NOTE: This feature will only work in DEV builds.
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableDebugTracing = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -22,8 +22,7 @@ export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.
 //
-// NOTE: This feature will only work in DEV builds.
-// WARNING: This feature does not yet exist in the new reconciler fork.
+// NOTE: This feature will only work in DEV mode; all callsights are wrapped with __DEV__.
 export const enableDebugTracing = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,7 +26,6 @@ export const {
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
-  enableSchedulingProfiler,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -34,6 +33,11 @@ export const {
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
+
+// Logs additional User Timing API marks for use with an experimental profiling tool.
+//
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,9 +35,7 @@ export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
-//
-// WARNING: This feature does not yet exist in the new reconciler fork.
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
+export const enableSchedulingProfiler = __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.


### PR DESCRIPTION
#19334 was reverted in #19366 because it caused test failures during a www sync.

This PR builds on top of PR #19375 and is comprised of a single commit, [79637ec](https://github.com/facebook/react/pull/19376/commits/79637ec670db7eb3eff3966b51e179415c5aac62?w=1).

* Syncs debug tracing and scheduling profiler code from old -> new fork.
  * (This was pretty manual given the ongoing effects list refactor.)
* Enables scheduling profiler for experimental OSS builds.
* Updates test `@gate` conditions.