### PR TITLE
[do not merge] Make enableSchedulingProfiler flag static

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,9 +19,12 @@ export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 
-// TODO: These features do not currently exist in the new reconciler fork.
-export const enableDebugTracing = !__VARIANT__;
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
+// Enable this flag to help with concurrent mode debugging.
+// It logs information to the console about React scheduling, rendering, and commit phases.
+//
+// NOTE: This feature will only work in DEV builds.
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableDebugTracing = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,7 +26,6 @@ export const {
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
-  enableSchedulingProfiler,
   enableFormEventDelegation,
 } = dynamicFeatureFlags;
 
@@ -35,6 +34,11 @@ export const {
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
+
+// Logs additional User Timing API marks for use with an experimental profiling tool.
+//
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.


### PR DESCRIPTION
Tests changes from PR #19375 applied to master right before the v17 bump. This will let me sync to www and test in isolation.