### PR TITLE
Conditionally enable profiler component stacks

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -24,9 +24,13 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
-import {enableNewReconciler} from 'shared/ReactFeatureFlags';
+import {
+  enableDebugTracing,
+  enableSchedulingProfiler,
+  enableNewReconciler,
+} from 'shared/ReactFeatureFlags';
 
-import {NoMode, BlockingMode} from './ReactTypeOfMode';
+import {NoMode, BlockingMode, DebugTracingMode} from './ReactTypeOfMode';
 import {
   NoLane,
   NoLanes,
@@ -88,6 +92,8 @@ import {
   warnAboutMultipleRenderersDEV,
 } from './ReactMutableSource.new';
 import {getIsRendering} from './ReactCurrentFiber';
+import {logStateUpdateScheduled} from './DebugTracing';
+import {markStateUpdateScheduled} from './SchedulingProfiler';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -1750,6 +1756,19 @@ function dispatchAction<S, A>(
       }
     }
     scheduleUpdateOnFiber(fiber, lane, eventTime);
+  }
+
+  if (__DEV__) {
+    if (enableDebugTracing) {
+      if (fiber.mode & DebugTracingMode) {
+        const name = getComponentName(fiber.type) || 'Unknown';
+        logStateUpdateScheduled(name, lane, action);
+      }
+    }
+  }
+
+  if (enableSchedulingProfiler) {
+    markStateUpdateScheduled(fiber, lane);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -39,6 +39,7 @@ import {
 } from './ReactWorkTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
+import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -95,6 +96,7 @@ import {
   setRefreshHandler,
   findHostInstancesForRefresh,
 } from './ReactFiberHotReloading.new';
+import {markRenderScheduled} from './SchedulingProfiler';
 
 export {registerMutableSourceForHydration} from './ReactMutableSource.new';
 export {createPortal} from './ReactPortal';
@@ -272,6 +274,10 @@ export function updateContainer(
   }
   const suspenseConfig = requestCurrentSuspenseConfig();
   const lane = requestUpdateLane(current, suspenseConfig);
+
+  if (enableSchedulingProfiler) {
+    markRenderScheduled(lane);
+  }
 
   const context = getContextForSubtree(parentComponent);
   if (container.context === null) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1361,7 +1361,7 @@ function handleError(root, thrownValue): void {
         // sibling, or the parent if there are no siblings. But since the root
         // has no siblings nor a parent, we set it to null. Usually this is
         // handled by `completeUnitOfWork` or `unwindWork`, but since we're
-        // interntionally not calling those, we need set it here.
+        // intentionally not calling those, we need set it here.
         // TODO: Consider calling `unwindWork` to pop the contexts.
         workInProgress = null;
         return;

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -351,8 +351,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -378,8 +384,14 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-forced-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 
@@ -461,8 +473,14 @@ describe('SchedulingProfiler', () => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
 
-    expect(marks.map(normalizeCodeLocInfo)).toContain(
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+    gate(({old}) =>
+      old
+        ? expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+          )
+        : expect(marks.map(normalizeCodeLocInfo)).toContain(
+            '--schedule-state-update-512-Example-\n    in Example (at **)',
+          ),
     );
   });
 });

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -19,6 +19,20 @@ function normalizeCodeLocInfo(str) {
   );
 }
 
+// TODO (enableSchedulingProfilerComponentStacks) Clean this up once the feature flag has been removed.
+function toggleComponentStacks(mark) {
+  let expectedMark = mark;
+  gate(({enableSchedulingProfilerComponentStacks}) => {
+    if (!enableSchedulingProfilerComponentStacks) {
+      const index = mark.indexOf('\n    ');
+      if (index >= 0) {
+        expectedMark = mark.substr(0, index);
+      }
+    }
+  });
+  return expectedMark;
+}
+
 describe('SchedulingProfiler', () => {
   let React;
   let ReactTestRenderer;
@@ -136,7 +150,9 @@ describe('SchedulingProfiler', () => {
     expect(marks).toEqual([
       '--schedule-render-1',
       '--render-start-1',
-      '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      ),
       '--render-stop',
       '--commit-start-1',
       '--layout-effects-start-1',
@@ -148,7 +164,9 @@ describe('SchedulingProfiler', () => {
 
     await fakeSuspensePromise;
     expect(marks).toEqual([
-      '--suspense-resolved-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-resolved-0-Example-\n    at Example\n    at Suspense',
+      ),
     ]);
   });
 
@@ -168,7 +186,9 @@ describe('SchedulingProfiler', () => {
     expect(marks).toEqual([
       '--schedule-render-1',
       '--render-start-1',
-      '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      ),
       '--render-stop',
       '--commit-start-1',
       '--layout-effects-start-1',
@@ -180,7 +200,9 @@ describe('SchedulingProfiler', () => {
 
     await expect(fakeSuspensePromise).rejects.toThrow();
     expect(marks).toEqual([
-      '--suspense-rejected-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-rejected-0-Example-\n    at Example\n    at Suspense',
+      ),
     ]);
   });
 
@@ -206,7 +228,9 @@ describe('SchedulingProfiler', () => {
 
     expect(marks).toEqual([
       '--render-start-512',
-      '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      ),
       '--render-stop',
       '--commit-start-512',
       '--layout-effects-start-512',
@@ -218,7 +242,9 @@ describe('SchedulingProfiler', () => {
 
     await fakeSuspensePromise;
     expect(marks).toEqual([
-      '--suspense-resolved-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-resolved-0-Example-\n    at Example\n    at Suspense',
+      ),
     ]);
   });
 
@@ -244,7 +270,9 @@ describe('SchedulingProfiler', () => {
 
     expect(marks).toEqual([
       '--render-start-512',
-      '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
+      ),
       '--render-stop',
       '--commit-start-512',
       '--layout-effects-start-512',
@@ -256,7 +284,9 @@ describe('SchedulingProfiler', () => {
 
     await expect(fakeSuspensePromise).rejects.toThrow();
     expect(marks).toEqual([
-      '--suspense-rejected-0-Example-\n    at Example\n    at Suspense',
+      toggleComponentStacks(
+        '--suspense-rejected-0-Example-\n    at Example\n    at Suspense',
+      ),
     ]);
   });
 
@@ -285,7 +315,9 @@ describe('SchedulingProfiler', () => {
       '--render-stop',
       '--commit-start-512',
       '--layout-effects-start-512',
-      '--schedule-state-update-1-Example-\n    in Example (at **)',
+      toggleComponentStacks(
+        '--schedule-state-update-1-Example-\n    in Example (at **)',
+      ),
       '--layout-effects-stop',
       '--render-start-1',
       '--render-stop',
@@ -319,7 +351,9 @@ describe('SchedulingProfiler', () => {
       '--render-stop',
       '--commit-start-512',
       '--layout-effects-start-512',
-      '--schedule-forced-update-1-Example-\n    in Example (at **)',
+      toggleComponentStacks(
+        '--schedule-forced-update-1-Example-\n    in Example (at **)',
+      ),
       '--layout-effects-stop',
       '--render-start-1',
       '--render-stop',
@@ -354,10 +388,14 @@ describe('SchedulingProfiler', () => {
     gate(({old}) =>
       old
         ? expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-state-update-1024-Example-\n    in Example (at **)',
+            ),
           )
         : expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-state-update-512-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-state-update-512-Example-\n    in Example (at **)',
+            ),
           ),
     );
   });
@@ -387,10 +425,14 @@ describe('SchedulingProfiler', () => {
     gate(({old}) =>
       old
         ? expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-forced-update-1024-Example-\n    in Example (at **)',
+            ),
           )
         : expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-forced-update-512-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-forced-update-512-Example-\n    in Example (at **)',
+            ),
           ),
     );
   });
@@ -418,7 +460,9 @@ describe('SchedulingProfiler', () => {
       '--render-stop',
       '--commit-start-512',
       '--layout-effects-start-512',
-      '--schedule-state-update-1-Example-\n    in Example (at **)',
+      toggleComponentStacks(
+        '--schedule-state-update-1-Example-\n    in Example (at **)',
+      ),
       '--layout-effects-stop',
       '--render-start-1',
       '--render-stop',
@@ -441,6 +485,7 @@ describe('SchedulingProfiler', () => {
     ReactTestRenderer.act(() => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
+
     expect(marks.map(normalizeCodeLocInfo)).toEqual([
       '--schedule-render-512',
       '--render-start-512',
@@ -450,7 +495,9 @@ describe('SchedulingProfiler', () => {
       '--layout-effects-stop',
       '--commit-stop',
       '--passive-effects-start-512',
-      '--schedule-state-update-1024-Example-\n    in Example (at **)',
+      toggleComponentStacks(
+        '--schedule-state-update-1024-Example-\n    in Example (at **)',
+      ),
       '--passive-effects-stop',
       '--render-start-1024',
       '--render-stop',
@@ -476,10 +523,14 @@ describe('SchedulingProfiler', () => {
     gate(({old}) =>
       old
         ? expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-state-update-1024-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-state-update-1024-Example-\n    in Example (at **)',
+            ),
           )
         : expect(marks.map(normalizeCodeLocInfo)).toContain(
-            '--schedule-state-update-512-Example-\n    in Example (at **)',
+            toggleComponentStacks(
+              '--schedule-state-update-512-Example-\n    in Example (at **)',
+            ),
           ),
     );
   });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -17,7 +17,7 @@ export const enableDebugTracing = false;
 
 // Adds user timing marks for e.g. state updates, suspense, and work loop stuff,
 // for an experimental scheduling profiler tool.
-export const enableSchedulingProfiler = false;
+export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
 // reducers by double invoking them in Strict Mode.

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -18,6 +18,7 @@ export const enableDebugTracing = false;
 // Adds user timing marks for e.g. state updates, suspense, and work loop stuff,
 // for an experimental scheduling profiler tool.
 export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
+export const enableSchedulingProfilerComponentStacks = false;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
 // reducers by double invoking them in Strict Mode.

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-fb';
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
 export const enableSchedulerTracing = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.test-renderer.www';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.testing';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.testing.www';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,9 +19,12 @@ export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 
-// TODO: These features do not currently exist in the new reconciler fork.
-export const enableDebugTracing = !__VARIANT__;
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
+// Enable this flag to help with concurrent mode debugging.
+// It logs information to the console about React scheduling, rendering, and commit phases.
+//
+// NOTE: This feature will only work in DEV builds.
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableDebugTracing = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -25,6 +25,12 @@ export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 // NOTE: This feature will only work in DEV mode; all callsights are wrapped with __DEV__.
 export const enableDebugTracing = false;
 
+// TODO: getStackByFiberInDevAndProd() causes errors when synced to www.
+// This flag can be used to disable component stacks for the profiler marks,
+// so that the feature can be synced for others,
+// while still enabling investigation into the underlying source of the errors.
+export const enableSchedulingProfilerComponentStacks = false;
+
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of
 // __VARIANT__ so that it's `false` when running against the new reconciler.

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -22,8 +22,7 @@ export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.
 //
-// NOTE: This feature will only work in DEV builds.
-// WARNING: This feature does not yet exist in the new reconciler fork.
+// NOTE: This feature will only work in DEV mode; all callsights are wrapped with __DEV__.
 export const enableDebugTracing = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,7 +26,6 @@ export const {
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
-  enableSchedulingProfiler,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -34,6 +33,11 @@ export const {
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
+
+// Logs additional User Timing API marks for use with an experimental profiling tool.
+//
+// WARNING: This feature does not yet exist in the new reconciler fork.
+export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,9 +35,7 @@ export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
-//
-// WARNING: This feature does not yet exist in the new reconciler fork.
-export const enableSchedulingProfiler = !__VARIANT__ && __PROFILE__;
+export const enableSchedulingProfiler = __PROFILE__;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,6 +26,7 @@ export const {
   deferRenderPhaseUpdateToNextBatch,
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
+  enableSchedulingProfilerComponentStacks,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
This PR stacks on top of #19376 and includes only one commit, [e6e3d8b](https://github.com/facebook/react/commit/e6e3d8b7a4321ee9a0b98d14173ce89a7b727e91?w=1)

The new component stack approach introduced in #18495 seems to cause bugs (e.g. [1](https://reactjs.org/docs/error-decoder.html?invariant=310), [2](https://reactjs.org/docs/error-decoder.html/?invariant=300)) when used by the new profiler marks (#19376), so this PR moves that part of the profiler behind a feature flag (off by default).

This will enable us to sync the new profiler marks to the new reconciler and let people start using them within Facebook safely, while still enable me to further investigate why the errors are happening. (I've done a www sync of this PR and verified that it fixes the 300 and 310 errors I've been seeing on Facebook.com)

Note that this is a dynamic feature flag, but it's only used once during initialization so it should be okay.