### PR TITLE
Fixed error message "is not a React function component" to "not valid because of casing"

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -913,12 +913,21 @@ function loopError(hook) {
 }
 
 function functionError(hook, fn) {
-  return {
-    message:
-      `React Hook "${hook}" is called in function "${fn}" that is neither ` +
-      'a React function component nor a custom React Hook function.' +
-      ' React component names must start with an uppercase letter.',
-  };
+  if (hook[0] === hook[0].toLowerCase()) {
+    return {
+      message:
+        `React Hook "${hook}" is called in function "${fn}" which is not ` +
+        'a valid React component because it does not start its name with ' +
+        'an upper case letter.',
+    };
+  } else {
+    return {
+      message:
+        `React Hook "${hook}" is called in function "${fn}" that is neither ` +
+        'a React function component nor a custom React Hook function.' +
+        ' React component names must start with an uppercase letter.',
+    };
+  }
 }
 
 function genericError(hook) {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -915,9 +915,9 @@ function loopError(hook) {
 function functionError(hook, fn) {
   return {
     message:
-      `React Hook "${hook}" is called in function "${fn}" which is not ` +
-      'a valid React component because it does not start its name with ' +
-      'an upper case letter.',
+      `React Hook "${hook}" is called in function "${fn}" that is neither ` +
+      'a React function component nor a custom React Hook function.' +
+      ' React component names must start with an uppercase letter.',
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -915,9 +915,9 @@ function loopError(hook) {
 function functionError(hook, fn) {
   return {
     message:
-      `React Hook "${hook}" is called in function "${fn}" that is neither ` +
-      'a React function component nor a custom React Hook function.' +
-      ' React component names must start with an uppercase letter.',
+      `React Hook "${hook}" is called in function "${fn}" which is not ` +
+      'a valid React component because it does not start its name with ' +
+      'an upper case letter.',
   };
 }
 

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -480,9 +480,8 @@ export default {
               const message =
                 `React Hook "${context.getSource(hook)}" is called in ` +
                 `function "${context.getSource(codePathFunctionName)}" ` +
-                'that is neither a React function component nor a custom ' +
-                'React Hook function.' +
-                ' React component names must start with an uppercase letter.';
+                'which is not a valid React component because it does not ' +
+                'start its name with an upper case letter.';
               context.report({node: hook, message});
             } else if (codePathNode.type === 'Program') {
               // These are dangerous if you have inline requires enabled.

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -480,8 +480,9 @@ export default {
               const message =
                 `React Hook "${context.getSource(hook)}" is called in ` +
                 `function "${context.getSource(codePathFunctionName)}" ` +
-                'which is not a valid React component because it does not ' +
-                'start its name with an upper case letter.';
+                'that is neither a React function component nor a custom ' +
+                'React Hook function.' +
+                ' React component names must start with an uppercase letter.';
               context.report({node: hook, message});
             } else if (codePathNode.type === 'Program') {
               // These are dangerous if you have inline requires enabled.

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -476,14 +476,29 @@ export default {
                 'React function component or a custom React Hook function.';
               context.report({node: hook, message});
             } else if (codePathFunctionName) {
-              // Custom message if we found an invalid function name.
-              const message =
-                `React Hook "${context.getSource(hook)}" is called in ` +
-                `function "${context.getSource(codePathFunctionName)}" ` +
-                'that is neither a React function component nor a custom ' +
-                'React Hook function.' +
-                ' React component names must start with an uppercase letter.';
-              context.report({node: hook, message});
+              if (
+                codePathFunctionName.name.charAt(0) ===
+                codePathFunctionName.name.charAt(0).toLowerCase()
+              ) {
+                // Custom message if we found an invalid function name due to a
+                // lowercase first letter.
+                const message =
+                  `React Hook "${context.getSource(hook)}" is called in ` +
+                  `function "${context.getSource(codePathFunctionName)}" ` +
+                  'which is not a valid React component because it does not ' +
+                  'start its name with an upper case letter.';
+                context.report({node: hook, message});
+              } else {
+                // Custom message if we found an invalid function name for all
+                // other cases.
+                const message =
+                  `React Hook "${context.getSource(hook)}" is called in ` +
+                  `function "${context.getSource(codePathFunctionName)}" ` +
+                  'that is neither a React function component nor a custom ' +
+                  'React Hook function.' +
+                  ' React component names must start with an uppercase letter.';
+                context.report({node: hook, message});
+              }
             } else if (codePathNode.type === 'Program') {
               // These are dangerous if you have inline requires enabled.
               const message =


### PR DESCRIPTION
## Summary
Fixed an error message that incorrectly stated "login is not a React function component" for something that is a function component. The error message now states that the component isn't valid because of casing.

From issue: https://github.com/facebook/react/issues/19402

## Test Plan
Corrected the relevant test in: packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js