### PR TITLE
Fix for react-tester-renderer swallowing error boundary logs

### DIFF
--- a/packages/react-reconciler/src/ReactFiberErrorLogger.js
+++ b/packages/react-reconciler/src/ReactFiberErrorLogger.js
@@ -32,6 +32,16 @@ export function logCapturedError(
       const source = errorInfo.source;
       const stack = errorInfo.stack;
       const componentStack = stack !== null ? stack : '';
+
+      if (error != null && boundary.type != null && !error._loggedByBrowser) {
+        // If an error boundary caught this error then we need to log it.
+        // However, we can't just always log it because the browser's
+        // implementation of invokeGuardedCallback will log the error and we
+        // don't want to log it twice. So, when the browser logs the error,
+        // we set the _loggedByBrowser expando and skip logging it here.
+        console['error'](error);
+      }
+
       // Browsers support silencing uncaught errors by calling
       // `preventDefault()` in window `error` handler.
       // We record this information as an expando on the error.

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -200,21 +200,33 @@ describe('ReactIncrementalErrorLogging', () => {
       ].filter(Boolean),
     );
 
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith(
-      __DEV__
-        ? expect.stringMatching(
-            new RegExp(
-              'The above error occurred in the <Foo> component:\n' +
-                '\\s+(in|at) Foo (.*)\n' +
-                '\\s+(in|at) ErrorBoundary (.*)\n\n' +
-                'React will try to recreate this component tree from scratch ' +
-                'using the error boundary you provided, ErrorBoundary.',
-            ),
-          )
-        : expect.objectContaining({
-            message: 'oops',
-          }),
-    );
+    if (__DEV__) {
+      expect(console.error).toHaveBeenCalledTimes(2);
+      expect(console.error).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'oops',
+        }),
+      );
+      expect(console.error).toHaveBeenNthCalledWith(
+        2,
+        expect.stringMatching(
+          new RegExp(
+            'The above error occurred in the <Foo> component:\n' +
+              '\\s+(in|at) Foo (.*)\n' +
+              '\\s+(in|at) ErrorBoundary (.*)\n\n' +
+              'React will try to recreate this component tree from scratch ' +
+              'using the error boundary you provided, ErrorBoundary.',
+          ),
+        ),
+      );
+    } else {
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'oops',
+        }),
+      );
+    }
   });
 });

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -165,6 +165,13 @@ if (__DEV__) {
       function handleWindowError(event) {
         error = event.error;
         didSetError = true;
+        if (error != null) {
+          try {
+            error._loggedByBrowser = true;
+          } catch (inner) {
+            // Ignore.
+          }
+        }
         if (error === null && event.colno === 0 && event.lineno === 0) {
           isCrossOriginError = true;
         }


### PR DESCRIPTION
## Overview

Previously, when using react-test-renderer, errors caught by error boundaries would not log the original error message, it would _only_ print the addendum "The above error occurred in the <ErrorThrowingComponent> component".

This PR fixes that behavior so that the test render logs errors even when error boundaries catch them, just like ReactDOM.