### PR TITLE
Generate RN renderers for stable builds

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -349,9 +349,7 @@ const bundles = [
 
   /******* React Native *******/
   {
-    bundleTypes: __EXPERIMENTAL__
-      ? [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING]
-      : [],
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
     global: 'ReactNativeRenderer',
@@ -379,9 +377,7 @@ const bundles = [
 
   /******* React Native Fabric *******/
   {
-    bundleTypes: __EXPERIMENTAL__
-      ? [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING]
-      : [],
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
     global: 'ReactFabric',
@@ -416,6 +412,8 @@ const bundles = [
       UMD_DEV,
       UMD_PROD,
       RN_FB_DEV,
+      RN_FB_PROD,
+      RN_FB_PROFILING,
     ],
     moduleType: RENDERER,
     entry: 'react-test-renderer',

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -349,7 +349,9 @@ const bundles = [
 
   /******* React Native *******/
   {
-    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    bundleTypes: __EXPERIMENTAL__
+      ? []
+      : [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer',
     global: 'ReactNativeRenderer',
@@ -377,7 +379,9 @@ const bundles = [
 
   /******* React Native Fabric *******/
   {
-    bundleTypes: [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
+    bundleTypes: __EXPERIMENTAL__
+      ? []
+      : [RN_FB_DEV, RN_FB_PROD, RN_FB_PROFILING],
     moduleType: RENDERER,
     entry: 'react-native-renderer/fabric',
     global: 'ReactFabric',


### PR DESCRIPTION
## Overview

Since we're switching RN to FB stable we also need generate the renderers for stable builds.

## Test

```
RELEASE_CHANNEL=stable yarn build --type=RN_FB
```

<img width="874" alt="Screen Shot 2020-07-20 at 4 14 49 PM" src="https://user-images.githubusercontent.com/2440089/87982030-29071a00-caa4-11ea-9b07-d91d4282b44a.png">
