### PR TITLE
Add failing onScroll test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -501,4 +501,32 @@ describe('ReactDOMEventListener', () => {
       document.body.removeChild(container);
     }
   });
+
+  // Unlike browsers, we delegate scroll events.
+  // (This doesn't make a lot of sense but it would be a breaking change not to.)
+  it('should delegate scroll events even without a direct listener', () => {
+    const container = document.createElement('div');
+    const ref = React.createRef();
+    const onScroll = jest.fn();
+    document.body.appendChild(container);
+    try {
+      ReactDOM.render(
+        <div onScroll={onScroll}>
+          {/* Intentionally no handler on the target: */}
+          <video ref={ref} />
+        </div>,
+        container,
+      );
+      ref.current.dispatchEvent(
+        new Event('scroll', {
+          bubbles: false,
+        }),
+      );
+      // Regression test: ensure React tree delegation still works
+      // even if the actual DOM element did not have a handler.
+      expect(onScroll).toHaveBeenCalledTimes(1);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
 });


### PR DESCRIPTION
This test used to work before we moved `scroll` out of the special capture phase. We need a plan on how we can address this specific use-case. This is how it previously work in React 16: https://github.com/facebook/react/commit/9fba65efa50fe5f38e5664729d4aa6f85cf7be92#diff-81456f8eb5dbadd61002899c8ee3a39aL342.