### PR TITLE
Fix possible scope `null` issue

### DIFF
--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -778,7 +778,8 @@ export function accumulateSinglePhaseListeners(
       enableCreateEventHandleAPI &&
       enableScopeAPI &&
       tag === ScopeComponent &&
-      lastHostComponent !== null
+      lastHostComponent !== null &&
+      stateNode !== null
     ) {
       const reactScopeInstance = stateNode;
       const eventHandlerlisteners = getEventHandlerListeners(


### PR DESCRIPTION
Internally, we seem to be finding a scope instance that is `null`. It's strange how this only surfaced after the recent refactors/changes, but this will hopefully fix the problem.