### PR TITLE
Remove `timeout` option from `scheduleCallback`

### DIFF
--- a/packages/scheduler/src/Scheduler.js
+++ b/packages/scheduler/src/Scheduler.js
@@ -276,27 +276,10 @@ function unstable_wrapCallback(callback) {
   };
 }
 
-function timeoutForPriorityLevel(priorityLevel) {
-  switch (priorityLevel) {
-    case ImmediatePriority:
-      return IMMEDIATE_PRIORITY_TIMEOUT;
-    case UserBlockingPriority:
-      return USER_BLOCKING_PRIORITY_TIMEOUT;
-    case IdlePriority:
-      return IDLE_PRIORITY_TIMEOUT;
-    case LowPriority:
-      return LOW_PRIORITY_TIMEOUT;
-    case NormalPriority:
-    default:
-      return NORMAL_PRIORITY_TIMEOUT;
-  }
-}
-
 function unstable_scheduleCallback(priorityLevel, callback, options) {
   var currentTime = getCurrentTime();
 
   var startTime;
-  var timeout;
   if (typeof options === 'object' && options !== null) {
     var delay = options.delay;
     if (typeof delay === 'number' && delay > 0) {
@@ -304,13 +287,28 @@ function unstable_scheduleCallback(priorityLevel, callback, options) {
     } else {
       startTime = currentTime;
     }
-    timeout =
-      typeof options.timeout === 'number'
-        ? options.timeout
-        : timeoutForPriorityLevel(priorityLevel);
   } else {
-    timeout = timeoutForPriorityLevel(priorityLevel);
     startTime = currentTime;
+  }
+
+  var timeout;
+  switch (priorityLevel) {
+    case ImmediatePriority:
+      timeout = IMMEDIATE_PRIORITY_TIMEOUT;
+      break;
+    case UserBlockingPriority:
+      timeout = USER_BLOCKING_PRIORITY_TIMEOUT;
+      break;
+    case IdlePriority:
+      timeout = IDLE_PRIORITY_TIMEOUT;
+      break;
+    case LowPriority:
+      timeout = LOW_PRIORITY_TIMEOUT;
+      break;
+    case NormalPriority:
+    default:
+      timeout = NORMAL_PRIORITY_TIMEOUT;
+      break;
   }
 
   var expirationTime = startTime + timeout;

--- a/packages/scheduler/src/__tests__/Scheduler-test.js
+++ b/packages/scheduler/src/__tests__/Scheduler-test.js
@@ -681,33 +681,6 @@ describe('Scheduler', () => {
       ]);
     });
 
-    it('schedules callback with both delay and timeout', () => {
-      scheduleCallback(
-        NormalPriority,
-        () => {
-          Scheduler.unstable_yieldValue('A');
-          Scheduler.unstable_advanceTime(100);
-        },
-        {delay: 100, timeout: 900},
-      );
-
-      Scheduler.unstable_advanceTime(99);
-      // Does not flush because delay has not elapsed
-      expect(Scheduler).toFlushAndYield([]);
-
-      // Delay has elapsed but task has not expired
-      Scheduler.unstable_advanceTime(1);
-      expect(Scheduler).toFlushExpired([]);
-
-      // Still not expired
-      Scheduler.unstable_advanceTime(899);
-      expect(Scheduler).toFlushExpired([]);
-
-      // Now it expires
-      Scheduler.unstable_advanceTime(1);
-      expect(Scheduler).toFlushExpired(['A']);
-    });
-
     it('cancels a delayed task', () => {
       // Schedule several tasks with the same delay
       const options = {delay: 100};


### PR DESCRIPTION
Since the Lanes refactor landed, we no longer rely on this anywhere, so we can remove it.

The `delay` option is still needed by our timer implementation (setTimeout polyfill). We'll keep the feature, but we'll likely change how it's exposed once we figure out the proper layering between the  various Scheduler APIs.