### PR TITLE
react-hooks-eslint-rule: add component props to pureScopes (#18051), …

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1376,6 +1376,27 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function Example({ sortBy }) {
+          const foo = () => useMemo(() => console.log(sortBy), [sortBy])
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function Example(props) {
+          const usefoo = () => useMemo(() => console.log(props.sortBy), [props.sortBy])
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function useMyThing(myRef) {
+          const foo = () => useCallback(() => console.log(myRef), [myRef]);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -6960,6 +6981,36 @@ const tests = {
                     foo.bar.baz = 43;
                     props.foo.bar.baz = 1;
                   }, [foo.bar, props.foo.bar]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          const local1 = {};
+          useMemo(() => {
+            console.log(local1);
+          }, [local1, props]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has an unnecessary dependency: 'props'. " +
+            'Either exclude it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [local1]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  const local1 = {};
+                  useMemo(() => {
+                    console.log(local1);
+                  }, [local1]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -290,7 +290,24 @@ export default {
         if (!currentScope) {
           return;
         }
-        componentScope = currentScope;
+        componentScope = getComponentScope(currentScope);
+        pureScopes.add(componentScope);
+      }
+
+      function getComponentScope(hookParentScope) {
+        let evaluatedScope = hookParentScope;
+
+        while (evaluatedScope) {
+          const blockId = evaluatedScope.block.id;
+          if (
+            blockId &&
+            (/^[A-Z]*$/.test(blockId.name[0]) || blockId.name.startsWith('use'))
+          ) {
+            return evaluatedScope;
+          }
+          evaluatedScope = evaluatedScope.upper;
+        }
+        return hookParentScope;
       }
 
       // Next we'll define a few helpers that helps us

--- a/yarn.lock
+++ b/yarn.lock
@@ -7619,7 +7619,7 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^15.2.1, "jsdom@npm:@gaearon/jsdom@15.2.1":
+jsdom@^15.2.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/@gaearon/jsdom/-/jsdom-15.2.1.tgz#23273b20b6c7b6ca70b54bc0b0eecdc518ae9694"
   integrity sha512-qQc4j+gyi06zrevvopql0pehAXrgTv71wGkKMQZg8bl2VYfv2dqbdtP0hD0TpHsuI7YF1XfE7DM62Nclr13vfA==
@@ -10113,6 +10113,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-is@^16.12.0, react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
…update yarn.lock

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Following #18051 [comment](https://github.com/facebook/react/issues/18051#issuecomment-600856619) by an unexpected behavior is found related code like this:
```js
function Example({ sortBy }) {
  const foo = () => useMemo(() => console.log(sortBy), [sortBy])
 }
```
An error message is thrown since `sortBy` is evaluated as an unnecessary dependency while it is a necessary dependency.

According to me this was happening because `pureScopes` array did not contain the scope where `sortBy` is defined. I think this is a bug because component props (as well as argument received by a custom hook) should be contained by `pureScopes` array.
I changed the code in order to make these scopes always contained by `pureScopes` array.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I have tested the desired behavior is obtained and even that  Component `props` are defined as necessary only if they are used by the hook.
