### PR TITLE
Don't emulate bubbling of the scroll event

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -674,12 +674,23 @@ describe('ReactDOMEventListener', () => {
           bubbles: false,
         }),
       );
-      expect(log).toEqual([
-        ['capture', 'grand'],
-        ['capture', 'parent'],
-        ['capture', 'child'],
-        ['bubble', 'child'],
-      ]);
+      if (gate(flags => flags.disableOnScrollBubbling)) {
+        expect(log).toEqual([
+          ['capture', 'grand'],
+          ['capture', 'parent'],
+          ['capture', 'child'],
+          ['bubble', 'child'],
+        ]);
+      } else {
+        expect(log).toEqual([
+          ['capture', 'grand'],
+          ['capture', 'parent'],
+          ['capture', 'child'],
+          ['bubble', 'child'],
+          ['bubble', 'parent'],
+          ['bubble', 'grand'],
+        ]);
+      }
     } finally {
       document.body.removeChild(container);
     }
@@ -720,7 +731,6 @@ describe('ReactDOMEventListener', () => {
           bubbles: false,
         }),
       );
-      //
       expect(log).toEqual([
         ['capture', 'grand'],
         ['capture', 'parent'],

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -539,7 +539,6 @@ describe('ReactDOMEventListener', () => {
     const container = document.createElement('div');
     const ref = React.createRef();
     const onPlay = jest.fn();
-    const onScroll = jest.fn();
     const onCancel = jest.fn();
     const onClose = jest.fn();
     const onToggle = jest.fn();
@@ -548,14 +547,12 @@ describe('ReactDOMEventListener', () => {
       ReactDOM.render(
         <div
           onPlay={onPlay}
-          onScroll={onScroll}
           onCancel={onCancel}
           onClose={onClose}
           onToggle={onToggle}>
           <div
             ref={ref}
             onPlay={onPlay}
-            onScroll={onScroll}
             onCancel={onCancel}
             onClose={onClose}
             onToggle={onToggle}
@@ -565,11 +562,6 @@ describe('ReactDOMEventListener', () => {
       );
       ref.current.dispatchEvent(
         new Event('play', {
-          bubbles: false,
-        }),
-      );
-      ref.current.dispatchEvent(
-        new Event('scroll', {
           bubbles: false,
         }),
       );
@@ -591,7 +583,6 @@ describe('ReactDOMEventListener', () => {
       // Regression test: ensure we still emulate bubbling with non-bubbling
       // media
       expect(onPlay).toHaveBeenCalledTimes(2);
-      expect(onScroll).toHaveBeenCalledTimes(2);
       expect(onCancel).toHaveBeenCalledTimes(2);
       expect(onClose).toHaveBeenCalledTimes(2);
       expect(onToggle).toHaveBeenCalledTimes(2);
@@ -638,6 +629,101 @@ describe('ReactDOMEventListener', () => {
         outerRef.current.firstChild,
         innerRef.current,
         outerRef.current,
+      ]);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
+  // We're moving towards aligning more closely with the browser.
+  // Currently we emulate bubbling for all non-bubbling events except scroll.
+  // We may expand this list in the future, removing emulated bubbling altogether.
+  it('should not emulate bubbling of scroll events', () => {
+    const container = document.createElement('div');
+    const ref = React.createRef();
+    const log = [];
+    const onScroll = jest.fn(e =>
+      log.push(['bubble', e.currentTarget.className]),
+    );
+    const onScrollCapture = jest.fn(e =>
+      log.push(['capture', e.currentTarget.className]),
+    );
+    document.body.appendChild(container);
+    try {
+      ReactDOM.render(
+        <div
+          className="grand"
+          onScroll={onScroll}
+          onScrollCapture={onScrollCapture}>
+          <div
+            className="parent"
+            onScroll={onScroll}
+            onScrollCapture={onScrollCapture}>
+            <div
+              className="child"
+              onScroll={onScroll}
+              onScrollCapture={onScrollCapture}
+              ref={ref}
+            />
+          </div>
+        </div>,
+        container,
+      );
+      ref.current.dispatchEvent(
+        new Event('scroll', {
+          bubbles: false,
+        }),
+      );
+      expect(log).toEqual([
+        ['capture', 'grand'],
+        ['capture', 'parent'],
+        ['capture', 'child'],
+        ['bubble', 'child'],
+      ]);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
+  // We're moving towards aligning more closely with the browser.
+  // Currently we emulate bubbling for all non-bubbling events except scroll.
+  // We may expand this list in the future, removing emulated bubbling altogether.
+  it('should not emulate bubbling of scroll events (no own handler)', () => {
+    const container = document.createElement('div');
+    const ref = React.createRef();
+    const log = [];
+    const onScroll = jest.fn(e =>
+      log.push(['bubble', e.currentTarget.className]),
+    );
+    const onScrollCapture = jest.fn(e =>
+      log.push(['capture', e.currentTarget.className]),
+    );
+    document.body.appendChild(container);
+    try {
+      ReactDOM.render(
+        <div
+          className="grand"
+          onScroll={onScroll}
+          onScrollCapture={onScrollCapture}>
+          <div
+            className="parent"
+            onScroll={onScroll}
+            onScrollCapture={onScrollCapture}>
+            {/* Intentionally no handler on the child: */}
+            <div className="child" ref={ref} />
+          </div>
+        </div>,
+        container,
+      );
+      ref.current.dispatchEvent(
+        new Event('scroll', {
+          bubbles: false,
+        }),
+      );
+      //
+      expect(log).toEqual([
+        ['capture', 'grand'],
+        ['capture', 'parent'],
       ]);
     } finally {
       document.body.removeChild(container);

--- a/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
@@ -165,13 +165,17 @@ function extractEvents(
       inCapturePhase,
     );
   } else {
-    // TODO: We may also want to re-use the accumulateTargetOnly flag to
-    // special case bubbling for onScroll/media events at a later point.
-    // In which case we will want to make this flag boolean and ensure
-    // we change the targetInst to be of the container instance. Like:
-    const accumulateTargetOnly = false;
+    // Some events don't bubble in the browser.
+    // In the past, React has always bubbled them, but this can be surprising.
+    // We're going to try aligning closer to the browser behavior by not bubbling
+    // them in React either. We'll start by not bubbling onScroll, and then expand.
+    const accumulateTargetOnly =
+      !inCapturePhase &&
+      // TODO: ideally, we'd eventually add all events from
+      // nonDelegatedEvents list in DOMPluginEventSystem.
+      // Then we can remove this special list.
+      topLevelType === DOMTopLevelEventTypes.TOP_SCROLL;
 
-    // We traverse only capture or bubble phase listeners
     accumulateSinglePhaseListeners(
       targetInst,
       dispatchQueue,

--- a/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
@@ -42,7 +42,10 @@ import {IS_EVENT_HANDLE_NON_MANAGED_NODE} from '../EventSystemFlags';
 import getEventCharCode from '../getEventCharCode';
 import {IS_CAPTURE_PHASE} from '../EventSystemFlags';
 
-import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
+import {
+  enableCreateEventHandleAPI,
+  disableOnScrollBubbling,
+} from 'shared/ReactFeatureFlags';
 
 function extractEvents(
   dispatchQueue: DispatchQueue,
@@ -169,12 +172,15 @@ function extractEvents(
     // In the past, React has always bubbled them, but this can be surprising.
     // We're going to try aligning closer to the browser behavior by not bubbling
     // them in React either. We'll start by not bubbling onScroll, and then expand.
-    const accumulateTargetOnly =
-      !inCapturePhase &&
-      // TODO: ideally, we'd eventually add all events from
-      // nonDelegatedEvents list in DOMPluginEventSystem.
-      // Then we can remove this special list.
-      topLevelType === DOMTopLevelEventTypes.TOP_SCROLL;
+    let accumulateTargetOnly = false;
+    if (disableOnScrollBubbling) {
+      accumulateTargetOnly =
+        !inCapturePhase &&
+        // TODO: ideally, we'd eventually add all events from
+        // nonDelegatedEvents list in DOMPluginEventSystem.
+        // Then we can remove this special list.
+        topLevelType === DOMTopLevelEventTypes.TOP_SCROLL;
+    }
 
     accumulateSinglePhaseListeners(
       targetInst,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -128,3 +128,5 @@ export const deferRenderPhaseUpdateToNextBatch = true;
 
 // Replacement for runWithPriority in React internals.
 export const decoupleUpdatePriorityFromScheduler = false;
+
+export const disableOnScrollBubbling = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -45,6 +45,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = false;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -44,6 +44,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = false;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -44,6 +44,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -44,6 +44,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -44,6 +44,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -44,6 +44,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = !__EXPERIMENTAL__;
 export const enableFilterEmptyStringAttributesDOM = false;
+export const disableOnScrollBubbling = false;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -18,6 +18,7 @@ export const disableInputAttributeSyncing = __VARIANT__;
 export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
+export const disableOnScrollBubbling = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -27,6 +27,7 @@ export const {
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
   enableSchedulingProfilerComponentStacks,
+  disableOnScrollBubbling,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Currently, scroll event is somewhat broken on master.

This will fire both handlers if we scroll the child:

```js
<div onScroll={onParentScroll}>
  <div onScroll={onChildScroll} />
</div>
```

But this **will not** fire the parent handler if we scroll the child:

```js
<div onScroll={onParentScroll}>
  <div />
</div>
```

In other words, bubbling the scroll event currently doesn't work if the event target itself doesn't have a React listener.

This is a regression in the modern system.

## Possible Fixes

This is based on @trueadm's writeup.

* **Option 1:** Add native `scroll` handler to every `div` so that we can't "miss" the event — whether it has a React handler or not. This is a similar strategy we use for other events that don't bubble in the browser (e.g. `toggle`, `invalid`, `play`, etc). However, for those cases, we know *which* elements need it (e.g. `audio` and `video`). Adding a `scroll` listener to every single `div` seems untenable. So this is ruled out for performance reasons.

* **Option 2 (Breaking Change):** Stop emulating bubbling for `onScroll`. It it confusing anyway (https://github.com/facebook/react/issues/19156, https://github.com/facebook/react/issues/15723). **This is what this PR does.** The downside is that now this event is special and different from all others.

* **Option 3 (Even Bigger Breaking Change):** Stop emulating bubbling for all events that don't bubble in the browser. This includes `invalid`, `load`, `toggle`, `close`, `cancel`, and media events. We could consider this but it's a bigger breaking change. Arguably, some of them, like `onInvalid`, are actually useful and not too confusing to bubble. So I think this needs to wait until 18.

* **Option 4 (Status Quo):** We could go back to React 16 behavior, which attaches `onScroll` in the capture phase. That would solve the current inconsistency, but wouldn't be in line with our strategy for how nested Reacts should work. It also wouldn't solve the problem that bubbling `onScroll` is inherently confusing.