### PR TITLE
Don't rely on Scheduler.didTimeout to tell us that SyncBatched is synchronous

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -44,7 +44,7 @@ import {
 } from './SchedulerWithReactIntegration.new';
 
 export const SyncLanePriority: LanePriority = 17;
-const SyncBatchedLanePriority: LanePriority = 16;
+export const SyncBatchedLanePriority: LanePriority = 16;
 
 const InputDiscreteHydrationLanePriority: LanePriority = 15;
 export const InputDiscreteLanePriority: LanePriority = 14;


### PR DESCRIPTION
Tasks with SyncBatchedPriority — used by Blocking Mode — should always be rendered by the `performSyncWorkOnRoot` path, not `performConcurrentWorkOnRoot`.

Currently, they go through the `performConcurrentWorkOnRoot` callback. Then, we check `didTimeout` to see if the task expired. Since SyncBatchedPriority translates to ImmediatePriority in the Scheduler, `didTimeout` is always `true`, so we mark it as expired. Then it exits and re-enters in the `performSyncWorkOnRoot` path.

Aside from being overly convoluted, we shouldn't rely on Scheduler to tell us that SyncBatchedPriority work is synchronous. We should handle that ourselves.

This will allow us to remove the `didTimeout` check. And it further decouples us from the Scheduler priority, so we can eventually remove that, too.