### PR TITLE
Use feature flags for React Native in the test renderer

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
+import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
+
+export const debugRenderPhaseSideEffectsForStrictMode = false;
+export const enableDebugTracing = false;
+export const enableSchedulingProfiler = false;
+export const enableSchedulingProfilerComponentStacks = false;
+export const warnAboutDeprecatedLifecycles = true;
+export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
+export const enableProfilerTimer = __PROFILE__;
+export const enableProfilerCommitHooks = false;
+export const enableSchedulerTracing = __PROFILE__;
+export const enableSuspenseServerRenderer = false;
+export const enableSelectiveHydration = false;
+export const enableBlocksAPI = false;
+export const enableLazyElements = false;
+export const disableJavaScriptURLs = false;
+export const disableInputAttributeSyncing = false;
+export const enableSchedulerDebugging = false;
+export const enableDeprecatedFlareAPI = false;
+export const enableFundamentalAPI = false;
+export const enableScopeAPI = false;
+export const enableCreateEventHandleAPI = false;
+export const warnAboutUnmockedScheduler = false;
+export const enableSuspenseCallback = false;
+export const warnAboutDefaultPropsOnFunctionComponents = false;
+export const warnAboutStringRefs = false;
+export const disableLegacyContext = false;
+export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
+export const enableTrustedTypesIntegration = false;
+export const disableTextareaChildren = false;
+export const disableModulePatternComponents = false;
+export const warnUnstableRenderSubtreeIntoContainer = false;
+export const warnAboutSpreadingKeyToJSX = false;
+export const enableComponentStackLocations = false;
+export const enableLegacyFBSupport = false;
+export const enableFilterEmptyStringAttributesDOM = false;
+
+export const enableNewReconciler = false;
+export const deferRenderPhaseUpdateToNextBatch = true;
+export const decoupleUpdatePriorityFromScheduler = false;
+
+// Flow magic to verify the exports of this file match the original version.
+// eslint-disable-next-line no-unused-vars
+type Check<_X, Y: _X, X: Y = _X> = null;
+// eslint-disable-next-line no-unused-expressions
+(null: Check<ExportsType, FeatureFlagsType>);

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -116,6 +116,13 @@ const forks = Object.freeze({
         }
       case 'react-test-renderer':
         switch (bundleType) {
+          case RN_FB_DEV:
+          case RN_FB_PROD:
+          case RN_FB_PROFILING:
+          case RN_OSS_DEV:
+          case RN_OSS_PROD:
+          case RN_OSS_PROFILING:
+            return 'shared/forks/ReactFeatureFlags.test-renderer.native.js';
           case FB_WWW_DEV:
           case FB_WWW_PROD:
           case FB_WWW_PROFILING:


### PR DESCRIPTION
## Overview

The React Native renderer has `enableComponentStackLocations` disabled, but the react-test-renderer for React Native has `enableComponentStackLocations ` enabled. This causes issues syncing React to React Native.