### PR TITLE
Check for passive effects on the root fiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -882,8 +882,6 @@ function commitUnmount(
                 effect.tag |= HookHasEffect;
 
                 current.effectTag |= Passive;
-
-                schedulePassiveEffectCallback();
               } else {
                 if (
                   enableProfilerTimer &&

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2183,7 +2183,10 @@ function commitRootImpl(root, renderPriorityLevel) {
     }
 
     // If there are pending passive effects, schedule a callback to process them.
-    if ((finishedWork.subtreeTag & PassiveSubtreeTag) !== NoSubtreeTag) {
+    if (
+      (finishedWork.subtreeTag & PassiveSubtreeTag) !== NoSubtreeTag ||
+      (finishedWork.effectTag & PassiveMask) !== NoEffect
+    ) {
       if (!rootDoesHavePassiveEffects) {
         rootDoesHavePassiveEffects = true;
         scheduleCallback(NormalSchedulerPriority, () => {


### PR DESCRIPTION
The root fiber doesn't have a parent from which we can read the `subtreeTag`, so we need to check its `effectTag` directly.

The root fiber previously did not have any pending passive effects, but it does now that deleted fibers are cleaned up in the passive phase.

This allows us to remove a `schedulePassiveEffectCallback` call from the synchronous unmount path.