### PR TITLE
Check PassiveStatic instead of Passive

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -68,7 +68,6 @@ import {
   Placement,
   Snapshot,
   Update,
-  Passive,
 } from './ReactSideEffectTags';
 import getComponentName from 'shared/getComponentName';
 import invariant from 'shared/invariant';
@@ -880,8 +879,6 @@ function commitUnmount(
               if ((tag & HookPassive) !== NoHookEffect) {
                 // TODO: Consider if we can move this block out of the synchronous commit phase
                 effect.tag |= HookHasEffect;
-
-                current.effectTag |= Passive;
 
                 schedulePassiveEffectCallback();
               } else {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2836,13 +2836,12 @@ function flushPassiveUnmountEffectsInsideOfDeletedTree(
       }
     }
 
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent:
-      case Block: {
-        const primaryEffectTag = fiber.effectTag & Passive;
-        if (primaryEffectTag !== NoEffect) {
+    if ((fiber.effectTag & PassiveStatic) !== NoEffect) {
+      switch (fiber.tag) {
+        case FunctionComponent:
+        case ForwardRef:
+        case SimpleMemoComponent:
+        case Block: {
           flushPassiveUnmountEffectsImpl(fiber);
         }
       }


### PR DESCRIPTION
Saves us from having to set a flag on `current` during the layout phase.

Could result in some redundant traversal, since PassiveStatic includes effects that don't need clean-up. But it's worth it to remove the work from the layout phase.

While I was editing this, I also re-arranged it so that we check the `effectTag` check before we check the `tag`, since the `effectTag` check is the one that's more likely to fail.