### PR TITLE
Move passive logic out of layout phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -206,7 +206,7 @@ function safelyDetachRef(current: Fiber) {
   }
 }
 
-function safelyCallDestroy(current, destroy) {
+export function safelyCallDestroy(current: Fiber, destroy: () => void) {
   if (__DEV__) {
     invokeGuardedCallback(null, destroy, null);
     if (hasCaughtError()) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -122,7 +122,6 @@ import {
   NoEffect as NoHookEffect,
   HasEffect as HookHasEffect,
   Layout as HookLayout,
-  Passive as HookPassive,
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork.new';
 import {
@@ -876,10 +875,7 @@ function commitUnmount(
           do {
             const {destroy, tag} = effect;
             if (destroy !== undefined) {
-              if ((tag & HookPassive) !== NoHookEffect) {
-                // TODO: Consider if we can move this block out of the synchronous commit phase
-                effect.tag |= HookHasEffect;
-              } else {
+              if ((tag & HookLayout) !== NoHookEffect) {
                 if (
                   enableProfilerTimer &&
                   enableProfilerCommitHooks &&

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2702,6 +2702,8 @@ function flushPassiveMountEffects(firstChild: Fiber): void {
 }
 
 function flushPassiveMountEffectsImpl(fiber: Fiber): void {
+  setCurrentDebugFiberInDEV(fiber);
+
   const updateQueue: FunctionComponentUpdateQueue | null = (fiber.updateQueue: any);
   const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
   if (lastEffect !== null) {
@@ -2715,7 +2717,6 @@ function flushPassiveMountEffectsImpl(fiber: Fiber): void {
         (tag & HookHasEffect) !== NoHookEffect
       ) {
         if (__DEV__) {
-          setCurrentDebugFiberInDEV(fiber);
           if (
             enableProfilerTimer &&
             enableProfilerCommitHooks &&
@@ -2742,7 +2743,6 @@ function flushPassiveMountEffectsImpl(fiber: Fiber): void {
             const error = clearCaughtError();
             captureCommitPhaseError(fiber, error);
           }
-          resetCurrentDebugFiberInDEV();
         } else {
           try {
             const create = effect.create;
@@ -2769,6 +2769,8 @@ function flushPassiveMountEffectsImpl(fiber: Fiber): void {
 
       effect = next;
     } while (effect !== firstEffect);
+
+    resetCurrentDebugFiberInDEV();
   }
 }
 
@@ -2858,6 +2860,8 @@ function flushPassiveUnmountEffectsImpl(fiber: Fiber): void {
   const updateQueue: FunctionComponentUpdateQueue | null = (fiber.updateQueue: any);
   const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
   if (lastEffect !== null) {
+    setCurrentDebugFiberInDEV(fiber);
+
     const firstEffect = lastEffect.next;
     let effect = firstEffect;
     do {
@@ -2871,7 +2875,6 @@ function flushPassiveUnmountEffectsImpl(fiber: Fiber): void {
 
         if (typeof destroy === 'function') {
           if (__DEV__) {
-            setCurrentDebugFiberInDEV(fiber);
             if (
               enableProfilerTimer &&
               enableProfilerCommitHooks &&
@@ -2888,7 +2891,6 @@ function flushPassiveUnmountEffectsImpl(fiber: Fiber): void {
               const error = clearCaughtError();
               captureCommitPhaseError(fiber, error);
             }
-            resetCurrentDebugFiberInDEV();
           } else {
             try {
               if (
@@ -2915,6 +2917,8 @@ function flushPassiveUnmountEffectsImpl(fiber: Fiber): void {
 
       effect = next;
     } while (effect !== firstEffect);
+
+    resetCurrentDebugFiberInDEV();
   }
 }
 


### PR DESCRIPTION
### tl;dr

Some minor refactoring so that I can delete `effect.tag |= HookHasEffect` from the synchronous deletion path.

---

We don't need to check HookHasEffect during a deletion; all effects are unmounted.

So we also don't have to set HookHasEffect during a deletion, either.

This allows us to remove the last remaining passive effect logic from the synchronous layout phase. (For deletions; there's still  some passive logic in the layout phase for mounts/updates that we've yet to remove.)