### PR TITLE
add failing test (#18051)

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1376,6 +1376,16 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function Component({ reportType }) {
+          let Report = Reports[reportType];
+          let child = useMemo(() => {
+            return <Report />;
+          }, [Report]);
+        }
+      `,
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Trying to solve #18051  and #18937 .
`exhaustive-deps` eslint rule does not recognize a `JSXIdentifier` as needed dependency.

This is because eslint scope `.references` does not include JSX.
I have pushed only a failing test with the aim to keep on working on it.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Failing test where an hook uses a `JSXIdentifier` that is properly added to deps array while the eslint rules marks it as unnecessary.
