### PR TITLE
Support untagged releases

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -87,6 +87,9 @@ Once this step is complete, you're ready to publish the release:
 
 ```sh
 scripts/release/publish.js --tags latest
+
+# Or, if you want to bump "next" as well:
+scripts/release/publish.js --tags latest next
 ```
 
 If the OTP code expires while publishing, re-run this command and answer "y" to the questions about whether it was expected for already published packages.
@@ -172,5 +175,5 @@ Upon completion, this script provides instructions for tagging the Git commit th
 #### Example usage
 To publish a release to NPM as both `next` and `latest`:
 ```sh
-scripts/release/publish.js --tags latest
+scripts/release/publish.js --tags latest next
 ```

--- a/scripts/release/publish-commands/confirm-version-and-tags.js
+++ b/scripts/release/publish-commands/confirm-version-and-tags.js
@@ -12,9 +12,8 @@ const run = async ({cwd, packages, tags}) => {
   clear();
 
   if (tags.length === 0) {
-    console.log(
-      theme`{spinnerSuccess ✓} You are about the publish the following packages without any tags:`
-    );
+    console.error('Expected at least one tag.');
+    process.exit(1);
   } else if (tags.length === 1) {
     console.log(
       theme`{spinnerSuccess ✓} You are about the publish the following packages under the tag {tag ${tags}}:`

--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -17,6 +17,7 @@ const paramDefinitions = [
     type: String,
     multiple: true,
     description: 'NPM tags to point to the new release.',
+    defaultValue: ['untagged'],
   },
   {
     name: 'skipPackages',
@@ -29,10 +30,20 @@ const paramDefinitions = [
 
 module.exports = () => {
   const params = commandLineArgs(paramDefinitions);
-  if (!params.tags || !params.tags.length) {
-    params.tags = [];
-  }
   splitCommaParams(params.skipPackages);
   splitCommaParams(params.tags);
+  params.tags.forEach(tag => {
+    switch (tag) {
+      case 'latest':
+      case 'next':
+      case 'experimental':
+      case 'untagged':
+        break;
+      default:
+        console.error('Unknown tag: "' + params.tag + '"');
+        process.exit(1);
+        break;
+    }
+  });
   return params;
 };

--- a/scripts/release/publish-commands/publish-to-npm.js
+++ b/scripts/release/publish-commands/publish-to-npm.js
@@ -54,6 +54,17 @@ const run = async ({cwd, dry, packages, tags}, otp) => {
           )
         );
       }
+
+      if (tags.includes('untagged')) {
+        // npm doesn't let us publish without a tag at all,
+        // so for one-off publishes we clean it up ourselves.
+        if (!dry) {
+          await exec(`npm dist-tag rm ${packageName}@untagged --otp=${otp}`);
+        }
+        console.log(
+          theme.command(`npm dist-tag rm ${packageName}@untagged --otp=${otp}`)
+        );
+      }
     }
   }
 };

--- a/scripts/release/publish-commands/validate-tags.js
+++ b/scripts/release/publish-commands/validate-tags.js
@@ -18,17 +18,42 @@ const run = async ({cwd, packages, tags}) => {
     'package.json'
   );
   const {version} = await readJson(packageJSONPath);
+  const isExperimentalVersion = version.indexOf('experimental') !== -1;
   if (version.indexOf('0.0.0') === 0) {
     if (tags.includes('latest')) {
+      if (isExperimentalVersion) {
+        console.log(
+          theme`{error Experimental release} {version ${version}} {error cannot be tagged as} {tag latest}`
+        );
+      } else {
+        console.log(
+          theme`{error Next release} {version ${version}} {error cannot be tagged as} {tag latest}`
+        );
+      }
+      process.exit(1);
+    }
+    if (tags.includes('next') && isExperimentalVersion) {
       console.log(
-        theme`{error Next release} {version ${version}} {error cannot be tagged as} {tag latest}`
+        theme`{error Experimental release} {version ${version}} {error cannot be tagged as} {tag next}`
+      );
+      process.exit(1);
+    }
+    if (tags.includes('experimental') && !isExperimentalVersion) {
+      console.log(
+        theme`{error Next release} {version ${version}} {error cannot be tagged as} {tag experimental}`
       );
       process.exit(1);
     }
   } else {
-    if (tags.includes('next')) {
+    if (!tags.includes('latest')) {
       console.log(
-        theme`{error Stable release} {version ${version}} {error cannot be tagged as} {tag next}`
+        theme`{error Stable release} {version ${version}} {error must always be tagged as} {tag latest}`
+      );
+      process.exit(1);
+    }
+    if (tags.includes('experimental')) {
+      console.log(
+        theme`{error Stable release} {version ${version}} {error cannot be tagged as} {tag experimental}`
       );
       process.exit(1);
     }


### PR DESCRIPTION
Second attempt at https://github.com/facebook/react/pull/19507.

This is a more limited change. We keep the `--tags` syntax but it's not required to pass now. The bug with `undefined` being used by mistake is fixed.

I kept the expanded error handling.