### PR TITLE
Turn off new component stacks for React Native

### DIFF
--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -137,6 +137,19 @@ const forks = Object.freeze({
             return 'shared/forks/ReactFeatureFlags.testing.www.js';
         }
         return 'shared/forks/ReactFeatureFlags.testing.js';
+      case 'react':
+        switch (bundleType) {
+          case FB_WWW_DEV:
+          case FB_WWW_PROD:
+          case FB_WWW_PROFILING:
+            return 'shared/forks/ReactFeatureFlags.www.js';
+          case RN_FB_DEV:
+          case RN_FB_PROD:
+          case RN_FB_PROFILING:
+            return 'shared/forks/ReactFeatureFlags.native-fb.js';
+          default:
+            return 'shared/ReactFeatureFlags.js';
+        }
       default:
         switch (bundleType) {
           case FB_WWW_DEV:


### PR DESCRIPTION
# Overview

This internal React build for React Native running off the main branch is not ready for the new component stack (e.g it breaks LogBox). To unblock the sync to React Native and test the React main branch we're turning off the new component stacks by using the React Native feature flags for React.

I've confirmed that the only major feature flag changes between the default and RN flags is the component stack flag. 