### PR TITLE
Use RN fork in default branch of feature flags

### DIFF
--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -137,7 +137,7 @@ const forks = Object.freeze({
             return 'shared/forks/ReactFeatureFlags.testing.www.js';
         }
         return 'shared/forks/ReactFeatureFlags.testing.js';
-      case 'react':
+      default:
         switch (bundleType) {
           case FB_WWW_DEV:
           case FB_WWW_PROD:
@@ -147,15 +147,6 @@ const forks = Object.freeze({
           case RN_FB_PROD:
           case RN_FB_PROFILING:
             return 'shared/forks/ReactFeatureFlags.native-fb.js';
-          default:
-            return 'shared/ReactFeatureFlags.js';
-        }
-      default:
-        switch (bundleType) {
-          case FB_WWW_DEV:
-          case FB_WWW_PROD:
-          case FB_WWW_PROFILING:
-            return 'shared/forks/ReactFeatureFlags.www.js';
         }
     }
     return null;


### PR DESCRIPTION
# Overview

When I did https://github.com/facebook/react/pull/19521 I didn't realize that react/jsx-runtime _also_ pulls in the component stack frames so this failed a test I didn't think to check.

To fix, this diff changes FB RN to fall back to use the FB RN feature flags for any entry point in the default case, similar to www.

## Testing
- Ran `yarn build` confirmed that only `JSXDevRuntime.js`, `JSXRuntime`, and `React-dev.js` change to remove the new component stacks.
- Sync internally and run tests to confirm all tests pass as expected.