### PR TITLE
Double Invoke Effects in __DEV__

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -12,13 +12,14 @@ import type {Lanes} from './ReactFiberLane';
 import type {UpdateQueue} from './ReactUpdateQueue.new';
 
 import * as React from 'react';
-import {Update, Snapshot} from './ReactFiberFlags';
+import {Update, Snapshot, MountLayoutDev} from './ReactFiberFlags';
 import {
   debugRenderPhaseSideEffectsForStrictMode,
   disableLegacyContext,
   enableDebugTracing,
   enableSchedulingProfiler,
   warnAboutDeprecatedLifecycles,
+  enableDoubleInvokingEffects,
 } from 'shared/ReactFeatureFlags';
 import ReactStrictModeWarnings from './ReactStrictModeWarnings.new';
 import {isMounted} from './ReactFiberTreeReflection';
@@ -890,7 +891,11 @@ function mountClassInstance(
   }
 
   if (typeof instance.componentDidMount === 'function') {
-    workInProgress.flags |= Update;
+    if (__DEV__ && enableDoubleInvokingEffects) {
+      workInProgress.flags |= MountLayoutDev | Update;
+    } else {
+      workInProgress.flags |= Update;
+    }
   }
 }
 
@@ -960,7 +965,11 @@ function resumeMountClassInstance(
     // If an update was already in progress, we should schedule an Update
     // effect even though we're bailing out, so that cWU/cDU are called.
     if (typeof instance.componentDidMount === 'function') {
-      workInProgress.flags |= Update;
+      if (__DEV__ && enableDoubleInvokingEffects) {
+        workInProgress.flags |= MountLayoutDev | Update;
+      } else {
+        workInProgress.flags |= Update;
+      }
     }
     return false;
   }
@@ -1003,13 +1012,21 @@ function resumeMountClassInstance(
       }
     }
     if (typeof instance.componentDidMount === 'function') {
-      workInProgress.flags |= Update;
+      if (__DEV__ && enableDoubleInvokingEffects) {
+        workInProgress.flags |= MountLayoutDev | Update;
+      } else {
+        workInProgress.flags |= Update;
+      }
     }
   } else {
     // If an update was already in progress, we should schedule an Update
     // effect even though we're bailing out, so that cWU/cDU are called.
     if (typeof instance.componentDidMount === 'function') {
-      workInProgress.flags |= Update;
+      if (__DEV__ && enableDoubleInvokingEffects) {
+        workInProgress.flags |= MountLayoutDev | Update;
+      } else {
+        workInProgress.flags |= Update;
+      }
     }
 
     // If shouldComponentUpdate returned false, we should still update the

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -10,50 +10,56 @@
 export type Flags = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoFlags = /*                     */ 0b0000000000000000;
-export const PerformedWork = /*                */ 0b0000000000000001;
+export const NoFlags = /*                      */ 0b000000000000000000;
+export const PerformedWork = /*                */ 0b000000000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*                    */ 0b0000000000000010;
-export const Update = /*                       */ 0b0000000000000100;
-export const PlacementAndUpdate = /*           */ 0b0000000000000110;
-export const Deletion = /*                     */ 0b0000000000001000;
-export const ContentReset = /*                 */ 0b0000000000010000;
-export const Callback = /*                     */ 0b0000000000100000;
-export const DidCapture = /*                   */ 0b0000000001000000;
-export const Ref = /*                          */ 0b0000000010000000;
-export const Snapshot = /*                     */ 0b0000000100000000;
-export const Passive = /*                      */ 0b0000001000000000;
+export const Placement = /*                    */ 0b000000000000000010;
+export const Update = /*                       */ 0b000000000000000100;
+export const PlacementAndUpdate = /*           */ 0b000000000000000110;
+export const Deletion = /*                     */ 0b000000000000001000;
+export const ContentReset = /*                 */ 0b000000000000010000;
+export const Callback = /*                     */ 0b000000000000100000;
+export const DidCapture = /*                   */ 0b000000000001000000;
+export const Ref = /*                          */ 0b000000000010000000;
+export const Snapshot = /*                     */ 0b000000000100000000;
+export const Passive = /*                      */ 0b000000001000000000;
 // TODO (effects) Remove this bit once the new reconciler is synced to the old.
-export const PassiveUnmountPendingDev = /*     */ 0b0010000000000000;
-export const Hydrating = /*                    */ 0b0000010000000000;
-export const HydratingAndUpdate = /*           */ 0b0000010000000100;
+export const PassiveUnmountPendingDev = /*     */ 0b000010000000000000;
+export const Hydrating = /*                    */ 0b000000010000000000;
+export const HydratingAndUpdate = /*           */ 0b000000010000000100;
 
 // Passive & Update & Callback & Ref & Snapshot
-export const LifecycleEffectMask = /*          */ 0b0000001110100100;
+export const LifecycleEffectMask = /*          */ 0b000000001110100100;
 
 // Union of all host effects
-export const HostEffectMask = /*               */ 0b0000011111111111;
+export const HostEffectMask = /*               */ 0b000000011111111111;
 
 // These are not really side effects, but we still reuse this field.
-export const Incomplete = /*                   */ 0b0000100000000000;
-export const ShouldCapture = /*                */ 0b0001000000000000;
-export const ForceUpdateForLegacySuspense = /* */ 0b0100000000000000;
+export const Incomplete = /*                   */ 0b000000100000000000;
+export const ShouldCapture = /*                */ 0b000001000000000000;
+export const ForceUpdateForLegacySuspense = /* */ 0b000100000000000000;
 
 // Static tags describe aspects of a fiber that are not specific to a render,
 // e.g. a fiber uses a passive effect (even if there are no updates on this particular render).
 // This enables us to defer more work in the unmount case,
 // since we can defer traversing the tree during layout to look for Passive effects,
 // and instead rely on the static flag as a signal that there may be cleanup work.
-export const PassiveStatic = /*                */ 0b1000000000000000;
+export const PassiveStatic = /*                */ 0b001000000000000000;
 
 // Union of side effect groupings as pertains to subtreeFlags
-export const BeforeMutationMask = /*           */ 0b0000001100001010;
-export const MutationMask = /*                 */ 0b0000010010011110;
-export const LayoutMask = /*                   */ 0b0000000010100100;
-export const PassiveMask = /*                  */ 0b0000001000001000;
+export const BeforeMutationMask = /*           */ 0b000000001100001010;
+export const MutationMask = /*                 */ 0b000000010010011110;
+export const LayoutMask = /*                   */ 0b000000000010100100;
+export const PassiveMask = /*                  */ 0b000000001000001000;
 
 // Union of tags that don't get reset on clones.
 // This allows certain concepts to persist without recalculting them,
 // e.g. whether a subtree contains passive effects or portals.
-export const StaticMask = /*                   */ 0b1000000000000000;
+export const StaticMask = /*                   */ 0b001000000000000000;
+
+// These flags allow us to traverse to fibers that have effects on mount
+// without traversing the entire tree after every commit for
+// double invoking
+export const MountLayoutDev = /*               */ 0b010000000000000000;
+export const MountPassiveDev = /*              */ 0b100000000000000000;

--- a/packages/react-reconciler/src/__tests__/ReactDoubleInvokeEvents-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactDoubleInvokeEvents-test.internal.js
@@ -1,0 +1,504 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactFeatureFlags;
+let ReactNoop;
+let Scheduler;
+
+describe('ReactDoubleInvokeEvents', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    React = require('react');
+    ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    ReactFeatureFlags.enableDoubleInvokingEffects = __VARIANT__;
+  });
+
+  it('double invoking for effects works properly', () => {
+    function App({text}) {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('useEffect mount');
+        return () => Scheduler.unstable_yieldValue('useEffect unmount');
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect mount');
+        return () => Scheduler.unstable_yieldValue('useLayoutEffect unmount');
+      });
+
+      return text;
+    }
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'useLayoutEffect unmount',
+        'useEffect unmount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'update'} />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect unmount',
+      'useLayoutEffect mount',
+      'useEffect unmount',
+      'useEffect mount',
+    ]);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect unmount',
+      'useEffect unmount',
+    ]);
+  });
+
+  it('multiple effects are double invoked in the right order (all mounted, all unmounted, all remounted)', () => {
+    function App({text}) {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('useEffect One mount');
+        return () => Scheduler.unstable_yieldValue('useEffect One unmount');
+      });
+
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('useEffect Two mount');
+        return () => Scheduler.unstable_yieldValue('useEffect Two unmount');
+      });
+
+      return text;
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'useEffect One mount',
+        'useEffect Two mount',
+        'useEffect One unmount',
+        'useEffect Two unmount',
+        'useEffect One mount',
+        'useEffect Two mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'useEffect One mount',
+        'useEffect Two mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'update'} />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useEffect One unmount',
+      'useEffect Two unmount',
+      'useEffect One mount',
+      'useEffect Two mount',
+    ]);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useEffect One unmount',
+      'useEffect Two unmount',
+    ]);
+  });
+
+  it('multiple layout effects are double invoked in the right order (all mounted, all unmounted, all remounted)', () => {
+    function App({text}) {
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect One mount');
+        return () =>
+          Scheduler.unstable_yieldValue('useLayoutEffect One unmount');
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect Two mount');
+        return () =>
+          Scheduler.unstable_yieldValue('useLayoutEffect Two unmount');
+      });
+
+      return text;
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect One mount',
+        'useLayoutEffect Two mount',
+        'useLayoutEffect One unmount',
+        'useLayoutEffect Two unmount',
+        'useLayoutEffect One mount',
+        'useLayoutEffect Two mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect One mount',
+        'useLayoutEffect Two mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'update'} />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect One unmount',
+      'useLayoutEffect Two unmount',
+      'useLayoutEffect One mount',
+      'useLayoutEffect Two mount',
+    ]);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect One unmount',
+      'useLayoutEffect Two unmount',
+    ]);
+  });
+
+  it('useEffect and useLayoutEffect is called twice when there is no unmount', () => {
+    function App({text}) {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('useEffect mount');
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect mount');
+      });
+
+      return text;
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'update'} />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect mount',
+      'useEffect mount',
+    ]);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded([]);
+  });
+
+  it('double invoking works for class components', () => {
+    class App extends React.PureComponent {
+      componentDidMount() {
+        Scheduler.unstable_yieldValue('componentDidMount');
+      }
+
+      componentDidUpdate() {
+        Scheduler.unstable_yieldValue('componentDidUpdate');
+      }
+
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue('componentWillUnmount');
+      }
+
+      render() {
+        return this.props.text;
+      }
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'componentDidMount',
+        'componentWillUnmount',
+        'componentDidMount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded(['componentDidMount']);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'update'} />);
+    });
+
+    expect(Scheduler).toHaveYielded(['componentDidUpdate']);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded(['componentWillUnmount']);
+  });
+
+  it('double flushing passive effects only results in one double invoke', () => {
+    function App({text}) {
+      const [state, setState] = React.useState(0);
+      React.useEffect(() => {
+        if (state !== 1) {
+          setState(1);
+        }
+        Scheduler.unstable_yieldValue('useEffect mount');
+        return () => Scheduler.unstable_yieldValue('useEffect unmount');
+      });
+
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect mount');
+        return () => Scheduler.unstable_yieldValue('useLayoutEffect unmount');
+      });
+
+      Scheduler.unstable_yieldValue(text);
+      return text;
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'mount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'useLayoutEffect unmount',
+        'useEffect unmount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'mount',
+        'useLayoutEffect unmount',
+        'useLayoutEffect mount',
+        'useEffect unmount',
+        'useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'mount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'mount',
+        'useLayoutEffect unmount',
+        'useLayoutEffect mount',
+        'useEffect unmount',
+        'useEffect mount',
+      ]);
+    }
+  });
+
+  it('newly mounted components after initial mount get double invoked', () => {
+    let _setShowChild;
+    function Child() {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('Child useEffect mount');
+        return () => Scheduler.unstable_yieldValue('Child useEffect unmount');
+      });
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('Child useLayoutEffect mount');
+        return () =>
+          Scheduler.unstable_yieldValue('Child useLayoutEffect unmount');
+      });
+
+      return null;
+    }
+
+    function App() {
+      const [showChild, setShowChild] = React.useState(false);
+      _setShowChild = setShowChild;
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('App useEffect mount');
+        return () => Scheduler.unstable_yieldValue('App useEffect unmount');
+      });
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('App useLayoutEffect mount');
+        return () =>
+          Scheduler.unstable_yieldValue('App useLayoutEffect unmount');
+      });
+
+      return showChild && <Child />;
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'App useLayoutEffect mount',
+        'App useEffect mount',
+        'App useLayoutEffect unmount',
+        'App useEffect unmount',
+        'App useLayoutEffect mount',
+        'App useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'App useLayoutEffect mount',
+        'App useEffect mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      _setShowChild(true);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'App useLayoutEffect unmount',
+        'Child useLayoutEffect mount',
+        'App useLayoutEffect mount',
+        'App useEffect unmount',
+        'Child useEffect mount',
+        'App useEffect mount',
+        'Child useLayoutEffect unmount',
+        'Child useEffect unmount',
+        'Child useLayoutEffect mount',
+        'Child useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'App useLayoutEffect unmount',
+        'Child useLayoutEffect mount',
+        'App useLayoutEffect mount',
+        'App useEffect unmount',
+        'Child useEffect mount',
+        'App useEffect mount',
+      ]);
+    }
+  });
+
+  it('classes and functions are double invoked together correctly', () => {
+    class ClassChild extends React.PureComponent {
+      componentDidMount() {
+        Scheduler.unstable_yieldValue('componentDidMount');
+      }
+
+      componentWillUnmount() {
+        Scheduler.unstable_yieldValue('componentWillUnmount');
+      }
+
+      render() {
+        return this.props.text;
+      }
+    }
+
+    function FunctionChild({text}) {
+      React.useEffect(() => {
+        Scheduler.unstable_yieldValue('useEffect mount');
+        return () => Scheduler.unstable_yieldValue('useEffect unmount');
+      });
+      React.useLayoutEffect(() => {
+        Scheduler.unstable_yieldValue('useLayoutEffect mount');
+        return () => Scheduler.unstable_yieldValue('useLayoutEffect unmount');
+      });
+      return text;
+    }
+
+    function App({text}) {
+      return (
+        <>
+          <ClassChild text={text} />
+          <FunctionChild text={text} />
+        </>
+      );
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    if (__DEV__ && __VARIANT__) {
+      expect(Scheduler).toHaveYielded([
+        'componentDidMount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+        'componentWillUnmount',
+        'useLayoutEffect unmount',
+        'useEffect unmount',
+        'componentDidMount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    } else {
+      expect(Scheduler).toHaveYielded([
+        'componentDidMount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
+    }
+
+    ReactNoop.act(() => {
+      ReactNoop.render(<App text={'mount'} />);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'useLayoutEffect unmount',
+      'useLayoutEffect mount',
+      'useEffect unmount',
+      'useEffect mount',
+    ]);
+
+    ReactNoop.act(() => {
+      ReactNoop.render(null);
+    });
+
+    expect(Scheduler).toHaveYielded([
+      'componentWillUnmount',
+      'useLayoutEffect unmount',
+      'useEffect unmount',
+    ]);
+  });
+});

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -136,3 +136,5 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
+
+export const enableDoubleInvokingEffects = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -52,6 +52,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = false;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -51,6 +51,8 @@ export const enableDiscreteEventFlushingChange = true;
 export const enableEagerRootListeners = true;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
+export const enableDoubleInvokingEffects = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -48,3 +48,5 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const enableTrustedTypesIntegration = false;
 export const disableSchedulerTimeoutBasedOnReactExpirationTime = false;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
+
+export const enableDoubleInvokingEffects = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -29,6 +29,7 @@ export const {
   skipUnmountedBoundaries,
   enableEagerRootListeners,
   disableSchedulerTimeoutInWorkLoop,
+  enableDoubleInvokingEffects,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
This PR double invokes effects in `__DEV__` mode. 

We are thinking about unmounting layout and/or passive effects for a hidden tree. To understand potential issues with this, we want to double invoke effects. This PR changes the behavior in DEV when an effect runs from `create()` to `create() -> destroy() -> create()`. The effect cleanup function will still be called before the effect runs in both dev and prod. (Note: This change is purely for research for now as it is likely to break real code.)

**Note: The change is fully behind a flag and does not affect any of the code on npm.**