### PR TITLE
[Scheduler] Get current time from performance.now in non-DOM environments

### DIFF
--- a/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerBrowser-test.js
@@ -42,7 +42,7 @@ describe('SchedulerBrowser', () => {
     );
 
     runtime = installMockBrowserRuntime();
-    performance = window.performance;
+    performance = global.performance;
     Scheduler = require('scheduler');
     cancelCallback = Scheduler.unstable_cancelCallback;
     scheduleCallback = Scheduler.unstable_scheduleCallback;
@@ -50,6 +50,8 @@ describe('SchedulerBrowser', () => {
   });
 
   afterEach(() => {
+    delete global.performance;
+
     if (!runtime.isLogEmpty()) {
       throw Error('Test exited without clearing log.');
     }
@@ -63,16 +65,16 @@ describe('SchedulerBrowser', () => {
 
     let eventLog = [];
 
-    const window = {};
-    global.window = window;
-
     let currentTime = 0;
 
-    window.performance = {
+    global.performance = {
       now() {
         return currentTime;
       },
     };
+
+    const window = {};
+    global.window = window;
 
     // TODO: Scheduler no longer requires these methods to be polyfilled. But
     // maybe we want to continue warning if they don't exist, to preserve the

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -16,14 +16,16 @@ export let requestPaint;
 export let getCurrentTime;
 export let forceFrameRate;
 
-const performance = window.performance;
+const isWindowUndefined = typeof window === 'undefined';
+
+const performance = isWindowUndefined ? global.performance : window.performance;
 if (
   typeof performance === 'object' &&
   typeof performance.now === 'function'
 ) {
   getCurrentTime = () => performance.now();
 } else {
-  const Date = window.Date;
+  const Date = isWindowUndefined ? global.Date : window.Date;
   const initialTime = Date.now();
   getCurrentTime = () => Date.now() - initialTime;
 }
@@ -31,7 +33,7 @@ if (
 if (
   // If Scheduler runs in a non-DOM environment, it falls back to a naive
   // implementation using setTimeout.
-  typeof window === 'undefined' ||
+  isWindowUndefined ||
   // Check if MessageChannel is supported, too.
   typeof MessageChannel !== 'function'
 ) {

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -16,24 +16,22 @@ export let requestPaint;
 export let getCurrentTime;
 export let forceFrameRate;
 
-const isWindowUndefined = typeof window === 'undefined';
+const hasPerformanceNow =
+  typeof performance === 'object' && typeof performance.now === 'function';
 
-const performance = isWindowUndefined ? global.performance : window.performance;
-if (
-  typeof performance === 'object' &&
-  typeof performance.now === 'function'
-) {
-  getCurrentTime = () => performance.now();
+if (hasPerformanceNow) {
+  const localPerformance = performance;
+  getCurrentTime = () => localPerformance.now();
 } else {
-  const Date = isWindowUndefined ? global.Date : window.Date;
-  const initialTime = Date.now();
-  getCurrentTime = () => Date.now() - initialTime;
+  const localDate = Date;
+  const initialTime = localDate.now();
+  getCurrentTime = () => localDate.now() - initialTime;
 }
 
 if (
   // If Scheduler runs in a non-DOM environment, it falls back to a naive
   // implementation using setTimeout.
-  isWindowUndefined ||
+  typeof window === 'undefined' ||
   // Check if MessageChannel is supported, too.
   typeof MessageChannel !== 'function'
 ) {

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -16,6 +16,18 @@ export let requestPaint;
 export let getCurrentTime;
 export let forceFrameRate;
 
+const performance = window.performance;
+if (
+  typeof performance === 'object' &&
+  typeof performance.now === 'function'
+) {
+  getCurrentTime = () => performance.now();
+} else {
+  const Date = window.Date;
+  const initialTime = Date.now();
+  getCurrentTime = () => Date.now() - initialTime;
+}
+
 if (
   // If Scheduler runs in a non-DOM environment, it falls back to a naive
   // implementation using setTimeout.
@@ -39,10 +51,6 @@ if (
         throw e;
       }
     }
-  };
-  const initialTime = Date.now();
-  getCurrentTime = function() {
-    return Date.now() - initialTime;
   };
   requestHostCallback = function(cb) {
     if (_callback !== null) {
@@ -68,8 +76,6 @@ if (
   requestPaint = forceFrameRate = function() {};
 } else {
   // Capture local references to native APIs, in case a polyfill overrides them.
-  const performance = window.performance;
-  const Date = window.Date;
   const setTimeout = window.setTimeout;
   const clearTimeout = window.clearTimeout;
 
@@ -96,16 +102,6 @@ if (
           'polyfill in older browsers. https://fb.me/react-polyfills',
       );
     }
-  }
-
-  if (
-    typeof performance === 'object' &&
-    typeof performance.now === 'function'
-  ) {
-    getCurrentTime = () => performance.now();
-  } else {
-    const initialTime = Date.now();
-    getCurrentTime = () => Date.now() - initialTime;
   }
 
   let isMessageLoopRunning = false;


### PR DESCRIPTION
## Summary

Scheduler makes an assumption that `performance.now` does not exist in a non-DOM environment. React Native is such environment, however, latest RN versions do have support for `performance.now` (https://github.com/facebook/react-native/commit/232517a5740f5b82cfe8779b3832e9a7a47a8d3d).

This PR changes `getCurrentTime` implementation to use `performance.now` if it is defined, and fallback to `Date.now` if the function is missing.

This change is required for React Profiler API to work properly in React Native. Without this change, the Profiler in RN uses `Date` which is not so precise.

## Test Plan

- Tests are passing
- Code lints
- I built `scheduler` and tested the change in a React Native project. Profiler API now takes time from `performance.now` and the precision is greatly improved.

![Screenshot 2020-08-05 at 14 42 40](https://user-images.githubusercontent.com/13116854/89409094-28b88100-d72a-11ea-9d3f-dbcbe1bc9f02.png)

