### PR TITLE
Remove unused argument from call to jest method

### DIFF
--- a/packages/react/src/__tests__/ReactChildren-test.js
+++ b/packages/react/src/__tests__/ReactChildren-test.js
@@ -460,7 +460,7 @@ describe('ReactChildren', () => {
     });
 
     function assertCalls() {
-      expect(callback).toHaveBeenCalledTimes(2, 0);
+      expect(callback).toHaveBeenCalledTimes(2);
       expect(callback).toHaveBeenCalledWith('a', 0);
       expect(callback).toHaveBeenCalledWith(13, 1);
       callback.mockClear();


### PR DESCRIPTION
This PR just removes an unused second argument from a call to `.toHaveBeenCalledTimes()`.

Cheers!
