### PR TITLE
Warn about undefined return value for memo and forwardRef

### DIFF
--- a/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
@@ -316,4 +316,24 @@ describe('ReactEmptyComponent', () => {
     const noscript2 = container.firstChild;
     expect(noscript2).toBe(null);
   });
+
+  it('should warn about React.forwardRef that returns undefined', () => {
+    const Empty = () => {};
+    const EmptyForwardRef = React.forwardRef(Empty);
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<EmptyForwardRef />);
+    }).toThrowError(
+      'ForwardRef(Empty)(...): Nothing was returned from render.',
+    );
+  });
+
+  it('should warn about React.memo that returns undefined', () => {
+    const Empty = () => {};
+    const EmptyMemo = React.memo(Empty);
+
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(<EmptyMemo />);
+    }).toThrowError('Empty(...): Nothing was returned from render.');
+  });
 });

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -29,7 +29,9 @@ import {
   ClassComponent,
   HostText,
   HostPortal,
+  ForwardRef,
   Fragment,
+  SimpleMemoComponent,
   Block,
 } from './ReactWorkTags';
 import invariant from 'shared/invariant';
@@ -1393,14 +1395,16 @@ function ChildReconciler(shouldTrackSideEffects) {
         // Intentionally fall through to the next case, which handles both
         // functions and classes
         // eslint-disable-next-lined no-fallthrough
-        case FunctionComponent: {
-          const Component = returnFiber.type;
+        case Block:
+        case FunctionComponent:
+        case ForwardRef:
+        case SimpleMemoComponent: {
           invariant(
             false,
             '%s(...): Nothing was returned from render. This usually means a ' +
               'return statement is missing. Or, to render nothing, ' +
               'return null.',
-            Component.displayName || Component.name || 'Component',
+            getComponentName(returnFiber.type) || 'Component',
           );
         }
       }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -29,7 +29,9 @@ import {
   ClassComponent,
   HostText,
   HostPortal,
+  ForwardRef,
   Fragment,
+  SimpleMemoComponent,
   Block,
 } from './ReactWorkTags';
 import invariant from 'shared/invariant';
@@ -1385,14 +1387,16 @@ function ChildReconciler(shouldTrackSideEffects) {
         // Intentionally fall through to the next case, which handles both
         // functions and classes
         // eslint-disable-next-lined no-fallthrough
-        case FunctionComponent: {
-          const Component = returnFiber.type;
+        case Block:
+        case FunctionComponent:
+        case ForwardRef:
+        case SimpleMemoComponent: {
           invariant(
             false,
             '%s(...): Nothing was returned from render. This usually means a ' +
               'return statement is missing. Or, to render nothing, ' +
               'return null.',
-            Component.displayName || Component.name || 'Component',
+            getComponentName(returnFiber.type) || 'Component',
           );
         }
       }


### PR DESCRIPTION
Seems wrong that we weren't warning about this before.

Resolves #19548
