### PR TITLE
Add ReactVersion to SchedulingProfiler render scheduled marks

### DIFF
--- a/packages/react-reconciler/src/SchedulingProfiler.js
+++ b/packages/react-reconciler/src/SchedulingProfiler.js
@@ -15,6 +15,7 @@ import {
   enableSchedulingProfiler,
   enableSchedulingProfilerComponentStacks,
 } from 'shared/ReactFeatureFlags';
+import ReactVersion from 'shared/ReactVersion';
 import getComponentName from 'shared/getComponentName';
 import {getStackByFiberInDevAndProd} from './ReactFiberComponentStack';
 
@@ -166,7 +167,9 @@ export function markRenderStopped(): void {
 export function markRenderScheduled(lane: Lane): void {
   if (enableSchedulingProfiler) {
     if (supportsUserTiming) {
-      performance.mark(`--schedule-render-${formatLanes(lane)}`);
+      performance.mark(
+        `--schedule-render-${formatLanes(lane)}-${ReactVersion}`,
+      );
     }
   }
 }

--- a/packages/react-reconciler/src/SchedulingProfiler.js
+++ b/packages/react-reconciler/src/SchedulingProfiler.js
@@ -30,6 +30,13 @@ function formatLanes(laneOrLanes: Lane | Lanes): string {
   return ((laneOrLanes: any): number).toString();
 }
 
+// Create a mark on React initialization
+if (enableSchedulingProfiler) {
+  if (supportsUserTiming) {
+    performance.mark(`--react-init-${ReactVersion}`);
+  }
+}
+
 export function markCommitStarted(lanes: Lanes): void {
   if (enableSchedulingProfiler) {
     if (supportsUserTiming) {
@@ -167,9 +174,7 @@ export function markRenderStopped(): void {
 export function markRenderScheduled(lane: Lane): void {
   if (enableSchedulingProfiler) {
     if (supportsUserTiming) {
-      performance.mark(
-        `--schedule-render-${formatLanes(lane)}-${ReactVersion}`,
-      );
+      performance.mark(`--schedule-render-${formatLanes(lane)}`);
     }
   }
 }

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import ReactVersion from 'shared/ReactVersion';
+
 function normalizeCodeLocInfo(str) {
   return (
     str &&
@@ -81,7 +83,7 @@ describe('SchedulingProfiler', () => {
     ReactTestRenderer.create(<div />);
 
     expect(marks).toEqual([
-      '--schedule-render-1',
+      `--schedule-render-1-${ReactVersion}`,
       '--render-start-1',
       '--render-stop',
       '--commit-start-1',
@@ -95,7 +97,7 @@ describe('SchedulingProfiler', () => {
   it('should mark concurrent render without suspends or state updates', () => {
     ReactTestRenderer.create(<div />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -128,7 +130,7 @@ describe('SchedulingProfiler', () => {
     expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
 
     expect(marks).toEqual([
-      '--schedule-render-512',
+      `--schedule-render-512-${ReactVersion}`,
       '--render-start-512',
       '--render-yield',
     ]);
@@ -148,7 +150,7 @@ describe('SchedulingProfiler', () => {
     );
 
     expect(marks).toEqual([
-      '--schedule-render-1',
+      `--schedule-render-1-${ReactVersion}`,
       '--render-start-1',
       toggleComponentStacks(
         '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
@@ -184,7 +186,7 @@ describe('SchedulingProfiler', () => {
     );
 
     expect(marks).toEqual([
-      '--schedule-render-1',
+      `--schedule-render-1-${ReactVersion}`,
       '--render-start-1',
       toggleComponentStacks(
         '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
@@ -220,7 +222,7 @@ describe('SchedulingProfiler', () => {
       {unstable_isConcurrent: true},
     );
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -262,7 +264,7 @@ describe('SchedulingProfiler', () => {
       {unstable_isConcurrent: true},
     );
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -304,7 +306,7 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -340,7 +342,7 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -377,7 +379,7 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -414,7 +416,7 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -449,7 +451,7 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual(['--schedule-render-512']);
+    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
 
     marks.splice(0);
 
@@ -489,7 +491,7 @@ describe('SchedulingProfiler', () => {
     gate(({old}) => {
       if (old) {
         expect(marks.map(normalizeCodeLocInfo)).toEqual([
-          '--schedule-render-512',
+          `--schedule-render-512-${ReactVersion}`,
           '--render-start-512',
           '--render-stop',
           '--commit-start-512',
@@ -508,7 +510,7 @@ describe('SchedulingProfiler', () => {
         ]);
       } else {
         expect(marks.map(normalizeCodeLocInfo)).toEqual([
-          '--schedule-render-512',
+          `--schedule-render-512-${ReactVersion}`,
           '--render-start-512',
           '--render-stop',
           '--commit-start-512',

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -56,6 +56,7 @@ describe('SchedulingProfiler', () => {
   beforeEach(() => {
     jest.resetModules();
     global.performance = createUserTimingPolyfill();
+    marks = [];
 
     React = require('react');
 
@@ -64,8 +65,6 @@ describe('SchedulingProfiler', () => {
     ReactNoop = require('react-noop-renderer');
 
     Scheduler = require('scheduler');
-
-    marks = [];
   });
 
   afterEach(() => {
@@ -79,11 +78,17 @@ describe('SchedulingProfiler', () => {
   });
 
   // @gate enableSchedulingProfiler
+  it('should log React version on initialization', () => {
+    expect(marks).toEqual([`--react-init-${ReactVersion}`]);
+  });
+
+  // @gate enableSchedulingProfiler
   it('should mark sync render without suspends or state updates', () => {
     ReactTestRenderer.create(<div />);
 
     expect(marks).toEqual([
-      `--schedule-render-1-${ReactVersion}`,
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-1',
       '--render-start-1',
       '--render-stop',
       '--commit-start-1',
@@ -97,7 +102,10 @@ describe('SchedulingProfiler', () => {
   it('should mark concurrent render without suspends or state updates', () => {
     ReactTestRenderer.create(<div />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -130,7 +138,8 @@ describe('SchedulingProfiler', () => {
     expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
 
     expect(marks).toEqual([
-      `--schedule-render-512-${ReactVersion}`,
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
       '--render-start-512',
       '--render-yield',
     ]);
@@ -150,7 +159,8 @@ describe('SchedulingProfiler', () => {
     );
 
     expect(marks).toEqual([
-      `--schedule-render-1-${ReactVersion}`,
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-1',
       '--render-start-1',
       toggleComponentStacks(
         '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
@@ -186,7 +196,8 @@ describe('SchedulingProfiler', () => {
     );
 
     expect(marks).toEqual([
-      `--schedule-render-1-${ReactVersion}`,
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-1',
       '--render-start-1',
       toggleComponentStacks(
         '--suspense-suspend-0-Example-\n    at Example\n    at Suspense',
@@ -222,7 +233,10 @@ describe('SchedulingProfiler', () => {
       {unstable_isConcurrent: true},
     );
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -264,7 +278,10 @@ describe('SchedulingProfiler', () => {
       {unstable_isConcurrent: true},
     );
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -306,7 +323,10 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -342,7 +362,10 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -379,7 +402,10 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -416,7 +442,10 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -451,7 +480,10 @@ describe('SchedulingProfiler', () => {
 
     ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
 
-    expect(marks).toEqual([`--schedule-render-512-${ReactVersion}`]);
+    expect(marks).toEqual([
+      `--react-init-${ReactVersion}`,
+      '--schedule-render-512',
+    ]);
 
     marks.splice(0);
 
@@ -491,7 +523,8 @@ describe('SchedulingProfiler', () => {
     gate(({old}) => {
       if (old) {
         expect(marks.map(normalizeCodeLocInfo)).toEqual([
-          `--schedule-render-512-${ReactVersion}`,
+          `--react-init-${ReactVersion}`,
+          '--schedule-render-512',
           '--render-start-512',
           '--render-stop',
           '--commit-start-512',
@@ -510,7 +543,8 @@ describe('SchedulingProfiler', () => {
         ]);
       } else {
         expect(marks.map(normalizeCodeLocInfo)).toEqual([
-          `--schedule-render-512-${ReactVersion}`,
+          `--react-init-${ReactVersion}`,
+          '--schedule-render-512',
           '--render-start-512',
           '--render-stop',
           '--commit-start-512',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

These `SchedulingProfiler` marks are currently being used by our experimental [concurrent mode profiler tool](https://react-scheduling-profiler.vercel.app).

Context: Brian at https://github.com/MLH-Fellowship/react/issues/5#issuecomment-656138017:

> Since we are actively changing the "lanes" implementation and what the semantic value of a given lane is (e.g. facebook#19287) it would be helpful for us to encode some info in our profile that lets us match this information up later.
>
> I had been thinking about eventually encoding what the lanes ranges are, so we could display some meaningful label in the profiler, but maybe that would be a hassle and for now- we could get away with just marking the version of React the profiling data corresponds to. This would let us at least manually match the lanes up later if we wanted to dig in deeper.

We only add version strings to the render scheduled marks as these marks do not appear often and would thus provide the profiler with information it needs without unnecessarily bloating the profiles.

There is a known limitation to this approach: because renders are not scheduled often (generally only on page load), it is possible to generate profiles that do not contain React version numbers. Ideally, we'd want to log `ReactVersion` when we detect the start of a profiling session, but as far as we can tell this is currently not possible without integrating with Chrome DevTools.

Resolves https://github.com/MLH-Fellowship/react/issues/35, and unblocks https://github.com/MLH-Fellowship/scheduling-profiler-prototype/issues/73

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

`yarn test`: tests for `SchedulingProfiler` have been updated. The new render scheduled marks look like this: `--schedule-render-1-17.0.0-alpha.0`.
