### PR TITLE
beforeInputPlugin: add native support for beforeinput

### DIFF
--- a/packages/react-dom/src/events/DOMEventNames.js
+++ b/packages/react-dom/src/events/DOMEventNames.js
@@ -17,6 +17,7 @@ export type DOMEventName =
   // 'animationend |
   // 'animationstart' |
   | 'beforeblur' // Not a real event. This is used by event experiments.
+  | 'beforeinput'
   | 'canplay'
   | 'canplaythrough'
   | 'cancel'

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -86,6 +86,7 @@ const otherDiscreteEvents: Array<DOMEventName> = [
   'compositionstart',
   'compositionend',
   'compositionupdate',
+  'beforeinput',
 ];
 
 if (enableCreateEventHandleAPI) {

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -264,6 +264,7 @@ export const ClipboardEventInterface: EventInterfaceType = {
 export const CompositionEventInterface: EventInterfaceType = {
   ...EventInterface,
   data: 0,
+  inputType: 0,
 };
 
 /**

--- a/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
@@ -14,6 +14,7 @@ import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
+import {enableNativeBeforeInput} from 'shared/ReactFeatureFlags';
 
 import {registerTwoPhaseEvent} from '../EventRegistry';
 import {
@@ -401,7 +402,7 @@ function extractBeforeInputEvent(
 ) {
   let chars;
 
-  if (canUseBeforeInputEvent) {
+  if (enableNativeBeforeInput && canUseBeforeInputEvent) {
     chars = getNativeBeforeInputChars(domEventName, nativeEvent);
   } else if (canUseTextInputEvent) {
     chars = getFallbackBeforeInputChars(domEventName, nativeEvent);

--- a/packages/react-dom/src/events/plugins/__tests__/BeforeInputEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/BeforeInputEventPlugin-test.js
@@ -845,4 +845,36 @@ describe('BeforeInputEventPlugin', () => {
   it('should extract onBeforeInput when simulating in env with only CompositionEvent on contenteditable', () => {
     testContentEditableComponent(environments[3], scenarios);
   });
+
+  describe('supporting the native beforeinput event', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      InputEvent.prototype.getTargetRanges = function() {};
+      React = require('react');
+      ReactDOM = require('react-dom');
+    });
+
+    afterEach(() => {
+      delete InputEvent.prototype.getTargetRanges;
+    });
+
+    function dispatchBeforeInputEvent(target, data) {
+      const event = new InputEvent('beforeinput', {bubbles: true, data});
+      target.dispatchEvent(event);
+    }
+
+    it('should extract onBeforeInput on an input', () => {
+      const onBeforeInput = jest.fn();
+      const ref = React.createRef();
+
+      function Test() {
+        return <input onBeforeInput={onBeforeInput} ref={ref} />;
+      }
+      ReactDOM.render(<Test />, container);
+
+      const target = ref.current;
+      dispatchBeforeInputEvent(target, 'A');
+      expect(onBeforeInput).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -138,3 +138,5 @@ export const enablePassiveEventIntervention = true;
 export const disableOnScrollBubbling = true;
 
 export const enableEagerRootListeners = true;
+
+export const enableNativeBeforeInput = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -52,6 +52,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -51,6 +51,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -51,6 +51,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -50,6 +50,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -51,6 +51,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -51,6 +51,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -51,6 +51,7 @@ export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = true;
 export const enablePassiveEventIntervention = true;
 export const enableEagerRootListeners = true;
+export const enableNativeBeforeInput = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -22,6 +22,7 @@ export const skipUnmountedBoundaries = __VARIANT__;
 export const enablePassiveEventIntervention = __VARIANT__;
 export const disableOnScrollBubbling = __VARIANT__;
 export const enableEagerRootListeners = !__VARIANT__;
+export const enableNativeBeforeInput = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -30,6 +30,7 @@ export const {
   enablePassiveEventIntervention,
   disableOnScrollBubbling,
   enableEagerRootListeners,
+  enableNativeBeforeInput,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
This PR adds support for the native `beforeinput` event (when we detected it), falling back to the alternatives if we don't find support for it. See https://github.com/facebook/react/issues/11211 for more context on this.

This PR should fix some long standing issues with DraftJS as well as providing better compatibility with modern browser events. This specific event is supported in all the major evergreen browsers, apart from Firefox.

TODO:
- Ensure we can use this internally without any issues
- Validate that the detection mechanism is reliable, or maybe switch to a better alternative