### PR TITLE
provide profiling bundle for react-reconciler

### DIFF
--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -488,7 +488,7 @@ const bundles = [
 
   /******* React Reconciler *******/
   {
-    bundleTypes: [NODE_DEV, NODE_PROD],
+    bundleTypes: [NODE_DEV, NODE_PROD, NODE_PROFILING],
     moduleType: RECONCILER,
     entry: 'react-reconciler',
     global: 'ReactReconciler',

--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -294,6 +294,20 @@ ${source}
     return exports;
 };`;
   },
+
+  /***************** NODE_PROFILING (reconciler only) *****************/
+  [NODE_PROFILING](source, globalName, filename, moduleType) {
+    return `/** @license React v${reactVersion}
+ * ${filename}
+ *
+${license}
+ */
+module.exports = function $$$reconciler($$$hostConfig) {
+    var exports = {};
+${source}
+    return exports;
+};`;
+  },
 };
 
 function wrapBundle(source, bundleType, globalName, filename, moduleType) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We're implementing a custom React renderer. We use `react-reconciler` to do that. We're able to use `react-devtools`' profiler to profile development builds, but the profiler displays a _"Profiling not supported"_ message when profiling a production build:

<img width="871" alt="Screen Shot 2020-08-07 at 3 09 53 PM" src="https://user-images.githubusercontent.com/811047/89692321-2daf3900-d8c0-11ea-8f13-4cf08aabc3f8.png">

(note the old 4.4.0 devtools version, but I'm assuming the same would happen if we were able to use the latest `react-devtools`' version, which we're currently not able to).

This PR provides a `react-reconciler` profiling bundle that we're able to use instead of the `react-reconciler` production bundle when profiling production builds. When doing that and setting the relevant module resolution settings in Webpack (see Test plan below), we're able to use the `react-devtools` profiler.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

To test this change, I went through the following steps:

1. I ran `yarn build reconciler` in my local checkout of this PR's branch, then copied the resulting `build/node_modules/react-reconciler/profiling.js` and `build/node_modules/react-reconciler/cjs/react-reconciler.profiling.min.js` files to my application's `node_modules/react-reconciler` directory

2. I setup the following module aliases in the application's Webpack configuration:

```
'scheduler/tracing$': 'scheduler/tracing-profiling',
`react-reconciler$': 'react-reconciler/profiling'
```

3. I built the application with the `NODE_ENV` environment variable set to `production`

4. I started the application and the `react-devtools`, and I was able to use the `react-devtools`' profiler:

<img width="874" alt="Screen Shot 2020-08-07 at 3 22 13 PM" src="https://user-images.githubusercontent.com/811047/89692911-cdb99200-d8c1-11ea-9be2-a211f020b131.png">
