### PR TITLE
test: Simulate mouseover in browser

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -966,7 +966,7 @@ describe('ReactDOMFiber', () => {
         container,
       );
 
-      simulateMouseMove(null, firstTarget);
+      simulateMouseMove(container, firstTarget);
       expect(ops).toEqual(['enter parent']);
 
       ops = [];

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -966,7 +966,7 @@ describe('ReactDOMFiber', () => {
         container,
       );
 
-      simulateMouseMove(container, firstTarget);
+      simulateMouseMove(firstTarget.parentElement, firstTarget);
       expect(ops).toEqual(['enter parent']);
 
       ops = [];
@@ -987,6 +987,40 @@ describe('ReactDOMFiber', () => {
     } finally {
       document.body.removeChild(portalContainer);
     }
+  });
+
+  it('does not fire mouseEnter twice', () => {
+    const ops = [];
+    let target = null;
+
+    function simulateMouseMove(from, to) {
+      if (from) {
+        from.dispatchEvent(
+          new MouseEvent('mouseout', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: to,
+          }),
+        );
+      }
+      if (to) {
+        to.dispatchEvent(
+          new MouseEvent('mouseover', {
+            bubbles: true,
+            cancelable: true,
+            relatedTarget: from,
+          }),
+        );
+      }
+    }
+
+    ReactDOM.render(
+      <div onMouseEnter={() => ops.push('enter')} ref={n => (target = n)} />,
+      container,
+    );
+
+    simulateMouseMove(target.parentElement, target);
+    expect(ops).toEqual(['enter']);
   });
 
   it('should throw on bad createPortal argument', () => {


### PR DESCRIPTION
## Summary

Failing test for https://github.com/facebook/react/issues/19562

@gaearon had the right idea in https://github.com/facebook/react/issues/19562#issuecomment-671103670

## Test Plan

See https://codesandbox.io/s/simulatemousemove-in-reactnext-hnhh3 for actual browser behavior. It first uses `simulateMouseMove` from this test. The same output is generated if you manually mouse over the first button.
