### PR TITLE
Update outdated lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7619,7 +7619,7 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsdom@^15.2.1, "jsdom@npm:@gaearon/jsdom@15.2.1":
+jsdom@^15.2.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/@gaearon/jsdom/-/jsdom-15.2.1.tgz#23273b20b6c7b6ca70b54bc0b0eecdc518ae9694"
   integrity sha512-qQc4j+gyi06zrevvopql0pehAXrgTv71wGkKMQZg8bl2VYfv2dqbdtP0hD0TpHsuI7YF1XfE7DM62Nclr13vfA==
@@ -10113,6 +10113,11 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-is@^16.12.0, react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

```bash
$ yarn -v 
1.22.4
$ yarn install
```
in a fresh clone creates a diff in the lockfile. This might be confusing since it might not be obvious if a (potential) failures comes from this diff or the changes you made in a PR.

## Test Plan

- [ ] CI green