### PR TITLE
Fix double-firing mouseenter

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -966,7 +966,7 @@ describe('ReactDOMFiber', () => {
         container,
       );
 
-      simulateMouseMove(null, firstTarget);
+      simulateMouseMove(container, firstTarget);
       expect(ops).toEqual(['enter parent']);
 
       ops = [];

--- a/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiber-test.js
@@ -991,7 +991,7 @@ describe('ReactDOMFiber', () => {
 
   // Regression test for https://github.com/facebook/react/issues/19562
   it('does not fire mouseEnter twice when relatedTarget is the root node', () => {
-    const ops = [];
+    let ops = [];
     let target = null;
 
     function simulateMouseMove(from, to) {
@@ -1016,13 +1016,28 @@ describe('ReactDOMFiber', () => {
     }
 
     ReactDOM.render(
-      <div onMouseEnter={() => ops.push('enter')} ref={n => (target = n)} />,
+      <div
+        ref={n => (target = n)}
+        onMouseEnter={() => ops.push('enter')}
+        onMouseLeave={() => ops.push('leave')}
+      />,
       container,
     );
 
     simulateMouseMove(null, container);
+    expect(ops).toEqual([]);
+
+    ops = [];
     simulateMouseMove(container, target);
     expect(ops).toEqual(['enter']);
+
+    ops = [];
+    simulateMouseMove(target, container);
+    expect(ops).toEqual(['leave']);
+
+    ops = [];
+    simulateMouseMove(container, null);
+    expect(ops).toEqual([]);
   });
 
   it('should throw on bad createPortal argument', () => {


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/19562.

Uses a test from https://github.com/facebook/react/pull/19567.

I think the intention of the original code was to detect if the node is in the React tree, but it didn't check for the root node. So if we got an event with `relatedTarget` being the container node itself, we would fail to filter it out.