### PR TITLE
Make undefined return value invariant a warning for memo and forwardRef

### DIFF
--- a/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactEmptyComponent-test.js
@@ -323,9 +323,7 @@ describe('ReactEmptyComponent', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<EmptyForwardRef />);
-    }).toThrowError(
-      'ForwardRef(Empty)(...): Nothing was returned from render.',
-    );
+    }).toWarnDev('ForwardRef(Empty)(...): Nothing was returned from render.');
   });
 
   it('should warn about React.memo that returns undefined', () => {
@@ -334,6 +332,6 @@ describe('ReactEmptyComponent', () => {
 
     expect(() => {
       ReactTestUtils.renderIntoDocument(<EmptyMemo />);
-    }).toThrowError('Empty(...): Nothing was returned from render.');
+    }).toWarnDev('Empty(...): Nothing was returned from render.');
   });
 });

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -1383,6 +1383,18 @@ function ChildReconciler(shouldTrackSideEffects) {
       // component, throw an error. If Fiber return types are disabled,
       // we already threw above.
       switch (returnFiber.tag) {
+        case Block:
+        case ForwardRef:
+        case SimpleMemoComponent:
+          if (__DEV__) {
+            console.warn(
+              '%s(...): Nothing was returned from render. This usually means a ' +
+                'return statement is missing. Or, to render nothing, ' +
+                'return null.',
+              getComponentName(returnFiber.type) || 'Component',
+            );
+          }
+          break;
         case ClassComponent: {
           if (__DEV__) {
             const instance = returnFiber.stateNode;
@@ -1395,10 +1407,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         // Intentionally fall through to the next case, which handles both
         // functions and classes
         // eslint-disable-next-lined no-fallthrough
-        case Block:
-        case FunctionComponent:
-        case ForwardRef:
-        case SimpleMemoComponent: {
+        case FunctionComponent: {
           invariant(
             false,
             '%s(...): Nothing was returned from render. This usually means a ' +

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -1375,6 +1375,18 @@ function ChildReconciler(shouldTrackSideEffects) {
       // component, throw an error. If Fiber return types are disabled,
       // we already threw above.
       switch (returnFiber.tag) {
+        case Block:
+        case ForwardRef:
+        case SimpleMemoComponent:
+          if (__DEV__) {
+            console.warn(
+              '%s(...): Nothing was returned from render. This usually means a ' +
+                'return statement is missing. Or, to render nothing, ' +
+                'return null.',
+              getComponentName(returnFiber.type) || 'Component',
+            );
+          }
+          break;
         case ClassComponent: {
           if (__DEV__) {
             const instance = returnFiber.stateNode;
@@ -1387,10 +1399,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         // Intentionally fall through to the next case, which handles both
         // functions and classes
         // eslint-disable-next-lined no-fallthrough
-        case Block:
-        case FunctionComponent:
-        case ForwardRef:
-        case SimpleMemoComponent: {
+        case FunctionComponent: {
           invariant(
             false,
             '%s(...): Nothing was returned from render. This usually means a ' +


### PR DESCRIPTION
Opening in case we decided to make this change for v17. I don't think it's the right change though.