### PR TITLE
Remove resolutions from test renderer package.json

### DIFF
--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -27,9 +27,6 @@
   "peerDependencies": {
     "react": "^17.0.0-alpha"
   },
-  "resolutions": {
-    "react-shallow-renderer/react-is": "^17.0.0-alpha"
-  },
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
This doesn't do anything. They're only taken into account in the top-level package.json AFAIK.