### PR TITLE
[react-reconciler] Optimize ReactFiberDevToolsHook for bundle size

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -24,7 +24,7 @@ export const isDevToolsPresent =
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
 
 export function injectInternals(internals: Object): boolean {
-  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+  if (!isDevToolsPresent) {
     // No DevTools
     return false;
   }

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
@@ -24,7 +24,7 @@ export const isDevToolsPresent =
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
 
 export function injectInternals(internals: Object): boolean {
-  if (typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
+  if (!isDevToolsPresent) {
     // No DevTools
     return false;
   }


### PR DESCRIPTION
## Summary

This piece of code:

https://github.com/facebook/react/blob/db6513914f99c260090f26f0a547ee1432c934e6/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js#L27-L30

can be optimized for bundle size if we reuse the same check that is performed just above:

https://github.com/facebook/react/blob/db6513914f99c260090f26f0a547ee1432c934e6/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js#L23-L24

Currently, the minified code is:

```js
function(e){if("undefined"==typeof __REACT_DEVTOOLS_GLOBAL_HOOK__)return!1;var t=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(t.isDisabled||!t.supportsFiber)return!0;
```

\- that's 155 bytes. After the change, the minified code will look like this:

```js
function(e){if(u)return!1;var t=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(t.isDisabled||!t.supportsFiber)return!0;
```

\- now it's 106 bytes!

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

The change is trivial, so it doesn't require a complex test plan.
