### PR TITLE
change destroy to safelyCallDestroy for Layout Effect Unmounts

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -327,7 +327,7 @@ function commitHookEffectListUnmount(tag: number, finishedWork: Fiber) {
         const destroy = effect.destroy;
         effect.destroy = undefined;
         if (destroy !== undefined) {
-          destroy();
+          safelyCallDestroy(finishedWork, destroy);
         }
       }
       effect = effect.next;


### PR DESCRIPTION
We use `safelyCallDestroy` for `commitUnmount` and passive effects unmounts but we call destroy directly in `commitHookEffectListUnmount` (AKA layout effects unmounts because we don't use this anywhere else). This PR changes the direct destroy call to `safelyCallDestroy` for consistency