### PR TITLE
[COH-13535] Delete unused dom element references without breaking the…

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -949,6 +949,18 @@ function commitUnmount(
       }
       return;
     }
+      case HostText:
+      {
+        for (var prop in current.stateNode) {
+          if (prop.indexOf('__reactEventHandlers$') > -1) {
+            delete current.stateNode[prop];
+          }
+          if (prop.indexOf('__reactInternalInstance$') > -1) {
+            delete current.stateNode[prop];
+          }
+        }
+        return;
+      }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -900,6 +900,14 @@ function commitUnmount(
     }
     case HostComponent: {
       safelyDetachRef(current);
+      for (let prop in current.stateNode) {
+        if(prop.indexOf('__reactEventHandlers$') > -1) {
+            delete current.stateNode[prop];
+        }
+        if(prop.indexOf('__reactInternalInstance$') > -1) {
+            delete current.stateNode[prop];
+        }
+      }
       return;
     }
     case HostPortal: {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -967,6 +967,18 @@ function commitUnmount(
       }
       return;
     }
+    case HostText:
+      {
+        for (var prop in current.stateNode) {
+          if (prop.indexOf('__reactEventHandlers$') > -1) {
+            delete current.stateNode[prop];
+          }
+          if (prop.indexOf('__reactInternalInstance$') > -1) {
+            delete current.stateNode[prop];
+          }
+        }
+        return;
+      }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -918,6 +918,14 @@ function commitUnmount(
     }
     case HostComponent: {
       safelyDetachRef(current);
+      for (let prop in current.stateNode) {
+        if(prop.indexOf('__reactEventHandlers$') > -1) {
+            delete current.stateNode[prop];
+        }
+        if(prop.indexOf('__reactInternalInstance$') > -1) {
+            delete current.stateNode[prop];
+        }
+      }
       return;
     }
     case HostPortal: {


### PR DESCRIPTION
## Add a patch to remove unused DOM instances that cause a memory leak

Some clients reported that using React 16.* with certain versions of V8 causes a memory leak.