### PR TITLE
fix: synchronize focused email input on blur to avoid check validity when inputting

### DIFF
--- a/packages/react-dom/src/client/ReactDOMInput.js
+++ b/packages/react-dom/src/client/ReactDOMInput.js
@@ -411,7 +411,7 @@ export function setDefaultValue(
 ) {
   if (
     // Focused number inputs synchronize on blur. See ChangeEventPlugin.js
-    type !== 'number' ||
+    (type !== 'number' && type !== 'email') ||
     node.ownerDocument.activeElement !== node
   ) {
     if (value == null) {

--- a/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
@@ -246,13 +246,17 @@ function getTargetInstForInputOrChangeEvent(
 function handleControlledInputBlur(node: HTMLInputElement) {
   const state = (node: any)._wrapperState;
 
-  if (!state || !state.controlled || node.type !== 'number') {
+  if (
+    !state ||
+    !state.controlled ||
+    (node.type !== 'number' && node.type !== 'email')
+  ) {
     return;
   }
 
   if (!disableInputAttributeSyncing) {
     // If controlled, assign the value attribute to the current value on blur
-    setDefaultValue((node: any), 'number', (node: any).value);
+    setDefaultValue((node: any), node.type, (node: any).value);
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
Fix #19563, similar to #7253. The [reproduce](https://codesandbox.io/s/react-cursor-jumps-to-end-for-input-type-email-9knfi?file=/src/App.js) shows that the cursor will skip to the beginning position of the email input when delete with backspace. The cause is that `node.defaultValue` will be set to the `node.value` when inputting, which triggers validation on the email input and make the cursor skip to the beginning position in blink. So similar to focused number input #7359, synchronize focused email input on blur, which should works.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
The [reproduce](https://codesandbox.io/s/react-cursor-jumps-to-start-of-input-for-input-type-email-99d7u?file=/src/App.js) show it works

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
