### PR TITLE
feat: backport allowing noModule attribute on script tags to React 15

### DIFF
--- a/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+++ b/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
@@ -112,6 +112,7 @@ var HTMLDOMPropertyConfig = {
     muted: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     name: 0,
     nonce: 0,
+    noModule: HAS_BOOLEAN_VALUE,
     noValidate: HAS_BOOLEAN_VALUE,
     open: HAS_BOOLEAN_VALUE,
     optimum: 0,


### PR DESCRIPTION
## Summary

This PR backports [this PR](https://github.com/facebook/react/pull/11900) which added support for the `nomodule` attribute to React 15 as well. I'm not sure how likely this is to get into a release, but we're still stuck on React 15 for a variety of reasons. It would be great if we could add support for this attribute to React 15.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-nomodule
>**nomodule**
This Boolean attribute is set to indicate that the script should not be executed in browsers that support ES2015 modules — in effect, this can be used to serve fallback scripts to older browsers that do not support modular JavaScript code.

## Test Plan

The tests pass locally, though I didn't add a new test since it seems like we haven't added one for each attribute (example for the PR which added `nonce` [here](https://github.com/facebook/react/pull/5442)) though I could look into that if need be.
