### PR TITLE
fix(#19629): devtool popup page opens two same tabs on firefox

### DIFF
--- a/packages/react-devtools-extensions/popups/shared.js
+++ b/packages/react-devtools-extensions/popups/shared.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const location = ln.href;
       ln.onclick = function() {
         chrome.tabs.create({active: true, url: location});
+        return false;
       };
     })();
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

clicking the troubleshooting instructions button on the devtools on Firefox opens 2 tabs because both the click event and the default event are triggered, so add `return false` to prevent default events.

## Test Plan

---

close #19629