### PR TITLE
Keep onTouchStart, onTouchMove, and onWheel passive

### DIFF
--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -342,6 +342,21 @@ export function listenToNativeEvent(
   if (domEventName === 'selectionchange') {
     target = (rootContainerElement: any).ownerDocument;
   }
+  if (isPassiveListener === undefined) {
+    // Browsers introduced an intervention, making these events
+    // passive by default on document. React doesn't bind them
+    // to document anymore, but changing this now would undo
+    // the performance wins from the change. So we emulate
+    // the existing behavior manually on the roots now.
+    // https://github.com/facebook/react/issues/19651
+    if (
+      domEventName === 'touchstart' ||
+      domEventName === 'touchmove' ||
+      domEventName === 'wheel'
+    ) {
+      isPassiveListener = true;
+    }
+  }
   // If the event can be delegated (or is capture phase), we can
   // register it to the root container. Otherwise, we should
   // register the event to the target element and mark it as
@@ -506,7 +521,7 @@ function addTrappedEventListener(
     };
   }
   if (isCapturePhaseListener) {
-    if (enableCreateEventHandleAPI && isPassiveListener !== undefined) {
+    if (isPassiveListener !== undefined) {
       unsubscribeListener = addEventCaptureListenerWithPassiveFlag(
         targetContainer,
         domEventName,
@@ -521,7 +536,7 @@ function addTrappedEventListener(
       );
     }
   } else {
-    if (enableCreateEventHandleAPI && isPassiveListener !== undefined) {
+    if (isPassiveListener !== undefined) {
       unsubscribeListener = addEventBubbleListenerWithPassiveFlag(
         targetContainer,
         domEventName,

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -53,6 +53,7 @@ import {
   enableLegacyFBSupport,
   enableCreateEventHandleAPI,
   enableScopeAPI,
+  enablePassiveEventIntervention,
 } from 'shared/ReactFeatureFlags';
 import {
   invokeGuardedCallbackAndCatchFirstError,
@@ -342,7 +343,7 @@ export function listenToNativeEvent(
   if (domEventName === 'selectionchange') {
     target = (rootContainerElement: any).ownerDocument;
   }
-  if (isPassiveListener === undefined) {
+  if (enablePassiveEventIntervention && isPassiveListener === undefined) {
     // Browsers introduced an intervention, making these events
     // passive by default on document. React doesn't bind them
     // to document anymore, but changing this now would undo

--- a/packages/react-dom/src/events/checkPassiveEvents.js
+++ b/packages/react-dom/src/events/checkPassiveEvents.js
@@ -8,13 +8,12 @@
  */
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 
 export let passiveBrowserEventsSupported = false;
 
 // Check if browser support events with passive listeners
 // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
-if (enableCreateEventHandleAPI && canUseDOM) {
+if (canUseDOM) {
   try {
     const options = {};
     // $FlowFixMe: Ignore Flow complaining about needing a value

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -537,7 +537,11 @@ describe('SimpleEventPlugin', function() {
         container,
       );
 
-      expect(passiveEvents).toEqual(['touchstart', 'touchmove', 'wheel']);
+      if (gate(flags => flags.enablePassiveEventIntervention)) {
+        expect(passiveEvents).toEqual(['touchstart', 'touchmove', 'wheel']);
+      } else {
+        expect(passiveEvents).toEqual([]);
+      }
     });
   });
 });

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -504,5 +504,40 @@ describe('SimpleEventPlugin', function() {
 
       expect(onClick).toHaveBeenCalledTimes(0);
     });
+
+    it('registers passive handlers for events affected by the intervention', () => {
+      container = document.createElement('div');
+
+      const passiveEvents = [];
+      const nativeAddEventListener = container.addEventListener;
+      container.addEventListener = function(type, fn, options) {
+        if (options !== null && typeof options === 'object') {
+          if (options.passive) {
+            passiveEvents.push(type);
+          }
+        }
+        return nativeAddEventListener.apply(this, arguments);
+      };
+
+      ReactDOM.render(
+        <div
+          // Affected by the intervention:
+          // https://github.com/facebook/react/issues/19651
+          onTouchStart={() => {}}
+          onTouchMove={() => {}}
+          onWheel={() => {}}
+          // A few events that should be unaffected:
+          onClick={() => {}}
+          onScroll={() => {}}
+          onTouchEnd={() => {}}
+          onChange={() => {}}
+          onPointerDown={() => {}}
+          onPointerMove={() => {}}
+        />,
+        container,
+      );
+
+      expect(passiveEvents).toEqual(['touchstart', 'touchmove', 'wheel']);
+    });
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -132,3 +132,6 @@ export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 
 export const enableDiscreteEventFlushingChange = false;
+
+// https://github.com/facebook/react/pull/19654
+export const enablePassiveEventIntervention = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -49,6 +49,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -48,6 +48,7 @@ export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = true;
+export const enablePassiveEventIntervention = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -19,6 +19,7 @@ export const enableFilterEmptyStringAttributesDOM = __VARIANT__;
 export const enableLegacyFBSupport = __VARIANT__;
 export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 export const skipUnmountedBoundaries = __VARIANT__;
+export const enablePassiveEventIntervention = __VARIANT__;
 
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -27,6 +27,7 @@ export const {
   decoupleUpdatePriorityFromScheduler,
   enableDebugTracing,
   skipUnmountedBoundaries,
+  enablePassiveEventIntervention,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Resolves https://github.com/facebook/react/issues/19651.

This means that `e.preventDefault()` in them stays broken, like it was in React 16 due to Chrome's intervention, even though we've switched from putting them on the `document` to putting them on the root.

This makes React 17 match the React 16 behavior closer, as our goal is to reduce the breaking changes between them.

Note that this also means that any browsers that **don't** implement the intervention but **do** implement passive events will now get the post-intervention behavior:

<img width="1160" alt="Screenshot 2020-08-19 at 17 33 57" src="https://user-images.githubusercontent.com/810438/90663995-4d404d00-e242-11ea-90ec-8128282d2cc2.png">

This seems like technically it could be breaking if you target iOS Safari, however MDN may be out of date.

For example, [this answer](https://stackoverflow.com/a/49582193) says iOS 11 aligned with Chrome.

So it should be ok.

## Test Plan

Should be self-explanatory but I did some manual testing for `onWheel`. <s>I'll test others before merge.</s> Tested.