### PR TITLE
Fix incorrect copy-paste in test

### DIFF
--- a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
@@ -967,8 +967,8 @@ describe('DOMPluginEventSystem', () => {
               <div ref={middleDivRef}>
                 <div
                   ref={divRef}
-                  onClick={onFocus}
-                  onClickCapture={onFocusCapture}
+                  onFocus={onFocus}
+                  onFocusCapture={onFocusCapture}
                   tabIndex={0}>
                   Click me!
                 </div>
@@ -980,7 +980,7 @@ describe('DOMPluginEventSystem', () => {
             React.useLayoutEffect(() => {
               // This should prevent the portalElement listeners from
               // capturing the events in the bubble phase.
-              middleDivRef.current.addEventListener('click', e => {
+              middleDivRef.current.addEventListener('focusin', e => {
                 e.stopPropagation();
               });
             });
@@ -1007,7 +1007,7 @@ describe('DOMPluginEventSystem', () => {
           const divElement = divRef.current;
           divElement.focus();
           expect(onFocus).toHaveBeenCalledTimes(1);
-          expect(onFocusCapture).toHaveBeenCalledTimes(1);
+          expect(onFocusCapture).toHaveBeenCalledTimes(3);
 
           document.body.removeChild(portalElement);
         });


### PR DESCRIPTION
This test doesn't quite make sense. It claims to be about `onFocus` but mixes `onFocus` with `onClick` and cancels propagation of `click` (which was never dispatched). It's likely a copy-paste of [this test](https://github.com/facebook/react/blob/64ddef44c69a18038b1683e04c4558a72af1b91a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js#L736-L796). I'm adjusting it to do what it advertises.