### PR TITLE
Scheduling Profiler: Extract and test scroll state from horizontal pan and zoom view

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/CanvasPage.js
+++ b/packages/react-devtools-scheduling-profiler/src/CanvasPage.js
@@ -149,8 +149,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
     ) => {
       syncedHorizontalPanAndZoomViewsRef.current.forEach(
         syncedView =>
-          triggeringView !== syncedView &&
-          syncedView.setPanAndZoomState(newState),
+          triggeringView !== syncedView && syncedView.setScrollState(newState),
       );
     };
 

--- a/packages/react-devtools-scheduling-profiler/src/view-base/HorizontalPanAndZoomView.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/HorizontalPanAndZoomView.js
@@ -18,54 +18,34 @@ import type {
   WheelWithMetaInteraction,
 } from './useCanvasInteraction';
 import type {Rect} from './geometry';
+import type {ScrollState} from './utils/scrollState';
 
 import {Surface} from './Surface';
 import {View} from './View';
 import {rectContainsPoint} from './geometry';
-import {clamp} from './utils/clamp';
 import {
-  MIN_ZOOM_LEVEL,
+  clampState,
+  moveStateToRange,
+  scrollStatesAreEqual,
+  translateState,
+  zoomState,
+} from './utils/scrollState';
+import {
+  DEFAULT_ZOOM_LEVEL,
   MAX_ZOOM_LEVEL,
+  MIN_ZOOM_LEVEL,
   MOVE_WHEEL_DELTA_THRESHOLD,
 } from './constants';
 
-type HorizontalPanAndZoomState = $ReadOnly<{|
-  /** Horizontal offset; positive in the left direction */
-  offsetX: number,
-  zoomLevel: number,
-|}>;
-
 export type HorizontalPanAndZoomViewOnChangeCallback = (
-  state: HorizontalPanAndZoomState,
+  state: ScrollState,
   view: HorizontalPanAndZoomView,
 ) => void;
 
-function panAndZoomStatesAreEqual(
-  state1: HorizontalPanAndZoomState,
-  state2: HorizontalPanAndZoomState,
-): boolean {
-  return (
-    state1.offsetX === state2.offsetX && state1.zoomLevel === state2.zoomLevel
-  );
-}
-
-function zoomLevelAndIntrinsicWidthToFrameWidth(
-  zoomLevel: number,
-  intrinsicWidth: number,
-): number {
-  return intrinsicWidth * zoomLevel;
-}
-
 export class HorizontalPanAndZoomView extends View {
   _intrinsicContentWidth: number;
-
-  _panAndZoomState: HorizontalPanAndZoomState = {
-    offsetX: 0,
-    zoomLevel: 0.25,
-  };
-
+  _scrollState: ScrollState;
   _isPanning = false;
-
   _onStateChange: HorizontalPanAndZoomViewOnChangeCallback = () => {};
 
   constructor(
@@ -78,17 +58,21 @@ export class HorizontalPanAndZoomView extends View {
     super(surface, frame);
     this.addSubview(contentView);
     this._intrinsicContentWidth = intrinsicContentWidth;
+    this._scrollState = {
+      offset: 0,
+      length: intrinsicContentWidth * DEFAULT_ZOOM_LEVEL,
+    };
     if (onStateChange) this._onStateChange = onStateChange;
   }
 
   setFrame(newFrame: Rect) {
     super.setFrame(newFrame);
 
-    // Revalidate panAndZoomState
-    this._setStateAndInformCallbacksIfChanged(this._panAndZoomState);
+    // Revalidate scrollState
+    this._setStateAndInformCallbacksIfChanged(this._scrollState);
   }
 
-  setPanAndZoomState(proposedState: HorizontalPanAndZoomState) {
+  setPanAndZoomState(proposedState: ScrollState) {
     this._setPanAndZoomState(proposedState);
   }
 
@@ -99,12 +83,17 @@ export class HorizontalPanAndZoomView extends View {
    * @returns Whether state was changed
    * @private
    */
-  _setPanAndZoomState(proposedState: HorizontalPanAndZoomState): boolean {
-    const clampedState = this._clampedProposedState(proposedState);
-    if (panAndZoomStatesAreEqual(clampedState, this._panAndZoomState)) {
+  _setPanAndZoomState(proposedState: ScrollState): boolean {
+    const clampedState = clampState({
+      state: proposedState,
+      minContentLength: this._intrinsicContentWidth * MIN_ZOOM_LEVEL,
+      maxContentLength: this._intrinsicContentWidth * MAX_ZOOM_LEVEL,
+      containerLength: this.frame.size.width,
+    });
+    if (scrollStatesAreEqual(clampedState, this._scrollState)) {
       return false;
     }
-    this._panAndZoomState = clampedState;
+    this._scrollState = clampedState;
     this.setNeedsDisplay();
     return true;
   }
@@ -112,11 +101,9 @@ export class HorizontalPanAndZoomView extends View {
   /**
    * @private
    */
-  _setStateAndInformCallbacksIfChanged(
-    proposedState: HorizontalPanAndZoomState,
-  ) {
+  _setStateAndInformCallbacksIfChanged(proposedState: ScrollState) {
     if (this._setPanAndZoomState(proposedState)) {
-      this._onStateChange(this._panAndZoomState, this);
+      this._onStateChange(this._scrollState, this);
     }
   }
 
@@ -133,17 +120,14 @@ export class HorizontalPanAndZoomView extends View {
   }
 
   layoutSubviews() {
-    const {offsetX, zoomLevel} = this._panAndZoomState;
+    const {offset, length} = this._scrollState;
     const proposedFrame = {
       origin: {
-        x: this.frame.origin.x + offsetX,
+        x: this.frame.origin.x + offset,
         y: this.frame.origin.y,
       },
       size: {
-        width: zoomLevelAndIntrinsicWidthToFrameWidth(
-          zoomLevel,
-          this._intrinsicContentWidth,
-        ),
+        width: length,
         height: this.frame.size.height,
       },
     };
@@ -157,27 +141,18 @@ export class HorizontalPanAndZoomView extends View {
    *
    * Does not inform callbacks of state change since this is a public API.
    */
-  zoomToRange(startX: number, endX: number) {
-    // Zoom and offset must be done separately, so that if the zoom level is
-    // clamped the offset will still be correct (unless it gets clamped too).
-    const zoomClampedState = this._clampedProposedStateZoomLevel({
-      ...this._panAndZoomState,
-      // Let:
-      //   I = intrinsic content width, i = zoom range = (endX - startX).
-      //   W = contentView's final zoomed width, w = this view's width
-      // Goal: we want the visible width w to only contain the requested range i.
-      // Derivation:
-      // (1)  i/I = w/W           (by intuitive definition of variables)
-      // (2)  W = zoomLevel * I   (definition of zoomLevel)
-      //      => zoomLevel = W/I  (algebraic manipulation)
-      //                   = w/i  (rearranging (1))
-      zoomLevel: this.frame.size.width / (endX - startX),
+  zoomToRange(rangeStart: number, rangeEnd: number) {
+    const newState = moveStateToRange({
+      state: this._scrollState,
+      rangeStart,
+      rangeEnd,
+      contentLength: this._intrinsicContentWidth,
+
+      minContentLength: this._intrinsicContentWidth * MIN_ZOOM_LEVEL,
+      maxContentLength: this._intrinsicContentWidth * MAX_ZOOM_LEVEL,
+      containerLength: this.frame.size.width,
     });
-    const offsetAdjustedState = this._clampedProposedStateOffsetX({
-      ...zoomClampedState,
-      offsetX: -startX * zoomClampedState.zoomLevel,
-    });
-    this._setPanAndZoomState(offsetAdjustedState);
+    this._setPanAndZoomState(newState);
   }
 
   _handleMouseDown(interaction: MouseDownInteraction) {
@@ -190,12 +165,12 @@ export class HorizontalPanAndZoomView extends View {
     if (!this._isPanning) {
       return;
     }
-    const {offsetX} = this._panAndZoomState;
-    const {movementX} = interaction.payload.event;
-    this._setStateAndInformCallbacksIfChanged({
-      ...this._panAndZoomState,
-      offsetX: offsetX + movementX,
+    const newState = translateState({
+      state: this._scrollState,
+      delta: interaction.payload.event.movementX,
+      containerLength: this.frame.size.width,
     });
+    this._setStateAndInformCallbacksIfChanged(newState);
   }
 
   _handleMouseUp(interaction: MouseUpInteraction) {
@@ -209,6 +184,7 @@ export class HorizontalPanAndZoomView extends View {
       location,
       delta: {deltaX, deltaY},
     } = interaction.payload;
+
     if (!rectContainsPoint(location, this.frame)) {
       return; // Not scrolling on view
     }
@@ -218,15 +194,16 @@ export class HorizontalPanAndZoomView extends View {
     if (absDeltaY > absDeltaX) {
       return; // Scrolling vertically
     }
-
     if (absDeltaX < MOVE_WHEEL_DELTA_THRESHOLD) {
       return;
     }
 
-    this._setStateAndInformCallbacksIfChanged({
-      ...this._panAndZoomState,
-      offsetX: this._panAndZoomState.offsetX - deltaX,
+    const newState = translateState({
+      state: this._scrollState,
+      delta: deltaX,
+      containerLength: this.frame.size.width,
     });
+    this._setStateAndInformCallbacksIfChanged(newState);
   }
 
   _handleWheelZoom(
@@ -239,6 +216,7 @@ export class HorizontalPanAndZoomView extends View {
       location,
       delta: {deltaY},
     } = interaction.payload;
+
     if (!rectContainsPoint(location, this.frame)) {
       return; // Not scrolling on view
     }
@@ -248,28 +226,16 @@ export class HorizontalPanAndZoomView extends View {
       return;
     }
 
-    const zoomClampedState = this._clampedProposedStateZoomLevel({
-      ...this._panAndZoomState,
-      zoomLevel: this._panAndZoomState.zoomLevel * (1 + 0.005 * -deltaY),
+    const newState = zoomState({
+      state: this._scrollState,
+      multiplier: 1 + 0.005 * -deltaY,
+      fixedPoint: location.x - this._scrollState.offset,
+
+      minContentLength: this._intrinsicContentWidth * MIN_ZOOM_LEVEL,
+      maxContentLength: this._intrinsicContentWidth * MAX_ZOOM_LEVEL,
+      containerLength: this.frame.size.width,
     });
-
-    // Determine where the mouse is, and adjust the offset so that point stays
-    // centered after zooming.
-    const oldMouseXInFrame = location.x - zoomClampedState.offsetX;
-    const fractionalMouseX =
-      oldMouseXInFrame / this._contentView.frame.size.width;
-    const newContentWidth = zoomLevelAndIntrinsicWidthToFrameWidth(
-      zoomClampedState.zoomLevel,
-      this._intrinsicContentWidth,
-    );
-    const newMouseXInFrame = fractionalMouseX * newContentWidth;
-
-    const offsetAdjustedState = this._clampedProposedStateOffsetX({
-      ...zoomClampedState,
-      offsetX: location.x - newMouseXInFrame,
-    });
-
-    this._setStateAndInformCallbacksIfChanged(offsetAdjustedState);
+    this._setStateAndInformCallbacksIfChanged(newState);
   }
 
   handleInteraction(interaction: Interaction) {
@@ -292,51 +258,5 @@ export class HorizontalPanAndZoomView extends View {
         this._handleWheelZoom(interaction);
         break;
     }
-  }
-
-  /**
-   * @private
-   */
-  _clampedProposedStateZoomLevel(
-    proposedState: HorizontalPanAndZoomState,
-  ): HorizontalPanAndZoomState {
-    // Content-based min zoom level to ensure that contentView's width >= our width.
-    const minContentBasedZoomLevel =
-      this.frame.size.width / this._intrinsicContentWidth;
-    const minZoomLevel = Math.max(MIN_ZOOM_LEVEL, minContentBasedZoomLevel);
-    return {
-      ...proposedState,
-      zoomLevel: clamp(minZoomLevel, MAX_ZOOM_LEVEL, proposedState.zoomLevel),
-    };
-  }
-
-  /**
-   * @private
-   */
-  _clampedProposedStateOffsetX(
-    proposedState: HorizontalPanAndZoomState,
-  ): HorizontalPanAndZoomState {
-    const newContentWidth = zoomLevelAndIntrinsicWidthToFrameWidth(
-      proposedState.zoomLevel,
-      this._intrinsicContentWidth,
-    );
-    return {
-      ...proposedState,
-      offsetX: clamp(
-        -(newContentWidth - this.frame.size.width),
-        0,
-        proposedState.offsetX,
-      ),
-    };
-  }
-
-  /**
-   * @private
-   */
-  _clampedProposedState(
-    proposedState: HorizontalPanAndZoomState,
-  ): HorizontalPanAndZoomState {
-    const zoomClampedState = this._clampedProposedStateZoomLevel(proposedState);
-    return this._clampedProposedStateOffsetX(zoomClampedState);
   }
 }

--- a/packages/react-devtools-scheduling-profiler/src/view-base/VerticalScrollView.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/VerticalScrollView.js
@@ -15,41 +15,33 @@ import type {
   WheelPlainInteraction,
 } from './useCanvasInteraction';
 import type {Rect} from './geometry';
+import type {ScrollState} from './utils/scrollState';
 
 import {Surface} from './Surface';
 import {View} from './View';
 import {rectContainsPoint} from './geometry';
-import {clamp} from './utils/clamp';
+import {
+  clampState,
+  areScrollStatesEqual,
+  translateState,
+} from './utils/scrollState';
 import {MOVE_WHEEL_DELTA_THRESHOLD} from './constants';
 
-type VerticalScrollState = $ReadOnly<{|
-  offsetY: number,
-|}>;
-
-function scrollStatesAreEqual(
-  state1: VerticalScrollState,
-  state2: VerticalScrollState,
-): boolean {
-  return state1.offsetY === state2.offsetY;
-}
-
 export class VerticalScrollView extends View {
-  _scrollState: VerticalScrollState = {
-    offsetY: 0,
-  };
-
+  _scrollState: ScrollState = {offset: 0, length: 0};
   _isPanning = false;
 
   constructor(surface: Surface, frame: Rect, contentView: View) {
     super(surface, frame);
     this.addSubview(contentView);
+    this._setScrollState(this._scrollState);
   }
 
   setFrame(newFrame: Rect) {
     super.setFrame(newFrame);
 
     // Revalidate scrollState
-    this._updateState(this._scrollState);
+    this._setScrollState(this._scrollState);
   }
 
   desiredSize() {
@@ -65,7 +57,7 @@ export class VerticalScrollView extends View {
   }
 
   layoutSubviews() {
-    const {offsetY} = this._scrollState;
+    const {offset} = this._scrollState;
     const desiredSize = this._contentView.desiredSize();
 
     const minimumHeight = this.frame.size.height;
@@ -76,7 +68,7 @@ export class VerticalScrollView extends View {
     const proposedFrame = {
       origin: {
         x: this.frame.origin.x,
-        y: this.frame.origin.y + offsetY,
+        y: this.frame.origin.y + offset,
       },
       size: {
         width: this.frame.size.width,
@@ -97,12 +89,12 @@ export class VerticalScrollView extends View {
     if (!this._isPanning) {
       return;
     }
-    const {offsetY} = this._scrollState;
-    const {movementY} = interaction.payload.event;
-    this._updateState({
-      ...this._scrollState,
-      offsetY: offsetY + movementY,
+    const newState = translateState({
+      state: this._scrollState,
+      delta: interaction.payload.event.movementY,
+      containerLength: this.frame.size.height,
     });
+    this._setScrollState(newState);
   }
 
   _handleMouseUp(interaction: MouseUpInteraction) {
@@ -130,10 +122,12 @@ export class VerticalScrollView extends View {
       return;
     }
 
-    this._updateState({
-      ...this._scrollState,
-      offsetY: this._scrollState.offsetY - deltaY,
+    const newState = translateState({
+      state: this._scrollState,
+      delta: -deltaY,
+      containerLength: this.frame.size.height,
     });
+    this._setScrollState(newState);
   }
 
   handleInteraction(interaction: Interaction) {
@@ -156,26 +150,18 @@ export class VerticalScrollView extends View {
   /**
    * @private
    */
-  _updateState(proposedState: VerticalScrollState) {
-    const clampedState = this._clampedProposedState(proposedState);
-    if (!scrollStatesAreEqual(clampedState, this._scrollState)) {
-      this._scrollState = clampedState;
-      this.setNeedsDisplay();
+  _setScrollState(proposedState: ScrollState) {
+    const height = this._contentView.frame.size.height;
+    const clampedState = clampState({
+      state: proposedState,
+      minContentLength: height,
+      maxContentLength: height,
+      containerLength: this.frame.size.height,
+    });
+    if (areScrollStatesEqual(clampedState, this._scrollState)) {
+      return;
     }
-  }
-
-  /**
-   * @private
-   */
-  _clampedProposedState(
-    proposedState: VerticalScrollState,
-  ): VerticalScrollState {
-    return {
-      offsetY: clamp(
-        -(this._contentView.frame.size.height - this.frame.size.height),
-        0,
-        proposedState.offsetY,
-      ),
-    };
+    this._scrollState = clampedState;
+    this.setNeedsDisplay();
   }
 }

--- a/packages/react-devtools-scheduling-profiler/src/view-base/constants.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/constants.js
@@ -11,3 +11,4 @@ export const MOVE_WHEEL_DELTA_THRESHOLD = 1;
 export const ZOOM_WHEEL_DELTA_THRESHOLD = 1;
 export const MIN_ZOOM_LEVEL = 0.25;
 export const MAX_ZOOM_LEVEL = 1000;
+export const DEFAULT_ZOOM_LEVEL = 0.25;

--- a/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/clamp-test.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/clamp-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {clamp} from '../clamp';
+
+describe(clamp, () => {
+  it('should return min if value < min', () => {
+    expect(clamp(0, 1, -1)).toBe(0);
+    expect(clamp(0.1, 1.1, 0.05)).toBe(0.1);
+  });
+
+  it('should return value if min <= value <= max', () => {
+    expect(clamp(0, 1, 0)).toBe(0);
+    expect(clamp(0, 1, 0.5)).toBe(0.5);
+    expect(clamp(0, 1, 1)).toBe(1);
+    expect(clamp(0.1, 1.1, 0.15)).toBe(0.15);
+  });
+
+  it('should return max if max < value', () => {
+    expect(clamp(0, 1, 2)).toBe(1);
+    expect(clamp(0.1, 1.1, 1.15)).toBe(1.1);
+  });
+});

--- a/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
@@ -10,7 +10,7 @@
 import {
   clampState,
   moveStateToRange,
-  scrollStatesAreEqual,
+  areScrollStatesEqual,
   translateState,
   zoomState,
 } from '../scrollState';
@@ -71,15 +71,15 @@ describe(clampState, () => {
     ).toBeCloseTo(0, 10);
   });
 
-  it('should passthrough length if inside range [minContentLength, maxContentLength]', () => {
+  it('should passthrough length if inside container length', () => {
     expect(
       clampState({
-        state: {offset: 0, length: 0},
+        state: {offset: 0, length: 70},
         minContentLength: 0,
         maxContentLength: 100,
         containerLength: 50,
       }).length,
-    ).toBeCloseTo(0, 10);
+    ).toBeCloseTo(70, 10);
     expect(
       clampState({
         state: {offset: 0, length: 50},
@@ -98,23 +98,42 @@ describe(clampState, () => {
     ).toBeCloseTo(100, 10);
   });
 
-  it('should clamp length if outside range [minContentLength, maxContentLength]', () => {
+  it('should clamp length to minimum of max(minContentLength, containerLength)', () => {
     expect(
       clampState({
-        state: {offset: 0, length: 3},
-        minContentLength: 5,
+        state: {offset: -20, length: 0},
+        minContentLength: 20,
         maxContentLength: 100,
         containerLength: 50,
       }).length,
-    ).toBeCloseTo(5, 10);
+    ).toBeCloseTo(50, 10);
     expect(
       clampState({
-        state: {offset: 0, length: 101},
+        state: {offset: -20, length: 0},
+        minContentLength: 50,
+        maxContentLength: 100,
+        containerLength: 20,
+      }).length,
+    ).toBeCloseTo(50, 10);
+  });
+
+  it('should clamp length to maximum of max(containerLength, maxContentLength)', () => {
+    expect(
+      clampState({
+        state: {offset: -20, length: 100},
         minContentLength: 0,
-        maxContentLength: 100,
+        maxContentLength: 40,
         containerLength: 50,
       }).length,
-    ).toBeCloseTo(100, 10);
+    ).toBeCloseTo(50, 10);
+    expect(
+      clampState({
+        state: {offset: -20, length: 100},
+        minContentLength: 0,
+        maxContentLength: 50,
+        containerLength: 40,
+      }).length,
+    ).toBeCloseTo(50, 10);
   });
 });
 
@@ -221,22 +240,22 @@ describe(moveStateToRange, () => {
   });
 });
 
-describe(scrollStatesAreEqual, () => {
+describe(areScrollStatesEqual, () => {
   it('should return true if equal', () => {
     expect(
-      scrollStatesAreEqual({offset: 0, length: 0}, {offset: 0, length: 0}),
+      areScrollStatesEqual({offset: 0, length: 0}, {offset: 0, length: 0}),
     ).toBe(true);
     expect(
-      scrollStatesAreEqual({offset: -1, length: 1}, {offset: -1, length: 1}),
+      areScrollStatesEqual({offset: -1, length: 1}, {offset: -1, length: 1}),
     ).toBe(true);
   });
 
   it('should return false if not equal', () => {
     expect(
-      scrollStatesAreEqual({offset: 0, length: 0}, {offset: -1, length: 0}),
+      areScrollStatesEqual({offset: 0, length: 0}, {offset: -1, length: 0}),
     ).toBe(false);
     expect(
-      scrollStatesAreEqual({offset: -1, length: 1}, {offset: -1, length: 0}),
+      areScrollStatesEqual({offset: -1, length: 1}, {offset: -1, length: 0}),
     ).toBe(false);
   });
 });

--- a/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
@@ -71,7 +71,7 @@ describe(clampState, () => {
     ).toBeCloseTo(0, 10);
   });
 
-  it('should passthrough length if inside container length', () => {
+  it('should passthrough length if container fits in content', () => {
     expect(
       clampState({
         state: {offset: 0, length: 70},

--- a/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/utils/__tests__/scrollState-test.js
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {
+  clampState,
+  moveStateToRange,
+  scrollStatesAreEqual,
+  translateState,
+  zoomState,
+} from '../scrollState';
+
+describe(clampState, () => {
+  it('should passthrough offset if state fits within container', () => {
+    expect(
+      clampState({
+        state: {offset: 0, length: 50},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(0, 10);
+    expect(
+      clampState({
+        state: {offset: -20, length: 100},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(-20, 10);
+  });
+
+  it('should clamp offset if offset causes content to go out of container', () => {
+    expect(
+      clampState({
+        state: {offset: -1, length: 50},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(0, 10);
+    expect(
+      clampState({
+        state: {offset: 1, length: 50},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(0, 10);
+
+    expect(
+      clampState({
+        state: {offset: -51, length: 100},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(-50, 10);
+    expect(
+      clampState({
+        state: {offset: 1, length: 100},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(0, 10);
+  });
+
+  it('should passthrough length if inside range [minContentLength, maxContentLength]', () => {
+    expect(
+      clampState({
+        state: {offset: 0, length: 0},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).length,
+    ).toBeCloseTo(0, 10);
+    expect(
+      clampState({
+        state: {offset: 0, length: 50},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).length,
+    ).toBeCloseTo(50, 10);
+    expect(
+      clampState({
+        state: {offset: 0, length: 100},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).length,
+    ).toBeCloseTo(100, 10);
+  });
+
+  it('should clamp length if outside range [minContentLength, maxContentLength]', () => {
+    expect(
+      clampState({
+        state: {offset: 0, length: 3},
+        minContentLength: 5,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).length,
+    ).toBeCloseTo(5, 10);
+    expect(
+      clampState({
+        state: {offset: 0, length: 101},
+        minContentLength: 0,
+        maxContentLength: 100,
+        containerLength: 50,
+      }).length,
+    ).toBeCloseTo(100, 10);
+  });
+});
+
+describe(translateState, () => {
+  it('should translate state by delta and leave length unchanged', () => {
+    expect(
+      translateState({
+        state: {offset: 0, length: 100},
+        delta: -3.14,
+        containerLength: 50,
+      }),
+    ).toEqual({offset: -3.14, length: 100});
+  });
+
+  it('should clamp resulting offset', () => {
+    expect(
+      translateState({
+        state: {offset: 0, length: 50},
+        delta: -3.14,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(0, 10);
+    expect(
+      translateState({
+        state: {offset: 0, length: 53},
+        delta: -100,
+        containerLength: 50,
+      }).offset,
+    ).toBeCloseTo(-3, 10);
+  });
+});
+
+describe(zoomState, () => {
+  it('should scale width by multiplier', () => {
+    expect(
+      zoomState({
+        state: {offset: 0, length: 100},
+        multiplier: 1.5,
+        fixedPoint: 0,
+
+        minContentLength: 0,
+        maxContentLength: 1000,
+        containerLength: 50,
+      }),
+    ).toEqual({offset: 0, length: 150});
+  });
+
+  it('should clamp zoomed state', () => {
+    const zoomedState = zoomState({
+      state: {offset: -20, length: 100},
+      multiplier: 0.1,
+      fixedPoint: 5,
+
+      minContentLength: 50,
+      maxContentLength: 100,
+      containerLength: 50,
+    });
+    expect(zoomedState.offset).toBeCloseTo(0, 10);
+    expect(zoomedState.length).toBeCloseTo(50, 10);
+  });
+
+  it('should maintain containerStart<->fixedPoint distance', () => {
+    const offset = -20;
+    const fixedPointFromContainer = 10;
+
+    const zoomedState = zoomState({
+      state: {offset, length: 100},
+      multiplier: 2,
+      fixedPoint: fixedPointFromContainer - offset,
+
+      minContentLength: 0,
+      maxContentLength: 1000,
+      containerLength: 50,
+    });
+
+    expect(zoomedState).toMatchInlineSnapshot(`
+      Object {
+        "length": 200,
+        "offset": -50,
+      }
+    `);
+  });
+});
+
+describe(moveStateToRange, () => {
+  it('should set [rangeStart, rangeEnd] = container', () => {
+    const movedState = moveStateToRange({
+      state: {offset: -20, length: 100},
+      rangeStart: 50,
+      rangeEnd: 100,
+      contentLength: 400,
+
+      minContentLength: 10,
+      maxContentLength: 1000,
+      containerLength: 50,
+    });
+
+    expect(movedState).toMatchInlineSnapshot(`
+      Object {
+        "length": 400,
+        "offset": -50,
+      }
+    `);
+  });
+});
+
+describe(scrollStatesAreEqual, () => {
+  it('should return true if equal', () => {
+    expect(
+      scrollStatesAreEqual({offset: 0, length: 0}, {offset: 0, length: 0}),
+    ).toBe(true);
+    expect(
+      scrollStatesAreEqual({offset: -1, length: 1}, {offset: -1, length: 1}),
+    ).toBe(true);
+  });
+
+  it('should return false if not equal', () => {
+    expect(
+      scrollStatesAreEqual({offset: 0, length: 0}, {offset: -1, length: 0}),
+    ).toBe(false);
+    expect(
+      scrollStatesAreEqual({offset: -1, length: 1}, {offset: -1, length: 0}),
+    ).toBe(false);
+  });
+});

--- a/packages/react-devtools-scheduling-profiler/src/view-base/utils/scrollState.js
+++ b/packages/react-devtools-scheduling-profiler/src/view-base/utils/scrollState.js
@@ -1,0 +1,187 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {clamp} from './clamp';
+
+/**
+ * Single-axis offset and length state.
+ *
+ * ```
+ * contentStart   containerStart  containerEnd   contentEnd
+ *     |<----------offset|              |             |
+ *     |<-------------------length------------------->|
+ * ```
+ */
+export type ScrollState = $ReadOnly<{|
+  offset: number,
+  length: number,
+|}>;
+
+function clampOffset(state: ScrollState, containerLength: number): ScrollState {
+  return {
+    offset: clamp(-(state.length - containerLength), 0, state.offset),
+    length: state.length,
+  };
+}
+
+function clampLength(
+  state: ScrollState,
+  minContentLength: number,
+  maxContentLength: number,
+): ScrollState {
+  return {
+    offset: state.offset,
+    length: clamp(minContentLength, maxContentLength, state.length),
+  };
+}
+
+export function clampState({
+  state,
+  minContentLength,
+  maxContentLength,
+  containerLength,
+}: {
+  state: ScrollState,
+  minContentLength: number,
+  maxContentLength: number,
+  containerLength: number,
+}): ScrollState {
+  return clampOffset(
+    clampLength(state, minContentLength, maxContentLength),
+    containerLength,
+  );
+}
+
+export function translateState({
+  state,
+  delta,
+  containerLength,
+}: {
+  state: ScrollState,
+  delta: number,
+  containerLength: number,
+}): ScrollState {
+  return clampOffset(
+    {
+      offset: state.offset + delta,
+      length: state.length,
+    },
+    containerLength,
+  );
+}
+
+/**
+ * Returns a new `state` zoomed by `multiplier`.
+ *
+ * The resulting state's `length` is clamped to `minContentLength` and
+ * `maxContentLength`, and its offset is clamped to ensure content remains in
+ * `containerLength`.
+ *
+ * The provided fixed point will also remain stationary relative to
+ * `containerStart`.
+ *
+ * ```
+ * contentStart   containerStart                fixedPoint containerEnd
+ *     |<---------offset-|                          x           |
+ *     |-fixedPoint-------------------------------->x           |
+ *                       |-fixedPointFromContainer->x           |
+ *                       |<----------containerLength----------->|
+ * ```
+ */
+export function zoomState({
+  state,
+  multiplier,
+  fixedPoint,
+
+  minContentLength,
+  maxContentLength,
+  containerLength,
+}: {
+  state: ScrollState,
+  multiplier: number,
+  fixedPoint: number,
+
+  minContentLength: number,
+  maxContentLength: number,
+  containerLength: number,
+}): ScrollState {
+  // Length and offset must be computed separately, so that if the length is
+  // clamped the offset will still be correct (unless it gets clamped too).
+
+  const zoomedState = clampLength(
+    {
+      offset: state.offset,
+      length: state.length * multiplier,
+    },
+    minContentLength,
+    maxContentLength,
+  );
+
+  // Adjust offset so that distance between containerStart<->fixedPoint is fixed
+  const fixedPointFromContainer = fixedPoint + state.offset;
+  const scaledFixedPoint = fixedPoint * (zoomedState.length / state.length);
+  const offsetAdjustedState = clampOffset(
+    {
+      offset: fixedPointFromContainer - scaledFixedPoint,
+      length: zoomedState.length,
+    },
+    containerLength,
+  );
+
+  return offsetAdjustedState;
+}
+
+export function moveStateToRange({
+  state,
+  rangeStart,
+  rangeEnd,
+  contentLength,
+
+  minContentLength,
+  maxContentLength,
+  containerLength,
+}: {
+  state: ScrollState,
+  rangeStart: number,
+  rangeEnd: number,
+  contentLength: number,
+
+  minContentLength: number,
+  maxContentLength: number,
+  containerLength: number,
+}): ScrollState {
+  // Length and offset must be computed separately, so that if the length is
+  // clamped the offset will still be correct (unless it gets clamped too).
+
+  const lengthClampedState = clampLength(
+    {
+      offset: state.offset,
+      length: contentLength * (containerLength / (rangeEnd - rangeStart)),
+    },
+    minContentLength,
+    maxContentLength,
+  );
+
+  const offsetAdjustedState = clampOffset(
+    {
+      offset: -rangeStart * (lengthClampedState.length / contentLength),
+      length: lengthClampedState.length,
+    },
+    containerLength,
+  );
+
+  return offsetAdjustedState;
+}
+
+export function scrollStatesAreEqual(
+  state1: ScrollState,
+  state2: ScrollState,
+): boolean {
+  return state1.offset === state2.offset && state1.length === state2.length;
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

1. Extract scroll state from `HorizontalPanAndZoomView` and `VerticalScrollView` into a bunch of functions.
1. Add tests for extracted code.

Also fixes this issue where zooming in/out results in offset jumps:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/12784593/91020124-a504fc80-e624-11ea-9fce-8cd5e9327c13.gif)


cc @bvaughn, @kartikcho

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

* CI
* Reload the app while zoomed out (browser zoom) to ensure no black bars appear on app start
* Zoom out to ensure no black areas appear on viewport resize
* Ensure vertical and horizontal scroll directions are unchanged