### PR TITLE
Add SuspenseList to devTools

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -8,7 +8,7 @@
  */
 
 import {
-  getDisplayName, 
+  getDisplayName,
   getDisplayNameForReactElement,
 } from 'react-devtools-shared/src/utils';
 import {
@@ -17,7 +17,7 @@ import {
   REACT_ELEMENT_TYPE as Element,
 } from 'shared/ReactSymbols';
 
- describe('utils', () => {
+describe('utils', () => {
   describe('getDisplayName', () => {
     it('should return a function name', () => {
       function FauxComponent() {}
@@ -49,31 +49,39 @@ import {
     it('should return correct display name for an element with function type', () => {
       function FauxComponent() {}
       FauxComponent.displayName = 'OverrideDisplayName';
-      const FauxElement = {type: FauxComponent}
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('OverrideDisplayName');
+      const FauxElement = {type: FauxComponent};
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+        'OverrideDisplayName',
+      );
     });
     it('should return correct display name for an element with a type of StrictMode', () => {
-      const FauxElement = {}
+      const FauxElement = {};
       FauxElement.type = StrictMode;
       FauxElement.$$typeof = Element;
       expect(getDisplayNameForReactElement(FauxElement)).toEqual('StrictMode');
     });
     it('should return correct display name for an element with a type of SuspenseList', () => {
-      const FauxElement = {}
+      const FauxElement = {};
       FauxElement.type = SuspenseList;
       FauxElement.$$typeof = Element;
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('SuspenseList');
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+        'SuspenseList',
+      );
     });
     it('should return NotImplementedInDevtools for an element with invalid symbol type', () => {
-      const FauxElement = {type: Symbol('foo')}
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('NotImplementedInDevtools');
+      const FauxElement = {type: Symbol('foo')};
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+        'NotImplementedInDevtools',
+      );
     });
     it('should return NotImplementedInDevtools for an element with invalid type', () => {
-      const FauxElement = {type: true}
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('NotImplementedInDevtools');
+      const FauxElement = {type: true};
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+        'NotImplementedInDevtools',
+      );
     });
     it('should return Element for null type', () => {
-      const FauxElement = {type: null}
+      const FauxElement = {type: null};
       expect(getDisplayNameForReactElement(FauxElement)).toEqual('Element');
     });
   });

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {getDisplayName} from 'react-devtools-shared/src/utils';
+import {getDisplayName, getDisplayNameForReactElement} from 'react-devtools-shared/src/utils';
 
 describe('utils', () => {
   describe('getDisplayName', () => {
@@ -35,6 +35,26 @@ describe('utils', () => {
     it('should return a fallback when the name prop is not a string', () => {
       const FauxComponent = {name: {}};
       expect(getDisplayName(FauxComponent, 'Fallback')).toEqual('Fallback');
+    });
+  });
+  describe('getDisplayNameForReactElement', () => {
+    it('should return correct display name for an element with function type', () => {
+      function FauxComponent() {}
+      FauxComponent.displayName = 'OverrideDisplayName';
+      const FauxElement = {type: FauxComponent}
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('OverrideDisplayName');
+    });
+    it('should return Anonymous for an element with invalid symbol type', () => {
+      const FauxElement = {type: Symbol('foo')}
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Anonymous');
+    });
+    it('should return Anonymous for an element with invalid type', () => {
+      const FauxElement = {type: true}
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Anonymous');
+    });
+    it('should return Element for null type', () => {
+      const FauxElement = {type: null}
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Element');
     });
   });
 });

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -14,8 +14,8 @@ import {
 import {
   REACT_SUSPENSE_LIST_TYPE as SuspenseList,
   REACT_STRICT_MODE_TYPE as StrictMode,
-  REACT_ELEMENT_TYPE as Element,
 } from 'shared/ReactSymbols';
+import { createElement } from 'react/src/ReactElement'
 
 describe('utils', () => {
   describe('getDisplayName', () => {
@@ -49,40 +49,36 @@ describe('utils', () => {
     it('should return correct display name for an element with function type', () => {
       function FauxComponent() {}
       FauxComponent.displayName = 'OverrideDisplayName';
-      const FauxElement = {type: FauxComponent};
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+      const element = createElement(FauxComponent)
+      expect(getDisplayNameForReactElement(element)).toEqual(
         'OverrideDisplayName',
       );
     });
     it('should return correct display name for an element with a type of StrictMode', () => {
-      const FauxElement = {};
-      FauxElement.type = StrictMode;
-      FauxElement.$$typeof = Element;
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('StrictMode');
+      const element = createElement(StrictMode);
+      expect(getDisplayNameForReactElement(element)).toEqual('StrictMode');
     });
     it('should return correct display name for an element with a type of SuspenseList', () => {
-      const FauxElement = {};
-      FauxElement.type = SuspenseList;
-      FauxElement.$$typeof = Element;
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+      const element = createElement(SuspenseList);
+      expect(getDisplayNameForReactElement(element)).toEqual(
         'SuspenseList',
       );
     });
     it('should return NotImplementedInDevtools for an element with invalid symbol type', () => {
-      const FauxElement = {type: Symbol('foo')};
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+      const element = createElement(Symbol('foo'));
+      expect(getDisplayNameForReactElement(element)).toEqual(
         'NotImplementedInDevtools',
       );
     });
     it('should return NotImplementedInDevtools for an element with invalid type', () => {
-      const FauxElement = {type: true};
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual(
+      const element = createElement(true)
+      expect(getDisplayNameForReactElement(element)).toEqual(
         'NotImplementedInDevtools',
       );
     });
     it('should return Element for null type', () => {
-      const FauxElement = {type: null};
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Element');
+      const element = createElement();
+      expect(getDisplayNameForReactElement(element)).toEqual('Element');
     });
   });
 });

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -8,8 +8,9 @@
  */
 
 import {getDisplayName, getDisplayNameForReactElement} from 'react-devtools-shared/src/utils';
+import { StrictMode, SuspenseList, Element} from 'react-is/src/ReactIs.js'
 
-describe('utils', () => {
+ describe('utils', () => {
   describe('getDisplayName', () => {
     it('should return a function name', () => {
       function FauxComponent() {}
@@ -43,6 +44,18 @@ describe('utils', () => {
       FauxComponent.displayName = 'OverrideDisplayName';
       const FauxElement = {type: FauxComponent}
       expect(getDisplayNameForReactElement(FauxElement)).toEqual('OverrideDisplayName');
+    });
+    it('should return correct display name for an element with a type of StrictMode', () => {
+      const FauxElement = {}
+      FauxElement.type = StrictMode;
+      FauxElement.$$typeof = Element;
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('StrictMode');
+    });
+    it('should return correct display name for an element with a type of SuspenseList', () => {
+      const FauxElement = {}
+      FauxElement.type = SuspenseList;
+      FauxElement.$$typeof = Element;
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('SuspenseList');
     });
     it('should return Anonymous for an element with invalid symbol type', () => {
       const FauxElement = {type: Symbol('foo')}

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -15,7 +15,7 @@ import {
   REACT_SUSPENSE_LIST_TYPE as SuspenseList,
   REACT_STRICT_MODE_TYPE as StrictMode,
 } from 'shared/ReactSymbols';
-import { createElement } from 'react/src/ReactElement'
+import {createElement} from 'react/src/ReactElement';
 
 describe('utils', () => {
   describe('getDisplayName', () => {
@@ -49,7 +49,7 @@ describe('utils', () => {
     it('should return correct display name for an element with function type', () => {
       function FauxComponent() {}
       FauxComponent.displayName = 'OverrideDisplayName';
-      const element = createElement(FauxComponent)
+      const element = createElement(FauxComponent);
       expect(getDisplayNameForReactElement(element)).toEqual(
         'OverrideDisplayName',
       );
@@ -60,9 +60,7 @@ describe('utils', () => {
     });
     it('should return correct display name for an element with a type of SuspenseList', () => {
       const element = createElement(SuspenseList);
-      expect(getDisplayNameForReactElement(element)).toEqual(
-        'SuspenseList',
-      );
+      expect(getDisplayNameForReactElement(element)).toEqual('SuspenseList');
     });
     it('should return NotImplementedInDevtools for an element with invalid symbol type', () => {
       const element = createElement(Symbol('foo'));
@@ -71,7 +69,7 @@ describe('utils', () => {
       );
     });
     it('should return NotImplementedInDevtools for an element with invalid type', () => {
-      const element = createElement(true)
+      const element = createElement(true);
       expect(getDisplayNameForReactElement(element)).toEqual(
         'NotImplementedInDevtools',
       );

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -7,8 +7,15 @@
  * @flow
  */
 
-import {getDisplayName, getDisplayNameForReactElement} from 'react-devtools-shared/src/utils';
-import { StrictMode, SuspenseList, Element} from 'react-is/src/ReactIs.js'
+import {
+  getDisplayName, 
+  getDisplayNameForReactElement,
+} from 'react-devtools-shared/src/utils';
+import {
+  REACT_SUSPENSE_LIST_TYPE as SuspenseList,
+  REACT_STRICT_MODE_TYPE as StrictMode,
+  REACT_ELEMENT_TYPE as Element,
+} from 'shared/ReactSymbols';
 
  describe('utils', () => {
   describe('getDisplayName', () => {
@@ -57,13 +64,13 @@ import { StrictMode, SuspenseList, Element} from 'react-is/src/ReactIs.js'
       FauxElement.$$typeof = Element;
       expect(getDisplayNameForReactElement(FauxElement)).toEqual('SuspenseList');
     });
-    it('should return Anonymous for an element with invalid symbol type', () => {
+    it('should return NotImplementedInDevtools for an element with invalid symbol type', () => {
       const FauxElement = {type: Symbol('foo')}
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Anonymous');
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('NotImplementedInDevtools');
     });
-    it('should return Anonymous for an element with invalid type', () => {
+    it('should return NotImplementedInDevtools for an element with invalid type', () => {
       const FauxElement = {type: true}
-      expect(getDisplayNameForReactElement(FauxElement)).toEqual('Anonymous');
+      expect(getDisplayNameForReactElement(FauxElement)).toEqual('NotImplementedInDevtools');
     });
     it('should return Element for null type', () => {
       const FauxElement = {type: null}

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -21,8 +21,8 @@ import {
   Profiler,
   StrictMode,
   Suspense,
-  SuspenseList,
 } from 'react-is';
+import {REACT_SUSPENSE_LIST_TYPE as SuspenseList} from 'shared/ReactSymbols';
 import {
   TREE_OPERATION_ADD,
   TREE_OPERATION_REMOVE,
@@ -44,7 +44,6 @@ import {
 } from 'react-devtools-shared/src/types';
 import {localStorageGetItem, localStorageSetItem} from './storage';
 import {meta} from './hydration';
-
 import type {ComponentFilter, ElementType} from './types';
 
 const cachedDisplayNames: WeakMap<Function, string> = new WeakMap();
@@ -499,7 +498,7 @@ export function getDisplayNameForReactElement(
       } else if (typeof type === 'function') {
         return getDisplayName(type, 'Anonymous');
       } else if (type != null) {
-        return 'Anonymous';
+        return 'NotImplementedInDevtools';
       } else {
         return 'Element';
       }

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -21,6 +21,7 @@ import {
   Profiler,
   StrictMode,
   Suspense,
+  SuspenseList,
 } from 'react-is';
 import {
   TREE_OPERATION_ADD,
@@ -489,12 +490,16 @@ export function getDisplayNameForReactElement(
       return 'StrictMode';
     case Suspense:
       return 'Suspense';
+    case SuspenseList:
+      return 'SuspenseList';
     default:
       const {type} = element;
       if (typeof type === 'string') {
         return type;
-      } else if (type != null) {
+      } else if (typeof type === 'function') {
         return getDisplayName(type, 'Anonymous');
+      } else if (type != null) {
+        return 'Anonymous';
       } else {
         return 'Element';
       }

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -21,6 +21,7 @@ import {
   REACT_PROVIDER_TYPE,
   REACT_STRICT_MODE_TYPE,
   REACT_SUSPENSE_TYPE,
+  REACT_SUSPENSE_LIST_TYPE,
 } from 'shared/ReactSymbols';
 import isValidElementType from 'shared/isValidElementType';
 
@@ -70,6 +71,7 @@ export const Portal = REACT_PORTAL_TYPE;
 export const Profiler = REACT_PROFILER_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 export const Suspense = REACT_SUSPENSE_TYPE;
+export const SuspenseList = REACT_SUSPENSE_LIST_TYPE;
 
 export {isValidElementType};
 

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -37,6 +37,7 @@ export function typeOf(object: any) {
           case REACT_PROFILER_TYPE:
           case REACT_STRICT_MODE_TYPE:
           case REACT_SUSPENSE_TYPE:
+          case REACT_SUSPENSE_LIST_TYPE:
             return type;
           default:
             const $$typeofType = type && type.$$typeof;

--- a/packages/react-is/src/ReactIs.js
+++ b/packages/react-is/src/ReactIs.js
@@ -72,7 +72,6 @@ export const Portal = REACT_PORTAL_TYPE;
 export const Profiler = REACT_PROFILER_TYPE;
 export const StrictMode = REACT_STRICT_MODE_TYPE;
 export const Suspense = REACT_SUSPENSE_TYPE;
-export const SuspenseList = REACT_SUSPENSE_LIST_TYPE;
 
 export {isValidElementType};
 


### PR DESCRIPTION
## Summary
Resolves #19674

I added SuspenseList as a possible type for printing JSX in devtools and also added a specific check to make sure that only function types can be passed in to getDisplayName on line 500 of react-devtools-shared/src/utils.js. 

I should mention I also added SuspenseList to the react-is typescript type library and will make a pr for that as well.


## Test Plan

I created unit tests for getDisplayNameForReactElement and ran them with yarn test-build-devtools and yarn test-prod after running build and build-for-devtools. I ran yarn flow with both dom and dom-browser options.
