### PR TITLE
Remove usage of PossiblyWeakSet from createEventHandle

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -9,7 +9,10 @@
 
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {ReactScopeInstance} from 'shared/ReactTypes';
-import type {ReactDOMEventHandleListener} from '../shared/ReactDOMTypes';
+import type {
+  ReactDOMEventHandle,
+  ReactDOMEventHandleListener,
+} from '../shared/ReactDOMTypes';
 import type {
   Container,
   TextInstance,
@@ -39,6 +42,7 @@ const internalPropsKey = '__reactProps$' + randomKey;
 const internalContainerInstanceKey = '__reactContainer$' + randomKey;
 const internalEventHandlersKey = '__reactEvents$' + randomKey;
 const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
+const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
 
 export type ElementListenerMap = Map<
   DOMEventName | string,
@@ -231,4 +235,26 @@ export function getEventHandlerListeners(
   scope: EventTarget | ReactScopeInstance,
 ): null | Set<ReactDOMEventHandleListener> {
   return (scope: any)[internalEventHandlerListenersKey] || null;
+}
+
+export function addEventHandleToTarget(
+  target: EventTarget | ReactScopeInstance,
+  eventHandle: ReactDOMEventHandle,
+): void {
+  let eventHandles = (target: any)[internalEventHandlesSetKey];
+  if (eventHandles === undefined) {
+    eventHandles = (target: any)[internalEventHandlesSetKey] = new Set();
+  }
+  eventHandles.add(eventHandle);
+}
+
+export function doesTargetHaveEventHandle(
+  target: EventTarget | ReactScopeInstance,
+  eventHandle: ReactDOMEventHandle,
+): boolean {
+  const eventHandles = (target: any)[internalEventHandlesSetKey];
+  if (eventHandles === undefined) {
+    return false;
+  }
+  return eventHandles.has(eventHandle);
 }


### PR DESCRIPTION
As mentioned by @gaearon in https://github.com/facebook/react/pull/19174#discussion_r475658160:

> Does this mean we leak memory on IE11? It looks like we always add targets to this Set, but it's never cleared (since it's assumed to be a WeakSet in modern browsers).

This is correct. To avoid this memory leak, we can avoid usage of `WeakSet` entirely and instead use a property on the target itself, which should allow for the target to be garbage collected properly.