### PR TITLE
Add React.startTransition

### DIFF
--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -46,6 +46,8 @@ export {
   useTransition as unstable_useTransition,
   useDeferredValue,
   useDeferredValue as unstable_useDeferredValue,
+  startTransition,
+  startTransition as unstable_startTransition,
   SuspenseList,
   SuspenseList as unstable_SuspenseList,
   unstable_withSuspenseConfig,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -42,6 +42,7 @@ export {
   // exposeConcurrentModeAPIs
   useTransition as unstable_useTransition,
   useDeferredValue as unstable_useDeferredValue,
+  startTransition as unstable_startTransition,
   SuspenseList as unstable_SuspenseList,
   unstable_withSuspenseConfig,
   // enableBlocksAPI

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -72,6 +72,7 @@ export {
   createFactory,
   useTransition,
   useTransition as unstable_useTransition,
+  startTransition as unstable_startTransition,
   useDeferredValue,
   useDeferredValue as unstable_useDeferredValue,
   SuspenseList,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -72,6 +72,7 @@ export {
   createFactory,
   useTransition,
   useTransition as unstable_useTransition,
+  startTransition,
   startTransition as unstable_startTransition,
   useDeferredValue,
   useDeferredValue as unstable_useDeferredValue,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -45,6 +45,8 @@ export {
   useTransition as unstable_useTransition,
   useDeferredValue,
   useDeferredValue as unstable_useDeferredValue,
+  startTransition,
+  startTransition as unstable_startTransition,
   SuspenseList,
   SuspenseList as unstable_SuspenseList,
   unstable_withSuspenseConfig,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -58,6 +58,7 @@ import {
 import {createMutableSource} from './ReactMutableSource';
 import ReactSharedInternals from './ReactSharedInternals';
 import {createFundamental} from './ReactFundamental';
+import {startTransition} from './ReactStartTransition';
 
 // TODO: Move this branching into the other module instead and just re-export.
 const createElement = __DEV__ ? createElementWithValidation : createElementProd;
@@ -107,6 +108,7 @@ export {
   createFactory,
   // Concurrent Mode
   useTransition,
+  startTransition,
   useDeferredValue,
   REACT_SUSPENSE_LIST_TYPE as SuspenseList,
   REACT_LEGACY_HIDDEN_TYPE as unstable_LegacyHidden,

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
+
+// Default to an arbitrarily large timeout. Effectively, this is infinite. The
+// eventual goal is to never timeout when refreshing already visible content.
+const IndefiniteTimeoutConfig = {timeoutMs: 100000};
+
+export function startTransition(scope: () => void) {
+  const previousConfig = ReactCurrentBatchConfig.suspense;
+  ReactCurrentBatchConfig.suspense = IndefiniteTimeoutConfig;
+  try {
+    scope();
+  } finally {
+    ReactCurrentBatchConfig.suspense = previousConfig;
+  }
+}


### PR DESCRIPTION
## Overview

**Experimental only**

This PR adds startTransition to the isomorphic package.

### Details

The `useTransition` hook allows deferring an update from appearing on the screen until all content is loaded in the next screen. As a hook this is useful because most of the time the trigger for an update is inside an event, like a click handler:

```js
function App() {
  const [currentPage, setPage] = useState('home');
  const [startTransition, isPending] = useTransition();

  function handleClick(nextPage) {
    startTransition(() => {
      setPage(nextPage);
    })
  }

  return <Page page={currentPage} onClick={handleClick} isPending={isPending} /> 
}
```

But this doesn't cover use cases that which don't have access to hooks. Sometimes you may want to trigger an update that causes a transition from outside of a component:

```js
let setPageOutsideComponent;

function App() {
  const [currentPage, setPage] = useState('home');
  setPageOutsideComponent = setPage;

  return <Page page={currentPage} /> 
}

// This could be in a data listener, or action creator.
// Anything that could trigger an update from outside the component.
setPageOutsideComponent('about');
```

These use cases also need to be able to defer an update, and for that we're exposing `React.startTransition`:

```js
React.startTransition(() => {
  setPageOutsideComponent('about');
});
```

Importantly, there's no `isPending` value because there's no mechanism to update that value. If you need to track the pending status of a transition, you should use a hook which has a built-in ability to update the pending state as it changes.

