### PR TITLE
Add an option to DevTools to enable double-logging

### DIFF
--- a/fixtures/devtools/standalone/index.html
+++ b/fixtures/devtools/standalone/index.html
@@ -1,250 +1,248 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>TODO List</title>
 
-<head>
-  <meta charset="UTF-8" />
-  <title>TODO List</title>
+    <!-- DevTools -->
+    <script src="http://localhost:8097"></script>
 
-  <!-- DevTools -->
-  <script src="http://localhost:8097"></script>
+    <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/immutable@4.0.0-rc.12/dist/immutable.js"></script>
 
-  <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
-  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/immutable@4.0.0-rc.12/dist/immutable.js"></script>
+    <!-- Don't use this in production: -->
+    <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
 
-  <!-- Don't use this in production: -->
-  <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
-
-  <style type="text/css">
-    .Input {
-      font-size: 1rem;
-      padding: 0.25rem;
-    }
-
-    .IconButton {
-      padding: 0.25rem;
-      border: none;
-      background: none;
-      cursor: pointer;
-    }
-
-    .List {
-      margin: 0.5rem 0 0;
-      padding: 0;
-    }
-
-    .ListItem {
-      list-style-type: none;
-    }
-
-    .Label {
-      cursor: pointer;
-      padding: 0.25rem;
-      color: #555;
-    }
-
-    .Label:hover {
-      color: #000;
-    }
-
-    .IconButton {
-      padding: 0.25rem;
-      border: none;
-      background: none;
-      cursor: pointer;
-    }
-  </style>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="text/babel">
-    const { Fragment, useCallback, useState } = React;
-
-    function List(props) {
-      const [newItemText, setNewItemText] = useState("");
-      const [items, setItems] = useState([
-        { id: 1, isComplete: true, text: "First" },
-        { id: 2, isComplete: true, text: "Second" },
-        { id: 3, isComplete: false, text: "Third" },
-      ]);
-      const [uid, setUID] = useState(4);
-
-      const handleClick = useCallback(() => {
-        if (newItemText !== "") {
-          setItems([
-            ...items,
-            {
-              id: uid,
-              isComplete: false,
-              text: newItemText
-            }
-          ]);
-          setUID(uid + 1);
-          setNewItemText("");
-        }
-      }, [newItemText, items, uid]);
-
-      const handleKeyPress = useCallback(
-        event => {
-          if (event.key === "Enter") {
-            handleClick();
-          }
-        },
-        [handleClick]
-      );
-
-      const handleChange = useCallback(
-        event => {
-          setNewItemText(event.currentTarget.value);
-        },
-        [setNewItemText]
-      );
-
-      const removeItem = useCallback(
-        itemToRemove => setItems(items.filter(item => item !== itemToRemove)),
-        [items]
-      );
-
-      const toggleItem = useCallback(
-        itemToToggle => {
-          const index = items.indexOf(itemToToggle);
-
-          setItems(
-            items
-              .slice(0, index)
-              .concat({
-                ...itemToToggle,
-                isComplete: !itemToToggle.isComplete
-              })
-              .concat(items.slice(index + 1))
-          );
-        },
-        [items]
-      );
-
-      return (
-        <Fragment>
-          <h1>List</h1>
-          <input
-            type="text"
-            placeholder="New list item..."
-            className="Input"
-            value={newItemText}
-            onChange={handleChange}
-            onKeyPress={handleKeyPress}
-          />
-          <button
-            className="IconButton"
-            disabled={newItemText === ""}
-            onClick={handleClick}
-          >
-            <span role="img" aria-label="Add item">
-              ➕
-              </span>
-          </button>
-          <ul className="List">
-            {items.map(item => (
-              <ListItem
-                key={item.id}
-                item={item}
-                removeItem={removeItem}
-                toggleItem={toggleItem}
-              />
-            ))}
-          </ul>
-        </Fragment>
-      );
-    }
-
-    function ListItem({ item, removeItem, toggleItem }) {
-      const handleDelete = useCallback(() => {
-        removeItem(item);
-      }, [item, removeItem]);
-
-      const handleToggle = useCallback(() => {
-        toggleItem(item);
-      }, [item, toggleItem]);
-
-      return (
-        <li className="ListItem">
-          <button className="IconButton" onClick={handleDelete}>
-            🗑
-            </button>
-          <label className="Label">
-            <input
-              className="Input"
-              checked={item.isComplete}
-              onChange={handleToggle}
-              type="checkbox"
-            />{" "}
-            {item.text}
-          </label>
-        </li>
-      );
-    }
-
-    function SimpleValues() {
-      return (
-        <ChildComponent
-          string="abc"
-          emptyString=""
-          number={123}
-          undefined={undefined}
-          null={null}
-          nan={NaN}
-          infinity={Infinity}
-          true={true}
-          false={false}
-        />
-      );
-    }
-
-    class Custom {
-      _number = 42;
-      get number() {
-        return this._number;
+    <style type="text/css">
+      .Input {
+        font-size: 1rem;
+        padding: 0.25rem;
       }
-    }
 
-    function CustomObject() {
-      return <ChildComponent customObject={new Custom()} />;
-    }
+      .IconButton {
+        padding: 0.25rem;
+        border: none;
+        background: none;
+        cursor: pointer;
+      }
 
-    const object = {
-      string: "abc",
-      longString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKJLMNOPQRSTUVWXYZ1234567890",
-      emptyString: "",
-      number: 123,
-      boolean: true,
-      undefined: undefined,
-      null: null
-    };
+      .List {
+        margin: 0.5rem 0 0;
+        padding: 0;
+      }
 
-    function ObjectProps() {
-      return (
-        <ChildComponent
-          object={{
-            outer: {
-              inner: object
+      .ListItem {
+        list-style-type: none;
+      }
+
+      .Label {
+        cursor: pointer;
+        padding: 0.25rem;
+        color: #555;
+      }
+      .Label:hover {
+        color: #000;
+      }
+
+      .IconButton {
+        padding: 0.25rem;
+        border: none;
+        background: none;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { Fragment, useCallback, useState } = React;
+
+      function List(props) {
+        const [newItemText, setNewItemText] = useState("");
+        const [items, setItems] = useState([
+          { id: 1, isComplete: true, text: "First" },
+          { id: 2, isComplete: true, text: "Second" },
+          { id: 3, isComplete: false, text: "Third" }
+        ]);
+        const [uid, setUID] = useState(4);
+
+        const handleClick = useCallback(() => {
+          if (newItemText !== "") {
+            setItems([
+              ...items,
+              {
+                id: uid,
+                isComplete: false,
+                text: newItemText
+              }
+            ]);
+            setUID(uid + 1);
+            setNewItemText("");
+          }
+        }, [newItemText, items, uid]);
+
+        const handleKeyPress = useCallback(
+          event => {
+            if (event.key === "Enter") {
+              handleClick();
             }
-          }}
-          array={["first", "second", "third"]}
-          objectInArray={[object]}
-          arrayInObject={{ array: ["first", "second", "third"] }}
-          deepObject={{
-            // Known limitation: we won't go deeper than several levels.
-            // In the future, we might offer a way to request deeper access on demand.
-            a: {
-              b: {
-                c: {
-                  d: {
-                    e: {
-                      f: {
-                        g: {
-                          h: {
-                            i: {
-                              j: 10
+          },
+          [handleClick]
+        );
+
+        const handleChange = useCallback(
+          event => {
+            setNewItemText(event.currentTarget.value);
+          },
+          [setNewItemText]
+        );
+
+        const removeItem = useCallback(
+          itemToRemove => setItems(items.filter(item => item !== itemToRemove)),
+          [items]
+        );
+
+        const toggleItem = useCallback(
+          itemToToggle => {
+            const index = items.indexOf(itemToToggle);
+
+            setItems(
+              items
+                .slice(0, index)
+                .concat({
+                  ...itemToToggle,
+                  isComplete: !itemToToggle.isComplete
+                })
+                .concat(items.slice(index + 1))
+            );
+          },
+          [items]
+        );
+
+        return (
+          <Fragment>
+            <h1>List</h1>
+            <input
+              type="text"
+              placeholder="New list item..."
+              className="Input"
+              value={newItemText}
+              onChange={handleChange}
+              onKeyPress={handleKeyPress}
+            />
+            <button
+              className="IconButton"
+              disabled={newItemText === ""}
+              onClick={handleClick}
+            >
+              <span role="img" aria-label="Add item">
+                ➕
+              </span>
+            </button>
+            <ul className="List">
+              {items.map(item => (
+                <ListItem
+                  key={item.id}
+                  item={item}
+                  removeItem={removeItem}
+                  toggleItem={toggleItem}
+                />
+              ))}
+            </ul>
+          </Fragment>
+        );
+      }
+
+      function ListItem({ item, removeItem, toggleItem }) {
+        const handleDelete = useCallback(() => {
+          removeItem(item);
+        }, [item, removeItem]);
+
+        const handleToggle = useCallback(() => {
+          toggleItem(item);
+        }, [item, toggleItem]);
+
+        return (
+          <li className="ListItem">
+            <button className="IconButton" onClick={handleDelete}>
+              🗑
+            </button>
+            <label className="Label">
+              <input
+                className="Input"
+                checked={item.isComplete}
+                onChange={handleToggle}
+                type="checkbox"
+              />{" "}
+              {item.text}
+            </label>
+          </li>
+        );
+      }
+
+      function SimpleValues() {
+        return (
+          <ChildComponent
+            string="abc"
+            emptyString=""
+            number={123}
+            undefined={undefined}
+            null={null}
+            nan={NaN}
+            infinity={Infinity}
+            true={true}
+            false={false}
+          />
+        );
+      }
+
+      class Custom {
+        _number = 42;
+        get number() {
+          return this._number;
+        }
+      }
+
+      function CustomObject() {
+        return <ChildComponent customObject={new Custom()} />;
+      }
+
+      const object = {
+        string: "abc",
+        longString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKJLMNOPQRSTUVWXYZ1234567890",
+        emptyString: "",
+        number: 123,
+        boolean: true,
+        undefined: undefined,
+        null: null
+      };
+
+      function ObjectProps() {
+        return (
+          <ChildComponent
+            object={{
+              outer: {
+                inner: object
+              }
+            }}
+            array={["first", "second", "third"]}
+            objectInArray={[object]}
+            arrayInObject={{ array: ["first", "second", "third"] }}
+            deepObject={{
+              // Known limitation: we won't go deeper than several levels.
+              // In the future, we might offer a way to request deeper access on demand.
+              a: {
+                b: {
+                  c: {
+                    d: {
+                      e: {
+                        f: {
+                          g: {
+                            h: {
+                              i: {
+                                j: 10
+                              }
                             }
                           }
                         }
@@ -253,65 +251,63 @@
                   }
                 }
               }
-            }
-          }}
-        />
-      );
-    }
+            }}
+          />
+        );
+      }
 
-    const set = new Set(['abc', 123]);
-    const map = new Map([['name', 'Brian'], ['food', 'sushi']]);
-    const setOfSets = new Set([new Set(['a', 'b', 'c']), new Set([1, 2, 3])]);
-    const mapOfMaps = new Map([['first', map], ['second', map]]);
-    const typedArray = Int8Array.from([100, -100, 0]);
-    const immutable = Immutable.fromJS({
-      a: [{ hello: 'there' }, 'fixed', true],
-      b: 123,
-      c: {
-        '1': 'xyz',
-        xyz: 1,
-      },
-    });
+      const set = new Set(['abc', 123]);
+      const map = new Map([['name', 'Brian'], ['food', 'sushi']]);
+      const setOfSets = new Set([new Set(['a', 'b', 'c']), new Set([1, 2, 3])]);
+      const mapOfMaps = new Map([['first', map], ['second', map]]);
+      const typedArray = Int8Array.from([100, -100, 0]);
+      const immutable = Immutable.fromJS({
+        a: [{ hello: 'there' }, 'fixed', true],
+        b: 123,
+        c: {
+          '1': 'xyz',
+          xyz: 1,
+        },
+      });
 
-    function UnserializableProps() {
-      return (
-        <ChildComponent
-          map={map}
-          set={set}
-          mapOfMaps={mapOfMaps}
-          setOfSets={setOfSets}
-          typedArray={typedArray}
-          immutable={immutable}
-        />
-      );
-    }
+      function UnserializableProps() {
+        return (
+          <ChildComponent
+            map={map}
+            set={set}
+            mapOfMaps={mapOfMaps}
+            setOfSets={setOfSets}
+            typedArray={typedArray}
+            immutable={immutable}
+          />
+        );
+      }
 
-    function ChildComponent(props: any) {
-      return null;
-    }
+      function ChildComponent(props: any) {
+        return null;
+      }
 
-    function InspectableElements() {
-      return (
-        <Fragment>
-          <SimpleValues />
-          <ObjectProps />
-          <UnserializableProps />
-          <CustomObject />
-        </Fragment>
-      );
-    }
+      function InspectableElements() {
+        return (
+          <Fragment>
+            <SimpleValues />
+            <ObjectProps />
+            <UnserializableProps />
+            <CustomObject />
+          </Fragment>
+        );
+      }
 
-    function App() {
-      return (
-        <Fragment>
-          <List />
-          <InspectableElements />
-        </Fragment>
-      );
-    }
+      function App() {
+        return (
+          <Fragment>
+            <List />
+            <InspectableElements />
+          </Fragment>
+        );
+      }
 
-    ReactDOM.render(<App />, document.getElementById("root"));
-  </script>
-</body>
-
+      ReactDOM.render(<App />, document.getElementById("root"));
+    </script>
+  </body>
 </html>

--- a/fixtures/devtools/standalone/index.html
+++ b/fixtures/devtools/standalone/index.html
@@ -1,248 +1,250 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>TODO List</title>
 
-    <!-- DevTools -->
-    <script src="http://localhost:8097"></script>
+<head>
+  <meta charset="UTF-8" />
+  <title>TODO List</title>
 
-    <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com/immutable@4.0.0-rc.12/dist/immutable.js"></script>
+  <!-- DevTools -->
+  <script src="http://localhost:8097"></script>
 
-    <!-- Don't use this in production: -->
-    <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
+  <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/immutable@4.0.0-rc.12/dist/immutable.js"></script>
 
-    <style type="text/css">
-      .Input {
-        font-size: 1rem;
-        padding: 0.25rem;
-      }
+  <!-- Don't use this in production: -->
+  <script src="https://unpkg.com/babel-standalone@6.15.0/babel.min.js"></script>
 
-      .IconButton {
-        padding: 0.25rem;
-        border: none;
-        background: none;
-        cursor: pointer;
-      }
+  <style type="text/css">
+    .Input {
+      font-size: 1rem;
+      padding: 0.25rem;
+    }
 
-      .List {
-        margin: 0.5rem 0 0;
-        padding: 0;
-      }
+    .IconButton {
+      padding: 0.25rem;
+      border: none;
+      background: none;
+      cursor: pointer;
+    }
 
-      .ListItem {
-        list-style-type: none;
-      }
+    .List {
+      margin: 0.5rem 0 0;
+      padding: 0;
+    }
 
-      .Label {
-        cursor: pointer;
-        padding: 0.25rem;
-        color: #555;
-      }
-      .Label:hover {
-        color: #000;
-      }
+    .ListItem {
+      list-style-type: none;
+    }
 
-      .IconButton {
-        padding: 0.25rem;
-        border: none;
-        background: none;
-        cursor: pointer;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="text/babel">
-      const { Fragment, useCallback, useState } = React;
+    .Label {
+      cursor: pointer;
+      padding: 0.25rem;
+      color: #555;
+    }
 
-      function List(props) {
-        const [newItemText, setNewItemText] = useState("");
-        const [items, setItems] = useState([
-          { id: 1, isComplete: true, text: "First" },
-          { id: 2, isComplete: true, text: "Second" },
-          { id: 3, isComplete: false, text: "Third" }
-        ]);
-        const [uid, setUID] = useState(4);
+    .Label:hover {
+      color: #000;
+    }
 
-        const handleClick = useCallback(() => {
-          if (newItemText !== "") {
-            setItems([
-              ...items,
-              {
-                id: uid,
-                isComplete: false,
-                text: newItemText
-              }
-            ]);
-            setUID(uid + 1);
-            setNewItemText("");
-          }
-        }, [newItemText, items, uid]);
+    .IconButton {
+      padding: 0.25rem;
+      border: none;
+      background: none;
+      cursor: pointer;
+    }
+  </style>
+</head>
 
-        const handleKeyPress = useCallback(
-          event => {
-            if (event.key === "Enter") {
-              handleClick();
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { Fragment, useCallback, useState } = React;
+
+    function List(props) {
+      const [newItemText, setNewItemText] = useState("");
+      const [items, setItems] = useState([
+        { id: 1, isComplete: true, text: "First" },
+        { id: 2, isComplete: true, text: "Second" },
+        { id: 3, isComplete: false, text: "Third" },
+      ]);
+      const [uid, setUID] = useState(4);
+
+      const handleClick = useCallback(() => {
+        if (newItemText !== "") {
+          setItems([
+            ...items,
+            {
+              id: uid,
+              isComplete: false,
+              text: newItemText
             }
-          },
-          [handleClick]
-        );
-
-        const handleChange = useCallback(
-          event => {
-            setNewItemText(event.currentTarget.value);
-          },
-          [setNewItemText]
-        );
-
-        const removeItem = useCallback(
-          itemToRemove => setItems(items.filter(item => item !== itemToRemove)),
-          [items]
-        );
-
-        const toggleItem = useCallback(
-          itemToToggle => {
-            const index = items.indexOf(itemToToggle);
-
-            setItems(
-              items
-                .slice(0, index)
-                .concat({
-                  ...itemToToggle,
-                  isComplete: !itemToToggle.isComplete
-                })
-                .concat(items.slice(index + 1))
-            );
-          },
-          [items]
-        );
-
-        return (
-          <Fragment>
-            <h1>List</h1>
-            <input
-              type="text"
-              placeholder="New list item..."
-              className="Input"
-              value={newItemText}
-              onChange={handleChange}
-              onKeyPress={handleKeyPress}
-            />
-            <button
-              className="IconButton"
-              disabled={newItemText === ""}
-              onClick={handleClick}
-            >
-              <span role="img" aria-label="Add item">
-                ➕
-              </span>
-            </button>
-            <ul className="List">
-              {items.map(item => (
-                <ListItem
-                  key={item.id}
-                  item={item}
-                  removeItem={removeItem}
-                  toggleItem={toggleItem}
-                />
-              ))}
-            </ul>
-          </Fragment>
-        );
-      }
-
-      function ListItem({ item, removeItem, toggleItem }) {
-        const handleDelete = useCallback(() => {
-          removeItem(item);
-        }, [item, removeItem]);
-
-        const handleToggle = useCallback(() => {
-          toggleItem(item);
-        }, [item, toggleItem]);
-
-        return (
-          <li className="ListItem">
-            <button className="IconButton" onClick={handleDelete}>
-              🗑
-            </button>
-            <label className="Label">
-              <input
-                className="Input"
-                checked={item.isComplete}
-                onChange={handleToggle}
-                type="checkbox"
-              />{" "}
-              {item.text}
-            </label>
-          </li>
-        );
-      }
-
-      function SimpleValues() {
-        return (
-          <ChildComponent
-            string="abc"
-            emptyString=""
-            number={123}
-            undefined={undefined}
-            null={null}
-            nan={NaN}
-            infinity={Infinity}
-            true={true}
-            false={false}
-          />
-        );
-      }
-
-      class Custom {
-        _number = 42;
-        get number() {
-          return this._number;
+          ]);
+          setUID(uid + 1);
+          setNewItemText("");
         }
+      }, [newItemText, items, uid]);
+
+      const handleKeyPress = useCallback(
+        event => {
+          if (event.key === "Enter") {
+            handleClick();
+          }
+        },
+        [handleClick]
+      );
+
+      const handleChange = useCallback(
+        event => {
+          setNewItemText(event.currentTarget.value);
+        },
+        [setNewItemText]
+      );
+
+      const removeItem = useCallback(
+        itemToRemove => setItems(items.filter(item => item !== itemToRemove)),
+        [items]
+      );
+
+      const toggleItem = useCallback(
+        itemToToggle => {
+          const index = items.indexOf(itemToToggle);
+
+          setItems(
+            items
+              .slice(0, index)
+              .concat({
+                ...itemToToggle,
+                isComplete: !itemToToggle.isComplete
+              })
+              .concat(items.slice(index + 1))
+          );
+        },
+        [items]
+      );
+
+      return (
+        <Fragment>
+          <h1>List</h1>
+          <input
+            type="text"
+            placeholder="New list item..."
+            className="Input"
+            value={newItemText}
+            onChange={handleChange}
+            onKeyPress={handleKeyPress}
+          />
+          <button
+            className="IconButton"
+            disabled={newItemText === ""}
+            onClick={handleClick}
+          >
+            <span role="img" aria-label="Add item">
+              ➕
+              </span>
+          </button>
+          <ul className="List">
+            {items.map(item => (
+              <ListItem
+                key={item.id}
+                item={item}
+                removeItem={removeItem}
+                toggleItem={toggleItem}
+              />
+            ))}
+          </ul>
+        </Fragment>
+      );
+    }
+
+    function ListItem({ item, removeItem, toggleItem }) {
+      const handleDelete = useCallback(() => {
+        removeItem(item);
+      }, [item, removeItem]);
+
+      const handleToggle = useCallback(() => {
+        toggleItem(item);
+      }, [item, toggleItem]);
+
+      return (
+        <li className="ListItem">
+          <button className="IconButton" onClick={handleDelete}>
+            🗑
+            </button>
+          <label className="Label">
+            <input
+              className="Input"
+              checked={item.isComplete}
+              onChange={handleToggle}
+              type="checkbox"
+            />{" "}
+            {item.text}
+          </label>
+        </li>
+      );
+    }
+
+    function SimpleValues() {
+      return (
+        <ChildComponent
+          string="abc"
+          emptyString=""
+          number={123}
+          undefined={undefined}
+          null={null}
+          nan={NaN}
+          infinity={Infinity}
+          true={true}
+          false={false}
+        />
+      );
+    }
+
+    class Custom {
+      _number = 42;
+      get number() {
+        return this._number;
       }
+    }
 
-      function CustomObject() {
-        return <ChildComponent customObject={new Custom()} />;
-      }
+    function CustomObject() {
+      return <ChildComponent customObject={new Custom()} />;
+    }
 
-      const object = {
-        string: "abc",
-        longString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKJLMNOPQRSTUVWXYZ1234567890",
-        emptyString: "",
-        number: 123,
-        boolean: true,
-        undefined: undefined,
-        null: null
-      };
+    const object = {
+      string: "abc",
+      longString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKJLMNOPQRSTUVWXYZ1234567890",
+      emptyString: "",
+      number: 123,
+      boolean: true,
+      undefined: undefined,
+      null: null
+    };
 
-      function ObjectProps() {
-        return (
-          <ChildComponent
-            object={{
-              outer: {
-                inner: object
-              }
-            }}
-            array={["first", "second", "third"]}
-            objectInArray={[object]}
-            arrayInObject={{ array: ["first", "second", "third"] }}
-            deepObject={{
-              // Known limitation: we won't go deeper than several levels.
-              // In the future, we might offer a way to request deeper access on demand.
-              a: {
-                b: {
-                  c: {
-                    d: {
-                      e: {
-                        f: {
-                          g: {
-                            h: {
-                              i: {
-                                j: 10
-                              }
+    function ObjectProps() {
+      return (
+        <ChildComponent
+          object={{
+            outer: {
+              inner: object
+            }
+          }}
+          array={["first", "second", "third"]}
+          objectInArray={[object]}
+          arrayInObject={{ array: ["first", "second", "third"] }}
+          deepObject={{
+            // Known limitation: we won't go deeper than several levels.
+            // In the future, we might offer a way to request deeper access on demand.
+            a: {
+              b: {
+                c: {
+                  d: {
+                    e: {
+                      f: {
+                        g: {
+                          h: {
+                            i: {
+                              j: 10
                             }
                           }
                         }
@@ -251,63 +253,65 @@
                   }
                 }
               }
-            }}
-          />
-        );
-      }
+            }
+          }}
+        />
+      );
+    }
 
-      const set = new Set(['abc', 123]);
-      const map = new Map([['name', 'Brian'], ['food', 'sushi']]);
-      const setOfSets = new Set([new Set(['a', 'b', 'c']), new Set([1, 2, 3])]);
-      const mapOfMaps = new Map([['first', map], ['second', map]]);
-      const typedArray = Int8Array.from([100, -100, 0]);
-      const immutable = Immutable.fromJS({
-        a: [{ hello: 'there' }, 'fixed', true],
-        b: 123,
-        c: {
-          '1': 'xyz',
-          xyz: 1,
-        },
-      });
+    const set = new Set(['abc', 123]);
+    const map = new Map([['name', 'Brian'], ['food', 'sushi']]);
+    const setOfSets = new Set([new Set(['a', 'b', 'c']), new Set([1, 2, 3])]);
+    const mapOfMaps = new Map([['first', map], ['second', map]]);
+    const typedArray = Int8Array.from([100, -100, 0]);
+    const immutable = Immutable.fromJS({
+      a: [{ hello: 'there' }, 'fixed', true],
+      b: 123,
+      c: {
+        '1': 'xyz',
+        xyz: 1,
+      },
+    });
 
-      function UnserializableProps() {
-        return (
-          <ChildComponent
-            map={map}
-            set={set}
-            mapOfMaps={mapOfMaps}
-            setOfSets={setOfSets}
-            typedArray={typedArray}
-            immutable={immutable}
-          />
-        );
-      }
+    function UnserializableProps() {
+      return (
+        <ChildComponent
+          map={map}
+          set={set}
+          mapOfMaps={mapOfMaps}
+          setOfSets={setOfSets}
+          typedArray={typedArray}
+          immutable={immutable}
+        />
+      );
+    }
 
-      function ChildComponent(props: any) {
-        return null;
-      }
+    function ChildComponent(props: any) {
+      return null;
+    }
 
-      function InspectableElements() {
-        return (
-          <Fragment>
-            <SimpleValues />
-            <ObjectProps />
-            <UnserializableProps />
-            <CustomObject />
-          </Fragment>
-        );
-      }
+    function InspectableElements() {
+      return (
+        <Fragment>
+          <SimpleValues />
+          <ObjectProps />
+          <UnserializableProps />
+          <CustomObject />
+        </Fragment>
+      );
+    }
 
-      function App() {
-        return (
-          <Fragment>
-            <List />
-            <InspectableElements />
-          </Fragment>
-        );
-      }
+    function App() {
+      return (
+        <Fragment>
+          <List />
+          <InspectableElements />
+        </Fragment>
+      );
+    }
 
-      ReactDOM.render(<App />, document.getElementById("root"));
-    </script>
-  </body>
+    ReactDOM.render(<App />, document.getElementById("root"));
+  </script>
+</body>
+
 </html>

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -18,6 +18,7 @@ import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
 import {
   getAppendComponentStack,
+  getEnableDoubleLogging,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
 } from 'react-devtools-shared/src/utils';
@@ -297,6 +298,9 @@ function startServer(
     const savedPreferencesString = `
       window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = ${JSON.stringify(
         getAppendComponentStack(),
+      )};
+      window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = ${JSON.stringify(
+        getEnableDoubleLogging(),
       )};
       window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = ${JSON.stringify(
         getBreakOnConsoleErrors(),

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -18,7 +18,7 @@ import Bridge from 'react-devtools-shared/src/bridge';
 import Store from 'react-devtools-shared/src/devtools/store';
 import {
   getAppendComponentStack,
-  getEnableDoubleLogging,
+  getsuppressDoubleLogging,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
 } from 'react-devtools-shared/src/utils';
@@ -299,8 +299,8 @@ function startServer(
       window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = ${JSON.stringify(
         getAppendComponentStack(),
       )};
-      window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = ${JSON.stringify(
-        getEnableDoubleLogging(),
+      window.__REACT_DEVTOOLS_SUPPRESS_DOUBLE_LOGGING__ = ${JSON.stringify(
+        getsuppressDoubleLogging(),
       )};
       window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = ${JSON.stringify(
         getBreakOnConsoleErrors(),

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -7,6 +7,7 @@ import Store from 'react-devtools-shared/src/devtools/store';
 import {getBrowserName, getBrowserTheme} from './utils';
 import {LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY} from 'react-devtools-shared/src/constants';
 import {
+  getEnableDoubleLogging,
   getAppendComponentStack,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
@@ -30,11 +31,15 @@ let panelCreated = false;
 // Instead it relies on the extension to pass filters through.
 function syncSavedPreferences() {
   const appendComponentStack = getAppendComponentStack();
+  const enableDoubleLogging = getEnableDoubleLogging();
   const breakOnConsoleErrors = getBreakOnConsoleErrors();
   const componentFilters = getSavedComponentFilters();
   chrome.devtools.inspectedWindow.eval(
     `window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = ${JSON.stringify(
       appendComponentStack,
+    )};
+    window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = ${JSON.stringify(
+      enableDoubleLogging,
     )};
     window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = ${JSON.stringify(
       breakOnConsoleErrors,

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -7,7 +7,7 @@ import Store from 'react-devtools-shared/src/devtools/store';
 import {getBrowserName, getBrowserTheme} from './utils';
 import {LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY} from 'react-devtools-shared/src/constants';
 import {
-  getEnableDoubleLogging,
+  getsuppressDoubleLogging,
   getAppendComponentStack,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
@@ -31,15 +31,15 @@ let panelCreated = false;
 // Instead it relies on the extension to pass filters through.
 function syncSavedPreferences() {
   const appendComponentStack = getAppendComponentStack();
-  const enableDoubleLogging = getEnableDoubleLogging();
+  const suppressDoubleLogging = getsuppressDoubleLogging();
   const breakOnConsoleErrors = getBreakOnConsoleErrors();
   const componentFilters = getSavedComponentFilters();
   chrome.devtools.inspectedWindow.eval(
     `window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = ${JSON.stringify(
       appendComponentStack,
     )};
-    window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = ${JSON.stringify(
-      enableDoubleLogging,
+    window.__REACT_DEVTOOLS_SUPPRESS_DOUBLE_LOGGING__ = ${JSON.stringify(
+      suppressDoubleLogging,
     )};
     window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = ${JSON.stringify(
       breakOnConsoleErrors,

--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -22,12 +22,14 @@ function startActivation(contentWindow: window) {
 
         const {
           appendComponentStack,
+          enableDoubleLogging,
           breakOnConsoleErrors,
           componentFilters,
         } = data;
 
         contentWindow.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
         contentWindow.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
+        contentWindow.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
         contentWindow.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
 
         // TRICKY
@@ -39,6 +41,7 @@ function startActivation(contentWindow: window) {
         if (contentWindow !== window) {
           window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
           window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
+          Window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
           window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
         }
 

--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -41,7 +41,7 @@ function startActivation(contentWindow: window) {
         if (contentWindow !== window) {
           window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
           window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
-          Window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
+          window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
           window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
         }
 

--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -22,14 +22,14 @@ function startActivation(contentWindow: window) {
 
         const {
           appendComponentStack,
-          enableDoubleLogging,
+          suppressDoubleLogging,
           breakOnConsoleErrors,
           componentFilters,
         } = data;
 
         contentWindow.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
         contentWindow.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
-        contentWindow.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
+        contentWindow.__REACT_DEVTOOLS_SUPPRESS_DOUBLE_LOGGING__ = suppressDoubleLogging;
         contentWindow.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
 
         // TRICKY
@@ -41,7 +41,7 @@ function startActivation(contentWindow: window) {
         if (contentWindow !== window) {
           window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = appendComponentStack;
           window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ = breakOnConsoleErrors;
-          window.__REACT_DEVTOOLS_ENABLE_DOUBLE_LOGGING__ = enableDoubleLogging;
+          window.__REACT_DEVTOOLS_SUPPRESS_DOUBLE_LOGGING__ = suppressDoubleLogging;
           window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = componentFilters;
         }
 

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -9,6 +9,7 @@ import {
   getAppendComponentStack,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
+  getEnableDoubleLogging
 } from 'react-devtools-shared/src/utils';
 import {
   MESSAGE_TYPE_GET_SAVED_PREFERENCES,
@@ -39,6 +40,7 @@ export function initialize(
           {
             type: MESSAGE_TYPE_SAVED_PREFERENCES,
             appendComponentStack: getAppendComponentStack(),
+            enableDoubleLogging: getEnableDoubleLogging(),
             breakOnConsoleErrors: getBreakOnConsoleErrors(),
             componentFilters: getSavedComponentFilters(),
           },

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -9,7 +9,7 @@ import {
   getAppendComponentStack,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
-  getEnableDoubleLogging
+  getEnableDoubleLogging,
 } from 'react-devtools-shared/src/utils';
 import {
   MESSAGE_TYPE_GET_SAVED_PREFERENCES,

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -9,7 +9,7 @@ import {
   getAppendComponentStack,
   getBreakOnConsoleErrors,
   getSavedComponentFilters,
-  getEnableDoubleLogging,
+  getsuppressDoubleLogging,
 } from 'react-devtools-shared/src/utils';
 import {
   MESSAGE_TYPE_GET_SAVED_PREFERENCES,
@@ -40,7 +40,7 @@ export function initialize(
           {
             type: MESSAGE_TYPE_SAVED_PREFERENCES,
             appendComponentStack: getAppendComponentStack(),
-            enableDoubleLogging: getEnableDoubleLogging(),
+            suppressDoubleLogging: getsuppressDoubleLogging(),
             breakOnConsoleErrors: getBreakOnConsoleErrors(),
             componentFilters: getSavedComponentFilters(),
           },

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -86,7 +86,6 @@ describe('console', () => {
       appendComponentStack: true,
       breakOnWarn: false,
     });
-
     expect(fakeConsole.error).toBe(error);
     expect(fakeConsole.warn).toBe(warn);
   });

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -446,9 +446,11 @@ export default class Agent extends EventEmitter<{|
   updateConsolePatchSettings = ({
     appendComponentStack,
     breakOnConsoleErrors,
+    enableDoubleLogging,
   }: {|
     appendComponentStack: boolean,
     breakOnConsoleErrors: boolean,
+    enableDoubleLogging: boolean,
   |}) => {
     // If the frontend preference has change,
     // or in the case of React Native- if the backend is just finding out the preference-

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -446,11 +446,11 @@ export default class Agent extends EventEmitter<{|
   updateConsolePatchSettings = ({
     appendComponentStack,
     breakOnConsoleErrors,
-    enableDoubleLogging,
+    suppressDoubleLogging,
   }: {|
     appendComponentStack: boolean,
     breakOnConsoleErrors: boolean,
-    enableDoubleLogging: boolean,
+    suppressDoubleLogging: boolean,
   |}) => {
     // If the frontend preference has change,
     // or in the case of React Native- if the backend is just finding out the preference-

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -88,7 +88,7 @@ type NativeStyleEditor_SetValueParams = {|
 type UpdateConsolePatchSettingsParams = {|
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
-  
+  enableDoubleLogging: boolean,
 |};
 
 type BackendEvents = {|

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -88,6 +88,7 @@ type NativeStyleEditor_SetValueParams = {|
 type UpdateConsolePatchSettingsParams = {|
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
+  
 |};
 
 type BackendEvents = {|

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -88,7 +88,7 @@ type NativeStyleEditor_SetValueParams = {|
 type UpdateConsolePatchSettingsParams = {|
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
-  enableDoubleLogging: boolean,
+  suppressDoubleLogging: boolean,
 |};
 
 type BackendEvents = {|

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -30,6 +30,9 @@ export const SESSION_STORAGE_RELOAD_AND_PROFILE_KEY =
 export const LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS =
   'React::DevTools::breakOnConsoleErrors';
 
+export const LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING =
+  'React::DevTools::enableDoubleLogging';
+  
 export const LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY =
   'React::DevTools::appendComponentStack';
 

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -32,7 +32,7 @@ export const LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS =
 
 export const LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING =
   'React::DevTools::enableDoubleLogging';
-  
+
 export const LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY =
   'React::DevTools::appendComponentStack';
 

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -31,7 +31,7 @@ export const LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS =
   'React::DevTools::breakOnConsoleErrors';
 
 export const LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING =
-  'React::DevTools::enableDoubleLogging';
+  'React::DevTools::suppressDoubleLogging';
 
 export const LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY =
   'React::DevTools::appendComponentStack';

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -30,7 +30,7 @@ export const SESSION_STORAGE_RELOAD_AND_PROFILE_KEY =
 export const LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS =
   'React::DevTools::breakOnConsoleErrors';
 
-export const LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING =
+export const LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING =
   'React::DevTools::suppressDoubleLogging';
 
 export const LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY =

--- a/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
@@ -17,6 +17,8 @@ export default function DebuggingSettings(_: {||}) {
   const {
     appendComponentStack,
     breakOnConsoleErrors,
+    enableDoubleLogging,
+    setEnableDoubleLogging,
     setAppendComponentStack,
     setBreakOnConsoleErrors,
   } = useContext(SettingsContext);
@@ -35,7 +37,18 @@ export default function DebuggingSettings(_: {||}) {
           Append component stacks to console warnings and errors.
         </label>
       </div>
-
+      <div className={styles.Setting}>
+        <label>
+          <input
+            type="checkbox"
+            checked={enableDoubleLogging}
+            onChange={({currentTarget}) =>
+              setEnableDoubleLogging(currentTarget.checked)
+            }
+          />{' '}
+          Enable double logging
+        </label>
+      </div>
       <div className={styles.Setting}>
         <label>
           <input

--- a/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/DebuggingSettings.js
@@ -17,8 +17,8 @@ export default function DebuggingSettings(_: {||}) {
   const {
     appendComponentStack,
     breakOnConsoleErrors,
-    enableDoubleLogging,
-    setEnableDoubleLogging,
+    suppressDoubleLogging,
+    setsuppressDoubleLogging,
     setAppendComponentStack,
     setBreakOnConsoleErrors,
   } = useContext(SettingsContext);
@@ -41,12 +41,12 @@ export default function DebuggingSettings(_: {||}) {
         <label>
           <input
             type="checkbox"
-            checked={enableDoubleLogging}
+            checked={!suppressDoubleLogging}
             onChange={({currentTarget}) =>
-              setEnableDoubleLogging(currentTarget.checked)
+              setsuppressDoubleLogging(!currentTarget.checked)
             }
           />{' '}
-          Enable double logging
+          Suppress console during development-only second render pass
         </label>
       </div>
       <div className={styles.Setting}>

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -21,6 +21,7 @@ import {
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
+  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING
 } from 'react-devtools-shared/src/constants';
 import {useLocalStorage} from '../hooks';
 import {BridgeContext} from '../context';
@@ -37,6 +38,9 @@ type Context = {|
   // Derived from display density.
   // Specified as a separate prop so it can trigger a re-render of FixedSizeList.
   lineHeight: number,
+
+  enableDoubleLogging : boolean,
+  setEnableDoubleLogging: (value: boolean) => void,
 
   appendComponentStack: boolean,
   setAppendComponentStack: (value: boolean) => void,
@@ -79,6 +83,12 @@ function SettingsContextController({
     'React::DevTools::theme',
     'auto',
   );
+
+  const [
+   enableDoubleLogging,
+   setEnableDoubleLogging,
+  ] = useLocalStorage<boolean>(LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING, false);
+
   const [
     appendComponentStack,
     setAppendComponentStack,
@@ -158,6 +168,7 @@ function SettingsContextController({
     () => ({
       appendComponentStack,
       breakOnConsoleErrors,
+      enableDoubleLogging,
       displayDensity,
       lineHeight:
         displayDensity === 'compact'
@@ -165,6 +176,7 @@ function SettingsContextController({
           : COMFORTABLE_LINE_HEIGHT,
       setAppendComponentStack,
       setBreakOnConsoleErrors,
+      setEnableDoubleLogging,
       setDisplayDensity,
       setTheme,
       setTraceUpdatesEnabled,
@@ -175,8 +187,10 @@ function SettingsContextController({
       appendComponentStack,
       breakOnConsoleErrors,
       displayDensity,
+      enableDoubleLogging,
       setAppendComponentStack,
       setBreakOnConsoleErrors,
+      setEnableDoubleLogging,
       setDisplayDensity,
       setTheme,
       setTraceUpdatesEnabled,

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -21,7 +21,7 @@ import {
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
-  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING
+  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
 } from 'react-devtools-shared/src/constants';
 import {useLocalStorage} from '../hooks';
 import {BridgeContext} from '../context';
@@ -39,7 +39,7 @@ type Context = {|
   // Specified as a separate prop so it can trigger a re-render of FixedSizeList.
   lineHeight: number,
 
-  enableDoubleLogging : boolean,
+  enableDoubleLogging: boolean,
   setEnableDoubleLogging: (value: boolean) => void,
 
   appendComponentStack: boolean,
@@ -85,9 +85,12 @@ function SettingsContextController({
   );
 
   const [
-   enableDoubleLogging,
-   setEnableDoubleLogging,
-  ] = useLocalStorage<boolean>(LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING, false);
+    enableDoubleLogging,
+    setEnableDoubleLogging,
+  ] = useLocalStorage<boolean>(
+    LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+    false,
+  );
 
   const [
     appendComponentStack,
@@ -157,8 +160,9 @@ function SettingsContextController({
     bridge.send('updateConsolePatchSettings', {
       appendComponentStack,
       breakOnConsoleErrors,
+      enableDoubleLogging,
     });
-  }, [bridge, appendComponentStack, breakOnConsoleErrors]);
+  }, [bridge, appendComponentStack, breakOnConsoleErrors, enableDoubleLogging]);
 
   useEffect(() => {
     bridge.send('setTraceUpdatesEnabled', traceUpdatesEnabled);

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -39,8 +39,8 @@ type Context = {|
   // Specified as a separate prop so it can trigger a re-render of FixedSizeList.
   lineHeight: number,
 
-  enableDoubleLogging: boolean,
-  setEnableDoubleLogging: (value: boolean) => void,
+  suppressDoubleLogging: boolean,
+  setsuppressDoubleLogging: (value: boolean) => void,
 
   appendComponentStack: boolean,
   setAppendComponentStack: (value: boolean) => void,
@@ -85,8 +85,8 @@ function SettingsContextController({
   );
 
   const [
-    enableDoubleLogging,
-    setEnableDoubleLogging,
+    suppressDoubleLogging,
+    setsuppressDoubleLogging,
   ] = useLocalStorage<boolean>(
     LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
     false,
@@ -160,9 +160,14 @@ function SettingsContextController({
     bridge.send('updateConsolePatchSettings', {
       appendComponentStack,
       breakOnConsoleErrors,
-      enableDoubleLogging,
+      suppressDoubleLogging,
     });
-  }, [bridge, appendComponentStack, breakOnConsoleErrors, enableDoubleLogging]);
+  }, [
+    bridge,
+    appendComponentStack,
+    breakOnConsoleErrors,
+    suppressDoubleLogging,
+  ]);
 
   useEffect(() => {
     bridge.send('setTraceUpdatesEnabled', traceUpdatesEnabled);
@@ -172,7 +177,7 @@ function SettingsContextController({
     () => ({
       appendComponentStack,
       breakOnConsoleErrors,
-      enableDoubleLogging,
+      suppressDoubleLogging,
       displayDensity,
       lineHeight:
         displayDensity === 'compact'
@@ -180,7 +185,7 @@ function SettingsContextController({
           : COMFORTABLE_LINE_HEIGHT,
       setAppendComponentStack,
       setBreakOnConsoleErrors,
-      setEnableDoubleLogging,
+      setsuppressDoubleLogging,
       setDisplayDensity,
       setTheme,
       setTraceUpdatesEnabled,
@@ -191,10 +196,10 @@ function SettingsContextController({
       appendComponentStack,
       breakOnConsoleErrors,
       displayDensity,
-      enableDoubleLogging,
+      suppressDoubleLogging,
       setAppendComponentStack,
       setBreakOnConsoleErrors,
-      setEnableDoubleLogging,
+      setsuppressDoubleLogging,
       setDisplayDensity,
       setTheme,
       setTraceUpdatesEnabled,

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -21,7 +21,7 @@ import {
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
-  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+  LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING,
 } from 'react-devtools-shared/src/constants';
 import {useLocalStorage} from '../hooks';
 import {BridgeContext} from '../context';
@@ -88,7 +88,7 @@ function SettingsContextController({
     suppressDoubleLogging,
     setsuppressDoubleLogging,
   ] = useLocalStorage<boolean>(
-    LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+    LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING,
     false,
   );
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -34,6 +34,7 @@ import {
   LOCAL_STORAGE_FILTER_PREFERENCES_KEY,
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
+  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING
 } from './constants';
 import {ComponentFilterElementType, ElementTypeHostComponent} from './types';
 import {
@@ -253,6 +254,25 @@ export function getBreakOnConsoleErrors(): boolean {
   try {
     const raw = localStorageGetItem(
       LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
+    );
+    if (raw != null) {
+      return JSON.parse(raw);
+    }
+  } catch (error) {}
+  return false;
+}
+
+export function setEnableDoubleLogging(value: boolean): void {
+  localStorageSetItem(
+    LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+    JSON.stringify(value),
+  );
+}
+
+export function getEnableDoubleLogging(): boolean {
+  try {
+    const raw = localStorageGetItem(
+      LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
     );
     if (raw != null) {
       return JSON.parse(raw);

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -34,7 +34,7 @@ import {
   LOCAL_STORAGE_FILTER_PREFERENCES_KEY,
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
-  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING
+  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
 } from './constants';
 import {ComponentFilterElementType, ElementTypeHostComponent} from './types';
 import {
@@ -271,9 +271,7 @@ export function setEnableDoubleLogging(value: boolean): void {
 
 export function getEnableDoubleLogging(): boolean {
   try {
-    const raw = localStorageGetItem(
-      LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
-    );
+    const raw = localStorageGetItem(LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING);
     if (raw != null) {
       return JSON.parse(raw);
     }

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -34,7 +34,7 @@ import {
   LOCAL_STORAGE_FILTER_PREFERENCES_KEY,
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
-  LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+  LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING,
 } from './constants';
 import {ComponentFilterElementType, ElementTypeHostComponent} from './types';
 import {
@@ -264,14 +264,16 @@ export function getBreakOnConsoleErrors(): boolean {
 
 export function setsuppressDoubleLogging(value: boolean): void {
   localStorageSetItem(
-    LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
+    LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING,
     JSON.stringify(value),
   );
 }
 
 export function getsuppressDoubleLogging(): boolean {
   try {
-    const raw = localStorageGetItem(LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING);
+    const raw = localStorageGetItem(
+      LOCAL_STORAGE_SHOULD_SUPPRESS_DOUBLE_LOGGING,
+    );
     if (raw != null) {
       return JSON.parse(raw);
     }

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -262,14 +262,14 @@ export function getBreakOnConsoleErrors(): boolean {
   return false;
 }
 
-export function setEnableDoubleLogging(value: boolean): void {
+export function setsuppressDoubleLogging(value: boolean): void {
   localStorageSetItem(
     LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING,
     JSON.stringify(value),
   );
 }
 
-export function getEnableDoubleLogging(): boolean {
+export function getsuppressDoubleLogging(): boolean {
   try {
     const raw = localStorageGetItem(LOCAL_STORAGE_SHOULD_ENABLE_DOUBLE_LOGGING);
     if (raw != null) {

--- a/packages/shared/ConsolePatchingDev.js
+++ b/packages/shared/ConsolePatchingDev.js
@@ -11,6 +11,7 @@
 // replaying on render function. This currently only patches the object
 // lazily which won't cover if the log function was extracted eagerly.
 // We could also eagerly patch the method.
+import {canUseDOM} from './ExecutionEnvironment';
 
 let disabledDepth = 0;
 let prevLog;
@@ -20,65 +21,85 @@ let prevError;
 let prevGroup;
 let prevGroupCollapsed;
 let prevGroupEnd;
+const {__REACT_DEVTOOLS_SUPPRESS_DOUBLE_LOGGING__: suppressLog} = canUseDOM
+  ? window
+  : global;
 
 function disabledLog() {}
 disabledLog.__reactDisabledLog = true;
 
+function patchConsole() {
+  /* eslint-disable react-internal/no-production-logging */
+  prevLog = console.log;
+  prevInfo = console.info;
+  prevWarn = console.warn;
+  prevError = console.error;
+  prevGroup = console.group;
+  prevGroupCollapsed = console.groupCollapsed;
+  prevGroupEnd = console.groupEnd;
+  // https://github.com/facebook/react/issues/19099
+  const props = {
+    configurable: true,
+    enumerable: true,
+    value: disabledLog,
+    writable: true,
+  };
+  // $FlowFixMe Flow thinks console is immutable.
+  Object.defineProperties(console, {
+    info: props,
+    log: props,
+    warn: props,
+    error: props,
+    group: props,
+    groupCollapsed: props,
+    groupEnd: props,
+  });
+  /* eslint-disable react-internal/no-production-logging */
+}
+
+function unPatchConsole() {
+  /* eslint-disable react-internal/no-production-logging */
+  const props = {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  };
+  // $FlowFixMe Flow thinks console is immutable.
+  Object.defineProperties(console, {
+    log: {...props, value: prevLog},
+    info: {...props, value: prevInfo},
+    warn: {...props, value: prevWarn},
+    error: {...props, value: prevError},
+    group: {...props, value: prevGroup},
+    groupCollapsed: {...props, value: prevGroupCollapsed},
+    groupEnd: {...props, value: prevGroupEnd},
+  });
+  /* eslint-enable react-internal/no-production-logging */
+}
+
+let suppressDoubleLogging = suppressLog;
 export function disableLogs(): void {
   if (__DEV__) {
     if (disabledDepth === 0) {
-      /* eslint-disable react-internal/no-production-logging */
-      prevLog = console.log;
-      prevInfo = console.info;
-      prevWarn = console.warn;
-      prevError = console.error;
-      prevGroup = console.group;
-      prevGroupCollapsed = console.groupCollapsed;
-      prevGroupEnd = console.groupEnd;
-      // https://github.com/facebook/react/issues/19099
-      const props = {
-        configurable: true,
-        enumerable: true,
-        value: disabledLog,
-        writable: true,
-      };
-      // $FlowFixMe Flow thinks console is immutable.
-      Object.defineProperties(console, {
-        info: props,
-        log: props,
-        warn: props,
-        error: props,
-        group: props,
-        groupCollapsed: props,
-        groupEnd: props,
-      });
-      /* eslint-enable react-internal/no-production-logging */
+      if (!suppressDoubleLogging) {
+        patchConsole();
+      }
     }
-    disabledDepth++;
   }
+  disabledDepth++;
 }
 
 export function reenableLogs(): void {
   if (__DEV__) {
     disabledDepth--;
     if (disabledDepth === 0) {
-      /* eslint-disable react-internal/no-production-logging */
-      const props = {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-      };
-      // $FlowFixMe Flow thinks console is immutable.
-      Object.defineProperties(console, {
-        log: {...props, value: prevLog},
-        info: {...props, value: prevInfo},
-        warn: {...props, value: prevWarn},
-        error: {...props, value: prevError},
-        group: {...props, value: prevGroup},
-        groupCollapsed: {...props, value: prevGroupCollapsed},
-        groupEnd: {...props, value: prevGroupEnd},
-      });
-      /* eslint-enable react-internal/no-production-logging */
+      try {
+        if (!suppressDoubleLogging) {
+          unPatchConsole();
+        }
+      } finally {
+        suppressDoubleLogging = suppressLog;
+      }
     }
     if (disabledDepth < 0) {
       console.error(


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 We currently plan to suppress double-logging in development by overriding console in #18547. However, this can be confusing for some scenarios and double logging may be preferable in them. This change adds a toggle to DevTools that would allow to re-enable it on this screen:

![90825360-b7372000-e330-11ea-9128-803d35d27e07](https://user-images.githubusercontent.com/23220841/91745574-13146b00-ebb3-11ea-9035-2eff4ed213a6.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
![Screenshot from 2020-09-04 00-18-20](https://user-images.githubusercontent.com/23220841/92182794-6ea95780-ee44-11ea-8156-0d77ec47487a.png)


