### PR TITLE
Add checkbox toggle for boolean values

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.css
@@ -3,7 +3,7 @@
   display: flex;
 }
 .CheckboxLabel:focus-within {
-  background-color: var(--color-button-background-focus);
+  /*background-color: var(--color-button-background-focus);*/
 }
 
 .Checkbox:focus {

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.css
@@ -1,13 +1,7 @@
-.CheckboxLabel {
-  flex: 1 1 100%;
-  display: flex;
-}
-.CheckboxLabel:focus-within {
-  /*background-color: var(--color-button-background-focus);*/
-}
-
-.Checkbox:focus {
-  outline: none;
+.Checkbox {
+  flex: 0 0 auto;
+  align-self: center;
+  margin: 0 0.25rem;
 }
 
 .Input {

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {Fragment, useRef} from 'react';
+import {Fragment} from 'react';
 import styles from './EditableValue.css';
 import {useEditableValue} from '../hooks';
 
@@ -27,7 +27,6 @@ export default function EditableValue({
   path,
   value,
 }: EditableValueProps) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
   const [state, dispatch] = useEditableValue(value);
   const {editableValue, hasPendingChanges, isValid, parsedValue} = state;
 
@@ -50,6 +49,12 @@ export default function EditableValue({
       editableValue: target.checked,
       externalValue: value,
     });
+
+    // Unlike <input type="text"> which has both an onChange and an onBlur,
+    // <input type="checkbox"> updates state *and* applies changes in a single event.
+    // So we read from target.checked rather than parsedValue (which has not yet updated).
+    // We also don't check isValid (because that hasn't changed yet either);
+    // we don't need to check it anyway, since target.checked is always a boolean.
     overrideValueFn(path, target.checked);
   };
 
@@ -93,7 +98,6 @@ export default function EditableValue({
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
-        ref={inputRef}
         type="text"
         value={editableValue}
       />

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -97,7 +97,7 @@ export default function EditableValue({
         type="text"
         value={editableValue}
       />
-       {isBool && (
+      {isBool && (
         <input
           className={styles.Checkbox}
           checked={parsedValue}

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -28,7 +28,6 @@ export default function EditableValue({
   value,
 }: EditableValueProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const checkBoxRef = useRef<HTMLInputElement | any>(null);
   const [state, dispatch] = useEditableValue(value);
   const {editableValue, hasPendingChanges, isValid, parsedValue} = state;
 
@@ -45,13 +44,13 @@ export default function EditableValue({
       externalValue: value,
     });
 
-  const handeCheckBoxToggle = ({target}) => {
+  const handleCheckBoxToggle = ({target}) => {
     dispatch({
       type: 'UPDATE',
       editableValue: target.checked,
       externalValue: value,
     });
-    applyChangesFromCheckBox();
+    overrideValueFn(path, target.checked);
   };
 
   const handleKeyDown = event => {
@@ -76,12 +75,6 @@ export default function EditableValue({
     }
   };
 
-  const applyChangesFromCheckBox = () => {
-    if (isValid) {
-      overrideValueFn(path, checkBoxRef.current.checked);
-    }
-  };
-
   let placeholder = '';
   if (editableValue === undefined) {
     placeholder = '(undefined)';
@@ -89,10 +82,8 @@ export default function EditableValue({
     placeholder = 'Enter valid JSON';
   }
 
-  let isBool = null;
-  if (parsedValue === true || parsedValue === false) {
-    isBool = parsedValue;
-  }
+  const isBool = parsedValue === true || parsedValue === false;
+
   return (
     <Fragment>
       <input
@@ -106,15 +97,13 @@ export default function EditableValue({
         type="text"
         value={editableValue}
       />
-      {typeof isBool === 'boolean' && (
-        <label className={styles.CheckboxLabel}>
-          <input
-            checked={isBool}
-            type="checkbox"
-            onClick={handeCheckBoxToggle}
-            ref={checkBoxRef}
-          />
-        </label>
+       {isBool && (
+        <input
+          className={styles.Checkbox}
+          checked={parsedValue}
+          type="checkbox"
+          onChange={handleCheckBoxToggle}
+        />
       )}
     </Fragment>
   );

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -50,7 +50,7 @@ export default function EditableValue({
       editableValue: target.checked,
       externalValue: value,
     });
-    applyChangesCheckBox();
+    applyChangesFromCheckBox();
   };
 
   const handleKeyDown = event => {
@@ -75,8 +75,8 @@ export default function EditableValue({
     }
   };
 
-  const applyChangesCheckBox = () => {
-    if (isValid && hasPendingChanges) {
+  const applyChangesFromCheckBox = () => {
+    if (isValid) {
       overrideValueFn(path, inputRef.current.checked);
     }
   };

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -43,6 +43,15 @@ export default function EditableValue({
       editableValue: target.value,
       externalValue: value,
     });
+  
+  const handeCheckBoxToggle = ({target})=> {
+    dispatch({
+      type: 'UPDATE',
+      editableValue: target.checked,
+      externalValue: value,
+    });
+    applyChangesCheckBox();
+  };
 
   const handleKeyDown = event => {
     // Prevent keydown events from e.g. change selected element in the tree
@@ -66,6 +75,12 @@ export default function EditableValue({
     }
   };
 
+  const applyChangesCheckBox = () => {
+    if (isValid && hasPendingChanges) {
+      overrideValueFn(path, inputRef.current.checked);
+    }
+  };
+
   let placeholder = '';
   if (editableValue === undefined) {
     placeholder = '(undefined)';
@@ -73,6 +88,10 @@ export default function EditableValue({
     placeholder = 'Enter valid JSON';
   }
 
+  let isBool=null;
+  if ( (parsedValue===true || parsedValue===false) ) {
+    isBool=parsedValue;
+  }
   return (
     <Fragment>
       <input
@@ -86,6 +105,14 @@ export default function EditableValue({
         type="text"
         value={editableValue}
       />
+      {typeof isBool==='boolean' && (<label className={styles.CheckboxLabel} >
+      <input 
+        checked={isBool}
+        type="checkbox"
+        onClick={handeCheckBoxToggle}
+        ref={inputRef}
+         />
+      </label>)}
     </Fragment>
   );
 }

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -28,6 +28,7 @@ export default function EditableValue({
   value,
 }: EditableValueProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const checkBoxRef = useRef<HTMLInputElement | any>(null);
   const [state, dispatch] = useEditableValue(value);
   const {editableValue, hasPendingChanges, isValid, parsedValue} = state;
 
@@ -77,7 +78,7 @@ export default function EditableValue({
 
   const applyChangesFromCheckBox = () => {
     if (isValid) {
-      overrideValueFn(path, inputRef.current.checked);
+      overrideValueFn(path, checkBoxRef.current.checked);
     }
   };
 
@@ -111,7 +112,7 @@ export default function EditableValue({
             checked={isBool}
             type="checkbox"
             onClick={handeCheckBoxToggle}
-            ref={inputRef}
+            ref={checkBoxRef}
           />
         </label>
       )}

--- a/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/EditableValue.js
@@ -43,8 +43,8 @@ export default function EditableValue({
       editableValue: target.value,
       externalValue: value,
     });
-  
-  const handeCheckBoxToggle = ({target})=> {
+
+  const handeCheckBoxToggle = ({target}) => {
     dispatch({
       type: 'UPDATE',
       editableValue: target.checked,
@@ -88,9 +88,9 @@ export default function EditableValue({
     placeholder = 'Enter valid JSON';
   }
 
-  let isBool=null;
-  if ( (parsedValue===true || parsedValue===false) ) {
-    isBool=parsedValue;
+  let isBool = null;
+  if (parsedValue === true || parsedValue === false) {
+    isBool = parsedValue;
   }
   return (
     <Fragment>
@@ -105,14 +105,16 @@ export default function EditableValue({
         type="text"
         value={editableValue}
       />
-      {typeof isBool==='boolean' && (<label className={styles.CheckboxLabel} >
-      <input 
-        checked={isBool}
-        type="checkbox"
-        onClick={handeCheckBoxToggle}
-        ref={inputRef}
-         />
-      </label>)}
+      {typeof isBool === 'boolean' && (
+        <label className={styles.CheckboxLabel}>
+          <input
+            checked={isBool}
+            type="checkbox"
+            onClick={handeCheckBoxToggle}
+            ref={inputRef}
+          />
+        </label>
+      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
Resolves #19662 

## Summary

Enhancement was made for react-devtools such that if a prop value is of type boolean, a checkbox appears to the left of the prop value, with relevant value-checked(if value of prop is true)/unchecked(if value of prop is false). On editing the prop value manually to any other valid value other than boolean the checkbox disappears.

## Test Plan

![boolean-toggle-devtools](https://user-images.githubusercontent.com/47082893/91502080-d7448180-e8e4-11ea-98a1-942da77443f8.gif)
