### PR TITLE
Revert "Append text string to <Text> error message (#19581)"

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -244,8 +244,7 @@ export function createTextInstance(
 ): TextInstance {
   invariant(
     hostContext.isInAParentText,
-    'Text string must be rendered within a <Text> component.\n\nText: %s',
-    text.length > 100 ? text.substr(0, 88) + ' (truncated)' : text,
+    'Text strings must be rendered within a <Text> component.',
   );
 
   const tag = nextReactTag;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -146,8 +146,7 @@ export function createTextInstance(
 ): TextInstance {
   invariant(
     hostContext.isInAParentText,
-    'Text string must be rendered within a <Text> component.\n\nText: %s',
-    text.length > 100 ? text.substr(0, 88) + ' (truncated)' : text,
+    'Text strings must be rendered within a <Text> component.',
   );
 
   const tag = allocateTag();

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -563,15 +563,7 @@ describe('ReactFabric', () => {
     }));
 
     expect(() => ReactFabric.render(<View>this should warn</View>, 11)).toThrow(
-      'Text string must be rendered within a <Text> component.\n\nText: this should warn',
-    );
-
-    expect(() =>
-      ReactFabric.render(<View>{'x'.repeat(200)}</View>, 11),
-    ).toThrow(
-      `Text string must be rendered within a <Text> component.\n\nText: ${'x'.repeat(
-        88,
-      )} (truncated)`,
+      'Text strings must be rendered within a <Text> component.',
     );
 
     expect(() =>
@@ -581,9 +573,7 @@ describe('ReactFabric', () => {
         </Text>,
         11,
       ),
-    ).toThrow(
-      'Text string must be rendered within a <Text> component.\n\nText: hi hello hi',
-    );
+    ).toThrow('Text strings must be rendered within a <Text> component.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -423,15 +423,7 @@ describe('ReactNative', () => {
     }));
 
     expect(() => ReactNative.render(<View>this should warn</View>, 11)).toThrow(
-      'Text string must be rendered within a <Text> component.\n\nText: this should warn',
-    );
-
-    expect(() =>
-      ReactNative.render(<View>{'x'.repeat(200)}</View>, 11),
-    ).toThrow(
-      `Text string must be rendered within a <Text> component.\n\nText: ${'x'.repeat(
-        88,
-      )} (truncated)`,
+      'Text strings must be rendered within a <Text> component.',
     );
 
     expect(() =>
@@ -441,9 +433,7 @@ describe('ReactNative', () => {
         </Text>,
         11,
       ),
-    ).toThrow(
-      'Text string must be rendered within a <Text> component.\n\nText: hi hello hi',
-    );
+    ).toThrow('Text strings must be rendered within a <Text> component.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {


### PR DESCRIPTION
This reverts commit 1a41a196bcb30d456d1692c4a40cb8273fa2cb92.

The reason for reverting this change is because of a potential security vulnerability associated with logging an error message using arbitrary user-supplied content. For example, if a plaintext password or credit card number were logged in an error message, it could be automatically uploaded to error management pipelines.