### PR TITLE
Add failing test for passive effect cleanup functions and memoized components

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1904,6 +1904,14 @@ function resetChildLanes(completedWork: Fiber) {
           mergeLanes(child.lanes, child.childLanes),
         );
 
+        // Preserve passive static flag even in the case of a bailout;
+        // otherwise a subsequent unmount may bailout before calling destroy functions.
+        subtreeTag |= child.subtreeTag & PassiveStaticSubtreeTag;
+        const effectTag = child.effectTag;
+        if ((effectTag & PassiveStatic) !== NoEffect) {
+          subtreeTag |= PassiveStaticSubtreeTag;
+        }
+
         treeBaseDuration += child.treeBaseDuration;
         child = child.sibling;
       }
@@ -1928,9 +1936,19 @@ function resetChildLanes(completedWork: Fiber) {
           mergeLanes(child.lanes, child.childLanes),
         );
 
+        // Preserve passive static flag even in the case of a bailout;
+        // otherwise a subsequent unmount may bailout before calling destroy functions.
+        subtreeTag |= child.subtreeTag & PassiveStaticSubtreeTag;
+        const effectTag = child.effectTag;
+        if ((effectTag & PassiveStatic) !== NoEffect) {
+          subtreeTag |= PassiveStaticSubtreeTag;
+        }
+
         child = child.sibling;
       }
     }
+
+    completedWork.subtreeTag |= subtreeTag;
   }
 
   completedWork.childLanes = newChildLanes;


### PR DESCRIPTION
Previously, if we bailed out during render (because of e.g. `memo`) we did not update the `subtreeTag`:
https://github.com/facebook/react/blob/2cfd73c4d02cfe4c745a1862ef4a9c44e8a41da4/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L1794-L1801

This was done to prevent us from e.g. calling layout and passive effect functions on the next commit. However it also meant that if a subsequent render unmounted the fiber, the traversal code that checks for passive effect cleanup would bailout also:
https://github.com/facebook/react/blob/2cfd73c4d02cfe4c745a1862ef4a9c44e8a41da4/packages/react-reconciler/src/ReactFiberWorkLoop.new.js#L2686-L2690

This PR fixes that by ensuring that we still bubble the special `PassiveStaticSubtreeTag` in the event of a bailout.