### PR TITLE
eslint-plugin-react-hooks: fix compatibility with @typescript-eslint/parser@4.0.0+

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -406,7 +406,10 @@ export default {
             });
           }
 
-          if (dependencyNode.parent.type === 'TSTypeQuery') {
+          if (
+            dependencyNode.parent.type === 'TSTypeQuery' ||
+            dependencyNode.parent.type === 'TSTypeReference'
+          ) {
             continue;
           }
 


### PR DESCRIPTION
## Summary

In addition to `TSTypeQuery`, dependency nodes with a `TSTypeReference`
parent need to be ignored as well. Without this fix, generic type
variables will be listed as missing dependencies.

Example:

```ts
export function useFoo<T>(): (foo: T) => boolean {
    return useCallback((foo: T) => false, []);
}
```

This will report the following issue:

    React Hook useCallback has a missing dependency: 'T'. Either include
    it or remove the dependency array

Closes: #19742

## Test Plan

I built the eslint-plugin-react-hooks bundle and copied it into the `node_modules` of my test project, which fixed the incorrect lint reports.

I don't think there is a good way to add a unit test for this, as the issue is TypeScript-specific?
