### PR TITLE
React DevTools: Show symbols used as keys in state

### DIFF
--- a/fixtures/devtools/standalone/index.html
+++ b/fixtures/devtools/standalone/index.html
@@ -209,54 +209,67 @@
       }
 
       const baseInheritedKeys = Object.create(Object.prototype, {
-      value1: {
+      enumerableStringBase: {
         value: 1,
         writable: true,
         enumerable: true,
         configurable: true,
       },
-      [Symbol('value1')]: {
+      [Symbol('enumerableSymbolBase')]: {
         value: 1,
         writable: true,
         enumerable: true,
+        configurable: true,
+      },
+      nonEnumerableStringBase: {
+        value: 1,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('nonEnumerableSymbolBase')]: {
+        value: 1,
+        writable: true,
+        enumerable: false,
         configurable: true,
       },
     });
 
     const inheritedKeys = Object.create(baseInheritedKeys, {
-      value2: {
+      enumerableString: {
         value: 2,
         writable: true,
         enumerable: true,
         configurable: true,
       },
-      value3: {
+      nonEnumerableString: {
         value: 3,
         writable: true,
         enumerable: false,
         configurable: true,
       },
-      3: {
+      123: {
         value: 3,
         writable: true,
         enumerable: true,
         configurable: true,
       },
-      [Symbol('value2')]: {
+      [Symbol('nonEnumerableSymbol')]: {
         value: 2,
         writable: true,
         enumerable: false,
         configurable: true,
       },
-      [Symbol('value3')]: {
+      [Symbol('enumerableSymbol')]: {
         value: 3,
         writable: true,
         enumerable: true,
         configurable: true,
       },
       });
+
       function InheritedKeys() {
-        return <ChildComponent inheritedKeys={inheritedKeys} />;
+        return <ChildComponent data={inheritedKeys} />;
       }
 
       const object = {

--- a/fixtures/devtools/standalone/index.html
+++ b/fixtures/devtools/standalone/index.html
@@ -208,6 +208,57 @@
         return <ChildComponent customObject={new Custom()} />;
       }
 
+      const baseInheritedKeys = Object.create(Object.prototype, {
+      value1: {
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('value1')]: {
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    });
+
+    const inheritedKeys = Object.create(baseInheritedKeys, {
+      value2: {
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      value3: {
+        value: 3,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      3: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('value2')]: {
+        value: 2,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('value3')]: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      });
+      function InheritedKeys() {
+        return <ChildComponent inheritedKeys={inheritedKeys} />;
+      }
+
       const object = {
         string: "abc",
         longString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKJLMNOPQRSTUVWXYZ1234567890",
@@ -294,6 +345,7 @@
             <ObjectProps />
             <UnserializableProps />
             <CustomObject />
+            <InheritedKeys />
           </Fragment>
         );
       }

--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -615,6 +615,25 @@ exports[`InspectedElementContext should support objects with overridden hasOwnPr
 }
 `;
 
+exports[`InspectedElementContext should support objects with with inherited keys: 1: Inspected element 2 1`] = `
+{
+  "id": 2,
+  "owners": null,
+  "context": null,
+  "hooks": null,
+  "props": {
+    "object": {
+      "3": 3,
+      "value2": 2,
+      "Symbol(value3)": 3,
+      "value1": 1,
+      "Symbol(value1)": 1
+    }
+  },
+  "state": null
+}
+`;
+
 exports[`InspectedElementContext should support simple data types: 1: Initial inspection 1`] = `
 {
   "id": 2,

--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -542,7 +542,7 @@ exports[`InspectedElementContext should support complex data types: 1: Inspected
       "inner": {}
     },
     "object_with_symbol": {
-      "Symbol(name)": "Hello World!"
+      "Symbol(name)": "hello"
     },
     "proxy": {},
     "react_element": {},

--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -623,11 +623,11 @@ exports[`InspectedElementContext should support objects with with inherited keys
   "hooks": null,
   "props": {
     "object": {
-      "3": 3,
-      "value2": 2,
-      "Symbol(value3)": 3,
-      "value1": 1,
-      "Symbol(value1)": 1
+      "123": 3,
+      "enumerableString": 2,
+      "Symbol(enumerableSymbol)": 3,
+      "enumerableStringBase": 1,
+      "Symbol(enumerableSymbolBase)": 1
     }
   },
   "state": null

--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/inspectedElementContext-test.js.snap
@@ -541,6 +541,9 @@ exports[`InspectedElementContext should support complex data types: 1: Inspected
     "object_of_objects": {
       "inner": {}
     },
+    "object_with_symbol": {
+      "Symbol(name)": "Hello World!"
+    },
     "proxy": {},
     "react_element": {},
     "regexp": {},

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -530,7 +530,10 @@ describe('InspectedElementContext', () => {
       ['second', mapShallow],
     ]);
     const objectOfObjects = {
-      inner: {str: 'ab', nb: 12, bool: true, [Symbol('sb')]: 'sb'},
+      inner: {string: 'abc', number: 123, boolean: true},
+    };
+    const objectWithSymbol = {
+      [Symbol('name')]: 'Hello World!',
     };
     const typedArray = Int8Array.from([100, -100, 0]);
     const arrayBuffer = typedArray.buffer;
@@ -575,6 +578,7 @@ describe('InspectedElementContext', () => {
           map={mapShallow}
           map_of_maps={mapOfMaps}
           object_of_objects={objectOfObjects}
+          object_with_symbol={objectWithSymbol}
           proxy={proxyInstance}
           react_element={<span />}
           regexp={/abc/giu}
@@ -628,6 +632,7 @@ describe('InspectedElementContext', () => {
       map,
       map_of_maps,
       object_of_objects,
+      object_with_symbol,
       proxy,
       react_element,
       regexp,
@@ -723,14 +728,16 @@ describe('InspectedElementContext', () => {
     );
     expect(map_of_maps[meta.preview_short]).toBe('Map(2)');
 
-    expect(object_of_objects.inner[meta.size]).toBe(4);
+    expect(object_of_objects.inner[meta.size]).toBe(3);
     expect(object_of_objects.inner[meta.inspectable]).toBe(true);
     expect(object_of_objects.inner[meta.name]).toBe('');
     expect(object_of_objects.inner[meta.type]).toBe('object');
     expect(object_of_objects.inner[meta.preview_long]).toBe(
-      '{Symbol(sb): "sb", bool: true, nb: 12, str: "ab"}',
+      '{boolean: true, number: 123, string: "abc"}',
     );
     expect(object_of_objects.inner[meta.preview_short]).toBe('{…}');
+    
+    expect(object_with_symbol['Symbol(name)']).toBe('Hello World!');
 
     expect(proxy[meta.inspectable]).toBe(false);
     expect(proxy[meta.name]).toBe('function');

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -736,7 +736,7 @@ describe('InspectedElementContext', () => {
       '{boolean: true, number: 123, string: "abc"}',
     );
     expect(object_of_objects.inner[meta.preview_short]).toBe('{…}');
-    
+
     expect(object_with_symbol['Symbol(name)']).toBe('Hello World!');
 
     expect(proxy[meta.inspectable]).toBe(false);

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -530,7 +530,7 @@ describe('InspectedElementContext', () => {
       ['second', mapShallow],
     ]);
     const objectOfObjects = {
-      inner: {string: 'abc', number: 123, boolean: true},
+      inner: {str: 'ab', nb: 12, bool: true, [Symbol('sb')]: 'sb'},
     };
     const typedArray = Int8Array.from([100, -100, 0]);
     const arrayBuffer = typedArray.buffer;
@@ -723,12 +723,12 @@ describe('InspectedElementContext', () => {
     );
     expect(map_of_maps[meta.preview_short]).toBe('Map(2)');
 
-    expect(object_of_objects.inner[meta.size]).toBe(3);
+    expect(object_of_objects.inner[meta.size]).toBe(4);
     expect(object_of_objects.inner[meta.inspectable]).toBe(true);
     expect(object_of_objects.inner[meta.name]).toBe('');
     expect(object_of_objects.inner[meta.type]).toBe('object');
     expect(object_of_objects.inner[meta.preview_long]).toBe(
-      '{boolean: true, number: 123, string: "abc"}',
+      '{Symbol(sb): "sb", bool: true, nb: 12, str: "ab"}',
     );
     expect(object_of_objects.inner[meta.preview_short]).toBe('{…}');
 

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -945,52 +945,65 @@ describe('InspectedElementContext', () => {
     const Example = () => null;
 
     const base = Object.create(Object.prototype, {
-      value1: {
+      enumerableStringBase: {
         value: 1,
         writable: true,
         enumerable: true,
         configurable: true,
       },
-      [Symbol('value1')]: {
+      [Symbol('enumerableSymbolBase')]: {
         value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      nonEnumerableStringBase: {
+        value: 1,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('nonEnumerableSymbolBase')]: {
+        value: 1,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    });
+
+    const object = Object.create(base, {
+      enumerableString: {
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      nonEnumerableString: {
+        value: 3,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [123]: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('nonEnumerableSymbol')]: {
+        value: 2,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('enumerableSymbol')]: {
+        value: 3,
         writable: true,
         enumerable: true,
         configurable: true,
       },
     });
 
-    const object = Object.create(base, {
-      value2: {
-        value: 2,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-      value3: {
-        value: 3,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      },
-      3: {
-        value: 3,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-      [Symbol('value2')]: {
-        value: 2,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      },
-      [Symbol('value3')]: {
-        value: 3,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-    });
     const container = document.createElement('div');
     await utils.actAsync(() =>
       ReactDOM.render(<Example object={object} />, container),
@@ -1023,11 +1036,11 @@ describe('InspectedElementContext', () => {
     expect(inspectedElement).not.toBeNull();
     expect(inspectedElement).toMatchSnapshot(`1: Inspected element ${id}`);
     expect(inspectedElement.props.object).toEqual({
-      '3': 3,
-      'Symbol(value1)': 1,
-      'Symbol(value3)': 3,
-      value1: 1,
-      value2: 2,
+      123: 3,
+      'Symbol(enumerableSymbol)': 3,
+      'Symbol(enumerableSymbolBase)': 1,
+      enumerableString: 2,
+      enumerableStringBase: 1,
     });
 
     done();

--- a/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElementContext-test.js
@@ -533,7 +533,7 @@ describe('InspectedElementContext', () => {
       inner: {string: 'abc', number: 123, boolean: true},
     };
     const objectWithSymbol = {
-      [Symbol('name')]: 'Hello World!',
+      [Symbol('name')]: 'hello',
     };
     const typedArray = Int8Array.from([100, -100, 0]);
     const arrayBuffer = typedArray.buffer;
@@ -737,7 +737,7 @@ describe('InspectedElementContext', () => {
     );
     expect(object_of_objects.inner[meta.preview_short]).toBe('{…}');
 
-    expect(object_with_symbol['Symbol(name)']).toBe('Hello World!');
+    expect(object_with_symbol['Symbol(name)']).toBe('hello');
 
     expect(proxy[meta.inspectable]).toBe(false);
     expect(proxy[meta.name]).toBe('function');

--- a/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
@@ -236,6 +236,29 @@ Object {
 }
 `;
 
+exports[`InspectedElementContext should support objects with with inherited keys: 1: Initial inspection 1`] = `
+Object {
+  "id": 2,
+  "type": "full-data",
+  "value": {
+  "id": 2,
+  "owners": null,
+  "context": {},
+  "hooks": null,
+  "props": {
+    "data": {
+      "3": 3,
+      "value2": 2,
+      "Symbol(value3)": 3,
+      "value1": 1,
+      "Symbol(value1)": 1
+    }
+  },
+  "state": null
+},
+}
+`;
+
 exports[`InspectedElementContext should support simple data types: 1: Initial inspection 1`] = `
 Object {
   "id": 2,

--- a/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/legacy/__snapshots__/inspectElement-test.js.snap
@@ -247,11 +247,11 @@ Object {
   "hooks": null,
   "props": {
     "data": {
-      "3": 3,
-      "value2": 2,
-      "Symbol(value3)": 3,
-      "value1": 1,
-      "Symbol(value1)": 1
+      "123": 3,
+      "enumerableString": 2,
+      "Symbol(enumerableSymbol)": 3,
+      "enumerableStringBase": 1,
+      "Symbol(enumerableSymbolBase)": 1
     }
   },
   "state": null

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -483,10 +483,7 @@ describe('InspectedElementContext', () => {
       },
     });
     act(() =>
-      ReactDOM.render(
-        <Example data={object} />,
-        document.createElement('div'),
-      ),
+      ReactDOM.render(<Example data={object} />, document.createElement('div')),
     );
 
     const id = ((store.getElementIDAtIndex(0): any): number);

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -432,6 +432,71 @@ describe('InspectedElementContext', () => {
     done();
   });
 
+  it('should support objects with with inherited keys', async done => {
+    const Example = () => null;
+
+    const base = Object.create(Object.prototype, {
+      value1: {
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('value1')]: {
+        value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    });
+
+    const object = Object.create(base, {
+      value2: {
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      value3: {
+        value: 3,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      3: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('value2')]: {
+        value: 2,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('value3')]: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+    });
+    act(() =>
+      ReactDOM.render(
+        <Example data={object} />,
+        document.createElement('div'),
+      ),
+    );
+
+    const id = ((store.getElementIDAtIndex(0): any): number);
+    const inspectedElement = await read(id);
+
+    expect(inspectedElement).toMatchSnapshot('1: Initial inspection');
+
+    done();
+  });
+
   it('should not dehydrate nested values until explicitly requested', async done => {
     const Example = () => null;
 

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -436,52 +436,65 @@ describe('InspectedElementContext', () => {
     const Example = () => null;
 
     const base = Object.create(Object.prototype, {
-      value1: {
+      enumerableStringBase: {
         value: 1,
         writable: true,
         enumerable: true,
         configurable: true,
       },
-      [Symbol('value1')]: {
+      [Symbol('enumerableSymbolBase')]: {
         value: 1,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      nonEnumerableStringBase: {
+        value: 1,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('nonEnumerableSymbolBase')]: {
+        value: 1,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    });
+
+    const object = Object.create(base, {
+      enumerableString: {
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      nonEnumerableString: {
+        value: 3,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [123]: {
+        value: 3,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      },
+      [Symbol('nonEnumerableSymbol')]: {
+        value: 2,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+      [Symbol('enumerableSymbol')]: {
+        value: 3,
         writable: true,
         enumerable: true,
         configurable: true,
       },
     });
 
-    const object = Object.create(base, {
-      value2: {
-        value: 2,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-      value3: {
-        value: 3,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      },
-      3: {
-        value: 3,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-      [Symbol('value2')]: {
-        value: 2,
-        writable: true,
-        enumerable: false,
-        configurable: true,
-      },
-      [Symbol('value3')]: {
-        value: 3,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      },
-    });
     act(() =>
       ReactDOM.render(<Example data={object} />, document.createElement('div')),
     );

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -88,7 +88,7 @@ function createDehydrated(
   if (type === 'array' || type === 'typed_array') {
     dehydrated.size = data.length;
   } else if (type === 'object') {
-    dehydrated.size = Object.keys(data).length;
+    dehydrated.size = Reflect.ownKeys(data).length;
   }
 
   if (type === 'iterator' || type === 'typed_array') {
@@ -291,16 +291,17 @@ export function dehydrate(
         return createDehydrated(type, true, data, cleaned, path);
       } else {
         const object = {};
-        for (const name in data) {
+        Reflect.ownKeys(data).forEach((key) => {
+          const name = key.toString()
           object[name] = dehydrate(
-            data[name],
+            data[key],
             cleaned,
             unserializable,
             path.concat([name]),
             isPathAllowed,
             isPathAllowedCheck ? 1 : level + 1,
           );
-        }
+        })
         return object;
       }
 

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -10,6 +10,7 @@
 import {
   getDataType,
   getDisplayNameForReactElement,
+  getAllEnumerableKeys,
   getInObject,
   formatDataForPreview,
   setInObject,
@@ -88,7 +89,7 @@ function createDehydrated(
   if (type === 'array' || type === 'typed_array') {
     dehydrated.size = data.length;
   } else if (type === 'object') {
-    dehydrated.size = Reflect.ownKeys(data).length;
+    dehydrated.size = Object.keys(data).length;
   }
 
   if (type === 'iterator' || type === 'typed_array') {
@@ -291,7 +292,7 @@ export function dehydrate(
         return createDehydrated(type, true, data, cleaned, path);
       } else {
         const object = {};
-        Reflect.ownKeys(data).forEach(key => {
+        getAllEnumerableKeys(data).forEach(key => {
           const name = key.toString();
           object[name] = dehydrate(
             data[key],

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -291,8 +291,8 @@ export function dehydrate(
         return createDehydrated(type, true, data, cleaned, path);
       } else {
         const object = {};
-        Reflect.ownKeys(data).forEach((key) => {
-          const name = key.toString()
+        Reflect.ownKeys(data).forEach(key => {
+          const name = key.toString();
           object[name] = dehydrate(
             data[key],
             cleaned,
@@ -301,7 +301,7 @@ export function dehydrate(
             isPathAllowed,
             isPathAllowedCheck ? 1 : level + 1,
           );
-        })
+        });
         return object;
       }
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -69,11 +69,21 @@ export function getAllEnumerableKeys(
   obj: Object,
 ): Array<string | number | Symbol> {
   const keys = [];
-  for (const key in obj) {
-    keys.push(key);
+  let current = obj;
+  while (current != null) {
+    const currentKeys = [
+      ...Object.keys(current),
+      ...Object.getOwnPropertySymbols(current),
+    ];
+    const descriptors = Object.getOwnPropertyDescriptors(current);
+    currentKeys.forEach(key => {
+      if (descriptors[key].enumerable) {
+        keys.push(key);
+      }
+    });
+    current = Object.getPrototypeOf(current);
   }
-
-  return keys.concat(Object.getOwnPropertySymbols(obj));
+  return keys;
 }
 
 export function getDisplayName(

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -65,6 +65,17 @@ export function alphaSortKeys(
   }
 }
 
+export function getAllEnumerableKeys(
+  obj: Object,
+): Array<string | number | Symbol> {
+  const keys = [];
+  for (const key in obj) {
+    keys.push(key);
+  }
+
+  return keys.concat(Object.getOwnPropertySymbols(obj));
+}
+
 export function getDisplayName(
   type: Function,
   fallbackName: string = 'Anonymous',
@@ -660,7 +671,7 @@ export function formatDataForPreview(
       return data.toString();
     case 'object':
       if (showFormattedValue) {
-        const keys = Reflect.ownKeys(data).sort(alphaSortKeys);
+        const keys = getAllEnumerableKeys(data).sort(alphaSortKeys);
 
         let formatted = '';
         for (let i = 0; i < keys.length; i++) {

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -52,7 +52,10 @@ const cachedDisplayNames: WeakMap<Function, string> = new WeakMap();
 // Try to reuse the already encoded strings.
 const encodedStringCache = new LRU({max: 1000});
 
-export function alphaSortKeys(a: string|number|Symbol, b: string|number|Symbol): number {
+export function alphaSortKeys(
+  a: string | number | Symbol,
+  b: string | number | Symbol,
+): number {
   if (a.toString() > b.toString()) {
     return 1;
   } else if (b.toString() > a.toString()) {
@@ -665,7 +668,10 @@ export function formatDataForPreview(
           if (i > 0) {
             formatted += ', ';
           }
-          formatted += `${key.toString()}: ${formatDataForPreview(data[key], false)}`;
+          formatted += `${key.toString()}: ${formatDataForPreview(
+            data[key],
+            false,
+          )}`;
           if (formatted.length > MAX_PREVIEW_STRING_LENGTH) {
             // Prevent doing a lot of unnecessary iteration...
             break;

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -77,6 +77,7 @@ export function getAllEnumerableKeys(
     ];
     const descriptors = Object.getOwnPropertyDescriptors(current);
     currentKeys.forEach(key => {
+      // $FlowFixMe: key can be a Symbol https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
       if (descriptors[key].enumerable) {
         keys.push(key);
       }

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -52,10 +52,10 @@ const cachedDisplayNames: WeakMap<Function, string> = new WeakMap();
 // Try to reuse the already encoded strings.
 const encodedStringCache = new LRU({max: 1000});
 
-export function alphaSortKeys(a: string, b: string): number {
-  if (a > b) {
+export function alphaSortKeys(a: string|number|Symbol, b: string|number|Symbol): number {
+  if (a.toString() > b.toString()) {
     return 1;
-  } else if (b > a) {
+  } else if (b.toString() > a.toString()) {
     return -1;
   } else {
     return 0;
@@ -657,7 +657,7 @@ export function formatDataForPreview(
       return data.toString();
     case 'object':
       if (showFormattedValue) {
-        const keys = Object.keys(data).sort(alphaSortKeys);
+        const keys = Reflect.ownKeys(data).sort(alphaSortKeys);
 
         let formatted = '';
         for (let i = 0; i < keys.length; i++) {
@@ -665,7 +665,7 @@ export function formatDataForPreview(
           if (i > 0) {
             formatted += ', ';
           }
-          formatted += `${key}: ${formatDataForPreview(data[key], false)}`;
+          formatted += `${key.toString()}: ${formatDataForPreview(data[key], false)}`;
           if (formatted.length > MAX_PREVIEW_STRING_LENGTH) {
             // Prevent doing a lot of unnecessary iteration...
             break;

--- a/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
@@ -17,6 +17,7 @@ import CustomObject from './CustomObject';
 import EdgeCaseObjects from './EdgeCaseObjects.js';
 import NestedProps from './NestedProps';
 import SimpleValues from './SimpleValues';
+import SymbolKeys from './SymbolKeys';
 
 // TODO Add Immutable JS example
 
@@ -32,6 +33,7 @@ export default function InspectableElements() {
       <CustomObject />
       <EdgeCaseObjects />
       <CircularReferences />
+      <SymbolKeys />
     </Fragment>
   );
 }

--- a/packages/react-devtools-shell/src/app/InspectableElements/SymbolKeys.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/SymbolKeys.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+const base = Object.create(Object.prototype, {
+  enumerableStringBase: {
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  },
+  [Symbol('enumerableSymbolBase')]: {
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  },
+  nonEnumerableStringBase: {
+    value: 1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  },
+  [Symbol('nonEnumerableSymbolBase')]: {
+    value: 1,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  },
+});
+
+const data = Object.create(base, {
+  enumerableString: {
+    value: 2,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  },
+  nonEnumerableString: {
+    value: 3,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  },
+  [123]: {
+    value: 3,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  },
+  [Symbol('nonEnumerableSymbol')]: {
+    value: 2,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  },
+  [Symbol('enumerableSymbol')]: {
+    value: 3,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  },
+});
+
+export default function SymbolKeys() {
+  return <ChildComponent data={data} />;
+}
+
+function ChildComponent(props: any) {
+  return null;
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.



  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
The issue #19784  is due when we trying to retrieve the keys of an object. We use `for ..in,` the problem with `for in in` is that it is return only the enumerable keys without symbol so the solution is to add `Object.GetOwnPropertySymbols()` in our keys.
![image](https://user-images.githubusercontent.com/15034695/92471811-d8c15400-f1d8-11ea-976a-121c50088d18.png)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
