### PR TITLE
Internal `act`: Flush timers at end of scope

### DIFF
--- a/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtilsAct.js
@@ -126,8 +126,9 @@ export function unstable_concurrentAct(scope: () => Thenable<mixed> | void) {
 }
 
 function flushActWork(resolve, reject) {
-  // TODO: Run timers to flush suspended fallbacks
-  // jest.runOnlyPendingTimers();
+  // Flush suspended fallbacks
+  // $FlowFixMe: Flow doesn't know about global Jest object
+  jest.runOnlyPendingTimers();
   enqueueTask(() => {
     try {
       const didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -1175,8 +1175,9 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   }
 
   function flushActWork(resolve, reject) {
-    // TODO: Run timers to flush suspended fallbacks
-    // jest.runOnlyPendingTimers();
+    // Flush suspended fallbacks
+    // $FlowFixMe: Flow doesn't know about global Jest object
+    jest.runOnlyPendingTimers();
     enqueueTask(() => {
       try {
         const didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -14,6 +14,7 @@ let useState;
 let Suspense;
 let block;
 let readString;
+let resolvePromises;
 let Scheduler;
 
 describe('ReactBlocks', () => {
@@ -28,15 +29,16 @@ describe('ReactBlocks', () => {
     useState = React.useState;
     Suspense = React.Suspense;
     const cache = new Map();
+    let unresolved = [];
     readString = function(text) {
       let entry = cache.get(text);
       if (!entry) {
         entry = {
           promise: new Promise(resolve => {
-            setTimeout(() => {
+            unresolved.push(() => {
               entry.resolved = true;
               resolve();
-            }, 100);
+            });
           }),
           resolved: false,
         };
@@ -46,6 +48,12 @@ describe('ReactBlocks', () => {
         throw entry.promise;
       }
       return text;
+    };
+
+    resolvePromises = () => {
+      const res = unresolved;
+      unresolved = [];
+      res.forEach(r => r());
     };
   });
 
@@ -144,7 +152,7 @@ describe('ReactBlocks', () => {
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
 
     await ReactNoop.act(async () => {
-      jest.advanceTimersByTime(1000);
+      resolvePromises();
     });
 
     expect(ReactNoop).toMatchRenderedOutput(<span>Name: Sebastian</span>);
@@ -291,7 +299,7 @@ describe('ReactBlocks', () => {
       ReactNoop.render(<App Page={loadParent('Sebastian')} />);
     });
     await ReactNoop.act(async () => {
-      jest.advanceTimersByTime(1000);
+      resolvePromises();
     });
     expect(ReactNoop).toMatchRenderedOutput(<span>Name: Sebastian</span>);
   });
@@ -336,7 +344,7 @@ describe('ReactBlocks', () => {
     });
     await ReactNoop.act(async () => {
       _setSuspend(false);
-      jest.advanceTimersByTime(1000);
+      resolvePromises();
     });
     expect(ReactNoop).toMatchRenderedOutput(<span>Sebastian</span>);
   });

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -684,8 +684,9 @@ function unstable_concurrentAct(scope: () => Thenable<mixed> | void) {
 }
 
 function flushActWork(resolve, reject) {
-  // TODO: Run timers to flush suspended fallbacks
-  // jest.runOnlyPendingTimers();
+  // Flush suspended fallbacks
+  // $FlowFixMe: Flow doesn't know about global Jest object
+  jest.runOnlyPendingTimers();
   enqueueTask(() => {
     try {
       const didFlushWork = Scheduler.unstable_flushAllWithoutAsserting();

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -42,6 +42,7 @@ module.exports = {
 
     // jest
     expect: true,
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 5,

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -42,6 +42,7 @@ module.exports = {
 
     // jest
     expect: true,
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 2015,

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -36,6 +36,9 @@ module.exports = {
     // Flight
     Uint8Array: true,
     Promise: true,
+
+    // jest
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 5,

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -31,6 +31,9 @@ module.exports = {
     ArrayBuffer: true,
 
     TaskController: true,
+
+    // jest
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 5,

--- a/scripts/rollup/validate/eslintrc.umd.js
+++ b/scripts/rollup/validate/eslintrc.umd.js
@@ -43,6 +43,9 @@ module.exports = {
     // Flight Webpack
     __webpack_chunk_load__: true,
     __webpack_require__: true,
+
+    // jest
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 5,


### PR DESCRIPTION
If there are any suspended fallbacks at the end of the `act` scope, force them to display by running the pending timers (i.e. `setTimeout`).

The public implementation of `act` achieves the same behavior with an extra check in the work loop (`shouldForceFlushFallbacks`). Since our internal `act` needs to work in both development and production, without additional runtime checks, we instead rely on Jest's mock timers.

This doesn't not affect refresh transitions, which are meant to delay indefinitely, because in that case we exit the work loop without posting a timer.

Also doesn't affect the public `act`, only the internal one used by our tests.