### PR TITLE
[Events] Make passiveness and priority non-configurable

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -20,7 +20,6 @@ import type {
   SuspenseInstance,
   Props,
 } from './ReactDOMHostConfig';
-import type {DOMEventName} from '../events/DOMEventNames';
 
 import {
   HostComponent,
@@ -43,16 +42,6 @@ const internalContainerInstanceKey = '__reactContainer$' + randomKey;
 const internalEventHandlersKey = '__reactEvents$' + randomKey;
 const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
 const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
-
-export type ElementListenerMap = Map<
-  DOMEventName | string,
-  ElementListenerMapEntry | null,
->;
-
-export type ElementListenerMapEntry = {
-  passive: void | boolean,
-  listener: any => void,
-};
 
 export function precacheFiberNode(
   hostInst: Fiber,
@@ -207,12 +196,12 @@ export function updateFiberProps(
   (node: any)[internalPropsKey] = props;
 }
 
-export function getEventListenerMap(node: EventTarget): ElementListenerMap {
-  let elementListenerMap = (node: any)[internalEventHandlersKey];
-  if (elementListenerMap === undefined) {
-    elementListenerMap = (node: any)[internalEventHandlersKey] = new Map();
+export function getEventListenerSet(node: EventTarget): Set<string> {
+  let elementListenerSet = (node: any)[internalEventHandlersKey];
+  if (elementListenerSet === undefined) {
+    elementListenerSet = (node: any)[internalEventHandlersKey] = new Set();
   }
-  return elementListenerMap;
+  return elementListenerSet;
 }
 
 export function getFiberFromScopeInstance(

--- a/packages/react-dom/src/client/ReactDOMEventHandle.js
+++ b/packages/react-dom/src/client/ReactDOMEventHandle.js
@@ -8,13 +8,12 @@
  */
 
 import type {DOMEventName} from '../events/DOMEventNames';
-import type {EventPriority, ReactScopeInstance} from 'shared/ReactTypes';
+import type {ReactScopeInstance} from 'shared/ReactTypes';
 import type {
   ReactDOMEventHandle,
   ReactDOMEventHandleListener,
 } from '../shared/ReactDOMTypes';
 
-import {getEventPriorityForListenerSystem} from '../events/DOMEventProperties';
 import {allNativeEvents} from '../events/EventRegistry';
 import {
   getClosestInstanceFromNode,
@@ -25,10 +24,7 @@ import {
   addEventHandleToTarget,
 } from './ReactDOMComponentTree';
 import {ELEMENT_NODE, COMMENT_NODE} from '../shared/HTMLNodeType';
-import {
-  listenToNativeEvent,
-  addEventTypeToDispatchConfig,
-} from '../events/DOMPluginEventSystem';
+import {listenToNativeEvent} from '../events/DOMPluginEventSystem';
 
 import {HostRoot, HostPortal} from 'react-reconciler/src/ReactWorkTags';
 import {IS_EVENT_HANDLE_NON_MANAGED_NODE} from '../events/EventSystemFlags';
@@ -42,8 +38,6 @@ import invariant from 'shared/invariant';
 
 type EventHandleOptions = {|
   capture?: boolean,
-  passive?: boolean,
-  priority?: EventPriority,
 |};
 
 function getNearestRootOrPortalContainer(node: Fiber): null | Element {
@@ -82,76 +76,76 @@ function createEventHandleListener(
 function registerEventOnNearestTargetContainer(
   targetFiber: Fiber,
   domEventName: DOMEventName,
-  isPassiveListener: boolean | void,
-  listenerPriority: EventPriority | void,
   isCapturePhaseListener: boolean,
   targetElement: Element | null,
 ): void {
-  // If it is, find the nearest root or portal and make it
-  // our event handle target container.
-  let targetContainer = getNearestRootOrPortalContainer(targetFiber);
-  if (targetContainer === null) {
-    invariant(
-      false,
-      'ReactDOM.createEventHandle: setListener called on an target ' +
-        'that did not have a corresponding root. This is likely a bug in React.',
+  if (!enableEagerRootListeners) {
+    // If it is, find the nearest root or portal and make it
+    // our event handle target container.
+    let targetContainer = getNearestRootOrPortalContainer(targetFiber);
+    if (targetContainer === null) {
+      if (__DEV__) {
+        console.error(
+          'ReactDOM.createEventHandle: setListener called on an target ' +
+            'that did not have a corresponding root. This is likely a bug in React.',
+        );
+      }
+      return;
+    }
+    if (targetContainer.nodeType === COMMENT_NODE) {
+      targetContainer = ((targetContainer.parentNode: any): Element);
+    }
+    listenToNativeEvent(
+      domEventName,
+      isCapturePhaseListener,
+      targetContainer,
+      targetElement,
     );
   }
-  if (targetContainer.nodeType === COMMENT_NODE) {
-    targetContainer = ((targetContainer.parentNode: any): Element);
-  }
-  listenToNativeEvent(
-    domEventName,
-    isCapturePhaseListener,
-    targetContainer,
-    targetElement,
-    isPassiveListener,
-    listenerPriority,
-  );
 }
 
 function registerReactDOMEvent(
   target: EventTarget | ReactScopeInstance,
   domEventName: DOMEventName,
-  isPassiveListener: boolean | void,
   isCapturePhaseListener: boolean,
-  listenerPriority: EventPriority | void,
 ): void {
   // Check if the target is a DOM element.
   if ((target: any).nodeType === ELEMENT_NODE) {
-    const targetElement = ((target: any): Element);
-    // Check if the DOM element is managed by React.
-    const targetFiber = getClosestInstanceFromNode(targetElement);
-    if (targetFiber === null) {
-      invariant(
-        false,
-        'ReactDOM.createEventHandle: setListener called on an element ' +
-          'target that is not managed by React. Ensure React rendered the DOM element.',
+    if (!enableEagerRootListeners) {
+      const targetElement = ((target: any): Element);
+      // Check if the DOM element is managed by React.
+      const targetFiber = getClosestInstanceFromNode(targetElement);
+      if (targetFiber === null) {
+        if (__DEV__) {
+          console.error(
+            'ReactDOM.createEventHandle: setListener called on an element ' +
+              'target that is not managed by React. Ensure React rendered the DOM element.',
+          );
+        }
+        return;
+      }
+      registerEventOnNearestTargetContainer(
+        targetFiber,
+        domEventName,
+        isCapturePhaseListener,
+        targetElement,
       );
     }
-    registerEventOnNearestTargetContainer(
-      targetFiber,
-      domEventName,
-      isPassiveListener,
-      listenerPriority,
-      isCapturePhaseListener,
-      targetElement,
-    );
   } else if (enableScopeAPI && isReactScope(target)) {
-    const scopeTarget = ((target: any): ReactScopeInstance);
-    const targetFiber = getFiberFromScopeInstance(scopeTarget);
-    if (targetFiber === null) {
-      // Scope is unmounted, do not proceed.
-      return;
+    if (!enableEagerRootListeners) {
+      const scopeTarget = ((target: any): ReactScopeInstance);
+      const targetFiber = getFiberFromScopeInstance(scopeTarget);
+      if (targetFiber === null) {
+        // Scope is unmounted, do not proceed.
+        return;
+      }
+      registerEventOnNearestTargetContainer(
+        targetFiber,
+        domEventName,
+        isCapturePhaseListener,
+        null,
+      );
     }
-    registerEventOnNearestTargetContainer(
-      targetFiber,
-      domEventName,
-      isPassiveListener,
-      listenerPriority,
-      isCapturePhaseListener,
-      null,
-    );
   } else if (isValidEventTarget(target)) {
     const eventTarget = ((target: any): EventTarget);
     // These are valid event targets, but they are also
@@ -161,8 +155,6 @@ function registerReactDOMEvent(
       isCapturePhaseListener,
       eventTarget,
       null,
-      isPassiveListener,
-      listenerPriority,
       IS_EVENT_HANDLE_NON_MANAGED_NODE,
     );
   } else {
@@ -181,46 +173,27 @@ export function createEventHandle(
   if (enableCreateEventHandleAPI) {
     const domEventName = ((type: any): DOMEventName);
 
-    if (enableEagerRootListeners) {
-      // We cannot support arbitrary native events with eager root listeners
-      // because the eager strategy relies on knowing the whole list ahead of time.
-      // If we wanted to support this, we'd have to add code to keep track
-      // (or search) for all portal and root containers, and lazily add listeners
-      // to them whenever we see a previously unknown event. This seems like a lot
-      // of complexity for something we don't even have a particular use case for.
-      // Unfortunately, the downside of this invariant is that *removing* a native
-      // event from the list of known events has now become a breaking change for
-      // any code relying on the createEventHandle API.
-      invariant(
-        allNativeEvents.has(domEventName) ||
-          domEventName === 'beforeblur' ||
-          domEventName === 'afterblur',
-        'Cannot call unstable_createEventHandle with "%s", as it is not an event known to React.',
-        domEventName,
-      );
-    }
+    // We cannot support arbitrary native events with eager root listeners
+    // because the eager strategy relies on knowing the whole list ahead of time.
+    // If we wanted to support this, we'd have to add code to keep track
+    // (or search) for all portal and root containers, and lazily add listeners
+    // to them whenever we see a previously unknown event. This seems like a lot
+    // of complexity for something we don't even have a particular use case for.
+    // Unfortunately, the downside of this invariant is that *removing* a native
+    // event from the list of known events has now become a breaking change for
+    // any code relying on the createEventHandle API.
+    invariant(
+      allNativeEvents.has(domEventName),
+      'Cannot call unstable_createEventHandle with "%s", as it is not an event known to React.',
+      domEventName,
+    );
 
     let isCapturePhaseListener = false;
-    let isPassiveListener = undefined; // Undefined means to use the browser default
-    let listenerPriority;
-
     if (options != null) {
       const optionsCapture = options.capture;
-      const optionsPassive = options.passive;
-      const optionsPriority = options.priority;
-
       if (typeof optionsCapture === 'boolean') {
         isCapturePhaseListener = optionsCapture;
       }
-      if (typeof optionsPassive === 'boolean') {
-        isPassiveListener = optionsPassive;
-      }
-      if (typeof optionsPriority === 'number') {
-        listenerPriority = optionsPriority;
-      }
-    }
-    if (listenerPriority === undefined) {
-      listenerPriority = getEventPriorityForListenerSystem(domEventName);
     }
 
     const eventHandle = (
@@ -234,15 +207,7 @@ export function createEventHandle(
       );
       if (!doesTargetHaveEventHandle(target, eventHandle)) {
         addEventHandleToTarget(target, eventHandle);
-        registerReactDOMEvent(
-          target,
-          domEventName,
-          isPassiveListener,
-          isCapturePhaseListener,
-          listenerPriority,
-        );
-        // Add the event to our known event types list.
-        addEventTypeToDispatchConfig(domEventName);
+        registerReactDOMEvent(target, domEventName, isCapturePhaseListener);
       }
       const listener = createEventHandleListener(
         domEventName,

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -89,6 +89,10 @@ const otherDiscreteEvents: Array<DOMEventName> = [
 ];
 
 if (enableCreateEventHandleAPI) {
+  // Special case: these two events don't have on* React handler
+  // and are only accessible via the createEventHandle API.
+  topLevelEventsToReactNames.set('beforeblur', null);
+  topLevelEventsToReactNames.set('afterblur', null);
   otherDiscreteEvents.push('beforeblur', 'afterblur');
 }
 
@@ -202,7 +206,7 @@ export function getEventPriorityForListenerSystem(
   if (__DEV__) {
     console.warn(
       'The event "%s" provided to createEventHandle() does not have a known priority type.' +
-        ' It is recommended to provide a "priority" option to specify a priority.',
+        ' This is likely a bug in React.',
       type,
     );
   }

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -19,8 +19,6 @@ import type {
   KnownReactSyntheticEvent,
   ReactSyntheticEvent,
 } from './ReactSyntheticEventType';
-import type {ElementListenerMapEntry} from '../client/ReactDOMComponentTree';
-import type {EventPriority} from 'shared/ReactTypes';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {registrationNameDependencies, allNativeEvents} from './EventRegistry';
@@ -41,7 +39,7 @@ import {
 import getEventTarget from './getEventTarget';
 import {
   getClosestInstanceFromNode,
-  getEventListenerMap,
+  getEventListenerSet,
   getEventHandlerListeners,
 } from '../client/ReactDOMComponentTree';
 import {COMMENT_NODE} from '../shared/HTMLNodeType';
@@ -69,7 +67,6 @@ import {
   addEventBubbleListenerWithPassiveFlag,
   addEventCaptureListenerWithPassiveFlag,
 } from './EventListener';
-import {topLevelEventsToReactNames} from './DOMEventProperties';
 import * as BeforeInputEventPlugin from './plugins/BeforeInputEventPlugin';
 import * as ChangeEventPlugin from './plugins/ChangeEventPlugin';
 import * as EnterLeaveEventPlugin from './plugins/EnterLeaveEventPlugin';
@@ -296,36 +293,24 @@ function dispatchEventsForPlugins(
   processDispatchQueue(dispatchQueue, eventSystemFlags);
 }
 
-function shouldUpgradeListener(
-  listenerEntry: void | ElementListenerMapEntry,
-  passive: void | boolean,
-): boolean {
-  return (
-    listenerEntry !== undefined && listenerEntry.passive === true && !passive
-  );
-}
-
 export function listenToNonDelegatedEvent(
   domEventName: DOMEventName,
   targetElement: Element,
 ): void {
   const isCapturePhaseListener = false;
-  const listenerMap = getEventListenerMap(targetElement);
-  const listenerMapKey = getListenerMapKey(
+  const listenerSet = getEventListenerSet(targetElement);
+  const listenerSetKey = getListenerSetKey(
     domEventName,
     isCapturePhaseListener,
   );
-  const listenerEntry = ((listenerMap.get(
-    listenerMapKey,
-  ): any): ElementListenerMapEntry | void);
-  if (listenerEntry === undefined) {
-    const listener = addTrappedEventListener(
+  if (!listenerSet.has(listenerSetKey)) {
+    addTrappedEventListener(
       targetElement,
       domEventName,
       IS_NON_DELEGATED,
       isCapturePhaseListener,
     );
-    listenerMap.set(listenerMapKey, {passive: false, listener});
+    listenerSet.add(listenerSetKey);
   }
 }
 
@@ -369,8 +354,6 @@ export function listenToNativeEvent(
   isCapturePhaseListener: boolean,
   rootContainerElement: EventTarget,
   targetElement: Element | null,
-  isPassiveListener?: boolean,
-  listenerPriority?: EventPriority,
   eventSystemFlags?: EventSystemFlags = 0,
 ): void {
   let target = rootContainerElement;
@@ -383,21 +366,6 @@ export function listenToNativeEvent(
     (rootContainerElement: any).nodeType !== DOCUMENT_NODE
   ) {
     target = (rootContainerElement: any).ownerDocument;
-  }
-  if (enablePassiveEventIntervention && isPassiveListener === undefined) {
-    // Browsers introduced an intervention, making these events
-    // passive by default on document. React doesn't bind them
-    // to document anymore, but changing this now would undo
-    // the performance wins from the change. So we emulate
-    // the existing behavior manually on the roots now.
-    // https://github.com/facebook/react/issues/19651
-    if (
-      domEventName === 'touchstart' ||
-      domEventName === 'touchmove' ||
-      domEventName === 'wheel'
-    ) {
-      isPassiveListener = true;
-    }
   }
   // If the event can be delegated (or is capture phase), we can
   // register it to the root container. Otherwise, we should
@@ -423,42 +391,24 @@ export function listenToNativeEvent(
     eventSystemFlags |= IS_NON_DELEGATED;
     target = targetElement;
   }
-  const listenerMap = getEventListenerMap(target);
-  const listenerMapKey = getListenerMapKey(
+  const listenerSet = getEventListenerSet(target);
+  const listenerSetKey = getListenerSetKey(
     domEventName,
     isCapturePhaseListener,
   );
-  const listenerEntry = ((listenerMap.get(
-    listenerMapKey,
-  ): any): ElementListenerMapEntry | void);
-  const shouldUpgrade = shouldUpgradeListener(listenerEntry, isPassiveListener);
-
   // If the listener entry is empty or we should upgrade, then
   // we need to trap an event listener onto the target.
-  if (listenerEntry === undefined || shouldUpgrade) {
-    // If we should upgrade, then we need to remove the existing trapped
-    // event listener for the target container.
-    if (shouldUpgrade) {
-      removeEventListener(
-        target,
-        domEventName,
-        ((listenerEntry: any): ElementListenerMapEntry).listener,
-        isCapturePhaseListener,
-      );
-    }
+  if (!listenerSet.has(listenerSetKey)) {
     if (isCapturePhaseListener) {
       eventSystemFlags |= IS_CAPTURE_PHASE;
     }
-    const listener = addTrappedEventListener(
+    addTrappedEventListener(
       target,
       domEventName,
       eventSystemFlags,
       isCapturePhaseListener,
-      false,
-      isPassiveListener,
-      listenerPriority,
     );
-    listenerMap.set(listenerMapKey, {passive: isPassiveListener, listener});
+    listenerSet.add(listenerSetKey);
   }
 }
 
@@ -480,11 +430,13 @@ export function listenToReactEvent(
     const isPolyfillEventPlugin = dependenciesLength !== 1;
 
     if (isPolyfillEventPlugin) {
-      const listenerMap = getEventListenerMap(rootContainerElement);
-      // For optimization, we register plugins on the listener map, so we
-      // don't need to check each of their dependencies each time.
-      if (!listenerMap.has(reactEvent)) {
-        listenerMap.set(reactEvent, null);
+      const listenerSet = getEventListenerSet(rootContainerElement);
+      // When eager listeners are off, this Set has a dual purpose: it both
+      // captures which native listeners we registered (e.g. "click__bubble")
+      // and *React* lazy listeners (e.g. "onClick") so we don't do extra checks.
+      // This second usage does not exist in the eager mode.
+      if (!listenerSet.has(reactEvent)) {
+        listenerSet.add(reactEvent);
         for (let i = 0; i < dependenciesLength; i++) {
           listenToNativeEvent(
             dependencies[i],
@@ -520,19 +472,29 @@ function addTrappedEventListener(
   eventSystemFlags: EventSystemFlags,
   isCapturePhaseListener: boolean,
   isDeferredListenerForLegacyFBSupport?: boolean,
-  isPassiveListener?: boolean,
-  listenerPriority?: EventPriority,
-): any => void {
+) {
   let listener = createEventListenerWrapperWithPriority(
     targetContainer,
     domEventName,
     eventSystemFlags,
-    listenerPriority,
   );
   // If passive option is not supported, then the event will be
   // active and not passive.
-  if (isPassiveListener === true && !passiveBrowserEventsSupported) {
-    isPassiveListener = false;
+  let isPassiveListener = undefined;
+  if (enablePassiveEventIntervention && passiveBrowserEventsSupported) {
+    // Browsers introduced an intervention, making these events
+    // passive by default on document. React doesn't bind them
+    // to document anymore, but changing this now would undo
+    // the performance wins from the change. So we emulate
+    // the existing behavior manually on the roots now.
+    // https://github.com/facebook/react/issues/19651
+    if (
+      domEventName === 'touchstart' ||
+      domEventName === 'touchmove' ||
+      domEventName === 'wheel'
+    ) {
+      isPassiveListener = true;
+    }
   }
 
   targetContainer =
@@ -564,6 +526,7 @@ function addTrappedEventListener(
       return originalListener.apply(this, p);
     };
   }
+  // TODO: There are too many combinations here. Consolidate them.
   if (isCapturePhaseListener) {
     if (isPassiveListener !== undefined) {
       unsubscribeListener = addEventCaptureListenerWithPassiveFlag(
@@ -595,7 +558,6 @@ function addTrappedEventListener(
       );
     }
   }
-  return unsubscribeListener;
 }
 
 function deferClickToDocumentForLegacyFBSupport(
@@ -1085,19 +1047,7 @@ export function accumulateEventHandleNonManagedNodeListeners(
   }
 }
 
-export function addEventTypeToDispatchConfig(type: DOMEventName): void {
-  const reactName = topLevelEventsToReactNames.get(type);
-  // If we don't have a reactName, then we're dealing with
-  // an event type that React does not know about (i.e. a custom event).
-  // We need to register an event config for this or the SimpleEventPlugin
-  // will not appropriately provide a SyntheticEvent, so we use out empty
-  // dispatch config for custom events.
-  if (reactName === undefined) {
-    topLevelEventsToReactNames.set(type, null);
-  }
-}
-
-export function getListenerMapKey(
+export function getListenerSetKey(
   domEventName: DOMEventName,
   capture: boolean,
 ): string {

--- a/packages/react-dom/src/events/EventRegistry.js
+++ b/packages/react-dom/src/events/EventRegistry.js
@@ -9,9 +9,14 @@
 
 import type {DOMEventName} from './DOMEventNames';
 
-import {enableEagerRootListeners} from 'shared/ReactFeatureFlags';
+import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 
 export const allNativeEvents: Set<DOMEventName> = new Set();
+
+if (enableCreateEventHandleAPI) {
+  allNativeEvents.add('beforeblur');
+  allNativeEvents.add('afterblur');
+}
 
 /**
  * Mapping from registration name to event name
@@ -60,9 +65,7 @@ export function registerDirectEvent(
     }
   }
 
-  if (enableEagerRootListeners) {
-    for (let i = 0; i < dependencies.length; i++) {
-      allNativeEvents.add(dependencies[i]);
-    }
+  for (let i = 0; i < dependencies.length; i++) {
+    allNativeEvents.add(dependencies[i]);
   }
 }

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,7 +8,6 @@
  */
 
 import type {AnyNativeEvent} from '../events/PluginModuleType';
-import type {EventPriority} from 'shared/ReactTypes';
 import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
 import type {Container, SuspenseInstance} from '../client/ReactDOMHostConfig';
 import type {DOMEventName} from '../events/DOMEventNames';
@@ -96,12 +95,8 @@ export function createEventListenerWrapperWithPriority(
   targetContainer: EventTarget,
   domEventName: DOMEventName,
   eventSystemFlags: EventSystemFlags,
-  priority?: EventPriority,
 ): Function {
-  const eventPriority =
-    priority === undefined
-      ? getEventPriorityForPluginSystem(domEventName)
-      : priority;
+  const eventPriority = getEventPriorityForPluginSystem(domEventName);
   let listenerWrapper;
   switch (eventPriority) {
     case DiscreteEvent:

--- a/packages/react-dom/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SelectEventPlugin.js
@@ -22,7 +22,7 @@ import {registerTwoPhaseEvent} from '../EventRegistry';
 import getActiveElement from '../../client/getActiveElement';
 import {
   getNodeFromInstance,
-  getEventListenerMap,
+  getEventListenerSet,
 } from '../../client/ReactDOMComponentTree';
 import {hasSelectionCapabilities} from '../../client/ReactInputSelection';
 import {DOCUMENT_NODE} from '../../shared/HTMLNodeType';
@@ -154,7 +154,7 @@ function extractEvents(
   targetContainer: EventTarget,
 ) {
   if (!enableEagerRootListeners) {
-    const eventListenerMap = getEventListenerMap(targetContainer);
+    const eventListenerSet = getEventListenerSet(targetContainer);
     // Track whether all listeners exists for this plugin. If none exist, we do
     // not extract events. See #3639.
     if (
@@ -163,8 +163,8 @@ function extractEvents(
       // event attached from the onChange plugin and we don't expose an
       // onSelectionChange event from React.
       domEventName !== 'selectionchange' &&
-      !eventListenerMap.has('onSelect') &&
-      !eventListenerMap.has('onSelectCapture')
+      !eventListenerSet.has('onSelect') &&
+      !eventListenerSet.has('onSelectCapture')
     ) {
       return;
     }

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -37,32 +37,6 @@ const isMac =
     ? /^Mac/.test(window.navigator.platform)
     : false;
 
-const canUseDOM: boolean = !!(
-  typeof window !== 'undefined' &&
-  typeof window.document !== 'undefined' &&
-  typeof window.document.createElement !== 'undefined'
-);
-
-let passiveBrowserEventsSupported = false;
-
-// Check if browser support events with passive listeners
-// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support
-if (canUseDOM) {
-  try {
-    const options = {};
-    // $FlowFixMe: Ignore Flow complaining about needing a value
-    Object.defineProperty(options, 'passive', {
-      get: function() {
-        passiveBrowserEventsSupported = true;
-      },
-    });
-    window.addEventListener('test', options, options);
-    window.removeEventListener('test', options, options);
-  } catch (e) {
-    passiveBrowserEventsSupported = false;
-  }
-}
-
 const hasPointerEvents =
   typeof window !== 'undefined' && window.PointerEvent != null;
 
@@ -78,20 +52,13 @@ const globalFocusVisibleEvents = hasPointerEvents
       'touchend',
     ];
 
-const passiveObject = {passive: true};
-const passiveObjectWithPriority = {passive: true, priority: 0};
-
 // Global state for tracking focus visible and emulation of mouse
 let isGlobalFocusVisible = true;
 let hasTrackedGlobalFocusVisible = false;
 
 function trackGlobalFocusVisible() {
   globalFocusVisibleEvents.forEach(type => {
-    window.addEventListener(
-      type,
-      handleGlobalFocusVisibleEvent,
-      passiveBrowserEventsSupported ? {capture: true, passive: true} : true,
-    );
+    window.addEventListener(type, handleGlobalFocusVisibleEvent, true);
   });
 }
 
@@ -171,9 +138,9 @@ function setFocusVisibleListeners(
 
 function useFocusVisibleInputHandles() {
   return [
-    useEvent('mousedown', passiveObject),
-    useEvent(hasPointerEvents ? 'pointerdown' : 'touchstart', passiveObject),
-    useEvent('keydown', passiveObject),
+    useEvent('mousedown'),
+    useEvent(hasPointerEvents ? 'pointerdown' : 'touchstart'),
+    useEvent('keydown'),
   ];
 }
 
@@ -200,8 +167,8 @@ export function useFocus(
   const stateRef = useRef<null | {isFocused: boolean, isFocusVisible: boolean}>(
     {isFocused: false, isFocusVisible: false},
   );
-  const focusHandle = useEvent('focusin', passiveObjectWithPriority);
-  const blurHandle = useEvent('focusout', passiveObjectWithPriority);
+  const focusHandle = useEvent('focusin');
+  const blurHandle = useEvent('focusout');
   const focusVisibleHandles = useFocusVisibleInputHandles();
 
   useLayoutEffect(() => {
@@ -297,10 +264,10 @@ export function useFocusWithin<T>(
   const stateRef = useRef<null | {isFocused: boolean, isFocusVisible: boolean}>(
     {isFocused: false, isFocusVisible: false},
   );
-  const focusHandle = useEvent('focusin', passiveObjectWithPriority);
-  const blurHandle = useEvent('focusout', passiveObjectWithPriority);
-  const afterBlurHandle = useEvent('afterblur', passiveObject);
-  const beforeBlurHandle = useEvent('beforeblur', passiveObject);
+  const focusHandle = useEvent('focusin');
+  const blurHandle = useEvent('focusout');
+  const afterBlurHandle = useEvent('afterblur');
+  const beforeBlurHandle = useEvent('beforeblur');
   const focusVisibleHandles = useFocusVisibleInputHandles();
 
   const useFocusWithinRef = useCallback(

--- a/packages/react-interactions/events/src/dom/create-event-handle/useEvent.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/useEvent.js
@@ -25,8 +25,6 @@ export default function useEvent(
   event: string,
   options?: {|
     capture?: boolean,
-    passive?: boolean,
-    priority?: 0 | 1 | 2,
   |},
 ): UseEventHandle {
   const handleRef = useRef<UseEventHandle | null>(null);


### PR DESCRIPTION
These are already non-configurable in public APIs, but they are configurable in `createEventHandle`. This introduces complexity for all paths, such as very hot normal event paths, but is only used for `createEventHandle`. Even for `createEventHandle`, this is not ideal because we're continually hitting these Map checks and can't benefit from eager listeners.

In this PR, I'm removing support for the options argument beyond `capture`. This lets us remove the Map checks every time `setHandle` is called — now `createEventHandle` also relies on the eager listeners. It also lets us remove the upgrade mechanism. It also lets us speed up the `createEventHandle` path because we don't need to search for Fibers or the closest containers. (I've turned invariants into warnings.)

Overall, the goal is to improve perf and reduce the API surface area for something we're not yet committed to supporting. We can revisit this after the planned changes to event defaults and the event replaying refactor.