### PR TITLE
Don't visit passive effects during layout phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1241,7 +1241,7 @@ function mountEffect(
     }
   }
   return mountEffectImpl(
-    UpdateEffect | PassiveEffect | PassiveStaticEffect,
+    PassiveEffect | PassiveStaticEffect,
     HookPassive,
     create,
     deps,
@@ -1258,12 +1258,7 @@ function updateEffect(
       warnIfNotCurrentlyActingEffectsInDEV(currentlyRenderingFiber);
     }
   }
-  return updateEffectImpl(
-    UpdateEffect | PassiveEffect,
-    HookPassive,
-    create,
-    deps,
-  );
+  return updateEffectImpl(PassiveEffect, HookPassive, create, deps);
 }
 
 function mountLayoutEffect(
@@ -1615,8 +1610,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     const setId = mountState(id)[1];
 
     if ((currentlyRenderingFiber.mode & BlockingMode) === NoMode) {
-      currentlyRenderingFiber.flags |=
-        UpdateEffect | PassiveEffect | PassiveStaticEffect;
+      currentlyRenderingFiber.flags |= PassiveEffect | PassiveStaticEffect;
       pushEffect(
         HookHasEffect | HookPassive,
         () => {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2623,7 +2623,7 @@ function flushPassiveMountEffects(firstChild: Fiber): void {
       flushPassiveMountEffects(fiber.child);
     }
 
-    if ((fiber.flags & Update) !== NoFlags) {
+    if ((fiber.flags & Passive) !== NoFlags) {
       setCurrentDebugFiberInDEV(fiber);
       commitPassiveEffectOnFiber(fiber);
       resetCurrentDebugFiberInDEV();


### PR DESCRIPTION
Removes the `Update` flag when scheduling a passive effect for `useEffect`. The `Passive` flag alone is sufficient.

This doesn't affect any behavior, but does optimize the performance of the commit phase.