### PR TITLE
Consider components in jsx as missing dependencies in @typescript-eslint/parser@4.x

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7947,13 +7947,31 @@ const testsTypescriptEslintParserV4 = {
     // It doesn't use any explicit types but any JS is still valid TS.
     {
       code: normalizeIndent`
-        export const Foo = ({ Component }) => {
+        function Foo({ Component }) {
           React.useEffect(() => {
             console.log(<Component />);
           }, []);
         };
       `,
-      errors: [{message: ''}],
+      errors: [
+        {
+          message:
+            "React Hook React.useEffect has a missing dependency: 'Component'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [Component]',
+              output: normalizeIndent`
+              function Foo({ Component }) {
+                React.useEffect(() => {
+                  console.log(<Component />);
+                }, [Component]);
+              };
+            `,
+            },
+          ],
+        },
+      ],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -31,6 +31,7 @@ function normalizeIndent(strings) {
 // }
 // ***************************************************
 
+// Tests that are valid/invalid across all parsers
 const tests = {
   valid: [
     {
@@ -7505,6 +7506,7 @@ const tests = {
   ],
 };
 
+// Tests that are only valid/invalid across parsers supporting Flow
 const testsFlow = {
   valid: [
     // Ignore Generic Type Variables for arrow functions
@@ -7540,6 +7542,7 @@ const testsFlow = {
   ],
 };
 
+// Tests that are only valid/invalid across parsers supporting TypeScript
 const testsTypescript = {
   valid: [
     {
@@ -7936,6 +7939,25 @@ const testsTypescript = {
   ],
 };
 
+// Tests that are only valid/invalid for `@typescript-eslint/parser@4.x`
+const testsTypescriptEslintParserV4 = {
+  valid: [],
+  invalid: [
+    // TODO: Should also be invalid as part of the JS test suite i.e. be invalid with babel eslint parsers.
+    // It doesn't use any explicit types but any JS is still valid TS.
+    {
+      code: normalizeIndent`
+        export const Foo = ({ Component }) => {
+          React.useEffect(() => {
+            console.log(<Component />);
+          }, []);
+        };
+      `,
+      errors: [{message: ''}],
+    },
+  ],
+};
+
 // For easier local testing
 if (!process.env.CI) {
   let only = [];
@@ -7947,6 +7969,8 @@ if (!process.env.CI) {
     ...testsFlow.invalid,
     ...testsTypescript.valid,
     ...testsTypescript.invalid,
+    ...testsTypescriptEslintParserV4.valid,
+    ...testsTypescriptEslintParserV4.invalid,
   ].forEach(t => {
     if (t.skip) {
       delete t.skip;
@@ -8028,9 +8052,14 @@ describe('react-hooks', () => {
   new ESLintTester({
     parser: require.resolve('@typescript-eslint/parser-v4'),
     parserOptions,
-  }).run(
-    'parser: @typescript-eslint/parser@4.x',
-    ReactHooksESLintRule,
-    testsTypescriptEslintParser
-  );
+  }).run('parser: @typescript-eslint/parser@4.x', ReactHooksESLintRule, {
+    valid: [
+      ...testsTypescriptEslintParserV4.valid,
+      ...testsTypescriptEslintParser.valid,
+    ],
+    invalid: [
+      ...testsTypescriptEslintParserV4.invalid,
+      ...testsTypescriptEslintParser.invalid,
+    ],
+  });
 });

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1622,7 +1622,7 @@ function markNode(node, optionalChains, result) {
  * Otherwise throw.
  */
 function analyzePropertyChain(node, optionalChains) {
-  if (node.type === 'Identifier') {
+  if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
     const result = node.name;
     if (optionalChains) {
       // Mark as required.
@@ -1779,7 +1779,7 @@ function isNodeLike(val) {
 
 function isSameIdentifier(a, b) {
   return (
-    a.type === 'Identifier' &&
+    (a.type === 'Identifier' || a.type === 'JSXIdentifier') &&
     a.name === b.name &&
     a.range[0] === b.range[0] &&
     a.range[1] === b.range[1]

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1780,6 +1780,7 @@ function isNodeLike(val) {
 function isSameIdentifier(a, b) {
   return (
     (a.type === 'Identifier' || a.type === 'JSXIdentifier') &&
+    a.type === b.type &&
     a.name === b.name &&
     a.range[0] === b.range[0] &&
     a.range[1] === b.range[1]


### PR DESCRIPTION
## Summary

Closes #19810

1. extract flow tests from `tests`
  This results in 3 test suites for JS, Flow and TypeScript. I originally thought #19810 was only  failing with TS parsers. So I wanted to also run all JS tests with the TS parsers (since any JS is also valid TS) but `tests` included some tests written for flow which isn't valid TS. Turns out the test in question only fails with a specific major of `@typyescript-eslint/parser` so that effort isn't strictly necessary for this PR but it increases test coverage nonetheless.
2. add minimal repro from https://github.com/facebook/react/issues/19810#issue-698822399 to failing tests
  Turns out this only crashes in `@typescript-eslint/parser@4.x`. All other parsers incorrectly mark this as valid which is tracked in https://github.com/facebook/react/issues/18051
3. Fix failing test by supporting `JSXIdentifier` 

## Test Plan

- [x] CI green
