### PR TITLE
Include JSX callsite in the missing key warning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactFunctionComponent-test.js
@@ -359,7 +359,7 @@ describe('ReactFunctionComponent', () => {
 
     expect(() => ReactTestUtils.renderIntoDocument(<Child />)).toErrorDev(
       'Each child in a list should have a unique "key" prop.\n\n' +
-        'Check the render method of `Child`.',
+        'Check the line ** in **.',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChildText-test.js
@@ -73,98 +73,102 @@ const expectChildren = function(container, children) {
  */
 describe('ReactMultiChildText', () => {
   it('should correctly handle all possible children for render and update', () => {
-    expect(() => {
-      // prettier-ignore
-      testAllPermutations([
-        // basic values
-        undefined, [],
-        null, [],
-        false, [],
-        true, [],
-        0, '0',
-        1.2, '1.2',
-        '', '',
-        'foo', 'foo',
+    spyOnDev(console, 'error');
+    // prettier-ignore
+    testAllPermutations([
+      // basic values
+      undefined, [],
+      null, [],
+      false, [],
+      true, [],
+      0, '0',
+      1.2, '1.2',
+      '', '',
+      'foo', 'foo',
 
-        [], [],
-        [undefined], [],
-        [null], [],
-        [false], [],
-        [true], [],
-        [0], ['0'],
-        [1.2], ['1.2'],
-        [''], [''],
-        ['foo'], ['foo'],
-        [<div />], [<div />],
+      [], [],
+      [undefined], [],
+      [null], [],
+      [false], [],
+      [true], [],
+      [0], ['0'],
+      [1.2], ['1.2'],
+      [''], [''],
+      ['foo'], ['foo'],
+      [<div />], [<div />],
 
-        // two adjacent values
-        [true, 0], ['0'],
-        [0, 0], ['0', '0'],
-        [1.2, 0], ['1.2', '0'],
-        [0, ''], ['0', ''],
-        ['foo', 0], ['foo', '0'],
-        [0, <div />], ['0', <div />],
+      // two adjacent values
+      [true, 0], ['0'],
+      [0, 0], ['0', '0'],
+      [1.2, 0], ['1.2', '0'],
+      [0, ''], ['0', ''],
+      ['foo', 0], ['foo', '0'],
+      [0, <div />], ['0', <div />],
 
-        [true, 1.2], ['1.2'],
-        [1.2, 0], ['1.2', '0'],
-        [1.2, 1.2], ['1.2', '1.2'],
-        [1.2, ''], ['1.2', ''],
-        ['foo', 1.2], ['foo', '1.2'],
-        [1.2, <div />], ['1.2', <div />],
+      [true, 1.2], ['1.2'],
+      [1.2, 0], ['1.2', '0'],
+      [1.2, 1.2], ['1.2', '1.2'],
+      [1.2, ''], ['1.2', ''],
+      ['foo', 1.2], ['foo', '1.2'],
+      [1.2, <div />], ['1.2', <div />],
 
-        [true, ''], [''],
-        ['', 0], ['', '0'],
-        [1.2, ''], ['1.2', ''],
-        ['', ''], ['', ''],
-        ['foo', ''], ['foo', ''],
-        ['', <div />], ['', <div />],
+      [true, ''], [''],
+      ['', 0], ['', '0'],
+      [1.2, ''], ['1.2', ''],
+      ['', ''], ['', ''],
+      ['foo', ''], ['foo', ''],
+      ['', <div />], ['', <div />],
 
-        [true, 'foo'], ['foo'],
-        ['foo', 0], ['foo', '0'],
-        [1.2, 'foo'], ['1.2', 'foo'],
-        ['foo', ''], ['foo', ''],
-        ['foo', 'foo'], ['foo', 'foo'],
-        ['foo', <div />], ['foo', <div />],
+      [true, 'foo'], ['foo'],
+      ['foo', 0], ['foo', '0'],
+      [1.2, 'foo'], ['1.2', 'foo'],
+      ['foo', ''], ['foo', ''],
+      ['foo', 'foo'], ['foo', 'foo'],
+      ['foo', <div />], ['foo', <div />],
 
-        // values separated by an element
-        [true, <div />, true], [<div />],
-        [1.2, <div />, 1.2], ['1.2', <div />, '1.2'],
-        ['', <div />, ''], ['', <div />, ''],
-        ['foo', <div />, 'foo'], ['foo', <div />, 'foo'],
+      // values separated by an element
+      [true, <div />, true], [<div />],
+      [1.2, <div />, 1.2], ['1.2', <div />, '1.2'],
+      ['', <div />, ''], ['', <div />, ''],
+      ['foo', <div />, 'foo'], ['foo', <div />, 'foo'],
 
-        [true, 1.2, <div />, '', 'foo'], ['1.2', <div />, '', 'foo'],
-        [1.2, '', <div />, 'foo', true], ['1.2', '', <div />, 'foo'],
-        ['', 'foo', <div />, true, 1.2], ['', 'foo', <div />, '1.2'],
+      [true, 1.2, <div />, '', 'foo'], ['1.2', <div />, '', 'foo'],
+      [1.2, '', <div />, 'foo', true], ['1.2', '', <div />, 'foo'],
+      ['', 'foo', <div />, true, 1.2], ['', 'foo', <div />, '1.2'],
 
-        [true, 1.2, '', <div />, 'foo', true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
-        ['', 'foo', true, <div />, 1.2, '', 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
+      [true, 1.2, '', <div />, 'foo', true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
+      ['', 'foo', true, <div />, 1.2, '', 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
 
-        // values inside arrays
-        [[true], [true]], [],
-        [[1.2], [1.2]], ['1.2', '1.2'],
-        [[''], ['']], ['', ''],
-        [['foo'], ['foo']], ['foo', 'foo'],
-        [[<div />], [<div />]], [<div />, <div />],
+      // values inside arrays
+      [[true], [true]], [],
+      [[1.2], [1.2]], ['1.2', '1.2'],
+      [[''], ['']], ['', ''],
+      [['foo'], ['foo']], ['foo', 'foo'],
+      [[<div />], [<div />]], [<div />, <div />],
 
-        [[true, 1.2, <div />], '', 'foo'], ['1.2', <div />, '', 'foo'],
-        [1.2, '', [<div />, 'foo', true]], ['1.2', '', <div />, 'foo'],
-        ['', ['foo', <div />, true], 1.2], ['', 'foo', <div />, '1.2'],
+      [[true, 1.2, <div />], '', 'foo'], ['1.2', <div />, '', 'foo'],
+      [1.2, '', [<div />, 'foo', true]], ['1.2', '', <div />, 'foo'],
+      ['', ['foo', <div />, true], 1.2], ['', 'foo', <div />, '1.2'],
 
-        [true, [1.2, '', <div />, 'foo'], true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
-        ['', 'foo', [true, <div />, 1.2, ''], 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
+      [true, [1.2, '', <div />, 'foo'], true, 1.2], ['1.2', '', <div />, 'foo', '1.2'],
+      ['', 'foo', [true, <div />, 1.2, ''], 'foo'], ['', 'foo', <div />, '1.2', '', 'foo'],
 
-        // values inside elements
-        [<div>{true}{1.2}{<div />}</div>, '', 'foo'], [<div />, '', 'foo'],
-        [1.2, '', <div>{<div />}{'foo'}{true}</div>], ['1.2', '', <div />],
-        ['', <div>{'foo'}{<div />}{true}</div>, 1.2], ['', <div />, '1.2'],
+      // values inside elements
+      [<div>{true}{1.2}{<div />}</div>, '', 'foo'], [<div />, '', 'foo'],
+      [1.2, '', <div>{<div />}{'foo'}{true}</div>], ['1.2', '', <div />],
+      ['', <div>{'foo'}{<div />}{true}</div>, 1.2], ['', <div />, '1.2'],
 
-        [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
-        ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
-      ]);
-    }).toErrorDev([
-      'Warning: Each child in a list should have a unique "key" prop.',
-      'Warning: Each child in a list should have a unique "key" prop.',
+      [true, <div>{1.2}{''}{<div />}{'foo'}</div>, true, 1.2], [<div />, '1.2'],
+      ['', 'foo', <div>{true}{<div />}{1.2}{''}</div>, 'foo'], ['', 'foo', <div />, 'foo'],
     ]);
+
+    if (__DEV__) {
+      for (let i = 0; i < console.error.calls.count(); i++) {
+        expect(console.error.calls.argsFor(i)[0]).toContain(
+          'Each child in a list should have a unique "key" prop',
+        );
+      }
+    }
   });
 
   it('should throw if rendering both HTML and children', () => {

--- a/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactBlocks-test.js
@@ -109,7 +109,7 @@ describe('ReactBlocks', () => {
       });
     }).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
-        '"key" prop.\n\nCheck the render method of `User`. See ' +
+        '"key" prop.\n\nCheck the line ** in **. See ' +
         'https://reactjs.org/link/warning-keys for more information.\n' +
         '    in span (at **)\n' +
         '    in User (at **)\n' +

--- a/packages/react/src/__tests__/ReactElementValidator-test.internal.js
+++ b/packages/react/src/__tests__/ReactElementValidator-test.internal.js
@@ -76,14 +76,16 @@ describe('ReactElementValidator', () => {
 
   it('warns for keys for arrays with no owner or parent info', () => {
     function Anonymous() {
-      return <div />;
+      return React.createElement('div');
     }
     Object.defineProperty(Anonymous, 'name', {value: undefined});
 
-    const divs = [<div />, <div />];
+    const divs = [React.createElement('div'), React.createElement('div')];
 
     expect(() => {
-      ReactTestUtils.renderIntoDocument(<Anonymous>{divs}</Anonymous>);
+      ReactTestUtils.renderIntoDocument(
+        React.createElement(Anonymous, null, divs),
+      );
     }).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
         '"key" prop. See https://reactjs.org/link/warning-keys for more information.\n' +
@@ -92,57 +94,15 @@ describe('ReactElementValidator', () => {
   });
 
   it('warns for keys for arrays of elements with no owner info', () => {
-    const divs = [<div />, <div />];
+    const divs = [React.createElement('div'), React.createElement('div')];
 
     expect(() => {
-      ReactTestUtils.renderIntoDocument(<div>{divs}</div>);
+      ReactTestUtils.renderIntoDocument(React.createElement('div', null, divs));
     }).toErrorDev(
       'Warning: Each child in a list should have a unique ' +
         '"key" prop.\n\nCheck the top-level render call using <div>. See ' +
         'https://reactjs.org/link/warning-keys for more information.\n' +
         '    in div (at **)',
-    );
-  });
-
-  it('warns for keys with component stack info', () => {
-    function Component() {
-      return <div>{[<div />, <div />]}</div>;
-    }
-
-    function Parent(props) {
-      return React.cloneElement(props.child);
-    }
-
-    function GrandParent() {
-      return <Parent child={<Component />} />;
-    }
-
-    expect(() => ReactTestUtils.renderIntoDocument(<GrandParent />)).toErrorDev(
-      'Warning: Each child in a list should have a unique ' +
-        '"key" prop.\n\nCheck the render method of `Component`. See ' +
-        'https://reactjs.org/link/warning-keys for more information.\n' +
-        '    in div (at **)\n' +
-        '    in Component (at **)\n' +
-        '    in Parent (at **)\n' +
-        '    in GrandParent (at **)',
-    );
-  });
-
-  it('does not warn for keys when passing children down', () => {
-    function Wrapper(props) {
-      return (
-        <div>
-          {props.children}
-          <footer />
-        </div>
-      );
-    }
-
-    ReactTestUtils.renderIntoDocument(
-      <Wrapper>
-        <span />
-        <span />
-      </Wrapper>,
     );
   });
 
@@ -528,7 +488,7 @@ describe('ReactElementValidator', () => {
         '(for built-in components) or a class/function (for composite ' +
         'components) but got: undefined. You likely forgot to export your ' +
         "component from the file it's defined in, or you might have mixed up " +
-        'default and named imports.\n\nCheck your code at **.',
+        'default and named imports.\n\nCheck the line ** in **.',
       {withoutStack: true},
     );
   });

--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -10,7 +10,7 @@ function normalizeCodeLocInfo(str) {
   }
   // This special case exists only for the special source location in
   // ReactElementValidator. That will go away if we remove source locations.
-  str = str.replace(/Check your code at .+?:\d+/g, 'Check your code at **');
+  str = str.replace(/Check the line \d+ in .+\.js/g, 'Check the line ** in **');
   // V8 format:
   //  at Component (/path/filename.js:123:45)
   // React format:


### PR DESCRIPTION
React 17 uses native browser frames for stack traces, which means that host elements like `<div>` no longer have line numbers. And for components, you get the definition frame rather than the JSX callsite frame. For the most part this is fine — especially if the browsers start using sourcemaps for when stack frames URLs are printed via `console.error`. However, there is one particular case that I feel has regressed in usability.

Key warnings really _are_ scoped to the particular JSX callsite. Often you may have several `map()` or such in one component, and figuring out which key is missing is annoying. Unlike other warnings where the fault may lie with props passed to the wrapper "design system" components, with missing keys in my experience the fix tends to be exactly where the JSX callsite is.

We already use source location in a custom way for the "invalid type" warning. In this PR, I'm reusing it (if available) to append an addendum with the line number and the filename to the message. This doesn't mess with the stack format but provides the exact pointer to what you need to fix for this particular warning. All other warnings are left as they are.

### React 16

<img width="598" alt="Screenshot 2020-09-11 at 15 29 09" src="https://user-images.githubusercontent.com/810438/92941691-9d2cc100-f448-11ea-9c52-c6bc4e234a34.png">

### React 17 (before this PR)

<img width="651" alt="Screenshot 2020-09-11 at 15 02 51" src="https://user-images.githubusercontent.com/810438/92946179-31e5ed80-f44e-11ea-9c47-b72afc56c4c7.png">

### React 17 (after this PR)

<img width="673" alt="Screenshot 2020-09-11 at 15 28 06" src="https://user-images.githubusercontent.com/810438/92941770-b33a8180-f448-11ea-8d22-24b67656aaee.png">

I verified the change in a real app with both new and old JSX transforms.