### PR TITLE
chore(docs): update url from fb.me to reactjs.org 

### DIFF
--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -365,7 +365,7 @@ describe('create-react-class-integration', () => {
       expect(() => Component()).toThrow(),
     ).toErrorDev(
       'Warning: Something is calling a React component directly. Use a ' +
-        'factory or JSX instead. See: https://reactjs.org/warnings/legacy-factories.html',
+        'factory or JSX instead. See: https://fb.me/react-legacyfactory',
       {withoutStack: true},
     );
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -365,7 +365,7 @@ describe('create-react-class-integration', () => {
       expect(() => Component()).toThrow(),
     ).toErrorDev(
       'Warning: Something is calling a React component directly. Use a ' +
-        'factory or JSX instead. See: https://fb.me/react-legacyfactory',
+        'factory or JSX instead. See: https://reactjs.org/warnings/legacy-factories.html',
       {withoutStack: true},
     );
   });

--- a/packages/scheduler/src/forks/SchedulerHostConfig.default.js
+++ b/packages/scheduler/src/forks/SchedulerHostConfig.default.js
@@ -85,7 +85,7 @@ if (
     // option to rely on it in the future?
     const requestAnimationFrame = window.requestAnimationFrame;
     const cancelAnimationFrame = window.cancelAnimationFrame;
-    // TODO: Remove fb.me link
+
     if (typeof requestAnimationFrame !== 'function') {
       // Using console['error'] to evade Babel and ESLint
       console['error'](


### PR DESCRIPTION
Fixes #16109

There was a single link left out in https://github.com/facebook/react/pull/19598, I've updated the url and removed a comment to reflect that the change is complete.