### PR TITLE
eslint-plugin-react-hooks: support async functions in additional hooks (#19034)

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1445,6 +1445,14 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent({foo}) {
+          useCustomEffect(async () => foo, [foo]);
+        }
+      `,
+      options: [{additionalHooks: 'useCustomEffect'}],
+    },
   ],
   invalid: [
     {
@@ -7526,6 +7534,31 @@ const tests = {
             "The 'foo' object makes the dependencies of useEffect Hook (at line 9) change on every render. " +
             "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
           suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent({foo}) {
+          useCustomEffect(async () => foo, []);
+        }
+      `,
+      options: [{additionalHooks: 'useCustomEffect'}],
+      errors: [
+        {
+          message:
+            "React Hook useCustomEffect has a missing dependency: 'foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [foo]',
+              output: normalizeIndent`
+                function MyComponent({foo}) {
+                  useCustomEffect(async () => foo, [foo]);
+                }
+              `,
+            },
+          ],
         },
       ],
     },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -96,7 +96,11 @@ export default {
       reactiveHookName,
       isEffect,
     ) {
-      if (isEffect && node.async) {
+      const isCustomAdditionalHook =
+        options.additionalHooks &&
+        options.additionalHooks.test(reactiveHookName);
+      // specified custom additional hooks do not have limits imposed on their argument types
+      if (isEffect && node.async && !isCustomAdditionalHook) {
         reportProblem({
           node: node,
           message:


### PR DESCRIPTION
## Summary

support async functions in additional hooks (#19034)

Simply don't warn users about using an async function as the first
argument when linting additional hooks, since it is an unfounded
restriction to custom dependency-using hooks.