### PR TITLE
Don't delegate the dblclick event

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -197,23 +197,6 @@ describe('ReactDOMEventListener', () => {
       });
     });
 
-    it('onDoubleClick', () => {
-      testNativeBubblingEvent({
-        type: 'div',
-        reactEvent: 'onDoubleClick',
-        reactEventType: 'dblclick',
-        nativeEvent: 'dblclick',
-        dispatch(node) {
-          node.dispatchEvent(
-            new KeyboardEvent('dblclick', {
-              bubbles: true,
-              cancelable: true,
-            }),
-          );
-        },
-      });
-    });
-
     it('onDrag', () => {
       testNativeBubblingEvent({
         type: 'div',
@@ -1242,6 +1225,28 @@ describe('ReactDOMEventListener', () => {
     });
   });
 
+  describe('bubbling events that are not delegated', () => {
+    // Although this event bubbles both in React and in the browser,
+    // it is not delegated because delegating it causes click delays:
+    // https://github.com/facebook/react/issues/19841
+    it('onDoubleClick', () => {
+      testNativeBubblingEventWithoutDelegation({
+        type: 'div',
+        reactEvent: 'onDoubleClick',
+        reactEventType: 'dblclick',
+        nativeEvent: 'dblclick',
+        dispatch(node) {
+          node.dispatchEvent(
+            new KeyboardEvent('dblclick', {
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        },
+      });
+    });
+  });
+
   // The tests for these events are currently very limited
   // because they are fully synthetic, and so they don't
   // work very well across different roots. For now, we'll
@@ -1807,6 +1812,19 @@ describe('ReactDOMEventListener', () => {
     testReactStopPropagationInOuterCapturePhase(config);
     testReactStopPropagationInInnerCapturePhase(config);
     testReactStopPropagationInInnerBubblePhase(config);
+    testNativeStopPropagationInOuterCapturePhase(config);
+    testNativeStopPropagationInInnerCapturePhase(config);
+  }
+
+  // Events that bubble in React and in the browser,
+  // but for some reason we can't use delegation for them.
+  function testNativeBubblingEventWithoutDelegation(config) {
+    testNativeBubblingEventWithTargetListener(config);
+    testNativeBubblingEventWithoutTargetListener(config);
+    testReactStopPropagationInOuterCapturePhase(config);
+    testReactStopPropagationInInnerCapturePhase(config);
+    testReactStopPropagationInInnerBubblePhase(config);
+    testReactStopPropagationInOuterBubblePhase(config);
     testNativeStopPropagationInOuterCapturePhase(config);
     testNativeStopPropagationInInnerCapturePhase(config);
   }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -375,6 +375,8 @@ function setInitialDOMProperties(
           listenToNonDelegatedEvent('scroll', domElement);
         } else if (propKey === 'onDoubleClick') {
           listenToNonDelegatedEvent('dblclick', domElement);
+        } else if (propKey === 'onDoubleClickCapture') {
+          listenToNonDelegatedEvent('dblclick', domElement, true);
         }
       }
     } else if (nextProp != null) {
@@ -840,6 +842,8 @@ export function diffProperties(
           listenToNonDelegatedEvent('scroll', domElement);
         } else if (propKey === 'onDoubleClick') {
           listenToNonDelegatedEvent('dblclick', domElement);
+        } else if (propKey === 'onDoubleClickCapture') {
+          listenToNonDelegatedEvent('dblclick', domElement, true);
         }
       }
       if (!updatePayload && lastProp !== nextProp) {
@@ -1094,6 +1098,8 @@ export function diffHydratedProperties(
           listenToNonDelegatedEvent('scroll', domElement);
         } else if (propKey === 'onDoubleClick') {
           listenToNonDelegatedEvent('dblclick', domElement);
+        } else if (propKey === 'onDoubleClickCapture') {
+          listenToNonDelegatedEvent('dblclick', domElement, true);
         }
       }
     } else if (

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -373,6 +373,8 @@ function setInitialDOMProperties(
           ensureListeningTo(rootContainerElement, propKey, domElement);
         } else if (propKey === 'onScroll') {
           listenToNonDelegatedEvent('scroll', domElement);
+        } else if (propKey === 'onDoubleClick') {
+          listenToNonDelegatedEvent('dblclick', domElement);
         }
       }
     } else if (nextProp != null) {
@@ -836,6 +838,8 @@ export function diffProperties(
           ensureListeningTo(rootContainerElement, propKey, domElement);
         } else if (propKey === 'onScroll') {
           listenToNonDelegatedEvent('scroll', domElement);
+        } else if (propKey === 'onDoubleClick') {
+          listenToNonDelegatedEvent('dblclick', domElement);
         }
       }
       if (!updatePayload && lastProp !== nextProp) {
@@ -1088,6 +1092,8 @@ export function diffHydratedProperties(
           ensureListeningTo(rootContainerElement, propKey, domElement);
         } else if (propKey === 'onScroll') {
           listenToNonDelegatedEvent('scroll', domElement);
+        } else if (propKey === 'onDoubleClick') {
+          listenToNonDelegatedEvent('dblclick', domElement);
         }
       }
     } else if (

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -135,7 +135,10 @@ const discreteReplayableEvents: Array<DOMEventName> = [
   'touchend',
   'touchstart',
   'auxclick',
-  'dblclick',
+  // Intentionally don't listen to the dblclick event
+  // because delegating it causes observable side effects:
+  // https://github.com/facebook/react/issues/19841
+  // 'dblclick',
   'pointercancel',
   'pointerdown',
   'pointerup',


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/19841.

My approach is to change it from being delegated to being listened to directly at the element. I chose this path because I don't believe the underlying issue is solvable in general — the click delay happens even with a [plain HTML repro](https://codesandbox.io/s/eloquent-resonance-6hv2x?file=%2Fsrc%2Findex.js). So the best we can do is to scope it to subtrees that actually *use* `onDoubleClick`.

Essentially, I'm adding it to the list of non-delegated events. But it's not as easy as it is with events like `load` because `dblclick` actually *does* bubble in the browser. So we need to deduplicate it. Otherwise, we would first bubble it via the React algorithm, and then receive it *again* for every parent we attached it to. And we can't rely on native bubbling alone because that would have broken the React portal behavior. We also can't compare `e.target` to `e.currentTarget` because we want React to receive events from nodes not managed by React (or managed by an inner nested React tree). To implement deduplication, I've added some state to the SimpleEventPlugin that tracks the last bubbled event, and bails out if it was the same instance of a `dblclick` event.

Note that this change is not behind any flag. I could put it behind one if it seems risky. I don't want to group it with the eager change because that might skew the data. Ideally we'd keep researching the eager regression independently since we know that internally, we were *already* subscribing to `dblclick` eagerly anyway due to event replaying.