### PR TITLE
Automatically stringify keys with type of 'symbol'

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -222,12 +222,33 @@ export function jsx(type, config, maybeKey) {
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
     key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
+    if (__DEV__) {
+      if (
+        maybeKey &&
+        typeof maybeKey !== 'string' &&
+        typeof maybeKey !== 'number'
+      ) {
+        console.warn(
+          'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidKey(config)) {
-    // key = typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
     key =
       typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
+    if (__DEV__) {
+      if (
+        config.key &&
+        typeof config.key !== 'string' &&
+        typeof config.key !== 'number'
+      ) {
+        console.warn(
+          'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidRef(config)) {
@@ -288,11 +309,26 @@ export function jsxDEV(type, config, maybeKey, source, self) {
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
     key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
+    if (__DEV__) {
+      if (typeof maybeKey !== 'string' && typeof maybeKey !== 'number') {
+        console.warn(
+          'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidKey(config)) {
     key =
       typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
+    if (__DEV__) {
+      if (typeof config.key !== 'string' && typeof config.key !== 'number') {
+        console.log('key', config.key, typeof config.key);
+        console.warn(
+          'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidRef(config)) {
@@ -372,6 +408,17 @@ export function createElement(type, config, children) {
         typeof config.key === 'symbol'
           ? config.key.toString()
           : '' + config.key;
+      if (__DEV__) {
+        if (
+          config.key &&
+          typeof config.key !== 'string' &&
+          typeof config.key !== 'number'
+        ) {
+          console.warn(
+            'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+          );
+        }
+      }
     }
 
     self = config.__self === undefined ? null : config.__self;
@@ -508,6 +555,17 @@ export function cloneElement(element, config, children) {
         typeof config.key === 'symbol'
           ? config.key.toString()
           : '' + config.key;
+      if (__DEV__) {
+        if (
+          config.key &&
+          typeof config.key !== 'string' &&
+          typeof config.key !== 'number'
+        ) {
+          console.warn(
+            'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+          );
+        }
+      }
     }
 
     // Remaining properties override existing props

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -323,7 +323,6 @@ export function jsxDEV(type, config, maybeKey, source, self) {
       typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
     if (__DEV__) {
       if (typeof config.key !== 'string' && typeof config.key !== 'number') {
-        console.log('key', config.key, typeof config.key);
         console.warn(
           'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
         );

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -221,7 +221,7 @@ export function jsx(type, config, maybeKey) {
   // <div {...props} key="Hi" />, because we aren't currently able to tell if
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
-    key = '' + maybeKey;
+    key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
   }
 
   if (hasValidKey(config)) {
@@ -287,7 +287,7 @@ export function jsxDEV(type, config, maybeKey, source, self) {
   // <div {...props} key="Hi" />, because we aren't currently able to tell if
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
-    key = '' + maybeKey;
+    key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
   }
 
   if (hasValidKey(config)) {

--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -225,7 +225,9 @@ export function jsx(type, config, maybeKey) {
   }
 
   if (hasValidKey(config)) {
-    key = '' + config.key;
+    // key = typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
+    key =
+      typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
   }
 
   if (hasValidRef(config)) {
@@ -289,7 +291,8 @@ export function jsxDEV(type, config, maybeKey, source, self) {
   }
 
   if (hasValidKey(config)) {
-    key = '' + config.key;
+    key =
+      typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
   }
 
   if (hasValidRef(config)) {
@@ -365,7 +368,10 @@ export function createElement(type, config, children) {
       }
     }
     if (hasValidKey(config)) {
-      key = '' + config.key;
+      key =
+        typeof config.key === 'symbol'
+          ? config.key.toString()
+          : '' + config.key;
     }
 
     self = config.__self === undefined ? null : config.__self;
@@ -498,7 +504,10 @@ export function cloneElement(element, config, children) {
       owner = ReactCurrentOwner.current;
     }
     if (hasValidKey(config)) {
-      key = '' + config.key;
+      key =
+        typeof config.key === 'symbol'
+          ? config.key.toString()
+          : '' + config.key;
     }
 
     // Remaining properties override existing props

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -497,4 +497,32 @@ describe('ReactElement', () => {
     const jsonElement = JSON.stringify(React.createElement('div'));
     expect(React.isValidElement(JSON.parse(jsonElement))).toBe(false);
   });
+  it('does not crash when a Symbol is provided as the unique key', () => {
+    const container = document.createElement('div');
+    const uniq = originalSymbol('uniq');
+    const App = () => {
+      return (
+        <div key={uniq}>
+          <h1>Hello</h1>
+        </div>
+      );
+    };
+    ReactDOM.render(<App />, container);
+    const element = React.createElement('div', {key: uniq});
+    const cloned = React.cloneElement(
+      {
+        $$typeof: 60103,
+        type: 'div',
+        key: undefined,
+        ref: null,
+        props: {},
+        _owner: null,
+        _store: {},
+      },
+      {key: uniq},
+    );
+    expect(container.innerHTML).toBe('<div><h1>Hello</h1></div>');
+    expect(React.isValidElement(element)).toBe(true);
+    expect(React.isValidElement(cloned)).toBe(true);
+  });
 });

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -557,10 +557,14 @@ describe('ReactElement', () => {
       );
     };
     ReactDOM.render(<App />, container);
-    expect(consoleOutput).toStrictEqual([
-      'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior%s',
-      'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior%s',
-      'Warning: Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s',
-    ]);
+    if (__DEV__) {
+      expect(consoleOutput).toStrictEqual([
+        'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior%s',
+        'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior%s',
+        'Warning: Encountered two children with the same key, `%s`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.%s',
+      ]);
+    } else {
+      expect(consoleOutput).toStrictEqual([]);
+    }
   });
 });

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -525,4 +525,25 @@ describe('ReactElement', () => {
     expect(React.isValidElement(element)).toBe(true);
     expect(React.isValidElement(cloned)).toBe(true);
   });
+
+  it('throws when two siblings have different Symbols for the same value as the key', () => {
+    const container = document.createElement('div');
+    const uniq = originalSymbol('uniq');
+    const uniq2 = originalSymbol('uniq');
+    const App = () => {
+      return (
+        <>
+          <div key={uniq2} />
+          <div key={uniq}>
+            <h1>Hello</h1>
+          </div>
+        </>
+      );
+    };
+    expect(() => {
+      ReactDOM.render(<App />, container);
+    }).toErrorDev(
+      'Warning: Encountered two children with the same key, `Symbol(uniq)`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.',
+    );
+  });
 });

--- a/packages/react/src/__tests__/ReactElement-test.js
+++ b/packages/react/src/__tests__/ReactElement-test.js
@@ -508,7 +508,7 @@ describe('ReactElement', () => {
       );
     };
     ReactDOM.render(<App />, container);
-    const element = React.createElement('div', {key: uniq});
+    const element = React.createElement('div', {}, uniq);
     const cloned = React.cloneElement(
       {
         $$typeof: 60103,
@@ -519,7 +519,7 @@ describe('ReactElement', () => {
         _owner: null,
         _store: {},
       },
-      {key: uniq},
+      uniq,
     );
     expect(container.innerHTML).toBe('<div><h1>Hello</h1></div>');
     expect(React.isValidElement(element)).toBe(true);

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -415,4 +415,13 @@ describe('ReactElement.jsx', () => {
     // TODO: an explicit expect for no warning?
     ReactDOM.render(JSXRuntime.jsx(Parent, {}), container);
   });
+  it('does not crash when a Symbol is provided as the unique key', () => {
+    const container = document.createElement('div');
+    const uniq = originalSymbol('uniq');
+    const App = () => {
+      return JSXRuntime.jsx('div', {key: uniq});
+    };
+    ReactDOM.render(<App />, container);
+    expect(container.innerHTML).toBe('<div></div>');
+  });
 });

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -419,7 +419,7 @@ describe('ReactElement.jsx', () => {
     const container = document.createElement('div');
     const uniq = originalSymbol('uniq');
     const App = () => {
-      return JSXRuntime.jsx('div', {key: uniq});
+      return JSXRuntime.jsx('div', {}, uniq);
     };
     ReactDOM.render(<App />, container);
     expect(container.innerHTML).toBe('<div></div>');

--- a/packages/react/src/__tests__/ReactElementJSX-test.js
+++ b/packages/react/src/__tests__/ReactElementJSX-test.js
@@ -415,13 +415,17 @@ describe('ReactElement.jsx', () => {
     // TODO: an explicit expect for no warning?
     ReactDOM.render(JSXRuntime.jsx(Parent, {}), container);
   });
-  it('does not crash when a Symbol is provided as the unique key', () => {
+  it('warns dev, but does not crash when a Symbol is provided as the unique key', () => {
     const container = document.createElement('div');
     const uniq = originalSymbol('uniq');
     const App = () => {
       return JSXRuntime.jsx('div', {}, uniq);
     };
-    ReactDOM.render(<App />, container);
+    expect(() => {
+      ReactDOM.render(<App />, container);
+    }).toWarnDev(
+      'Warning: React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+    );
     expect(container.innerHTML).toBe('<div></div>');
   });
 });

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -226,7 +226,8 @@ export function jsx(type, config, maybeKey) {
   }
 
   if (hasValidKey(config)) {
-    key = '' + config.key;
+    key =
+      typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
   }
 
   if (hasValidRef(config)) {
@@ -291,7 +292,10 @@ export function jsxDEV(type, config, maybeKey, source, self) {
     }
 
     if (hasValidKey(config)) {
-      key = '' + config.key;
+      key =
+        typeof config.key === 'symbol'
+          ? config.key.toString()
+          : '' + config.key;
     }
 
     if (hasValidRef(config)) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -223,11 +223,33 @@ export function jsx(type, config, maybeKey) {
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
     key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
+    if (__DEV__) {
+      if (
+        config.key &&
+        typeof maybeKey !== 'string' &&
+        typeof maybeKey !== 'number'
+      ) {
+        console.warn(
+          'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidKey(config)) {
     key =
       typeof config.key === 'symbol' ? config.key.toString() : '' + config.key;
+    if (__DEV__) {
+      if (
+        config.key &&
+        typeof maybeKey !== 'string' &&
+        typeof maybeKey !== 'number'
+      ) {
+        console.warn(
+          'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+        );
+      }
+    }
   }
 
   if (hasValidRef(config)) {
@@ -289,6 +311,17 @@ export function jsxDEV(type, config, maybeKey, source, self) {
     // key is explicitly declared to be undefined or not.
     if (maybeKey !== undefined) {
       key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
+      if (__DEV__) {
+        if (
+          maybeKey &&
+          typeof maybeKey !== 'string' &&
+          typeof maybeKey !== 'number'
+        ) {
+          console.warn(
+            'React expects unique keys to be of type string or number. Other types will be automatically converted to strings, and may cause unexpected behavior',
+          );
+        }
+      }
     }
 
     if (hasValidKey(config)) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -222,7 +222,7 @@ export function jsx(type, config, maybeKey) {
   // <div {...props} key="Hi" />, because we aren't currently able to tell if
   // key is explicitly declared to be undefined or not.
   if (maybeKey !== undefined) {
-    key = '' + maybeKey;
+    key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
   }
 
   if (hasValidKey(config)) {
@@ -288,7 +288,7 @@ export function jsxDEV(type, config, maybeKey, source, self) {
     // <div {...props} key="Hi" />, because we aren't currently able to tell if
     // key is explicitly declared to be undefined or not.
     if (maybeKey !== undefined) {
-      key = '' + maybeKey;
+      key = typeof maybeKey === 'symbol' ? maybeKey.toString() : '' + maybeKey;
     }
 
     if (hasValidKey(config)) {


### PR DESCRIPTION


## Summary

Addresses #19851.

Currently using a symbol as a unique key causes a cryptic-ish error.

Now Symbol keys are stringified just like number keys, etc.
Symbol keys don't automatically crash the app.
If the dev does something bad, like " return (<><div key={ Symbol('foo') } ><div key={ Symbol('foo') } ></> ", they will get a descriptive error about duplicate keys.

## Test Plan
I ran yarn test and yarn test-prod.
