### PR TITLE
Don't call onCommit et al if there are no effects

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -60,8 +60,6 @@ import {
   Hydrating,
   ContentReset,
   DidCapture,
-  Update,
-  Passive,
   Ref,
   Deletion,
   ForceUpdateForLegacySuspense,
@@ -675,9 +673,6 @@ function updateProfiler(
   renderLanes: Lanes,
 ) {
   if (enableProfilerTimer) {
-    // TODO: Only call onRender et al if subtree has effects
-    workInProgress.flags |= Update | Passive;
-
     // Reset effect durations for the next eventual effect phase.
     // These are reset during render to allow the DevTools commit hook a chance to read them,
     const stateNode = workInProgress.stateNode;
@@ -3117,16 +3112,6 @@ function beginWork(
         }
         case Profiler:
           if (enableProfilerTimer) {
-            // Profiler should only call onRender when one of its descendants actually rendered.
-            // TODO: Only call onRender et al if subtree has effects
-            const hasChildWork = includesSomeLane(
-              renderLanes,
-              workInProgress.childLanes,
-            );
-            if (hasChildWork) {
-              workInProgress.flags |= Passive | Update;
-            }
-
             // Reset effect durations for the next eventual effect phase.
             // These are reset during render to allow the DevTools commit hook a chance to read them,
             const stateNode = workInProgress.stateNode;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -71,6 +71,7 @@ import {
   Placement,
   Snapshot,
   Update,
+  Callback,
   PassiveMask,
 } from './ReactFiberFlags';
 import getComponentName from 'shared/getComponentName';
@@ -792,10 +793,17 @@ function commitLifeCycles(
       if (enableProfilerTimer) {
         const {onCommit, onRender} = finishedWork.memoizedProps;
         const {effectDuration} = finishedWork.stateNode;
+        const flags = finishedWork.flags;
 
         const commitTime = getCommitTime();
 
-        if (typeof onRender === 'function') {
+        const OnRenderFlag = Update;
+        const OnCommitFlag = Callback;
+
+        if (
+          (flags & OnRenderFlag) !== NoFlags &&
+          typeof onRender === 'function'
+        ) {
           if (enableSchedulerTracing) {
             onRender(
               finishedWork.memoizedProps.id,
@@ -819,7 +827,10 @@ function commitLifeCycles(
         }
 
         if (enableProfilerCommitHooks) {
-          if (typeof onCommit === 'function') {
+          if (
+            (flags & OnCommitFlag) !== NoFlags &&
+            typeof onCommit === 'function'
+          ) {
             if (enableSchedulerTracing) {
               onCommit(
                 finishedWork.memoizedProps.id,


### PR DESCRIPTION
Checks `subtreeFlags` before scheduling an effect on the Profiler.

TODO: Need to update Profiler tests