### PR TITLE
eslint-plugin-react-hooks: JSX support for react-hooks/exhaustive-deps (#18051)

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1568,6 +1568,69 @@ const tests = {
         }
       `,
     },
+    // check JSXAttribute
+    {
+      code: normalizeIndent`
+        function Example({component: Component, attribute}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component attribute={attribute} />
+          }), [Component, attribute]);
+
+          return memoized.render();
+        }
+      `,
+    },
+    // check the JSX in a JSXAttribute
+    {
+      code: normalizeIndent`
+        function Example({
+          component: Component,
+          anotherComponent: AnotherComponent,
+        }) {
+          const memoized = useMemo(() => ({
+            render: () => <Component comp={AnotherComponent} />
+          }), [AnotherComponent, Component]);
+
+          return memoized.render();
+        }
+      `,
+    },
+    // check JSXSpreadAttribute
+    {
+      code: normalizeIndent`
+        function Example({component: Component, props}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component {...props} />
+          }), [Component, props]);
+
+          return memoized.render();
+        }
+      `,
+    },
+    // check JSXExpressionContainer
+    {
+      code: normalizeIndent`
+        function Example({component: Component, text}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component>{text}</Component>
+          }), [Component, text]);
+
+          return memoized.render();
+        }
+      `,
+    },
+    // check JSXMemberExpression
+    {
+      code: normalizeIndent`
+        function Example({component: Component}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component.Foo />
+          }), [Component]);
+
+          return memoized.render();
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -7693,6 +7756,179 @@ const tests = {
                   const memoized = useMemo(() => ({
                     render: () => null
                   }), []);
+
+                  return memoized.render();
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // check JSXExpressionContainer and JSXAttribute
+    {
+      code: normalizeIndent`
+        function Example({component: Component, attribute}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component attribute={attribute} />
+          }), [Component]);
+
+          return memoized.render();
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'attribute'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [Component, attribute]',
+              output: normalizeIndent`
+                function Example({component: Component, attribute}) {
+                  const memoized = useMemo(() => ({
+                    render: () => <Component attribute={attribute} />
+                  }), [Component, attribute]);
+
+                  return memoized.render();
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // check the JSX in a JSXAttribute
+    {
+      code: normalizeIndent`
+        function Example({
+          component: Component,
+          anotherComponent: AnotherComponent,
+        }) {
+          const memoized = useMemo(() => ({
+            render: () => <Component comp={AnotherComponent} />
+          }), [Component]);
+
+          return memoized.render();
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'AnotherComponent'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc:
+                'Update the dependencies array to be: [AnotherComponent, Component]',
+              output: normalizeIndent`
+                function Example({
+                  component: Component,
+                  anotherComponent: AnotherComponent,
+                }) {
+                  const memoized = useMemo(() => ({
+                    render: () => <Component comp={AnotherComponent} />
+                  }), [AnotherComponent, Component]);
+
+                  return memoized.render();
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // check JSXSpreadAttribute
+    {
+      code: normalizeIndent`
+        function Example({component: Component, props}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component {...props} />
+          }), [Component]);
+
+          return memoized.render();
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'props'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [Component, props]',
+              output: normalizeIndent`
+                function Example({component: Component, props}) {
+                  const memoized = useMemo(() => ({
+                    render: () => <Component {...props} />
+                  }), [Component, props]);
+
+                  return memoized.render();
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // check JSXExpressionContainer
+    {
+      code: normalizeIndent`
+        function Example({component: Component, text}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component>{text}</Component>
+          }), [Component]);
+
+          return memoized.render();
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'text'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [Component, text]',
+              output: normalizeIndent`
+                function Example({component: Component, text}) {
+                  const memoized = useMemo(() => ({
+                    render: () => <Component>{text}</Component>
+                  }), [Component, text]);
+
+                  return memoized.render();
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    // check JSXMemberExpression
+    {
+      code: normalizeIndent`
+        function Example({component: Component}) {
+          const memoized = useMemo(() => ({
+            render: () => <Component.Foo />
+          }), []);
+
+          return memoized.render();
+        }
+      `,
+      errors: [
+        {
+          message:
+            "React Hook useMemo has a missing dependency: 'Component'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [Component]',
+              output: normalizeIndent`
+                function Example({component: Component}) {
+                  const memoized = useMemo(() => ({
+                    render: () => <Component.Foo />
+                  }), [Component]);
 
                   return memoized.render();
                 }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -442,9 +442,99 @@ export default {
           }
         }
 
+        gatherJSXDependencies(currentScope);
+
         for (const childScope of currentScope.childScopes) {
           gatherDependenciesRecursively(childScope);
         }
+      }
+
+      function gatherJSXDependencies(currentScope) {
+        if (currentScope.type !== 'function') return;
+
+        const {body} = currentScope.block;
+        const JSXComponents = [];
+
+        // check JSXElement/JSXFragment for arrow functions
+        // and BlockStatement for traditional functions
+        switch (body.type) {
+          case 'JSXElement':
+          case 'JSXFragment':
+            findJSXComponents(body);
+            break;
+          case 'BlockStatement':
+            const bodyElements = [].concat(body.body);
+
+            bodyElements.forEach(element => {
+              if (
+                element.type === 'ReturnStatement' &&
+                (element.argument.type === 'JSXElement' ||
+                  isFragment(element.argument))
+              ) {
+                findJSXComponents(element.argument);
+              }
+            });
+            break;
+          default:
+            break;
+        }
+
+        function isHTMLElement(name) {
+          return /^[a-z]/.test(name);
+        }
+
+        function isFragment(element) {
+          // <> </>
+          if (element.type === 'JSXFragment') return true;
+
+          if (element.type !== 'JSXElement') return false;
+
+          const name = element.openingElement.name;
+
+          // <Fragment> </Fragment>
+          return (
+            name.name === 'Fragment' ||
+            // <React.Fragment> </React.Fragment>
+            (name.type === 'JSXMemberExpression' &&
+              name.object.name === 'React' &&
+              name.object.type === 'JSXIdentifier' &&
+              name.property.name === 'Fragment' &&
+              name.property.type === 'JSXIdentifier')
+          );
+        }
+
+        // check JSX elements tree
+        function findJSXComponents(element) {
+          const elements = [element];
+
+          while (elements.length) {
+            const current = elements.shift();
+
+            if (!isFragment(current)) {
+              const {openingElement} = current;
+              const elementName = openingElement.name.name;
+
+              if (
+                !isHTMLElement(elementName) &&
+                !JSXComponents.includes(elementName)
+              ) {
+                JSXComponents.push(elementName);
+              }
+            }
+
+            current.children.forEach(child => {
+              if (child.type === 'JSXElement') {
+                elements.push(child);
+              }
+            });
+          }
+        }
+
+        JSXComponents.forEach(component =>
+          dependencies.set(component, {
+            references: [],
+          }),
+        );
       }
 
       // Warn about accessing .current in cleanup effects.
@@ -939,7 +1029,10 @@ export default {
           // Is this a variable from top scope?
           const topScopeRef = componentScope.set.get(missingDep);
           const usedDep = dependencies.get(missingDep);
-          if (usedDep.references[0].resolved !== topScopeRef) {
+          if (
+            usedDep.references.length === 0 ||
+            usedDep.references[0].resolved !== topScopeRef
+          ) {
             return;
           }
           // Is this a destructured prop?


### PR DESCRIPTION
## Summary

#18051

As mentioned in the [discussion](https://github.com/eslint/eslint-scope/issues/61), ESLint does not implement React-specific logic, and therefore JSX Identifiers will not be treated by ESLint as regular variables with references to them in scopes.

Because of this circumstance, when we collect hook callback dependencies, JSX variables don't end up in the list of dependencies and JSX-component variables declared in the hook dependencies array are considered exhaustive, but they are not.

So I implemented a prototype of a possible solution to this problem — handling JSX-expressions in the dependency gathering logic of the plugin.

In a nutshell, if JSX is found in the callback hook, then I traverse the JSX tree of elements and collect a list of React components. In the process, I filter out all elements that are not React components. Then I add the resulting array to the list of collected dependencies, which will be checked for exhaustiveness or lack of dependencies.

My prototype solution is imperfect at the moment, it doesn't find JSX-expressions in if/else constructions, it does not fully support JSXMemberExpressions, I have not yet written Typescript tests, etc. But I will do my best if I know that this is the right way.

Thanks!

## Test Plan
✅ All test, test-prod, lint, flow checks are passed.
Added some new tests for positive and negative cases of JSX support.