### PR TITLE
Scheduling Profiler: Improve import performance by dropping IE support

### DIFF
--- a/packages/react-devtools-scheduling-profiler/babel.config.js
+++ b/packages/react-devtools-scheduling-profiler/babel.config.js
@@ -1,0 +1,33 @@
+module.exports = api => {
+  const isTest = api.env('test');
+
+  const plugins = [
+    ['@babel/plugin-transform-flow-strip-types'],
+    ['@babel/plugin-proposal-class-properties', {loose: false}],
+
+    // The plugins below fix compilation errors on Webpack 4.
+    // See: https://github.com/webpack/webpack/issues/10227
+    // TODO: Remove once we're on Webpack 5.
+    ['@babel/plugin-proposal-optional-chaining'],
+    ['@babel/plugin-proposal-nullish-coalescing-operator'],
+  ];
+  if (process.env.NODE_ENV !== 'production') {
+    plugins.push(['@babel/plugin-transform-react-jsx-source']);
+  }
+
+  return {
+    plugins,
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: isTest
+            ? {node: 'current'}
+            : 'last 2 Chrome versions, last 2 Firefox versions',
+        },
+      ],
+      '@babel/preset-react',
+      '@babel/preset-flow',
+    ],
+  };
+};

--- a/packages/react-devtools-scheduling-profiler/webpack.config.js
+++ b/packages/react-devtools-scheduling-profiler/webpack.config.js
@@ -27,12 +27,7 @@ const DEVTOOLS_VERSION = getVersionString();
 const imageInlineSizeLimit = 10000;
 
 const babelOptions = {
-  configFile: resolve(
-    __dirname,
-    '..',
-    'react-devtools-shared',
-    'babel.config.js',
-  ),
+  configFile: resolve(__dirname, 'babel.config.js'),
   plugins: shouldUseDevServer
     ? [resolve(builtModulesDir, 'react-refresh/babel')]
     : [],


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves https://github.com/facebook/react/pull/19759#issuecomment-687177142 by forking the [shared DevTools Babel config](https://github.com/facebook/react/blob/8b2d3783e58d1acea53428a10d2035a8399060fe/packages/react-devtools-shared/babel.config.js) and disabling IE support. I think this should be okay for our standalone app, but we'll likely hit this perf issue again when this is merged into the main DevTools.

cc @bvaughn

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Manually tested with our 57MB facebook.com profile.

Current https://react-scheduling-profiler.vercel.app/ (deployed from https://github.com/MLH-Fellowship/scheduling-profiler-prototype):

![image](https://user-images.githubusercontent.com/12784593/93750229-ba724400-fc2d-11ea-9847-88f5355a9abe.png)

`master`:

![image](https://user-images.githubusercontent.com/12784593/93750308-dbd33000-fc2d-11ea-85c8-e631dfaccbeb.png)

This branch. It's about 5%-15% slower than https://react-scheduling-profiler.vercel.app/:

![image](https://user-images.githubusercontent.com/12784593/93752869-d972d500-fc31-11ea-88f2-00ad5248870a.png)

Alternate approach (b48ab94): reducing supported browsers to just `last 2 Chrome/Firefox versions`. This has a runtime similar to https://react-scheduling-profiler.vercel.app/:

![image](https://user-images.githubusercontent.com/12784593/93750465-189f2700-fc2e-11ea-9da0-f5110aa2a3e4.png)