### PR TITLE
Use single quotes in getComponentName return

### DIFF
--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -66,7 +66,7 @@ function getComponentName(type: mixed): string | null {
     case REACT_PORTAL_TYPE:
       return 'Portal';
     case REACT_PROFILER_TYPE:
-      return `Profiler`;
+      return 'Profiler';
     case REACT_STRICT_MODE_TYPE:
       return 'StrictMode';
     case REACT_SUSPENSE_TYPE:


### PR DESCRIPTION
Hi everyone,

this PR replaces backticks with single quotes in a one-word string.
All other returns in the same switch use single quotes.

Cheers!