### PR TITLE
DevTools: Drop IE 11 support

### DIFF
--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -17,6 +17,11 @@ const __DEV__ = NODE_ENV === 'development';
 
 const DEVTOOLS_VERSION = getVersionString();
 
+// This targets RN/Hermes.
+process.env.BABEL_CONFIG_ADDITIONAL_TARGETS = JSON.stringify({
+  ie: '11',
+});
+
 module.exports = {
   mode: __DEV__ ? 'development' : 'production',
   devtool: __DEV__ ? 'cheap-module-eval-source-map' : 'source-map',

--- a/packages/react-devtools-shared/babel.config.js
+++ b/packages/react-devtools-shared/babel.config.js
@@ -25,8 +25,13 @@ module.exports = api => {
     targets.chrome = minChromeVersion.toString();
     targets.firefox = minFirefoxVersion.toString();
 
-    // This targets RN/Hermes.
-    targets.ie = '11';
+    let additionalTargets = process.env.BABEL_CONFIG_ADDITIONAL_TARGETS;
+    if (additionalTargets) {
+      additionalTargets = JSON.parse(additionalTargets);
+      for (const target in additionalTargets) {
+        targets[target] = additionalTargets[target];
+      }
+    }
   }
   const plugins = [
     ['@babel/plugin-transform-flow-strip-types'],


### PR DESCRIPTION
Alternative to #19872

DevTools shared Babel config previously supported IE 11 to target Hermes (for the standalone backend that gets embedded within React Native apps). This targeting resulted in less optimal code for other DevTools targets though which did not need to support IE 11. This PR updates the shared config to remove IE 11 support by default, and only enables it for the standalone backend target.

cc @taneliang