### PR TITLE
Enable new reconciler in npm builds

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -90,13 +90,13 @@ export const warnAboutSpreadingKeyToJSX = false;
 
 export const enableComponentStackLocations = true;
 
-export const enableNewReconciler = false;
+export const enableNewReconciler = true;
 
 // Errors that are thrown while unmounting (or after in the case of passive effects)
 // should bypass any error boundaries that are also unmounting (or have unmounted)
 // and be handled by the nearest still-mounted boundary.
 // If there are no still-mounted boundaries, the errors should be rethrown.
-export const skipUnmountedBoundaries = false;
+export const skipUnmountedBoundaries = true;
 
 // --------------------------
 // Future APIs to be deprecated

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -42,9 +42,9 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableComponentStackLocations = true;
 export const enableLegacyFBSupport = false;
 export const enableFilterEmptyStringAttributesDOM = false;
-export const skipUnmountedBoundaries = false;
+export const skipUnmountedBoundaries = true;
 
-export const enableNewReconciler = false;
+export const enableNewReconciler = true;
 export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;


### PR DESCRIPTION
For the next 17 RC since we want to include it in stable.

But this means that when 17 ships, we need to copy the files and revert this PR, or we'll start shipping every risky update.