### PR TITLE
Refactor layout effect methods

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -455,9 +455,8 @@ function recursivelyCommitLayoutEffects(
 
       let child = finishedWork.child;
       while (child !== null) {
-        const primaryFlags = child.flags & LayoutMask;
-        const primarySubtreeFlags = child.subtreeFlags & LayoutMask;
-        if (primaryFlags !== NoFlags || primarySubtreeFlags !== NoFlags) {
+        const primarySubtreeFlags = finishedWork.subtreeFlags & LayoutMask;
+        if (primarySubtreeFlags !== NoFlags) {
           if (__DEV__) {
             const prevCurrentFiberInDEV = currentDebugFiberInDEV;
             setCurrentDebugFiberInDEV(child);
@@ -541,9 +540,8 @@ function recursivelyCommitLayoutEffects(
     default: {
       let child = finishedWork.child;
       while (child !== null) {
-        const primaryFlags = child.flags & LayoutMask;
-        const primarySubtreeFlags = child.subtreeFlags & LayoutMask;
-        if (primaryFlags !== NoFlags || primarySubtreeFlags !== NoFlags) {
+        const primarySubtreeFlags = finishedWork.subtreeFlags & LayoutMask;
+        if (primarySubtreeFlags !== NoFlags) {
           if (__DEV__) {
             const prevCurrentFiberInDEV = currentDebugFiberInDEV;
             setCurrentDebugFiberInDEV(child);
@@ -644,18 +642,18 @@ function recursivelyCommitLayoutEffects(
           }
         }
       }
-      break;
-    }
-  }
 
-  if (enableScopeAPI) {
-    // TODO: This is a temporary solution that allowed us to transition away from React Flare on www.
-    if (flags & Ref && tag !== ScopeComponent) {
-      commitAttachRef(finishedWork);
-    }
-  } else {
-    if (flags & Ref) {
-      commitAttachRef(finishedWork);
+      if (enableScopeAPI) {
+        // TODO: This is a temporary solution that allowed us to transition away from React Flare on www.
+        if (flags & Ref && tag !== ScopeComponent) {
+          commitAttachRef(finishedWork);
+        }
+      } else {
+        if (flags & Ref) {
+          commitAttachRef(finishedWork);
+        }
+      }
+      break;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -121,7 +121,6 @@ import {
   resolveRetryWakeable,
   markCommitTimeOfFallback,
   schedulePassiveEffectCallback,
-  penultimateProfilerOnStack,
 } from './ReactFiberWorkLoop.new';
 import {
   NoFlags as NoHookEffect,
@@ -425,13 +424,6 @@ function commitProfilerPassiveEffect(
             );
           }
         }
-
-        // Bubble times to the next nearest ancestor Profiler.
-        // After we process that Profiler, we'll bubble further up.
-        if (penultimateProfilerOnStack !== null) {
-          const stateNode = penultimateProfilerOnStack.stateNode;
-          stateNode.passiveEffectDuration += passiveEffectDuration;
-        }
         break;
       }
       default:
@@ -727,13 +719,6 @@ function commitLifeCycles(
                 commitTime,
               );
             }
-          }
-
-          // Propagate layout effect durations to the next nearest Profiler ancestor.
-          // Do not reset these values until the next render so DevTools has a chance to read them first.
-          if (penultimateProfilerOnStack !== null) {
-            const stateNode = penultimateProfilerOnStack.stateNode;
-            stateNode.effectDuration += effectDuration;
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1764,7 +1764,7 @@ function commitResetTextContent(current: Fiber): void {
   resetTextContent(current.stateNode);
 }
 
-function commitPassiveUnmountInsideDeletedTree(finishedWork: Fiber): void {
+function commitPassiveUnmount(finishedWork: Fiber): void {
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:
@@ -1794,7 +1794,7 @@ function commitPassiveUnmountInsideDeletedTree(finishedWork: Fiber): void {
   }
 }
 
-function commitPassiveUnmount(
+function commitPassiveUnmountInsideDeletedTree(
   current: Fiber,
   nearestMountedAncestor: Fiber | null,
 ): void {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -121,6 +121,7 @@ import {
   resolveRetryWakeable,
   markCommitTimeOfFallback,
   schedulePassiveEffectCallback,
+  penultimateProfilerOnStack,
 } from './ReactFiberWorkLoop.new';
 import {
   NoFlags as NoHookEffect,
@@ -427,15 +428,9 @@ function commitProfilerPassiveEffect(
 
         // Bubble times to the next nearest ancestor Profiler.
         // After we process that Profiler, we'll bubble further up.
-        // TODO: Use JS Stack instead
-        let parentFiber = finishedWork.return;
-        while (parentFiber !== null) {
-          if (parentFiber.tag === Profiler) {
-            const parentStateNode = parentFiber.stateNode;
-            parentStateNode.passiveEffectDuration += passiveEffectDuration;
-            break;
-          }
-          parentFiber = parentFiber.return;
+        if (penultimateProfilerOnStack !== null) {
+          const stateNode = penultimateProfilerOnStack.stateNode;
+          stateNode.passiveEffectDuration += passiveEffectDuration;
         }
         break;
       }
@@ -736,15 +731,9 @@ function commitLifeCycles(
 
           // Propagate layout effect durations to the next nearest Profiler ancestor.
           // Do not reset these values until the next render so DevTools has a chance to read them first.
-          // TODO: Use JS Stack instead
-          let parentFiber = finishedWork.return;
-          while (parentFiber !== null) {
-            if (parentFiber.tag === Profiler) {
-              const parentStateNode = parentFiber.stateNode;
-              parentStateNode.effectDuration += effectDuration;
-              break;
-            }
-            parentFiber = parentFiber.return;
+          if (penultimateProfilerOnStack !== null) {
+            const stateNode = penultimateProfilerOnStack.stateNode;
+            stateNode.effectDuration += effectDuration;
           }
         }
       }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2563,7 +2563,7 @@ function flushPassiveUnmountEffects(firstChild: Fiber): void {
     const primaryFlags = fiber.flags & Passive;
     if (primaryFlags !== NoFlags) {
       setCurrentDebugFiberInDEV(fiber);
-      commitPassiveUnmountInsideDeletedTreeOnFiber(fiber);
+      commitPassiveUnmountOnFiber(fiber);
       resetCurrentDebugFiberInDEV();
     }
 
@@ -2592,7 +2592,10 @@ function flushPassiveUnmountEffectsInsideOfDeletedTree(
 
   if ((fiberToDelete.flags & PassiveStatic) !== NoFlags) {
     setCurrentDebugFiberInDEV(fiberToDelete);
-    commitPassiveUnmountOnFiber(fiberToDelete, nearestMountedAncestor);
+    commitPassiveUnmountInsideDeletedTreeOnFiber(
+      fiberToDelete,
+      nearestMountedAncestor,
+    );
     resetCurrentDebugFiberInDEV();
   }
 }


### PR DESCRIPTION
Follow up to PR #19862 (see https://github.com/facebook/react/pull/19862#discussion_r491130225).

---

Commit phase durations (layout and passive) are stored on the nearest (ancestor) Profiler and bubble up during the commit phase. This bubbling used to be implemented by traversing the return path each time we finished working on a Profiler to find the next nearest Profiler.

This commit removes that traversal. Instead, we maintain a stack of nearest Profiler ancestor while recursing the tree. This stack is maintained in the work loop (since that's where the recursive functions are) and so bubbling of durations has also been moved from commit-work to the work loop.

This PR also refactors the methods used to recurse and apply effects in preparation for the new Offscreen component type.