### PR TITLE
Temporarily disable Profiler commit hooks flag

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -35,7 +35,9 @@ export const {
 // It's not used anywhere in production yet.
 
 export const enableProfilerTimer = __PROFILE__;
-export const enableProfilerCommitHooks = __PROFILE__;
+
+// Temporarily disable commit hooks flag to verify it does not cause a regression.
+export const enableProfilerCommitHooks = false;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
 export const enableSchedulingProfiler = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -37,6 +37,7 @@ export const {
 export const enableProfilerTimer = __PROFILE__;
 
 // Temporarily disable commit hooks flag to verify it does not cause a regression.
+// TODO (brian) Re-enable this flag if performance is mostly neutral.
 export const enableProfilerCommitHooks = false;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.


### PR DESCRIPTION
This will enable us to enable/disable it on www to see if it causes a regression.

At first I thought I'd make this flag static. Converting a static flag to dynamic isn't great, but this particular flag doesn't add any additional fields to a `Fiber`. However it would add an additional runtime check to a hot path so I'm going to just disable it entirely for now.

This PR does not need to land to take this measurement. I'll do an out-of-band sync with it.