### PR TITLE
Remove arguments from hot path

### DIFF
--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -19,7 +19,7 @@ type EventInterfaceType = {
  * @interface Event
  * @see http://www.w3.org/TR/DOM-Level-3-Events/
  */
-const EventInterface: EventInterfaceType = {
+export const EventInterface: EventInterfaceType = {
   eventPhase: 0,
   bubbles: 0,
   cancelable: 0,
@@ -57,7 +57,7 @@ export function SyntheticEvent(
   targetInst: Fiber,
   nativeEvent: {[propName: string]: mixed},
   nativeEventTarget: null | EventTarget,
-  Interface: EventInterfaceType = EventInterface,
+  Interface: EventInterfaceType,
 ) {
   this._reactName = reactName;
   this._targetInst = targetInst;

--- a/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
@@ -12,7 +12,7 @@ import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
 
 import {registerTwoPhaseEvent} from '../EventRegistry';
-import {SyntheticEvent} from '../SyntheticEvent';
+import {SyntheticEvent, EventInterface} from '../SyntheticEvent';
 import isTextInputElement from '../isTextInputElement';
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 
@@ -55,6 +55,7 @@ function createAndAccumulateChangeEvent(
     null,
     nativeEvent,
     target,
+    EventInterface,
   );
   // Flag this event loop as needing state restore.
   enqueueStateRestore(((target: any): Node));

--- a/packages/react-dom/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SelectEventPlugin.js
@@ -13,7 +13,7 @@ import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
-import {SyntheticEvent} from '../../events/SyntheticEvent';
+import {SyntheticEvent, EventInterface} from '../../events/SyntheticEvent';
 import isTextInputElement from '../isTextInputElement';
 import shallowEqual from 'shared/shallowEqual';
 import {enableEagerRootListeners} from 'shared/ReactFeatureFlags';
@@ -119,6 +119,7 @@ function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
       null,
       nativeEvent,
       nativeEventTarget,
+      EventInterface,
     );
     syntheticEvent.target = activeElement;
 

--- a/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
@@ -15,6 +15,7 @@ import type {EventSystemFlags} from '../EventSystemFlags';
 
 import {
   SyntheticEvent,
+  EventInterface,
   AnimationEventInterface,
   ClipboardEventInterface,
   FocusEventInterface,
@@ -62,7 +63,7 @@ function extractEvents(
   if (reactName === undefined) {
     return;
   }
-  let EventInterface;
+  let eventInterface = EventInterface;
   let reactEventType = domEventName;
   switch (domEventName) {
     case 'keypress':
@@ -75,19 +76,19 @@ function extractEvents(
     /* falls through */
     case 'keydown':
     case 'keyup':
-      EventInterface = KeyboardEventInterface;
+      eventInterface = KeyboardEventInterface;
       break;
     case 'focusin':
       reactEventType = 'focus';
-      EventInterface = FocusEventInterface;
+      eventInterface = FocusEventInterface;
       break;
     case 'focusout':
       reactEventType = 'blur';
-      EventInterface = FocusEventInterface;
+      eventInterface = FocusEventInterface;
       break;
     case 'beforeblur':
     case 'afterblur':
-      EventInterface = FocusEventInterface;
+      eventInterface = FocusEventInterface;
       break;
     case 'click':
       // Firefox creates a click event on right mouse clicks. This removes the
@@ -106,7 +107,7 @@ function extractEvents(
     case 'mouseout':
     case 'mouseover':
     case 'contextmenu':
-      EventInterface = MouseEventInterface;
+      eventInterface = MouseEventInterface;
       break;
     case 'drag':
     case 'dragend':
@@ -116,32 +117,32 @@ function extractEvents(
     case 'dragover':
     case 'dragstart':
     case 'drop':
-      EventInterface = DragEventInterface;
+      eventInterface = DragEventInterface;
       break;
     case 'touchcancel':
     case 'touchend':
     case 'touchmove':
     case 'touchstart':
-      EventInterface = TouchEventInterface;
+      eventInterface = TouchEventInterface;
       break;
     case ANIMATION_END:
     case ANIMATION_ITERATION:
     case ANIMATION_START:
-      EventInterface = AnimationEventInterface;
+      eventInterface = AnimationEventInterface;
       break;
     case TRANSITION_END:
-      EventInterface = TransitionEventInterface;
+      eventInterface = TransitionEventInterface;
       break;
     case 'scroll':
-      EventInterface = UIEventInterface;
+      eventInterface = UIEventInterface;
       break;
     case 'wheel':
-      EventInterface = WheelEventInterface;
+      eventInterface = WheelEventInterface;
       break;
     case 'copy':
     case 'cut':
     case 'paste':
-      EventInterface = ClipboardEventInterface;
+      eventInterface = ClipboardEventInterface;
       break;
     case 'gotpointercapture':
     case 'lostpointercapture':
@@ -151,7 +152,7 @@ function extractEvents(
     case 'pointerout':
     case 'pointerover':
     case 'pointerup':
-      EventInterface = PointerEventInterface;
+      eventInterface = PointerEventInterface;
       break;
     default:
       // Unknown event. This is used by createEventHandle.
@@ -163,7 +164,7 @@ function extractEvents(
     null,
     nativeEvent,
     nativeEventTarget,
-    EventInterface,
+    eventInterface,
   );
 
   const inCapturePhase = (eventSystemFlags & IS_CAPTURE_PHASE) !== 0;

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -15,7 +15,7 @@ import {
   HostComponent,
   HostText,
 } from 'react-reconciler/src/ReactWorkTags';
-import {SyntheticEvent} from '../events/SyntheticEvent';
+import {SyntheticEvent, EventInterface} from '../events/SyntheticEvent';
 import invariant from 'shared/invariant';
 import {ELEMENT_NODE} from '../shared/HTMLNodeType';
 import {act} from './ReactTestUtilsPublicAct';
@@ -589,6 +589,7 @@ function makeSimulator(eventType) {
       targetInst,
       fakeNativeEvent,
       domNode,
+      EventInterface,
     );
 
     // Since we aren't using pooling, always persist the event. This will make


### PR DESCRIPTION
`SyntheticEvent` factory is very hot. The default argument syntax compiles to `arguments` access which may be triggering deopts. To be safe, let's not use it and always pass the last argument explicitly.