### PR TITLE
Create Synthetic Events Lazily

### DIFF
--- a/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
@@ -226,23 +226,25 @@ function extractCompositionEvent(
     }
   }
 
-  const event = new SyntheticCompositionEvent(
-    eventType,
-    domEventName,
-    null,
-    nativeEvent,
-    nativeEventTarget,
-  );
-  accumulateTwoPhaseListeners(targetInst, dispatchQueue, event);
-
-  if (fallbackData) {
-    // Inject data generated from fallback path into the synthetic event.
-    // This matches the property of native CompositionEventInterface.
-    event.data = fallbackData;
-  } else {
-    const customData = getDataFromCustomEvent(nativeEvent);
-    if (customData !== null) {
-      event.data = customData;
+  const listeners = accumulateTwoPhaseListeners(targetInst, eventType);
+  if (listeners.length > 0) {
+    const event = new SyntheticCompositionEvent(
+      eventType,
+      domEventName,
+      null,
+      nativeEvent,
+      nativeEventTarget,
+    );
+    dispatchQueue.push({event, listeners});
+    if (fallbackData) {
+      // Inject data generated from fallback path into the synthetic event.
+      // This matches the property of native CompositionEventInterface.
+      event.data = fallbackData;
+    } else {
+      const customData = getDataFromCustomEvent(nativeEvent);
+      if (customData !== null) {
+        event.data = customData;
+      }
     }
   }
 }
@@ -394,15 +396,18 @@ function extractBeforeInputEvent(
     return null;
   }
 
-  const event = new SyntheticInputEvent(
-    'onBeforeInput',
-    'beforeinput',
-    null,
-    nativeEvent,
-    nativeEventTarget,
-  );
-  accumulateTwoPhaseListeners(targetInst, dispatchQueue, event);
-  event.data = chars;
+  const listeners = accumulateTwoPhaseListeners(targetInst, 'onBeforeInput');
+  if (listeners.length > 0) {
+    const event = new SyntheticInputEvent(
+      'onBeforeInput',
+      'beforeinput',
+      null,
+      nativeEvent,
+      nativeEventTarget,
+    );
+    dispatchQueue.push({event, listeners});
+    event.data = chars;
+  }
 }
 
 /**

--- a/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
@@ -49,16 +49,19 @@ function createAndAccumulateChangeEvent(
   nativeEvent,
   target,
 ) {
-  const event = new SyntheticEvent(
-    'onChange',
-    'change',
-    null,
-    nativeEvent,
-    target,
-  );
   // Flag this event loop as needing state restore.
   enqueueStateRestore(((target: any): Node));
-  accumulateTwoPhaseListeners(inst, dispatchQueue, event);
+  const listeners = accumulateTwoPhaseListeners(inst, 'onChange');
+  if (listeners.length > 0) {
+    const event = new SyntheticEvent(
+      'onChange',
+      'change',
+      null,
+      nativeEvent,
+      target,
+    );
+    dispatchQueue.push({event, listeners});
+  }
 }
 /**
  * For IE shims

--- a/packages/react-dom/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SelectEventPlugin.js
@@ -113,20 +113,21 @@ function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
   if (!lastSelection || !shallowEqual(lastSelection, currentSelection)) {
     lastSelection = currentSelection;
 
-    const syntheticEvent = new SyntheticEvent(
-      'onSelect',
-      'select',
-      null,
-      nativeEvent,
-      nativeEventTarget,
-    );
-    syntheticEvent.target = activeElement;
-
-    accumulateTwoPhaseListeners(
+    const listeners = accumulateTwoPhaseListeners(
       activeElementInst,
-      dispatchQueue,
-      syntheticEvent,
+      'onSelect',
     );
+    if (listeners.length > 0) {
+      const event = new SyntheticEvent(
+        'onSelect',
+        'select',
+        null,
+        nativeEvent,
+        nativeEventTarget,
+      );
+      dispatchQueue.push({event, listeners});
+      event.target = activeElement;
+    }
   }
 }
 


### PR DESCRIPTION
Currently we create them very aggressively — especially with the eager change — but many may not end up being used. While the allocation itself is not a significant cost, we are actually running a bunch of code there, including iterating over the event interface, copying every known property into `this`, and running our normalization polyfills. In some cases, our polyfills also do some other extra work (e.g. some calculations).

However, this is just an artifact of the initial code structure. We don't actually need to create the synthetic events early except the enter/leave case where it's much more convenient. In other cases, we can make them lazy and create if we actually found some listeners. This also lets us delay any other extra work.

I should note that with a throttled CPU, the SyntheticEvent constructor takes a noticeable amount of time for noops, which is why I want to optimize this.