### PR TITLE
ReactDebugHooks clones refs before shallow render (and warns on mutate)

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -158,7 +158,7 @@ function useReducer<S, I, A>(
 
 function useRef<T>(initialValue: T): {|current: T|} {
   const hook = nextHook();
-  const ref = hook !== null ? hook.memoizedState : {current: initialValue};
+  const ref = hook !== null ? {...hook.memoizedState} : {current: initialValue};
   hookLog.push({
     primitive: 'Ref',
     stackError: new Error(),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->
Fixes #19114

## Summary
The bug is due to the fact that to read the hooks the debug tools use the real object ref. The problem is that if this object is modified by the debug tools it is never cleaned (in our case we created a new function with a dummy setstate). So my fix is to make a shallow copy for the useref case. Maybe we have to do it for all hooks or do a deep copy?
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
