### PR TITLE
Moved createElement, cloneElement & createFactory into the new module

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -22,12 +22,7 @@ import {
 import {Component, PureComponent} from './ReactBaseClasses';
 import {createRef} from './ReactCreateRef';
 import {forEach, map, count, toArray, only} from './ReactChildren';
-import {
-  createElement as createElementProd,
-  createFactory as createFactoryProd,
-  cloneElement as cloneElementProd,
-  isValidElement,
-} from './ReactElement';
+import {isValidElement} from './ReactElement';
 import {createContext} from './ReactContext';
 import {lazy} from './ReactLazy';
 import {forwardRef} from './ReactForwardRef';
@@ -49,7 +44,11 @@ import {
   useDeferredValue,
   useOpaqueIdentifier,
 } from './ReactHooks';
-import {createElement, cloneElement, createFactory} from './ReactElementCreator';
+import {
+  createElement,
+  cloneElement,
+  createFactory,
+} from './ReactElementCreator';
 import {createMutableSource} from './ReactMutableSource';
 import ReactSharedInternals from './ReactSharedInternals';
 import {createFundamental} from './ReactFundamental';

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -49,20 +49,11 @@ import {
   useDeferredValue,
   useOpaqueIdentifier,
 } from './ReactHooks';
-import {
-  createElementWithValidation,
-  createFactoryWithValidation,
-  cloneElementWithValidation,
-} from './ReactElementValidator';
+import {createElement, cloneElement, createFactory} from './ReactElementCreator';
 import {createMutableSource} from './ReactMutableSource';
 import ReactSharedInternals from './ReactSharedInternals';
 import {createFundamental} from './ReactFundamental';
 import {startTransition} from './ReactStartTransition';
-
-// TODO: Move this branching into the other module instead and just re-export.
-const createElement = __DEV__ ? createElementWithValidation : createElementProd;
-const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;
-const createFactory = __DEV__ ? createFactoryWithValidation : createFactoryProd;
 
 const Children = {
   map,

--- a/packages/react/src/ReactElementCreator.js
+++ b/packages/react/src/ReactElementCreator.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {
+  createElementWithValidation,
+  createFactoryWithValidation,
+  cloneElementWithValidation,
+} from './ReactElementValidator';
+
+const createElement = __DEV__ ? createElementWithValidation : createElementProd;
+const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;
+const createFactory = __DEV__ ? createFactoryWithValidation : createFactoryProd;
+
+export {createElement, cloneElement, createFactory};

--- a/packages/react/src/ReactElementCreator.js
+++ b/packages/react/src/ReactElementCreator.js
@@ -12,6 +12,11 @@ import {
   createFactoryWithValidation,
   cloneElementWithValidation,
 } from './ReactElementValidator';
+import {
+  createElement as createElementProd,
+  createFactory as createFactoryProd,
+  cloneElement as cloneElementProd,
+} from './ReactElement';
 
 const createElement = __DEV__ ? createElementWithValidation : createElementProd;
 const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;


### PR DESCRIPTION
## Summary

There was 7-month TODO comment. Just moved `__DEV__` branching to independent module and re-exported it. Thereby production build size reduced for 3~ KB.

## Test Plan

No special tests required