### PR TITLE
Debug tracing tests for CPU bound suspense

### DIFF
--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -191,12 +191,23 @@ describe('DebugTracing', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-    ]);
+    gate(flags => {
+      if (flags.new) {
+        expect(logs).toEqual([
+          'group: ⚛️ render (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+        ]);
+      } else {
+        expect(logs).toEqual([
+          'group: ⚛️ render (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
+          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+        ]);
+      }
+    });
   });
 
   // @gate experimental && build === 'development' && enableDebugTracing
@@ -274,12 +285,24 @@ describe('DebugTracing', () => {
         {unstable_isConcurrent: true},
       );
     });
-    expect(logs).toEqual([
-      'group: ⚛️ render (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)', // debugRenderPhaseSideEffectsForStrictMode
-      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-    ]);
+
+    gate(flags => {
+      if (flags.new) {
+        expect(logs).toEqual([
+          'group: ⚛️ render (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)', // debugRenderPhaseSideEffectsForStrictMode
+          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+        ]);
+      } else {
+        expect(logs).toEqual([
+          'group: ⚛️ render (0b0000000000000000000001000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
+          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)', // debugRenderPhaseSideEffectsForStrictMode
+          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+        ]);
+      }
+    });
   });
 
   // @gate experimental && build === 'development' && enableDebugTracing

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -25,7 +25,7 @@ export const enableEagerRootListeners = !__VARIANT__;
 // It logs information to the console about React scheduling, rendering, and commit phases.
 //
 // NOTE: This feature will only work in DEV mode; all callsights are wrapped with __DEV__.
-export const enableDebugTracing = false;
+export const enableDebugTracing = __EXPERIMENTAL__;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of


### PR DESCRIPTION
Follow up for PR #19936

Add "debug tracing" tests for CPU-bound Suspense API.

I also noticed that the test coverage for the `enableDebugTracing ` flag was accidentally broken during a reconciler sync (51267c4ac9de8bf190505fbb7670ed99aae325f7). This PR also re-enables it for our `test-www-variant` target.