### PR TITLE
Remove unnecessary error overriding in

### DIFF
--- a/packages/shared/__tests__/ReactErrorProd-test.internal.js
+++ b/packages/shared/__tests__/ReactErrorProd-test.internal.js
@@ -11,27 +11,9 @@
 let formatProdErrorMessage;
 
 describe('ReactErrorProd', () => {
-  let globalErrorMock;
-
   beforeEach(() => {
-    if (!__DEV__) {
-      // In production, our Jest environment overrides the global Error
-      // class in order to decode error messages automatically. However
-      // this is a single test where we actually *don't* want to decode
-      // them. So we assert that the OriginalError exists, and temporarily
-      // set the global Error object back to it.
-      globalErrorMock = global.Error;
-      global.Error = globalErrorMock.OriginalError;
-      expect(typeof global.Error).toBe('function');
-    }
     jest.resetModules();
     formatProdErrorMessage = require('shared/formatProdErrorMessage').default;
-  });
-
-  afterEach(() => {
-    if (!__DEV__) {
-      global.Error = globalErrorMock;
-    }
   });
 
   it('should throw with the correct number of `%s`s in the URL', () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Motivation: Existing test code has extraneous behavior that confuses its purpose.

There's `beforeEach`/`afterEach` logic in one of the tests for the shared package that overrides Jest's replacement `Error` logic. This shouldn't be necessary, though, since the function it tests (`formatProdErrorMessage`) doesn't throw any errors in the first place.

If there's a reason that this behavior is here, it doesn't seem adequately explained in the comments that are present. Please let me know if this is serving some function, and I can update the comments to elaborate!

## Test Plan

Tests should run exactly as before; this change just cleans up unnecessary mock override logic.
