### PR TITLE
Treat <time> tag as a normal HTML tag.

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1273,10 +1273,6 @@ describe('ReactDOMComponent', () => {
           if (this instanceof window.HTMLUnknownElement) {
             return '[object HTMLUnknownElement]';
           }
-          // Special case! Read explanation below in the test.
-          if (this instanceof window.HTMLTimeElement) {
-            return '[object HTMLUnknownElement]';
-          }
           return realToString.apply(this, arguments);
         };
         Object.prototype.toString = wrappedToString; // eslint-disable-line no-extend-native
@@ -1289,11 +1285,6 @@ describe('ReactDOMComponent', () => {
           'The tag <foo> is unrecognized in this browser',
         );
         ReactTestUtils.renderIntoDocument(<foo />);
-        // This is a funny case.
-        // Chrome is the only major browser not shipping <time>. But as of July
-        // 2017 it intends to ship it due to widespread usage. We intentionally
-        // *don't* warn for <time> even if it's unrecognized by Chrome because
-        // it soon will be, and many apps have been using it anyway.
         ReactTestUtils.renderIntoDocument(<time />);
         // Corner case. Make sure out deduplication logic doesn't break with weird tag.
         expect(() =>

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -112,11 +112,6 @@ let normalizeHTML;
 
 if (__DEV__) {
   warnedUnknownTags = {
-    // Chrome is the only major browser not shipping <time>. But as of July
-    // 2017 it intends to ship it due to widespread usage. We intentionally
-    // *don't* warn for <time> even if it's unrecognized by Chrome because
-    // it soon will be, and many apps have been using it anyway.
-    time: true,
     // There are working polyfills for <dialog>. Let people use it.
     dialog: true,
     // Electron ships a custom <webview> tag to display external web content in


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Before Chrome 62(this is in 2017) , chrome didn't support `<time>` despite it being widely used.  At the time the Chrome team probably announced that they will be supporting the `<time>` tag in their next release. To avoid React complain before the Chrome release, some code to suppress these errors is in place.

It's 2020 now and there's no need to have the code to suppress errors  as `<time>` tag is supported by Chrome. This PR removes that code.

## Test Plan
This is the test log of relevant tests.

```
shivam@shivam-desktop:~/coding/opensource/react$ yarn test ReactDOMComponent-test.js
yarn run v1.22.5
$ node ./scripts/jest/jest-cli.js ReactDOMComponent-test.js
$ NODE_ENV=development RELEASE_CHANNEL=experimental node ./scripts/jest/jest.js --config ./scripts/jest/config.source.js ReactDOMComponent-test.js

Running tests for default (experimental)...
 PASS  packages/react-dom/src/__tests__/ReactDOMComponent-test.js (15.737s)
  ReactDOMComponent
    ✓ receives events in specific order (85ms)
    updateDOM
      ✓ should handle className (309ms)
      ✓ should gracefully handle various style value types (95ms)
      ✓ should not update styles when mutating a proxy style object (108ms)
      ✓ should throw when mutating style objects (104ms)
      ✓ should warn for unknown prop (86ms)
      ✓ should group multiple unknown prop warnings together (87ms)
      ✓ should warn for onDblClick prop (84ms)
      ✓ should warn for unknown string event handlers (90ms)
      ✓ should warn for unknown function event handlers (99ms)
      ✓ should warn for badly cased React attributes (85ms)
      ✓ should not warn for "0" as a unitless style value (80ms)
      ✓ should warn nicely about NaN in style (86ms)
      ✓ should update styles if initially null (92ms)
      ✓ should update styles if updated to null multiple times (90ms)
      ✓ should allow named slot projection on both web components and regular DOM elements (88ms)
      ✓ should skip reserved props on web components (92ms)
      ✓ should skip dangerouslySetInnerHTML on web components (83ms)
      ✓ should render null and undefined as empty but print other falsy values (86ms)
      ✓ should remove attributes (84ms)
      ✓ should remove properties (86ms)
      ✓ should not set null/undefined attributes (94ms)
      ✓ should apply React-specific aliases to HTML elements (86ms)
      ✓ should apply React-specific aliases to SVG elements (101ms)
      ✓ should properly update custom attributes on custom elements (80ms)
      ✓ should not apply React-specific aliases to custom elements (82ms)
      ✓ should clear a single style prop when changing `style` (92ms)
      ✓ should reject attribute key injection attack on markup for regular DOM (SSR) (73ms)
      ✓ should reject attribute key injection attack on markup for custom elements (SSR) (68ms)
      ✓ should reject attribute key injection attack on mount for regular DOM (95ms)
      ✓ should reject attribute key injection attack on mount for custom elements (92ms)
      ✓ should reject attribute key injection attack on update for regular DOM (90ms)
      ✓ should reject attribute key injection attack on update for custom elements (105ms)
      ✓ should update arbitrary attributes for tags containing dashes (82ms)
      ✓ should clear all the styles when removing `style` (80ms)
      ✓ should update styles when `style` changes from null to object (83ms)
      ✓ should not reset innerHTML for when children is null (85ms)
      ✓ should reset innerHTML when switching from a direct text child to an empty child (85ms)
      ✓ should empty element when removing innerHTML (86ms)
      ✓ should transition from string content to innerHTML (90ms)
      ✓ should transition from innerHTML to string content (80ms)
      ✓ should transition from innerHTML to children in nested el (81ms)
      ✓ should transition from children to innerHTML in nested el (84ms)
      ✓ should not incur unnecessary DOM mutations for attributes (91ms)
      ✓ should not incur unnecessary DOM mutations for string properties (91ms)
      ✓ should not incur unnecessary DOM mutations for boolean properties (84ms)
      ✓ should ignore attribute list for elements with the "is" attribute (85ms)
      ✓ should warn about non-string "is" attribute (79ms)
      ✓ should not update when switching between null/undefined (81ms)
      ✓ handles multiple child updates without interference (83ms)
    createOpenTagMarkup
      ✓ should generate the correct markup with className (85ms)
      ✓ should escape style names and values (70ms)
    createContentMarkup
      ✓ should handle dangerouslySetInnerHTML (66ms)
    mountComponent
      ✓ should work error event on <source> element (84ms)
      ✓ should not duplicate uppercased selfclosing tags (78ms)
      ✓ should warn on upper case HTML tags, not SVG nor custom tags (83ms)
      ✓ should warn on props reserved for future use (86ms)
      ✓ should warn if the tag is unrecognized (98ms)
      ✓ should throw on children for void elements (145ms)
      ✓ should throw on dangerouslySetInnerHTML for void elements (80ms)
      ✓ should treat menuitem as a void element but still create the closing tag (84ms)
      ✓ should validate against multiple children props (86ms)
      ✓ should validate against use of innerHTML (86ms)
      ✓ should validate against use of innerHTML without case sensitivity (82ms)
      ✓ should validate use of dangerouslySetInnerHTML (80ms)
      ✓ should validate use of dangerouslySetInnerHTML (79ms)
      ✓ should allow {__html: null} (84ms)
      ✓ should warn about contentEditable and children (86ms)
      ✓ should respect suppressContentEditableWarning (81ms)
      ✓ should validate against invalid styles (85ms)
      ✓ should throw for children on void elements (85ms)
      ✓ should support custom elements which extend native elements (78ms)
      ✓ should work load and error events on <image> element in SVG (81ms)
      ✓ should receive a load event on <link> elements (92ms)
      ✓ should receive an error event on <link> elements (82ms)
    updateComponent
      ✓ should warn against children for void elements (84ms)
      ✓ should warn against dangerouslySetInnerHTML for void elements (89ms)
      ✓ should validate against multiple children props (82ms)
      ✓ should warn about contentEditable and children (79ms)
      ✓ should validate against invalid styles (89ms)
      ✓ should report component containing invalid styles (91ms)
      ✓ should properly escape text content and attributes values (66ms)
    unmountComponent
      ✓ unmounts children before unsetting DOM node info (80ms)
    tag sanitization
      ✓ should throw when an invalid tag name is used server-side (79ms)
      ✓ should throw when an attack vector is used server-side (64ms)
      ✓ should throw when an invalid tag name is used (78ms)
      ✓ should throw when an attack vector is used (86ms)
    nesting validation
      ✓ warns on invalid nesting (86ms)
      ✓ warns on invalid nesting at root (78ms)
      ✓ warns nicely for table rows (86ms)
      ✓ gives useful context in warnings (85ms)
      ✓ gives useful context in warnings 2 (84ms)
      ✓ gives useful context in warnings 3 (96ms)
      ✓ gives useful context in warnings 4 (86ms)
      ✓ gives useful context in warnings 5 (88ms)
      ✓ should warn about incorrect casing on properties (ssr) (70ms)
      ✓ should warn about incorrect casing on event handlers (ssr) (75ms)
      ✓ should warn about incorrect casing on properties (79ms)
      ✓ should warn about incorrect casing on event handlers (91ms)
      ✓ should warn about class (78ms)
      ✓ should warn about class (ssr) (72ms)
      ✓ should warn about props that are no longer supported (81ms)
      ✓ should warn about props that are no longer supported without case sensitivity (81ms)
      ✓ should warn about props that are no longer supported (ssr) (73ms)
      ✓ should warn about props that are no longer supported without case sensitivity (ssr) (74ms)
      ✓ gives source code refs for unknown prop warning (85ms)
      ✓ gives source code refs for unknown prop warning (ssr) (74ms)
      ✓ gives source code refs for unknown prop warning for update render (81ms)
      ✓ gives source code refs for unknown prop warning for exact elements (82ms)
      ✓ gives source code refs for unknown prop warning for exact elements (ssr) (69ms)
      ✓ gives source code refs for unknown prop warning for exact elements in composition (102ms)
      ✓ gives source code refs for unknown prop warning for exact elements in composition (ssr) (77ms)
      ✓ should suggest property name if available (82ms)
      ✓ should suggest property name if available (ssr) (74ms)
    whitespace
      ✓ renders innerHTML and preserves whitespace (80ms)
      ✓ render and then updates innerHTML and preserves whitespace (83ms)
    Attributes with aliases
      ✓ sets aliased attributes on HTML attributes (92ms)
      ✓ sets incorrectly cased aliased attributes on HTML attributes with a warning (83ms)
      ✓ sets aliased attributes on SVG elements with a warning (87ms)
      ✓ sets aliased attributes on custom elements (78ms)
      ✓ aliased attributes on custom elements with bad casing (83ms)
      ✓ updates aliased attributes on custom elements (80ms)
    Custom attributes
      ✓ allows assignment of custom attributes with string values (83ms)
      ✓ removes custom attributes (91ms)
      ✓ does not assign a boolean custom attributes as a string (80ms)
      ✓ does not assign an implicit boolean custom attributes (83ms)
      ✓ assigns a numeric custom attributes as a string (78ms)
      ✓ will not assign a function custom attributes (86ms)
      ✓ will assign an object custom attributes (84ms)
      ✓ allows cased data attributes (83ms)
      ✓ allows cased custom attributes (79ms)
      ✓ warns on NaN attributes (85ms)
      ✓ removes a property when it becomes invalid (81ms)
      ✓ warns on bad casing of known HTML attributes (80ms)
    Object stringification
      ✓ allows objects on known properties (90ms)
      ✓ should pass objects as attributes if they define toString (88ms)
      ✓ passes objects on known SVG attributes if they do not define toString (78ms)
      ✓ passes objects on custom attributes if they do not define toString (77ms)
      ✓ allows objects that inherit a custom toString method (83ms)
      ✓ assigns ajaxify (an important internal FB attribute) (78ms)
    String boolean attributes
      ✓ does not assign string boolean attributes for custom attributes (79ms)
      ✓ stringifies the boolean true for allowed attributes (87ms)
      ✓ stringifies the boolean false for allowed attributes (84ms)
      ✓ stringifies implicit booleans for allowed attributes (76ms)
    Boolean attributes
      ✓ warns on the ambiguous string value "false" (79ms)
      ✓ warns on the potentially-ambiguous string value "true" (90ms)
    Hyphenated SVG elements
      ✓ the font-face element is not a custom element (81ms)
      ✓ the font-face element does not allow unknown boolean values (89ms)
    Custom elements
      ✓ does not strip unknown boolean attributes (81ms)
      ✓ does not strip the on* attributes (86ms)
    iOS Tap Highlight
      ✓ adds onclick handler to elements with onClick prop (78ms)
      ✓ adds onclick handler to a portal root (79ms)
      ✓ does not add onclick handler to the React root (97ms)

Test Suites: 1 passed, 1 total
Tests:       153 passed, 153 total
Snapshots:   0 total
Time:        16.557s
Ran all test suites matching /ReactDOMComponent-test.js/i.
Done in 18.45s.

```
