### PR TITLE
delete dead code in updateHostRoot

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -1066,10 +1066,6 @@ function updateHostRoot(current, workInProgress, renderLanes) {
   // Caution: React DevTools currently depends on this property
   // being called "element".
   const nextChildren = nextState.element;
-  if (nextChildren === prevChildren) {
-    resetHydrationState();
-    return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
-  }
   const root: FiberRoot = workInProgress.stateNode;
   if (root.hydrate && enterHydrationState(workInProgress)) {
     // If we don't have any current children this might be the first pass.


### PR DESCRIPTION
1. In general, The FiberRoot does not change and It is bailed in beginWork.
2. If a root rebuild occurs, its prevChildren is null. Therefore, it will not be executed here.
    For example:mount root.
    If nextChildren is null, This page is noop.(Even so, it's normal)
Suggest. If root element is null or undefined, we can early exit.It's noop.