### PR TITLE
handled a missing suspense fiber when suspense is filtered on the profiler

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/storeComponentFilters-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/storeComponentFilters-test.js.snap
@@ -84,6 +84,19 @@ exports[`Store component filters should ignore invalid ElementTypeRoot filter: 2
       <div>
 `;
 
+exports[`Store component filters should not break when Suspense nodes are filtered from the tree: 1: suspended 1`] = `
+[root]
+  ▾ <Wrapper>
+    ▾ <Loading>
+        <div>
+`;
+
+exports[`Store component filters should not break when Suspense nodes are filtered from the tree: 2: resolved 1`] = `
+[root]
+  ▾ <Wrapper>
+      <Component>
+`;
+
 exports[`Store component filters should support filtering by element type: 1: mount 1`] = `
 [root]
   ▾ <Root>

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -227,4 +227,34 @@ describe('Store component filters', () => {
         ]),
     );
   });
+
+  it('should not break when Suspense nodes are filtered from the tree', () => {
+    const promise = new Promise(() => {});
+
+    const Loading = () => <div>Loading...</div>;
+
+    const Component = ({shouldSuspend}) => {
+      if (shouldSuspend) {
+        throw promise;
+      }
+      return null;
+    };
+
+    const Wrapper = ({shouldSuspend}) => (
+      <React.Suspense fallback={<Loading />}>
+        <Component shouldSuspend={shouldSuspend} />
+      </React.Suspense>
+    );
+
+    store.componentFilters = [
+      utils.createElementTypeFilter(Types.ElementTypeSuspense),
+    ];
+
+    const container = document.createElement('div');
+    act(() => ReactDOM.render(<Wrapper shouldSuspend={true} />, container));
+    expect(store).toMatchSnapshot('1: suspended');
+
+    act(() => ReactDOM.render(<Wrapper shouldSuspend={false} />, container));
+    expect(store).toMatchSnapshot('2: resolved');
+  });
 });

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1572,7 +1572,7 @@ export function attach(
       if (nextPrimaryChildSet !== null) {
         mountFiberRecursively(
           nextPrimaryChildSet,
-          nextFiber,
+          shouldIncludeInTree ? nextFiber : parentFiber,
           true,
           traceNearestHostComponentUpdate,
         );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

fixes [#18256](https://github.com/facebook/react/issues/18256#issue-578077772) and fixes [#19633](https://github.com/facebook/react/issues/19633#issue-680756123)

If suspense is filtered in the profiler and started profiling, when the suspense fallback unmounts, the primary fiber tries to mount to the suspense fiber above it, but because it is filtered the profiler throws those errors thus the missing fiber in this [#19633](https://github.com/facebook/react/issues/19633#issue-680756123) and the undefined in this [#18256](https://github.com/facebook/react/issues/18256#issue-578077772). 
So instead of that, when suspense is filtered I re-parent it to the parent fiber of the suspense fiber.

That said, this problem also generates this issue [#19547](https://github.com/facebook/react/issues/19547#issue-674411480) and this one [#18924](https://github.com/facebook/react/issues/18924#issue-618218428). Depending on the place of the suspense fiber in the tree relatively to the rendered elements (is it rendered alone, or rendered with siblings, or only its children are rendered...) a different error is thrown.
In the example below suspense is rendered along with a `<h1>Hello </h1>`  sibling and a div parent.

**Before:**
![before the fix](https://user-images.githubusercontent.com/31975500/95536759-b131f700-09e3-11eb-9276-afc9824ce212.gif)

**After:**
![after the fix](https://user-images.githubusercontent.com/31975500/95536924-20a7e680-09e4-11eb-82f7-8c449dea4982.gif)
