### PR TITLE
Remove Set bookkeeping for root events

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -996,6 +996,6 @@ describe('ReactDOMEventListener', () => {
       document.addEventListener = originalDocAddEventListener;
     }
 
-    expect(log).toEqual([false, true]);
+    expect(log).toEqual([false]);
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventListener-test.js
@@ -973,4 +973,29 @@ describe('ReactDOMEventListener', () => {
       document.body.removeChild(container);
     }
   });
+
+  it('should not subscribe to selectionchange twice', () => {
+    const log = [];
+
+    const originalDocAddEventListener = document.addEventListener;
+    document.addEventListener = function(type, fn, options) {
+      switch (type) {
+        case 'selectionchange':
+          log.push(options);
+          break;
+        default:
+          throw new Error(
+            `Did not expect to add a document-level listener for the "${type}" event.`,
+          );
+      }
+    };
+    try {
+      ReactDOM.render(<input />, document.createElement('div'));
+      ReactDOM.render(<input />, document.createElement('div'));
+    } finally {
+      document.addEventListener = originalDocAddEventListener;
+    }
+
+    expect(log).toEqual([false, true]);
+  });
 });

--- a/packages/react-dom/src/client/ReactDOMEventHandle.js
+++ b/packages/react-dom/src/client/ReactDOMEventHandle.js
@@ -22,9 +22,7 @@ import {
   addEventHandleToTarget,
 } from './ReactDOMComponentTree';
 import {ELEMENT_NODE} from '../shared/HTMLNodeType';
-import {listenToNativeEvent} from '../events/DOMPluginEventSystem';
-
-import {IS_EVENT_HANDLE_NON_MANAGED_NODE} from '../events/EventSystemFlags';
+import {listenToNativeEventForNonManagedEventTarget} from '../events/DOMPluginEventSystem';
 
 import {
   enableScopeAPI,
@@ -69,12 +67,10 @@ function registerReactDOMEvent(
     const eventTarget = ((target: any): EventTarget);
     // These are valid event targets, but they are also
     // non-managed React nodes.
-    listenToNativeEvent(
+    listenToNativeEventForNonManagedEventTarget(
       domEventName,
       isCapturePhaseListener,
       eventTarget,
-      null,
-      IS_EVENT_HANDLE_NON_MANAGED_NODE,
     );
   } else {
     invariant(

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -295,6 +295,15 @@ export function listenToNonDelegatedEvent(
   domEventName: DOMEventName,
   targetElement: Element,
 ): void {
+  if (__DEV__) {
+    if (!nonDelegatedEvents.has(domEventName)) {
+      console.error(
+        'Did not expect a listenToNonDelegatedEvent() call for "%s". ' +
+          'This is a bug in React. Please file an issue.',
+        domEventName,
+      );
+    }
+  }
   const isCapturePhaseListener = false;
   const listenerSet = getEventListenerSet(targetElement);
   const listenerSetKey = getListenerSetKey(
@@ -317,6 +326,16 @@ export function listenToNativeEvent(
   isCapturePhaseListener: boolean,
   rootContainerElement: EventTarget,
 ): void {
+  if (__DEV__) {
+    if (nonDelegatedEvents.has(domEventName) && !isCapturePhaseListener) {
+      console.error(
+        'Did not expect a listenToNativeEvent() call for "%s" in the bubble phase. ' +
+          'This is a bug in React. Please file an issue.',
+        domEventName,
+      );
+    }
+  }
+
   let eventSystemFlags = 0;
   let target = rootContainerElement;
 

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -397,7 +397,7 @@ export function listenToAllSupportedEvents(rootContainerElement: EventTarget) {
     const ownerDocument =
       (rootContainerElement: any).nodeType === DOCUMENT_NODE
         ? rootContainerElement
-        : rootContainerElement.ownerDocument;
+        : (rootContainerElement: any).ownerDocument;
     if (ownerDocument !== null) {
       // The selectionchange event also needs deduplication
       // but it is attached to the document.

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -363,37 +363,12 @@ export function listenToNativeEvent(
   ) {
     target = (rootContainerElement: any).ownerDocument;
   }
-  // If the event can be delegated (or is capture phase), we can
-  // register it to the root container. Otherwise, we should
-  // register the event to the target element and mark it as
-  // a non-delegated event.
-  if (
-    targetElement !== null &&
-    !isCapturePhaseListener &&
-    nonDelegatedEvents.has(domEventName)
-  ) {
-    // For all non-delegated events, apart from scroll, we attach
-    // their event listeners to the respective elements that their
-    // events fire on. That means we can skip this step, as event
-    // listener has already been added previously. However, we
-    // special case the scroll event because the reality is that any
-    // element can scroll.
-    // TODO: ideally, we'd eventually apply the same logic to all
-    // events from the nonDelegatedEvents list. Then we can remove
-    // this special case and use the same logic for all events.
-    if (domEventName !== 'scroll') {
-      return;
-    }
-    eventSystemFlags |= IS_NON_DELEGATED;
-    target = targetElement;
-  }
+
   const listenerSet = getEventListenerSet(target);
   const listenerSetKey = getListenerSetKey(
     domEventName,
     isCapturePhaseListener,
   );
-  // If the listener entry is empty or we should upgrade, then
-  // we need to trap an event listener onto the target.
   if (!listenerSet.has(listenerSetKey)) {
     if (isCapturePhaseListener) {
       eventSystemFlags |= IS_CAPTURE_PHASE;

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -312,39 +312,6 @@ export function listenToNonDelegatedEvent(
   }
 }
 
-const listeningMarker =
-  '_reactListening' +
-  Math.random()
-    .toString(36)
-    .slice(2);
-
-export function listenToAllSupportedEvents(rootContainerElement: EventTarget) {
-  if ((rootContainerElement: any)[listeningMarker]) {
-    // Performance optimization: don't iterate through events
-    // for the same portal container or root node more than once.
-    // TODO: once we remove the flag, we may be able to also
-    // remove some of the bookkeeping maps used for laziness.
-    return;
-  }
-  (rootContainerElement: any)[listeningMarker] = true;
-  allNativeEvents.forEach(domEventName => {
-    if (!nonDelegatedEvents.has(domEventName)) {
-      listenToNativeEvent(
-        domEventName,
-        false,
-        ((rootContainerElement: any): Element),
-        null,
-      );
-    }
-    listenToNativeEvent(
-      domEventName,
-      true,
-      ((rootContainerElement: any): Element),
-      null,
-    );
-  });
-}
-
 export function listenToNativeEvent(
   domEventName: DOMEventName,
   isCapturePhaseListener: boolean,
@@ -381,6 +348,39 @@ export function listenToNativeEvent(
     );
     listenerSet.add(listenerSetKey);
   }
+}
+
+const listeningMarker =
+  '_reactListening' +
+  Math.random()
+    .toString(36)
+    .slice(2);
+
+export function listenToAllSupportedEvents(rootContainerElement: EventTarget) {
+  if ((rootContainerElement: any)[listeningMarker]) {
+    // Performance optimization: don't iterate through events
+    // for the same portal container or root node more than once.
+    // TODO: once we remove the flag, we may be able to also
+    // remove some of the bookkeeping maps used for laziness.
+    return;
+  }
+  (rootContainerElement: any)[listeningMarker] = true;
+  allNativeEvents.forEach(domEventName => {
+    if (!nonDelegatedEvents.has(domEventName)) {
+      listenToNativeEvent(
+        domEventName,
+        false,
+        ((rootContainerElement: any): Element),
+        null,
+      );
+    }
+    listenToNativeEvent(
+      domEventName,
+      true,
+      ((rootContainerElement: any): Element),
+      null,
+    );
+  });
 }
 
 function addTrappedEventListener(


### PR DESCRIPTION
See individual commits.

This removes some dead code now that we don't use eager listeners. Then this forks the code between createEventHandle and the normal subscriptions since they have slightly different needs. Finally, this removes the Set bookkeeping for root events only (but it's still needed for non-managed createEventHandle and for non-delegated codepath which I haven't changed). I've needed to slightly restructure the code to keep deduplicating `selectionchange` (by the document).

I think the end result is a bit simpler. It also slightly reduces the work per portal creation.