### PR TITLE
test: Add regression test for hooks after error boundaries

### DIFF
--- a/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+
+describe('ReactErrorBoundariesHooks', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    ReactDOM = require('react-dom');
+    React = require('react');
+  });
+
+  it('should preserve hook order if errors are caught', () => {
+    function ErrorThrower() {
+      React.useMemo(() => undefined, []);
+      throw new Error('expected');
+      return null;
+    }
+
+    function StatefulComponent() {
+      React.useState(null);
+      return ' | stateful';
+    }
+
+    class ErrorHandler extends React.Component {
+      state = {error: null};
+
+      componentDidCatch(error) {
+        return this.setState({error});
+      }
+
+      render() {
+        if (this.state.error !== null) {
+          return <p>Handled error: {this.state.error.message}</p>;
+        }
+        return this.props.children;
+      }
+    }
+
+    function App(props) {
+      return (
+        <React.Fragment>
+          <ErrorHandler>
+            <ErrorThrower />
+          </ErrorHandler>
+          <StatefulComponent />
+        </React.Fragment>
+      );
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(<App />, container);
+
+    expect(() => {
+      ReactDOM.render(<App />, container);
+    }).not.toThrow();
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactErrorBoundariesHooks-test.internal.js
@@ -23,7 +23,6 @@ describe('ReactErrorBoundariesHooks', () => {
     function ErrorThrower() {
       React.useMemo(() => undefined, []);
       throw new Error('expected');
-      return null;
     }
 
     function StatefulComponent() {


### PR DESCRIPTION

## Summary

Closes #15301
Closes #15219

The issue itself is fixed starting with `16.9.0`. It was fixed in https://github.com/facebook/react/pull/15387.

Adding it to `./packages/react-dom/src/__tests__/ReactErrorBoundaries-test.internal.js` is not sufficient since the test is passing in `v16.8.6` with `replayFailedUnitOfWorkWithInvokeGuardedCallback = false`

## Test Plan

1. Reproduced error with 16.8.6: https://codesandbox.io/s/caught-error-with-sibling-hooks-o13p0
1. Could not reproduce with 16.9.0: https://codesandbox.io/s/caught-error-with-sibling-hooks-1690-j79yw
1. Add test file
   ```js
    /**
     * Copyright (c) Facebook, Inc. and its affiliates.
     *
     * This source code is licensed under the MIT license found in the
     * LICENSE file in the root directory of this source tree.
     *
     * @emails react-core
     */

    'use strict';

    let React;
    let ReactDOM;

    describe('ReactErrorBoundariesHooks', () => {
      beforeEach(() => {
        jest.resetModules();
        ReactDOM = require('react-dom');
        React = require('react');
      });

      it('should preserve hook order if errors are caught', () => {
        function ErrorThrower() {
          React.useMemo(() => undefined, []);
          throw new Error('expected');
        }

        function StatefulComponent() {
          React.useState(null);
          return ' | stateful';
        }

        class ErrorHandler extends React.Component {
          state = {error: null};

          componentDidCatch(error) {
            return this.setState({error});
          }

          render() {
            if (this.state.error !== null) {
              return <p>Handled error: {this.state.error.message}</p>;
            }
            return this.props.children;
          }
        }

        function App(props) {
          return (
            <React.Fragment>
              <ErrorHandler>
                <ErrorThrower />
              </ErrorHandler>
              <StatefulComponent />
            </React.Fragment>
          );
        }

        const container = document.createElement('div');
        ReactDOM.render(<App />, container);

        expect(() => {
          ReactDOM.render(<App />, container);
        }).not.toThrow();
      });
    });

   ```
1. create `bisect.sh`
   ```sh
    #!/bin/bash
    yarn
    ! yarn test ReactErrorBoundariesHooks
    exit $?
   ```
```sh
$ git merge-base v16.8.6 v16.9.0 # 3e5556043879c9c7b98dd9edfc0e89df0366714b
$ git bisect start --term-new=fixed --term-old=unfixed
$ git checkout v16.9.0
$ git bisect fixed
$ git checkout 3e5556043879c9c7b98dd9edfc0e89df0366714b # merge base of 16.8.6. and 16.9.0
$ git bisect unfixed
$ git bisect run ./bisect.sh
9055e31e5c82d03f0a365c459f7bc79e402dbef5 is the first fixed commit

