### PR TITLE
Fix bad null check in DevTools highlight code

### DIFF
--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -103,7 +103,7 @@ export default function setupHighlighter(
     }
 
     let nodes: ?Array<HTMLElement> = null;
-    if (renderer !== null) {
+    if (renderer != null) {
       nodes = ((renderer.findNativeNodesForFiberID(
         id,
       ): any): ?Array<HTMLElement>);


### PR DESCRIPTION
Noticed this error while looking into another DevTools error:
> TypeError: Cannot read property 'findNativeNodesForFiberID' of undefined

The null check was bad.