### PR TITLE
fixed unfound node error when Suspense is filtered

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/storeComponentFilters-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/storeComponentFilters-test.js.snap
@@ -97,6 +97,13 @@ exports[`Store component filters should not break when Suspense nodes are filter
       <Component>
 `;
 
+exports[`Store component filters should not break when Suspense nodes are filtered from the tree: 3: suspended 1`] = `
+[root]
+  ▾ <Wrapper>
+    ▾ <Loading>
+        <div>
+`;
+
 exports[`Store component filters should support filtering by element type: 1: mount 1`] = `
 [root]
   ▾ <Root>

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -256,5 +256,8 @@ describe('Store component filters', () => {
 
     act(() => ReactDOM.render(<Wrapper shouldSuspend={false} />, container));
     expect(store).toMatchSnapshot('2: resolved');
+
+    act(() => ReactDOM.render(<Wrapper shouldSuspend={true} />, container));
+    expect(store).toMatchSnapshot('3: suspended');
   });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test-prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

fixes [#18924](https://github.com/facebook/react/issues/18924#issue-618218428)
fixes another occurrence of [#18256](https://github.com/facebook/react/issues/18256#issue-578077772) and [#19633](https://github.com/facebook/react/issues/19633#issue-680756123).

Reordering children of Suspense in a timed-out state can't be done, as in this state, it has two Fragment children one for the fallback and the other for the primary child, and for the tree to be built correctly, the primary child should be removed or skipped.

## How to reproduce it
Here's [the codesandbox](https://codesandbox.io/s/could-not-find-suspense-node-error-u0crl) code.

![Untitled_ Oct 14, 2020 1_08 PM](https://user-images.githubusercontent.com/31975500/95989416-278a8b00-0e22-11eb-8593-61dc9c2f5859.gif)

cc @bvaughn 

