### PR TITLE
Use state component ref warning

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -65,7 +65,6 @@ import {
 } from './ReactFiberWorkLoop.old';
 
 import invariant from 'shared/invariant';
-import isValidElementType from 'shared/isValidElementType';
 import getComponentName from 'shared/getComponentName';
 import is from 'shared/objectIs';
 import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork.old';
@@ -90,7 +89,6 @@ import {
 import {getIsRendering} from './ReactCurrentFiber';
 import {logStateUpdateScheduled} from './DebugTracing';
 import {markStateUpdateScheduled} from './SchedulingProfiler';
-import {REACT_FORWARD_REF_TYPE, REACT_MEMO_TYPE} from 'shared/ReactSymbols';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -622,7 +622,7 @@ function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
   // $FlowFixMe: Flow doesn't like mixed types
   if (__DEV__) {
     if (isLikelyComponentType(action)) {
-      console.error('u sure?');
+      console.error('You can\'t set React Component reference to state, because it\'s treated as "Functional update" function');
     }
   }
   return typeof action === 'function' ? action(state) : action;

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -267,7 +267,7 @@ describe('ReactHooks', () => {
 
     expect(() => {
       act(() => setComponent(Bar));
-    }).toErrorDev('Warning: u sure?', {withoutStack: true});
+    }).toErrorDev('Warning: You can\'t set React Component reference to state, because it\'s treated as "Functional update" function', {withoutStack: true});
   });
 
   it('warns about setState second argument', () => {

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -246,6 +246,30 @@ describe('ReactHooks', () => {
     expect(Scheduler).toHaveYielded(['Parent: 1, 2 (dark)']);
   });
 
+  it('warns about passing React Component as a setState argument', () => {
+    const {useState} = React;
+
+    function Bar() {
+      return 'hi';
+    }
+
+    let setComponent;
+    function Foo() {
+      const [Component, _setComponent] = useState(null);
+      setComponent = _setComponent;
+
+      return Component && <Component />;
+    }
+
+    const root = ReactTestRenderer.create(null, {unstable_isConcurrent: true});
+    root.update(<Foo />);
+    expect(Scheduler).toFlushAndYield([]);
+
+    expect(() => {
+      act(() => setComponent(Bar));
+    }).toErrorDev('Warning: u sure?', {withoutStack: true});
+  });
+
   it('warns about setState second argument', () => {
     const {useState} = React;
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I would like to address the issue, when you want to store React Component reference in local state, like this:

```js
function Bar() { return <div /> }
...
function Foo() {
    const [component, setComponent] = useState(null);
    setComponent(Bar)
}
...
```

As the hook API implements ["functional updates" feature](https://reactjs.org/docs/hooks-reference.html#functional-updates), the component reference is treated as an ordinary function, which is called with previous state value under the hood.

The problem is, that the error message is not descriptive:

```Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.```

You can reproduce it via [codesandbox example](https://codesandbox.io/s/eloquent-wave-3wsf0).

My simple PoC, address the issue via printing additional warning message to the console on DEV environment.
I copied `isLikelyComponentType` helper function from [react-fresh package](https://github.com/facebook/react/blob/4c6470cb3b821f3664955290cd4c4c7ac0de733a/packages/react-refresh/src/ReactFreshRuntime.js#L650) to recognize whether the given function is a React Component or not. I hope there is a better way to do it...

## Test Plan

[codesandbox](https://codesandbox.io/s/eloquent-wave-3wsf0)
