### PR TITLE
Fix exhaustive deps for custom namespaced hook

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -3432,7 +3432,7 @@ const tests = {
           React.useEffect(() => {
             console.log(props.foo);
           }, []);
-          React.useCustomEffect(() => {
+          customModule.useCustomEffect(() => {
             console.log(props.foo);
           }, []);
         }
@@ -3457,7 +3457,7 @@ const tests = {
                   React.useEffect(() => {
                     console.log(props.foo);
                   }, []);
-                  React.useCustomEffect(() => {
+                  customModule.useCustomEffect(() => {
                     console.log(props.foo);
                   }, []);
                 }
@@ -3483,7 +3483,7 @@ const tests = {
                   React.useEffect(() => {
                     console.log(props.foo);
                   }, []);
-                  React.useCustomEffect(() => {
+                  customModule.useCustomEffect(() => {
                     console.log(props.foo);
                   }, []);
                 }
@@ -3509,9 +3509,35 @@ const tests = {
                   React.useEffect(() => {
                     console.log(props.foo);
                   }, [props.foo]);
-                  React.useCustomEffect(() => {
+                  customModule.useCustomEffect(() => {
                     console.log(props.foo);
                   }, []);
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message:
+            "React Hook customModule.useCustomEffect has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  React.useEffect(() => {
+                    console.log(props.foo);
+                  }, []);
+                  customModule.useCustomEffect(() => {
+                    console.log(props.foo);
+                  }, [props.foo]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1115,7 +1115,7 @@ export default {
       }
       const callback = node.arguments[callbackIndex];
       const reactiveHook = node.callee;
-      const reactiveHookName = getNodeWithoutReactNamespace(reactiveHook).name;
+      const reactiveHookName = getNodeWithoutNamespace(reactiveHook).name;
       const declaredDependenciesNode = node.arguments[callbackIndex + 1];
       const isEffect = /Effect($|[^a-z])/g.test(reactiveHookName);
 
@@ -1653,11 +1653,10 @@ function analyzePropertyChain(node, optionalChains) {
   }
 }
 
-function getNodeWithoutReactNamespace(node, options) {
+function getNodeWithoutNamespace(node, options) {
   if (
     node.type === 'MemberExpression' &&
     node.object.type === 'Identifier' &&
-    node.object.name === 'React' &&
     node.property.type === 'Identifier' &&
     !node.computed
   ) {
@@ -1672,7 +1671,8 @@ function getNodeWithoutReactNamespace(node, options) {
 // 1 for useImperativeHandle(ref, fn).
 // For additionally configured Hooks, assume that they're like useEffect (0).
 function getReactiveHookCallbackIndex(calleeNode, options) {
-  const node = getNodeWithoutReactNamespace(calleeNode);
+  const node = getNodeWithoutNamespace(calleeNode);
+
   if (node.type !== 'Identifier') {
     return -1;
   }
@@ -1687,7 +1687,7 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
       // useImperativeHandle(ref, fn)
       return 1;
     default:
-      if (node === calleeNode && options && options.additionalHooks) {
+      if (options && options.additionalHooks) {
         // Allow the user to provide a regular expression which enables the lint to
         // target custom reactive hooks.
         let name;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I have a few custom hooks in my projects that I'd like to access using the namespaced module pattern like so:

```js
import * as customModule from './customModule'

//...
          customModule.useCustomEffect(() => {
            console.log(props.foo);
          }, []);
```

However, even if I add `additionalHooks: 'useCustomEffect'` as an option to the exhaustive-deps rule, it still wouldn't check my hooks when called this way in the previous implementation.

I looked into the code for the rule and was able to update the rule to support this pattern properly, and modified one of the existing test cases to prevent it from regressing in the future.

## Test Plan

I have updated the test suite with the following new test case:

```
                  customModule.useCustomEffect(() => {
                    console.log(props.foo);
                  }, []);
```

And verified that the expected errors are thrown.

One thing I'm unsure about though, is related to the fact that we previously had a test case for the following:

```
                  React.useCustomEffect(() => {
                    console.log(props.foo);
                  }, []);
```

And expected to have no errors, which ended up failing after my change, as it'd now error due to the missing props.foo dependency. 

I ended up removing this test case because the premise didn't make any sense to me: Why shouldn't we check calls to `useCustomEffect` just because it has `React` as the namespace? The user could very well have a custom module that aliases the react module (`export * from 'react'`) and then exposes other custom hooks along with it. I could definitely be missing some nuance here, so please let me know if the test case is actually valid and I'll try to address it in a follow up.