### PR TITLE
Bump versions for 17

### DIFF
--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-subscription",
   "description": "utility for subscribing to external data sources inside React components",
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",
@@ -15,7 +15,7 @@
     "cjs/"
   ],
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "devDependencies": {
     "rxjs": "^5.5.6"

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",

--- a/packages/jest-mock-scheduler/package.json
+++ b/packages/jest-mock-scheduler/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://reactjs.org/",
   "peerDependencies": {
     "jest": "^23.0.1 || ^24.0.0 || ^25.1.0",
-    "scheduler": "^0.15.0"
+    "scheduler": "^0.20.0"
   },
   "files": [
     "LICENSE",

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-react",
-  "version": "0.12.0-alpha.0",
+  "version": "0.12.0",
   "description": "Jest matchers and utilities for testing React components.",
   "main": "index.js",
   "repository": {
@@ -20,8 +20,8 @@
   "homepage": "https://reactjs.org/",
   "peerDependencies": {
     "jest": "^23.0.1 || ^24.0.0 || ^25.1.0",
-    "react": "^17.0.0-alpha",
-    "react-test-renderer": "^17.0.0-alpha"
+    "react": "^17.0.0",
+    "react-test-renderer": "^17.0.0"
   },
   "dependencies": {
     "object-assign": "^4.1.1"

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-art",
   "description": "React ART is a JavaScript library for drawing vector graphics using React. It provides declarative and reactive bindings to the ART library. Using the same declarative API you can render the output to either Canvas, SVG or VML (IE8).",
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -26,10 +26,10 @@
     "create-react-class": "^15.6.2",
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "scheduler": "^0.19.0"
+    "scheduler": "^0.20.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "17.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-cache/package.json
+++ b/packages/react-cache/package.json
@@ -17,6 +17,6 @@
     "umd/"
   ],
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   }
 }

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -24,7 +24,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -26,7 +26,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "dependencies": {
     "error-stack-parser": "^2.0.2",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dom",
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "description": "React package for working with the DOM.",
   "main": "index.js",
   "repository": {
@@ -19,10 +19,10 @@
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "scheduler": "^0.19.0"
+    "scheduler": "^0.20.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "17.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-fetch/package.json
+++ b/packages/react-fetch/package.json
@@ -18,7 +18,7 @@
     "cjs/"
   ],
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "browser": {
     "./index.js": "./index.browser.js"

--- a/packages/react-interactions/package.json
+++ b/packages/react-interactions/package.json
@@ -38,7 +38,7 @@
     "loose-envify": "^1.1.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "browserify": {
     "transform": [

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is",
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "description": "Brand checking of React Elements.",
   "main": "index.js",
   "repository": {

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -12,6 +12,6 @@
     "scheduler": "^0.11.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   }
 }

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -17,7 +17,7 @@
     "react-server": "*"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-reconciler",
   "description": "React package for creating custom renderers.",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "keywords": [
     "react"
   ],
@@ -26,12 +26,12 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",
     "object-assign": "^4.1.1",
-    "scheduler": "^0.19.0"
+    "scheduler": "^0.20.0"
   },
   "browserify": {
     "transform": [

--- a/packages/react-refresh/package.json
+++ b/packages/react-refresh/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "0.8.3",
+  "version": "0.9.0",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -27,7 +27,7 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "dependencies": {
     "loose-envify": "^1.1.0",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-test-renderer",
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "description": "React package for snapshot testing.",
   "main": "index.js",
   "repository": {
@@ -20,12 +20,12 @@
   "homepage": "https://reactjs.org/",
   "dependencies": {
     "object-assign": "^4.1.1",
-    "react-is": "^17.0.0-alpha",
+    "react-is": "^17.0.0",
     "react-shallow-renderer": "^16.13.1",
-    "scheduler": "^0.19.0"
+    "scheduler": "^0.20.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "17.0.0"
   },
   "files": [
     "LICENSE",

--- a/packages/react-transport-dom-relay/package.json
+++ b/packages/react-transport-dom-relay/package.json
@@ -12,7 +12,7 @@
     "scheduler": "^0.11.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha",
-    "react-dom": "^17.0.0-alpha"
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
   }
 }

--- a/packages/react-transport-dom-webpack/package.json
+++ b/packages/react-transport-dom-webpack/package.json
@@ -34,8 +34,8 @@
     "node": ">=0.10.0"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha",
-    "react-dom": "^17.0.0-alpha",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "webpack": "^4.43.0"
   },
   "dependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "react"
   ],
-  "version": "17.0.0-alpha.0",
+  "version": "17.0.0",
   "homepage": "https://reactjs.org/",
   "bugs": "https://github.com/facebook/react/issues",
   "license": "MIT",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scheduler",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Cooperative scheduler for the browser environment.",
   "main": "index.js",
   "repository": {

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -6,4 +6,4 @@
  */
 
 // TODO: this is special because it gets imported during build.
-export default '17.0.0-alpha.0';
+export default '17.0.0';

--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-subscription",
   "description": "Reusable hooks",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",
@@ -19,7 +19,7 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^17.0.0-alpha"
+    "react": "^17.0.0"
   },
   "devDependencies": {
     "rxjs": "^5.5.6"


### PR DESCRIPTION
Just re-doing the same our script did on build + bumps a few more that are private but stale.
I changed `peerDeps` for React and ReactDOM to use an exact version of React. Kept it a caret in other places.