### PR TITLE
Fix todo: remove any type from render of subtree

### DIFF
--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -184,9 +184,7 @@ function legacyRenderSubtreeIntoContainer(
     warnOnInvalidCallback(callback === undefined ? null : callback, 'render');
   }
 
-  // TODO: Without `any` type, Flow says "Property cannot be accessed on any
-  // member of intersection type." Whyyyyyy.
-  let root: RootType = (container._reactRootContainer: any);
+  let root: ?RootType = container._reactRootContainer;
   let fiberRoot;
   if (!root) {
     // Initial mount


### PR DESCRIPTION
## Summary

I noticed one small todo task when I was diving into codebase:
Flow was throwing type error when we try to assign `container._reactRootContainer` to `root` so we casted `container._reactRootContainer` to any type.
Error happens because `container._reactRootContainer` may be an undefined, but `root` may not.

I just add undefined support to `root` definition :)

This move is type safe because we check for undefined in code bellow

P.S.: It's my first PR and I have already signed CLA.