### PR TITLE
Make DevTools Websocket retry delay configurable

### DIFF
--- a/packages/react-devtools-core/README.md
+++ b/packages/react-devtools-core/README.md
@@ -24,6 +24,7 @@ The `config` object may contain:
 * `useHttps: boolean` (defaults to `false`) - Websocked should use a secure protocol (wss).
 * `websocket: Websocket` - Custom websocket to use. Overrides `host` and `port` settings if provided.
 * `resolveRNStyle: (style: number) => ?Object` - Used by the React Native style plug-in.
+* `retryConnectionDelay: number` (defaults to `2000`) - Milliseconds delay to wait between retrying a failed Websocket connection.
 * `isAppActive: () => boolean` - If provided, DevTools will poll this method and wait until it returns true before connecting to React.
 
 ## `react-devtools-core/standalone`

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -26,6 +26,7 @@ type ConnectOptions = {
   port?: number,
   useHttps?: boolean,
   resolveRNStyle?: ResolveNativeStyle,
+  retryConnectionDelay?: number,
   isAppActive?: () => boolean,
   websocket?: ?WebSocket,
   ...
@@ -60,6 +61,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
     port = 8097,
     websocket,
     resolveRNStyle = null,
+    retryConnectionDelay = 2000,
     isAppActive = () => true,
   } = options || {};
 
@@ -69,7 +71,10 @@ export function connectToDevTools(options: ?ConnectOptions) {
   function scheduleRetry() {
     if (retryTimeoutID === null) {
       // Two seconds because RN had issues with quick retries.
-      retryTimeoutID = setTimeout(() => connectToDevTools(options), 2000);
+      retryTimeoutID = setTimeout(
+        () => connectToDevTools(options),
+        retryConnectionDelay,
+      );
     }
   }
 


### PR DESCRIPTION
Default behavior remains unchanged (retry after 2s).

Relates to issue #20095