### PR TITLE
Allow Node 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "yargs": "^15.3.1"
   },
   "devEngines": {
-    "node": "8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x"
+    "node": "8.x || 9.x || 10.x || 11.x || 12.x || 13.x || 14.x || 15.x"
   },
   "jest": {
     "testRegex": "/scripts/jest/dont-run-jest-directly\\.js$"


### PR DESCRIPTION
## Summary

Allow Node 15.x for developing react

## Test Plan

I ran `yarn`, `yarn lint`, `yarn flow dom`, `yarn test`, `yarn test --prod` and `yarn build` to check possible errors with new Node version.