### PR TITLE
[Flight] Add support for Module References in transport protocol

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -41,8 +41,9 @@ export type JSONValue =
 
 const PENDING = 0;
 const RESOLVED_MODEL = 1;
-const INITIALIZED = 2;
-const ERRORED = 3;
+const RESOLVED_MODULE = 2;
+const INITIALIZED = 3;
+const ERRORED = 4;
 
 type PendingChunk = {
   _status: 0,
@@ -56,14 +57,20 @@ type ResolvedModelChunk = {
   _response: Response,
   then(resolve: () => mixed): void,
 };
-type InitializedChunk<T> = {
+type ResolvedModuleChunk<T> = {
   _status: 2,
+  _value: ModuleReference<T>,
+  _response: Response,
+  then(resolve: () => mixed): void,
+};
+type InitializedChunk<T> = {
+  _status: 3,
   _value: T,
   _response: Response,
   then(resolve: () => mixed): void,
 };
 type ErroredChunk = {
-  _status: 3,
+  _status: 4,
   _value: Error,
   _response: Response,
   then(resolve: () => mixed): void,
@@ -71,6 +78,7 @@ type ErroredChunk = {
 type SomeChunk<T> =
   | PendingChunk
   | ResolvedModelChunk
+  | ResolvedModuleChunk<T>
   | InitializedChunk<T>
   | ErroredChunk;
 
@@ -105,6 +113,8 @@ function readChunk<T>(chunk: SomeChunk<T>): T {
       return chunk._value;
     case RESOLVED_MODEL:
       return initializeModelChunk(chunk);
+    case RESOLVED_MODULE:
+      return initializeModuleChunk(chunk);
     case PENDING:
       // eslint-disable-next-line no-throw-literal
       throw (chunk: Wakeable);
@@ -155,6 +165,13 @@ function createResolvedModelChunk(
   return new Chunk(RESOLVED_MODEL, value, response);
 }
 
+function createResolvedModuleChunk<T>(
+  response: Response,
+  value: ModuleReference<T>,
+): ResolvedModuleChunk<T> {
+  return new Chunk(RESOLVED_MODULE, value, response);
+}
+
 function resolveModelChunk<T>(
   chunk: SomeChunk<T>,
   value: UninitializedModel,
@@ -170,8 +187,31 @@ function resolveModelChunk<T>(
   wakeChunk(listeners);
 }
 
+function resolveModuleChunk<T>(
+  chunk: SomeChunk<T>,
+  value: ModuleReference<T>,
+): void {
+  if (chunk._status !== PENDING) {
+    // We already resolved. We didn't expect to see this.
+    return;
+  }
+  const listeners = chunk._value;
+  const resolvedChunk: ResolvedModuleChunk<T> = (chunk: any);
+  resolvedChunk._status = RESOLVED_MODULE;
+  resolvedChunk._value = value;
+  wakeChunk(listeners);
+}
+
 function initializeModelChunk<T>(chunk: ResolvedModelChunk): T {
   const value: T = parseModel(chunk._response, chunk._value);
+  const initializedChunk: InitializedChunk<T> = (chunk: any);
+  initializedChunk._status = INITIALIZED;
+  initializedChunk._value = value;
+  return value;
+}
+
+function initializeModuleChunk<T>(chunk: ResolvedModuleChunk<T>): T {
+  const value: T = requireModule(chunk._value);
   const initializedChunk: InitializedChunk<T> = (chunk: any);
   initializedChunk._status = INITIALIZED;
   initializedChunk._value = value;
@@ -241,7 +281,7 @@ function createElement(type, key, props): React$Element<any> {
 
 type UninitializedBlockPayload<Data> = [
   mixed,
-  ModuleMetaData | SomeChunk<ModuleMetaData>,
+  BlockRenderFunction<any, Data> | SomeChunk<BlockRenderFunction<any, Data>>,
   Data | SomeChunk<Data>,
   Response,
 ];
@@ -250,14 +290,7 @@ function initializeBlock<Props, Data>(
   tuple: UninitializedBlockPayload<Data>,
 ): BlockComponent<Props, Data> {
   // Require module first and then data. The ordering matters.
-  const moduleMetaData: ModuleMetaData = readMaybeChunk(tuple[1]);
-  const moduleReference: ModuleReference<
-    BlockRenderFunction<Props, Data>,
-  > = resolveModuleReference(moduleMetaData);
-  // TODO: Do this earlier, as the chunk is resolved.
-  preloadModule(moduleReference);
-
-  const moduleExport = requireModule(moduleReference);
+  const moduleExport = readMaybeChunk(tuple[1]);
 
   // The ordering here is important because this call might suspend.
   // We don't want that to prevent the module graph for being initialized.
@@ -360,6 +393,28 @@ export function resolveModel(
     chunks.set(id, createResolvedModelChunk(response, model));
   } else {
     resolveModelChunk(chunk, model);
+  }
+}
+
+export function resolveModule(
+  response: Response,
+  id: number,
+  model: UninitializedModel,
+): void {
+  const chunks = response._chunks;
+  const chunk = chunks.get(id);
+  const moduleMetaData = parseModel<ModuleMetaData>(response, model);
+  const moduleReference = resolveModuleReference(moduleMetaData);
+
+  // TODO: Add an option to encode modules that are lazy loaded.
+  // For now we preload all modules as early as possible since it's likely
+  // that we'll need them.
+  preloadModule(moduleReference);
+
+  if (!chunk) {
+    chunks.set(id, createResolvedModuleChunk(response, moduleReference));
+  } else {
+    resolveModuleChunk(chunk, moduleReference);
   }
 }
 

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -403,7 +403,7 @@ export function resolveModule(
 ): void {
   const chunks = response._chunks;
   const chunk = chunks.get(id);
-  const moduleMetaData = parseModel<ModuleMetaData>(response, model);
+  const moduleMetaData: ModuleMetaData = parseModel(response, model);
   const moduleReference = resolveModuleReference(moduleMetaData);
 
   // TODO: Add an option to encode modules that are lazy loaded.

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -10,6 +10,7 @@
 import type {Response} from './ReactFlightClientHostConfigStream';
 
 import {
+  resolveModule,
   resolveModel,
   resolveError,
   createResponse as createResponseBase,
@@ -37,6 +38,13 @@ function processFullRow(response: Response, row: string): void {
       const id = parseInt(row.substring(1, colon), 16);
       const json = row.substring(colon + 1);
       resolveModel(response, id, json);
+      return;
+    }
+    case 'M': {
+      const colon = row.indexOf(':', 1);
+      const id = parseInt(row.substring(1, colon), 16);
+      const json = row.substring(colon + 1);
+      resolveModule(response, id, json);
       return;
     }
     case 'E': {

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -56,9 +56,9 @@ function processFullRow(response: Response, row: string): void {
       return;
     }
     default: {
-      // Assume this is the root model.
-      resolveModel(response, 0, row);
-      return;
+      throw new Error(
+        "Error parsing the data. It's probably an error code or network corruption.",
+      );
     }
   }
 }

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -54,16 +54,20 @@ describe('ReactFlight', () => {
   });
 
   function block(render, load) {
+    const reference = {
+      $$typeof: Symbol.for('noop.module.reference'),
+      value: render,
+    };
     if (load === undefined) {
       return () => {
-        return ReactNoopFlightServerRuntime.serverBlockNoData(render);
+        return ReactNoopFlightServerRuntime.serverBlockNoData(reference);
       };
     }
     return function(...args) {
       const curriedLoad = () => {
         return load(...args);
       };
-      return ReactNoopFlightServerRuntime.serverBlock(render, curriedLoad);
+      return ReactNoopFlightServerRuntime.serverBlock(reference, curriedLoad);
     };
   }
 

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -53,21 +53,29 @@ describe('ReactFlight', () => {
     };
   });
 
-  function block(render, load) {
-    const reference = {
-      $$typeof: Symbol.for('noop.module.reference'),
-      value: render,
+  function moduleReference(value) {
+    return {
+      $$typeof: Symbol.for('react.module.reference'),
+      value: value,
     };
+  }
+
+  function block(render, load) {
     if (load === undefined) {
       return () => {
-        return ReactNoopFlightServerRuntime.serverBlockNoData(reference);
+        return ReactNoopFlightServerRuntime.serverBlockNoData(
+          moduleReference(render),
+        );
       };
     }
     return function(...args) {
       const curriedLoad = () => {
         return load(...args);
       };
-      return ReactNoopFlightServerRuntime.serverBlock(reference, curriedLoad);
+      return ReactNoopFlightServerRuntime.serverBlock(
+        moduleReference(render),
+        curriedLoad,
+      );
     };
   }
 
@@ -99,6 +107,35 @@ describe('ReactFlight', () => {
         ),
       },
     });
+  });
+
+  it('can render a client component using a module reference and render there', () => {
+    function UserClient(props) {
+      return (
+        <span>
+          {props.greeting}, {props.name}
+        </span>
+      );
+    }
+    const User = moduleReference(UserClient);
+
+    function Greeting({firstName, lastName}) {
+      return <User greeting="Hello" name={firstName + ' ' + lastName} />;
+    }
+
+    const model = {
+      greeting: <Greeting firstName="Seb" lastName="Smith" />,
+    };
+
+    const transport = ReactNoopFlightServer.render(model);
+
+    act(() => {
+      const rootModel = ReactNoopFlightClient.read(transport);
+      const greeting = rootModel.greeting;
+      ReactNoop.render(greeting);
+    });
+
+    expect(ReactNoop).toMatchRenderedOutput(<span>Hello, Seb Smith</span>);
   });
 
   if (ReactFeatureFlags.enableBlocksAPI) {

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -42,8 +42,14 @@ const ReactNoopFlightServer = ReactFlightServer({
   formatChunk(type: string, props: Object): Uint8Array {
     return Buffer.from(JSON.stringify({type, props}), 'utf8');
   },
-  resolveModuleMetaData(config: void, renderFn: Function) {
-    return saveModule(renderFn);
+  isModuleReference(reference: Object): boolean {
+    return reference.$$typeof === Symbol.for('react.module.reference');
+  },
+  resolveModuleMetaData(
+    config: void,
+    reference: {$$typeof: Symbol, value: any},
+  ) {
+    return saveModule(reference.value);
   },
 });
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -26,6 +26,7 @@ import {
   processModelChunk,
   processErrorChunk,
   resolveModuleMetaData,
+  isModuleReference,
 } from './ReactFlightServerConfig';
 
 import {
@@ -391,6 +392,13 @@ export function resolveModelToJSON(
     switch (key) {
       case '1': {
         // Module reference
+        if (!isModuleReference(value)) {
+          invariant(
+            false,
+            'Unsupported server component type: %s',
+            describeValueForErrorMessage(value),
+          );
+        }
         const moduleReference: ModuleReference<any> = (value: any);
         try {
           const moduleMetaData: ModuleMetaData = resolveModuleMetaData(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -476,6 +476,7 @@ export function resolveModelToJSON(
           request.bundlerConfig,
           moduleReference,
         );
+        request.pendingChunks++;
         const moduleId = request.nextChunkId++;
         emitModuleChunk(request, moduleId, moduleMetaData);
         return serializeIDRef(moduleId);

--- a/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
+++ b/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
@@ -12,4 +12,5 @@ declare var $$$hostConfig: any;
 export opaque type BundlerConfig = mixed; // eslint-disable-line no-undef
 export opaque type ModuleReference<T> = mixed; // eslint-disable-line no-undef
 export opaque type ModuleMetaData: any = mixed; // eslint-disable-line no-undef
+export const isModuleReference = $$$hostConfig.isModuleReference;
 export const resolveModuleMetaData = $$$hostConfig.resolveModuleMetaData;

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -14,8 +14,7 @@
 FLIGHT PROTOCOL GRAMMAR
 
 Response
-- JSONData RowSequence
-- JSONData
+- RowSequence
 
 RowSequence
 - Row RowSequence
@@ -23,6 +22,7 @@ RowSequence
 
 Row
 - "J" RowID JSONData
+- "M" RowID JSONModuleData
 - "H" RowID HTMLData
 - "B" RowID BlobData
 - "U" RowID URLData

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -104,6 +104,21 @@ export function processModelChunk(
   return convertStringToBuffer(row);
 }
 
+export function processModuleChunk(
+  request: Request,
+  id: number,
+  moduleMetaData: ReactModel,
+): Chunk {
+  const json = stringify(moduleMetaData);
+  let row;
+  if (id === 0) {
+    row = json + '\n';
+  } else {
+    row = serializeRowHeader('M', id) + json + '\n';
+  }
+  return convertStringToBuffer(row);
+}
+
 export {
   scheduleWork,
   flushBuffered,

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -95,12 +95,7 @@ export function processModelChunk(
   model: ReactModel,
 ): Chunk {
   const json = stringify(model, request.toJSON);
-  let row;
-  if (id === 0) {
-    row = json + '\n';
-  } else {
-    row = serializeRowHeader('J', id) + json + '\n';
-  }
+  const row = serializeRowHeader('J', id) + json + '\n';
   return convertStringToBuffer(row);
 }
 
@@ -110,12 +105,7 @@ export function processModuleChunk(
   moduleMetaData: ReactModel,
 ): Chunk {
   const json = stringify(moduleMetaData);
-  let row;
-  if (id === 0) {
-    row = json + '\n';
-  } else {
-    row = serializeRowHeader('M', id) + json + '\n';
-  }
+  const row = serializeRowHeader('M', id) + json + '\n';
   return convertStringToBuffer(row);
 }
 

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -10,6 +10,7 @@
 export {
   createResponse,
   resolveModel,
+  resolveModule,
   resolveError,
   close,
 } from 'react-client/src/ReactFlightClient';

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClientHostConfig.js
@@ -9,6 +9,10 @@
 
 import type {JSONValue, ResponseBase} from 'react-client/src/ReactFlightClient';
 
+import type JSResourceReference from 'JSResourceReference';
+
+export type ModuleReference<T> = JSResourceReference<T>;
+
 import {
   parseModelString,
   parseModelTuple,
@@ -20,10 +24,7 @@ export {
   requireModule,
 } from 'ReactFlightDOMRelayClientIntegration';
 
-export type {
-  ModuleReference,
-  ModuleMetaData,
-} from 'ReactFlightDOMRelayClientIntegration';
+export type {ModuleMetaData} from 'ReactFlightDOMRelayClientIntegration';
 
 export opaque type UninitializedModel = JSONValue;
 

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -9,10 +9,13 @@
 
 import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
 
+import JSResourceReference from 'JSResourceReference';
+
+export type ModuleReference<T> = JSResourceReference<T>;
+
 import type {
   Destination,
   BundlerConfig,
-  ModuleReference,
   ModuleMetaData,
 } from 'ReactFlightDOMRelayServerIntegration';
 
@@ -27,9 +30,12 @@ import {
 export type {
   Destination,
   BundlerConfig,
-  ModuleReference,
   ModuleMetaData,
 } from 'ReactFlightDOMRelayServerIntegration';
+
+export function isModuleReference(reference: Object): boolean {
+  return reference instanceof JSResourceReference;
+}
 
 export function resolveModuleMetaData<T>(
   config: BundlerConfig,

--- a/packages/react-transport-dom-relay/src/__mocks__/JSResourceReference.js
+++ b/packages/react-transport-dom-relay/src/__mocks__/JSResourceReference.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+class JSResourceReference {
+  constructor(exportedValue) {
+    this._moduleId = exportedValue;
+  }
+}
+
+module.exports = JSResourceReference;

--- a/packages/react-transport-dom-relay/src/__mocks__/JSResourceReference.js
+++ b/packages/react-transport-dom-relay/src/__mocks__/JSResourceReference.js
@@ -11,6 +11,9 @@ class JSResourceReference {
   constructor(exportedValue) {
     this._moduleId = exportedValue;
   }
+  getModuleID() {
+    return this._moduleId;
+  }
 }
 
 module.exports = JSResourceReference;

--- a/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayClientIntegration.js
+++ b/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayClientIntegration.js
@@ -7,13 +7,15 @@
 
 'use strict';
 
+import JSResourceReference from 'JSResourceReference';
+
 const ReactFlightDOMRelayClientIntegration = {
   resolveModuleReference(moduleData) {
-    return moduleData;
+    return new JSResourceReference(moduleData);
   },
   preloadModule(moduleReference) {},
   requireModule(moduleReference) {
-    return moduleReference;
+    return moduleReference._moduleId;
   },
 };
 

--- a/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
+++ b/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
@@ -15,6 +15,13 @@ const ReactFlightDOMRelayServerIntegration = {
       json: json,
     });
   },
+  emitModule(destination, id, json) {
+    destination.push({
+      type: 'module',
+      id: id,
+      json: json,
+    });
+  },
   emitError(destination, id, message, stack) {
     destination.push({
       type: 'error',

--- a/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
+++ b/packages/react-transport-dom-relay/src/__mocks__/ReactFlightDOMRelayServerIntegration.js
@@ -24,7 +24,7 @@ const ReactFlightDOMRelayServerIntegration = {
   },
   close(destination) {},
   resolveModuleMetaData(config, resource) {
-    return resource;
+    return resource._moduleId;
   },
 };
 

--- a/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -34,6 +34,8 @@ describe('ReactFlightDOMRelay', () => {
       const chunk = data[i];
       if (chunk.type === 'json') {
         ReactDOMFlightRelayClient.resolveModel(response, chunk.id, chunk.json);
+      } else if (chunk.type === 'module') {
+        ReactDOMFlightRelayClient.resolveModule(response, chunk.id, chunk.json);
       } else {
         ReactDOMFlightRelayClient.resolveError(
           response,

--- a/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -102,6 +102,39 @@ describe('ReactFlightDOMRelay', () => {
   });
 
   // @gate experimental
+  it('can render a client component using a module reference and render there', () => {
+    function UserClient(props) {
+      return (
+        <span>
+          {props.greeting}, {props.name}
+        </span>
+      );
+    }
+    const User = new JSResourceReference(UserClient);
+
+    function Greeting({firstName, lastName}) {
+      return <User greeting="Hello" name={firstName + ' ' + lastName} />;
+    }
+
+    const model = {
+      greeting: <Greeting firstName="Seb" lastName="Smith" />,
+    };
+
+    const transport = [];
+    ReactDOMFlightRelayServer.render(model, transport);
+
+    const modelClient = readThrough(transport);
+
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
+    act(() => {
+      root.render(modelClient.greeting);
+    });
+
+    expect(container.innerHTML).toEqual('<span>Hello, Seb Smith</span>');
+  });
+
+  // @gate experimental
   it('can transfer a Block to the client and render there', () => {
     function load(firstName, lastName) {
       return {name: firstName + ' ' + lastName};

--- a/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -10,6 +10,7 @@
 let act;
 let React;
 let ReactDOM;
+let JSResourceReference;
 let ReactDOMFlightRelayServer;
 let ReactDOMFlightRelayServerRuntime;
 let ReactDOMFlightRelayClient;
@@ -24,6 +25,7 @@ describe('ReactFlightDOMRelay', () => {
     ReactDOMFlightRelayServer = require('react-transport-dom-relay/server');
     ReactDOMFlightRelayServerRuntime = require('react-transport-dom-relay/server-runtime');
     ReactDOMFlightRelayClient = require('react-transport-dom-relay');
+    JSResourceReference = require('JSResourceReference');
   });
 
   function readThrough(data) {
@@ -47,14 +49,18 @@ describe('ReactFlightDOMRelay', () => {
   }
 
   function block(render, load) {
+    const reference = new JSResourceReference(render);
     if (load === undefined) {
-      return ReactDOMFlightRelayServerRuntime.serverBlock(render);
+      return ReactDOMFlightRelayServerRuntime.serverBlock(reference);
     }
     return function(...args) {
       const curriedLoad = () => {
         return load(...args);
       };
-      return ReactDOMFlightRelayServerRuntime.serverBlock(render, curriedLoad);
+      return ReactDOMFlightRelayServerRuntime.serverBlock(
+        reference,
+        curriedLoad,
+      );
     };
   }
 

--- a/packages/react-transport-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-transport-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -14,7 +14,10 @@ type WebpackMap = {
 export type BundlerConfig = WebpackMap;
 
 // eslint-disable-next-line no-unused-vars
-export type ModuleReference<T> = string;
+export type ModuleReference<T> = {
+  $$typeof: Symbol,
+  name: string,
+};
 
 export type ModuleMetaData = {
   id: string,
@@ -22,9 +25,15 @@ export type ModuleMetaData = {
   name: string,
 };
 
+const MODULE_TAG = Symbol.for('react.module.reference');
+
+export function isModuleReference(reference: Object): boolean {
+  return reference.$$typeof === MODULE_TAG;
+}
+
 export function resolveModuleMetaData<T>(
   config: BundlerConfig,
-  modulePath: ModuleReference<T>,
+  moduleReference: ModuleReference<T>,
 ): ModuleMetaData {
-  return config[modulePath];
+  return config[moduleReference.name];
 }

--- a/packages/react-transport-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-transport-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -83,8 +83,9 @@ describe('ReactFlightDOM', () => {
       const curriedLoad = () => {
         return load(...args);
       };
+      const MODULE_TAG = Symbol.for('react.module.reference');
       return ReactTransportDOMServerRuntime.serverBlock(
-        'path/' + idx,
+        {$$typeof: MODULE_TAG, name: 'path/' + idx},
         curriedLoad,
       );
     };

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -27,6 +27,11 @@ import {
 } from 'shared/ReactSymbols';
 import {enableScopeAPI} from './ReactFeatureFlags';
 
+let REACT_MODULE_REFERENCE: number | Symbol = 0;
+if (typeof Symbol === 'function') {
+  REACT_MODULE_REFERENCE = Symbol.for('react.module.reference');
+}
+
 export default function isValidElementType(type: mixed) {
   if (typeof type === 'string' || typeof type === 'function') {
     return true;
@@ -54,6 +59,12 @@ export default function isValidElementType(type: mixed) {
       type.$$typeof === REACT_CONTEXT_TYPE ||
       type.$$typeof === REACT_FORWARD_REF_TYPE ||
       type.$$typeof === REACT_FUNDAMENTAL_TYPE ||
+      // This needs to include all possible module reference object
+      // types supported by any Flight configuration anywhere since
+      // we don't know which Flight build this will end up being used
+      // with.
+      type.$$typeof === REACT_MODULE_REFERENCE ||
+      type._moduleId !== undefined ||
       type.$$typeof === REACT_BLOCK_TYPE ||
       type[(0: any)] === REACT_SERVER_BLOCK_TYPE
     ) {

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -64,7 +64,7 @@ export default function isValidElementType(type: mixed) {
       // we don't know which Flight build this will end up being used
       // with.
       type.$$typeof === REACT_MODULE_REFERENCE ||
-      type._moduleId !== undefined ||
+      type.getModuleID !== undefined ||
       type.$$typeof === REACT_BLOCK_TYPE ||
       type[(0: any)] === REACT_SERVER_BLOCK_TYPE
     ) {

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -31,6 +31,11 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
     id: number,
     json: JSONValue,
   ): void;
+  declare export function emitModule(
+    destination: Destination,
+    id: number,
+    json: ModuleMetaData,
+  ): void;
   declare export function emitError(
     destination: Destination,
     id: number,

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -15,6 +15,14 @@ type JSONValue =
   | {+[key: string]: JSONValue}
   | $ReadOnlyArray<JSONValue>;
 
+declare class JSResourceReference<T> {
+  _moduleId: T;
+}
+
+declare module 'JSResourceReference' {
+  declare export default typeof JSResourceReference;
+}
+
 declare module 'ReactFlightDOMRelayServerIntegration' {
   declare export opaque type Destination;
   declare export opaque type BundlerConfig;
@@ -31,24 +39,22 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
   ): void;
   declare export function close(destination: Destination): void;
 
-  declare export opaque type ModuleReference<T>;
   declare export type ModuleMetaData = JSONValue;
   declare export function resolveModuleMetaData<T>(
     config: BundlerConfig,
-    resourceReference: ModuleReference<T>,
+    resourceReference: JSResourceReference<T>,
   ): ModuleMetaData;
 }
 
 declare module 'ReactFlightDOMRelayClientIntegration' {
-  declare export opaque type ModuleReference<T>;
   declare export opaque type ModuleMetaData;
   declare export function resolveModuleReference<T>(
     moduleData: ModuleMetaData,
-  ): ModuleReference<T>;
+  ): JSResourceReference<T>;
   declare export function preloadModule<T>(
-    moduleReference: ModuleReference<T>,
+    moduleReference: JSResourceReference<T>,
   ): void;
   declare export function requireModule<T>(
-    moduleReference: ModuleReference<T>,
+    moduleReference: JSResourceReference<T>,
   ): T;
 }

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -34,6 +34,7 @@ jest.mock('react-server/flight', () => {
     jest.mock(shimServerStreamConfigPath, () => config);
     jest.mock(shimServerFormatConfigPath, () => config);
     jest.mock('react-server/src/ReactFlightServerBundlerConfigCustom', () => ({
+      isModuleReference: config.isModuleReference,
       resolveModuleMetaData: config.resolveModuleMetaData,
     }));
     jest.mock(shimFlightServerConfigPath, () =>

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -301,6 +301,7 @@ const bundles = [
       'react',
       'react-dom/server',
       'ReactFlightDOMRelayServerIntegration',
+      'JSResourceReference',
     ],
   },
   {
@@ -308,7 +309,11 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-transport-dom-relay/server-runtime',
     global: 'ReactFlightDOMRelayServerRuntime',
-    externals: ['react', 'ReactFlightDOMRelayServerIntegration'],
+    externals: [
+      'react',
+      'ReactFlightDOMRelayServerIntegration',
+      'JSResourceReference',
+    ],
   },
 
   /******* React DOM Flight Client Relay *******/
@@ -317,7 +322,11 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-transport-dom-relay',
     global: 'ReactFlightDOMRelayClient',
-    externals: ['react', 'ReactFlightDOMRelayClientIntegration'],
+    externals: [
+      'react',
+      'ReactFlightDOMRelayClientIntegration',
+      'JSResourceReference',
+    ],
   },
 
   /******* React ART *******/


### PR DESCRIPTION
This is the first in a series of refactors. It adds a first-class type of row value for modules. This was always the idea since they can be preloaded earlier if they're special cased in the stream.

It also accepts a "Module Reference" object anywhere to be serialized in the protocol. This includes the type position of JSX. This is now how client components are defined.

These objects need a non-JSON serializable brand check like symbol check or instanceof. However, React doesn't actually define what kind of object it is. The host environment, i.e. bundler, does. So for the Relay www integration we use JSResource. For the webpack one I temporarily use a react symbol but it should really be something else like an [AssetReference](https://github.com/tc39/proposal-asset-references#assetreference) object.

All these has to now be allowlisted in isValidElementTypes for every possible bundler environment.

Some follow ups:

- [ ] Dedupe the module reference if it occurs multiple times in a request.
- [ ] Currently the modules just resolve into their value on the client. They should probably resolve into a module reference there instead but then React DOM needs to be made aware of them. We could also resolve them to generic React.lazy values. At least in the element position. This is important because otherwise we end up suspending while resolving the parent rather than when we render the element.
- [ ] Make server components that suspend able to lazily resolve on the client by making the element itself a React.lazy value. Only blocks currently have the ability to progressively reveal.