### PR TITLE
Add Relay specific React Native build of Flight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,7 @@ jobs:
             - RELEASE_CHANNEL
             - facebook-www
             - facebook-react-native
+            - facebook-relay
             - node_modules
             - react-native
             - dist
@@ -268,6 +269,7 @@ jobs:
             - RELEASE_CHANNEL
             - facebook-www
             - facebook-react-native
+            - facebook-relay
             - node_modules
             - react-native
             - dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -188,7 +188,10 @@ module.exports = {
       },
     },
     {
-      files: ['packages/react-native-renderer/**/*.js'],
+      files: [
+        'packages/react-native-renderer/**/*.js',
+        'packages/react-transport-native-relay/**/*.js'
+      ],
       globals: {
         nativeFabricUIManager: true,
       },

--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.native-relay.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.native-relay.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-transport-native-relay/src/ReactFlightNativeRelayClientHostConfig';
+export * from '../ReactFlightClientHostConfigNoStream';

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.native-relay.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.native-relay.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-native-renderer/src/ReactFabricHostConfig';

--- a/packages/react-server/src/ReactNativeServerFormatConfig.js
+++ b/packages/react-server/src/ReactNativeServerFormatConfig.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {convertStringToBuffer} from 'react-server/src/ReactServerStreamConfig';
+
+export function formatChunkAsString(type: string, props: Object): string {
+  let str = '<' + type + '>';
+  if (typeof props.children === 'string') {
+    str += props.children;
+  }
+  str += '</' + type + '>';
+  return str;
+}
+
+export function formatChunk(type: string, props: Object): Uint8Array {
+  return convertStringToBuffer(formatChunkAsString(type, props));
+}

--- a/packages/react-server/src/forks/ReactFlightServerConfig.native-relay.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.native-relay.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig';

--- a/packages/react-server/src/forks/ReactServerFormatConfig.native-relay.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.native-relay.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from '../ReactNativeServerFormatConfig';

--- a/packages/react-server/src/forks/ReactServerStreamConfig.native-relay.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.native-relay.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from '../ReactServerStreamConfigNode';

--- a/packages/react-transport-native-relay/index.js
+++ b/packages/react-transport-native-relay/index.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactFlightNativeRelayClient';

--- a/packages/react-transport-native-relay/package.json
+++ b/packages/react-transport-native-relay/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "react-transport-native-relay",
+  "version": "0.1.0",
+  "private": true,
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-transport-native-relay"
+  },
+  "dependencies": {
+    "object-assign": "^4.1.1",
+    "scheduler": "^0.11.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0",
+    "react-native-renderer": "^17.0.0"
+  }
+}

--- a/packages/react-transport-native-relay/server.js
+++ b/packages/react-transport-native-relay/server.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactFlightNativeRelayServer';

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayClient.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {
+  createResponse,
+  resolveModel,
+  resolveModule,
+  resolveError,
+  close,
+} from 'react-client/src/ReactFlightClient';

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayClientHostConfig.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {JSONValue, ResponseBase} from 'react-client/src/ReactFlightClient';
+
+import type JSResourceReference from 'JSResourceReference';
+
+export type ModuleReference<T> = JSResourceReference<T>;
+
+import {
+  parseModelString,
+  parseModelTuple,
+} from 'react-client/src/ReactFlightClient';
+
+export {
+  resolveModuleReference,
+  preloadModule,
+  requireModule,
+} from 'ReactFlightNativeRelayClientIntegration';
+
+export type {ModuleMetaData} from 'ReactFlightNativeRelayClientIntegration';
+
+export opaque type UninitializedModel = JSONValue;
+
+export type Response = ResponseBase;
+
+function parseModelRecursively(response: Response, parentObj, value) {
+  if (typeof value === 'string') {
+    return parseModelString(response, parentObj, value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        (value: any)[i] = parseModelRecursively(response, value, value[i]);
+      }
+      return parseModelTuple(response, value);
+    } else {
+      for (const innerKey in value) {
+        (value: any)[innerKey] = parseModelRecursively(
+          response,
+          value,
+          value[innerKey],
+        );
+      }
+    }
+  }
+  return value;
+}
+
+const dummy = {};
+
+export function parseModel<T>(response: Response, json: UninitializedModel): T {
+  return (parseModelRecursively(response, dummy, json): any);
+}

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayServer.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayServer.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {
+  BundlerConfig,
+  Destination,
+} from './ReactFlightNativeRelayServerHostConfig';
+
+import {createRequest, startWork} from 'react-server/src/ReactFlightServer';
+
+function render(
+  model: ReactModel,
+  destination: Destination,
+  config: BundlerConfig,
+): void {
+  const request = createRequest(model, destination, config);
+  startWork(request);
+}
+
+export {render};

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
+
+import JSResourceReferenceImpl from 'JSResourceReferenceImpl';
+
+export type ModuleReference<T> = JSResourceReferenceImpl<T>;
+
+import type {
+  Destination,
+  BundlerConfig,
+  ModuleMetaData,
+} from 'ReactFlightNativeRelayServerIntegration';
+
+import {resolveModelToJSON} from 'react-server/src/ReactFlightServer';
+
+import {
+  emitModel,
+  emitModule,
+  emitError,
+  resolveModuleMetaData as resolveModuleMetaDataImpl,
+} from 'ReactFlightNativeRelayServerIntegration';
+
+export type {
+  Destination,
+  BundlerConfig,
+  ModuleMetaData,
+} from 'ReactFlightNativeRelayServerIntegration';
+
+export function isModuleReference(reference: Object): boolean {
+  return reference instanceof JSResourceReferenceImpl;
+}
+
+export function resolveModuleMetaData<T>(
+  config: BundlerConfig,
+  resource: ModuleReference<T>,
+): ModuleMetaData {
+  return resolveModuleMetaDataImpl(config, resource);
+}
+
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | {+[key: string]: JSONValue}
+  | Array<JSONValue>;
+
+export type Chunk =
+  | {
+      type: 'json',
+      id: number,
+      json: JSONValue,
+    }
+  | {
+      type: 'module',
+      id: number,
+      json: ModuleMetaData,
+    }
+  | {
+      type: 'error',
+      id: number,
+      json: {
+        message: string,
+        stack: string,
+        ...
+      },
+    };
+
+export function processErrorChunk(
+  request: Request,
+  id: number,
+  message: string,
+  stack: string,
+): Chunk {
+  return {
+    type: 'error',
+    id: id,
+    json: {
+      message,
+      stack,
+    },
+  };
+}
+
+function convertModelToJSON(
+  request: Request,
+  parent: {+[key: string]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  key: string,
+  model: ReactModel,
+): JSONValue {
+  const json = resolveModelToJSON(request, parent, key, model);
+  if (typeof json === 'object' && json !== null) {
+    if (Array.isArray(json)) {
+      const jsonArray: Array<JSONValue> = [];
+      for (let i = 0; i < json.length; i++) {
+        jsonArray[i] = convertModelToJSON(request, json, '' + i, json[i]);
+      }
+      return jsonArray;
+    } else {
+      const jsonObj: {[key: string]: JSONValue} = {};
+      for (const nextKey in json) {
+        jsonObj[nextKey] = convertModelToJSON(
+          request,
+          json,
+          nextKey,
+          json[nextKey],
+        );
+      }
+      return jsonObj;
+    }
+  }
+  return json;
+}
+
+export function processModelChunk(
+  request: Request,
+  id: number,
+  model: ReactModel,
+): Chunk {
+  const json = convertModelToJSON(request, {}, '', model);
+  return {
+    type: 'json',
+    id: id,
+    json: json,
+  };
+}
+
+export function processModuleChunk(
+  request: Request,
+  id: number,
+  moduleMetaData: ModuleMetaData,
+): Chunk {
+  // The moduleMetaData is already a JSON serializable value.
+  return {
+    type: 'module',
+    id: id,
+    json: moduleMetaData,
+  };
+}
+
+export function scheduleWork(callback: () => void) {
+  callback();
+}
+
+export function flushBuffered(destination: Destination) {}
+
+export function beginWriting(destination: Destination) {}
+
+export function writeChunk(destination: Destination, chunk: Chunk): boolean {
+  if (chunk.type === 'json') {
+    emitModel(destination, chunk.id, chunk.json);
+  } else if (chunk.type === 'module') {
+    emitModule(destination, chunk.id, chunk.json);
+  } else {
+    emitError(destination, chunk.id, chunk.json.message, chunk.json.stack);
+  }
+  return true;
+}
+
+export function completeWriting(destination: Destination) {}
+
+export {close} from 'ReactFlightNativeRelayServerIntegration';

--- a/packages/react-transport-native-relay/src/__mocks__/JSResourceReferenceImpl.js
+++ b/packages/react-transport-native-relay/src/__mocks__/JSResourceReferenceImpl.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+class JSResourceReferenceImpl {
+  constructor(exportedValue) {
+    this._moduleId = exportedValue;
+  }
+  getModuleId() {
+    return this._moduleId;
+  }
+}
+
+module.exports = JSResourceReferenceImpl;

--- a/packages/react-transport-native-relay/src/__mocks__/ReactFlightNativeRelayClientIntegration.js
+++ b/packages/react-transport-native-relay/src/__mocks__/ReactFlightNativeRelayClientIntegration.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import JSResourceReference from 'JSResourceReference';
+
+const ReactFlightNativeRelayClientIntegration = {
+  resolveModuleReference(moduleData) {
+    return new JSResourceReference(moduleData);
+  },
+  preloadModule(moduleReference) {},
+  requireModule(moduleReference) {
+    return moduleReference._moduleId;
+  },
+};
+
+module.exports = ReactFlightNativeRelayClientIntegration;

--- a/packages/react-transport-native-relay/src/__mocks__/ReactFlightNativeRelayServerIntegration.js
+++ b/packages/react-transport-native-relay/src/__mocks__/ReactFlightNativeRelayServerIntegration.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const ReactFlightNativeRelayServerIntegration = {
+  emitModel(destination, id, json) {
+    destination.push({
+      type: 'json',
+      id: id,
+      json: json,
+    });
+  },
+  emitModule(destination, id, json) {
+    destination.push({
+      type: 'module',
+      id: id,
+      json: json,
+    });
+  },
+  emitError(destination, id, message, stack) {
+    destination.push({
+      type: 'error',
+      id: id,
+      json: {message, stack},
+    });
+  },
+  close(destination) {},
+  resolveModuleMetaData(config, resource) {
+    return resource._moduleId;
+  },
+};
+
+module.exports = ReactFlightNativeRelayServerIntegration;

--- a/packages/react-transport-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
+++ b/packages/react-transport-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+let React;
+let ReactFabric;
+let createReactNativeComponentClass;
+let View;
+let Text;
+let JSResourceReferenceImpl;
+let ReactNativeFlightRelayServer;
+let ReactNativeFlightRelayClient;
+
+describe('ReactFlightNativeRelay', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
+
+    React = require('react');
+    // TODO: Switch this out to react-native
+    ReactFabric = require('react-native-renderer/fabric');
+    createReactNativeComponentClass = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
+      .ReactNativeViewConfigRegistry.register;
+    View = createReactNativeComponentClass('RCTView', () => ({
+      validAttributes: {},
+      uiViewClassName: 'RCTView',
+    }));
+    Text = createReactNativeComponentClass('RCTText', () => ({
+      validAttributes: {},
+      uiViewClassName: 'RCTText',
+    }));
+
+    ReactNativeFlightRelayServer = require('react-transport-native-relay/server');
+    ReactNativeFlightRelayClient = require('react-transport-native-relay');
+    JSResourceReferenceImpl = require('JSResourceReferenceImpl');
+  });
+
+  function readThrough(data) {
+    const response = ReactNativeFlightRelayClient.createResponse();
+    for (let i = 0; i < data.length; i++) {
+      const chunk = data[i];
+      if (chunk.type === 'json') {
+        ReactNativeFlightRelayClient.resolveModel(
+          response,
+          chunk.id,
+          chunk.json,
+        );
+      } else if (chunk.type === 'module') {
+        ReactNativeFlightRelayClient.resolveModule(
+          response,
+          chunk.id,
+          chunk.json,
+        );
+      } else {
+        ReactNativeFlightRelayClient.resolveError(
+          response,
+          chunk.id,
+          chunk.json.message,
+          chunk.json.stack,
+        );
+      }
+    }
+    ReactNativeFlightRelayClient.close(response);
+    const model = response.readRoot();
+    return model;
+  }
+
+  it('can render a server component', () => {
+    function Bar({text}) {
+      return <Text>{text.toUpperCase()}</Text>;
+    }
+    function Foo() {
+      return {
+        bar: (
+          <View>
+            <Bar text="a" /> <Bar text="b" />
+          </View>
+        ),
+      };
+    }
+    const transport = [];
+    ReactNativeFlightRelayServer.render(
+      {
+        foo: <Foo />,
+      },
+      transport,
+    );
+
+    const model = readThrough(transport);
+    expect(model).toMatchSnapshot();
+  });
+
+  it('can render a client component using a module reference and render there', () => {
+    function UserClient(props) {
+      return (
+        <Text>
+          {props.greeting}, {props.name}
+        </Text>
+      );
+    }
+    const User = new JSResourceReferenceImpl(UserClient);
+
+    function Greeting({firstName, lastName}) {
+      return <User greeting="Hello" name={firstName + ' ' + lastName} />;
+    }
+
+    const model = {
+      greeting: <Greeting firstName="Seb" lastName="Smith" />,
+    };
+
+    const transport = [];
+    ReactNativeFlightRelayServer.render(model, transport);
+
+    const modelClient = readThrough(transport);
+
+    ReactFabric.render(modelClient.greeting, 1);
+    expect(
+      nativeFabricUIManager.__dumpHierarchyForJestTestsOnly(),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/react-transport-native-relay/src/__tests__/__snapshots__/ReactFlightNativeRelay-test.internal.js.snap
+++ b/packages/react-transport-native-relay/src/__tests__/__snapshots__/ReactFlightNativeRelay-test.internal.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReactFlightNativeRelay can render a client component using a module reference and render there 1`] = `
+"1
+ RCTText null
+   RCTRawText {\\"text\\":\\"Hello\\"}
+   RCTRawText {\\"text\\":\\", \\"}
+   RCTRawText {\\"text\\":\\"Seb Smith\\"}"
+`;
+
+exports[`ReactFlightNativeRelay can render a server component 1`] = `
+Object {
+  "foo": Object {
+    "bar": <RCTView>
+      <RCTText>
+        A
+      </RCTText>
+       
+      <RCTText>
+        B
+      </RCTText>
+    </RCTView>,
+  },
+}
+`;

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -17,10 +17,19 @@ type JSONValue =
 
 declare class JSResourceReference<T> {
   _moduleId: T;
+  getModuleId(): string;
 }
 
+// Haste
 declare module 'JSResourceReference' {
   declare export default typeof JSResourceReference;
+}
+
+// Metro
+declare module 'JSResourceReferenceImpl' {
+  declare export default class JSResourceReferenceImpl<
+    T,
+  > extends JSResourceReference<T> {}
 }
 
 declare module 'ReactFlightDOMRelayServerIntegration' {
@@ -52,6 +61,47 @@ declare module 'ReactFlightDOMRelayServerIntegration' {
 }
 
 declare module 'ReactFlightDOMRelayClientIntegration' {
+  declare export opaque type ModuleMetaData;
+  declare export function resolveModuleReference<T>(
+    moduleData: ModuleMetaData,
+  ): JSResourceReference<T>;
+  declare export function preloadModule<T>(
+    moduleReference: JSResourceReference<T>,
+  ): void;
+  declare export function requireModule<T>(
+    moduleReference: JSResourceReference<T>,
+  ): T;
+}
+
+declare module 'ReactFlightNativeRelayServerIntegration' {
+  declare export opaque type Destination;
+  declare export opaque type BundlerConfig;
+  declare export function emitModel(
+    destination: Destination,
+    id: number,
+    json: JSONValue,
+  ): void;
+  declare export function emitModule(
+    destination: Destination,
+    id: number,
+    json: ModuleMetaData,
+  ): void;
+  declare export function emitError(
+    destination: Destination,
+    id: number,
+    message: string,
+    stack: string,
+  ): void;
+  declare export function close(destination: Destination): void;
+
+  declare export type ModuleMetaData = JSONValue;
+  declare export function resolveModuleMetaData<T>(
+    config: BundlerConfig,
+    resourceReference: JSResourceReference<T>,
+  ): ModuleMetaData;
+}
+
+declare module 'ReactFlightNativeRelayClientIntegration' {
   declare export opaque type ModuleMetaData;
   declare export function resolveModuleReference<T>(
     moduleData: ModuleMetaData,

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -298,7 +298,7 @@ const bundles = [
     ],
   },
 
-  /******* React DOM Flight Client Relay *******/
+  /******* React Transport DOM Client Relay *******/
   {
     bundleTypes: [FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RENDERER,
@@ -308,6 +308,32 @@ const bundles = [
       'react',
       'ReactFlightDOMRelayClientIntegration',
       'JSResourceReference',
+    ],
+  },
+
+  /******* React Transport Native Server Relay *******/
+  {
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD],
+    moduleType: RENDERER,
+    entry: 'react-transport-native-relay/server',
+    global: 'ReactFlightNativeRelayServer',
+    externals: [
+      'react',
+      'ReactFlightNativeRelayServerIntegration',
+      'JSResourceReferenceImpl',
+    ],
+  },
+
+  /******* React Transport Native Client Relay *******/
+  {
+    bundleTypes: [RN_FB_DEV, RN_FB_PROD],
+    moduleType: RENDERER,
+    entry: 'react-transport-native-relay',
+    global: 'ReactFlightNativeRelayClient',
+    externals: [
+      'react',
+      'ReactFlightNativeRelayClientIntegration',
+      'JSResourceReferenceImpl',
     ],
   },
 

--- a/scripts/rollup/packaging.js
+++ b/scripts/rollup/packaging.js
@@ -79,6 +79,8 @@ function getBundleOutputPath(bundleType, filename, packageName) {
             /\.js$/,
             '.fb.js'
           )}`;
+        case 'react-transport-native-relay':
+          return `build/facebook-relay/flight/${filename}`;
         default:
           throw new Error('Unknown RN package.');
       }

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -92,6 +92,16 @@ module.exports = [
     isServerSupported: true,
   },
   {
+    shortName: 'native-relay',
+    entryPoints: [
+      'react-transport-native-relay',
+      'react-transport-native-relay/server',
+    ],
+    paths: ['react-native-renderer', 'react-transport-native-relay'],
+    isFlowTyped: true,
+    isServerSupported: true,
+  },
+  {
     shortName: 'custom',
     entryPoints: [
       'react-reconciler',


### PR DESCRIPTION
This adds a new dimension similar to dom-relay. It's different from "native" which would be Flight for RN without Relay.

This has some copy-pasta that's the same between the two Relay builds but the key difference will be Metro and we're not quite sure what other differences there will be yet.

It builds to a new folder `facebook-relay` so we can put it together with other Relay FB specific things for now.

We still have to add this folder to the sync script to pull it in.