### PR TITLE
Add "nested-update" phase to Profiler API

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -21,6 +21,7 @@ import {
   enableSuspenseServerRenderer,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
   enableProfilerTimer,
+  enableProfilerNestedUpdatePhase,
   enableSchedulerTracing,
   warnAboutUnmockedScheduler,
   deferRenderPhaseUpdateToNextBatch,
@@ -195,9 +196,11 @@ import {
 } from './ReactFiberStack.new';
 
 import {
+  markNestedUpdateScheduled,
   recordCommitTime,
   startProfilerTimer,
   stopProfilerTimerIfRunningAndRecordDelta,
+  syncNestedUpdateFlag,
 } from './ReactProfilerTimer.new';
 
 // DEV stuff
@@ -939,6 +942,10 @@ function markRootSuspended(root, suspendedLanes) {
 // This is the entry point for synchronous tasks that don't go
 // through Scheduler
 function performSyncWorkOnRoot(root) {
+  if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
+    syncNestedUpdateFlag();
+  }
+
   invariant(
     (executionContext & (RenderContext | CommitContext)) === NoContext,
     'Should not already be working.',
@@ -1996,6 +2003,10 @@ function commitRootImpl(root, renderPriorityLevel) {
   }
 
   if (remainingLanes === SyncLane) {
+    if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
+      markNestedUpdateScheduled();
+    }
+
     // Count the number of times the root synchronously re-renders without
     // finishing. If there are too many, it indicates an infinite update loop.
     if (root === rootWithNestedUpdates) {

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -28,6 +28,7 @@ let resourcePromise;
 function loadModules({
   enableProfilerTimer = true,
   enableProfilerCommitHooks = true,
+  enableProfilerNestedUpdatePhase = true,
   enableSchedulerTracing = true,
   replayFailedUnitOfWorkWithInvokeGuardedCallback = false,
   useNoopRenderer = false,
@@ -36,6 +37,7 @@ function loadModules({
 
   ReactFeatureFlags.enableProfilerTimer = enableProfilerTimer;
   ReactFeatureFlags.enableProfilerCommitHooks = enableProfilerCommitHooks;
+  ReactFeatureFlags.enableProfilerNestedUpdatePhase = enableProfilerNestedUpdatePhase;
   ReactFeatureFlags.enableSchedulerTracing = enableSchedulerTracing;
   ReactFeatureFlags.replayFailedUnitOfWorkWithInvokeGuardedCallback = replayFailedUnitOfWorkWithInvokeGuardedCallback;
 
@@ -1098,7 +1100,7 @@ describe('Profiler', () => {
                 );
 
                 // The update includes the ErrorBoundary and its fallback child
-                expect(updateCall[1]).toBe('update');
+                expect(updateCall[1]).toBe('nested-update');
                 // actual time includes: 2 (ErrorBoundary) + 20 (AdvanceTime)
                 expect(updateCall[2]).toBe(22);
                 // base time includes: 2 (ErrorBoundary) + 20 (AdvanceTime)
@@ -1456,7 +1458,7 @@ describe('Profiler', () => {
 
         expect(call).toHaveLength(enableSchedulerTracing ? 5 : 4);
         expect(call[0]).toBe('mount-test');
-        expect(call[1]).toBe('update');
+        expect(call[1]).toBe('nested-update');
         expect(call[2]).toBe(130); // durations
         expect(call[3]).toBe(1200001011); // commit start time (before mutations or effects)
         expect(call[4]).toEqual(enableSchedulerTracing ? new Set() : undefined); // interaction events
@@ -1485,7 +1487,7 @@ describe('Profiler', () => {
 
         expect(call).toHaveLength(enableSchedulerTracing ? 5 : 4);
         expect(call[0]).toBe('update-test');
-        expect(call[1]).toBe('update');
+        expect(call[1]).toBe('nested-update');
         expect(call[2]).toBe(10000); // durations
         expect(call[3]).toBe(3300011272); // commit start time (before mutations or effects)
         expect(call[4]).toEqual(enableSchedulerTracing ? new Set() : undefined); // interaction events
@@ -1716,7 +1718,7 @@ describe('Profiler', () => {
         // Cleanup render from error boundary
         expect(call).toHaveLength(enableSchedulerTracing ? 5 : 4);
         expect(call[0]).toBe('root');
-        expect(call[1]).toBe('update');
+        expect(call[1]).toBe('nested-update');
         expect(call[2]).toBe(100000000); // durations
         expect(call[3]).toBe(10110111); // commit start time (before mutations or effects)
         expect(call[4]).toEqual(enableSchedulerTracing ? new Set() : undefined); // interaction events
@@ -1847,7 +1849,7 @@ describe('Profiler', () => {
         // Cleanup render from error boundary
         expect(call).toHaveLength(enableSchedulerTracing ? 5 : 4);
         expect(call[0]).toBe('root');
-        expect(call[1]).toBe('update');
+        expect(call[1]).toBe('nested-update');
         expect(call[2]).toBe(100001000); // durations
         expect(call[3]).toBe(11221221); // commit start time (before mutations or effects)
         expect(call[4]).toEqual(enableSchedulerTracing ? new Set() : undefined); // interaction events
@@ -1905,7 +1907,7 @@ describe('Profiler', () => {
 
           expect(call).toHaveLength(enableSchedulerTracing ? 5 : 4);
           expect(call[0]).toBe('root');
-          expect(call[1]).toBe('update');
+          expect(call[1]).toBe('nested-update');
           expect(call[4]).toMatchInteractions([interaction]);
         });
       }

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -36,6 +36,9 @@ export const enableProfilerTimer = __PROFILE__;
 // Record durations for commit and passive effects phases.
 export const enableProfilerCommitHooks = false;
 
+// Phase param passed to onRender callback differentiates between an "update" and a "cascading-update".
+export const enableProfilerNestedUpdatePhase = false;
+
 // Trace which interactions trigger each commit.
 export const enableSchedulerTracing = __PROFILE__;
 

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -15,6 +15,7 @@ export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -17,6 +17,7 @@ export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -17,6 +17,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -17,6 +17,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -17,6 +17,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -17,6 +17,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = __PROFILE__;
 export const enableSuspenseServerRenderer = false;
 export const enableSelectiveHydration = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -17,6 +17,7 @@ export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;
 export const enableProfilerCommitHooks = false;
+export const enableProfilerNestedUpdatePhase = false;
 export const enableSchedulerTracing = false;
 export const enableSuspenseServerRenderer = true;
 export const enableSelectiveHydration = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -36,6 +36,7 @@ export const {
 
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
+export const enableProfilerNestedUpdatePhase = __PROFILE__;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
 export const enableSchedulingProfiler = __PROFILE__;


### PR DESCRIPTION
## Background

State updates that are scheduled in a layout effect ([`useLayoutEffect`](https://reactjs.org/docs/hooks-reference.html#uselayouteffect) or [`componentDidMount`](https://reactjs.org/docs/react-component.html#componentdidmount) / [`componentDidUpdate`](https://reactjs.org/docs/react-component.html#componentdidupdate)) get processed **synchronously** by React before it yields to the browser to paint. This is done so that components can *adjust their layout* (e.g. position and size a tooltip) without any visible shifting being seen by users. This type of update is often called a "nested update" or a "cascading update".

Because they delay paint and block the main (JavaScript) thread, nested updates are considered **expensive** and should be avoided when possible. For example, effects that do not impact layout (e.g. adding event handlers, logging impressions) can be safely deferred to the *passive* effect phase by using [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) instead.

This PR updates the [Profiler API](https://reactjs.org/docs/profiler.html#gatsby-focus-wrapper) to explicitly flag nested updates so they can be monitored for and avoided when possible.

## API

I considered a few approaches for this.
1. Add a new callback (e.g. `onNestedUpdateScheduled`) to the Profiler that gets called when a nested updates gets scheduled.
2. Add an additional boolean parameter to the end of existing callbacks (e.g. `wasNestedUpdate`).
3. Update the `phase` param to add an additional variant: `"mount"`, `"update"`, or `"nested-update"` (new).

I think the third option makes for the best API so that's what I've implemented in this PR.

Because the Profiler API is stable, this change will need to remain behind a feature flag until v18. I've turned the feature flag on for Facebook builds though after confirming that Web Speed does not currently make use of the `phase` parameter.

## Quirks

One quirk about the implementation I've chosen is that errors thrown during the layout phase are also reported as nested updates. I believe this is appropriate since these errors get processed synchronously and block paint. Errors thrown during render or from within passive effects are not affected by this change.