### PR TITLE
[Flight] Encode Symbols as special rows that can be referenced by models …

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -132,6 +132,13 @@ function createErrorChunk(response: Response, error: Error): ErroredChunk {
   return new Chunk(ERRORED, error, response);
 }
 
+function createInitializedChunk<T>(
+  response: Response,
+  value: T,
+): InitializedChunk<T> {
+  return new Chunk(INITIALIZED, value, response);
+}
+
 function wakeChunk(listeners: null | Array<() => mixed>) {
   if (listeners !== null) {
     for (let i = 0; i < listeners.length; i++) {
@@ -371,6 +378,17 @@ export function resolveModule(
   } else {
     resolveModuleChunk(chunk, moduleReference);
   }
+}
+
+export function resolveSymbol(
+  response: Response,
+  id: number,
+  name: string,
+): void {
+  const chunks = response._chunks;
+  // We assume that we'll always emit the symbol before anything references it
+  // to save a few bytes.
+  chunks.set(id, createInitializedChunk(response, Symbol.for(name)));
 }
 
 export function resolveError(

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -12,6 +12,7 @@ import type {Response} from './ReactFlightClientHostConfigStream';
 import {
   resolveModule,
   resolveModel,
+  resolveSymbol,
   resolveError,
   createResponse as createResponseBase,
   parseModelString,
@@ -32,26 +33,28 @@ function processFullRow(response: Response, row: string): void {
     return;
   }
   const tag = row[0];
+  // When tags that are not text are added, check them here before
+  // parsing the row as text.
+  // switch (tag) {
+  // }
+  const colon = row.indexOf(':', 1);
+  const id = parseInt(row.substring(1, colon), 16);
+  const text = row.substring(colon + 1);
   switch (tag) {
     case 'J': {
-      const colon = row.indexOf(':', 1);
-      const id = parseInt(row.substring(1, colon), 16);
-      const json = row.substring(colon + 1);
-      resolveModel(response, id, json);
+      resolveModel(response, id, text);
       return;
     }
     case 'M': {
-      const colon = row.indexOf(':', 1);
-      const id = parseInt(row.substring(1, colon), 16);
-      const json = row.substring(colon + 1);
-      resolveModule(response, id, json);
+      resolveModule(response, id, text);
+      return;
+    }
+    case 'S': {
+      resolveSymbol(response, id, JSON.parse(text));
       return;
     }
     case 'E': {
-      const colon = row.indexOf(':', 1);
-      const id = parseInt(row.substring(1, colon), 16);
-      const json = row.substring(colon + 1);
-      const errorInfo = JSON.parse(json);
+      const errorInfo = JSON.parse(text);
       resolveError(response, id, errorInfo.message, errorInfo.stack);
       return;
     }

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -174,7 +174,7 @@ describe('ReactFlight', () => {
           <ErrorBoundary expectedMessage="Functions cannot be passed directly to client components because they're not serializable.">
             <Client transport={fn} />
           </ErrorBoundary>
-          <ErrorBoundary expectedMessage="Symbol values (foo) cannot be passed to client components.">
+          <ErrorBoundary expectedMessage="Only global symbols received from Symbol.for(...) can be passed to client components.">
             <Client transport={symbol} />
           </ErrorBoundary>
           <ErrorBoundary expectedMessage="Refs cannot be used in server components, nor passed to client components.">

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -109,6 +109,16 @@ export function processModuleChunk(
   return convertStringToBuffer(row);
 }
 
+export function processSymbolChunk(
+  request: Request,
+  id: number,
+  name: string,
+): Chunk {
+  const json = stringify(name);
+  const row = serializeRowHeader('S', id) + json + '\n';
+  return convertStringToBuffer(row);
+}
+
 export {
   scheduleWork,
   flushBuffered,

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -15,6 +15,7 @@ import {
   createResponse,
   resolveModel,
   resolveModule,
+  resolveSymbol,
   resolveError,
   close,
 } from 'react-client/src/ReactFlightClient';
@@ -26,6 +27,9 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {
     resolveModule(response, chunk[1], chunk[2]);
+  } else if (chunk[0] === 'S') {
+    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+    resolveSymbol(response, chunk[1], chunk[2]);
   } else {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
     resolveError(response, chunk[1], chunk[2].message, chunk[2].stack);

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -20,6 +20,7 @@ export type JSONValue =
 export type RowEncoding =
   | ['J', number, JSONValue]
   | ['M', number, ModuleMetaData]
+  | ['S', number, string]
   | [
       'E',
       number,

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -111,6 +111,14 @@ export function processModuleChunk(
   return ['M', id, moduleMetaData];
 }
 
+export function processSymbolChunk(
+  request: Request,
+  id: number,
+  name: string,
+): Chunk {
+  return ['S', id, name];
+}
+
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-transport-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -153,11 +153,14 @@ describe('ReactFlightDOMRelay', () => {
       foo: {
         bar: (
           <div>
-            {'Fragment child'}
-            {'Profiler child'}
-            {'StrictMode child'}
-            {'Suspense child'}
-            {['SuspenseList row 1', 'SuspenseList row 2']}
+            Fragment child
+            <Profiler>Profiler child</Profiler>
+            <StrictMode>StrictMode child</StrictMode>
+            <Suspense fallback="Loading...">Suspense child</Suspense>
+            <SuspenseList fallback="Loading...">
+              {'SuspenseList row 1'}
+              {'SuspenseList row 2'}
+            </SuspenseList>
             <div>Hello world</div>
           </div>
         ),

--- a/packages/react-transport-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-transport-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -282,10 +282,6 @@ describe('ReactFlightDOM', () => {
       );
     }
 
-    function Placeholder({children, fallback}) {
-      return <Suspense fallback={fallback}>{children}</Suspense>;
-    }
-
     // Model
     function Text({children}) {
       return children;
@@ -347,22 +343,21 @@ describe('ReactFlightDOM', () => {
     }
 
     const MyErrorBoundaryClient = moduleReference(MyErrorBoundary);
-    const PlaceholderClient = moduleReference(Placeholder);
 
     function ProfileContent() {
       return (
         <>
           <ProfileDetails avatar={<Text>:avatar:</Text>} />
-          <PlaceholderClient fallback={<p>(loading sidebar)</p>}>
+          <Suspense fallback={<p>(loading sidebar)</p>}>
             <ProfileSidebar friends={<Friends>:friends:</Friends>} />
-          </PlaceholderClient>
-          <PlaceholderClient fallback={<p>(loading posts)</p>}>
+          </Suspense>
+          <Suspense fallback={<p>(loading posts)</p>}>
             <ProfilePosts posts={<Posts>:posts:</Posts>} />
-          </PlaceholderClient>
+          </Suspense>
           <MyErrorBoundaryClient>
-            <PlaceholderClient fallback={<p>(loading games)</p>}>
+            <Suspense fallback={<p>(loading games)</p>}>
               <ProfileGames games={<Games>:games:</Games>} />
-            </PlaceholderClient>
+            </Suspense>
           </MyErrorBoundaryClient>
         </>
       );

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayClient.js
@@ -15,6 +15,7 @@ import {
   createResponse,
   resolveModel,
   resolveModule,
+  resolveSymbol,
   resolveError,
   close,
 } from 'react-client/src/ReactFlightClient';
@@ -26,6 +27,9 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {
     resolveModule(response, chunk[1], chunk[2]);
+  } else if (chunk[0] === 'S') {
+    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+    resolveSymbol(response, chunk[1], chunk[2]);
   } else {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
     resolveError(response, chunk[1], chunk[2].message, chunk[2].stack);

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -20,6 +20,7 @@ export type JSONValue =
 export type RowEncoding =
   | ['J', number, JSONValue]
   | ['M', number, ModuleMetaData]
+  | ['S', number, string]
   | [
       'E',
       number,

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -111,6 +111,14 @@ export function processModuleChunk(
   return ['M', id, moduleMetaData];
 }
 
+export function processSymbolChunk(
+  request: Request,
+  id: number,
+  name: string,
+): Chunk {
+  return ['S', id, name];
+}
+
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -364,7 +364,7 @@
   "373": "This Hook is not supported in Server Components.",
   "374": "Event handlers cannot be passed to client component props. Remove %s from these props if possible: %s\nIf you need interactivity, consider converting part of this to a client component.",
   "375": "Functions cannot be passed directly to client components because they're not serializable. Remove %s (%s) from this object, or avoid the entire object: %s",
-  "376": "Symbol values (%s) cannot be passed to client components. Remove %s from this object, or avoid the entire object: %s",
+  "376": "Only global symbols received from Symbol.for(...) can be passed to client components. The symbol Symbol.for(%s) cannot be found among global symbols. Remove %s from this object, or avoid the entire object: %s",
   "377": "BigInt (%s) is not yet supported in client component props. Remove %s from this object or use a plain number instead: %s",
   "378": "Type %s is not supported in client component props. Remove %s from this object, or avoid the entire object: %s",
   "379": "Refs cannot be used in server components, nor passed to client components."


### PR DESCRIPTION
If a symbol was extracted from `Symbol.for(...)` then we can reliably recreate the same symbol on the client.

```
S123:"react.suspense"
J456:{"mySymbol": "$123"}
```

This doesn't suffer from the XSS problem because you have to write actual code to create one of these symbols. That problem is only a problem because values pass through common other usages of JSON which are not secure.

Since React encodes its built-ins as symbols, we can now use all of them as long as its props are serializable. Like Suspense.

This also allows this pattern to be used with custom objects. I.e. you can tag sensitize objects with symbols that shouldn't otherwise pass through other JSON serialization.