### PR TITLE
[Flight] Dedupe modules

### DIFF
--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -45,6 +45,9 @@ const ReactNoopFlightServer = ReactFlightServer({
   isModuleReference(reference: Object): boolean {
     return reference.$$typeof === Symbol.for('react.module.reference');
   },
+  getModuleKey(reference: Object): Object {
+    return reference;
+  },
   resolveModuleMetaData(
     config: void,
     reference: {$$typeof: Symbol, value: any},

--- a/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
+++ b/packages/react-server/src/ReactFlightServerBundlerConfigCustom.js
@@ -12,5 +12,7 @@ declare var $$$hostConfig: any;
 export opaque type BundlerConfig = mixed; // eslint-disable-line no-undef
 export opaque type ModuleReference<T> = mixed; // eslint-disable-line no-undef
 export opaque type ModuleMetaData: any = mixed; // eslint-disable-line no-undef
+export opaque type ModuleKey: any = mixed; // eslint-disable-line no-undef
 export const isModuleReference = $$$hostConfig.isModuleReference;
+export const getModuleKey = $$$hostConfig.getModuleKey;
 export const resolveModuleMetaData = $$$hostConfig.resolveModuleMetaData;

--- a/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-transport-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -38,6 +38,14 @@ export function isModuleReference(reference: Object): boolean {
   return reference instanceof JSResourceReference;
 }
 
+export type ModuleKey = ModuleReference<any>;
+
+export function getModuleKey(reference: ModuleReference<any>): ModuleKey {
+  // We use the reference object itself as the key because we assume the
+  // object will be cached by the bundler runtime.
+  return reference;
+}
+
 export function resolveModuleMetaData<T>(
   config: BundlerConfig,
   resource: ModuleReference<T>,

--- a/packages/react-transport-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-transport-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -25,7 +25,13 @@ export type ModuleMetaData = {
   name: string,
 };
 
+export type ModuleKey = string;
+
 const MODULE_TAG = Symbol.for('react.module.reference');
+
+export function getModuleKey(reference: ModuleReference<any>): ModuleKey {
+  return reference.name;
+}
 
 export function isModuleReference(reference: Object): boolean {
   return reference.$$typeof === MODULE_TAG;

--- a/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-transport-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -38,6 +38,14 @@ export function isModuleReference(reference: Object): boolean {
   return reference instanceof JSResourceReferenceImpl;
 }
 
+export type ModuleKey = ModuleReference<any>;
+
+export function getModuleKey(reference: ModuleReference<any>): ModuleKey {
+  // We use the reference object itself as the key because we assume the
+  // object will be cached by the bundler runtime.
+  return reference;
+}
+
 export function resolveModuleMetaData<T>(
   config: BundlerConfig,
   resource: ModuleReference<T>,

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -35,6 +35,7 @@ jest.mock('react-server/flight', () => {
     jest.mock(shimServerFormatConfigPath, () => config);
     jest.mock('react-server/src/ReactFlightServerBundlerConfigCustom', () => ({
       isModuleReference: config.isModuleReference,
+      getModuleKey: config.getModuleKey,
       resolveModuleMetaData: config.resolveModuleMetaData,
     }));
     jest.mock(shimFlightServerConfigPath, () =>


### PR DESCRIPTION
This adds a custom host config for extracting a unique get from a module reference (typically just the module name).

For www/Relay, we'll assume that the reference object itself has already been deduped.