### PR TITLE
feat(eslint-plugin): allow ignoring dependencies

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -50,6 +50,8 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 ## Advanced Configuration
 
+### additionalHooks
+
 `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
 
@@ -58,13 +60,32 @@ This option accepts a regex to match the names of custom Hooks that have depende
   "rules": {
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+      "additionalHooks": "^(useMyCustomHook|useMyOtherCustomHook)$"
     }]
   }
 }
 ```
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
+
+### ignoredDependencies
+
+`exhaustive-deps` can be configured to ignore some dependencies with the `ignoredDependencies` option.
+This option accepts a regex to match any variable that you don't want to add to your dependencies.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "ignoredDependencies": "^(someConstantFromLibrary|someOtherConstant)$"
+    }]
+  }
+}
+```
+
+We suggest to use this option **with extra care**. Keep in mind that any variable with a name matching the regex will be ignored without additional consideration. Always use a global regex to avoid too wide matching (start it with `^` and finish with `$`)
+
 
 ## Valid and Invalid Examples
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -535,6 +535,17 @@ const tests = {
     {
       code: normalizeIndent`
         function MyComponent(props) {
+          const navigation = useNavigation();
+          useEffect(() => {
+            navigation.goBack();
+          }, []);
+        }
+      `,
+      options: [{ignoredDependencies: '^(navigation|otherVariable)$'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
           useWithoutEffectSuffix(() => {
             console.log(props.foo);
           }, []);
@@ -3512,6 +3523,37 @@ const tests = {
                   React.useCustomEffect(() => {
                     console.log(props.foo);
                   }, []);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          const navigation = useNavigation();
+          useEffect(() => {
+            navigation.goBack();
+          }, []);
+        }
+      `,
+      options: [{ignoredDependencies: '$(nav)^'}],
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'navigation'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [navigation]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  const navigation = useNavigation();
+                  useEffect(() => {
+                    navigation.goBack();
+                  }, [navigation]);
                 }
               `,
             },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -29,6 +29,9 @@ export default {
           additionalHooks: {
             type: 'string',
           },
+          ignoredDependencies: {
+            type: 'string',
+          },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
@@ -45,6 +48,13 @@ export default {
         ? new RegExp(context.options[0].additionalHooks)
         : undefined;
 
+    const ignoredDependencies =
+      context.options &&
+      context.options[0] &&
+      context.options[0].ignoredDependencies
+        ? new RegExp(context.options[0].ignoredDependencies)
+        : undefined;
+
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
       (context.options &&
         context.options[0] &&
@@ -53,6 +63,7 @@ export default {
 
     const options = {
       additionalHooks,
+      ignoredDependencies,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
     };
 
@@ -157,6 +168,9 @@ export default {
       //       ^^^ true for this reference
       // False for everything else.
       function isStableKnownHookValue(resolved) {
+        if (options.ignoredDependencies && options.ignoredDependencies.test(resolved.name)) {
+          return true;
+        }
         if (!Array.isArray(resolved.defs)) {
           return false;
         }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Package: eslint-plugin-react-hook
Rule: exhaustive-deps

Many warning comes from the react-hook/exhaustive-deps rule. As a project owner, I know some dependencies the linter shouldn't care about (`dispatch` from react-redux, `navigation` from react-navigation, ...)

This PR allow a more extensive rule configuration

Exemple configuration:

```
    'react-hooks/exhaustive-deps': [
      'warn',
      {
        ignoredDependencies: '^(dispatch|navigation)$',
      },
    ],
```

## Test Plan

Added Jest tests