### PR TITLE
Improved dev experience when DevTools hook is disabled

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -20,6 +20,7 @@ import type {
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {REACT_MEMO_TYPE, REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
+import warning from 'fbjs/lib/warning';
 
 type Signature = {|
   ownKey: string,
@@ -467,8 +468,9 @@ export function injectIntoGlobalHook(globalObject: any): void {
     // Checks if DevTools hook is disabled
     if (hook.isDisabled) {
       if (__DEV__) {
-        console.error('React DevTools hook is disabled. Try to enable the hook ' +
-        'or update your React DevTools. ',);
+        warning('React DevTools hook is disabled. Try to enable the hook ' +
+          'or update your React DevTools. ',
+);
       }
     }
 

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -467,11 +467,8 @@ export function injectIntoGlobalHook(globalObject: any): void {
     // Checks if DevTools hook is disabled
     if (hook.isDisabled) {
       if (__DEV__) {
-        warning(
-          false,
-          'React DevTools hook is disabled. Try to enable the hook ' +
-          'or update your React DevTools. ',
-        );
+        console.error('React DevTools hook is disabled. Try to enable the hook ' +
+        'or update your React DevTools. ',);
       }
     }
 

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -20,7 +20,6 @@ import type {
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {REACT_MEMO_TYPE, REACT_FORWARD_REF_TYPE} from 'shared/ReactSymbols';
-import warning from 'fbjs/lib/warning';
 
 type Signature = {|
   ownKey: string,
@@ -465,12 +464,13 @@ export function injectIntoGlobalHook(globalObject: any): void {
         onCommitFiberUnmount() {},
       };
     }
+    
     // Checks if DevTools hook is disabled
     if (hook.isDisabled) {
       if (__DEV__) {
-        warning('React DevTools hook is disabled. Try to enable the hook ' +
+        console.error('React DevTools hook is disabled. Try to enable the hook ' +
           'or update your React DevTools. ',
-);
+        );
       }
     }
 

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -467,7 +467,8 @@ export function injectIntoGlobalHook(globalObject: any): void {
     // Checks if DevTools hook is disabled
     if (hook.isDisabled) {
       if (__DEV__) {
-        console.warn(
+        warning(
+          false,
           'React DevTools hook is disabled. Try to enable the hook ' +
           'or update your React DevTools. ',
         );

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -464,6 +464,15 @@ export function injectIntoGlobalHook(globalObject: any): void {
         onCommitFiberUnmount() {},
       };
     }
+    // Checks if DevTools hook is disabled
+    if (hook.isDisabled) {
+      if (__DEV__) {
+        console.warn(
+          'React DevTools hook is disabled. Try to enable the hook ' +
+          'or update your React DevTools. ',
+        );
+      }
+    }
 
     // Here, we just want to get a reference to scheduleRefresh.
     const oldInject = hook.inject;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This pull request allows Fast Refresh to check if the DevTools hook is disabled and print a Dev warning if it's disabled. 