### PR TITLE
[dbg] resolves adding in proper warning for debugging size prop

### DIFF
--- a/packages/react-dom/src/shared/DOMProperty.js
+++ b/packages/react-dom/src/shared/DOMProperty.js
@@ -136,6 +136,12 @@ export function shouldRemoveAttributeWithWarning(
         return prefix !== 'data-' && prefix !== 'aria-';
       }
     }
+    case 'string': {
+      if (name === 'size') {
+        return true;
+      }
+      return false;
+    }
     default:
       return false;
   }

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -212,7 +212,9 @@ if (__DEV__) {
       shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
     ) {
       if (name === 'size') {
-        console.error(`The size attribute value of "${value}" has the wrong type. The size attribute is a well-known HTML attribute. You should be using data-size="${value}" instead.`);
+        console.error(
+          `The size attribute value of "${value}" has the wrong type. The size attribute is a well-known HTML attribute. You should be using data-size="${value}" instead.`,
+        );
       }
       warnedProperties[name] = true;
       return true;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -207,6 +207,17 @@ if (__DEV__) {
       return true;
     }
 
+    if (
+      typeof value === 'string' &&
+      shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
+    ) {
+      if (name === 'size') {
+        console.error(`The size attribute value of "${value}" has the wrong type. The size attribute is a well-known HTML attribute. You should be using data-size="${value}" instead.`);
+      }
+      warnedProperties[name] = true;
+      return true;
+    }
+
     // Warn when a known attribute is a bad type
     if (shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)) {
       warnedProperties[name] = true;

--- a/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js
@@ -209,11 +209,15 @@ if (__DEV__) {
 
     if (
       typeof value === 'string' &&
+      tagName !== 'select' &&
+      tagName !== 'input' &&
       shouldRemoveAttributeWithWarning(name, value, propertyInfo, false)
     ) {
       if (name === 'size') {
         console.error(
-          `The size attribute value of "${value}" has the wrong type. The size attribute is a well-known HTML attribute. You should be using data-size="${value}" instead.`,
+          'The size attribute value of %s has the wrong type. The size attribute is a well-known HTML attribute. You should be using data-size="%s" instead.',
+          value,
+          value,
         );
       }
       warnedProperties[name] = true;


### PR DESCRIPTION
## Summary

Resolves adding in a more intuitive warning for the size attribute on components that are not the input or select tag.

#20159 