### PR TITLE
Patch Flight Fixture 

### DIFF
--- a/fixtures/flight/server/handler.js
+++ b/fixtures/flight/server/handler.js
@@ -10,7 +10,7 @@ module.exports = function(req, res) {
     // TODO: Read from a map on the disk.
     './src/Counter.client.js': {
       id: './src/Counter.client.js',
-      chunks: ['2'],
+      chunks: ['1'],
       name: 'default',
     },
   });


### PR DESCRIPTION
A while ago, I had a twitter conversation with Sophie, Dan and a few others about "Flight" and "Blocks". Since then I've been watching the React repo. 

When I saw Seb's commit recently expanding the flight fixture, I couldn't resist playing with it. However, when I did so, I received an error: 
![image](https://user-images.githubusercontent.com/787007/98454390-b4b9c900-21af-11eb-81c6-3260111e2f64.png)


It appears that the Module reference is expecting the Client.counter.js file to be in the `2.` chunk, however, webpack isn't producing that chunk.

This patches things by telling flight that `client.counter.js` is in the `1` chunk. 

After this change, the client component is correctly loaded: 
![image](https://user-images.githubusercontent.com/787007/98454798-28f66b80-21b4-11eb-80b1-5ccfada60f4a.png)


(I realise that the React team often doesn't accept external contributions, but thought I might as well raise this) 

