### PR TITLE
style: remove redundant defination

### DIFF
--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -18,11 +18,7 @@ export function setExtraStackFrame(stack: null | string) {
 }
 
 if (__DEV__) {
-  ReactDebugCurrentFrame.setExtraStackFrame = function(stack: null | string) {
-    if (__DEV__) {
-      currentExtraStackFrame = stack;
-    }
-  };
+  ReactDebugCurrentFrame.setExtraStackFrame = setExtraStackFrame;
   // Stack implementation injected by the current renderer.
   ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
 


### PR DESCRIPTION
We defined 2 times `setExtraStackFrame` and I think it's redundant so I removed :)