### PR TITLE
Scheduling profiler tweaks

### DIFF
--- a/packages/react-reconciler/src/SchedulingProfiler.js
+++ b/packages/react-reconciler/src/SchedulingProfiler.js
@@ -20,31 +20,63 @@ import getComponentName from 'shared/getComponentName';
  * require.
  */
 const supportsUserTiming =
-  typeof performance !== 'undefined' && typeof performance.mark === 'function';
+  typeof performance !== 'undefined' &&
+  typeof performance.mark === 'function' &&
+  typeof performance.clearMarks === 'function';
+
+let supportsUserTimingV3 = false;
+if (enableSchedulingProfiler) {
+  if (supportsUserTiming) {
+    const CHECK_V3_MARK = '__v3';
+    const markOptions = {};
+    // $FlowFixMe: Ignore Flow complaining about needing a value
+    Object.defineProperty(markOptions, 'startTime', {
+      get: function() {
+        supportsUserTimingV3 = true;
+        return 0;
+      },
+      set: function() {},
+    });
+
+    try {
+      // $FlowFixMe: Flow expects the User Timing level 2 API.
+      performance.mark(CHECK_V3_MARK, markOptions);
+    } catch (error) {
+      // Ignore
+    } finally {
+      performance.clearMarks(CHECK_V3_MARK);
+    }
+  }
+}
 
 function formatLanes(laneOrLanes: Lane | Lanes): string {
   return ((laneOrLanes: any): number).toString();
 }
 
+function markAndClear(name) {
+  performance.mark(name);
+  performance.clearMarks(name);
+}
+
 // Create a mark on React initialization
 if (enableSchedulingProfiler) {
-  if (supportsUserTiming) {
-    performance.mark(`--react-init-${ReactVersion}`);
+  if (supportsUserTimingV3) {
+    markAndClear(`--react-init-${ReactVersion}`);
   }
 }
 
 export function markCommitStarted(lanes: Lanes): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark(`--commit-start-${formatLanes(lanes)}`);
+    if (supportsUserTimingV3) {
+      markAndClear(`--commit-start-${formatLanes(lanes)}`);
     }
   }
 }
 
 export function markCommitStopped(): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark('--commit-stop');
+    if (supportsUserTimingV3) {
+      markAndClear('--commit-stop');
     }
   }
 }
@@ -63,14 +95,14 @@ function getWakeableID(wakeable: Wakeable): number {
 
 export function markComponentSuspended(fiber: Fiber, wakeable: Wakeable): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
+    if (supportsUserTimingV3) {
       const id = getWakeableID(wakeable);
       const componentName = getComponentName(fiber.type) || 'Unknown';
       // TODO Add component stack id
-      performance.mark(`--suspense-suspend-${id}-${componentName}`);
+      markAndClear(`--suspense-suspend-${id}-${componentName}`);
       wakeable.then(
-        () => performance.mark(`--suspense-resolved-${id}-${componentName}`),
-        () => performance.mark(`--suspense-rejected-${id}-${componentName}`),
+        () => markAndClear(`--suspense-resolved-${id}-${componentName}`),
+        () => markAndClear(`--suspense-rejected-${id}-${componentName}`),
       );
     }
   }
@@ -78,74 +110,74 @@ export function markComponentSuspended(fiber: Fiber, wakeable: Wakeable): void {
 
 export function markLayoutEffectsStarted(lanes: Lanes): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark(`--layout-effects-start-${formatLanes(lanes)}`);
+    if (supportsUserTimingV3) {
+      markAndClear(`--layout-effects-start-${formatLanes(lanes)}`);
     }
   }
 }
 
 export function markLayoutEffectsStopped(): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark('--layout-effects-stop');
+    if (supportsUserTimingV3) {
+      markAndClear('--layout-effects-stop');
     }
   }
 }
 
 export function markPassiveEffectsStarted(lanes: Lanes): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark(`--passive-effects-start-${formatLanes(lanes)}`);
+    if (supportsUserTimingV3) {
+      markAndClear(`--passive-effects-start-${formatLanes(lanes)}`);
     }
   }
 }
 
 export function markPassiveEffectsStopped(): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark('--passive-effects-stop');
+    if (supportsUserTimingV3) {
+      markAndClear('--passive-effects-stop');
     }
   }
 }
 
 export function markRenderStarted(lanes: Lanes): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark(`--render-start-${formatLanes(lanes)}`);
+    if (supportsUserTimingV3) {
+      markAndClear(`--render-start-${formatLanes(lanes)}`);
     }
   }
 }
 
 export function markRenderYielded(): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark('--render-yield');
+    if (supportsUserTimingV3) {
+      markAndClear('--render-yield');
     }
   }
 }
 
 export function markRenderStopped(): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark('--render-stop');
+    if (supportsUserTimingV3) {
+      markAndClear('--render-stop');
     }
   }
 }
 
 export function markRenderScheduled(lane: Lane): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
-      performance.mark(`--schedule-render-${formatLanes(lane)}`);
+    if (supportsUserTimingV3) {
+      markAndClear(`--schedule-render-${formatLanes(lane)}`);
     }
   }
 }
 
 export function markForceUpdateScheduled(fiber: Fiber, lane: Lane): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
+    if (supportsUserTimingV3) {
       const componentName = getComponentName(fiber.type) || 'Unknown';
       // TODO Add component stack id
-      performance.mark(
+      markAndClear(
         `--schedule-forced-update-${formatLanes(lane)}-${componentName}`,
       );
     }
@@ -154,10 +186,10 @@ export function markForceUpdateScheduled(fiber: Fiber, lane: Lane): void {
 
 export function markStateUpdateScheduled(fiber: Fiber, lane: Lane): void {
   if (enableSchedulingProfiler) {
-    if (supportsUserTiming) {
+    if (supportsUserTimingV3) {
       const componentName = getComponentName(fiber.type) || 'Unknown';
       // TODO Add component stack id
-      performance.mark(
+      markAndClear(
         `--schedule-state-update-${formatLanes(lane)}-${componentName}`,
       );
     }

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -25,6 +25,8 @@ export const decoupleUpdatePriorityFromScheduler = __VARIANT__;
 // NOTE: This feature will only work in DEV mode; all callsights are wrapped with __DEV__.
 export const enableDebugTracing = __EXPERIMENTAL__;
 
+export const enableSchedulingProfiler = __VARIANT__;
+
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of
 // __VARIANT__ so that it's `false` when running against the new reconciler.

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -40,7 +40,8 @@ export const enableProfilerNestedUpdateScheduledHook =
   __PROFILE__ && dynamicFeatureFlags.enableProfilerNestedUpdateScheduledHook;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
-export const enableSchedulingProfiler = __PROFILE__;
+export const enableSchedulingProfiler =
+  __PROFILE__ && dynamicFeatureFlags.enableSchedulingProfiler;
 
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.


### PR DESCRIPTION
This PR makes two changes (as separate commits):

### Make the `enableSchedulingProfiler` flag dynamic for Facebook builds

The dynamic flag allows us to avoid logging User Timing marks for users who happen to be running the profiling build of React on Facebook. These users aren't going to be using our scheduling profiler, and there's some evidence that the overhead this adds is not trivial for at least Firefox.

### Update the scheduling profiler feature check to require User Timing level 3

Browsers that implement User Timing level 2 (e.g. Firefox) apparently struggle to keep up with the number of marks the scheduling profiler is logging. To avoid this, the feature detection has been updated to require User Timing level 3 support. In addition to this, marks are cleared immediately after being logged to avoid perpetually growing the entries buffer.

---

Resolves #20215