### PR TITLE
fix: remove unnecessary condition for freeze

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -190,10 +190,9 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
       writable: false,
       value: source,
     });
-    if (Object.freeze) {
-      Object.freeze(element.props);
-      Object.freeze(element);
-    }
+
+    Object.freeze(element.props);
+    Object.freeze(element);
   }
 
   return element;
@@ -392,9 +391,7 @@ export function createElement(type, config, children) {
       childArray[i] = arguments[i + 2];
     }
     if (__DEV__) {
-      if (Object.freeze) {
-        Object.freeze(childArray);
-      }
+      Object.freeze(childArray);
     }
     props.children = childArray;
   }

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -358,9 +358,7 @@ export function jsxWithValidation(
             validateChildKeys(children[i], type);
           }
 
-          if (Object.freeze) {
-            Object.freeze(children);
-          }
+          Object.freeze(children);
         } else {
           if (__DEV__) {
             console.error(

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -191,10 +191,9 @@ const ReactElement = function(type, key, ref, self, source, owner, props) {
       writable: false,
       value: source,
     });
-    if (Object.freeze) {
-      Object.freeze(element.props);
-      Object.freeze(element);
-    }
+
+    Object.freeze(element.props);
+    Object.freeze(element);
   }
 
   return element;

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -373,9 +373,7 @@ export function jsxWithValidation(
               validateChildKeys(children[i], type);
             }
 
-            if (Object.freeze) {
-              Object.freeze(children);
-            }
+            Object.freeze(children);
           } else {
             console.error(
               'React.jsx: Static children should always be an array. ' +


### PR DESCRIPTION
`Object.freeze` is completely compatible so we don't need to check it.