### PR TITLE
Widen peer dependency range of use-subscription

### DIFF
--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -19,7 +19,7 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "react": "^17.0.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "rxjs": "^5.5.6"


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/20224.

Please see https://github.com/facebook/react/issues/20224#issuecomment-725720030 and let me know if you'd like me to make the same change for those internal React packages as well. 🙂

## Test Plan

The new range is a strict superset of the range in 1.4.1 and the range in 1.5.0.
