### PR TITLE
Untangle circular dependencies, the sequel

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-import type {Wakeable} from 'shared/ReactTypes';
-import type {LazyComponent} from 'react/src/ReactLazy';
+import type {LazyComponent, Wakeable} from 'shared/ReactTypes';
 
 import type {
   ModuleReference,

--- a/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
@@ -13,7 +13,7 @@
 // (which use different values for ReactTypeOfWork).
 
 import type {Source} from 'shared/ReactElementType';
-import type {LazyComponent} from 'react/src/ReactLazy';
+import type {LazyComponent} from 'shared/ReactTypes';
 import type {CurrentDispatcherRef} from './types';
 
 import {

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -9,8 +9,7 @@
 
 import type {ThreadID} from './ReactThreadIDAllocator';
 import type {ReactElement} from 'shared/ReactElementType';
-import type {LazyComponent} from 'react/src/ReactLazy';
-import type {ReactProvider, ReactContext} from 'shared/ReactTypes';
+import type {ReactProvider, ReactContext, LazyComponent} from 'shared/ReactTypes';
 
 import * as React from 'react';
 import invariant from 'shared/invariant';

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -9,7 +9,11 @@
 
 import type {ThreadID} from './ReactThreadIDAllocator';
 import type {ReactElement} from 'shared/ReactElementType';
-import type {ReactProvider, ReactContext, LazyComponent} from 'shared/ReactTypes';
+import type {
+  ReactProvider,
+  ReactContext,
+  LazyComponent,
+} from 'shared/ReactTypes';
 
 import * as React from 'react';
 import invariant from 'shared/invariant';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import type {ReactProviderType, ReactContext, LazyComponent as LazyComponentType} from 'shared/ReactTypes';
+import type {
+  ReactProviderType,
+  ReactContext,
+  LazyComponent as LazyComponentType,
+} from 'shared/ReactTypes';
 import type {Fiber} from './ReactInternalTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
-import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
+import type {ReactProviderType, ReactContext, LazyComponent as LazyComponentType} from 'shared/ReactTypes';
 import type {Fiber} from './ReactInternalTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -7,7 +7,11 @@
  * @flow
  */
 
-import type {ReactProviderType, ReactContext, LazyComponent as LazyComponentType} from 'shared/ReactTypes';
+import type {
+  ReactProviderType,
+  ReactContext,
+  LazyComponent as LazyComponentType,
+} from 'shared/ReactTypes';
 import type {Fiber} from './ReactInternalTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
-import type {LazyComponent as LazyComponentType} from 'react/src/ReactLazy';
+import type {ReactProviderType, ReactContext, LazyComponent as LazyComponentType} from 'shared/ReactTypes';
 import type {Fiber} from './ReactInternalTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';

--- a/packages/react/src/ReactCurrentDispatcher.js
+++ b/packages/react/src/ReactCurrentDispatcher.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
 
 /**
  * Keeps track of the current dispatcher.
@@ -17,7 +16,7 @@ const ReactCurrentDispatcher = {
    * @internal
    * @type {ReactComponent}
    */
-  current: (null: null | Dispatcher),
+  current: (null: any),
 };
 
 export default ReactCurrentDispatcher;

--- a/packages/react/src/ReactCurrentDispatcher.js
+++ b/packages/react/src/ReactCurrentDispatcher.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-
 /**
  * Keeps track of the current dispatcher.
  */

--- a/packages/react/src/ReactCurrentOwner.js
+++ b/packages/react/src/ReactCurrentOwner.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
-
 /**
  * Keeps track of the current owner.
  *
@@ -20,7 +18,7 @@ const ReactCurrentOwner = {
    * @internal
    * @type {ReactComponent}
    */
-  current: (null: null | Fiber),
+  current: (null: any),
 };
 
 export default ReactCurrentOwner;

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Wakeable, Thenable} from 'shared/ReactTypes';
+import type {LazyComponent, Thenable, Wakeable} from 'shared/ReactTypes';
 
 import {REACT_LAZY_TYPE} from 'shared/ReactSymbols';
 
@@ -41,12 +41,6 @@ type Payload<T> =
   | PendingPayload
   | ResolvedPayload<T>
   | RejectedPayload;
-
-export type LazyComponent<T, P> = {
-  $$typeof: Symbol | number,
-  _payload: P,
-  _init: (payload: P) => T,
-};
 
 function lazyInitializer<T>(payload: Payload<T>): T {
   if (payload._status === Uninitialized) {

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -6,7 +6,7 @@
  */
 
 import getComponentName from 'shared/getComponentName';
-import ReactSharedInternals from 'shared/ReactSharedInternals';
+import ReactSharedInternals from '../ReactSharedInternals';
 
 import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -27,7 +27,7 @@ import {jsxDEV} from './ReactJSXElement';
 
 import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFrame';
 
-import ReactSharedInternals from 'shared/ReactSharedInternals';
+import ReactSharedInternals from '../ReactSharedInternals';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;

--- a/packages/shared/ReactComponentStackFrame.js
+++ b/packages/shared/ReactComponentStackFrame.js
@@ -8,7 +8,7 @@
  */
 
 import type {Source} from 'shared/ReactElementType';
-import type {LazyComponent} from 'react/src/ReactLazy';
+import type {LazyComponent} from './ReactTypes';
 
 import {enableComponentStackLocations} from 'shared/ReactFeatureFlags';
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -82,6 +82,12 @@ export type ReactPortal = {
   ...
 };
 
+export type LazyComponent<T, P> = {
+  $$typeof: Symbol | number,
+  _payload: P,
+  _init: (payload: P) => T,
+};
+
 export type RefObject = {|
   current: any,
 |};

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -20,7 +20,11 @@ import {
   REACT_SUSPENSE_LIST_TYPE,
   REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
-import type {LazyComponent, ReactContext, ReactProviderType} from 'shared/ReactTypes';
+import type {
+  LazyComponent,
+  ReactContext,
+  ReactProviderType,
+} from 'shared/ReactTypes';
 
 function getWrappedName(
   outerType: mixed,

--- a/packages/shared/getComponentName.js
+++ b/packages/shared/getComponentName.js
@@ -7,8 +7,6 @@
  * @flow
  */
 
-import type {LazyComponent} from 'react/src/ReactLazy';
-
 import {
   REACT_CONTEXT_TYPE,
   REACT_FORWARD_REF_TYPE,
@@ -22,7 +20,7 @@ import {
   REACT_SUSPENSE_LIST_TYPE,
   REACT_LAZY_TYPE,
 } from 'shared/ReactSymbols';
-import type {ReactContext, ReactProviderType} from 'shared/ReactTypes';
+import type {LazyComponent, ReactContext, ReactProviderType} from 'shared/ReactTypes';
 
 function getWrappedName(
   outerType: mixed,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
After discussion with @gaearon , and iterating in PRs #19997 and #19971 , this should balance all the feedback and constraints.

At its core, this approach removes the type definitions from the ReactCurrent* and makes the polymorphism late-binding via (future) type checks at runtime (presumably in __DEV__ mode). This eliminates the root of most of the type import cycle.

The other type import cycle was LazyComponent, which I moved to be alongside the other component type definitions. Looking at the resulting changes in import statements, this looks like is coheres better and follows the convention of storing those component typedefs in that file.

I did not remove the cyclical dependency workarounds in the jest and rollup scripts, to keep this PR small.

Thanks again for taking the time to review and discuss.

## Test Plan
I ran `yarn test`, `yarn flow dom|dom-relay|test|fabric`, and `yarn lint`.
