### PR TITLE
Remove noinline directives from new commit phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -209,7 +209,6 @@ function safelyCallComponentWillUnmount(current, instance) {
   }
 }
 
-/** @noinline */
 function safelyDetachRef(current: Fiber) {
   const ref = current.ref;
   if (ref !== null) {
@@ -273,7 +272,6 @@ export function safelyCallDestroy(current: Fiber, destroy: () => void) {
   }
 }
 
-/** @noinline */
 function commitHookEffectListUnmount(flags: HookFlags, finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
@@ -294,7 +292,6 @@ function commitHookEffectListUnmount(flags: HookFlags, finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const lastEffect = updateQueue !== null ? updateQueue.lastEffect : null;
@@ -506,7 +503,6 @@ function iterativelyCommitBeforeMutationEffects_complete() {
   }
 }
 
-/** @noinline */
 function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
   const current = finishedWork.alternate;
   const flags = finishedWork.flags;
@@ -621,7 +617,6 @@ function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function commitBeforeMutationEffectsDeletions(deletions: Array<Fiber>) {
   for (let i = 0; i < deletions.length; i++) {
     const fiber = deletions[i];
@@ -763,7 +758,6 @@ function iterativelyCommitMutationEffects_complete(
   }
 }
 
-/** @noinline */
 function commitMutationEffectsOnFiber(
   fiber: Fiber,
   root: FiberRoot,
@@ -834,7 +828,6 @@ function commitMutationEffectsOnFiber(
   }
 }
 
-/** @noinline */
 function commitMutationEffectsDeletions(
   deletions: Array<Fiber>,
   root: FiberRoot,
@@ -1320,7 +1313,6 @@ function commitLayoutEffectsOnFiber(
   }
 }
 
-/** @noinline */
 function commitLayoutEffectsForProfiler(
   finishedWork: Fiber,
   finishedRoot: FiberRoot,
@@ -1393,7 +1385,6 @@ function commitLayoutEffectsForProfiler(
   }
 }
 
-/** @noinline */
 function commitLayoutEffectsForClassComponent(finishedWork: Fiber) {
   const instance = finishedWork.stateNode;
   const current = finishedWork.alternate;
@@ -1542,7 +1533,6 @@ function commitLayoutEffectsForClassComponent(finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function commitLayoutEffectsForHostRoot(finishedWork: Fiber) {
   // TODO: I think this is now always non-null by the time it reaches the
   // commit phase. Consider removing the type check.
@@ -1563,7 +1553,6 @@ function commitLayoutEffectsForHostRoot(finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function commitLayoutEffectsForHostComponent(finishedWork: Fiber) {
   const instance: Instance = finishedWork.stateNode;
   const current = finishedWork.alternate;
@@ -1579,7 +1568,6 @@ function commitLayoutEffectsForHostComponent(finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function hideOrUnhideAllChildren(finishedWork, isHidden) {
   if (supportsMutation) {
     // We only have the top Fiber that was inserted but we need to recurse down its
@@ -2866,7 +2854,6 @@ function commitSuspenseComponent(finishedWork: Fiber) {
   }
 }
 
-/** @noinline */
 function commitSuspenseHydrationCallbacks(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,


### PR DESCRIPTION
My theory for too much inlining contributing to overall stack size is likely flawed, because Closure reuses variables within a function to optimize registers.

Even if my theory were correct, the impact would be minimal anyway because the recursive implementation of the commit phase traversals is behind a disabled feature flag.

Going to revert this. We can maybe test the impact once we land the commit phase changes. In the meantime, I'd prefer to eliminate this delta from the new fork.