### PR TITLE
Remove cycle between ReactFiberHooks and ReactInternalTypes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -13,7 +13,7 @@ import type {
   MutableSourceSubscribeFn,
   ReactContext,
 } from 'shared/ReactTypes';
-import type {Fiber, Dispatcher} from './ReactInternalTypes';
+import type {Fiber, Dispatcher, HookType} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {ReactPriorityLevel} from './ReactInternalTypes';
@@ -117,22 +117,6 @@ type UpdateQueue<S, A> = {|
   lastRenderedReducer: ((S, A) => S) | null,
   lastRenderedState: S | null,
 |};
-
-export type HookType =
-  | 'useState'
-  | 'useReducer'
-  | 'useContext'
-  | 'useRef'
-  | 'useEffect'
-  | 'useLayoutEffect'
-  | 'useCallback'
-  | 'useMemo'
-  | 'useImperativeHandle'
-  | 'useDebugValue'
-  | 'useDeferredValue'
-  | 'useTransition'
-  | 'useMutableSource'
-  | 'useOpaqueIdentifier';
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -13,7 +13,7 @@ import type {
   MutableSourceSubscribeFn,
   ReactContext,
 } from 'shared/ReactTypes';
-import type {Fiber, Dispatcher} from './ReactInternalTypes';
+import type {Fiber, Dispatcher, HookType} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {ReactPriorityLevel} from './ReactInternalTypes';
@@ -108,22 +108,6 @@ type UpdateQueue<S, A> = {|
   lastRenderedReducer: ((S, A) => S) | null,
   lastRenderedState: S | null,
 |};
-
-export type HookType =
-  | 'useState'
-  | 'useReducer'
-  | 'useContext'
-  | 'useRef'
-  | 'useEffect'
-  | 'useLayoutEffect'
-  | 'useCallback'
-  | 'useMemo'
-  | 'useImperativeHandle'
-  | 'useDebugValue'
-  | 'useDeferredValue'
-  | 'useTransition'
-  | 'useMutableSource'
-  | 'useOpaqueIdentifier';
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -21,11 +21,27 @@ import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {Flags} from './ReactFiberFlags';
 import type {Lane, LanePriority, Lanes, LaneMap} from './ReactFiberLane';
-import type {HookType} from './ReactFiberHooks.old';
 import type {RootTag} from './ReactRootTags';
 import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Interaction} from 'scheduler/src/Tracing';
+
+// Unwind Circular: moved from ReactFiberHooks.old
+export type HookType =
+  | 'useState'
+  | 'useReducer'
+  | 'useContext'
+  | 'useRef'
+  | 'useEffect'
+  | 'useLayoutEffect'
+  | 'useCallback'
+  | 'useMemo'
+  | 'useImperativeHandle'
+  | 'useDebugValue'
+  | 'useDeferredValue'
+  | 'useTransition'
+  | 'useMutableSource'
+  | 'useOpaqueIdentifier';
 
 export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
 


### PR DESCRIPTION
## Summary

React's reconciler package has a number of cyclic dependencies between modules. While cycles don't seem to cause any immediate problems, they do make it difficult to understand the reconciler's logic, and difficult to port that logic to other languages and ecosystems that don't handle cycles as gracefully.

This change is the first of several I'd like to propose to unwind these cycles.

### Cycle detection

I used a tool called [`madge`](https://github.com/pahen/madge) to detect cyclical imports. This change brings the number of cycles in the `packages/react-reconciler` package down from 147 to 50.

<details>
  <summary>Cycles before change:</summary>
  
  ```
  Processed 143 files (5s) (1 warning)

  1) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js
  2) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactCurrentFiber.js > ReactFiberComponentStack.js
  3) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactCurrentFiber.js
  4) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberDevToolsHook.old.js
  5) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberContext.old.js > ReactFiberStack.old.js
  6) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberContext.old.js > ReactFiberTreeReflection.js > ReactFiberSuspenseComponent.old.js
  7) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberContext.old.js > ReactFiberTreeReflection.js > ReactFiberSuspenseComponent.old.js
  8) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberContext.old.js > ReactFiberTreeReflection.js
  9) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberContext.old.js
  10) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js
  11) ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js
  12) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js
  13) ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js
  14) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js
  15) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js
  16) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js
  17) ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberNewContext.old.js
  18) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberNewContext.old.js
  19) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberNewContext.old.js
  20) ReactUpdateQueue.old.js > ReactFiberNewContext.old.js
  21) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  22) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactCapturedValue.js
  23) ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  24) ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  25) ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  26) ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  27) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  28) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js > ReactFiberOffscreenComponent.js
  29) ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  30) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  31) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js > ReactProfilerTimer.old.js
  32) ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  33) ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js
  34) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberFundamental.old.js
  35) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberHostContext.old.js
  36) ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberHydrationContext.old.js
  37) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberHydrationContext.old.js
  38) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberHydrationContext.old.js
  39) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js
  40) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberScope.old.js
  41) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactFiberSuspenseContext.old.js
  42) ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js
  43) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js
  44) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > ReactMutableSource.old.js
  45) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > SchedulerWithReactIntegration.old.js
  46) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js > SchedulerWithReactIntegration.old.js
  47) ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  48) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  49) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  50) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js > ReactFiberErrorLogger.js > ReactFiberErrorDialog.js
  51) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js > ReactFiberErrorLogger.js
  52) ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  53) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  54) ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  55) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  56) ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  57) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js > SchedulingProfiler.js
  58) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js > SchedulingProfiler.js
  59) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberUnwindWork.old.js
  60) ReactFiberWorkLoop.old.js > ReactFiberUnwindWork.old.js
  61) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactFiberUnwindWork.old.js
  62) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  63) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js > ReactStrictModeWarnings.old.js
  64) ReactUpdateQueue.old.js > ReactFiberWorkLoop.old.js
  65) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactFiberRoot.old.js > ReactUpdateQueue.old.js
  66) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js
  67) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js > ReactFiberReconciler.old.js > ReactMutableSource.new.js
  68) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js > ReactFiberHotReloading.old.js
  69) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js
  70) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiber.old.js
  71) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js
  72) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js
  73) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js
  74) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js
  75) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js
  76) ReactFiberHooks.old.js > ReactFiberBeginWork.old.js
  77) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js
  78) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberContext.new.js > ReactFiberStack.new.js
  79) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberContext.new.js
  80) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberDevToolsHook.new.js
  81) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js
  82) ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js
  83) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js
  84) ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiber.new.js
  85) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiber.new.js
  86) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiber.new.js
  87) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js
  88) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js
  89) ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js
  90) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js
  91) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js
  92) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js > ReactUpdateQueue.new.js
  93) ReactFiberNewContext.new.js > ReactUpdateQueue.new.js
  94) ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js > ReactUpdateQueue.new.js
  95) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactFiberNewContext.new.js > ReactUpdateQueue.new.js
  96) ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js
  97) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js
  98) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js > ReactFiberClassComponent.new.js > ReactStrictModeWarnings.new.js
  99) ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js
  100) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js
  101) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactChildFiber.new.js
  102) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js
  103) ReactFiberBeginWork.new.js > ReactFiberHooks.new.js
  104) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > ReactFiberHydrationContext.new.js
  105) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > ReactFiberHydrationContext.new.js > ReactFiberSuspenseComponent.new.js
  106) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > ReactFiberHydrationContext.new.js > ReactFiberSuspenseComponent.new.js
  107) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > ReactFiberHydrationContext.new.js
  108) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js
  109) ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js
  110) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js
  111) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > SchedulerWithReactIntegration.new.js
  112) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHooks.new.js > SchedulerWithReactIntegration.new.js
  113) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberHostContext.new.js
  114) ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js
  115) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js
  116) ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js
  117) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactFiberSuspenseContext.new.js
  118) ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js
  119) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js
  120) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberBeginWork.new.js > ReactProfilerTimer.new.js
  121) ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js
  122) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js
  123) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js > ReactFiberFundamental.new.js
  124) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  125) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js > ReactFiberScope.new.js
  126) ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  127) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  128) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js
  129) DebugTracing.js > ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  130) ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  131) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  132) ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  133) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  134) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberUnwindWork.new.js
  135) ReactFiberWorkLoop.new.js > ReactFiberUnwindWork.new.js
  136) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js > ReactFiberUnwindWork.new.js
  137) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js > ReactFiberWorkLoop.new.js
  138) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberHotReloading.new.js
  139) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js
  140) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js
  141) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js
  142) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js > ReactFiberReconciler.js > ReactFiberReconciler.new.js
  143) ReactInternalTypes.js > ReactFiberHooks.old.js > ReactFiberBeginWork.old.js
  144) ReactFiberLane.js > ReactInternalTypes.js > ReactFiberHooks.old.js
  145) ReactInternalTypes.js > ReactFiberHooks.old.js
  146) ReactFiberLane.js > ReactInternalTypes.js
  147) ReactFiberHotReloading.js
  ```
</details>

<details>
  <summary>Cycles after change:</summary>
  
  ```
  Processed 143 files (4s) (1 warning)
  
  1) ReactFiberLane.js > ReactInternalTypes.js
  2) ReactFiberLane.js > SchedulerWithReactIntegration.new.js
  3) ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js
  4) ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js
  5) ReactChildFiber.new.js > ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js
  6) ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js
  7) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js
  8) ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js
  9) ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js
  10) ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js
  11) ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js > ReactFiberHooks.new.js
  12) ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js > ReactFiberHooks.new.js > ReactFiberHydrationContext.new.js
  13) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js > ReactFiberHooks.new.js
  14) ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js > ReactFiberHooks.new.js
  15) ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js
  16) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCommitWork.new.js
  17) ReactChildFiber.new.js > ReactFiber.new.js > ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  18) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  19) ReactFiberWorkLoop.new.js > ReactFiberCompleteWork.new.js
  20) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js
  21) ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  22) ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  23) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberThrow.new.js
  24) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js > ReactFiberUnwindWork.new.js
  25) ReactFiberWorkLoop.new.js > ReactFiberUnwindWork.new.js
  26) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js > ReactFiberWorkLoop.new.js
  27) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberClassComponent.new.js
  28) ReactFiberHotReloading.new.js > ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js
  29) ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js
  30) ReactFiberReconciler.new.js > ReactFiberRoot.new.js > ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js > ReactFiberReconciler.js
  31) ReactFiberReconciler.old.js > ReactFiberHotReloading.old.js
  32) ReactFiberHotReloading.old.js > ReactFiberWorkLoop.old.js > ReactFiber.old.js
  33) ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js > ReactFiberNewContext.old.js
  34) ReactFiberNewContext.old.js > ReactUpdateQueue.old.js
  35) ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js > ReactFiberNewContext.old.js > ReactUpdateQueue.old.js
  36) ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js > ReactFiberClassComponent.old.js
  37) ReactFiberHotReloading.old.js > ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js > ReactChildFiber.old.js
  38) ReactFiberBeginWork.old.js > ReactFiberHooks.old.js
  39) ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js > ReactFiberHooks.old.js
  40) ReactFiberHotReloading.old.js > ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js
  41) ReactFiberReconciler.js > ReactFiberReconciler.old.js > ReactFiberHotReloading.old.js > ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js
  42) ReactFiberWorkLoop.old.js > ReactFiberBeginWork.old.js
  43) ReactFiberWorkLoop.old.js > ReactFiberCommitWork.old.js
  44) ReactFiberWorkLoop.old.js > ReactFiberCompleteWork.old.js
  45) ReactFiberHotReloading.old.js > ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  46) ReactFiberWorkLoop.old.js > ReactFiberThrow.old.js
  47) ReactFiberWorkLoop.old.js > ReactFiberUnwindWork.old.js
  48) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js > ReactFiberBeginWork.new.js
  49) ReactUpdateQueue.new.js > ReactFiberNewContext.new.js
  50) ReactFiberHotReloading.js
  ```
</details>

## Test Plan

Since this change only affects the location of a type definition, there shouldn't be any need to add or change tests.
