### PR TITLE
Add new effect fields to old fork, and vice versa

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
           // Disabled because it's also used by the Hook type.
           // 'lastEffect',
         ],
-        new: ['subtreeFlags'],
+        new: [],
       },
     ],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,12 +116,7 @@ module.exports = {
     'react-internal/no-cross-fork-types': [
       ERROR,
       {
-        old: [
-          'firstEffect',
-          'nextEffect',
-          // Disabled because it's also used by the Hook type.
-          // 'lastEffect',
-        ],
+        old: [],
         new: [],
       },
     ],
@@ -190,7 +185,7 @@ module.exports = {
     {
       files: [
         'packages/react-native-renderer/**/*.js',
-        'packages/react-transport-native-relay/**/*.js'
+        'packages/react-transport-native-relay/**/*.js',
       ],
       globals: {
         nativeFabricUIManager: true,

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -141,6 +141,10 @@ function FiberNode(
 
   // Effects
   this.flags = NoFlags;
+  this.nextEffect = null;
+
+  this.firstEffect = null;
+  this.lastEffect = null;
   this.subtreeFlags = NoFlags;
   this.deletions = null;
 
@@ -805,6 +809,9 @@ export function assignFiberPropertiesInDEV(
   target.dependencies = source.dependencies;
   target.mode = source.mode;
   target.flags = source.flags;
+  target.nextEffect = source.nextEffect;
+  target.firstEffect = source.firstEffect;
+  target.lastEffect = source.lastEffect;
   target.subtreeFlags = source.subtreeFlags;
   target.deletions = source.deletions;
   target.lanes = source.lanes;

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -145,6 +145,8 @@ function FiberNode(
 
   this.firstEffect = null;
   this.lastEffect = null;
+  this.subtreeFlags = NoFlags;
+  this.deletions = null;
 
   this.lanes = NoLanes;
   this.childLanes = NoLanes;
@@ -284,6 +286,8 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     workInProgress.nextEffect = null;
     workInProgress.firstEffect = null;
     workInProgress.lastEffect = null;
+    workInProgress.subtreeFlags = NoFlags;
+    workInProgress.deletions = null;
 
     if (enableProfilerTimer) {
       // We intentionally reset, rather than copy, actualDuration & actualStartTime.
@@ -372,6 +376,7 @@ export function resetWorkInProgress(workInProgress: Fiber, renderLanes: Lanes) {
     workInProgress.lanes = renderLanes;
 
     workInProgress.child = null;
+    workInProgress.subtreeFlags = NoFlags;
     workInProgress.memoizedProps = null;
     workInProgress.memoizedState = null;
     workInProgress.updateQueue = null;
@@ -392,6 +397,8 @@ export function resetWorkInProgress(workInProgress: Fiber, renderLanes: Lanes) {
     workInProgress.lanes = current.lanes;
 
     workInProgress.child = current.child;
+    workInProgress.subtreeFlags = current.subtreeFlags;
+    workInProgress.deletions = null;
     workInProgress.memoizedProps = current.memoizedProps;
     workInProgress.memoizedState = current.memoizedState;
     workInProgress.updateQueue = current.updateQueue;
@@ -814,6 +821,8 @@ export function assignFiberPropertiesInDEV(
   target.nextEffect = source.nextEffect;
   target.firstEffect = source.firstEffect;
   target.lastEffect = source.lastEffect;
+  target.subtreeFlags = source.subtreeFlags;
+  target.deletions = source.deletions;
   target.lanes = source.lanes;
   target.childLanes = source.childLanes;
   target.alternate = source.alternate;


### PR DESCRIPTION
We need to bisect the changes to the recent commit phase refactor. To do this, we'll need to add back the effect list temporarily.

This makes it so the memory usage is the same in both forks.