### PR TITLE
Autofix imports when running replace-fork

### DIFF
--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -64,13 +64,14 @@ function intersect(files, patterns) {
   return [...new Set(intersection)];
 }
 
-function runESLint({onlyChanged}) {
+function runESLint({onlyChanged, ...options}) {
   if (typeof onlyChanged !== 'boolean') {
     throw new Error('Pass options.onlyChanged as a boolean.');
   }
   const {errorCount, warningCount, output} = runESLintOnFilesWithOptions(
     allPaths,
-    onlyChanged
+    onlyChanged,
+    options
   );
   console.log(output);
   return errorCount === 0 && warningCount === 0;

--- a/scripts/merge-fork/replace-fork.js
+++ b/scripts/merge-fork/replace-fork.js
@@ -6,6 +6,7 @@
 
 const {promisify} = require('util');
 const glob = promisify(require('glob'));
+const {spawnSync} = require('child_process');
 const fs = require('fs');
 
 const stat = promisify(fs.stat);
@@ -14,6 +15,9 @@ const copyFile = promisify(fs.copyFile);
 async function main() {
   const oldFilenames = await glob('packages/react-reconciler/**/*.old.js');
   await Promise.all(oldFilenames.map(unforkFile));
+
+  // Use ESLint to autofix imports
+  spawnSync('yarn', ['linc', '--fix']);
 }
 
 async function unforkFile(oldFilename) {

--- a/scripts/tasks/eslint.js
+++ b/scripts/tasks/eslint.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+const minimist = require('minimist');
 const runESLint = require('../eslint');
 
 console.log('Linting all files...');
@@ -15,7 +16,8 @@ if (!process.env.CI) {
   console.log('Hint: run `yarn linc` to only lint changed files.');
 }
 
-if (runESLint({onlyChanged: false})) {
+const cliOptions = minimist(process.argv.slice(2));
+if (runESLint({onlyChanged: false, ...cliOptions})) {
   console.log('Lint passed.');
 } else {
   console.log('Lint failed.');

--- a/scripts/tasks/linc.js
+++ b/scripts/tasks/linc.js
@@ -7,11 +7,13 @@
 
 'use strict';
 
+const minimist = require('minimist');
 const runESLint = require('../eslint');
 
 console.log('Linting changed files...');
 
-if (runESLint({onlyChanged: true})) {
+const cliOptions = minimist(process.argv.slice(2));
+if (runESLint({onlyChanged: true, ...cliOptions})) {
   console.log('Lint passed for changed files.');
 } else {
   console.log('Lint failed for changed files.');


### PR DESCRIPTION
We have a custom ESLint rule that can autofix cross-fork imports.

Usually, after running the `replace-fork` script, you need to run `yarn lint --fix` to fix the imports.

This combines the two steps into one.