### PR TITLE
Check for deletions in hadNoMutationsEffects

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -178,12 +178,18 @@ function hadNoMutationsEffects(current: null | Fiber, completedWork: Fiber) {
     return true;
   }
 
+  if ((completedWork.flags & Deletion) !== NoFlags) {
+    return false;
+  }
+
+  // TODO: If we move the `hadNoMutationsEffects` call after `bubbleProperties`
+  // then we only have to check the `completedWork.subtreeFlags`.
   let child = completedWork.child;
   while (child !== null) {
-    if ((child.flags & MutationMask) !== NoFlags) {
+    if ((child.flags & (MutationMask | Deletion)) !== NoFlags) {
       return false;
     }
-    if ((child.subtreeFlags & MutationMask) !== NoFlags) {
+    if ((child.subtreeFlags & (MutationMask | Deletion)) !== NoFlags) {
       return false;
     }
     child = child.sibling;


### PR DESCRIPTION
This commit was approved as part of https://github.com/facebook/react/pull/20133, but since that PR is blocked I'm going to land it separately.

Only affects persistent mode.

---

When detecting if a host tree was changed, we must check for deletions in addition to mounts and updates.