### PR TITLE
Properly reset Profiler nested-update flag

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -199,6 +199,7 @@ import {
 import {
   markNestedUpdateScheduled,
   recordCommitTime,
+  resetNestedUpdateFlag,
   startProfilerTimer,
   stopProfilerTimerIfRunningAndRecordDelta,
   syncNestedUpdateFlag,
@@ -746,6 +747,10 @@ function ensureRootIsScheduled(root: FiberRoot, currentTime: number) {
 // This is the entry point for every concurrent task, i.e. anything that
 // goes through Scheduler.
 function performConcurrentWorkOnRoot(root) {
+  if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
+    resetNestedUpdateFlag();
+  }
+
   // Since we know we're in a React event, we can clear the current
   // event time. The next update will compute a new event time.
   currentEventTime = NoTimestamp;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -213,6 +213,7 @@ import {
   markNestedUpdateScheduled,
   recordCommitTime,
   recordPassiveEffectDuration,
+  resetNestedUpdateFlag,
   startPassiveEffectTimer,
   startProfilerTimer,
   stopProfilerTimerIfRunningAndRecordDelta,
@@ -770,6 +771,10 @@ function ensureRootIsScheduled(root: FiberRoot, currentTime: number) {
 // This is the entry point for every concurrent task, i.e. anything that
 // goes through Scheduler.
 function performConcurrentWorkOnRoot(root) {
+  if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
+    resetNestedUpdateFlag();
+  }
+
   // Since we know we're in a React event, we can clear the current
   // event time. The next update will compute a new event time.
   currentEventTime = NoTimestamp;

--- a/packages/react-reconciler/src/ReactProfilerTimer.new.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.new.js
@@ -68,6 +68,13 @@ function markNestedUpdateScheduled(): void {
   }
 }
 
+function resetNestedUpdateFlag(): void {
+  if (enableProfilerNestedUpdatePhase) {
+    currentUpdateIsNested = false;
+    nestedUpdateScheduled = false;
+  }
+}
+
 function syncNestedUpdateFlag(): void {
   if (enableProfilerNestedUpdatePhase) {
     currentUpdateIsNested = nestedUpdateScheduled;
@@ -206,6 +213,7 @@ export {
   recordCommitTime,
   recordLayoutEffectDuration,
   recordPassiveEffectDuration,
+  resetNestedUpdateFlag,
   startLayoutEffectTimer,
   startPassiveEffectTimer,
   startProfilerTimer,

--- a/packages/react-reconciler/src/ReactProfilerTimer.old.js
+++ b/packages/react-reconciler/src/ReactProfilerTimer.old.js
@@ -68,6 +68,13 @@ function markNestedUpdateScheduled(): void {
   }
 }
 
+function resetNestedUpdateFlag(): void {
+  if (enableProfilerNestedUpdatePhase) {
+    currentUpdateIsNested = false;
+    nestedUpdateScheduled = false;
+  }
+}
+
 function syncNestedUpdateFlag(): void {
   if (enableProfilerNestedUpdatePhase) {
     currentUpdateIsNested = nestedUpdateScheduled;
@@ -206,6 +213,7 @@ export {
   recordCommitTime,
   recordLayoutEffectDuration,
   recordPassiveEffectDuration,
+  resetNestedUpdateFlag,
   startLayoutEffectTimer,
   startPassiveEffectTimer,
   startProfilerTimer,


### PR DESCRIPTION
Previously this flag was not being reset correctly if a concurrent update followed a nested (sync) update. This PR fixes the behavior and adds a regression test.
