### PR TITLE
Unwind cycles reconciler fiber lanes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -13,10 +13,9 @@ import type {
   MutableSourceSubscribeFn,
   ReactContext,
 } from 'shared/ReactTypes';
-import type {Fiber, Dispatcher, HookType} from './ReactInternalTypes';
+import type {Fiber, Dispatcher, HookType, ReactPriorityLevel} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {HookFlags} from './ReactHookEffectTags';
-import type {ReactPriorityLevel} from './ReactInternalTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {OpaqueIDType} from './ReactFiberHostConfig';
 
@@ -72,6 +71,8 @@ import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork.old';
 import {
   UserBlockingPriority,
   NormalPriority,
+} from './ReactFiberSchedulerPriorities';
+import {
   runWithPriority,
   getCurrentPriorityLevel,
 } from './SchedulerWithReactIntegration.old';

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -13,7 +13,12 @@ import type {
   MutableSourceSubscribeFn,
   ReactContext,
 } from 'shared/ReactTypes';
-import type {Fiber, Dispatcher, HookType, ReactPriorityLevel} from './ReactInternalTypes';
+import type {
+  Fiber,
+  Dispatcher,
+  HookType,
+  ReactPriorityLevel,
+} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {FiberRoot} from './ReactInternalTypes';

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -73,10 +73,7 @@ import invariant from 'shared/invariant';
 import getComponentName from 'shared/getComponentName';
 import is from 'shared/objectIs';
 import {markWorkInProgressReceivedUpdate} from './ReactFiberBeginWork.old';
-import {
-  UserBlockingPriority,
-  NormalPriority,
-} from './ReactFiberSchedulerPriorities';
+import {UserBlockingPriority, NormalPriority} from './ReactPriorityLevel';
 import {
   runWithPriority,
   getCurrentPriorityLevel,

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -16,7 +16,6 @@ import type {
   Lanes,
 } from './ReactInternalTypes';
 
-// unwind-cycles: Re-export lane definitions here
 export type {Lane, LanePriority, LaneMap, Lanes};
 
 import invariant from 'shared/invariant';
@@ -28,7 +27,7 @@ import {
   LowPriority as LowSchedulerPriority,
   IdlePriority as IdleSchedulerPriority,
   NoPriority as NoSchedulerPriority,
-} from './ReactFiberSchedulerPriorities';
+} from './ReactPriorityLevel';
 
 export const SyncLanePriority: LanePriority = 15;
 export const SyncBatchedLanePriority: LanePriority = 14;

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -7,7 +7,14 @@
  * @flow
  */
 
-import type {FiberRoot, ReactPriorityLevel, Lane, LanePriority, LaneMap, Lanes} from './ReactInternalTypes';
+import type {
+  FiberRoot,
+  ReactPriorityLevel,
+  Lane,
+  LanePriority,
+  LaneMap,
+  Lanes,
+} from './ReactInternalTypes';
 
 // unwind-cycles: Re-export lane definitions here
 export type {Lane, LanePriority, LaneMap, Lanes};

--- a/packages/react-reconciler/src/ReactFiberLane.js
+++ b/packages/react-reconciler/src/ReactFiberLane.js
@@ -7,30 +7,10 @@
  * @flow
  */
 
-import type {FiberRoot, ReactPriorityLevel} from './ReactInternalTypes';
+import type {FiberRoot, ReactPriorityLevel, Lane, LanePriority, LaneMap, Lanes} from './ReactInternalTypes';
 
-export opaque type LanePriority =
-  | 0
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
-  | 13
-  | 14
-  | 15
-  | 16
-  | 17;
-export opaque type Lanes = number;
-export opaque type Lane = number;
-export opaque type LaneMap<T> = Array<T>;
+// unwind-cycles: Re-export lane definitions here
+export type {Lane, LanePriority, LaneMap, Lanes};
 
 import invariant from 'shared/invariant';
 
@@ -41,7 +21,7 @@ import {
   LowPriority as LowSchedulerPriority,
   IdlePriority as IdleSchedulerPriority,
   NoPriority as NoSchedulerPriority,
-} from './SchedulerWithReactIntegration.new';
+} from './ReactFiberSchedulerPriorities';
 
 export const SyncLanePriority: LanePriority = 15;
 export const SyncBatchedLanePriority: LanePriority = 14;

--- a/packages/react-reconciler/src/ReactFiberSchedulerPriorities.js
+++ b/packages/react-reconciler/src/ReactFiberSchedulerPriorities.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// unwind-cycles: Extract type and constant definitions to common dependency
+export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
+
+// Except for NoPriority, these correspond to Scheduler priorities. We use
+// ascending numbers so we can compare them like numbers. They start at 90 to
+// avoid clashing with Scheduler's priorities.
+export const ImmediatePriority: ReactPriorityLevel = 99;
+export const UserBlockingPriority: ReactPriorityLevel = 98;
+export const NormalPriority: ReactPriorityLevel = 97;
+export const LowPriority: ReactPriorityLevel = 96;
+export const IdlePriority: ReactPriorityLevel = 95;
+// NoPriority is the absence of priority. Also React-only.
+export const NoPriority: ReactPriorityLevel = 90;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -36,6 +36,12 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
 
 import {
+  NoPriority as NoSchedulerPriority,
+  ImmediatePriority as ImmediateSchedulerPriority,
+  UserBlockingPriority as UserBlockingSchedulerPriority,
+  NormalPriority as NormalSchedulerPriority,
+} from './ReactFiberSchedulerPriorities';
+import {
   scheduleCallback,
   cancelCallback,
   getCurrentPriorityLevel,
@@ -43,10 +49,6 @@ import {
   shouldYield,
   requestPaint,
   now,
-  NoPriority as NoSchedulerPriority,
-  ImmediatePriority as ImmediateSchedulerPriority,
-  UserBlockingPriority as UserBlockingSchedulerPriority,
-  NormalPriority as NormalSchedulerPriority,
   flushSyncCallbackQueue,
   scheduleSyncCallback,
 } from './SchedulerWithReactIntegration.old';

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -40,7 +40,7 @@ import {
   ImmediatePriority as ImmediateSchedulerPriority,
   UserBlockingPriority as UserBlockingSchedulerPriority,
   NormalPriority as NormalSchedulerPriority,
-} from './ReactFiberSchedulerPriorities';
+} from './ReactPriorityLevel';
 import {
   scheduleCallback,
   cancelCallback,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -25,7 +25,7 @@ import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Interaction} from 'scheduler/src/Tracing';
 
-export type {ReactPriorityLevel} from './ReactFiberSchedulerPriorities';
+export type {ReactPriorityLevel} from './ReactPriorityLevel';
 
 export type HookType =
   | 'useState'

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -20,13 +20,13 @@ import type {SuspenseInstance} from './ReactFiberHostConfig';
 import type {WorkTag} from './ReactWorkTags';
 import type {TypeOfMode} from './ReactTypeOfMode';
 import type {Flags} from './ReactFiberFlags';
-import type {Lane, LanePriority, Lanes, LaneMap} from './ReactFiberLane';
 import type {RootTag} from './ReactRootTags';
 import type {TimeoutHandle, NoTimeout} from './ReactFiberHostConfig';
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Interaction} from 'scheduler/src/Tracing';
 
-// Unwind Circular: moved from ReactFiberHooks.old
+export type {ReactPriorityLevel} from './ReactFiberSchedulerPriorities';
+
 export type HookType =
   | 'useState'
   | 'useReducer'
@@ -43,7 +43,28 @@ export type HookType =
   | 'useMutableSource'
   | 'useOpaqueIdentifier';
 
-export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
+export type LanePriority =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17;
+export type Lanes = number;
+export type Lane = number;
+export type LaneMap<T> = Array<T>;
 
 export type ContextDependency<T> = {
   context: ReactContext<T>,

--- a/packages/react-reconciler/src/ReactPriorityLevel.js
+++ b/packages/react-reconciler/src/ReactPriorityLevel.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-// unwind-cycles: Extract type and constant definitions to common dependency
 export type ReactPriorityLevel = 99 | 98 | 97 | 96 | 95 | 90;
 
 // Except for NoPriority, these correspond to Scheduler priorities. We use

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
@@ -14,7 +14,6 @@ import {
   NormalPriority,
   LowPriority,
   IdlePriority,
-  NoPriority,
 } from './ReactFiberSchedulerPriorities';
 
 // Intentionally not named imports because Rollup would use dynamic dispatch for

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
@@ -8,6 +8,14 @@
  */
 
 import type {ReactPriorityLevel} from './ReactInternalTypes';
+import {
+  ImmediatePriority,
+  UserBlockingPriority,
+  NormalPriority,
+  LowPriority,
+  IdlePriority,
+  NoPriority,
+} from './ReactFiberSchedulerPriorities';
 
 // Intentionally not named imports because Rollup would use dynamic dispatch for
 // CommonJS interop named imports.
@@ -58,17 +66,6 @@ export type SchedulerCallback = (isSync: boolean) => SchedulerCallback | null;
 type SchedulerCallbackOptions = {timeout?: number, ...};
 
 const fakeCallbackNode = {};
-
-// Except for NoPriority, these correspond to Scheduler priorities. We use
-// ascending numbers so we can compare them like numbers. They start at 90 to
-// avoid clashing with Scheduler's priorities.
-export const ImmediatePriority: ReactPriorityLevel = 99;
-export const UserBlockingPriority: ReactPriorityLevel = 98;
-export const NormalPriority: ReactPriorityLevel = 97;
-export const LowPriority: ReactPriorityLevel = 96;
-export const IdlePriority: ReactPriorityLevel = 95;
-// NoPriority is the absence of priority. Also React-only.
-export const NoPriority: ReactPriorityLevel = 90;
 
 export const shouldYield = Scheduler_shouldYield;
 export const requestPaint =

--- a/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
+++ b/packages/react-reconciler/src/SchedulerWithReactIntegration.old.js
@@ -14,7 +14,7 @@ import {
   NormalPriority,
   LowPriority,
   IdlePriority,
-} from './ReactFiberSchedulerPriorities';
+} from './ReactPriorityLevel';
 
 // Intentionally not named imports because Rollup would use dynamic dispatch for
 // CommonJS interop named imports.


### PR DESCRIPTION
## Summary

Following https://github.com/facebook/react/pull/20242, this PR untangles a slightly more elaborate cycle. In order to do so, I needed to make the types `Lane`, `Lanes`, `LaneMap`, and `LanePriority` into non-opaque types, which may go against their intent. Open to suggestions if there's a cleaner way to remove the cycle between `ReactFiberLane` and `ReactInternalTypes` that preserves the opaque tag.

### Cycle detection

I used a tool called [`madge`](https://github.com/pahen/madge) to detect cyclical imports. This change brings the number of cycles in the `packages/react-reconciler` package down from 50 to 48.

This eliminates the following cycles:
```
1) ReactFiberLane.js > ReactInternalTypes.js
2) ReactFiberLane.js > SchedulerWithReactIntegration.new.js
```

## Test Plan

Since this change only affects the location of a type and constant definitions, there shouldn't be any need to add or change tests.
