### PR TITLE
docs: add a sample about createTextInstance

### DIFF
--- a/packages/react-reconciler/README.md
+++ b/packages/react-reconciler/README.md
@@ -111,7 +111,7 @@ This method happens **in the render phase**. It can (and usually should) mutate 
 
 #### `createTextInstance(text, rootContainer, hostContext, internalHandle)`
 
-Same as `createInstance`, but for text nodes. If your renderer doesn't support text nodes, you can throw here.
+Same as `createInstance`, but for text nodes. If your renderer doesn't support text nodes, you can throw here, for example in **React Native** you must use `Text` component around a texts.
 
 #### `appendInitialChild(parentInstance, child)`
 


### PR DESCRIPTION
I added a sample about `createTextInstance` usage in an amazing doc about `react-reconciler`