### PR TITLE
clear the fiber and props cache when unmounting DOM nodes

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -11,10 +11,6 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
-const {
-  getFiberCurrentPropsFromNode,
-  getInstanceFromNode,
-} = require('../client/ReactDOMComponentTree');
 
 describe('ReactMount', () => {
   it('should destroy a react root upon request', () => {
@@ -167,3 +163,26 @@ describe('ReactMount', () => {
     );
   });
 });
+
+function getInstanceFromNode(node) {
+  // the prefix must be the same as in the internalInstanceKey in ReactDOMComponentTree
+  return getPrefixedValueFromNode(node, '__reactFiber$');
+}
+
+function getFiberCurrentPropsFromNode(node) {
+  // the prefix must be the same as in the internalPropsKey in ReactDOMComponentTree
+  return getPrefixedValueFromNode(node, '__reactProps$');
+}
+
+function getPrefixedValueFromNode(node, prefix) {
+  const keys = Object.keys(node);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key.startsWith(prefix)) {
+      return node[key];
+    }
+  }
+  throw new Error(
+    'node ' + node + ' has no property prefixed "' + prefix + '".',
+  );
+}

--- a/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
+++ b/packages/react-dom/src/__tests__/ReactMountDestruction-test.js
@@ -11,6 +11,10 @@
 
 const React = require('react');
 const ReactDOM = require('react-dom');
+const {
+  getFiberCurrentPropsFromNode,
+  getInstanceFromNode,
+} = require('../client/ReactDOMComponentTree');
 
 describe('ReactMount', () => {
   it('should destroy a react root upon request', () => {
@@ -36,6 +40,83 @@ describe('ReactMount', () => {
     expect(firstRootDiv.firstChild).toBeNull();
     ReactDOM.unmountComponentAtNode(secondRootDiv);
     expect(secondRootDiv.firstChild).toBeNull();
+  });
+
+  describe('when unmounting the container node', () => {
+    it('should remove references from rendered DOM elements to their fiber nodes', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <div>
+          <span>Hello World</span>
+        </div>,
+        container,
+      );
+      const node = container.firstChild;
+      expect(getInstanceFromNode(node)).not.toBeNull();
+      const nestedNode = node.firstChild;
+      expect(getInstanceFromNode(nestedNode)).not.toBeNull();
+
+      ReactDOM.unmountComponentAtNode(container);
+      expect(getInstanceFromNode(node)).toBeNull();
+      expect(getInstanceFromNode(nestedNode)).toBeNull();
+    });
+    it("should remove references from rendered DOM elements to their fiber's props", () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <div className="hello">
+          <span className="world" />
+        </div>,
+        container,
+      );
+      const node = container.firstChild;
+      expect(getFiberCurrentPropsFromNode(node)).not.toBeNull();
+      const nestedNode = node.firstChild;
+      expect(getFiberCurrentPropsFromNode(nestedNode)).not.toBeNull();
+
+      ReactDOM.unmountComponentAtNode(container);
+      expect(getFiberCurrentPropsFromNode(node)).toBeNull();
+      expect(getFiberCurrentPropsFromNode(nestedNode)).toBeNull();
+    });
+  });
+  describe('when unmounting a non-container node', () => {
+    it('should remove references from rendered DOM elements to their fiber nodes', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <div>
+          <span>
+            <i>Hello World</i>
+          </span>
+        </div>,
+        container,
+      );
+      const node = container.firstChild.firstChild;
+      expect(getInstanceFromNode(node)).not.toBeNull();
+      const nestedNode = node.firstChild;
+      expect(getInstanceFromNode(nestedNode)).not.toBeNull();
+
+      ReactDOM.render(<div />, container);
+      expect(getInstanceFromNode(node)).toBeNull();
+      expect(getInstanceFromNode(nestedNode)).toBeNull();
+    });
+    it("should remove references from rendered DOM elements to their fiber's props", () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <div>
+          <span className="hello">
+            <i className="world" />
+          </span>
+        </div>,
+        container,
+      );
+      const node = container.firstChild.firstChild;
+      expect(getFiberCurrentPropsFromNode(node)).not.toBeNull();
+      const nestedNode = node.firstChild;
+      expect(getFiberCurrentPropsFromNode(nestedNode)).not.toBeNull();
+
+      ReactDOM.render(<div />, container);
+      expect(getFiberCurrentPropsFromNode(node)).toBeNull();
+      expect(getFiberCurrentPropsFromNode(nestedNode)).toBeNull();
+    });
   });
 
   it('should warn when unmounting a non-container root node', () => {

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -50,6 +50,12 @@ export function precacheFiberNode(
   (node: any)[internalInstanceKey] = hostInst;
 }
 
+export function clearFiberNodeCache(
+  node: Instance | TextInstance | SuspenseInstance | ReactScopeInstance,
+): void {
+  (node: any)[internalInstanceKey] = null;
+}
+
 export function markContainerAsRoot(hostRoot: Fiber, node: Container): void {
   node[internalContainerInstanceKey] = hostRoot;
 }
@@ -194,6 +200,12 @@ export function updateFiberProps(
   props: Props,
 ): void {
   (node: any)[internalPropsKey] = props;
+}
+
+export function clearFiberPropsCache(
+  node: Instance | TextInstance | SuspenseInstance,
+): void {
+  (node: any)[internalPropsKey] = null;
 }
 
 export function getEventListenerSet(node: EventTarget): Set<string> {


### PR DESCRIPTION
This is another attempt at solving the memory leak issues mentioned in #17581 and #20088.

This PR is similar to #18690 except that it also clears the cached props from the unmounted DOM nodes.

Unlike #18814, this PR clears the cached fibers and props from *all* unmounted DOM nodes, not just the ones with refs. This is necessary because of #17581: if the browser leaks input nodes, then all of their sibling and parent nodes (up until the node that was detached from the rest of the document) are still accessible from the leaked input node. If any of those nodes still has a reference to a fiber or props, those will leak as well.

That being said, it *may* be feasible to treat input nodes like the special snowflakes that they are and explicitly detach them from the rest of the detached nodes so that only the input nodes may actually be retained by the browsers. However, this may also concern other nodes like textareas or select boxes and maybe even contenteditable nodes. So just removing the references to the fibers and props from all unmounted nodes seems a lot simpler to me.

Neither #18690 nor #18814 solved the memory leaks for my app, which regularly uses multiple gigabytes of RAM and sometimes even crashes Chrome because it can't allocate more memory. The changes in this PR seemingly brought the memory usage back to more appropriate levels (megabytes instead of gigabytes), though I haven't pushed them to production yet. Also, clearing the fiber and props cache helped me to resolve an unrelated memory leak in my app because it was *much* easier to see which DOM nodes still had references to my components without having to comb through every possible branch of the fiber tree.
