### PR TITLE
Profiler onNestedUpdateScheduled accepts id as first param

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -549,12 +549,12 @@ export function scheduleUpdateOnFiber(
         let current = fiber;
         while (current !== null) {
           if (current.tag === Profiler) {
-            const {onNestedUpdateScheduled} = current.memoizedProps;
+            const {id, onNestedUpdateScheduled} = current.memoizedProps;
             if (typeof onNestedUpdateScheduled === 'function') {
               if (enableSchedulerTracing) {
-                onNestedUpdateScheduled(root.memoizedInteractions);
+                onNestedUpdateScheduled(id, root.memoizedInteractions);
               } else {
-                onNestedUpdateScheduled();
+                onNestedUpdateScheduled(id);
               }
             }
           }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -549,12 +549,12 @@ export function scheduleUpdateOnFiber(
         let current = fiber;
         while (current !== null) {
           if (current.tag === Profiler) {
-            const {onNestedUpdateScheduled} = current.memoizedProps;
+            const {id, onNestedUpdateScheduled} = current.memoizedProps;
             if (typeof onNestedUpdateScheduled === 'function') {
               if (enableSchedulerTracing) {
-                onNestedUpdateScheduled(root.memoizedInteractions);
+                onNestedUpdateScheduled(id, root.memoizedInteractions);
               } else {
-                onNestedUpdateScheduled();
+                onNestedUpdateScheduled(id);
               }
             }
           }

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -2583,7 +2583,8 @@ describe('Profiler', () => {
         expect(Scheduler).toHaveYielded(['Component:false', 'Component:true']);
         expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(1);
         if (ReactFeatureFlags.enableSchedulerTracing) {
-          expect(onNestedUpdateScheduled.mock.calls[0][0]).toMatchInteractions([
+          expect(onNestedUpdateScheduled.mock.calls[0][0]).toBe('test');
+          expect(onNestedUpdateScheduled.mock.calls[0][1]).toMatchInteractions([
             interactionCreation,
           ]);
         }
@@ -2624,7 +2625,9 @@ describe('Profiler', () => {
 
         expect(Scheduler).toHaveYielded(['Component:false', 'Component:true']);
         expect(onNestedUpdateScheduledOne).toHaveBeenCalledTimes(1);
+        expect(onNestedUpdateScheduledOne.mock.calls[0][0]).toBe('one');
         expect(onNestedUpdateScheduledTwo).toHaveBeenCalledTimes(1);
+        expect(onNestedUpdateScheduledTwo.mock.calls[0][0]).toBe('two');
         expect(onNestedUpdateScheduledThree).not.toHaveBeenCalled();
       });
 
@@ -2817,7 +2820,8 @@ describe('Profiler', () => {
         ]);
         expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(1);
         if (ReactFeatureFlags.enableSchedulerTracing) {
-          expect(onNestedUpdateScheduled.mock.calls[0][0]).toMatchInteractions([
+          expect(onNestedUpdateScheduled.mock.calls[0][0]).toBe('test');
+          expect(onNestedUpdateScheduled.mock.calls[0][1]).toMatchInteractions([
             interactionCreation,
           ]);
         }
@@ -2850,7 +2854,8 @@ describe('Profiler', () => {
         ]);
         expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(2);
         if (ReactFeatureFlags.enableSchedulerTracing) {
-          expect(onNestedUpdateScheduled.mock.calls[1][0]).toMatchInteractions([
+          expect(onNestedUpdateScheduled.mock.calls[1][0]).toBe('test');
+          expect(onNestedUpdateScheduled.mock.calls[1][1]).toMatchInteractions([
             interactionUpdate,
           ]);
         }
@@ -2898,7 +2903,8 @@ describe('Profiler', () => {
         expect(Scheduler).toHaveYielded(['Component:false', 'Component:true']);
         expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(1);
         if (ReactFeatureFlags.enableSchedulerTracing) {
-          expect(onNestedUpdateScheduled.mock.calls[0][0]).toMatchInteractions([
+          expect(onNestedUpdateScheduled.mock.calls[0][0]).toBe('test');
+          expect(onNestedUpdateScheduled.mock.calls[0][1]).toMatchInteractions([
             interactionCreation,
           ]);
         }
@@ -2969,7 +2975,8 @@ describe('Profiler', () => {
         ]);
         expect(onNestedUpdateScheduled).toHaveBeenCalledTimes(1);
         if (ReactFeatureFlags.enableSchedulerTracing) {
-          expect(onNestedUpdateScheduled.mock.calls[0][0]).toMatchInteractions([
+          expect(onNestedUpdateScheduled.mock.calls[0][0]).toBe('test');
+          expect(onNestedUpdateScheduled.mock.calls[0][1]).toMatchInteractions([
             interactionCreation,
           ]);
         }


### PR DESCRIPTION
It was an oversight to omit this param initially.