### PR TITLE
Exclude fixtures from Flow config

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/scripts/bench/.*
 .*/build/.*
+.*/fixtures/.*
 .*/.tempUserDataDir/.*
 
 # These shims are copied into external projects:


### PR DESCRIPTION
I couldn't run Flow for a few months. This solves it. I don't think we need it there anyway.