### PR TITLE
Include actual type of `Profiler#id` on type mismatch

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -650,7 +650,10 @@ function createFiberFromProfiler(
 ): Fiber {
   if (__DEV__) {
     if (typeof pendingProps.id !== 'string') {
-      console.error('Profiler must specify an "id" as a prop');
+      console.error(
+        'Profiler must specify an "id" of type `string` as a prop. Received the type `%s` instead.',
+        typeof pendingProps.id,
+      );
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -650,7 +650,10 @@ function createFiberFromProfiler(
 ): Fiber {
   if (__DEV__) {
     if (typeof pendingProps.id !== 'string') {
-      console.error('Profiler must specify an "id" as a prop');
+      console.error(
+        'Profiler must specify an "id" of type `string` as a prop. Received the type `%s` instead.',
+        typeof pendingProps.id,
+      );
     }
   }
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -136,9 +136,12 @@ describe('Profiler', () => {
             it('should warn if required params are missing', () => {
               expect(() => {
                 ReactTestRenderer.create(<React.Profiler />);
-              }).toErrorDev('Profiler must specify an "id" as a prop', {
-                withoutStack: true,
-              });
+              }).toErrorDev(
+                'Profiler must specify an "id" of type `string` as a prop. Received the type `undefined` instead.',
+                {
+                  withoutStack: true,
+                },
+              );
             });
           }
 


### PR DESCRIPTION
## Summary

The dev-only warning now includes the given type of the `id` prop if it does not match the expected type.

Accidentally passed a number the other day and was confused for a bit what I did wrong.

## Test Plan

- [x] CI passes
