### PR TITLE
Ignore node_modules when printing warnings

### DIFF
--- a/scripts/print-warnings/print-warnings.js
+++ b/scripts/print-warnings/print-warnings.js
@@ -90,6 +90,7 @@ gs([
   '!packages/react-devtools*/**/*.js',
   '!**/__tests__/**/*.js',
   '!**/__mocks__/**/*.js',
+  '!**/node_modules/**/*.js',
 ]).pipe(
   through.obj(transform, cb => {
     process.stdout.write(


### PR DESCRIPTION
This found acorn and fails to extract warnings from it. Also, this seemed slow. We don't need to extract warnings elsewhere.
