### PR TITLE
[Flight] Add rudimentary PG binding

### DIFF
--- a/packages/react-pg/README.md
+++ b/packages/react-pg/README.md
@@ -1,0 +1,12 @@
+# react-pg
+
+This package is meant to be used alongside yet-to-be-released, experimental React features. It's unlikely to be useful in any other context.
+
+**Do not use in a real application.** We're publishing this early for
+demonstration purposes.
+
+**Use it at your own risk.**
+
+# No, Really, It Is Unstable
+
+The API ~~may~~ will change wildly between versions.

--- a/packages/react-pg/index.browser.js
+++ b/packages/react-pg/index.browser.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+throw new Error(
+  'This entry point is not yet supported in the browser environment',
+);

--- a/packages/react-pg/index.js
+++ b/packages/react-pg/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export * from './index.node';

--- a/packages/react-pg/index.node.js
+++ b/packages/react-pg/index.node.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export * from './src/ReactPostgres';

--- a/packages/react-pg/npm/index.browser.js
+++ b/packages/react-pg/npm/index.browser.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-pg.browser.production.min.js');
+} else {
+  module.exports = require('./cjs/react-pg.browser.development.js');
+}

--- a/packages/react-pg/npm/index.js
+++ b/packages/react-pg/npm/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./index.node');

--- a/packages/react-pg/npm/index.node.js
+++ b/packages/react-pg/npm/index.node.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-pg.node.production.min.js');
+} else {
+  module.exports = require('./cjs/react-pg.node.development.js');
+}

--- a/packages/react-pg/package.json
+++ b/packages/react-pg/package.json
@@ -1,0 +1,27 @@
+{
+  "private": true,
+  "name": "react-pg",
+  "description": "React bindings for PostgreSQL",
+  "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-pg"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "build-info.json",
+    "index.js",
+    "index.node.js",
+    "index.browser.js",
+    "cjs/"
+  ],
+  "peerDependencies": {
+    "react": "^17.0.0",
+    "pg": "*"
+  },
+  "browser": {
+    "./index.js": "./index.browser.js"
+  }
+}

--- a/packages/react-pg/src/ReactPostgres.js
+++ b/packages/react-pg/src/ReactPostgres.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Wakeable} from 'shared/ReactTypes';
+
+import {unstable_getCacheForType} from 'react';
+import {Pool as PostgresPool} from 'pg';
+
+const Pending = 0;
+const Resolved = 1;
+const Rejected = 2;
+
+type PendingResult = {|
+  status: 0,
+  value: Wakeable,
+|};
+
+type ResolvedResult = {|
+  status: 1,
+  value: mixed,
+|};
+
+type RejectedResult = {|
+  status: 2,
+  value: mixed,
+|};
+
+type Result = PendingResult | ResolvedResult | RejectedResult;
+
+function toResult(thenable): Result {
+  const result: Result = {
+    status: Pending,
+    value: thenable,
+  };
+  thenable.then(
+    value => {
+      if (result.status === Pending) {
+        const resolvedResult = ((result: any): ResolvedResult);
+        resolvedResult.status = Resolved;
+        resolvedResult.value = value;
+      }
+    },
+    err => {
+      if (result.status === Pending) {
+        const rejectedResult = ((result: any): RejectedResult);
+        rejectedResult.status = Rejected;
+        rejectedResult.value = err;
+      }
+    },
+  );
+  return result;
+}
+
+function readResult(result: Result) {
+  if (result.status === Resolved) {
+    return result.value;
+  } else {
+    throw result.value;
+  }
+}
+
+export function Pool(options: mixed) {
+  this.pool = new PostgresPool(options);
+  // Unique function per instance because it's used for cache identity.
+  this.createResultMap = function() {
+    return new Map();
+  };
+}
+
+Pool.prototype.query = function(query: string, values?: Array<mixed>) {
+  const pool = this.pool;
+  const map = unstable_getCacheForType(this.createResultMap);
+  // TODO: Is this sufficient? What about more complex types?
+  const key = JSON.stringify({query, values});
+  let entry = map.get(key);
+  if (!entry) {
+    const thenable = pool.query(query, values);
+    entry = toResult(thenable);
+    map.set(key, entry);
+  }
+  return readResult(entry);
+};

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -77,3 +77,9 @@ declare module 'pg' {
     query: (query: string, values?: Array<mixed>) => void,
   };
 }
+
+declare module 'pg/lib/utils' {
+  declare module.exports: {
+    prepareValue(val: any): mixed,
+  };
+}

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -69,3 +69,11 @@ declare module 'EventListener' {
 
 declare function __webpack_chunk_load__(id: string): Promise<mixed>;
 declare function __webpack_require__(id: string): any;
+
+declare module 'pg' {
+  declare var Pool: (
+    options: mixed,
+  ) => {
+    query: (query: string, values?: Array<mixed>) => void,
+  };
+}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -153,6 +153,24 @@ const bundles = [
     externals: ['react', 'http', 'https'],
   },
 
+  /******* React PG Browser (experimental, new) *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-pg/index.browser',
+    global: 'ReactPostgres',
+    externals: [],
+  },
+
+  /******* React PG Node (experimental, new) *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-pg/index.node',
+    global: 'ReactPostgres',
+    externals: ['react', 'pg'],
+  },
+
   /******* React DOM *******/
   {
     bundleTypes: [


### PR DESCRIPTION
Adds a minimal Suspensey PG binding.

I've added a browser shim that throws which can later be replaced by some worker proxy thing. Not sure if the `browser` entry point is the right division. I can maybe remove this.

The `Pool` class proxies to PG `Pool` and you can call `.query()` on it. Very similar to [this](https://node-postgres.com/guides/async-express).

No tests.