### PR TITLE
fixed: typo in react-devtools/README.md Websocked -> Websocket

### DIFF
--- a/packages/react-devtools-core/README.md
+++ b/packages/react-devtools-core/README.md
@@ -21,7 +21,7 @@ Be sure to run this function *before* importing e.g. `react`, `react-dom`, `reac
 The `config` object may contain:
 * `host: string` (defaults to "localhost") - Websocket will connect to this host.
 * `port: number` (defaults to `8097`) - Websocket will connect to this port.
-* `useHttps: boolean` (defaults to `false`) - Websocked should use a secure protocol (wss).
+* `useHttps: boolean` (defaults to `false`) - Websocket should use a secure protocol (wss).
 * `websocket: Websocket` - Custom websocket to use. Overrides `host` and `port` settings if provided.
 * `resolveRNStyle: (style: number) => ?Object` - Used by the React Native style plug-in.
 * `retryConnectionDelay: number` (defaults to `2000`) - Milliseconds delay to wait between retrying a failed Websocket connection.


### PR DESCRIPTION
Hi I am a new contributing to react, Kindly consider the PR I have done, there is a typo in `packages/react-devtools-core/README.md`  which I have fixed.

```
Websocked -> websocket
```