### PR TITLE
Fix Flight Prod Fixture

### DIFF
--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -68,7 +68,9 @@
     "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
     "start:client": "node scripts/start.js",
     "start:server": "NODE_ENV=development node --experimental-loader ./loader/index.js --conditions=react-server server",
-    "start:prod": "node scripts/build.js && NODE_ENV=production node server",
+    "start:prod": "node scripts/build.js && concurrently \"npm run start:prod-server\" \"npm run start:prod-client\"",
+    "start:prod-client": "cd ./build && python -m SimpleHTTPServer 3000",
+    "start:prod-server": "NODE_ENV=production node --experimental-loader ./loader/index.js --conditions=react-server server",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"
   },

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -1,20 +1,26 @@
 'use strict';
 
 import {pipeToNodeWritable} from 'react-transport-dom-webpack/server';
-import {readFileSync} from 'fs';
+import {readFile} from 'fs';
 import {resolve} from 'path';
 import * as React from 'react';
 
-module.exports = async function(req, res) {
-  const m = await import('../src/App.server.js');
+module.exports = function(req, res) {
   // const m = require('../src/App.server.js');
-  const App = m.default.default || m.default;
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  const moduleMap = JSON.parse(
-    readFileSync(
+  import('../src/App.server.js').then(m => {
+    readFile(
       resolve(__dirname, '../dist/react-transport-manifest.json'),
-      'utf8'
-    )
-  );
-  pipeToNodeWritable(<App />, res, moduleMap);
+      'utf8',
+      (err, data) => {
+        if (err) {
+          throw err;
+        }
+
+        const App = m.default.default || m.default;
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        const moduleMap = JSON.parse(data);
+        pipeToNodeWritable(<App />, res, moduleMap);
+      }
+    );
+  });
 };

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -8,8 +8,9 @@ import * as React from 'react';
 module.exports = function(req, res) {
   // const m = require('../src/App.server.js');
   import('../src/App.server.js').then(m => {
+    const dist = process.env.NODE_ENV === 'development' ? 'dist' : 'build';
     readFile(
-      resolve(__dirname, '../dist/react-transport-manifest.json'),
+      resolve(__dirname, `../${dist}/react-transport-manifest.json`),
       'utf8',
       (err, data) => {
         if (err) {


### PR DESCRIPTION
Something is messed with Babel where it inserts a dependency on an async helper which is an ESM module. This doesn't work in modern Node from a CommonJS file so it errors before it has a chance to transpile it. I have no idea why this is only affecting prod.

The solution is just to not use async/await.

Also wired up some helper so now the prod example works.