### PR TITLE
Fix ESLint crash on empty react effect hook

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1693,6 +1693,35 @@ const tests = {
       ],
     },
     {
+      code: normalizeIndent`
+        function MyComponent() {
+          useEffect()
+          useCallback()
+          useMemo()
+        }
+      `,
+      errors: [
+        {
+          message:
+            'React Hook useEffect will crash when called with no arguments. ' +
+            'Did you forget to pass a function and an array of dependencies?',
+          suggestions: undefined,
+        },
+        {
+          message:
+            'React Hook useCallback will crash when called with no arguments. ' +
+            'Did you forget to pass a function and an array of dependencies?',
+          suggestions: undefined,
+        },
+        {
+          message:
+            'React Hook useMemo will crash when called with no arguments. ' +
+            'Did you forget to pass a function and an array of dependencies?',
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
       // Regression test
       code: normalizeIndent`
         function MyComponent() {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1705,25 +1705,25 @@ const tests = {
         {
           message:
             'React Hook useEffect will crash when called with no arguments. ' +
-            'Did you forget to pass a function and an array of dependencies?',
+            'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
             'React Hook useLayoutEffect will crash when called with no arguments. ' +
-            'Did you forget to pass a function and an array of dependencies?',
+            'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
             'React Hook useCallback will crash when called with no arguments. ' +
-            'Did you forget to pass a function and an array of dependencies?',
+            'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
             'React Hook useMemo will crash when called with no arguments. ' +
-            'Did you forget to pass a function and an array of dependencies?',
+            'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
       ],

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1696,6 +1696,7 @@ const tests = {
       code: normalizeIndent`
         function MyComponent() {
           useEffect()
+          useLayoutEffect()
           useCallback()
           useMemo()
         }
@@ -1704,6 +1705,12 @@ const tests = {
         {
           message:
             'React Hook useEffect will crash when called with no arguments. ' +
+            'Did you forget to pass a function and an array of dependencies?',
+          suggestions: undefined,
+        },
+        {
+          message:
+            'React Hook useLayoutEffect will crash when called with no arguments. ' +
             'Did you forget to pass a function and an array of dependencies?',
           suggestions: undefined,
         },

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1704,25 +1704,25 @@ const tests = {
       errors: [
         {
           message:
-            'React Hook useEffect will crash when called with no arguments. ' +
+            'React Hook useEffect requires an effect callback. ' +
             'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
-            'React Hook useLayoutEffect will crash when called with no arguments. ' +
+            'React Hook useLayoutEffect requires an effect callback. ' +
             'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
-            'React Hook useCallback will crash when called with no arguments. ' +
+            'React Hook useCallback requires an effect callback. ' +
             'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },
         {
           message:
-            'React Hook useMemo will crash when called with no arguments. ' +
+            'React Hook useMemo requires an effect callback. ' +
             'Did you forget to pass a callback to the hook?',
           suggestions: undefined,
         },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1127,7 +1127,7 @@ export default {
           node: reactiveHook,
           message:
             `React Hook ${reactiveHookName} will crash when called with no arguments. ` +
-            `Did you forget to pass a function and an array of dependencies?`,
+            `Did you forget to pass a callback to the hook?`,
         });
         return;
       }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1119,8 +1119,8 @@ export default {
       const declaredDependenciesNode = node.arguments[callbackIndex + 1];
       const isEffect = /Effect($|[^a-z])/g.test(reactiveHookName);
 
-      // Check whether a callback is supplied to useEffect. If there is no
-      // callback supplied then the hook will not work and React will throw a TypeError.
+      // Check whether a callback is supplied. If there is no callback supplied
+      // then the hook will not work and React will throw a TypeError.
       // So no need to check for dependency inclusion.
       if (!callback) {
         reportProblem({

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1119,6 +1119,19 @@ export default {
       const declaredDependenciesNode = node.arguments[callbackIndex + 1];
       const isEffect = /Effect($|[^a-z])/g.test(reactiveHookName);
 
+      // Check whether a callback is supplied to useEffect. If there is no
+      // callback supplied then the hook will not work and React will throw a TypeError.
+      // So no need to check for dependency inclusion.
+      if (!callback) {
+        reportProblem({
+          node: reactiveHook,
+          message:
+            `React Hook ${reactiveHookName} will crash when called with no arguments. ` +
+            `Did you forget to pass a function and an array of dependencies?`,
+        });
+        return;
+      }
+
       // Check the declared dependencies for this reactive hook. If there is no
       // second argument then the reactive callback will re-run on every render.
       // So no need to check for dependency inclusion.

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1126,7 +1126,7 @@ export default {
         reportProblem({
           node: reactiveHook,
           message:
-            `React Hook ${reactiveHookName} will crash when called with no arguments. ` +
+            `React Hook ${reactiveHookName} requires an effect callback. ` +
             `Did you forget to pass a callback to the hook?`,
         });
         return;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

ESLint crashes due to the `eslint-plugin-react-hooks` plugin, when an empty (no arguments) `useEffect`, `useLayoutEffect`,  `useMemo` or `useCallback` is written.

If any of these hooks are empty during runtime, React will also throw a TypeError, so this should also be a lint warning in my opinion.

To resolve this crash, a check is added to see if there is any callback supplied and creates a lint warning if there isn't one.

Resolves #20343

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I built the `eslint-plugin-react-hooks` bundle and copied it into the node_modules of my test project, which fixed the crashes.

I also verified this new lint check didn't impact custom hooks and it didn't. 

I added a test case for these empty hooks to check if the correct problem is shown by ESLint. I also ran the tests for the whole repository to ensure there were no other problems.
