### PR TITLE
Optimizing part of the PureConponent code

### DIFF
--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -120,9 +120,6 @@ if (__DEV__) {
   }
 }
 
-function ComponentDummy() {}
-ComponentDummy.prototype = Component.prototype;
-
 /**
  * Convenience component with default shallow equality check for sCU.
  */
@@ -134,7 +131,7 @@ function PureComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-const pureComponentPrototype = (PureComponent.prototype = new ComponentDummy());
+const pureComponentPrototype = (PureComponent.prototype = Object.create(Component.prototype));
 pureComponentPrototype.constructor = PureComponent;
 // Avoid an extra prototype jump for these methods.
 Object.assign(pureComponentPrototype, Component.prototype);

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -131,7 +131,9 @@ function PureComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-const pureComponentPrototype = (PureComponent.prototype = Object.create(Component.prototype));
+const pureComponentPrototype = (PureComponent.prototype = Object.create(
+  Component.prototype,
+));
 pureComponentPrototype.constructor = PureComponent;
 // Avoid an extra prototype jump for these methods.
 Object.assign(pureComponentPrototype, Component.prototype);


### PR DESCRIPTION
Using intermediate functions to avoid instantiating `Component` objects.

the `Object.create` method achieves the same goal!

Adds a bit of readability