### PR TITLE
Update part of the PureComponent code

### DIFF
--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -120,9 +120,6 @@ if (__DEV__) {
   }
 }
 
-function ComponentDummy() {}
-ComponentDummy.prototype = Component.prototype;
-
 /**
  * Convenience component with default shallow equality check for sCU.
  */
@@ -134,7 +131,7 @@ function PureComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-const pureComponentPrototype = (PureComponent.prototype = new ComponentDummy());
+const pureComponentPrototype = (PureComponent.prototype = Object.create(Component.prototype));
 pureComponentPrototype.constructor = PureComponent;
 // Avoid an extra prototype jump for these methods.
 Object.assign(pureComponentPrototype, Component.prototype);

--- a/packages/react/src/ReactBaseClasses.js
+++ b/packages/react/src/ReactBaseClasses.js
@@ -131,7 +131,9 @@ function PureComponent(props, context, updater) {
   this.updater = updater || ReactNoopUpdateQueue;
 }
 
-const pureComponentPrototype = (PureComponent.prototype = Object.create(Component.prototype));
+const pureComponentPrototype = (PureComponent.prototype = Object.create(
+  Component.prototype,
+));
 pureComponentPrototype.constructor = PureComponent;
 // Avoid an extra prototype jump for these methods.
 Object.assign(pureComponentPrototype, Component.prototype);


### PR DESCRIPTION
Some redundant logic is reduced and the `Object.create` interface is adopted instead of the original `new Object()` mode