### PR TITLE
Remove `catch` from Scheduler build

### DIFF
--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -519,21 +519,25 @@ const performWorkUntilDeadline = () => {
     // the message event.
     deadline = currentTime + yieldInterval;
     const hasTimeRemaining = true;
+
+    // If a scheduler task throws, exit the current browser task so the
+    // error can be observed.
+    //
+    // Intentionally not using a try-catch, since that makes some debugging
+    // techniques harder. Instead, if `scheduledHostCallback` errors, then
+    // `hasMoreWork` will remain true, and we'll continue the work loop.
+    let hasMoreWork = true;
     try {
-      const hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
-      if (!hasMoreWork) {
-        isMessageLoopRunning = false;
-        scheduledHostCallback = null;
-      } else {
+      hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
+    } finally {
+      if (hasMoreWork) {
         // If there's more work, schedule the next message event at the end
         // of the preceding one.
         port.postMessage(null);
+      } else {
+        isMessageLoopRunning = false;
+        scheduledHostCallback = null;
       }
-    } catch (error) {
-      // If a scheduler task throws, exit the current browser task so the
-      // error can be observed.
-      port.postMessage(null);
-      throw error;
     }
   } else {
     isMessageLoopRunning = false;


### PR DESCRIPTION
Makes debugging errors harder.

In this case, we can use `finally` instead.