### PR TITLE
Clear `deletions` in `detachFiber`

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1074,6 +1074,7 @@ function detachFiberMutation(fiber: Fiber) {
   // and one of its descendants throws while unmounting a passive effect.
   fiber.alternate = null;
   fiber.child = null;
+  fiber.deletions = null;
   fiber.dependencies = null;
   fiber.firstEffect = null;
   fiber.lastEffect = null;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1074,6 +1074,7 @@ function detachFiberMutation(fiber: Fiber) {
   // and one of its descendants throws while unmounting a passive effect.
   fiber.alternate = null;
   fiber.child = null;
+  fiber.deletions = null;
   fiber.dependencies = null;
   fiber.firstEffect = null;
   fiber.lastEffect = null;


### PR DESCRIPTION
This was added in a later step of the refactor but since `deletions` array already landed, clearing it should, too.

I think it's unlikely that this causes GC problems but worth adding anyway.