### PR TITLE
[Flight] Use assets API + writeToDisk instead of directly writing to disk

### DIFF
--- a/fixtures/flight/config/webpackDevServer.config.js
+++ b/fixtures/flight/config/webpackDevServer.config.js
@@ -90,6 +90,9 @@ module.exports = function(proxy, allowedHost) {
     watchOptions: {
       ignored: ignoredFiles(paths.appSrc),
     },
+    writeToDisk: filePath => {
+      return /react-client-manifest\.json$/.test(filePath);
+    },
     https: getHttpsConfig(),
     host,
     overlay: false,

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -10,7 +10,7 @@ module.exports = function(req, res) {
   import('../src/App.server.js').then(m => {
     const dist = process.env.NODE_ENV === 'development' ? 'dist' : 'build';
     readFile(
-      resolve(__dirname, `../${dist}/react-transport-manifest.json`),
+      resolve(__dirname, `../${dist}/react-client-manifest.json`),
       'utf8',
       (err, data) => {
         if (err) {


### PR DESCRIPTION
The writeToDisk config exists to emit a webpack-dev-server asset to disk so that the server can pick it up.
