### PR TITLE
[Flight] Add rudimentary FS binding

### DIFF
--- a/packages/react-fs/README.md
+++ b/packages/react-fs/README.md
@@ -1,0 +1,12 @@
+# react-fs
+
+This package is meant to be used alongside yet-to-be-released, experimental React features. It's unlikely to be useful in any other context.
+
+**Do not use in a real application.** We're publishing this early for
+demonstration purposes.
+
+**Use it at your own risk.**
+
+# No, Really, It Is Unstable
+
+The API ~~may~~ will change wildly between versions.

--- a/packages/react-fs/index.browser.js
+++ b/packages/react-fs/index.browser.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+throw new Error(
+  'This entry point is not yet supported in the browser environment',
+);

--- a/packages/react-fs/index.js
+++ b/packages/react-fs/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export * from './index.node';

--- a/packages/react-fs/index.node.js
+++ b/packages/react-fs/index.node.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export * from './src/ReactFilesystem';

--- a/packages/react-fs/npm/index.browser.js
+++ b/packages/react-fs/npm/index.browser.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-fs.browser.production.min.js');
+} else {
+  module.exports = require('./cjs/react-fs.browser.development.js');
+}

--- a/packages/react-fs/npm/index.js
+++ b/packages/react-fs/npm/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./index.node');

--- a/packages/react-fs/npm/index.node.js
+++ b/packages/react-fs/npm/index.node.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-fs.node.production.min.js');
+} else {
+  module.exports = require('./cjs/react-fs.node.development.js');
+}

--- a/packages/react-fs/package.json
+++ b/packages/react-fs/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "react-fs",
+  "description": "React bindings for the filesystem",
+  "version": "0.0.0",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/react.git",
+    "directory": "packages/react-fs"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "build-info.json",
+    "index.js",
+    "index.node.js",
+    "index.browser.js",
+    "cjs/"
+  ],
+  "browser": {
+    "./index.js": "./index.browser.js"
+  }
+}

--- a/packages/react-fs/package.json
+++ b/packages/react-fs/package.json
@@ -17,6 +17,9 @@
     "index.browser.js",
     "cjs/"
   ],
+  "peerDependencies": {
+    "react": "^17.0.0"
+  },
   "browser": {
     "./index.js": "./index.browser.js"
   }

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -75,9 +75,9 @@ export function readFile(
     | string
     | {
         encoding?: string | null,
-        // Ignored:
-        flag?: string,
-        signal?: mixed,
+        // Unsupported:
+        flag?: string, // Doesn't make sense except "r"
+        signal?: mixed, // We'll have our own signal
       },
 ): string | Buffer {
   const map = unstable_getCacheForType(createReadFileCache);
@@ -91,7 +91,21 @@ export function readFile(
   if (!options) {
     return result;
   }
-  const encoding = typeof options === 'string' ? options : options.encoding;
+  let encoding;
+  if (typeof options === 'string') {
+    encoding = options;
+  } else {
+    const flag = options.flag;
+    if (flag != null && flag !== 'r') {
+      throw Error(
+        'The flag option is not supported, and always defaults to "r".',
+      );
+    }
+    if (options.signal) {
+      throw Error('The signal option is not supported.');
+    }
+    encoding = options.encoding;
+  }
   if (typeof encoding !== 'string') {
     return result;
   }

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Wakeable, Thenable} from 'shared/ReactTypes';
+
+import {unstable_getCacheForType} from 'react';
+import * as fs from 'fs/promises';
+
+const Pending = 0;
+const Resolved = 1;
+const Rejected = 2;
+
+type PendingResult = {|
+  status: 0,
+  value: Wakeable,
+|};
+
+type ResolvedResult<T> = {|
+  status: 1,
+  value: T,
+|};
+
+type RejectedResult = {|
+  status: 2,
+  value: mixed,
+|};
+
+type Result<T> = PendingResult | ResolvedResult<T> | RejectedResult;
+
+function toResult<T>(thenable: Thenable<T>): Result<T> {
+  const result: Result<T> = {
+    status: Pending,
+    value: thenable,
+  };
+  thenable.then(
+    value => {
+      if (result.status === Pending) {
+        const resolvedResult = ((result: any): ResolvedResult<T>);
+        resolvedResult.status = Resolved;
+        resolvedResult.value = value;
+      }
+    },
+    err => {
+      if (result.status === Pending) {
+        const rejectedResult = ((result: any): RejectedResult);
+        rejectedResult.status = Rejected;
+        rejectedResult.value = err;
+      }
+    },
+  );
+  return result;
+}
+
+function readResult<T>(result: Result<T>): T {
+  if (result.status === Resolved) {
+    return result.value;
+  } else {
+    throw result.value;
+  }
+}
+
+function createReadFileCache(): Map<string, Result<Buffer>> {
+  return new Map();
+}
+
+export function readFile(
+  path: string,
+  options:
+    | string
+    | {
+        encoding?: string | null,
+        // Ignored:
+        flag?: string,
+        signal?: mixed,
+      },
+): string | Buffer {
+  const map = unstable_getCacheForType(createReadFileCache);
+  let entry = map.get(path);
+  if (!entry) {
+    const thenable = fs.readFile(path);
+    entry = toResult(thenable);
+    map.set(path, entry);
+  }
+  const result: Buffer = readResult(entry);
+  if (!options) {
+    return result;
+  }
+  const encoding = typeof options === 'string' ? options : options.encoding;
+  if (typeof encoding !== 'string') {
+    return result;
+  }
+  const textCache =
+    (result: any)._reactTextCache || ((result: any)._reactTextCache = []);
+  for (let i = 0; i < textCache.length; i += 2) {
+    if (textCache[i] === encoding) {
+      return textCache[i + 1];
+    }
+  }
+  const text = result.toString((encoding: any));
+  textCache.push(encoding, text);
+  return text;
+}

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -11,6 +11,7 @@ import type {Wakeable, Thenable} from 'shared/ReactTypes';
 
 import {unstable_getCacheForType} from 'react';
 import * as fs from 'fs/promises';
+import {resolve} from 'path';
 
 const Pending = 0;
 const Resolved = 1;
@@ -85,11 +86,12 @@ export function readFile(
       },
 ): string | Buffer {
   const map = unstable_getCacheForType(createReadFileCache);
-  let entry = map.get(path);
+  const resolvedPath = resolve(path);
+  let entry = map.get(resolvedPath);
   if (!entry) {
-    const thenable = fs.readFile(path);
+    const thenable = fs.readFile(resolvedPath);
     entry = toResult(thenable);
-    map.set(path, entry);
+    map.set(resolvedPath, entry);
   }
   const result: Buffer = readResult(entry);
   if (!options) {

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -19,16 +19,19 @@ const Rejected = 2;
 type PendingResult = {|
   status: 0,
   value: Wakeable,
+  cache: Array<mixed>,
 |};
 
 type ResolvedResult<T> = {|
   status: 1,
   value: T,
+  cache: Array<mixed>,
 |};
 
 type RejectedResult = {|
   status: 2,
   value: mixed,
+  cache: Array<mixed>,
 |};
 
 type Result<T> = PendingResult | ResolvedResult<T> | RejectedResult;
@@ -37,6 +40,7 @@ function toResult<T>(thenable: Thenable<T>): Result<T> {
   const result: Result<T> = {
     status: Pending,
     value: thenable,
+    cache: [],
   };
   thenable.then(
     value => {
@@ -109,11 +113,10 @@ export function readFile(
   if (typeof encoding !== 'string') {
     return result;
   }
-  const textCache =
-    (result: any)._reactTextCache || ((result: any)._reactTextCache = []);
+  const textCache = entry.cache;
   for (let i = 0; i < textCache.length; i += 2) {
     if (textCache[i] === encoding) {
-      return textCache[i + 1];
+      return (textCache[i + 1]: any);
     }
   }
   const text = result.toString((encoding: any));

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -70,6 +70,16 @@ declare module 'EventListener' {
 declare function __webpack_chunk_load__(id: string): Promise<mixed>;
 declare function __webpack_require__(id: string): any;
 
+declare module 'fs/promises' {
+  declare var readFile: (
+    path: string,
+    options?:
+      | ?string
+      | {
+          encoding?: ?string,
+        },
+  ) => Promise<Buffer>;
+}
 declare module 'pg' {
   declare var Pool: (
     options: mixed,

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -168,7 +168,7 @@ const bundles = [
     moduleType: ISOMORPHIC,
     entry: 'react-fs/index.node',
     global: 'ReactFilesystem',
-    externals: ['react', 'fs/promises'],
+    externals: ['react', 'fs/promises', 'path'],
   },
 
   /******* React PG Browser (experimental, new) *******/

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -153,6 +153,24 @@ const bundles = [
     externals: ['react', 'http', 'https'],
   },
 
+  /******* React FS Browser (experimental, new) *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-fs/index.browser',
+    global: 'ReactFilesystem',
+    externals: [],
+  },
+
+  /******* React FS Node (experimental, new) *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'react-fs/index.node',
+    global: 'ReactFilesystem',
+    externals: ['react', 'fs/promises'],
+  },
+
   /******* React PG Browser (experimental, new) *******/
   {
     bundleTypes: [NODE_DEV, NODE_PROD],


### PR DESCRIPTION
This only has `readFile` in it. I will be adding a few more as follow-up commits.

For `readFile` it makes sense to always get the buffer because that's what Node does anyway. And then we cache the decoded versions, once per encoding. I keep them in an array `[enc1, text1, enc2, text2, ...]` since there's likely very few (usually one).

For others it might make sense to do something different. E.g. many have `'utf8'` as the default and I don't think it makes sense to grab the buffer first. For those I'd just consider buffer one of possible encodings, and get each separately on demand.