### PR TITLE
[Flight] Add read-only fs methods

### DIFF
--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -92,7 +92,7 @@ function checkPathInDev(path: string) {
   }
 }
 
-function createAccessCache(): Map<string, Array<number | Record<void>>> {
+function createAccessMap(): Map<string, Array<number | Record<void>>> {
   return new Map();
 }
 
@@ -101,7 +101,7 @@ export function access(path: string, mode?: number): void {
   if (mode == null) {
     mode = 0; // fs.constants.F_OK
   }
-  const map = unstable_getCacheForType(createAccessCache);
+  const map = unstable_getCacheForType(createAccessMap);
   let accessCache = map.get(path);
   if (!accessCache) {
     accessCache = [];
@@ -124,7 +124,7 @@ export function access(path: string, mode?: number): void {
   readRecord(record); // No return value.
 }
 
-function createLstatCache(): Map<string, Array<boolean | Record<mixed>>> {
+function createLstatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
@@ -134,7 +134,7 @@ export function lstat(path: string, options?: {bigint?: boolean}): mixed {
   if (options && options.bigint) {
     bigint = true;
   }
-  const map = unstable_getCacheForType(createLstatCache);
+  const map = unstable_getCacheForType(createLstatMap);
   let lstatCache = map.get(path);
   if (!lstatCache) {
     lstatCache = [];
@@ -158,7 +158,7 @@ export function lstat(path: string, options?: {bigint?: boolean}): mixed {
   return stats;
 }
 
-function createReaddirCache(): Map<
+function createReaddirMap(): Map<
   string,
   Array<string | boolean | Record<mixed>>,
 > {
@@ -182,7 +182,7 @@ export function readdir(
       withFileTypes = true;
     }
   }
-  const map = unstable_getCacheForType(createReaddirCache);
+  const map = unstable_getCacheForType(createReaddirMap);
   let readdirCache = map.get(path);
   if (!readdirCache) {
     readdirCache = [];
@@ -207,7 +207,7 @@ export function readdir(
   return files;
 }
 
-function createReadFileCache(): Map<string, Record<Buffer>> {
+function createReadFileMap(): Map<string, Record<Buffer>> {
   return new Map();
 }
 
@@ -223,7 +223,7 @@ export function readFile(
       },
 ): string | Buffer {
   checkPathInDev(path);
-  const map = unstable_getCacheForType(createReadFileCache);
+  const map = unstable_getCacheForType(createReadFileMap);
   let record = map.get(path);
   if (!record) {
     const thenable = fs.readFile(path);
@@ -264,7 +264,7 @@ export function readFile(
   return text;
 }
 
-function createReadlinkCache(): Map<string, Array<string | Record<mixed>>> {
+function createReadlinkMap(): Map<string, Array<string | Record<mixed>>> {
   return new Map();
 }
 
@@ -281,7 +281,7 @@ export function readlink(
       encoding = options.encoding;
     }
   }
-  const map = unstable_getCacheForType(createReadlinkCache);
+  const map = unstable_getCacheForType(createReadlinkMap);
   let readlinkCache = map.get(path);
   if (!readlinkCache) {
     readlinkCache = [];
@@ -305,7 +305,7 @@ export function readlink(
   return linkString;
 }
 
-function createRealpathCache(): Map<string, Array<string | Record<mixed>>> {
+function createRealpathMap(): Map<string, Array<string | Record<mixed>>> {
   return new Map();
 }
 
@@ -322,7 +322,7 @@ export function realpath(
       encoding = options.encoding;
     }
   }
-  const map = unstable_getCacheForType(createRealpathCache);
+  const map = unstable_getCacheForType(createRealpathMap);
   let realpathCache = map.get(path);
   if (!realpathCache) {
     realpathCache = [];
@@ -346,7 +346,7 @@ export function realpath(
   return resolvedPath;
 }
 
-function createStatCache(): Map<string, Array<boolean | Record<mixed>>> {
+function createStatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
@@ -356,7 +356,7 @@ export function stat(path: string, options?: {bigint?: boolean}): mixed {
   if (options && options.bigint) {
     bigint = true;
   }
-  const map = unstable_getCacheForType(createStatCache);
+  const map = unstable_getCacheForType(createStatMap);
   let statCache = map.get(path);
   if (!statCache) {
     statCache = [];

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -84,6 +84,10 @@ declare module 'fs/promises' {
           encoding?: ?string,
         },
   ) => Promise<Buffer>;
+  declare var stat: (
+    path: string,
+    options?: ?{bigint?: boolean},
+  ) => Promise<mixed>;
 }
 declare module 'pg' {
   declare var Pool: (

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -71,6 +71,7 @@ declare function __webpack_chunk_load__(id: string): Promise<mixed>;
 declare function __webpack_require__(id: string): any;
 
 declare module 'fs/promises' {
+  declare var access: (path: string, mode?: number) => Promise<void>;
   declare var readFile: (
     path: string,
     options?:

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -101,6 +101,14 @@ declare module 'fs/promises' {
           encoding?: ?string,
         },
   ) => Promise<mixed>;
+  declare var realpath: (
+    path: string,
+    options?:
+      | ?string
+      | {
+          encoding?: ?string,
+        },
+  ) => Promise<mixed>;
   declare var stat: (
     path: string,
     options?: ?{bigint?: boolean},

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -93,6 +93,14 @@ declare module 'fs/promises' {
           encoding?: ?string,
         },
   ) => Promise<Buffer>;
+  declare var readlink: (
+    path: string,
+    options?:
+      | ?string
+      | {
+          encoding?: ?string,
+        },
+  ) => Promise<mixed>;
   declare var stat: (
     path: string,
     options?: ?{bigint?: boolean},

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -76,6 +76,15 @@ declare module 'fs/promises' {
     path: string,
     options?: ?{bigint?: boolean},
   ) => Promise<mixed>;
+  declare var readdir: (
+    path: string,
+    options?:
+      | ?string
+      | {
+          encoding?: ?string,
+          withFileTypes?: ?boolean,
+        },
+  ) => Promise<Buffer>;
   declare var readFile: (
     path: string,
     options?:

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -72,6 +72,10 @@ declare function __webpack_require__(id: string): any;
 
 declare module 'fs/promises' {
   declare var access: (path: string, mode?: number) => Promise<void>;
+  declare var lstat: (
+    path: string,
+    options?: ?{bigint?: boolean},
+  ) => Promise<mixed>;
   declare var readFile: (
     path: string,
     options?:

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -10,6 +10,7 @@ const HAS_NO_SIDE_EFFECTS_ON_IMPORT = false;
 // const HAS_SIDE_EFFECTS_ON_IMPORT = true;
 const importSideEffects = Object.freeze({
   fs: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'fs/promises': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   path: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'prop-types/checkPropTypes': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface': HAS_NO_SIDE_EFFECTS_ON_IMPORT,


### PR DESCRIPTION
This adds all read-only methods mirroring [`fs/promises`](https://nodejs.org/dist/latest-v15.x/docs/api/fs.html#fs_fs_promises_api).

The first commit is an optimization that removes the unnecessary `[]` allocation for every entry, since we only need it for `readFile`. Other commits add each individual method one by one.

I've used a flat `[optionA1, optionB1, record1, optionA2, optionB2, record2, ...]` format. Most of these actually have just one option, although `readdir` has two (thus `+= 3` in the loop).

Tested manually.