### PR TITLE
Turn on double effects for www test renderer

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -51,7 +51,7 @@ export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 export const enableDiscreteEventFlushingChange = false;
 
-export const enableDoubleInvokingEffects = false;
+export const enableDoubleInvokingEffects = true;
 export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;


### PR DESCRIPTION
This will enable people to test the new double effects behavior using either `StrictMode` or `createRoot` APIs.