### PR TITLE
Put .server.js at the end of bundle filenames

### DIFF
--- a/packages/react-server-dom-webpack/npm/writer.browser.server.js
+++ b/packages/react-server-dom-webpack/npm/writer.browser.server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-server-dom-webpack-writer.browser.server.production.min.js');
+  module.exports = require('./cjs/react-server-dom-webpack-writer.browser.production.min.server.js');
 } else {
-  module.exports = require('./cjs/react-server-dom-webpack-writer.browser.server.development.js');
+  module.exports = require('./cjs/react-server-dom-webpack-writer.browser.development.server.js');
 }

--- a/packages/react-server-dom-webpack/npm/writer.node.server.js
+++ b/packages/react-server-dom-webpack/npm/writer.node.server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-server-dom-webpack-writer.node.server.production.min.js');
+  module.exports = require('./cjs/react-server-dom-webpack-writer.node.production.min.server.js');
 } else {
-  module.exports = require('./cjs/react-server-dom-webpack-writer.node.server.development.js');
+  module.exports = require('./cjs/react-server-dom-webpack-writer.node.development.server.js');
 }

--- a/packages/react/npm/unstable-index.server.js
+++ b/packages/react/npm/unstable-index.server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-unstable-index.server.production.min.js');
+  module.exports = require('./cjs/react-unstable-index.production.min.server.js');
 } else {
-  module.exports = require('./cjs/react-unstable-index.server.development.js');
+  module.exports = require('./cjs/react-unstable-index.development.server.js');
 }

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -873,12 +873,17 @@ function getOriginalFilename(bundle, bundleType) {
 
 function getFilename(bundle, bundleType) {
   const originalFilename = getOriginalFilename(bundle, bundleType);
+  // Ensure .server.js or .client.js is the final suffix.
+  // This is important for the Server tooling convention.
   if (originalFilename.indexOf('.server.') !== -1) {
-    // Ensure .server.js is the final suffix.
-    // This is important for the Server tooling convention.
     return originalFilename
       .replace('.server.', '.')
       .replace('.js', '.server.js');
+  }
+  if (originalFilename.indexOf('.client.') !== -1) {
+    return originalFilename
+      .replace('.client.', '.')
+      .replace('.js', '.client.js');
   }
   return originalFilename;
 }

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -834,7 +834,7 @@ deepFreeze(bundles);
 deepFreeze(bundleTypes);
 deepFreeze(moduleTypes);
 
-function getFilename(bundle, bundleType) {
+function getOriginalFilename(bundle, bundleType) {
   let name = bundle.entry;
   const globalName = bundle.global;
   // we do this to replace / to -, for react-dom/server
@@ -869,6 +869,18 @@ function getFilename(bundle, bundleType) {
     case RN_OSS_PROFILING:
       return `${globalName}-profiling.js`;
   }
+}
+
+function getFilename(bundle, bundleType) {
+  const originalFilename = getOriginalFilename(bundle, bundleType);
+  if (originalFilename.indexOf('.server.') !== -1) {
+    // Ensure .server.js is the final suffix.
+    // This is important for the Server tooling convention.
+    return originalFilename
+      .replace('.server.', '.')
+      .replace('.js', '.server.js');
+  }
+  return originalFilename;
 }
 
 module.exports = {


### PR DESCRIPTION
This prepares us to enforce the convention even when hidden behind aliases. Which is important so we can prevent server imports from universal files.