### PR TITLE
[Flight] Support concatenated modules in Webpack plugin

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -172,26 +172,31 @@ export default class ReactFlightWebpackPlugin {
       const json = {};
       compilation.chunkGroups.forEach(chunkGroup => {
         const chunkIds = chunkGroup.chunks.map(c => c.id);
+
+        function recordModule(id, mod) {
+          // TODO: Hook into deps instead of the target module.
+          // That way we know by the type of dep whether to include.
+          // It also resolves conflicts when the same module is in multiple chunks.
+          if (!/\.client\.js$/.test(mod.resource)) {
+            return;
+          }
+          const moduleExports = {};
+          ['', '*'].concat(mod.buildMeta.providedExports).forEach(name => {
+            moduleExports[name] = {
+              id: mod.id,
+              chunks: chunkIds,
+              name: name,
+            };
+          });
+          const href = pathToFileURL(mod.resource).href;
+          if (href !== undefined) {
+            json[href] = moduleExports;
+          }
+        }
+
         chunkGroup.chunks.forEach(chunk => {
           chunk.getModules().forEach(mod => {
-            // TODO: Hook into deps instead of the target module.
-            // That way we know by the type of dep whether to include.
-            // It also resolves conflicts when the same module is in multiple chunks.
-            if (!/\.client\.js$/.test(mod.resource)) {
-              return;
-            }
-            const moduleExports = {};
-            ['', '*'].concat(mod.buildMeta.providedExports).forEach(name => {
-              moduleExports[name] = {
-                id: mod.id,
-                chunks: chunkIds,
-                name: name,
-              };
-            });
-            const href = pathToFileURL(mod.resource).href;
-            if (href !== undefined) {
-              json[href] = moduleExports;
-            }
+            recordModule(mod.id, mod);
           });
         });
       });

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -183,7 +183,7 @@ export default class ReactFlightWebpackPlugin {
           const moduleExports = {};
           ['', '*'].concat(mod.buildMeta.providedExports).forEach(name => {
             moduleExports[name] = {
-              id: mod.id,
+              id: id,
               chunks: chunkIds,
               name: name,
             };
@@ -197,6 +197,12 @@ export default class ReactFlightWebpackPlugin {
         chunkGroup.chunks.forEach(chunk => {
           chunk.getModules().forEach(mod => {
             recordModule(mod.id, mod);
+            // If this is a concatenation, register each child to the parent ID.
+            if (mod.modules) {
+              mod.modules.forEach(concatenatedMod => {
+                recordModule(mod.id, concatenatedMod);
+              });
+            }
           });
         });
       });


### PR DESCRIPTION
In production mode, webpack can emit concatenated modules. A concatenated module won't have the right `.resource` so we will mistakingly skip it, causing a Client reference to be missing in the manifest. Instead, we should look into its inner `.modules`, and register each logical child with the physical parent ID. Verified this fixes a production build.