### PR TITLE
Add useRefresh hook to react-debug-tools

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -73,6 +73,10 @@ function getPrimitiveStackCache(): Map<string, Array<any>> {
       Dispatcher.useState(null);
       Dispatcher.useReducer((s, a) => s, null);
       Dispatcher.useRef(null);
+      if (typeof Dispatcher.useCacheRefresh === 'function') {
+        // This type check is for Flow only.
+        Dispatcher.useCacheRefresh();
+      }
       Dispatcher.useLayoutEffect(() => {});
       Dispatcher.useEffect(() => {});
       Dispatcher.useImperativeHandle(undefined, () => null);
@@ -169,6 +173,16 @@ function useRef<T>(initialValue: T): {|current: T|} {
     value: ref.current,
   });
   return ref;
+}
+
+function useCacheRefresh(): () => void {
+  const hook = nextHook();
+  hookLog.push({
+    primitive: 'CacheRefresh',
+    stackError: new Error(),
+    value: hook !== null ? hook.memoizedState : function refresh() {},
+  });
+  return () => {};
 }
 
 function useLayoutEffect(
@@ -305,6 +319,7 @@ function useOpaqueIdentifier(): OpaqueIDType | void {
 const Dispatcher: DispatcherType = {
   getCacheForType,
   readContext,
+  useCacheRefresh,
   useCallback,
   useContext,
   useEffect,


### PR DESCRIPTION
This prevents DevTools from throwing an error when inspecting a component that uses the new refresh hook.

~~Stacks with PR #20456~~

### Before
When inspecting a component that uses the new refresh hook:
![Screen Shot 2021-01-04 at 9 14 11 AM](https://user-images.githubusercontent.com/29597/103543891-3efb7200-4e6d-11eb-806e-121f16219136.png)

### After
When inspecting a component that uses the new refresh hook:
![Screen Shot 2021-01-04 at 9 29 18 AM](https://user-images.githubusercontent.com/29597/103545356-6fdca680-4e6f-11eb-924b-6375213b8b00.png)

### Caveat

Given the code patterns below:
```js
// Pattern 1
const refresh = React.unstable_useRefresh();

// Pattern 2
import { unstable_useRefresh } from "react";
const refresh = unstable_useRefresh();

// Pattern 3
import { unstable_useRefresh as useRefresh } from "react";
const refresh = useRefresh();
```

Because of how we parse stacks, pattern 1 above displays like this:
![Screen Shot 2020-12-14 at 1 10 59 PM](https://user-images.githubusercontent.com/29597/102118678-09cfa700-3e0e-11eb-855d-952cab628736.png)

Patterns 2 and 3 display like this:
![Screen Shot 2020-12-14 at 1 10 45 PM](https://user-images.githubusercontent.com/29597/102118675-09371080-3e0e-11eb-8a19-b941e0b38e80.png)

This is not specific to the refresh hook so I didn't do anything about it in this PR. I could send a separate PR to address pattern 1 if we think it's worth the effort.