### PR TITLE
devtools: Display shortcuts for prev/next search result

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Button.js
@@ -16,14 +16,14 @@ import tooltipStyles from './Tooltip.css';
 type Props = {
   children: React$Node,
   className?: string,
-  title?: string,
+  title: React$Node,
   ...
 };
 
 export default function Button({
   children,
   className = '',
-  title = '',
+  title,
   ...rest
 }: Props) {
   let button = (

--- a/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
@@ -34,25 +34,6 @@ export default function SearchInput(props: Props) {
     [dispatch],
   );
 
-  const handleKeyDown = useCallback(
-    event => {
-      // For convenience, let up/down arrow keys change Tree selection.
-      switch (event.key) {
-        case 'ArrowDown':
-          dispatch({type: 'SELECT_NEXT_ELEMENT_IN_TREE'});
-          event.preventDefault();
-          break;
-        case 'ArrowUp':
-          dispatch({type: 'SELECT_PREVIOUS_ELEMENT_IN_TREE'});
-          event.preventDefault();
-          break;
-        default:
-          break;
-      }
-    },
-    [dispatch],
-  );
-
   const handleInputKeyPress = useCallback(
     ({key, shiftKey}) => {
       if (key === 'Enter') {
@@ -98,7 +79,6 @@ export default function SearchInput(props: Props) {
       <input
         className={styles.Input}
         onChange={handleTextChange}
-        onKeyDown={handleKeyDown}
         onKeyPress={handleInputKeyPress}
         placeholder="Search (text or /regex/)"
         ref={inputRef}

--- a/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SearchInput.js
@@ -95,14 +95,23 @@ export default function SearchInput(props: Props) {
         className={styles.IconButton}
         disabled={!searchText}
         onClick={() => dispatch({type: 'GO_TO_PREVIOUS_SEARCH_RESULT'})}
-        title="Scroll to previous search result">
+        title={
+          <React.Fragment>
+            Scroll to previous search result (<kbd>Shift</kbd> +{' '}
+            <kbd>Enter</kbd>)
+          </React.Fragment>
+        }>
         <ButtonIcon type="up" />
       </Button>
       <Button
         className={styles.IconButton}
         disabled={!searchText}
         onClick={() => dispatch({type: 'GO_TO_NEXT_SEARCH_RESULT'})}
-        title="Scroll to next search result">
+        title={
+          <React.Fragment>
+            Scroll to next search result (<kbd>Enter</kbd>)
+          </React.Fragment>
+        }>
         <ButtonIcon type="down" />
       </Button>
       <Button


### PR DESCRIPTION
## Summary

Helps discover keyboard shortcuts (I didn't know this particular one existed).

![devtools-searchinput-kbd](https://user-images.githubusercontent.com/12292047/102255393-55677b00-3f0a-11eb-8aa1-9d1d87008770.gif)


While I was looking at SearchInput I recognized that the prev/next element shortcut logic is duplicated. It's already handled in https://github.com/facebook/react/blob/98dba66ee1e5fcf3b88a0fe0331c8d84e9ddfbed/packages%2Freact-devtools-shared%2Fsrc%2Fdevtools%2Fviews%2FComponents%2FTree.js#L182

## Test Plan

- verified visuals in shell app
- checked manually that arrow key navigation still works in shell app