### PR TITLE
#20205 Add `safeHooks` option to exhaustive-deps rule

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -66,6 +66,21 @@ This option accepts a regex to match the names of custom Hooks that have depende
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
 
+You can also mark certain hooks as "safe" if you know that they always return stable values. For example, if you have a hook called `useRefWrapper` that returns the ref from `useRef`, that will be stable so you can mark it as safe.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "safeHooks": "(useRefWrapper|useOtherRefWrapper)"
+    }]
+  }
+}
+```
+
+**Warning:** This can be very dangerous! If you use this on hooks that don't return stable values, then you'll be invalidating this rule and could create some nasty bugs. It's recommended you only use this for hooks that wrap stable React hooks.
+
 ## Valid and Invalid Examples
 
 Please refer to the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) documentation and the [Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#what-exactly-do-the-lint-rules-enforce) to learn more about this rule.

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -544,6 +544,19 @@ const tests = {
     {
       code: normalizeIndent`
         function MyComponent(props) {
+          const ref = useRefWrapper();
+          const ref2 = useRefWrapper2();
+          useEffect(() => {
+            console.log(ref.current);
+            console.log(ref2.current);
+          }, []);
+        }
+      `,
+      options: [{safeHooks: 'useRefWrapper2?'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
           return renderHelperConfusedWithEffect(() => {
             console.log(props.foo);
           }, []);
@@ -4571,6 +4584,23 @@ const tests = {
           `and use that variable in the cleanup function.`,
       ],
       options: [{additionalHooks: 'useLayoutEffect_SAFE_FOR_SSR'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          const ref = useRefWrapper();
+          const ref2 = useRefWrapper2();
+          useEffect(() => {
+            console.log(ref.current);
+            console.log(ref2.current);
+          }, []);
+        }
+      `,
+      options: [{safeHooks: '^useRefWrapper$'}],
+      errors: [
+        `React Hook useEffect has a missing dependency: 'ref2'.` +
+          ` Either include it or remove the dependency array.`,
+      ],
     },
     {
       // Autofix ignores constant primitives (leaving the ones that are there).

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -9,6 +9,23 @@
 
 'use strict';
 
+/**
+ * Check if the given hook is "safe", meaning we assume its return value is
+ * stable and therefore doesn't need to appear in dependency arrays. This
+ * automatically applies to useRef, but can be extended to apply to other hooks
+ * as well with a regex.
+ * @param {object} id Identifier AST node
+ * @param {string} name Identifier name
+ * @param {RegExp} safeHooks Optional regex that defines which extra hooks have
+ *  been declared safe via the user's config
+ */
+function isHookSafe(id, name, safeHooks) {
+  return (
+    id.type === 'Identifier' &&
+    (name === 'useRef' || (safeHooks && safeHooks.test(name)))
+  );
+}
+
 export default {
   meta: {
     type: 'suggestion',
@@ -224,12 +241,7 @@ export default {
         }
         const id = def.node.id;
         const {name} = callee;
-        // Check if the hook is named `useRef` or one of the other hooks that's
-        // been deemed "safe"
-        if (
-          id.type === 'Identifier' &&
-          (name === 'useRef' || (safeHooks && safeHooks.test(name)))
-        ) {
+        if (isHookSafe(id, name, safeHooks)) {
           // Assume the return value is stable
           return true;
         } else if (name === 'useState' || name === 'useReducer') {


### PR DESCRIPTION
## Summary

In some cases we have hooks that wrap stable hooks, e.g. something like `useRefWrapper`:

```js
const useRefWrapper = () => {
  const ref = useRef();
  if (ref.current) {
    console.log('hi!');
  }
  return ref;
}
```

This PR adds an option to ignore hooks like that, so you don't need to fill your dependency arrays with unnecessary items. Obviously this is potentially dangerous if people use it incorrectly, so I tried to include a sufficient warning in the docs.

## Test Plan

Added two unit tests, one for the positive test case and one for the negative. I also tested this manually by running the rule with the configuration against one of my code bases. When enabled in the config, it ignored the hook from dependency lists. I couldn't think of any other test cases since the logic is simple enough, let me know if anything is missing though.