### PR TITLE
Add option to ignore stable hooks from eslint-exhaustive-deps rule

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1445,7 +1445,7 @@ const tests = {
           }, []);
         }
       `,
-      options: [{ stableHooksPattern: 'useCustomStableHook' }],
+      options: [{stableHooksPattern: 'useCustomStableHook'}],
     },
     {
       code: normalizeIndent`
@@ -1456,7 +1456,7 @@ const tests = {
           }, []);
         }
       `,
-      options: [{ stableHooksPattern: 'use(.*)Ref' }],
+      options: [{stableHooksPattern: 'use(.*)Ref'}],
     },
   ],
   invalid: [
@@ -7534,11 +7534,11 @@ const tests = {
           }, []);
         }
       `,
-      options: [{ stableHooksPattern: 'useSomething' }],
+      options: [{stableHooksPattern: 'useSomething'}],
       errors: [
         {
           message:
-            "React Hook useCallback has a missing dependency: 'otherSomething'. " +
+            "React Hook useEffect has a missing dependency: 'otherSomething'. " +
             'Either include it or remove the dependency array.',
           suggestions: [
             {
@@ -7568,7 +7568,7 @@ const tests = {
           return <div ref={customRef} />;
         }
       `,
-      options: [{ stableHooksPattern: 'useCustomRef' }],
+      options: [{stableHooksPattern: 'useCustomRef'}],
       errors: [
         {
           message:

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -32,6 +32,9 @@ export default {
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
+          stableHooksPattern: {
+            type: 'string',
+          },
         },
       },
     ],
@@ -51,9 +54,17 @@ export default {
         context.options[0].enableDangerousAutofixThisMayCauseInfiniteLoops) ||
       false;
 
+    const stableHooksPattern =
+      context.options &&
+      context.options[0] &&
+      context.options[0].stableHooksPattern
+        ? new RegExp(context.options[0].stableHooksPattern)
+        : undefined;
+
     const options = {
       additionalHooks,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
+      stableHooksPattern,
     };
 
     function reportProblem(problem) {
@@ -218,7 +229,12 @@ export default {
         }
         const id = def.node.id;
         const {name} = callee;
-        if (name === 'useRef' && id.type === 'Identifier') {
+        if (
+          options.stableHooksPattern &&
+          options.stableHooksPattern.test(name)
+        ) {
+          return true;
+        } else if (name === 'useRef' && id.type === 'Identifier') {
           // useRef() return value is stable.
           return true;
         } else if (name === 'useState' || name === 'useReducer') {


### PR DESCRIPTION
## Summary

I find myself using a bunch of custom `ref`-esque dependencies inside of `useEffect`. I'd like to ignore them from exhaustive deps errors just like the rule currently ignores `useRef`. My `useEffect` deps are usually decorated with `eslint-ignore`s due to this, and non of my deps are linted anymore, including ones that are not coming from stable hooks.

It would be nice to be able to ignore some of these globally, per file, or on a line basis. One way to go about it is to either add a pattern for stable hooks.

Example:
```js
/*eslint react-hooks/exhaustive-deps: ["error", { stableHooksPattern: "use(.*)Ref" }]*/

function MyComponent(props) {
  const myCustomRef = useMyCustomRef();
  const isMounted  = useIsMounted();

  useEffect(() => {
    console.log(myCustomRef.current);
    console.log(isMounted.current);
  }, []);
}
```

resolves #16873 

## Test Plan

I wrote a couple of tests for valid and invalid cases.