### PR TITLE
add ignoreThisDependency option to exhaustive-deps

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -49,7 +49,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 
 ## Advanced Configuration
-
+### additionalHooks
 `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
 
@@ -65,6 +65,27 @@ This option accepts a regex to match the names of custom Hooks that have depende
 ```
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
+
+### ignoreThisDependency
+You may find `exhaustive-deps` requires entire `props` if you use something like `props.doSomething()` in hooks.
+This is intended behavior because `props` is referred as `this` by `doSomething`.
+You can resolve it by destructuring as `exhaustive-deps` suggests.
+
+However, in some cases, you may want to avoid destructuring because of your coding style or conflict with `no-shadow`.
+In the case, `ignoreThisDependency` may help.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "ignoreThisDependency": "props"
+    }]
+  }
+}
+```
+
+Valid options are `never` (default behavior), `props`, `always`.
 
 ## Valid and Invalid Examples
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1436,6 +1436,31 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => props.someEffect(), [props.someEffect]);
+        }
+      `,
+      options: [{ignoreThisDependency: 'always'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          const foo = {bar: () => null}
+          useEffect(() => foo.bar(), [foo.bar]);
+        }
+      `,
+      options: [{ignoreThisDependency: 'always'}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => props.someEffect(), [props.someEffect]);
+        }
+      `,
+      options: [{ignoreThisDependency: 'props'}],
+    },
   ],
   invalid: [
     {
@@ -7566,6 +7591,33 @@ const tests = {
             "The 'foo' object makes the dependencies of useEffect Hook (at line 9) change on every render. " +
             "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
           suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          const foo = {bar: () => null}
+          useEffect(() => foo.bar(), [foo.bar]);
+        }
+      `,
+      options: [{ignoreThisDependency: 'props'}],
+      errors: [
+        {
+          message:
+            "React Hook useEffect has a missing dependency: 'foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [foo, foo.bar]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  const foo = {bar: () => null}
+                  useEffect(() => foo.bar(), [foo, foo.bar]);
+                }
+              `,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I added `ignoreThisDependency` option to the ESLint rule `exhaustive-deps`.
It's like my suggestion in https://github.com/facebook/react/issues/16265#issuecomment-685723348 .

This helps people who doesn't prefer destructuring.
You can find such people at #16265 .

In my case, our project uses React Redux `connect` like below.
```js
import { doSomething } from 'foobar';

const mapDispatchToProps = { doSomething };

// ...

export default connect(null, mapDispatchToProps)(MyComponent)
```
Destructuring `props` conflicts with `eslint no-shadow`.
And I don't want to establish naming convention for auxiliary variables to pass the linter.

## Test Plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Run tests (I added some new valid cases and a invalid case)
- Installed in my local projects

<details><summary>Screen shots</summary>

ignoreThisDependency = 'never'
<img width="435" alt="Screen Shot 2020-12-30 at 16 15 56" src="https://user-images.githubusercontent.com/20365512/103336064-4f50cd00-4aba-11eb-898f-07d535369d89.png">


ignoreThisDependency = 'props'
<img width="463" alt="Screen Shot 2020-12-30 at 16 16 20" src="https://user-images.githubusercontent.com/20365512/103336083-5d9ee900-4aba-11eb-948e-e35a8eae9dc7.png">

</details>