### PR TITLE
Make fast-refresh compatible with ReScript

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -692,11 +692,21 @@ export function isLikelyComponentType(type: any): boolean {
           // This looks like a regular function with empty prototype.
         }
         // For plain functions and arrows, use name as a heuristic.
+        //
+        // - For JavaScript the name has to start with a capital letter when the
+        //   function is used in JSX
+        // - For ReScript, React-components can be named `$$default` for the
+        //   default export and they can be named `make`, or `make$` + a number
         const name = type.name || type.displayName;
-        return typeof name === 'string' && /^[A-Z]/.test(name);
+        return (
+          typeof name === 'string' &&
+          (/^[A-Z]/.test(name) || /^make/.test(name) || name === '$$default')
+        );
       }
       case 'object': {
         if (type != null) {
+          // `in` doesn't trigger proxy getters
+          if ('make' in type) return true;
           switch (getProperty(type, '$$typeof')) {
             case REACT_FORWARD_REF_TYPE:
             case REACT_MEMO_TYPE:

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -3661,6 +3661,16 @@ describe('ReactFresh', () => {
       class Point extends Figure {}
       expect(ReactFreshRuntime.isLikelyComponentType(Point)).toBe(false);
 
+      expect(ReactFreshRuntime.isLikelyComponentType(function make() {})).toBe(
+        true,
+      );
+      expect(
+        ReactFreshRuntime.isLikelyComponentType(function $$default() {}),
+      ).toBe(true);
+      expect(
+        ReactFreshRuntime.isLikelyComponentType({make: function make() {}}),
+      ).toBe(true);
+
       // Run the same tests without Babel.
       // This tests real arrow functions and classes, as implemented in Node.
 

--- a/packages/react-refresh/src/__tests__/ReactFresh-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFresh-test.js
@@ -3667,6 +3667,12 @@ describe('ReactFresh', () => {
       expect(
         ReactFreshRuntime.isLikelyComponentType(function $$default() {}),
       ).toBe(true);
+      expect(ReactFreshRuntime.isLikelyComponentType(function make() {})).toBe(
+        true,
+      );
+      expect(
+        ReactFreshRuntime.isLikelyComponentType(function make$1() {}),
+      ).toBe(true);
       expect(
         ReactFreshRuntime.isLikelyComponentType({make: function make() {}}),
       ).toBe(true);
@@ -3719,6 +3725,18 @@ describe('ReactFresh', () => {
         expect(ReactFreshRuntime.isLikelyComponentType(Figure)).toBe(false);
         class Point extends Figure {}
         expect(ReactFreshRuntime.isLikelyComponentType(Point)).toBe(false);
+        expect(
+          ReactFreshRuntime.isLikelyComponentType(function $$default() {}),
+        ).toBe(true);
+        expect(ReactFreshRuntime.isLikelyComponentType(function make() {})).toBe(
+          true,
+        );
+        expect(
+          ReactFreshRuntime.isLikelyComponentType(function make$1() {}),
+        ).toBe(true);
+        expect(
+          ReactFreshRuntime.isLikelyComponentType({make: function make() {}}),
+        ).toBe(true);
       `,
       )(global, React, ReactFreshRuntime, expect, createReactClass);
     }


### PR DESCRIPTION
## Summary

ReScript doesn't always generate capitalized React components. This breaks `fast-refresh`. There are a few things that can happen:

- ReScript generates a default export function named `$$default` when the react component is a default export.
- ReScript generates a function named `make` or `make$1` (or a higher number after the `$`).
- Subcomponents in a file are exported as an object with a `make` function (this is the actual component).

## Test Plan

Added tests for these scenarios, testing the behavior of `ReactFreshRuntime.isLikelyComponentType` in `ReactFresh-test.js`