### PR TITLE
Add test for useEffect warning when destroy is not a function

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -729,7 +729,7 @@ describe('ReactHooks', () => {
     ReactTestRenderer.create(<App deps={undefined} />);
   });
 
-  it('assumes useEffect clean-up function is either a function or undefined', () => {
+  it('assumes useLayoutEffect clean-up function is either a function or undefined', () => {
     const {useLayoutEffect} = React;
 
     function App(props) {
@@ -763,6 +763,45 @@ describe('ReactHooks', () => {
     expect(() => {
       root3.update(null);
     }).toThrow('is not a function');
+  });
+
+  it('assumes useEffect clean-up function is either a function or undefined', () => {
+    const {useEffect} = React;
+
+    function App(props) {
+      useEffect(() => {
+        return props.return;
+      });
+      return null;
+    }
+
+    const root1 = ReactTestRenderer.create(null);
+    expect(() => act(() => root1.update(<App return={17} />))).toErrorDev([
+      'Warning: An effect function must not return anything besides a ' +
+        'function, which is used for clean-up. You returned: 17',
+    ]);
+
+    const root2 = ReactTestRenderer.create(null);
+    expect(() => act(() => root2.update(<App return={null} />))).toErrorDev([
+      'Warning: An effect function must not return anything besides a ' +
+        'function, which is used for clean-up. You returned null. If your ' +
+        'effect does not require clean up, return undefined (or nothing).',
+    ]);
+
+    const root3 = ReactTestRenderer.create(null);
+    expect(() =>
+      act(() => root3.update(<App return={Promise.resolve()} />)),
+    ).toErrorDev([
+      'Warning: An effect function must not return anything besides a ' +
+        'function, which is used for clean-up.\n\n' +
+        'It looks like you wrote useEffect(async () => ...) or returned a Promise.',
+    ]);
+
+    // TODO: we're not checking that the passive destroy function
+    // is a function like we do for layout effects in the test above.
+    expect(() => act(() => root3.update(null))).toErrorDev(
+      'func.apply is not a function',
+    );
   });
 
   it('does not forget render phase useState updates inside an effect', () => {


### PR DESCRIPTION
## Overview

We have this test for layout effects but not passive effects.

Found this because it used to be broken and we've _fixed_ this in the new fork, which causes some internal tests to fail. With this test, we would have caught whatever regression broke it (if it was ever working).