### PR TITLE
Retry with fresh otp if publish fails

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -48,8 +48,22 @@ const run = async () => {
     await confirmVersionAndTags(params);
     await validateSkipPackages(params);
     await checkNPMPermissions(params);
-    const otp = await promptForOTP(params);
-    await publishToNPM(params, otp);
+
+    while (true) {
+      try {
+        const otp = await promptForOTP(params);
+        await publishToNPM(params, otp);
+        break;
+      } catch (error) {
+        console.error(error.message);
+        console.log();
+        console.log(
+          theme.error`Publish failed. Enter a fresh otp code to retry.`
+        );
+        continue;
+      }
+    }
+
     await updateStableVersionNumbers(params);
     await printFollowUpInstructions(params);
   } catch (error) {


### PR DESCRIPTION
Currently, if publishing a package fails, the script crashes, and the user must start it again from the beginning. Usually this happens because the one-time password has timed out.

With this change, the user will be prompted for a fresh otp, and the script will resume publishing.
