### PR TITLE
Convert ReactSuspenseWithNoopRenderer tests to use built-in cache

### DIFF
--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -84,6 +84,11 @@ function getTestFlags() {
 
       ...featureFlags,
       ...environmentFlags,
+
+      // FIXME: www-classic has enableCache on, but when running the source
+      // tests, Jest doesn't expose the API correctly. Fix then remove
+      // this override.
+      enableCache: __EXPERIMENTAL__,
     },
     {
       get(flags, flagName) {


### PR DESCRIPTION
We should start using the built-in cache in our tests, so that they are as "idiomatic" as possible. Not a huge deal, just going to start gradually migrating them over. Started with this file because it has the bulk of the important Suspense tests.