### PR TITLE
Fix prod build in ci/codesandbox

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/server,react-dom/test-utils,scheduler/index,scheduler/tracing",
+  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/server,react-dom/test-utils,scheduler/index,scheduler/unstable_no_dom,scheduler/tracing",
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom",


### PR DESCRIPTION
## Summary

Currently deploying a prod build from a codesandbox using a PR fails due to `scheduler/unstable_no_dom` not being built in codesandbox/ci.

codesandbox using https://github.com/facebook/react/pull/20604: https://codesandbox.io/s/react-forked-grtg9?file=/src/App.js
build failure: https://vercel.com/eps1lon/csb-grtg9/r7r8rfpwn

## Test Plan

- [x] Deploy codesandbox from this PR
	Codesandbox: https://codesandbox.io/s/react-forked-0g32x
  Deploy: https://vercel.com/eps1lon/csb-0g32x/6akmbpj6x