### PR TITLE
Store interleaved updates on separate queue until end of render

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -213,7 +213,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update);
+    enqueueUpdate(fiber, update, lane);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
 
     if (__DEV__) {
@@ -245,7 +245,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update);
+    enqueueUpdate(fiber, update, lane);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
 
     if (__DEV__) {
@@ -276,7 +276,7 @@ const classComponentUpdater = {
       update.callback = callback;
     }
 
-    enqueueUpdate(fiber, update);
+    enqueueUpdate(fiber, update, lane);
     scheduleUpdateOnFiber(fiber, lane, eventTime);
 
     if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberInterleavedUpdates.new.js
+++ b/packages/react-reconciler/src/ReactFiberInterleavedUpdates.new.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {UpdateQueue as HookQueue} from './ReactFiberHooks.new';
+import type {SharedQueue as ClassQueue} from './ReactUpdateQueue.new';
+
+// An array of all update queues that received updates during the current
+// render. When this render exits, either because it finishes or because it is
+// interrupted, the interleaved updates will be transfered onto the main part
+// of the queue.
+let interleavedQueues: Array<
+  HookQueue<any, any> | ClassQueue<any>,
+> | null = null;
+
+export function pushInterleavedQueue(
+  queue: HookQueue<any, any> | ClassQueue<any>,
+) {
+  if (interleavedQueues === null) {
+    interleavedQueues = [queue];
+  } else {
+    interleavedQueues.push(queue);
+  }
+}
+
+export function enqueueInterleavedUpdates() {
+  // Transfer the interleaved updates onto the main queue. Each queue has a
+  // `pending` field and an `interleaved` field. When they are not null, they
+  // point to the last node in a circular linked list. We need to append the
+  // interleaved list to the end of the pending list by joining them into a
+  // single, circular list.
+  if (interleavedQueues !== null) {
+    for (let i = 0; i < interleavedQueues.length; i++) {
+      const queue = interleavedQueues[i];
+      const lastInterleavedUpdate = queue.interleaved;
+      if (lastInterleavedUpdate !== null) {
+        queue.interleaved = null;
+        const firstInterleavedUpdate = lastInterleavedUpdate.next;
+        const lastPendingUpdate = queue.pending;
+        if (lastPendingUpdate !== null) {
+          const firstPendingUpdate = lastPendingUpdate.next;
+          lastPendingUpdate.next = (firstInterleavedUpdate: any);
+          lastInterleavedUpdate.next = (firstPendingUpdate: any);
+        }
+        queue.pending = (lastInterleavedUpdate: any);
+      }
+    }
+    interleavedQueues = null;
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -314,7 +314,7 @@ export function updateContainer(
     update.callback = callback;
   }
 
-  enqueueUpdate(current, update);
+  enqueueUpdate(current, update, lane);
   scheduleUpdateOnFiber(current, lane, eventTime);
 
   return lane;

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -293,7 +293,7 @@ function throwException(
               // prevent a bail out.
               const update = createUpdate(NoTimestamp, SyncLane);
               update.tag = ForceUpdate;
-              enqueueUpdate(sourceFiber, update);
+              enqueueUpdate(sourceFiber, update, SyncLane);
             }
           }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -204,6 +204,7 @@ import {
   pop as popFromStack,
   createCursor,
 } from './ReactFiberStack.new';
+import {enqueueInterleavedUpdates} from './ReactFiberInterleavedUpdates.new';
 
 import {
   markNestedUpdateScheduled,
@@ -534,6 +535,7 @@ export function scheduleUpdateOnFiber(
     }
   }
 
+  // TODO: Consolidate with `isInterleavedUpdate` check
   if (root === workInProgressRoot) {
     // Received an update to a tree that's in the middle of rendering. Mark
     // that there was an interleaved update work on this root. Unless the
@@ -669,6 +671,22 @@ function markUpdateLaneFromFiberToRoot(
   } else {
     return null;
   }
+}
+
+export function isInterleavedUpdate(fiber: Fiber, lane: Lane) {
+  return (
+    // TODO: Optimize slightly by comparing to root that fiber belongs to.
+    // Requires some refactoring. Not a big deal though since it's rare for
+    // concurrent apps to have more than a single root.
+    workInProgressRoot !== null &&
+    (fiber.mode & BlockingMode) !== NoMode &&
+    // If this is a render phase update (i.e. UNSAFE_componentWillReceiveProps),
+    // then don't treat this as an interleaved update. This pattern is
+    // accompanied by a warning but we haven't fully deprecated it yet. We can
+    // remove once the deferRenderPhaseUpdateToNextBatch flag is enabled.
+    (deferRenderPhaseUpdateToNextBatch ||
+      (executionContext & RenderContext) === NoContext)
+  );
 }
 
 // Use this function to schedule a task for a root. There's only one task per
@@ -1351,6 +1369,8 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes) {
   workInProgressRootSkippedLanes = NoLanes;
   workInProgressRootUpdatedLanes = NoLanes;
   workInProgressRootPingedLanes = NoLanes;
+
+  enqueueInterleavedUpdates();
 
   if (enableSchedulerTracing) {
     spawnedWorkDuringRender = null;
@@ -2282,7 +2302,7 @@ function captureCommitPhaseErrorOnRoot(
 ) {
   const errorInfo = createCapturedValue(error, sourceFiber);
   const update = createRootErrorUpdate(rootFiber, errorInfo, (SyncLane: Lane));
-  enqueueUpdate(rootFiber, update);
+  enqueueUpdate(rootFiber, update, (SyncLane: Lane));
   const eventTime = requestEventTime();
   const root = markUpdateLaneFromFiberToRoot(rootFiber, (SyncLane: Lane));
   if (root !== null) {
@@ -2319,7 +2339,7 @@ export function captureCommitPhaseError(sourceFiber: Fiber, error: mixed) {
           errorInfo,
           (SyncLane: Lane),
         );
-        enqueueUpdate(fiber, update);
+        enqueueUpdate(fiber, update, (SyncLane: Lane));
         const eventTime = requestEventTime();
         const root = markUpdateLaneFromFiberToRoot(fiber, (SyncLane: Lane));
         if (root !== null) {

--- a/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactInterleavedUpdates-test.js
@@ -1,0 +1,129 @@
+let React;
+let ReactNoop;
+let Scheduler;
+let startTransition;
+let useState;
+let useEffect;
+
+describe('ReactInterleavedUpdates', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    Scheduler = require('scheduler');
+    startTransition = React.unstable_startTransition;
+    useState = React.useState;
+    useEffect = React.useEffect;
+  });
+
+  function Text({text}) {
+    Scheduler.unstable_yieldValue(text);
+    return text;
+  }
+
+  test('update during an interleaved event is not processed during the current render', async () => {
+    const updaters = [];
+
+    function Child() {
+      const [state, setState] = useState(0);
+      useEffect(() => {
+        updaters.push(setState);
+      }, []);
+      return <Text text={state} />;
+    }
+
+    function updateChildren(value) {
+      for (let i = 0; i < updaters.length; i++) {
+        const setState = updaters[i];
+        setState(value);
+      }
+    }
+
+    const root = ReactNoop.createRoot();
+
+    await ReactNoop.act(async () => {
+      root.render(
+        <>
+          <Child />
+          <Child />
+          <Child />
+        </>,
+      );
+    });
+    expect(Scheduler).toHaveYielded([0, 0, 0]);
+    expect(root).toMatchRenderedOutput('000');
+
+    await ReactNoop.act(async () => {
+      updateChildren(1);
+      // Partially render the children. Only the first one.
+      expect(Scheduler).toFlushAndYieldThrough([1]);
+
+      // In an interleaved event, schedule an update on each of the children.
+      // Including the two that haven't rendered yet.
+      updateChildren(2);
+
+      // We should continue rendering without including the interleaved updates.
+      expect(Scheduler).toFlushUntilNextPaint([1, 1]);
+      expect(root).toMatchRenderedOutput('111');
+    });
+    // The interleaved updates flush in a separate render.
+    expect(Scheduler).toHaveYielded([2, 2, 2]);
+    expect(root).toMatchRenderedOutput('222');
+  });
+
+  // @gate experimental
+  test('low priority update during an interleaved event is not processed during the current render', async () => {
+    // Same as previous test, but the interleaved update is lower priority than
+    // the in-progress render.
+    const updaters = [];
+
+    function Child() {
+      const [state, setState] = useState(0);
+      useEffect(() => {
+        updaters.push(setState);
+      }, []);
+      return <Text text={state} />;
+    }
+
+    function updateChildren(value) {
+      for (let i = 0; i < updaters.length; i++) {
+        const setState = updaters[i];
+        setState(value);
+      }
+    }
+
+    const root = ReactNoop.createRoot();
+
+    await ReactNoop.act(async () => {
+      root.render(
+        <>
+          <Child />
+          <Child />
+          <Child />
+        </>,
+      );
+    });
+    expect(Scheduler).toHaveYielded([0, 0, 0]);
+    expect(root).toMatchRenderedOutput('000');
+
+    await ReactNoop.act(async () => {
+      updateChildren(1);
+      // Partially render the children. Only the first one.
+      expect(Scheduler).toFlushAndYieldThrough([1]);
+
+      // In an interleaved event, schedule an update on each of the children.
+      // Including the two that haven't rendered yet.
+      startTransition(() => {
+        updateChildren(2);
+      });
+
+      // We should continue rendering without including the interleaved updates.
+      expect(Scheduler).toFlushUntilNextPaint([1, 1]);
+      expect(root).toMatchRenderedOutput('111');
+    });
+    // The interleaved updates flush in a separate render.
+    expect(Scheduler).toHaveYielded([2, 2, 2]);
+    expect(root).toMatchRenderedOutput('222');
+  });
+});


### PR DESCRIPTION
## Motivation

An *interleaved* update is one that is scheduled while a render is already in progress, typically from a concurrent user input event.

We have to take care not to process these updates during the current render, because a multiple interleaved updates may have been scheduled across many components; to avoid tearing, we cannot render some of those updates without rendering all of them.

## Old approach

What we currently do when we detect an interleaved update is assign a lane that is not part of the current render.

This has some unfortunate drawbacks. For example, we will eventually run out of lanes at a given priority level. When this happens, our last resort is to interrupt the current render and start over from scratch. If this happens enough, it can lead to starvation.

More concerning, there are a surprising number of places that must separately account for this case, often in subtle ways. The maintenance complexity has led to a number of tearing bugs.

## New approach

I added a new field to the update queue, `interleaved`. It's a linked list, just like the `pending` field. When an interleaved update is scheduled, we add it to the `interleaved` list instead of `pending`.

Then we push the entire queue object onto a global array. When the current render exits, we iterate through the array of interleaved queues and transfer the `interleaved` list to the `pending` list.

So, until the current render has exited (whether due to a commit or an interruption), it's impossible to process an interleaved update, because they have not yet been enqueued.

In this new approach, we don't need to resort to clever lanes tricks to avoid inconsistencies. This should allow us to simplify a lot of the logic that's currently in ReactFiberWorkLoop and ReactFiberLane, especially `findUpdateLane` and `getNextLanes`. All the logic for interleaved updates is isolated to one place.

## Rollout plan

This is a moderately risky change, so I'm going to land this only in the new fork.

I'll wait until after the effects refactor has landed.

In this first PR, I've implemented the new queueing behavior, but I haven't yet cleaned up any of the old logic we used to rely on to address the same problem. Cleaning that stuff up is the main motivation for this change, but it introduces additional risk. So I'll follow up with a separate PR, in case there's a bug and we need to bisect.