### PR TITLE
Avoid .valueOf to close #20594

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -222,14 +222,15 @@ function coerceRef(
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
   if (returnFiber.type !== 'textarea') {
+    const childString = Object.prototype.toString.call(newChild);
     invariant(
       false,
       'Objects are not valid as a React child (found: %s). ' +
         'If you meant to render a collection of children, use an array ' +
         'instead.',
-      Object.prototype.toString.call(newChild) === '[object Object]'
+      childString === '[object Object]'
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
-        : newChild,
+        : childString,
     );
   }
 }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -222,14 +222,15 @@ function coerceRef(
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
   if (returnFiber.type !== 'textarea') {
+    const childString = Object.prototype.toString.call(newChild);
     invariant(
       false,
       'Objects are not valid as a React child (found: %s). ' +
         'If you meant to render a collection of children, use an array ' +
         'instead.',
-      Object.prototype.toString.call(newChild) === '[object Object]'
+      childString === '[object Object]'
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
-        : newChild,
+        : childString,
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

close #20594

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`invariant` interpolates the arguments using `+`, which means `.valueOf` is called.
some types throw on `.valueOf` in order to prevent arithmetic operations (questionable, but still...)
this change 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

See #20594 