### PR TITLE
Flow ignore new build2 directory

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/scripts/bench/.*
 .*/build/.*
+.*/build2/.*
 .*/fixtures/.*
 .*/.tempUserDataDir/.*
 


### PR DESCRIPTION
Looks like an oversight from the in-progress build script refactor.