### PR TITLE
Error for deferred value and transition in Server Components

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -773,12 +773,8 @@ const Dispatcher: DispatcherType = {
     return callback;
   },
   useDebugValue(): void {},
-  useDeferredValue<T>(value: T): T {
-    return value;
-  },
-  useTransition(): [(callback: () => void) => void, boolean] {
-    return [() => {}, false];
-  },
+  useDeferredValue: (unsupportedHook: any),
+  useTransition: (unsupportedHook: any),
   getCacheForType<T>(resourceType: () => T): T {
     invariant(
       currentCache,


### PR DESCRIPTION
These are not exported in the server version of React anyway so you can't get to them.

In theory they could work since they can have fake values which might help incremental conversion, but it's not quite semantically equivalent since this request could be part of an update and then deferred value and transition can be expected to be something else. I'm not sure we're ready to commit to these never being stateful.

It's not really different from any state hook. We could always return initial state for a state hook as long as you never call setState it's equivalent. But it's not really helpful to do so because it doesn't provide clarity what a Server Component can and cannot do.