### PR TITLE
Experiment: Unsuspend all lanes on update

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
@@ -733,13 +733,19 @@ describe('ReactExpiration', () => {
       // Both normal pri updates should have expired.
       expect(Scheduler).toFlushExpired([
         'Sibling',
-        // Note: we also flushed the high pri update here, because in the
-        // current implementation, once we pick the next lanes to work on, we
-        // entangle it with all pending at equal or higher priority. We could
-        // feasibly change this heuristic so that the high pri update doesn't
-        // render until after the expired updates have finished. But the
-        // important thing in this test is that the normal updates expired.
-        'High pri: 1',
+        gate(flags => flags.enableTransitionEntanglement)
+          ? // Notice that the high pri update didn't flush yet. Expiring one lane
+            // doesn't affect other lanes. (Unless they are intentionally
+            // entangled, like we do for overlapping transitions that affect the
+            // same state.)
+            'High pri: 0'
+          : // In the current implementation, once we pick the next lanes to work
+            // on, we entangle it with all pending at equal or higher priority.
+            // We could feasibly change this heuristic so that the high pri
+            // update doesn't render until after the expired updates have
+            // finished. But the important thing in this test is that the normal
+            // updates expired.
+            'High pri: 1',
         'Normal pri: 2',
         'Sibling',
       ]);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -143,3 +143,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
+
+// Experiment to simplify/improve how transitions are scheduled
+export const enableTransitionEntanglement = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -57,6 +57,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -56,6 +56,7 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
+export const enableTransitionEntanglement = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -54,3 +54,4 @@ export const enableUseRefAccessWarning = __VARIANT__;
 
 export const enableProfilerNestedUpdateScheduledHook = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
+export const enableTransitionEntanglement = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -30,6 +30,7 @@ export const {
   enableUseRefAccessWarning,
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
+  enableTransitionEntanglement,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.


### PR DESCRIPTION
Adds a feature flag to tweak the internal heuristic used to "unsuspend" lanes when a new update comes in.

A lane is "suspended" if we couldn't finish rendering it because it was missing data, and we chose not to commit the fallback. (In this context, "suspended" does not include updates that finished with a fallback.)

When we receive new data in the form of an update, we need to retry rendering the suspended lanes, since the new data may have unblocked the previously suspended work. For example, the new update could navigate back to an already loaded route.

It's impractical to retry every combination of suspended lanes, so we need some heuristic that decides which lanes to retry and in which order.

The existing heuristic roughly approximates the old Expiration Times model. It unsuspends all lower priority lanes, but leaves higher priority lanes suspended.

Then when we start rendering, we choose the lanes that have the highest LanePriority and render those -- and then we add to that all the lanes that are higher priority.

If this sounds terribly confusing, it's because it barely makes sense. (It made more sense in the Expiration Times world, I promise, but it was still confusing.) I don't think it's worth me trying to explain the old behavior too much because the point here is that we can replace it with something simpler.

The new heuristic is to unsuspend all suspended lanes whenever there's an update.

This is effectively what we already do except in a few very specific edge cases, ever since we removed the delayed suspense feature from everything that's not a refresh transition.

We can optimize this in the future to only unsuspend lanes that are either 1) in the `lanes` or `subtreeLanes` of the node that was updated, or 2) in the `lanes` of the return path of the node that was updated. This would exclude lanes that are only located in unrelated sibling trees. But, this optimization wouldn't be useful currently because we assign the same transition lane to all transitions. It will become relevant again once we start assigning arbitrary lanes to transitions -- but that in turn requires us to implement entanglement of overlapping transitions, one of our planned projects.

So to sum up: the goal here is to remove the weird edge cases and switch to a simpler model, on top of which we can make more substantial improvements.

I put it behind a flag so I can run an A/B test and confirm it doesn't cause a regression.
