### PR TITLE
Set default release channel for download-experimental-build script

### DIFF
--- a/scripts/release/download-experimental-build.js
+++ b/scripts/release/download-experimental-build.js
@@ -3,7 +3,11 @@
 'use strict';
 
 const {join} = require('path');
-const {getPublicPackages, handleError} = require('./utils');
+const {
+  addDefaultParamValue,
+  getPublicPackages,
+  handleError,
+} = require('./utils');
 
 const checkEnvironmentVariables = require('./shared-commands/check-environment-variables');
 const downloadBuildArtifacts = require('./shared-commands/download-build-artifacts');
@@ -13,6 +17,8 @@ const printSummary = require('./download-experimental-build-commands/print-summa
 
 const run = async () => {
   try {
+    addDefaultParamValue('-r', '--releaseChannel', 'experimental');
+
     const params = parseParams();
     params.cwd = join(__dirname, '..', '..');
     params.packages = await getPublicPackages(true);

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -17,6 +17,21 @@ const logger = createLogger({
   storagePath: join(__dirname, '.progress-estimator'),
 });
 
+const addDefaultParamValue = (shortName, longName, defaultValue) => {
+  let found = false;
+  for (let i = 0; i < process.argv.length; i++) {
+    const current = process.argv[i];
+    if (current === shortName || current.startsWith(`${longName}=`)) {
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    process.argv.push(shortName, defaultValue);
+  }
+};
+
 const confirm = async message => {
   const confirmation = await prompt(theme`\n{caution ${message}} (y/N) `);
   prompt.done();
@@ -249,6 +264,7 @@ const updateVersionsForNext = async (cwd, reactVersion, version) => {
 };
 
 module.exports = {
+  addDefaultParamValue,
   confirm,
   execRead,
   getArtifactsList,


### PR DESCRIPTION
Recent changes to the build scripts made this a required param, but it didn't make sense for the `download-experimental-build` script (used when building DevTools) to ever download anything but an experimental release, so I added a default value for that param.

### Before
![Screen Shot 2021-01-26 at 9 29 39 AM](https://user-images.githubusercontent.com/29597/105858230-11f83600-5fb9-11eb-8bef-86eab4cee4b5.png)

### After
![Screen Shot 2021-01-26 at 9 30 30 AM](https://user-images.githubusercontent.com/29597/105858304-26d4c980-5fb9-11eb-9d8f-65efcc3beba8.png)
