### PR TITLE
Debug tools supports custom hooks with the same name as primitives

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -335,4 +335,472 @@ describe('ReactHooksInspection', () => {
       ]);
     });
   });
+
+  describe('custom and primitive hook naming conflicts', () => {
+    it('use case one', () => {
+      function noop() {}
+
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function HooksNamingConflict() {
+        useCustom();
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'Custom',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: false,
+              name: 'Effect',
+              subHooks: [],
+              value: noop,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case two', () => {
+      function noop() {}
+
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        useCustom();
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'Custom',
+          subHooks: [
+            {
+              id: 3,
+              isStateEditable: false,
+              name: 'Effect',
+              subHooks: [],
+              value: noop,
+            },
+          ],
+          value: undefined,
+        },
+      ]);
+    });
+
+    it('use case three', () => {
+      function noop() {}
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function useState(value) {
+        React.useState(value);
+        useCustom();
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'Custom',
+              subHooks: [
+                {
+                  id: 1,
+                  isStateEditable: false,
+                  name: 'Effect',
+                  subHooks: [],
+                  value: noop,
+                },
+              ],
+              value: undefined,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+      ]);
+    });
+
+    it('use case four', () => {
+      function useState(value) {
+        React.useReducer(() => 0, 0);
+        React.useState(value);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case five', () => {
+      function useStateIndirection(value) {
+        React.useState(value);
+      }
+
+      function useState(value) {
+        useStateIndirection(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'StateIndirection',
+              subHooks: [
+                {
+                  id: 0,
+                  isStateEditable: true,
+                  name: 'State',
+                  subHooks: [],
+                  value: 0,
+                },
+              ],
+              value: undefined,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case six', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useStateIndirection(value) {
+        useState(value);
+      }
+
+      function HooksNamingConflict() {
+        useStateIndirection(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'StateIndirection',
+          subHooks: [
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'State',
+              subHooks: [
+                {
+                  id: 0,
+                  isStateEditable: true,
+                  name: 'State',
+                  subHooks: [],
+                  value: 0,
+                },
+                {
+                  id: 1,
+                  isStateEditable: true,
+                  name: 'Reducer',
+                  subHooks: [],
+                  value: 0,
+                },
+              ],
+              value: undefined,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case seven', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useState(true);
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: true,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case eight', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+        React.useState(true);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: true,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+  });
 });

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2343,4 +2343,62 @@ describe('InspectedElement', () => {
       `);
     });
   });
+
+  it('should gracefully handle custom hooks that have the same name as primitive hooks', async done => {
+    function useState() {
+      React.useState(0);
+      React.useEffect(() => {});
+    }
+
+    function HooksNamingConflict() {
+      useState();
+      React.useMemo(() => 0, []);
+      return null;
+    }
+
+    const container = document.createElement('div');
+    await utils.actAsync(() =>
+      ReactDOM.render(<HooksNamingConflict />, container),
+    );
+
+    const inspectedElement = await inspectElementAtIndex(0);
+    expect(inspectedElement.hooks).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": null,
+          "isStateEditable": false,
+          "name": "State",
+          "subHooks": Array [
+            Object {
+              "id": 0,
+              "isStateEditable": true,
+              "name": "State",
+              "subHooks": Array [],
+              "value": 0,
+            },
+            Object {
+              "id": 1,
+              "isStateEditable": false,
+              "name": "Effect",
+              "subHooks": Array [],
+              "value": Dehydrated {
+                "preview_short": ƒ () {},
+                "preview_long": ƒ () {},
+              },
+            },
+          ],
+          "value": undefined,
+        },
+        Object {
+          "id": 2,
+          "isStateEditable": false,
+          "name": "Memo",
+          "subHooks": Array [],
+          "value": 0,
+        },
+      ]
+    `);
+
+    done();
+  });
 });


### PR DESCRIPTION
See issue #20613; I suggest reviewing with [whitespace changes ignored](https://github.com/facebook/react/pull/20664/files?w=1).

## The problem

A use case like the following breaks debug tools:
```js
function useState(value) {
  React.useState(value);
}

function Test() {
  useState(0);
  return null;
}
```

Depending on the combination of hooks, the "break" manifests as either an invalid array of hooks metadata _or_ an actual runtime error here:
https://github.com/facebook/react/blob/a511dc7090523ee49ce21a08e55c41917d8af311/packages/react-debug-tools/src/ReactDebugHooks.js#L517

## The fix

I think the best way to fix this issue is to detect when it has already happened, flag the misidentified frame, and restart parsing completely.

I tried several approaches to fix the partial invalid hooks tree by adjusting it, but these attempts only worked in some scenarios, so I resorted to a complete restart. At least this shouldn't happen often.

## Background

The core of this problem is here:
https://github.com/facebook/react/blob/a511dc7090523ee49ce21a08e55c41917d8af311/packages/react-debug-tools/src/ReactDebugHooks.js#L439-L444

This check in `findPrimitiveIndex` is what causes the "primitive index" to advance too far if a custom hook name matches the current built-in hook.

Generally this incrementing is intentional, to handle wrappers added by packagers with the same name:
https://github.com/facebook/react/blob/a511dc7090523ee49ce21a08e55c41917d8af311/packages/react-debug-tools/src/ReactDebugHooks.js#L431-L432

The problem is when it causes us to _over increment_.