### PR TITLE
Improve error message when mutable sources are mutated during render

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -904,6 +904,18 @@ function readFromUnsubcribedMutableSource<Source, Snapshot>(
   const getVersion = source._getVersion;
   const version = getVersion(source._source);
 
+  let mutableSourceSideEffectDetected = false;
+  if (__DEV__) {
+    // Detect side effects that update a mutable source during render.
+    // See https://github.com/facebook/react/issues/19948
+    if (source._currentlyRenderingFiber !== currentlyRenderingFiber) {
+      source._currentlyRenderingFiber = currentlyRenderingFiber;
+      source._initialVersionAsOfFirstRender = version;
+    } else if (source._initialVersionAsOfFirstRender !== version) {
+      mutableSourceSideEffectDetected = true;
+    }
+  }
+
   // Is it safe for this component to read from this source during the current render?
   let isSafeToReadFromSource = false;
 
@@ -966,9 +978,20 @@ function readFromUnsubcribedMutableSource<Source, Snapshot>(
     // but there's nothing we can do about that (short of throwing here and refusing to continue the render).
     markSourceAsDirty(source);
 
+    if (__DEV__) {
+      if (mutableSourceSideEffectDetected) {
+        const componentName = getComponentName(currentlyRenderingFiber.type);
+        console.warn(
+          'A mutable source was mutated while the %s component was rendering. This is not supported. ' +
+            'Move any mutations into event handlers or effects.',
+          componentName,
+        );
+      }
+    }
+
     invariant(
       false,
-      'Cannot read from mutable source during the current render without tearing. This is a bug in React. Please file an issue.',
+      'Cannot read from mutable source during the current render without tearing. This may be a bug in React. Please file an issue.',
     );
   }
 }

--- a/packages/react/src/ReactMutableSource.js
+++ b/packages/react/src/ReactMutableSource.js
@@ -23,6 +23,11 @@ export function createMutableSource<Source: $NonMaybeType<mixed>>(
   if (__DEV__) {
     mutableSource._currentPrimaryRenderer = null;
     mutableSource._currentSecondaryRenderer = null;
+
+    // Used to detect side effects that update a mutable source during render.
+    // See https://github.com/facebook/react/issues/19948
+    mutableSource._currentlyRenderingFiber = null;
+    mutableSource._initialVersionAsOfFirstRender = null;
   }
 
   return mutableSource;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -197,6 +197,12 @@ export type MutableSource<Source: $NonMaybeType<mixed>> = {|
   // Used to detect multiple renderers using the same mutable source.
   _currentPrimaryRenderer?: Object | null,
   _currentSecondaryRenderer?: Object | null,
+
+  // DEV only
+  // Used to detect side effects that update a mutable source during render.
+  // See https://github.com/facebook/react/issues/19948
+  _currentlyRenderingFiber?: Fiber | null,
+  _initialVersionAsOfFirstRender?: MutableSourceVersion | null,
 |};
 
 // The subset of a Thenable required by things thrown by Suspense.

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -372,5 +372,6 @@
   "381": "This feature is not supported by ReactSuspenseTestUtils.",
   "382": "This query has received more parameters than the last time the same query was used. Always pass the exact number of parameters that the query needs.",
   "383": "This query has received fewer parameters than the last time the same query was used. Always pass the exact number of parameters that the query needs.",
-  "384": "Refreshing the cache is not supported in Server Components."
+  "384": "Refreshing the cache is not supported in Server Components.",
+  "385": "Cannot read from mutable source during the current render without tearing. This may be a bug in React. Please file an issue."
 }


### PR DESCRIPTION
Resolves #19948.

```js
function MutateDuringRead() {
  const value = useMutableSource(mutableSource, getSnapshot, subscribe);

  // This is not a supported/recommended pattern.
  if (value === "initial") {
    source.value = "updated";
  }

  return null;
}
```

Previously, if a component modified a mutable source during render (as shown above) React would throw the following error:
> Cannot read from mutable source during the current render without tearing. **This is a bug in React. Please file an issue.**

Mutating a mutable source (or any external variable) during render **is not expected to be supported**. However this error message misattributes the mutation as a React bug.

### Should this use case be supported?
This seems very similar [lazily initializing a ref](https://reactjs.org/docs/hooks-faq.html#how-to-create-expensive-objects-lazily) so it might be tempting to think it's okay. Mutable sources are external though, so modifying them during render is a side effect [which makes it unsafe and unsupported](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects). So while we could "support" this case in a very limited way, we shouldn't.

### Should we throw a better error?
There are ways that we could detect this case and throw a better error. Conceptually, checking the mutable source version an additional time before returning the result of the render would be sufficient to detect this. However I think it's not something we'd want to do in production and throwing a different error in DEV seems wrong.

### So what should we do?
I think the right solution here is to:
1. Detect this case (in DEV only) and add a new warning for it.
2. Change the error message from "this **is** a bug in React" to "this **may be** a bug in React". 🤪

This is the change I've implemented in this PR.