### PR TITLE
Add queue microtask to host configs

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -330,7 +330,7 @@ export function getChildHostContext() {
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
-export function queueMicrotask() {
+export function queueMicrotask(callback: Function) {
   invariant(false, 'Not implemented.');
 }
 

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -330,6 +330,9 @@ export function getChildHostContext() {
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
+export function queueMicrotask() {
+  invariant(false, 'Not implemented.');
+}
 
 export function shouldSetTextContent(type, props) {
   return (

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -384,6 +384,21 @@ export const scheduleTimeout: any =
 export const cancelTimeout: any =
   typeof clearTimeout === 'function' ? clearTimeout : (undefined: any);
 export const noTimeout = -1;
+export const queueMicrotask: (Function => void) | undefined =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : typeof Promise !== 'undefined'
+    ? callback =>
+        Promise.resolve(null)
+          .then(callback)
+          .catch(handleErrorInNextTick)
+    : scheduleTimeout;
+
+function handleErrorInNextTick(error) {
+  setTimeout(() => {
+    throw error;
+  });
+}
 
 // -------------------
 //     Mutation

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -384,9 +384,9 @@ export const scheduleTimeout: any =
 export const cancelTimeout: any =
   typeof clearTimeout === 'function' ? clearTimeout : (undefined: any);
 export const noTimeout = -1;
-export const queueMicrotask: (Function => void) | undefined =
-  typeof queueMicrotask === 'function'
-    ? queueMicrotask
+export const queueMicrotask: any =
+  typeof global.queueMicrotask === 'function'
+    ? global.queueMicrotask
     : typeof Promise !== 'undefined'
     ? callback =>
         Promise.resolve(null)

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -348,7 +348,7 @@ export const warnsIfNotActing = false;
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
-export function queueMicrotask() {
+export function queueMicrotask(callback: Function) {
   invariant(false, 'Not implemented.');
 }
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -348,6 +348,9 @@ export const warnsIfNotActing = false;
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
+export function queueMicrotask() {
+  invariant(false, 'Not implemented.');
+}
 
 // -------------------
 //     Persistence

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -247,7 +247,7 @@ export const warnsIfNotActing = true;
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
-export function queueMicrotask() {
+export function queueMicrotask(callback: Function) {
   invariant(false, 'Not implemented.');
 }
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -247,6 +247,9 @@ export const warnsIfNotActing = true;
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const noTimeout = -1;
+export function queueMicrotask() {
+  invariant(false, 'Not implemented.');
+}
 
 export function shouldSetTextContent(type: string, props: Props): boolean {
   // TODO (bvaughn) Revisit this decision.

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -29,7 +29,6 @@ import {
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import enqueueTask from 'shared/enqueueTask';
-import {scheduleTimeout} from 'react-dom/src/client/ReactDOMHostConfig';
 const {IsSomeRendererActing} = ReactSharedInternals;
 
 type Container = {
@@ -384,7 +383,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
                   throw error;
                 });
               })
-        : scheduleTimeout,
+        : setTimeout,
 
     prepareForCommit(): null | Object {
       return null;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -29,6 +29,7 @@ import {
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import enqueueTask from 'shared/enqueueTask';
+import {scheduleTimeout} from 'react-dom/src/client/ReactDOMHostConfig';
 const {IsSomeRendererActing} = ReactSharedInternals;
 
 type Container = {
@@ -371,6 +372,19 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     scheduleTimeout: setTimeout,
     cancelTimeout: clearTimeout,
     noTimeout: -1,
+    queueMicrotask:
+      typeof queueMicrotask === 'function'
+        ? queueMicrotask
+        : typeof Promise !== 'undefined'
+        ? callback =>
+            Promise.resolve(null)
+              .then(callback)
+              .catch(error => {
+                setTimeout(() => {
+                  throw error;
+                });
+              })
+        : scheduleTimeout,
 
     prepareForCommit(): null | Object {
       return null;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -54,6 +54,7 @@ export const shouldSetTextContent = $$$hostConfig.shouldSetTextContent;
 export const createTextInstance = $$$hostConfig.createTextInstance;
 export const scheduleTimeout = $$$hostConfig.scheduleTimeout;
 export const cancelTimeout = $$$hostConfig.cancelTimeout;
+export const queueMicrotask = $$$hostConfig.queueMicrotask;
 export const noTimeout = $$$hostConfig.noTimeout;
 export const now = $$$hostConfig.now;
 export const isPrimaryRenderer = $$$hostConfig.isPrimaryRenderer;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -221,10 +221,10 @@ export const warnsIfNotActing = true;
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
 export const queueMicrotask =
-  typeof queueMicrotask === 'function'
-    ? queueMicrotask
+  typeof global.queueMicrotask === 'function'
+    ? global.queueMicrotask
     : typeof Promise !== 'undefined'
-    ? callback =>
+    ? (callback: Function) =>
         Promise.resolve(null)
           .then(callback)
           .catch(handleErrorInNextTick)

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -220,6 +220,21 @@ export const warnsIfNotActing = true;
 
 export const scheduleTimeout = setTimeout;
 export const cancelTimeout = clearTimeout;
+export const queueMicrotask =
+  typeof queueMicrotask === 'function'
+    ? queueMicrotask
+    : typeof Promise !== 'undefined'
+    ? callback =>
+        Promise.resolve(null)
+          .then(callback)
+          .catch(handleErrorInNextTick)
+    : scheduleTimeout;
+
+function handleErrorInNextTick(error) {
+  setTimeout(() => {
+    throw error;
+  });
+}
 export const noTimeout = -1;
 
 // -------------------


### PR DESCRIPTION
## Overview

This PR is part of this stack:

- [Improve tests that use discrete events](https://github.com/facebook/react/pull/20667)
- [Add queue microtask to host configs (this PR)](https://github.com/facebook/react/pull/20668)
- [Queue discrete events in microtask](https://github.com/facebook/react/pull/20669)

Here we add a `queueMicrotask` implementation to the host configs it makes sense for.