### PR TITLE
Add automatic retry to download script

### DIFF
--- a/scripts/release/get-build-id-for-commit.js
+++ b/scripts/release/get-build-id-for-commit.js
@@ -2,33 +2,48 @@
 
 const fetch = require('node-fetch');
 
+const POLLING_INTERVAL = 5 * 1000; // 5 seconds
+const RETRY_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+
+function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), ms);
+  });
+}
+
 async function getBuildIdForCommit(sha) {
-  let ciBuildId = null;
-  const statusesResponse = await fetch(
-    `https://api.github.com/repos/facebook/react/commits/${sha}/status`
-  );
+  const retryLimit = Date.now() + RETRY_TIMEOUT;
+  retry: while (true) {
+    const statusesResponse = await fetch(
+      `https://api.github.com/repos/facebook/react/commits/${sha}/status`
+    );
 
-  if (!statusesResponse.ok) {
-    throw Error('Could not find commit for: ' + sha);
-  }
+    if (!statusesResponse.ok) {
+      throw Error('Could not find commit for: ' + sha);
+    }
 
-  const {statuses, state} = await statusesResponse.json();
-  if (state === 'failure') {
-    throw new Error(`Base commit is broken: ${sha}`);
-  }
-  for (let i = 0; i < statuses.length; i++) {
-    const status = statuses[i];
-    if (status.context === `ci/circleci: process_artifacts_combined`) {
-      if (status.state === 'success') {
-        ciBuildId = /\/facebook\/react\/([0-9]+)/.exec(status.target_url)[1];
-        break;
-      }
-      if (status.state === 'pending') {
-        throw new Error(`Build job for base commit is still pending: ${sha}`);
+    const {statuses, state} = await statusesResponse.json();
+    if (state === 'failure') {
+      throw new Error(`Base commit is broken: ${sha}`);
+    }
+    for (let i = 0; i < statuses.length; i++) {
+      const status = statuses[i];
+      if (status.context === `ci/circleci: process_artifacts_combined`) {
+        if (status.state === 'success') {
+          return /\/facebook\/react\/([0-9]+)/.exec(status.target_url)[1];
+        }
+        if (status.state === 'failure') {
+          throw new Error(`Build job for commit failed: ${sha}`);
+        }
+        if (Date.now() < retryLimit) {
+          await wait(POLLING_INTERVAL);
+          continue retry;
+        }
+        throw new Error('Exceeded retry limit. Build job is still pending.');
       }
     }
+    throw new Error('Could not find build for commit: ' + sha);
   }
-  return ciBuildId;
 }
 
 module.exports = getBuildIdForCommit;


### PR DESCRIPTION
## Based on #20703

If build job is still pending, the script will continuously poll until it reaches the retry limit.

I've set the limit at 10 minutes, since our CI pipeline almost always finishes before that.