### PR TITLE
Fix release script --commit param

### DIFF
--- a/scripts/release/download-experimental-build.js
+++ b/scripts/release/download-experimental-build.js
@@ -11,18 +11,13 @@ const {
 
 const checkEnvironmentVariables = require('./shared-commands/check-environment-variables');
 const downloadBuildArtifacts = require('./shared-commands/download-build-artifacts');
-const getLatestMasterBuildNumber = require('./shared-commands/get-latest-master-build-number');
 const parseParams = require('./shared-commands/parse-params');
 const printSummary = require('./download-experimental-build-commands/print-summary');
 
 const run = async () => {
   try {
     addDefaultParamValue('-r', '--releaseChannel', 'experimental');
-    addDefaultParamValue(
-      null,
-      '--build',
-      await getLatestMasterBuildNumber(true)
-    );
+    addDefaultParamValue(null, '--commit', 'master');
 
     const params = await parseParams();
     params.cwd = join(__dirname, '..', '..');

--- a/scripts/release/shared-commands/parse-params.js
+++ b/scripts/release/shared-commands/parse-params.js
@@ -38,12 +38,8 @@ module.exports = async () => {
   const params = commandLineArgs(paramDefinitions);
 
   if (params.build !== null) {
-    if (params.commit !== null) {
-      console.error(
-        '`build` and `commmit` params are mutually exclusive. Choose one or the other.`'
-      );
-      process.exit(1);
-    }
+    // TODO: Should we just remove the `build` param? Seems like `commit` is a
+    // sufficient replacement.
   } else {
     if (params.commit === null) {
       console.error('Must provide either `build` or `commit`.');


### PR DESCRIPTION
PR #20717 accidentally broke the `--commit` parameter because the script errors if you provide both a `--build` and a `--commit`.

I solved by removing the validation error. When there's a conflict, it will choose the `--build`.

(Although maybe we should remove `--build` and always use `--commit`. I think `--commit` is a sufficient replacement.)