### PR TITLE
Suggestion: Support consuming multiple Contexts in Class.contextType

### DIFF
--- a/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactLegacyContextDisabled-test.internal.js
@@ -229,4 +229,92 @@ describe('ReactLegacyContextDisabled', () => {
     expect(lifecycleContextLog).toEqual(['b', 'b']); // sCU skipped due to changed context value.
     ReactDOM.unmountComponentAtNode(container);
   });
+
+  it('renders a tree with array of modern context', () => {
+    const Ctx1 = React.createContext();
+    const Ctx2 = React.createContext();
+
+    class Provider extends React.Component {
+      render() {
+        return (
+          <Ctx1.Provider value={this.props.value}>
+            <Ctx2.Provider value={this.props.value2}>
+              {this.props.children}
+            </Ctx2.Provider>
+          </Ctx1.Provider>
+        );
+      }
+    }
+
+    class RenderPropConsumer extends React.Component {
+      render() {
+        return <Ctx1.Consumer>{value => formatValue(value)}</Ctx1.Consumer>;
+      }
+    }
+
+    const lifecycleContextLog = [];
+    class ContextTypeConsumer extends React.Component {
+      static contextType = [Ctx1, Ctx2];
+      shouldComponentUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+        return true;
+      }
+      UNSAFE_componentWillReceiveProps(nextProps, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      UNSAFE_componentWillUpdate(nextProps, nextState, nextContext) {
+        lifecycleContextLog.push(nextContext);
+      }
+      render() {
+        return formatValue(this.context[0]) + formatValue(this.context[1]);
+      }
+    }
+
+    function FnConsumer() {
+      return formatValue(React.useContext(Ctx1));
+    }
+
+    const container = document.createElement('div');
+    ReactDOM.render(
+      <Provider value="a" value2="b">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+      container,
+    );
+    expect(container.textContent).toBe('aaba');
+    expect(lifecycleContextLog).toEqual([]);
+
+    // Test update path
+    ReactDOM.render(
+      <Provider value="a" value2="b">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+      container,
+    );
+    expect(container.textContent).toBe('aaba');
+    expect(lifecycleContextLog).toEqual([['a', 'b'], ['a', 'b'], ['a', 'b']]);
+    lifecycleContextLog.length = 0;
+
+    ReactDOM.render(
+      <Provider value="b" value2="a">
+        <span>
+          <RenderPropConsumer />
+          <ContextTypeConsumer />
+          <FnConsumer />
+        </span>
+      </Provider>,
+      container,
+    );
+    expect(container.textContent).toBe('bbab');
+    expect(lifecycleContextLog).toEqual([['b', 'a'], ['b', 'a']]); // sCU skipped due to changed context value.
+    ReactDOM.unmountComponentAtNode(container);
+  });
 });

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -602,6 +602,11 @@ function constructClassInstance(
       const isValid =
         // Allow null for conditional declaration
         contextType === null ||
+        (Array.isArray(contextType) && contextType.every(item =>
+          item !== undefined &&
+          item.$$typeof === REACT_CONTEXT_TYPE &&
+          item._context === undefined
+        )) ||
         (contextType !== undefined &&
           contextType.$$typeof === REACT_CONTEXT_TYPE &&
           contextType._context === undefined); // Not a <Context.Consumer>
@@ -639,7 +644,9 @@ function constructClassInstance(
     }
   }
 
-  if (typeof contextType === 'object' && contextType !== null) {
+  if (Array.isArray(contextType)) {
+    context = contextType.map(c => readContext(c))
+  } else if (typeof contextType === 'object' && contextType !== null) {
     context = readContext((contextType: any));
   } else if (!disableLegacyContext) {
     unmaskedContext = getUnmaskedContext(workInProgress, ctor, true);
@@ -839,7 +846,9 @@ function mountClassInstance(
   initializeUpdateQueue(workInProgress);
 
   const contextType = ctor.contextType;
-  if (typeof contextType === 'object' && contextType !== null) {
+  if (Array.isArray(contextType)) {
+    instance.context = contextType.map(c => readContext(c))
+  } else if (typeof contextType === 'object' && contextType !== null) {
     instance.context = readContext(contextType);
   } else if (disableLegacyContext) {
     instance.context = emptyContextObject;
@@ -934,7 +943,9 @@ function resumeMountClassInstance(
   const oldContext = instance.context;
   const contextType = ctor.contextType;
   let nextContext = emptyContextObject;
-  if (typeof contextType === 'object' && contextType !== null) {
+  if (Array.isArray(contextType)) {
+    nextContext = contextType.map(c => readContext(c))
+  } else if (typeof contextType === 'object' && contextType !== null) {
     nextContext = readContext(contextType);
   } else if (!disableLegacyContext) {
     const nextLegacyUnmaskedContext = getUnmaskedContext(
@@ -1103,7 +1114,9 @@ function updateClassInstance(
   const oldContext = instance.context;
   const contextType = ctor.contextType;
   let nextContext = emptyContextObject;
-  if (typeof contextType === 'object' && contextType !== null) {
+  if (Array.isArray(contextType)) {
+    nextContext = contextType.map(c => readContext(c))
+  } else if (typeof contextType === 'object' && contextType !== null) {
     nextContext = readContext(contextType);
   } else if (!disableLegacyContext) {
     const nextUnmaskedContext = getUnmaskedContext(workInProgress, ctor, true);


### PR DESCRIPTION
## Summary

For the code, which uses class components without hooks, it would be very useful to consume multiple contexts at once with Class.contextType. This feature gives us such kind of advantages:
1. Developer can use any context in lifecycle methods
2. No need to wrap component to N consumers - reduce deep level of component tree is good for performance.

This is just a proof of concept of feature. Please tell me what do you think about it, if it fits good to react I can continue to work on this.

See also #14532