### PR TITLE
Add --ci option to publish script

### DIFF
--- a/scripts/release/publish-commands/confirm-version-and-tags.js
+++ b/scripts/release/publish-commands/confirm-version-and-tags.js
@@ -8,7 +8,7 @@ const {join} = require('path');
 const {confirm} = require('../utils');
 const theme = require('../theme');
 
-const run = async ({cwd, packages, tags}) => {
+const run = async ({cwd, packages, tags, ci}) => {
   clear();
 
   if (tags.length === 0) {
@@ -40,7 +40,9 @@ const run = async ({cwd, packages, tags}) => {
     );
   }
 
-  await confirm('Do you want to proceed?');
+  if (!ci) {
+    await confirm('Do you want to proceed?');
+  }
 
   clear();
 };

--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -26,6 +26,12 @@ const paramDefinitions = [
     description: 'Packages to exclude from publishing',
     defaultValue: [],
   },
+  {
+    name: 'ci',
+    type: Boolean,
+    description: 'Run in automated environment, without interactive prompts.',
+    defaultValue: false,
+  },
 ];
 
 module.exports = () => {
@@ -40,7 +46,7 @@ module.exports = () => {
       case 'untagged':
         break;
       default:
-        console.error('Unknown tag: "' + params.tag + '"');
+        console.error('Unsupported tag: "' + tag + '"');
         process.exit(1);
         break;
     }

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -50,28 +50,35 @@ const run = async () => {
     await validateSkipPackages(params);
     await checkNPMPermissions(params);
 
-    clear();
-    let otp = await promptForOTP(params);
     const packageNames = params.packages;
-    for (let i = 0; i < packageNames.length; ) {
-      const packageName = packageNames[i];
-      try {
-        await publishToNPM(params, packageName, otp);
-        i++;
-      } catch (error) {
-        console.error(error.message);
-        console.log();
-        console.log(
-          theme.error`Publish failed. Enter a fresh otp code to retry.`
-        );
-        otp = await promptForOTP(params);
-        // Try publishing package again
-        continue;
-      }
-    }
 
-    await updateStableVersionNumbers(params);
-    await printFollowUpInstructions(params);
+    if (params.ci) {
+      for (let i = 0; i < packageNames.length; i++) {
+        const packageName = packageNames[i];
+        await publishToNPM(params, packageName, null);
+      }
+    } else {
+      clear();
+      let otp = await promptForOTP(params);
+      for (let i = 0; i < packageNames.length; ) {
+        const packageName = packageNames[i];
+        try {
+          await publishToNPM(params, packageName, otp);
+          i++;
+        } catch (error) {
+          console.error(error.message);
+          console.log();
+          console.log(
+            theme.error`Publish failed. Enter a fresh otp code to retry.`
+          );
+          otp = await promptForOTP(params);
+          // Try publishing package again
+          continue;
+        }
+      }
+      await updateStableVersionNumbers(params);
+      await printFollowUpInstructions(params);
+    }
   } catch (error) {
     handleError(error);
   }


### PR DESCRIPTION
When running in CI, the publish script will skip interactive prompts, including the prompt for a one-time password.

Instead, CI will need to use an automation access token: https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow

Tested by running with `--dry` flag.