### PR TITLE
Implement CI publish prerelease job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,16 +358,22 @@ jobs:
         type: string
       release_channel:
         type: string
+      dist_tag:
+        type: string
     docker: *docker
     environment: *environment
     steps:
       - checkout
       - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
-      # TODO: This doesn't actually publish anything yet. Just logs the inputs.
-      - run: |
-          echo "<< parameters.commit_sha >>"
-          echo "<< parameters.release_channel >>"
+      - run:
+          name: Run publish script
+          command: |
+            git fetch origin master
+            cd ./scripts/release && yarn && cd ../../
+            scripts/release/prepare-release-from-ci.js --skipTests -r << parameters.release_channel >> --commit=<< parameters.commit_sha >>
+            cp ./scripts/release/ci-npmrc ~/.npmrc
+            scripts/release/publish.js --ci --tags << parameters.dist_tag >>
 
 workflows:
   version: 2
@@ -516,12 +522,16 @@ workflows:
     jobs:
       - setup
       - publish_prerelease:
+          name: Publish to Next channel
           requires:
             - setup
-          matrix:
-            parameters:
-              commit_sha:
-                - << pipeline.parameters.prerelease_commit_sha >>
-              release_channel:
-                - stable
-                - experimental
+          commit_sha: << pipeline.parameters.prerelease_commit_sha >>
+          release_channel: stable
+          dist_tag: next
+      - publish_prerelease:
+          name: Publish to Experimental channel
+          requires:
+            - setup
+          commit_sha: << pipeline.parameters.prerelease_commit_sha >>
+          release_channel: experimental
+          dist_tag: experimental

--- a/scripts/release/ci-npmrc
+++ b/scripts/release/ci-npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -53,9 +53,23 @@ const run = async () => {
     const packageNames = params.packages;
 
     if (params.ci) {
+      let failed = false;
       for (let i = 0; i < packageNames.length; i++) {
-        const packageName = packageNames[i];
-        await publishToNPM(params, packageName, null);
+        try {
+          const packageName = packageNames[i];
+          await publishToNPM(params, packageName, null);
+        } catch (error) {
+          failed = true;
+          console.error(error.message);
+          console.log();
+          console.log(
+            theme.error`Publish failed. Will attempt to publish remaining packages.`
+          );
+        }
+      }
+      if (failed) {
+        console.log(theme.error`One or more packages failed to publish.`);
+        process.exit(1);
       }
     } else {
       clear();


### PR DESCRIPTION
PR #20728 added a command to initiate a prerelease using CI, but it left the publish job unimplemented. This fills in the publish job.

Uses an npm automation token for authorization, which bypasses the need for a one-time password. The token is configured via CircleCI's environment variable panel.

Currently, it will always publish the head of the main branch. If the head has already been published, it will exit gracefully.

It does not yet support publishing arbitrary commits, though we could easily add that. I don't know how important that use case is, because for PR branches, you can use CodeSandbox CI instead. Or as a last resort, run the publish script locally.

Always publishing from main is nice because it further incentivizes us to keep main in a releasable state. It also takes the guesswork out of publishing a prerelease that's in a broken state: as long as we don't merge broken PRs, we're fine.

## Test plan

```sh
❯ yarn publish-prereleases
Using globally installed version of Yarn
yarn run v1.12.1
$ node ./scripts/release/publish-using-ci-workflow.js
✓ Creating CI workflow 253 ms
✓ Publishing in CI workflow: https://app.circleci.com/pipelines/workflows/894684e1-f09f-4c40-9310-65603cf3eb9e 2.5
mins
✨  Done in 154.82s.
```

Corresponding CI workflow that successfully published: https://app.circleci.com/pipelines/github/facebook/react/9764/workflows/894684e1-f09f-4c40-9310-65603cf3eb9e