### PR TITLE
Broken base revision should not affect PR status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,11 +169,18 @@ jobs:
       - *restore_node_modules
       - run:
           name: Download artifacts for base revision
+          # FIXME: I intentionally broke this step to test that it recovers
+          # gracefully. Undo before landing.
           command: |
-              git fetch origin master
-              cd ./scripts/release && yarn && cd ../../
-              scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/master)
-              mv ./build2 ./base-build
+            if [[ $(false) -gt 0 ]]; then
+              echo "Failed to download build artifacts. This likely means the base revision is broken. Try rebasing onto the latest changes."
+              circleci-agent step halt
+            fi
+          # command: |
+          #     git fetch origin master
+          #     cd ./scripts/release && yarn && cd ../../
+          #     scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/master)
+          #     mv ./build2 ./base-build
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
Currently if a PR's base revision is broken (or at least has broken status as reported by GitHub), the PR's status will also be broken, because the sizebot can't download the base build artifacts.

Instead, if the download step fails, we should exit gracefully.

## Test plan

I intentionally broke the step that downloads the artifacts in the `get_base_build` job to confirm that the next step recovers gracefully.