### PR TITLE
Align event group constant naming with lane naming

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -32,7 +32,7 @@ import {
   flushPassiveEffects,
   IsThisRendererActing,
   attemptSynchronousHydration,
-  attemptUserBlockingHydration,
+  attemptDiscreteHydration,
   attemptContinuousHydration,
   attemptHydrationAtCurrentPriority,
   runWithPriority,
@@ -56,7 +56,7 @@ import {
 import {restoreControlledState} from './ReactDOMComponent';
 import {
   setAttemptSynchronousHydration,
-  setAttemptUserBlockingHydration,
+  setAttemptDiscreteHydration,
   setAttemptContinuousHydration,
   setAttemptHydrationAtCurrentPriority,
   queueExplicitHydrationTarget,
@@ -71,7 +71,7 @@ import {
 } from '../events/ReactDOMControlledComponent';
 
 setAttemptSynchronousHydration(attemptSynchronousHydration);
-setAttemptUserBlockingHydration(attemptUserBlockingHydration);
+setAttemptDiscreteHydration(attemptDiscreteHydration);
 setAttemptContinuousHydration(attemptContinuousHydration);
 setAttemptHydrationAtCurrentPriority(attemptHydrationAtCurrentPriority);
 setGetCurrentUpdatePriority(getCurrentUpdateLanePriority);

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -20,7 +20,7 @@ import {
 import {
   DiscreteEvent,
   UserBlockingEvent,
-  ContinuousEvent,
+  DefaultEvent,
 } from 'shared/ReactTypes';
 
 import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
@@ -116,7 +116,7 @@ const userBlockingPairsForSimpleEventPlugin: Array<string | DOMEventName> = [
 ];
 
 // prettier-ignore
-const continuousPairsForSimpleEventPlugin: Array<string | DOMEventName> = [
+const defaultPairsForSimpleEventPlugin: Array<string | DOMEventName> = [
   ('abort': DOMEventName), 'abort',
   (ANIMATION_END: DOMEventName), 'animationEnd',
   (ANIMATION_ITERATION: DOMEventName), 'animationIteration',
@@ -190,10 +190,10 @@ export function getEventPriorityForPluginSystem(
   domEventName: DOMEventName,
 ): EventPriority {
   const priority = eventPriorities.get(domEventName);
-  // Default to a ContinuousEvent. Note: we might
+  // Default to a DefaultEvent. Note: we might
   // want to warn if we can't detect the priority
   // for the event.
-  return priority === undefined ? ContinuousEvent : priority;
+  return priority === undefined ? DefaultEvent : priority;
 }
 
 export function getEventPriorityForListenerSystem(
@@ -210,7 +210,7 @@ export function getEventPriorityForListenerSystem(
       type,
     );
   }
-  return ContinuousEvent;
+  return DefaultEvent;
 }
 
 export function registerSimpleEvents() {
@@ -223,8 +223,8 @@ export function registerSimpleEvents() {
     UserBlockingEvent,
   );
   registerSimplePluginEventsAndSetTheirPriorities(
-    continuousPairsForSimpleEventPlugin,
-    ContinuousEvent,
+    defaultPairsForSimpleEventPlugin,
+    DefaultEvent,
   );
   setEventPriorities(otherDiscreteEvents, DiscreteEvent);
 }

--- a/packages/react-dom/src/events/DOMEventProperties.js
+++ b/packages/react-dom/src/events/DOMEventProperties.js
@@ -17,11 +17,7 @@ import {
   ANIMATION_START,
   TRANSITION_END,
 } from './DOMEventNames';
-import {
-  DiscreteEvent,
-  UserBlockingEvent,
-  DefaultEvent,
-} from 'shared/ReactTypes';
+import {DiscreteEvent, ContinuousEvent, DefaultEvent} from 'shared/ReactTypes';
 
 import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 
@@ -97,7 +93,7 @@ if (enableCreateEventHandleAPI) {
 }
 
 // prettier-ignore
-const userBlockingPairsForSimpleEventPlugin: Array<string | DOMEventName> = [
+const continuousPairsForSimpleEventPlugin: Array<string | DOMEventName> = [
   ('drag': DOMEventName), 'drag',
   ('dragenter': DOMEventName), 'dragEnter',
   ('dragexit': DOMEventName), 'dragExit',
@@ -219,8 +215,8 @@ export function registerSimpleEvents() {
     DiscreteEvent,
   );
   registerSimplePluginEventsAndSetTheirPriorities(
-    userBlockingPairsForSimpleEventPlugin,
-    UserBlockingEvent,
+    continuousPairsForSimpleEventPlugin,
+    ContinuousEvent,
   );
   registerSimplePluginEventsAndSetTheirPriorities(
     defaultPairsForSimpleEventPlugin,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -43,11 +43,7 @@ import {
   decoupleUpdatePriorityFromScheduler,
   enableNewReconciler,
 } from 'shared/ReactFeatureFlags';
-import {
-  UserBlockingEvent,
-  DefaultEvent,
-  DiscreteEvent,
-} from 'shared/ReactTypes';
+import {ContinuousEvent, DefaultEvent, DiscreteEvent} from 'shared/ReactTypes';
 import {getEventPriorityForPluginSystem} from './DOMEventProperties';
 import {dispatchEventForPluginEventSystem} from './DOMPluginEventSystem';
 import {
@@ -118,8 +114,8 @@ export function createEventListenerWrapperWithPriority(
     case DiscreteEvent:
       listenerWrapper = dispatchDiscreteEvent;
       break;
-    case UserBlockingEvent:
-      listenerWrapper = dispatchUserBlockingUpdate;
+    case ContinuousEvent:
+      listenerWrapper = dispatchContinuousEvent;
       break;
     case DefaultEvent:
     default:
@@ -157,7 +153,7 @@ function dispatchDiscreteEvent(
   );
 }
 
-function dispatchUserBlockingUpdate(
+function dispatchContinuousEvent(
   domEventName,
   eventSystemFlags,
   container,

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -45,7 +45,7 @@ import {
 } from 'shared/ReactFeatureFlags';
 import {
   UserBlockingEvent,
-  ContinuousEvent,
+  DefaultEvent,
   DiscreteEvent,
 } from 'shared/ReactTypes';
 import {getEventPriorityForPluginSystem} from './DOMEventProperties';
@@ -121,7 +121,7 @@ export function createEventListenerWrapperWithPriority(
     case UserBlockingEvent:
       listenerWrapper = dispatchUserBlockingUpdate;
       break;
-    case ContinuousEvent:
+    case DefaultEvent:
     default:
       listenerWrapper = dispatchEvent;
       break;

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -39,10 +39,10 @@ export function setAttemptSynchronousHydration(fn: (fiber: Object) => void) {
   attemptSynchronousHydration = fn;
 }
 
-let attemptUserBlockingHydration: (fiber: Object) => void;
+let attemptDiscreteHydration: (fiber: Object) => void;
 
-export function setAttemptUserBlockingHydration(fn: (fiber: Object) => void) {
-  attemptUserBlockingHydration = fn;
+export function setAttemptDiscreteHydration(fn: (fiber: Object) => void) {
+  attemptDiscreteHydration = fn;
 }
 
 let attemptContinuousHydration: (fiber: Object) => void;
@@ -489,7 +489,7 @@ function replayUnblockedEvents() {
       // the next discrete event.
       const fiber = getInstanceFromNode(nextDiscreteEvent.blockedOn);
       if (fiber !== null) {
-        attemptUserBlockingHydration(fiber);
+        attemptDiscreteHydration(fiber);
       }
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -29,7 +29,7 @@ import {
   IsThisRendererActing as IsThisRendererActing_old,
   getPublicRootInstance as getPublicRootInstance_old,
   attemptSynchronousHydration as attemptSynchronousHydration_old,
-  attemptUserBlockingHydration as attemptUserBlockingHydration_old,
+  attemptDiscreteHydration as attemptDiscreteHydration_old,
   attemptContinuousHydration as attemptContinuousHydration_old,
   attemptHydrationAtCurrentPriority as attemptHydrationAtCurrentPriority_old,
   findHostInstance as findHostInstance_old,
@@ -69,7 +69,7 @@ import {
   IsThisRendererActing as IsThisRendererActing_new,
   getPublicRootInstance as getPublicRootInstance_new,
   attemptSynchronousHydration as attemptSynchronousHydration_new,
-  attemptUserBlockingHydration as attemptUserBlockingHydration_new,
+  attemptDiscreteHydration as attemptDiscreteHydration_new,
   attemptContinuousHydration as attemptContinuousHydration_new,
   attemptHydrationAtCurrentPriority as attemptHydrationAtCurrentPriority_new,
   findHostInstance as findHostInstance_new,
@@ -134,9 +134,9 @@ export const getPublicRootInstance = enableNewReconciler
 export const attemptSynchronousHydration = enableNewReconciler
   ? attemptSynchronousHydration_new
   : attemptSynchronousHydration_old;
-export const attemptUserBlockingHydration = enableNewReconciler
-  ? attemptUserBlockingHydration_new
-  : attemptUserBlockingHydration_old;
+export const attemptDiscreteHydration = enableNewReconciler
+  ? attemptDiscreteHydration_new
+  : attemptDiscreteHydration_old;
 export const attemptContinuousHydration = enableNewReconciler
   ? attemptContinuousHydration_new
   : attemptContinuousHydration_old;

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -397,7 +397,7 @@ function markRetryLaneIfNotHydrated(fiber: Fiber, retryLane: Lane) {
   }
 }
 
-export function attemptUserBlockingHydration(fiber: Fiber): void {
+export function attemptDiscreteHydration(fiber: Fiber): void {
   if (fiber.tag !== SuspenseComponent) {
     // We ignore HostRoots here because we can't increase
     // their priority and they should not suspend on I/O,

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -397,7 +397,7 @@ function markRetryLaneIfNotHydrated(fiber: Fiber, retryLane: Lane) {
   }
 }
 
-export function attemptUserBlockingHydration(fiber: Fiber): void {
+export function attemptDiscreteHydration(fiber: Fiber): void {
   if (fiber.tag !== SuspenseComponent) {
     // We ignore HostRoots here because we can't increase
     // their priority and they should not suspend on I/O,

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -89,7 +89,7 @@ export type RefObject = {|
 export type EventPriority = 0 | 1 | 2;
 
 export const DiscreteEvent: EventPriority = 0;
-export const UserBlockingEvent: EventPriority = 1;
+export const ContinuousEvent: EventPriority = 1;
 export const DefaultEvent: EventPriority = 2;
 
 export type ReactFundamentalComponentInstance<C, H> = {|

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -90,7 +90,7 @@ export type EventPriority = 0 | 1 | 2;
 
 export const DiscreteEvent: EventPriority = 0;
 export const UserBlockingEvent: EventPriority = 1;
-export const ContinuousEvent: EventPriority = 2;
+export const DefaultEvent: EventPriority = 2;
 
 export type ReactFundamentalComponentInstance<C, H> = {|
   currentFiber: Object,


### PR DESCRIPTION
The naming used by the event system has gotten out of sync with the naming used by the core. This makes the code quite difficult to trace. For example, the event system categorizes events into Discrete (e.g. `click`), UserBlocking (e.g. `mousemove`), and Continuous (e.g. `load`). However, event replaying and the reconciler calls `mousemove` Continuous (whereas `load` etc would be Default). Still, some parts of the reconciler refer to Continuous as UserBlocking.

I'm consolidating these few places to match the Lane terminology (which we tend to use in the informal discussions):

* **Discrete** (e.g. `click`)
* **Continuous** (e.g. `mousemove`)
* **Default** (e.g. `load`)

The name `UserBlocking` is now only used in the context of the Scheduler priority, and isn't related to events.

It might be easier to read the two commits separately. **No changes to the logic, this is purely a naming change.**