### PR TITLE
sizebot: Fix wrong order of base, head arguments

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -92,7 +92,7 @@ function getBundleSizes(pathToSizesDir) {
 async function printResultsForChannel(baseResults, headResults) {
   // Take the JSON of the build response and
   // make an array comparing the results for printing
-  const results = generateResultsArray(baseResults, headResults);
+  const results = generateResultsArray(headResults, baseResults);
 
   const packagesToShow = results
     .filter(


### PR DESCRIPTION
The base and head arguments were flipped, so an n% decrease in bundle size was instead reported as an n% increase.

##  Test plan

I pushed the commit to https://github.com/facebook/react/pull/20746 to confirm it fixes the sizebot results