### PR TITLE
Use Lanes instead of priority event constants

### DIFF
--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -86,12 +86,6 @@ export type RefObject = {|
   current: any,
 |};
 
-export type EventPriority = 0 | 1 | 2;
-
-export const DiscreteEvent: EventPriority = 0;
-export const ContinuousEvent: EventPriority = 1;
-export const DefaultEvent: EventPriority = 2;
-
 export type ReactScope = {|
   $$typeof: Symbol | number,
 |};


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/20760, preparation for https://github.com/facebook/react/pull/20748.

It's only used in one file now, but I'll be adding more usage.