### PR TITLE
Land enableTransitionEntanglement flag

### DIFF
--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -276,23 +276,12 @@ describe('DebugTracing', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    gate(flags => {
-      if (flags.new) {
-        expect(logs).toEqual([
-          'group: ⚛️ render (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
-          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-        ]);
-      } else {
-        expect(logs).toEqual([
-          'group: ⚛️ render (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-        ]);
-      }
-    });
+    expect(logs).toEqual([
+      'group: ⚛️ render (0b0000000000000000000001000000000)',
+      'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+      'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+    ]);
   });
 
   // @gate experimental && build === 'development' && enableDebugTracing
@@ -327,9 +316,6 @@ describe('DebugTracing', () => {
     ]);
   });
 
-  // This test is coupled to lane implementation details, so I'm disabling it
-  // until it stabilizes so we don't have to repeatedly update it.
-  // @gate !enableTransitionEntanglement
   // @gate experimental && build === 'development' && enableDebugTracing
   it('should log cascading passive updates', () => {
     function Example() {
@@ -350,7 +336,7 @@ describe('DebugTracing', () => {
     });
     expect(logs).toEqual([
       'group: ⚛️ passive effects (0b0000000000000000000001000000000)',
-      'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
+      'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
       'groupEnd: ⚛️ passive effects (0b0000000000000000000001000000000)',
     ]);
   });
@@ -374,23 +360,12 @@ describe('DebugTracing', () => {
       );
     });
 
-    gate(flags => {
-      if (flags.new) {
-        expect(logs).toEqual([
-          'group: ⚛️ render (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000001000000000)', // debugRenderPhaseSideEffectsForStrictMode
-          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-        ]);
-      } else {
-        expect(logs).toEqual([
-          'group: ⚛️ render (0b0000000000000000000001000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)',
-          'log: ⚛️ Example updated state (0b0000000000000000000010000000000)', // debugRenderPhaseSideEffectsForStrictMode
-          'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
-        ]);
-      }
-    });
+    expect(logs).toEqual([
+      'group: ⚛️ render (0b0000000000000000000001000000000)',
+      'log: ⚛️ Example updated state (0b0000000000000000000001000000000)',
+      'log: ⚛️ Example updated state (0b0000000000000000000001000000000)', // debugRenderPhaseSideEffectsForStrictMode
+      'groupEnd: ⚛️ render (0b0000000000000000000001000000000)',
+    ]);
   });
 
   // @gate experimental && build === 'development' && enableDebugTracing

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -589,7 +589,8 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   // Note: This test was written to test a heuristic used in the expiration
   // times model. Might not make sense in the new model.
-  // @gate enableCache || enableTransitionEntanglement
+  // TODO: This test doesn't over what it was originally designed to test.
+  // Either rewrite or delete.
   it('tries each subsequent level after suspending', async () => {
     const root = ReactNoop.createRoot();
 
@@ -642,26 +643,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       root.render(<App step={4} shouldSuspend={false} />);
     });
 
-    if (gate(flags => flags.enableTransitionEntanglement)) {
-      expect(Scheduler).toHaveYielded(['Sibling', 'Step 4']);
-    } else {
-      // Old implementation
-      expect(Scheduler).toHaveYielded([
-        'Sibling',
-
-        // NOTE: The final of the update got pushed into a lower priority range of
-        // lanes, leading to the extra intermediate render. This is because when
-        // we schedule the fourth update, we're already in the middle of rendering
-        // the three others. Since there are only three lanes in the default
-        // range, the fourth lane is shifted to slightly lower priority. This
-        // could easily change when we tweak our batching heuristics. Ideally,
-        // they'd all have default priority and render in a single batch.
-        'Suspend! [Step 3]',
-        'Sibling',
-
-        'Step 4',
-      ]);
-    }
+    expect(Scheduler).toHaveYielded(['Sibling', 'Step 4']);
   });
 
   // @gate enableCache
@@ -2798,21 +2780,10 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       foo.setState({suspend: false});
     });
 
-    if (gate(flags => flags.enableTransitionEntanglement)) {
-      expect(Scheduler).toHaveYielded([
-        // First setState
-        'Foo',
-      ]);
-    } else {
-      expect(Scheduler).toHaveYielded([
-        // First setState
-        'Foo',
-        // Second setState. This update was scheduled while we were in the
-        // middle of rendering the previous update, so it was pushed to a separate
-        // batch to avoid invalidating the work-in-progress tree.
-        'Foo',
-      ]);
-    }
+    expect(Scheduler).toHaveYielded([
+      // First setState
+      'Foo',
+    ]);
     expect(root).toMatchRenderedOutput(<span prop="Foo" />);
   });
 

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -399,11 +399,7 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    gate(({old}) =>
-      old
-        ? expectMarksToContain('--schedule-state-update-1024-Example')
-        : expectMarksToContain('--schedule-state-update-512-Example'),
-    );
+    expectMarksToContain('--schedule-state-update-512-Example');
   });
 
   // @gate enableSchedulingProfiler
@@ -431,11 +427,7 @@ describe('SchedulingProfiler', () => {
       expect(Scheduler).toFlushUntilNextPaint([]);
     }).toErrorDev('Cannot update during an existing state transition');
 
-    gate(({old}) =>
-      old
-        ? expectMarksToContain('--schedule-forced-update-1024-Example')
-        : expectMarksToContain('--schedule-forced-update-512-Example'),
-    );
+    expectMarksToContain('--schedule-forced-update-512-Example');
   });
 
   // @gate enableSchedulingProfiler
@@ -476,7 +468,6 @@ describe('SchedulingProfiler', () => {
 
   // This test is coupled to lane implementation details, so I'm disabling it in
   // the new fork until it stabilizes so we don't have to repeatedly update it.
-  // @gate !enableTransitionEntanglement
   // @gate enableSchedulingProfiler
   it('should mark cascading passive updates', () => {
     function Example() {
@@ -501,11 +492,11 @@ describe('SchedulingProfiler', () => {
       '--layout-effects-stop',
       '--commit-stop',
       '--passive-effects-start-512',
-      '--schedule-state-update-1024-Example',
+      '--schedule-state-update-512-Example',
       '--passive-effects-stop',
-      '--render-start-1024',
+      '--render-start-512',
       '--render-stop',
-      '--commit-start-1024',
+      '--commit-start-512',
       '--commit-stop',
     ]);
   });
@@ -524,10 +515,6 @@ describe('SchedulingProfiler', () => {
       ReactTestRenderer.create(<Example />, {unstable_isConcurrent: true});
     });
 
-    gate(({old}) =>
-      old
-        ? expectMarksToContain('--schedule-state-update-1024-Example')
-        : expectMarksToContain('--schedule-state-update-512-Example'),
-    );
+    expectMarksToContain('--schedule-state-update-512-Example');
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -147,9 +147,6 @@ export const enableRecursiveCommitTraversal = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
 
-// Experiment to simplify/improve how transitions are scheduled
-export const enableTransitionEntanglement = false;
-
 export const enableNonInterruptingNormalPri = false;
 
 export const enableDiscreteEventMicroTasks = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableTransitionEntanglement = false;
 export const enableNonInterruptingNormalPri = false;
 export const enableDiscreteEventMicroTasks = false;
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -55,7 +55,6 @@ export const enableUseRefAccessWarning = __VARIANT__;
 
 export const enableProfilerNestedUpdateScheduledHook = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
-export const enableTransitionEntanglement = __VARIANT__;
 export const enableNonInterruptingNormalPri = __VARIANT__;
 export const enableDiscreteEventMicroTasks = __VARIANT__;
 export const enableNativeEventPriorityInference = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -31,7 +31,6 @@ export const {
   enableUseRefAccessWarning,
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
-  enableTransitionEntanglement,
   enableNonInterruptingNormalPri,
   enableDiscreteEventMicroTasks,
   enableNativeEventPriorityInference,


### PR DESCRIPTION
Next step is to hardcode each priority level to a single lane. (Except transitions and retries.)