### PR TITLE
Move scheduler priority check into ReactDOM

### DIFF
--- a/packages/react-dom/src/events/DOMEventNames.js
+++ b/packages/react-dom/src/events/DOMEventNames.js
@@ -62,6 +62,7 @@ export type DOMEventName =
   | 'loadeddata'
   | 'loadedmetadata'
   | 'lostpointercapture'
+  | 'message'
   | 'mousedown'
   | 'mouseenter'
   | 'mouseleave'

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -55,6 +55,7 @@ import {
   DefaultLanePriority as DefaultLanePriority_old,
   getCurrentUpdateLanePriority as getCurrentUpdateLanePriority_old,
   setCurrentUpdateLanePriority as setCurrentUpdateLanePriority_old,
+  schedulerPriorityToLanePriority as schedulerPriorityToLanePriority_old,
 } from 'react-reconciler/src/ReactFiberLane.old';
 import {
   InputDiscreteLanePriority as InputDiscreteLanePriority_new,
@@ -62,7 +63,10 @@ import {
   DefaultLanePriority as DefaultLanePriority_new,
   getCurrentUpdateLanePriority as getCurrentUpdateLanePriority_new,
   setCurrentUpdateLanePriority as setCurrentUpdateLanePriority_new,
+  schedulerPriorityToLanePriority as schedulerPriorityToLanePriority_new,
 } from 'react-reconciler/src/ReactFiberLane.new';
+import {getCurrentPriorityLevel as getCurrentPriorityLevel_old} from 'react-reconciler/src/SchedulerWithReactIntegration.old';
+import {getCurrentPriorityLevel as getCurrentPriorityLevel_new} from 'react-reconciler/src/SchedulerWithReactIntegration.new';
 
 const InputDiscreteLanePriority = enableNewReconciler
   ? InputDiscreteLanePriority_new
@@ -79,6 +83,12 @@ const getCurrentUpdateLanePriority = enableNewReconciler
 const setCurrentUpdateLanePriority = enableNewReconciler
   ? setCurrentUpdateLanePriority_new
   : setCurrentUpdateLanePriority_old;
+const schedulerPriorityToLanePriority = enableNewReconciler
+  ? schedulerPriorityToLanePriority_new
+  : schedulerPriorityToLanePriority_old;
+const getCurrentPriorityLevel = enableNewReconciler
+  ? getCurrentPriorityLevel_new
+  : getCurrentPriorityLevel_old;
 
 const {
   unstable_UserBlockingPriority: UserBlockingPriority,
@@ -428,6 +438,13 @@ export function getEventPriority(domEventName: DOMEventName): * {
     case 'mouseenter':
     case 'mouseleave':
       return InputContinuousLanePriority;
+    case 'message': {
+      // We might be in the Scheduler callback.
+      // Eventually this mechanism will be replaced by a check
+      // of the current priority on the native scheduler.
+      const schedulerPriority = getCurrentPriorityLevel();
+      return schedulerPriorityToLanePriority(schedulerPriority);
+    }
     default:
       return DefaultLanePriority;
   }

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -443,6 +443,8 @@ export function getEventPriority(domEventName: DOMEventName): * {
       // Eventually this mechanism will be replaced by a check
       // of the current priority on the native scheduler.
       const schedulerPriority = getCurrentPriorityLevel();
+      // TODO: Inline schedulerPriorityToLanePriority into this file
+      // when we delete the enableNativeEventPriorityInference flag.
       return schedulerPriorityToLanePriority(schedulerPriority);
     }
     default:

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -465,15 +465,7 @@ export function requestUpdateLane(fiber: Fiber): Lane {
   } else {
     if (enableNativeEventPriorityInference) {
       const eventLanePriority = getCurrentEventPriority();
-      if (eventLanePriority === DefaultLanePriority) {
-        // TODO: move this case into the ReactDOM host config.
-        const schedulerLanePriority = schedulerPriorityToLanePriority(
-          schedulerPriority,
-        );
-        lane = findUpdateLane(schedulerLanePriority, currentEventWipLanes);
-      } else {
-        lane = findUpdateLane(eventLanePriority, currentEventWipLanes);
-      }
+      lane = findUpdateLane(eventLanePriority, currentEventWipLanes);
     } else {
       const schedulerLanePriority = schedulerPriorityToLanePriority(
         schedulerPriority,


### PR DESCRIPTION
Follow-up to https://github.com/facebook/react/pull/20748. When the `enableNativeEventPriorityInference` flag is on, we'll only be reading the scheduler priority inside `message` events — since that's where `scheduleCallback` callbacks are flushed.

None of the other places should be needing this because they won't have the scheduler priority set in the first place.