### PR TITLE
Debug tools supports custom hooks with the same name as primitives (alt 2)

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -335,4 +335,472 @@ describe('ReactHooksInspection', () => {
       ]);
     });
   });
+
+  describe('custom and primitive hook naming conflicts', () => {
+    it('use case one', () => {
+      function noop() {}
+
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function HooksNamingConflict() {
+        useCustom();
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'Custom',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: false,
+              name: 'Effect',
+              subHooks: [],
+              value: noop,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case two', () => {
+      function noop() {}
+
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        useCustom();
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'Custom',
+          subHooks: [
+            {
+              id: 3,
+              isStateEditable: false,
+              name: 'Effect',
+              subHooks: [],
+              value: noop,
+            },
+          ],
+          value: undefined,
+        },
+      ]);
+    });
+
+    it('use case three', () => {
+      function noop() {}
+
+      function useCustom() {
+        React.useEffect(noop);
+      }
+
+      function useState(value) {
+        React.useState(value);
+        useCustom();
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'Custom',
+              subHooks: [
+                {
+                  id: 1,
+                  isStateEditable: false,
+                  name: 'Effect',
+                  subHooks: [],
+                  value: noop,
+                },
+              ],
+              value: undefined,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+      ]);
+    });
+
+    it('use case four', () => {
+      function useState(value) {
+        React.useReducer(() => 0, 0);
+        React.useState(value);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case five', () => {
+      function useStateIndirection(value) {
+        React.useState(value);
+      }
+
+      function useState(value) {
+        useStateIndirection(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'StateIndirection',
+              subHooks: [
+                {
+                  id: 0,
+                  isStateEditable: true,
+                  name: 'State',
+                  subHooks: [],
+                  value: 0,
+                },
+              ],
+              value: undefined,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case six', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+      }
+
+      function useStateIndirection(value) {
+        useState(value);
+      }
+
+      function HooksNamingConflict() {
+        useStateIndirection(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'StateIndirection',
+          subHooks: [
+            {
+              id: null,
+              isStateEditable: false,
+              name: 'State',
+              subHooks: [
+                {
+                  id: 0,
+                  isStateEditable: true,
+                  name: 'State',
+                  subHooks: [],
+                  value: 0,
+                },
+                {
+                  id: 1,
+                  isStateEditable: true,
+                  name: 'Reducer',
+                  subHooks: [],
+                  value: 0,
+                },
+              ],
+              value: undefined,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 2,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case seven', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useState(true);
+        React.useReducer(() => 0, 0);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: true,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+
+    it('use case eight', () => {
+      function useState(value) {
+        React.useState(value);
+        React.useReducer(() => 0, 0);
+        React.useState(true);
+      }
+
+      function HooksNamingConflict() {
+        useState(0);
+        React.useMemo(() => 0, []);
+        return null;
+      }
+
+      const tree = ReactDebugTools.inspectHooks(HooksNamingConflict, {});
+      expect(tree).toEqual([
+        {
+          id: null,
+          isStateEditable: false,
+          name: 'State',
+          subHooks: [
+            {
+              id: 0,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 1,
+              isStateEditable: true,
+              name: 'Reducer',
+              subHooks: [],
+              value: 0,
+            },
+            {
+              id: 2,
+              isStateEditable: true,
+              name: 'State',
+              subHooks: [],
+              value: true,
+            },
+          ],
+          value: undefined,
+        },
+        {
+          id: 3,
+          isStateEditable: false,
+          name: 'Memo',
+          subHooks: [],
+          value: 0,
+        },
+      ]);
+    });
+  });
 });

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2343,4 +2343,62 @@ describe('InspectedElement', () => {
       `);
     });
   });
+
+  it('should gracefully handle custom hooks that have the same name as primitive hooks', async done => {
+    function useState() {
+      React.useState(0);
+      React.useEffect(() => {});
+    }
+
+    function HooksNamingConflict() {
+      useState();
+      React.useMemo(() => 0, []);
+      return null;
+    }
+
+    const container = document.createElement('div');
+    await utils.actAsync(() =>
+      ReactDOM.render(<HooksNamingConflict />, container),
+    );
+
+    const inspectedElement = await inspectElementAtIndex(0);
+    expect(inspectedElement.hooks).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": null,
+          "isStateEditable": false,
+          "name": "State",
+          "subHooks": Array [
+            Object {
+              "id": 0,
+              "isStateEditable": true,
+              "name": "State",
+              "subHooks": Array [],
+              "value": 0,
+            },
+            Object {
+              "id": 1,
+              "isStateEditable": false,
+              "name": "Effect",
+              "subHooks": Array [],
+              "value": Dehydrated {
+                "preview_short": ƒ () {},
+                "preview_long": ƒ () {},
+              },
+            },
+          ],
+          "value": undefined,
+        },
+        Object {
+          "id": 2,
+          "isStateEditable": false,
+          "name": "Memo",
+          "subHooks": Array [],
+          "value": 0,
+        },
+      ]
+    `);
+
+    done();
+  });
 });


### PR DESCRIPTION
Alternative fix to #20664