### PR TITLE
Cross-fork lint: Support named export declaration

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -103,7 +103,7 @@ export {
   DefaultLanePriority as DefaultEventPriority,
 } from './ReactFiberLane.old';
 
-export {registerMutableSourceForHydration} from './ReactMutableSource.new';
+export {registerMutableSourceForHydration} from './ReactMutableSource.old';
 export {createPortal} from './ReactPortal';
 export {
   createComponentSelector,

--- a/scripts/eslint-rules/__tests__/no-cross-fork-imports-test.internal.js
+++ b/scripts/eslint-rules/__tests__/no-cross-fork-imports-test.internal.js
@@ -94,5 +94,29 @@ ruleTester.run('eslint-rules/no-cross-fork-imports', rule, {
       ],
       output: "import {scheduleUpdateOnFiber} from './ReactFiberWorkLoop.new';",
     },
+    {
+      code: "export {DiscreteEventPriority} from './ReactFiberLane.old.js';",
+      filename: 'ReactFiberReconciler.new.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the new fork cannot import a module ' +
+            'from the old fork.',
+        },
+      ],
+      output: "export {DiscreteEventPriority} from './ReactFiberLane.new';",
+    },
+    {
+      code: "export {DiscreteEventPriority} from './ReactFiberLane.new.js';",
+      filename: 'ReactFiberReconciler.old.js',
+      errors: [
+        {
+          message:
+            'A module that belongs to the old fork cannot import a module ' +
+            'from the new fork.',
+        },
+      ],
+      output: "export {DiscreteEventPriority} from './ReactFiberLane.old';",
+    },
   ],
 });


### PR DESCRIPTION
Noticed this didn't work when I ran `replace-fork` and a named export declaration in ReactFiberReconciler was not properly fixed.