### PR TITLE
DevTools: Restore inspect-element bridge optimizations

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -26,15 +26,14 @@ describe('InspectedElementContext', () => {
 
   async function read(
     id: number,
-    inspectedPaths?: Object = {},
+    path?: Array<string | number> = null,
   ): Promise<Object> {
     const rendererID = ((store.getRendererIDForElement(id): any): number);
     const promise = backendAPI
       .inspectElement({
         bridge,
-        forceUpdate: true,
         id,
-        inspectedPaths,
+        path,
         rendererID,
       })
       .then(data =>
@@ -686,7 +685,7 @@ describe('InspectedElementContext', () => {
       }
     `);
 
-    inspectedElement = await read(id, {props: {nestedObject: {a: {}}}});
+    inspectedElement = await read(id, ['props', 'nestedObject', 'a']);
     expect(inspectedElement.props).toMatchInlineSnapshot(`
       Object {
         "nestedObject": Object {
@@ -702,9 +701,7 @@ describe('InspectedElementContext', () => {
       }
     `);
 
-    inspectedElement = await read(id, {
-      props: {nestedObject: {a: {b: {c: {}}}}},
-    });
+    inspectedElement = await read(id, ['props', 'nestedObject', 'a', 'b', 'c']);
     expect(inspectedElement.props).toMatchInlineSnapshot(`
       Object {
         "nestedObject": Object {
@@ -724,9 +721,15 @@ describe('InspectedElementContext', () => {
       }
     `);
 
-    inspectedElement = await read(id, {
-      props: {nestedObject: {a: {b: {c: {0: {d: {}}}}}}},
-    });
+    inspectedElement = await read(id, [
+      'props',
+      'nestedObject',
+      'a',
+      'b',
+      'c',
+      0,
+      'd',
+    ]);
     expect(inspectedElement.props).toMatchInlineSnapshot(`
       Object {
         "nestedObject": Object {

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -70,8 +70,7 @@ type CopyElementParams = {|
 
 type InspectElementParams = {|
   id: number,
-  inspectedPaths: Object,
-  forceUpdate: boolean,
+  path: Array<string | number> | null,
   rendererID: number,
   requestID: number,
 |};
@@ -332,8 +331,7 @@ export default class Agent extends EventEmitter<{|
 
   inspectElement = ({
     id,
-    inspectedPaths,
-    forceUpdate,
+    path,
     rendererID,
     requestID,
   }: InspectElementParams) => {
@@ -343,7 +341,7 @@ export default class Agent extends EventEmitter<{|
     } else {
       this._bridge.send(
         'inspectedElement',
-        renderer.inspectElement(requestID, id, inspectedPaths, forceUpdate),
+        renderer.inspectElement(requestID, id, path),
       );
 
       // When user selects an element, stop trying to restore the selection,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -258,20 +258,28 @@ export const InspectElementFullDataType = 'full-data';
 export const InspectElementNoChangeType = 'no-change';
 export const InspectElementNotFoundType = 'not-found';
 
-type InspectElementFullData = {|
+export type InspectElementFullData = {|
   id: number,
   responseID: number,
   type: 'full-data',
   value: InspectedElement,
 |};
 
-type InspectElementNoChange = {|
+export type InspectElementHydratedPath = {|
+  id: number,
+  responseID: number,
+  type: 'hydrated-path',
+  path: Array<string | number>,
+  value: any,
+|};
+
+export type InspectElementNoChange = {|
   id: number,
   responseID: number,
   type: 'no-change',
 |};
 
-type InspectElementNotFound = {|
+export type InspectElementNotFound = {|
   id: number,
   responseID: number,
   type: 'not-found',
@@ -279,6 +287,7 @@ type InspectElementNotFound = {|
 
 export type InspectedElementPayload =
   | InspectElementFullData
+  | InspectElementHydratedPath
   | InspectElementNoChange
   | InspectElementNotFound;
 
@@ -316,7 +325,6 @@ export type RendererInterface = {
     requestID: number,
     id: number,
     inspectedPaths: Object,
-    forceUpdate: boolean,
   ) => InspectedElementPayload,
   logElementToConsole: (id: number) => void,
   overrideSuspense: (id: number, forceFallback: boolean) => void,

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -86,15 +86,13 @@ export function copyInspectedElementPath({
 
 export function inspectElement({
   bridge,
-  forceUpdate,
   id,
-  inspectedPaths,
+  path,
   rendererID,
 }: {|
   bridge: FrontendBridge,
-  forceUpdate: boolean,
   id: number,
-  inspectedPaths: Object,
+  path: Array<string | number> | null,
   rendererID: number,
 |}): Promise<InspectedElementPayload> {
   const requestID = requestCounter++;
@@ -105,9 +103,8 @@ export function inspectElement({
   );
 
   bridge.send('inspectElement', {
-    forceUpdate,
     id,
-    inspectedPaths,
+    path,
     rendererID,
     requestID,
   });
@@ -254,7 +251,7 @@ export function convertInspectedElementBackendToFrontend(
   return inspectedElement;
 }
 
-function hydrateHelper(
+export function hydrateHelper(
   dehydratedData: DehydratedData | null,
   path?: Array<string | number>,
 ): Object | null {

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -89,8 +89,7 @@ type ViewAttributeSourceParams = {|
 
 type InspectElementParams = {|
   ...ElementAndRendererID,
-  forceUpdate: boolean,
-  inspectedPaths: Object,
+  path: Array<number | string> | null,
   requestID: number,
 |};
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -27,6 +27,8 @@ import type {InspectedElement} from './types';
 
 export type Props = {||};
 
+// TODO Make edits and deletes also use transition API!
+
 export default function InspectedElementWrapper(_: Props) {
   const {inspectedElementID} = useContext(TreeStateContext);
   const dispatch = useContext(TreeDispatcherContext);

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -56,7 +56,10 @@ export function InspectedElementContextController({children}: Props) {
 
   const refresh = useCacheRefresh();
 
-  // Track the paths insepected for the currently selected element.
+  // Temporarily stores most recently-inspected (hydrated) path.
+  // The transition that updates this causes the component to re-render and ask the cache->backend for the new path.
+  // When a path is sent along with an "inspectElement" request,
+  // the backend knows to send its dehydrated data even if the element hasn't updated since the last request.
   const [state, setState] = useState<{|
     element: Element | null,
     path: Array<number | string> | null,
@@ -97,7 +100,8 @@ export function InspectedElementContextController({children}: Props) {
     [setState, state],
   );
 
-  // Reset path
+  // Reset path now that we've asked the backend to hydrate it.
+  // The backend is stateful, so we don't need to remember this path the next time we inspect.
   useEffect(() => {
     if (state.path !== null) {
       setState({

--- a/packages/react-devtools-shared/src/devtools/views/Components/types.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/types.js
@@ -56,6 +56,12 @@ export type OwnersList = {|
   owners: Array<Owner> | null,
 |};
 
+export type InspectedElementResponseType =
+  | 'full-data'
+  | 'hydrated-path'
+  | 'no-change'
+  | 'not-found';
+
 export type InspectedElement = {|
   id: number,
 

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -12,17 +12,10 @@ import {
   unstable_startTransition as startTransition,
 } from 'react';
 import Store from './devtools/store';
-import {
-  convertInspectedElementBackendToFrontend,
-  inspectElement as inspectElementAPI,
-} from './backendAPI';
+import {inspectElement as inspectElementMutableSource} from './inspectedElementMutableSource';
 
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {Wakeable} from 'shared/ReactTypes';
-import type {
-  InspectedElement as InspectedElementBackend,
-  InspectedElementPayload,
-} from 'react-devtools-shared/src/backend/types';
 import type {
   Element,
   InspectedElement as InspectedElementFrontend,
@@ -88,13 +81,13 @@ function createCacheSeed(
  */
 export function inspectElement(
   element: Element,
-  inspectedPaths: Object,
-  forceUpdate: boolean,
+  path: Array<string | number> | null,
   store: Store,
   bridge: FrontendBridge,
 ): InspectedElementFrontend | null {
   const map = getRecordMap();
   let record = map.get(element);
+
   if (!record) {
     const callbacks = new Set();
     const wakeable: Wakeable = {
@@ -116,50 +109,31 @@ export function inspectElement(
     if (rendererID == null) {
       const rejectedRecord = ((newRecord: any): RejectedRecord);
       rejectedRecord.status = Rejected;
-      rejectedRecord.value = 'Inspected element not found.';
+      rejectedRecord.value = `Could not inspect element with id ${element.id}`;
+
+      map.set(element, record);
+
       return null;
     }
 
-    inspectElementAPI({
+    inspectElementMutableSource({
       bridge,
-      forceUpdate: true,
-      id: element.id,
-      inspectedPaths,
+      element,
+      path,
       rendererID: ((rendererID: any): number),
     }).then(
-      (data: InspectedElementPayload) => {
-        if (newRecord.status === Pending) {
-          switch (data.type) {
-            case 'no-change':
-              // This response type should never be received.
-              // We always send forceUpdate:true when we have a cache miss.
-              break;
-
-            case 'not-found':
-              const notFoundRecord = ((newRecord: any): RejectedRecord);
-              notFoundRecord.status = Rejected;
-              notFoundRecord.value = 'Inspected element not found.';
-              wake();
-              break;
-
-            case 'full-data':
-              const resolvedRecord = ((newRecord: any): ResolvedRecord<InspectedElementFrontend>);
-              resolvedRecord.status = Resolved;
-              resolvedRecord.value = convertInspectedElementBackendToFrontend(
-                ((data.value: any): InspectedElementBackend),
-              );
-              wake();
-              break;
-          }
-        }
+      (inspectedElement: InspectedElementFrontend) => {
+        const resolvedRecord = ((newRecord: any): ResolvedRecord<InspectedElementFrontend>);
+        resolvedRecord.status = Resolved;
+        resolvedRecord.value = inspectedElement;
+        wake();
       },
 
-      () => {
-        // Timed out without receiving a response.
+      error => {
         if (newRecord.status === Pending) {
-          const timedOutRecord = ((newRecord: any): RejectedRecord);
-          timedOutRecord.status = Rejected;
-          timedOutRecord.value = 'Inspected element timed out.';
+          const rejectedRecord = ((newRecord: any): RejectedRecord);
+          rejectedRecord.status = Rejected;
+          rejectedRecord.value = `Could not inspect element with id ${element.id}`;
           wake();
         }
       },
@@ -184,37 +158,28 @@ type RefreshFunction = (
 export function checkForUpdate({
   bridge,
   element,
-  inspectedPaths,
   refresh,
   store,
 }: {
   bridge: FrontendBridge,
   element: Element,
-  inspectedPaths: Object,
   refresh: RefreshFunction,
   store: Store,
 }): void {
   const {id} = element;
   const rendererID = store.getRendererIDForElement(id);
   if (rendererID != null) {
-    inspectElementAPI({
+    inspectElementMutableSource({
       bridge,
-      forceUpdate: false,
-      id,
-      inspectedPaths,
-      rendererID,
-    }).then((data: InspectedElementPayload) => {
-      switch (data.type) {
-        case 'full-data':
-          const inspectedElement = convertInspectedElementBackendToFrontend(
-            ((data.value: any): InspectedElementBackend),
-          );
-          startTransition(() => {
-            const [key, value] = createCacheSeed(element, inspectedElement);
-            refresh(key, value);
-          });
-          break;
-      }
+      element,
+      path: null,
+      rendererID: ((rendererID: any): number),
+    }).then((inspectedElement: InspectedElementFrontend) => {
+      // TODO only start transition if we got an update; right now we over-update even after "no-change"
+      startTransition(() => {
+        const [key, value] = createCacheSeed(element, inspectedElement);
+        refresh(key, value);
+      });
     });
   }
 }

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -19,6 +19,7 @@ import type {Wakeable} from 'shared/ReactTypes';
 import type {
   Element,
   InspectedElement as InspectedElementFrontend,
+  InspectedElementResponseType,
 } from 'react-devtools-shared/src/devtools/views/Components/types';
 
 const Pending = 0;
@@ -122,7 +123,7 @@ export function inspectElement(
       path,
       rendererID: ((rendererID: any): number),
     }).then(
-      (inspectedElement: InspectedElementFrontend) => {
+      ([inspectedElement: InspectedElementFrontend]) => {
         const resolvedRecord = ((newRecord: any): ResolvedRecord<InspectedElementFrontend>);
         resolvedRecord.status = Resolved;
         resolvedRecord.value = inspectedElement;
@@ -174,12 +175,18 @@ export function checkForUpdate({
       element,
       path: null,
       rendererID: ((rendererID: any): number),
-    }).then((inspectedElement: InspectedElementFrontend) => {
-      // TODO only start transition if we got an update; right now we over-update even after "no-change"
-      startTransition(() => {
-        const [key, value] = createCacheSeed(element, inspectedElement);
-        refresh(key, value);
-      });
-    });
+    }).then(
+      ([
+        inspectedElement: InspectedElementFrontend,
+        responseType: InspectedElementResponseType,
+      ]) => {
+        if (responseType === 'full-data') {
+          startTransition(() => {
+            const [key, value] = createCacheSeed(element, inspectedElement);
+            refresh(key, value);
+          });
+        }
+      },
+    );
   }
 }

--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {
+  convertInspectedElementBackendToFrontend,
+  hydrateHelper,
+  inspectElement as inspectElementAPI,
+} from 'react-devtools-shared/src/backendAPI';
+import {fillInPath} from 'react-devtools-shared/src/hydration';
+
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+import type {
+  InspectElementFullData,
+  InspectElementHydratedPath,
+} from 'react-devtools-shared/src/backend/types';
+import type {
+  Element,
+  InspectedElement as InspectedElementFrontend,
+} from 'react-devtools-shared/src/devtools/views/Components/types';
+
+// Map an Element in the Store to the most recent copy of its inspected data.
+// As updates comes from the backend, inspected data is updated.
+// Both this map and the inspected objects in it are mutable.
+// They should never be read from directly during render;
+// Use a Suspense cache to ensure that transitions work correctly and there is no tearing.
+const inspectedElementMap: WeakMap<
+  Element,
+  InspectedElementFrontend,
+> = new WeakMap();
+
+type Path = Array<string | number>;
+
+export function inspectElement({
+  bridge,
+  element,
+  path,
+  rendererID,
+}: {|
+  bridge: FrontendBridge,
+  element: Element,
+  path: Path | null,
+  rendererID: number,
+|}): Promise<InspectedElementFrontend> {
+  const {id} = element;
+  return inspectElementAPI({
+    bridge,
+    id,
+    path,
+    rendererID,
+  }).then((data: any) => {
+    const {type} = data;
+
+    let inspectedElement;
+    switch (type) {
+      case 'no-change':
+        // This is a no-op for the purposes of our cache.
+        inspectedElement = inspectedElementMap.get(element);
+        if (inspectedElement != null) {
+          return inspectedElement;
+        }
+        break;
+
+      case 'not-found':
+        // This is effectively a no-op.
+        // If the Element is still in the Store, we can eagerly remove it from the Map.
+        inspectedElementMap.delete(element);
+
+        throw Error(`Element ${id} not found`);
+
+      case 'full-data':
+        const fullData = ((data: any): InspectElementFullData);
+
+        // New data has come in.
+        // We should replace the data in our local mutable copy.
+        inspectedElement = convertInspectedElementBackendToFrontend(
+          fullData.value,
+        );
+
+        inspectedElementMap.set(element, inspectedElement);
+
+        return inspectedElement;
+
+      case 'hydrated-path':
+        const hydratedPathData = ((data: any): InspectElementHydratedPath);
+        const {value} = hydratedPathData;
+
+        // A path has been hydrated.
+        // Merge it with the latest copy we have locally and resolve with the merged value.
+        inspectedElement = inspectedElementMap.get(element) || null;
+        if (inspectedElement !== null) {
+          // Clone element
+          inspectedElement = {...inspectedElement};
+
+          // Merge hydrated data
+          fillInPath(
+            inspectedElement,
+            value,
+            ((path: any): Path),
+            hydrateHelper(value, ((path: any): Path)),
+          );
+
+          inspectedElementMap.set(element, inspectedElement);
+
+          return inspectedElement;
+        }
+        break;
+
+      default:
+        // Should never happen.
+        if (__DEV__) {
+          console.error(
+            `Unexpected inspected element response data: "${type}"`,
+          );
+        }
+        break;
+    }
+
+    throw Error(`Unable to inspect element with id ${id}`);
+  });
+}

--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -22,6 +22,7 @@ import type {
 import type {
   Element,
   InspectedElement as InspectedElementFrontend,
+  InspectedElementResponseType,
 } from 'react-devtools-shared/src/devtools/views/Components/types';
 
 // Map an Element in the Store to the most recent copy of its inspected data.
@@ -36,6 +37,11 @@ const inspectedElementMap: WeakMap<
 
 type Path = Array<string | number>;
 
+type InspectElementReturnType = [
+  InspectedElementFrontend,
+  InspectedElementResponseType,
+];
+
 export function inspectElement({
   bridge,
   element,
@@ -46,7 +52,7 @@ export function inspectElement({
   element: Element,
   path: Path | null,
   rendererID: number,
-|}): Promise<InspectedElementFrontend> {
+|}): Promise<InspectElementReturnType> {
   const {id} = element;
   return inspectElementAPI({
     bridge,
@@ -62,7 +68,7 @@ export function inspectElement({
         // This is a no-op for the purposes of our cache.
         inspectedElement = inspectedElementMap.get(element);
         if (inspectedElement != null) {
-          return inspectedElement;
+          return [inspectedElement, type];
         }
         break;
 
@@ -84,7 +90,7 @@ export function inspectElement({
 
         inspectedElementMap.set(element, inspectedElement);
 
-        return inspectedElement;
+        return [inspectedElement, type];
 
       case 'hydrated-path':
         const hydratedPathData = ((data: any): InspectElementHydratedPath);
@@ -107,7 +113,7 @@ export function inspectElement({
 
           inspectedElementMap.set(element, inspectedElement);
 
-          return inspectedElement;
+          return [inspectedElement, type];
         }
         break;
 


### PR DESCRIPTION
Follow up to PR #20548

Improve Suspense cache integration and restore some of the bridge traffic optimizations that were removed during the initial integration.

### TODO
- [x] Add mutable source (`packages/react-devtools-shared/src/inspectedElementMutableSource`) on the frontend between backend and Suspense cache
- [x] Using the new mutable source, restore "hydrated-path" response type to avoid having to re-send entire inspected element any time a path was inspected
- [x] Don't over-eagerly refresh the cache in our ping-for-updates handler

### Follow up
- [ ] Make inspected element edits and deletes also use transition API
