### PR TITLE
Parallelize Flow in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
   yarn_flow:
     docker: *docker
     environment: *environment
+    parallelism: 5
 
     steps:
       - checkout
@@ -384,9 +385,6 @@ workflows:
       - yarn_lint:
           requires:
             - setup
-      - yarn_flow:
-          requires:
-            - setup
       - RELEASE_CHANNEL_stable_yarn_build:
           requires:
             - setup
@@ -426,6 +424,9 @@ workflows:
     unless: << pipeline.parameters.prerelease_commit_sha >>
     jobs:
       - setup
+      - yarn_flow:
+          requires:
+            - setup
       - yarn_test:
           requires:
             - setup

--- a/scripts/tasks/flow-ci.js
+++ b/scripts/tasks/flow-ci.js
@@ -14,12 +14,22 @@ process.on('unhandledRejection', err => {
 const runFlow = require('../flow/runFlow');
 const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
 
+// Parallelize tests across multiple tasks.
+const nodeTotal = process.env.CIRCLE_NODE_TOTAL
+  ? parseInt(process.env.CIRCLE_NODE_TOTAL, 10)
+  : 1;
+const nodeIndex = process.env.CIRCLE_NODE_TOTAL
+  ? parseInt(process.env.CIRCLE_NODE_INDEX, 10)
+  : 0;
+
 async function checkAll() {
-  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-  for (let rendererInfo of inlinedHostConfigs) {
-    if (rendererInfo.isFlowTyped) {
-      await runFlow(rendererInfo.shortName, ['check']);
-      console.log();
+  for (let i = 0; i < inlinedHostConfigs.length; i++) {
+    if (i % nodeTotal === nodeIndex) {
+      const rendererInfo = inlinedHostConfigs[i];
+      if (rendererInfo.isFlowTyped) {
+        await runFlow(rendererInfo.shortName, ['check']);
+        console.log();
+      }
     }
   }
 }

--- a/scripts/tasks/flow-ci.js
+++ b/scripts/tasks/flow-ci.js
@@ -18,7 +18,7 @@ const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
 const nodeTotal = process.env.CIRCLE_NODE_TOTAL
   ? parseInt(process.env.CIRCLE_NODE_TOTAL, 10)
   : 1;
-const nodeIndex = process.env.CIRCLE_NODE_TOTAL
+const nodeIndex = process.env.CIRCLE_NODE_INDEX
   ? parseInt(process.env.CIRCLE_NODE_INDEX, 10)
   : 0;
 


### PR DESCRIPTION
We added more host configs recently, and we run all the checks in sequence, so sometimes Flow ends up being the slowest CI job.

This splits the job across multiple processes.