### PR TITLE
Remove deps from replace-fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,8 +384,6 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - run: yarn workspaces info | head -n -1 > workspace_info.txt
-      - *restore_node_modules
       - run:
           name: Confirm reconciler forks are the same
           command: |


### PR DESCRIPTION
## Overview

This means we don't need to restore the node_module cache in CI, making this check faster than the rest. Which is good, because if you accidentally forget this, you want to know about it first.