### PR TITLE
Improving feedback for "Text strings must be rendered within a <Text> component." errors.

### DIFF
--- a/packages/react-native-renderer/src/AssertTextIsInTextComponent.js
+++ b/packages/react-native-renderer/src/AssertTextIsInTextComponent.js
@@ -1,16 +1,20 @@
 import invariant from 'shared/invariant';
 
+export type HostContext = $ReadOnly<{|
+  isInAParentText: boolean,
+|}>;
+
 function stripInformation(
-  internalInstanceHandle: Object
+  internalInstanceHandle: Object,
 ) {
-  var possibleCause = '\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.';
+  const possibleCause = '\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.';
   if (internalInstanceHandle && internalInstanceHandle.sibling) {
-    var debugOwner = internalInstanceHandle.sibling._debugOwner;
-    var debugSource = internalInstanceHandle.sibling._debugSource;
+    const debugOwner = internalInstanceHandle.sibling._debugOwner;
+    const debugSource = internalInstanceHandle.sibling._debugSource;
     if (debugOwner && debugSource) {
-      var parentComponentName = debugOwner.type.name;
-      var siblingSource = '"' + debugSource.fileName + '" line ' + debugSource.lineNumber + ', column ' + debugSource.columnNumber;
-      return ' Error may have occured in component <' + parentComponentName + '> near ' + siblingSource + '.' + possibleCause;
+      const parentComponentName = debugOwner.type.name;
+      const siblingSource = `"${debugSource.fileName}" line ${debugSource.lineNumber}, column ${debugSource.columnNumber}`;
+      return ` Error may have occured in component <${parentComponentName}> near ${siblingSource}. ${possibleCause}`;
     }
   }
   return possibleCause;
@@ -19,10 +23,12 @@ function stripInformation(
 export function assertTextInTextComponent(
   hostContext: HostContext,
   text: string,
-  internalInstanceHandle: Object
+  internalInstanceHandle: Object,
 ) {
   invariant(
     hostContext.isInAParentText,
-    'Text string "' + text + '" must be rendered within a <Text> component.' + stripInformation(internalInstanceHandle),
+    'Text string "%s" must be rendered within a <Text> component.%s',
+    text,
+    stripInformation(internalInstanceHandle),
   );
 }

--- a/packages/react-native-renderer/src/AssertTextIsInTextComponent.js
+++ b/packages/react-native-renderer/src/AssertTextIsInTextComponent.js
@@ -1,0 +1,28 @@
+import invariant from 'shared/invariant';
+
+function stripInformation(
+  internalInstanceHandle: Object
+) {
+  var possibleCause = '\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.';
+  if (internalInstanceHandle && internalInstanceHandle.sibling) {
+    var debugOwner = internalInstanceHandle.sibling._debugOwner;
+    var debugSource = internalInstanceHandle.sibling._debugSource;
+    if (debugOwner && debugSource) {
+      var parentComponentName = debugOwner.type.name;
+      var siblingSource = '"' + debugSource.fileName + '" line ' + debugSource.lineNumber + ', column ' + debugSource.columnNumber;
+      return ' Error may have occured in component <' + parentComponentName + '> near ' + siblingSource + '.' + possibleCause;
+    }
+  }
+  return possibleCause;
+}
+
+export function assertTextInTextComponent(
+  hostContext: HostContext,
+  text: string,
+  internalInstanceHandle: Object
+) {
+  invariant(
+    hostContext.isInAParentText,
+    'Text string "' + text + '" must be rendered within a <Text> component.' + stripInformation(internalInstanceHandle),
+  );
+}

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -20,6 +20,7 @@ import type {
 
 import {mountSafeCallback_NOT_REALLY_SAFE} from './NativeMethodsMixinUtils';
 import {create, diff} from './ReactNativeAttributePayload';
+import {assertTextInTextComponent} from './AssertTextIsInTextComponent';
 
 import {enableNewReconciler} from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';
@@ -250,10 +251,7 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  invariant(
-    hostContext.isInAParentText,
-    'Text strings must be rendered within a <Text> component.',
-  );
+  assertTextInTextComponent(hostContext, text, internalInstanceHandle);
 
   const tag = nextReactTag;
   nextReactTag += 2;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -29,6 +29,7 @@ import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 
 import {DefaultLanePriority as DefaultLanePriority_old} from 'react-reconciler/src/ReactFiberLane.old';
 import {DefaultLanePriority as DefaultLanePriority_new} from 'react-reconciler/src/ReactFiberLane.new';
+import { assertTextInTextComponent } from './AssertTextIsInTextComponent';
 
 const DefaultLanePriority = enableNewReconciler
   ? DefaultLanePriority_new
@@ -152,10 +153,7 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  invariant(
-    hostContext.isInAParentText,
-    'Text strings must be rendered within a <Text> component.',
-  );
+  assertTextInTextComponent(hostContext, text, internalInstanceHandle);
 
   const tag = allocateTag();
 

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -625,7 +625,7 @@ describe('ReactFabric', () => {
     }));
 
     expect(() => ReactFabric.render(<View>this should warn</View>, 11)).toThrow(
-      'Text strings must be rendered within a <Text> component.',
+      'Text string "this should warn" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.',
     );
 
     expect(() =>
@@ -635,7 +635,7 @@ describe('ReactFabric', () => {
         </Text>,
         11,
       ),
-    ).toThrow('Text strings must be rendered within a <Text> component.');
+    ).toThrow('Text string "hi hello hi" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -488,7 +488,7 @@ describe('ReactNative', () => {
     }));
 
     expect(() => ReactNative.render(<View>this should warn</View>, 11)).toThrow(
-      'Text strings must be rendered within a <Text> component.',
+      'Text string "this should warn" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.',
     );
 
     expect(() =>
@@ -498,7 +498,7 @@ describe('ReactNative', () => {
         </Text>,
         11,
       ),
-    ).toThrow('Text strings must be rendered within a <Text> component.');
+    ).toThrow('Text string "hi hello hi" must be rendered within a <Text> component.\n\nProbably result of a conditional rendering using boolean concatination as in `cond && <Component ...>`.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->


## Summary

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

This PR is meant to be a draft for changes in the renderer. In our company we sometimes facing "Text strings must be rendered within a \<Text\> component." errors related to conditional concatenation with components. Since conditionals are often values provided by services, it is difficult to track down the exact location where they occur. Unfortunately, both the error component stack and the call stack do not provide enough information to find the corresponding location in the code. For this reason, we patched React Native locally to drastically reduce the debugging time associated with such errors.

The provided changes of this PR are basically the patch applied locally to React Native in our project. The improvements to the messages from our patch include the actual text that could not be rendered, as well as a sibling component and its exact location in the source code. This allows my colleagues and me to quickly track down problems and locate the approximate point of failure in our code. It also gives a hint that the problem might be related to a concatenation between a value and a component.

However, this solution is not quite perfect, as the information is not detailed enough in cases where the error is caused by code, such as the following:

```
<View>
  forgot to wrap this text with text component...
</View>
```

Obviously, in this situation, there are no sibling components from which we can infer the source code location or parent component. Nevertheless, in such cases the message contains at least the text which could not be rendered without `<Text>` component. The question we have is whether it is possible to make the error message more verbose in all cases?
