### PR TITLE
Change spawnedWorkDuringRender to a bitmask

### DIFF
--- a/fixtures/tracing/test.js
+++ b/fixtures/tracing/test.js
@@ -1,5 +1,5 @@
 const {createElement, Component, Suspense} = React;
-const {createRoot} = ReactDOM;
+const {unstable_createRoot} = ReactDOM;
 const {
   unstable_subscribe: subscribe,
   unstable_trace: trace,
@@ -90,7 +90,7 @@ subscribe({
 
 const element = document.getElementById('root');
 trace('initial_render', performance.now(), () => {
-  const root = createRoot(element);
+  const root = unstable_createRoot(element);
   log.app('render()');
   root.render(
     createElement(TestApp),


### PR DESCRIPTION
As lanes define a bitmask of different kinds of work to be performed on a fiber, this could be merged in one single lane instead of using an array.

This assumes that scheduling a pending interaction for the same lane a second time is redundant work.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This probably could deliver a little bit of a performance improvement and simplify this piece of code.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

All the tests are passing, I just had to make a little fix for one test.
