### PR TITLE
PoC: support launch editor feature for selected component

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -76,6 +76,12 @@ type InspectElementParams = {|
   requestID: number,
 |};
 
+type LaunchEditorParams = {|
+  launchEditorEndpoint: string,
+  fileName: string,
+  lineNumber: string,
+|};
+
 type OverrideHookParams = {|
   id: number,
   hookID: number,
@@ -180,6 +186,7 @@ export default class Agent extends EventEmitter<{|
     bridge.addListener('getProfilingStatus', this.getProfilingStatus);
     bridge.addListener('getOwnersList', this.getOwnersList);
     bridge.addListener('inspectElement', this.inspectElement);
+    bridge.addListener('launchEditor', this.launchEditor);
     bridge.addListener('logElementToConsole', this.logElementToConsole);
     bridge.addListener('overrideSuspense', this.overrideSuspense);
     bridge.addListener('overrideValueAtPath', this.overrideValueAtPath);
@@ -364,6 +371,31 @@ export default class Agent extends EventEmitter<{|
       // https://github.com/bvaughn/react-devtools-experimental/issues/102
       // (Setting $0 doesn't work, and calling inspect() switches the tab.)
     }
+  };
+
+  launchEditor = ({
+    launchEditorEndpoint,
+    fileName,
+    lineNumber,
+  }: LaunchEditorParams) => {
+    fetch(
+      `/${launchEditorEndpoint}?fileName=${fileName}&lineNumber=${lineNumber}`,
+    )
+      .then(res => {
+        if (res.ok) {
+          console.log(`open ${fileName} in editor success`);
+        } else {
+          console.warn(`open ${fileName} in editor failed`);
+          console.warn(
+            'Please make sure the open editor server middleware(e.g. react-dev-utils) is installed correctly!',
+          );
+        }
+      })
+      .catch(_ => {
+        console.error(
+          'make sure the open editor server middleware(e.g. react-dev-utils) installed correctly!',
+        );
+      });
   };
 
   logElementToConsole = ({id, rendererID}: ElementAndRendererID) => {

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -119,6 +119,12 @@ type UpdateConsolePatchSettingsParams = {|
   showInlineWarningsAndErrors: boolean,
 |};
 
+type LauchEditorParams = {|
+  launchEditorEndpoint: string,
+  fileName: string,
+  lineNumber: string,
+|};
+
 export type BackendEvents = {|
   extensionBackendInitialized: [],
   inspectedElement: [InspectedElementPayload],
@@ -155,6 +161,7 @@ type FrontendEvents = {|
   getProfilingStatus: [],
   highlightNativeElement: [HighlightElementInDOM],
   inspectElement: [InspectElementParams],
+  launchEditor: [LauchEditorParams],
   logElementToConsole: [ElementAndRendererID],
   overrideSuspense: [OverrideSuspense],
   overrideValueAtPath: [OverrideValueAtPath],

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -38,6 +38,9 @@ export const LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY =
 export const LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY =
   'React::DevTools::showInlineWarningsAndErrors';
 
+export const LOCAL_STORAGE_OPEN_EDITOR_ENDPOINT_KEY =
+  'React::DevTools::launchEditorEndpoint';
+
 export const LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY =
   'React::DevTools::traceUpdatesEnabled';
 
@@ -48,6 +51,8 @@ export const CHANGE_LOG_URL =
 
 export const UNSUPPORTED_VERSION_URL =
   'https://reactjs.org/blog/2019/08/15/new-react-devtools.html#how-do-i-get-the-old-version-back';
+
+export const DEFAULT_OPEN_EDITOR_ENDPOINT = '__open-stack-frame-in-editor';
 
 // HACK
 //

--- a/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
+++ b/packages/react-devtools-shared/src/devtools/views/ButtonIcon.js
@@ -23,6 +23,7 @@ export type IconType =
   | 'export'
   | 'filter'
   | 'import'
+  | 'launch-editor'
   | 'log-data'
   | 'more'
   | 'next'
@@ -81,6 +82,9 @@ export default function ButtonIcon({className = '', type}: Props) {
       break;
     case 'import':
       pathData = PATH_IMPORT;
+      break;
+    case 'launch-editor':
+      pathData = PATH_LAUNCH_EDITOR;
       break;
     case 'log-data':
       pathData = PATH_LOG_DATA;
@@ -244,3 +248,9 @@ const PATH_VIEW_DOM = `
 const PATH_VIEW_SOURCE = `
   M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z
   `;
+
+const PATH_LAUNCH_EDITOR = `M896 435.2a25.6 25.6 0 0 1-25.6-25.6v-256H640a25.6 25.6 0 1 1 0-51.2h256a25.6 25.6 0 0 1 25.6
+  25.6v281.6a25.6 25.6 0 0 1-25.6 25.6zM844.8 921.6H128a25.6 25.6 0 0 1-25.6-25.6V179.2a25.6 25.6 0 0 1 25.6-25.6h358.4a25.6
+  25.6 0 1 1 0 51.2H153.6v665.6h665.6V537.6a25.6 25.6 0 1 1 51.2 0V896a25.6 25.6 0 0 1-25.6 25.6zM533.952 515.648a25.6
+  25.6 0 0 1-18.112-43.712l362.048-362.048a25.6 25.6 0 0 1 36.224 36.224L552.064 508.16a25.472 25.472 0 0 1-18.112 7.488z
+`;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -12,6 +12,7 @@ import * as React from 'react';
 import {Fragment, useCallback, useContext} from 'react';
 import {TreeDispatcherContext} from './TreeContext';
 import {BridgeContext, ContextMenuContext, StoreContext} from '../context';
+import {SettingsContext} from '../Settings/SettingsContext';
 import ContextMenu from '../../ContextMenu/ContextMenu';
 import ContextMenuItem from '../../ContextMenu/ContextMenuItem';
 import Button from '../Button';
@@ -241,13 +242,28 @@ type SourceProps = {|
 |};
 
 function Source({fileName, lineNumber}: SourceProps) {
+  const bridge = useContext(BridgeContext);
+  const {launchEditorEndpoint} = useContext(SettingsContext);
+
   const handleCopy = () => copy(`${fileName}:${lineNumber}`);
+  const handleLaunchEditor = () => {
+    bridge.send('launchEditor', {
+      launchEditorEndpoint,
+      fileName,
+      lineNumber,
+    });
+  };
   return (
     <div className={styles.Source}>
       <div className={styles.SourceHeaderRow}>
         <div className={styles.SourceHeader}>source</div>
         <Button onClick={handleCopy} title="Copy to clipboard">
           <ButtonIcon type="copy" />
+        </Button>
+        <Button
+          onClick={handleLaunchEditor}
+          title="open react component source file in your editor">
+          <ButtonIcon type="search" />
         </Button>
       </div>
       <div className={styles.SourceOneLiner}>

--- a/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/GeneralSettings.js
@@ -18,8 +18,10 @@ import styles from './SettingsShared.css';
 export default function GeneralSettings(_: {||}) {
   const {
     displayDensity,
+    launchEditorEndpoint,
     setDisplayDensity,
     setTheme,
+    setLaunchEditorEndpoint,
     setTraceUpdatesEnabled,
     theme,
     traceUpdatesEnabled,
@@ -52,6 +54,18 @@ export default function GeneralSettings(_: {||}) {
           <option value="compact">Compact</option>
           <option value="comfortable">Comfortable</option>
         </select>
+      </div>
+
+      <div className={styles.Setting}>
+        <div className={styles.RadioLabel}>Launch Editor Endpoint</div>
+        <input
+          className={styles.Input}
+          onChange={({currentTarget}) =>
+            setLaunchEditorEndpoint(currentTarget.value)
+          }
+          type="txt"
+          placeholder={launchEditorEndpoint}
+        />
       </div>
 
       {supportsTraceUpdates && (

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -18,10 +18,12 @@ import {
 import {
   COMFORTABLE_LINE_HEIGHT,
   COMPACT_LINE_HEIGHT,
+  DEFAULT_OPEN_EDITOR_ENDPOINT,
   LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
   LOCAL_STORAGE_SHOULD_PATCH_CONSOLE_KEY,
   LOCAL_STORAGE_TRACE_UPDATES_ENABLED_KEY,
   LOCAL_STORAGE_SHOW_INLINE_WARNINGS_AND_ERRORS_KEY,
+  LOCAL_STORAGE_OPEN_EDITOR_ENDPOINT_KEY,
 } from 'react-devtools-shared/src/constants';
 import {useLocalStorage} from '../hooks';
 import {BridgeContext} from '../context';
@@ -44,6 +46,9 @@ type Context = {|
 
   breakOnConsoleErrors: boolean,
   setBreakOnConsoleErrors: (value: boolean) => void,
+
+  launchEditorEndpoint: string,
+  setLaunchEditorEndpoint(value: string): void,
 
   showInlineWarningsAndErrors: boolean,
   setShowInlineWarningsAndErrors: (value: boolean) => void,
@@ -83,6 +88,7 @@ function SettingsContextController({
     'React::DevTools::theme',
     'auto',
   );
+
   const [
     appendComponentStack,
     setAppendComponentStack,
@@ -93,6 +99,13 @@ function SettingsContextController({
   ] = useLocalStorage<boolean>(
     LOCAL_STORAGE_SHOULD_BREAK_ON_CONSOLE_ERRORS,
     false,
+  );
+  const [
+    launchEditorEndpoint,
+    setLaunchEditorEndpoint,
+  ] = useLocalStorage<string>(
+    LOCAL_STORAGE_OPEN_EDITOR_ENDPOINT_KEY,
+    DEFAULT_OPEN_EDITOR_ENDPOINT,
   );
   const [
     showInlineWarningsAndErrors,
@@ -176,6 +189,7 @@ function SettingsContextController({
       appendComponentStack,
       breakOnConsoleErrors,
       displayDensity,
+      launchEditorEndpoint,
       lineHeight:
         displayDensity === 'compact'
           ? COMPACT_LINE_HEIGHT
@@ -183,6 +197,7 @@ function SettingsContextController({
       setAppendComponentStack,
       setBreakOnConsoleErrors,
       setDisplayDensity,
+      setLaunchEditorEndpoint,
       setTheme,
       setTraceUpdatesEnabled,
       setShowInlineWarningsAndErrors,
@@ -194,9 +209,11 @@ function SettingsContextController({
       appendComponentStack,
       breakOnConsoleErrors,
       displayDensity,
+      launchEditorEndpoint,
       setAppendComponentStack,
       setBreakOnConsoleErrors,
       setDisplayDensity,
+      setLaunchEditorEndpoint,
       setTheme,
       setTraceUpdatesEnabled,
       setShowInlineWarningsAndErrors,


### PR DESCRIPTION
## Summary

### support launch editor feature
Original Feature Request #20435 

![launchEditor](https://user-images.githubusercontent.com/14012511/107875836-0f746680-6efd-11eb-899b-c22a7b1f7d60.gif)

When you inspected a react component, you can click the `launch editor` icon to jump to your editor and navigate to the source code original file position.

### supoort set custom `launchEditorEndpoint`
![2021-02-14 20 16 23](https://user-images.githubusercontent.com/14012511/107876681-51ec7200-6f02-11eb-94c7-57beac6e8f1f.png)

Why we need this ? Because different launch editor server middleware use different endpoint.

`create-react-app` user must use `__open-stack-frame-in-editor` as endpoint cause these hard code.
> https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/launchEditorEndpoint.js#L9-L10
```js
// TODO: we might want to make this injectable to support DEV-time non-root URLs.
module.exports = '/__open-stack-frame-in-editor';
```
`launch-editor-middleware` user often use `__open-in-editor` as endpoint.
> https://github.com/yyx990803/launch-editor#middleware
```js
const launchMiddleware = require('launch-editor-middleware')
app.use('/__open-in-editor', launchMiddleware())
```
![2021-02-14 20 39 20](https://user-images.githubusercontent.com/14012511/107877028-c2948e00-6f04-11eb-9a09-5ba31ad689cb.png)
Both middleware have many user around world (and exist many custom middleware actually).

## Issues need to fix
1. Can we get the releative file path from devtools ? Now the `source` path is absolute(e.g. `/Users/iChenLei/Documents/cra/reactapp/src/App.js:24`).
2. If we only can use absolute file path, we need create pr for `create-react-app/react-dev-utils` to support absolute path.
`https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/launchEditor.js#L287-L290`
```diff
+ const filePath = path.relative(process.cwd(), fileName)
```
3. Please help me make a suitable svg icon for `launch editor`feature, Thanks for `facebook/react` official.
4. Is there `common toast` ui component to show message about set custom endpoint success ? I think feedback is necessary.

@bvaughn Sir, I need your code review and advices, thanks. 

> I must say that it's too hard for me to run the devtools extension build and test script, many network error / script error and other problems, It drives me crazy 😭 .

## Test Plan

will add necessary unit test later

## Circle CI Artifacts
Every one can download this build artifacts to test `launch editor`, but you must modilfy your `launch editor` middleware to support `absolute file path` otherwise you can't launch editor success. I will create a pull request to `create-react-app/react-dev-utils` to support absolute file path. Welcome any suggestion !
```diff
// for example
// ./node_modules/react-dev-utils/launchEditor.js
function launchEditor(fileName, lineNumber, colNumber) {
+ fileName = path.relative(process.cwd(), fileName)
  if (!fs.existsSync(fileName)) {
    return;
  }
```
> React devtools build download ->  [build/devtools.tgz](https://270891-10270250-gh.circle-artifacts.com/0/build/devtools.tgz)