### PR TITLE
[CI] Use constant commit sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,7 +579,7 @@ workflows:
           name: Publish to Next channel
           requires:
             - setup
-          commit_sha: master
+          commit_sha: << pipeline.git.revision >>
           release_channel: stable
           dist_tag: next
       - publish_prerelease:
@@ -590,7 +590,7 @@ workflows:
             # different versions of the same package, even if they use different
             # dist tags.
             - Publish to Next channel
-          commit_sha: master
+          commit_sha: << pipeline.git.revision >>
           release_channel: experimental
           dist_tag: experimental
 

--- a/scripts/release/publish-using-ci-workflow.js
+++ b/scripts/release/publish-using-ci-workflow.js
@@ -77,14 +77,19 @@ async function pollUntilWorkflowFinishes(workflowID) {
 }
 
 async function main() {
+  const headCommitResponse = await fetch(
+    'https://api.github.com/repos/facebook/react/commits/master'
+  );
+  const headCommitJSON = await headCommitResponse.json();
+  const headCommitSha = headCommitJSON.sha;
+
   const pipelineResponse = await fetch(
     'https://circleci.com/api/v2/project/github/facebook/react/pipeline',
     {
       method: 'post',
       body: JSON.stringify({
         parameters: {
-          // TODO: Make commit SHA configurable
-          prerelease_commit_sha: 'master',
+          prerelease_commit_sha: headCommitSha,
         },
       }),
       headers: {


### PR DESCRIPTION
When running the publish workflow, either via the command line or via the daily cron job, we should use a constant SHA instead of whatever happens to be at the head of the main branch at the time the workflow is run.

The difference is subtle: currently, the SHA is read at runtime, each time the workflow is run. With this change, the SHA is read right before the workflow is created and passed in as a constant parameter.

In practical terms, this means if a workflow is re-run via the CircleCI web UI, it will always re-run using the same commit SHA as the original workflow, instead of fetching the latest SHA from GitHub, which may have changed.

Also avoids a race condition where the head SHA changes in between the Next publish job and the Experimental publish job.