### PR TITLE
fix: use SharedArrayBuffer only when cross-origin isolation is enabled

### DIFF
--- a/packages/scheduler/src/SchedulerProfiling.js
+++ b/packages/scheduler/src/SchedulerProfiling.js
@@ -24,7 +24,7 @@ export const sharedProfilingBuffer = enableProfiling
   ?
   isEnabledSharedArrayBuffer
     ? new SharedArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT)
-    : // $FlowFixMe Flow doesn't know about ArrayBuffer
+    :
     typeof ArrayBuffer === 'function'
     ? new ArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT)
     : null // Don't crash the init path on IE9

--- a/packages/scheduler/src/SchedulerProfiling.js
+++ b/packages/scheduler/src/SchedulerProfiling.js
@@ -15,10 +15,14 @@ import {NoPriority} from './SchedulerPriorities';
 let runIdCounter: number = 0;
 let mainThreadIdCounter: number = 0;
 
+// We only use SharedArrayBuffer when cross origin isolation is enabled.
+// $FlowFixMe Flow doesn't know about SharedArrayBuffer
+const isEnabledSharedArrayBuffer = typeof SharedArrayBuffer === 'function' && typeof window !== 'undefined' && window.crossOriginIsolated === true
+
 const profilingStateSize = 4;
 export const sharedProfilingBuffer = enableProfiling
-  ? // $FlowFixMe Flow doesn't know about SharedArrayBuffer
-    typeof SharedArrayBuffer === 'function'
+  ?
+  isEnabledSharedArrayBuffer
     ? new SharedArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT)
     : // $FlowFixMe Flow doesn't know about ArrayBuffer
     typeof ArrayBuffer === 'function'

--- a/packages/scheduler/src/SchedulerProfiling.js
+++ b/packages/scheduler/src/SchedulerProfiling.js
@@ -15,17 +15,18 @@ import {NoPriority} from './SchedulerPriorities';
 let runIdCounter: number = 0;
 let mainThreadIdCounter: number = 0;
 
-// We only use SharedArrayBuffer when cross origin isolation is enabled.
-// $FlowFixMe Flow doesn't know about SharedArrayBuffer
-const isEnabledSharedArrayBuffer = typeof SharedArrayBuffer === 'function' && typeof window !== 'undefined' && window.crossOriginIsolated === true
+const isEnabledSharedArrayBuffer =
+  // $FlowFixMe Flow doesn't know about SharedArrayBuffer
+  typeof SharedArrayBuffer === 'function' &&
+  // We only use SharedArrayBuffer when cross origin isolation is enabled.
+  typeof window !== 'undefined' &&
+  window.crossOriginIsolated === true;
 
 const profilingStateSize = 4;
 export const sharedProfilingBuffer = enableProfiling
-  ?
-  isEnabledSharedArrayBuffer
+  ? isEnabledSharedArrayBuffer
     ? new SharedArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT)
-    :
-    typeof ArrayBuffer === 'function'
+    : typeof ArrayBuffer === 'function'
     ? new ArrayBuffer(profilingStateSize * Int32Array.BYTES_PER_ELEMENT)
     : null // Don't crash the init path on IE9
   : null;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Fixes #20829
I've changed to use SharedArrayBuffer only when cross-origin isolation is enabled.
We might be able to use `self` instead of `window`, but ESLint doesn't allow us to use `self` by `no-restricted-globals`.

I've also removed an unused `$FlowFixMe` comment in the statement. I'll revert it if I shouldn't include the change in this PR.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

I've confirmed that the warning, `[Deprecation] SharedArrayBuffer will require cross-origin isolation as of M91, around May 2021.`, has been disappeared on Chrome Canary.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
