### PR TITLE
Disable (unstable) scheduler sampling profiler for OSS builds

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -8,7 +8,7 @@
 
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
-export const enableProfiling = __PROFILE__;
+export const enableProfiling = false;
 
 // TODO: enable to fix https://github.com/facebook/react/issues/20756.
 export const enableSetImmediate = __VARIANT__;

--- a/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
@@ -44,7 +44,8 @@ function priorityLevelToString(priorityLevel) {
 }
 
 describe('Scheduler', () => {
-  if (!__PROFILE__) {
+  const {enableProfiling} = require('scheduler/src/SchedulerFeatureFlags');
+  if (!enableProfiling) {
     // The tests in this suite only apply when profiling is on
     it('profiling APIs are not available', () => {
       Scheduler = require('scheduler');

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -219,12 +219,16 @@ function workLoop(hasTimeRemaining, initialTime) {
       currentTask.callback = null;
       currentPriorityLevel = currentTask.priorityLevel;
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
-      markTaskRun(currentTask, currentTime);
+      if (enableProfiling) {
+        markTaskRun(currentTask, currentTime);
+      }
       const continuationCallback = callback(didUserCallbackTimeout);
       currentTime = getCurrentTime();
       if (typeof continuationCallback === 'function') {
         currentTask.callback = continuationCallback;
-        markTaskYield(currentTask, currentTime);
+        if (enableProfiling) {
+          markTaskYield(currentTask, currentTime);
+        }
       } else {
         if (enableProfiling) {
           markTaskCompleted(currentTask, currentTime);

--- a/packages/scheduler/src/forks/SchedulerMock.js
+++ b/packages/scheduler/src/forks/SchedulerMock.js
@@ -183,12 +183,16 @@ function workLoop(hasTimeRemaining, initialTime) {
       currentTask.callback = null;
       currentPriorityLevel = currentTask.priorityLevel;
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
-      markTaskRun(currentTask, currentTime);
+      if (enableProfiling) {
+        markTaskRun(currentTask, currentTime);
+      }
       const continuationCallback = callback(didUserCallbackTimeout);
       currentTime = getCurrentTime();
       if (typeof continuationCallback === 'function') {
         currentTask.callback = continuationCallback;
-        markTaskYield(currentTask, currentTime);
+        if (enableProfiling) {
+          markTaskYield(currentTask, currentTime);
+        }
       } else {
         if (enableProfiling) {
           markTaskCompleted(currentTask, currentTime);

--- a/packages/scheduler/src/forks/SchedulerNoDOM.js
+++ b/packages/scheduler/src/forks/SchedulerNoDOM.js
@@ -185,12 +185,16 @@ function workLoop(hasTimeRemaining, initialTime) {
       currentTask.callback = null;
       currentPriorityLevel = currentTask.priorityLevel;
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
-      markTaskRun(currentTask, currentTime);
+      if (enableProfiling) {
+        markTaskRun(currentTask, currentTime);
+      }
       const continuationCallback = callback(didUserCallbackTimeout);
       currentTime = getCurrentTime();
       if (typeof continuationCallback === 'function') {
         currentTask.callback = continuationCallback;
-        markTaskYield(currentTask, currentTime);
+        if (enableProfiling) {
+          markTaskYield(currentTask, currentTime);
+        }
       } else {
         if (enableProfiling) {
           markTaskCompleted(currentTask, currentTime);

--- a/packages/scheduler/src/forks/SchedulerPostTaskOnly.js
+++ b/packages/scheduler/src/forks/SchedulerPostTaskOnly.js
@@ -210,12 +210,16 @@ function workLoop(hasTimeRemaining, initialTime) {
       currentTask.callback = null;
       currentPriorityLevel = currentTask.priorityLevel;
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
-      markTaskRun(currentTask, currentTime);
+      if (enableProfiling) {
+        markTaskRun(currentTask, currentTime);
+      }
       const continuationCallback = callback(didUserCallbackTimeout);
       currentTime = getCurrentTime();
       if (typeof continuationCallback === 'function') {
         currentTask.callback = continuationCallback;
-        markTaskYield(currentTask, currentTime);
+        if (enableProfiling) {
+          markTaskYield(currentTask, currentTime);
+        }
       } else {
         if (enableProfiling) {
           markTaskCompleted(currentTask, currentTime);


### PR DESCRIPTION
Disables scheduler's unstable sampling profiler for OSS builds and adds a feature flag wrap around some calls to it that were previously missing.