### PR TITLE
Use setImmediate when available over MessageChannel

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -9,4 +9,7 @@
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
 export const enableProfiling = __PROFILE__;
-export const enableSetImmediate = true;
+
+// TODO: enable to fix https://github.com/facebook/react/issues/20756.
+// Once enabled, remove describe.skip() from SchedulerDOMSetImmediate-test.
+export const enableSetImmediate = false;

--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -11,5 +11,4 @@ export const enableIsInputPending = false;
 export const enableProfiling = __PROFILE__;
 
 // TODO: enable to fix https://github.com/facebook/react/issues/20756.
-// Once enabled, remove describe.skip() from SchedulerDOMSetImmediate-test.
-export const enableSetImmediate = false;
+export const enableSetImmediate = __VARIANT__;

--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -9,3 +9,4 @@
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
 export const enableProfiling = __PROFILE__;
+export const enableSetImmediate = true;

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -1,0 +1,269 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ * @jest-environment node
+ */
+
+/* eslint-disable no-for-of-loops/no-for-of-loops */
+
+'use strict';
+
+let Scheduler;
+let runtime;
+let performance;
+let cancelCallback;
+let scheduleCallback;
+let NormalPriority;
+
+// The Scheduler implementation uses browser APIs like `MessageChannel` and
+// `setTimeout` to schedule work on the main thread. Most of our tests treat
+// these as implementation details; however, the sequence and timing of these
+// APIs are not precisely specified, and can vary across browsers.
+//
+// To prevent regressions, we need the ability to simulate specific edge cases
+// that we may encounter in various browsers.
+//
+// This test suite mocks all browser methods used in our implementation. It
+// assumes as little as possible about the order and timing of events.
+describe('SchedulerBrowser', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    // Un-mock scheduler
+    jest.mock('scheduler', () => require.requireActual('scheduler'));
+
+    runtime = installMockBrowserRuntime();
+    performance = global.performance;
+    Scheduler = require('scheduler');
+    cancelCallback = Scheduler.unstable_cancelCallback;
+    scheduleCallback = Scheduler.unstable_scheduleCallback;
+    NormalPriority = Scheduler.unstable_NormalPriority;
+  });
+
+  afterEach(() => {
+    delete global.performance;
+
+    if (!runtime.isLogEmpty()) {
+      throw Error('Test exited without clearing log.');
+    }
+  });
+
+  function installMockBrowserRuntime() {
+    let hasPendingMessageEvent = false;
+
+    let timerIDCounter = 0;
+    // let timerIDs = new Map();
+
+    let eventLog = [];
+
+    let currentTime = 0;
+
+    global.performance = {
+      now() {
+        return currentTime;
+      },
+    };
+
+    const window = {};
+    global.window = window;
+
+    // TODO: Scheduler no longer requires these methods to be polyfilled. But
+    // maybe we want to continue warning if they don't exist, to preserve the
+    // option to rely on it in the future?
+    window.requestAnimationFrame = window.cancelAnimationFrame = () => {};
+
+    window.setTimeout = (cb, delay) => {
+      const id = timerIDCounter++;
+      log(`Set Timer`);
+      // TODO
+      return id;
+    };
+    window.clearTimeout = id => {
+      // TODO
+    };
+
+    const port1 = {};
+    const port2 = {
+      postMessage() {
+        if (hasPendingMessageEvent) {
+          throw Error('Message event already scheduled');
+        }
+        log('Post Message');
+        hasPendingMessageEvent = true;
+      },
+    };
+    global.MessageChannel = function MessageChannel() {
+      this.port1 = port1;
+      this.port2 = port2;
+    };
+
+    function ensureLogIsEmpty() {
+      if (eventLog.length !== 0) {
+        throw Error('Log is not empty. Call assertLog before continuing.');
+      }
+    }
+    function advanceTime(ms) {
+      currentTime += ms;
+    }
+    function fireMessageEvent() {
+      ensureLogIsEmpty();
+      if (!hasPendingMessageEvent) {
+        throw Error('No message event was scheduled');
+      }
+      hasPendingMessageEvent = false;
+      const onMessage = port1.onmessage;
+      log('Message Event');
+      onMessage();
+    }
+    function log(val) {
+      eventLog.push(val);
+    }
+    function isLogEmpty() {
+      return eventLog.length === 0;
+    }
+    function assertLog(expected) {
+      const actual = eventLog;
+      eventLog = [];
+      expect(actual).toEqual(expected);
+    }
+    return {
+      advanceTime,
+      fireMessageEvent,
+      log,
+      isLogEmpty,
+      assertLog,
+    };
+  }
+
+  it('task that finishes before deadline', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('Task');
+    });
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'Task']);
+  });
+
+  it('task with continuation', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('Task');
+      while (!Scheduler.unstable_shouldYield()) {
+        runtime.advanceTime(1);
+      }
+      runtime.log(`Yield at ${performance.now()}ms`);
+      return () => {
+        runtime.log('Continuation');
+      };
+    });
+    runtime.assertLog(['Post Message']);
+
+    runtime.fireMessageEvent();
+    runtime.assertLog([
+      'Message Event',
+      'Task',
+      'Yield at 5ms',
+      'Post Message',
+    ]);
+
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'Continuation']);
+  });
+
+  it('multiple tasks', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('A');
+    });
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('B');
+    });
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'A', 'B']);
+  });
+
+  it('multiple tasks with a yield in between', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('A');
+      runtime.advanceTime(4999);
+    });
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('B');
+    });
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog([
+      'Message Event',
+      'A',
+      // Ran out of time. Post a continuation event.
+      'Post Message',
+    ]);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'B']);
+  });
+
+  it('cancels tasks', () => {
+    const task = scheduleCallback(NormalPriority, () => {
+      runtime.log('Task');
+    });
+    runtime.assertLog(['Post Message']);
+    cancelCallback(task);
+    runtime.assertLog([]);
+  });
+
+  it('throws when a task errors then continues in a new event', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('Oops!');
+      throw Error('Oops!');
+    });
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('Yay');
+    });
+    runtime.assertLog(['Post Message']);
+
+    expect(() => runtime.fireMessageEvent()).toThrow('Oops!');
+    runtime.assertLog(['Message Event', 'Oops!', 'Post Message']);
+
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'Yay']);
+  });
+
+  it('schedule new task after queue has emptied', () => {
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('A');
+    });
+
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'A']);
+
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('B');
+    });
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'B']);
+  });
+
+  it('schedule new task after a cancellation', () => {
+    const handle = scheduleCallback(NormalPriority, () => {
+      runtime.log('A');
+    });
+
+    runtime.assertLog(['Post Message']);
+    cancelCallback(handle);
+
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event']);
+
+    scheduleCallback(NormalPriority, () => {
+      runtime.log('B');
+    });
+    runtime.assertLog(['Post Message']);
+    runtime.fireMessageEvent();
+    runtime.assertLog(['Message Event', 'B']);
+  });
+});

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -91,9 +91,9 @@ describe('SchedulerDOMSetImmediate', () => {
         port2: {
           postMessage() {
             throw Error('Should be unused');
-          }
-        }
-      }
+          },
+        },
+      };
     };
 
     let pendingSetImmediateCallback = null;

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -29,9 +29,7 @@ let NormalPriority;
 //
 // This test suite mocks all browser methods used in our implementation. It
 // assumes as little as possible about the order and timing of events.
-
-// FIXME: temporarily skipped until we enable the flag.
-describe.skip('SchedulerDOMSetImmediate', () => {
+describe('SchedulerDOMSetImmediate', () => {
   beforeEach(() => {
     jest.resetModules();
 
@@ -88,7 +86,14 @@ describe.skip('SchedulerDOMSetImmediate', () => {
 
     // Unused: we expect setImmediate to be preferred.
     global.MessageChannel = function() {
-      throw Error('Should be unused');
+      return {
+        port1: {},
+        port2: {
+          postMessage() {
+            throw Error('Should be unused');
+          }
+        }
+      }
     };
 
     let pendingSetImmediateCallback = null;
@@ -138,6 +143,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     };
   }
 
+  // @gate enableSchedulerSetImmediate
   it('task that finishes before deadline', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -147,6 +153,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Task']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('task with continuation', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -172,6 +179,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Continuation']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('multiple tasks', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -184,6 +192,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'A', 'B']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('multiple tasks with a yield in between', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -204,6 +213,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'B']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('cancels tasks', () => {
     const task = scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -213,6 +223,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog([]);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('throws when a task errors then continues in a new event', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Oops!');
@@ -230,6 +241,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Yay']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('schedule new task after queue has emptied', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -247,6 +259,7 @@ describe.skip('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'B']);
   });
 
+  // @gate enableSchedulerSetImmediate
   it('schedule new task after a cancellation', () => {
     const handle = scheduleCallback(NormalPriority, () => {
       runtime.log('A');

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -29,7 +29,9 @@ let NormalPriority;
 //
 // This test suite mocks all browser methods used in our implementation. It
 // assumes as little as possible about the order and timing of events.
-describe('SchedulerDOMSetImmediate', () => {
+
+// FIXME: temporarily skipped until we enable the flag.
+describe.skip('SchedulerDOMSetImmediate', () => {
   beforeEach(() => {
     jest.resetModules();
 

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -85,7 +85,9 @@ describe('SchedulerDOMSetImmediate', () => {
     };
 
     // Unused: we expect setImmediate to be preferred.
-    window.MessageChannel = function() {};
+    global.MessageChannel = function() {
+      throw Error('Should be unused');
+    };
 
     let pendingSetImmediateCallback = null;
     window.setImmediate = function(cb) {

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -88,6 +88,7 @@ var isHostTimeoutScheduled = false;
 // Capture local references to native APIs, in case a polyfill overrides them.
 const setTimeout = window.setTimeout;
 const clearTimeout = window.clearTimeout;
+const setImmediate = window.setImmediate; // IE and Node.js
 
 if (typeof console !== 'undefined') {
   // TODO: Scheduler no longer requires these methods to be polyfilled. But
@@ -547,13 +548,30 @@ const performWorkUntilDeadline = () => {
   needsPaint = false;
 };
 
-const channel = new MessageChannel();
-const port = channel.port2;
-channel.port1.onmessage = performWorkUntilDeadline;
-
-const schedulePerformWorkUntilDeadline = () => {
-  port.postMessage(null);
-};
+let schedulePerformWorkUntilDeadline;
+if (typeof setImmediate === 'function') {
+  // Node.js and old IE.
+  // There's a few reasons for why we prefer setImmediate.
+  //
+  // Unlike MessageChannel, it doesn't prevent a Node.js process from exiting.
+  // (Even though this is a DOM fork of the Scheduler, you could get here
+  // with a mix of Node.js 15+, which has a MessageChannel, and jsdom.)
+  // https://github.com/facebook/react/issues/20756
+  //
+  // But also, it runs earlier which is the semantic we want.
+  // If other browsers ever implement it, it's better to use it.
+  // Although both of these would be inferior to native scheduling.
+  schedulePerformWorkUntilDeadline = () => {
+    setImmediate(performWorkUntilDeadline);
+  };
+} else {
+  const channel = new MessageChannel();
+  const port = channel.port2;
+  channel.port1.onmessage = performWorkUntilDeadline;
+  schedulePerformWorkUntilDeadline = () => {
+    port.postMessage(null);
+  };
+}
 
 function requestHostCallback(callback) {
   scheduledHostCallback = callback;

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -11,6 +11,7 @@
 import {
   enableSchedulerDebugging,
   enableProfiling,
+  enableSetImmediate,
 } from '../SchedulerFeatureFlags';
 
 import {push, pop, peek} from '../SchedulerMinHeap';
@@ -549,7 +550,7 @@ const performWorkUntilDeadline = () => {
 };
 
 let schedulePerformWorkUntilDeadline;
-if (typeof setImmediate === 'function') {
+if (enableSetImmediate && typeof setImmediate === 'function') {
   // Node.js and old IE.
   // There's a few reasons for why we prefer setImmediate.
   //

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -88,7 +88,7 @@ var isHostTimeoutScheduled = false;
 // Capture local references to native APIs, in case a polyfill overrides them.
 const setTimeout = window.setTimeout;
 const clearTimeout = window.clearTimeout;
-const setImmediate = window.setImmediate; // IE and Node.js
+const setImmediate = window.setImmediate; // IE and Node.js + jsdom
 
 if (typeof console !== 'undefined') {
   // TODO: Scheduler no longer requires these methods to be polyfilled. But

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -533,7 +533,7 @@ const performWorkUntilDeadline = () => {
       if (hasMoreWork) {
         // If there's more work, schedule the next message event at the end
         // of the preceding one.
-        port.postMessage(null);
+        schedulePerformWorkUntilDeadline();
       } else {
         isMessageLoopRunning = false;
         scheduledHostCallback = null;
@@ -551,11 +551,15 @@ const channel = new MessageChannel();
 const port = channel.port2;
 channel.port1.onmessage = performWorkUntilDeadline;
 
+const schedulePerformWorkUntilDeadline = () => {
+  port.postMessage(null);
+};
+
 function requestHostCallback(callback) {
   scheduledHostCallback = callback;
   if (!isMessageLoopRunning) {
     isMessageLoopRunning = true;
-    port.postMessage(null);
+    schedulePerformWorkUntilDeadline();
   }
 }
 

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -10,6 +10,7 @@ export const {
   enableIsInputPending,
   enableSchedulerDebugging,
   enableProfiling: enableProfilingFeatureFlag,
+  enableSetImmediate,
 } = require('SchedulerFeatureFlags');
 
 export const enableProfiling = __PROFILE__ && enableProfilingFeatureFlag;

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -55,6 +55,7 @@ function getTestFlags() {
   // These are required on demand because some of our tests mutate them. We try
   // not to but there are exceptions.
   const featureFlags = require('shared/ReactFeatureFlags');
+  const schedulerFeatureFlags = require('scheduler/src/SchedulerFeatureFlags');
 
   // TODO: This is a heuristic to detect the release channel by checking a flag
   // that is known to only be enabled in www. What we should do instead is set
@@ -89,6 +90,10 @@ function getTestFlags() {
       // tests, Jest doesn't expose the API correctly. Fix then remove
       // this override.
       enableCache: __EXPERIMENTAL__,
+
+      // This is from SchedulerFeatureFlags. Needed because there's no equivalent
+      // of ReactFeatureFlags-www.dynamic for it. Remove when enableSetImmediate is gone.
+      enableSchedulerSetImmediate: schedulerFeatureFlags.enableSetImmediate,
     },
     {
       get(flags, flagName) {


### PR DESCRIPTION
Will fix https://github.com/facebook/react/issues/20756 after we toggle the flag, alternative to https://github.com/facebook/react/pull/20790.

The idea is that `setImmediate` models the semantics we want closer than `MessageChannel`. But it's only available in IE and Node.js. Using it in Node.js when we're in a jsdom environment solves https://github.com/facebook/react/issues/20756. For IE, we think using `setImmediate` would be good — and if other browsers implement it (which is pretty unlikely), that also should be an improvement. Although native scheduling would still be preferred over this version.

See individual commits. I added a new test to verify the behavior.

Possible concerns:

- We'd still have to either provide a workaround or ship a dozen Scheduler patches backporting this change for different 16.x releases. This doesn't sound exciting.
- We need to verify this _actually works_ in IE and doesn't make something worse.
- What about polyfills? A bad or slow `setImmediate` polyfill could screw things up in modern browsers, making this a more risky change. 
