### PR TITLE
Add concept of StrictMode levels 1 & 2 (no public API yet)

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -46,7 +46,7 @@ import {
 } from './ReactFiber.new';
 import {emptyRefsObject} from './ReactFiberClassComponent.new';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.new';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -114,7 +114,7 @@ function coerceRef(
       // TODO: Clean this up once we turn on the string ref warning for
       // everyone, because the strict mode case will no longer be relevant
       if (
-        (returnFiber.mode & StrictMode || warnAboutStringRefs) &&
+        (returnFiber.mode & StrictModeL1 || warnAboutStringRefs) &&
         // We warn in ReactElement.js if owner and self are equal for string refs
         // because these cannot be automatically converted to an arrow function
         // using a codemod. Therefore, we don't have to warn about string refs again.

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -46,7 +46,7 @@ import {
 } from './ReactFiber.new';
 import {emptyRefsObject} from './ReactFiberClassComponent.new';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.new';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -114,7 +114,7 @@ function coerceRef(
       // TODO: Clean this up once we turn on the string ref warning for
       // everyone, because the strict mode case will no longer be relevant
       if (
-        (returnFiber.mode & StrictModeL1 || warnAboutStringRefs) &&
+        (returnFiber.mode & StrictLegacyMode || warnAboutStringRefs) &&
         // We warn in ReactElement.js if owner and self are equal for string refs
         // because these cannot be automatically converted to an arrow function
         // using a codemod. Therefore, we don't have to warn about string refs again.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -46,7 +46,7 @@ import {
 } from './ReactFiber.old';
 import {emptyRefsObject} from './ReactFiberClassComponent.old';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.old';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -114,7 +114,7 @@ function coerceRef(
       // TODO: Clean this up once we turn on the string ref warning for
       // everyone, because the strict mode case will no longer be relevant
       if (
-        (returnFiber.mode & StrictModeL1 || warnAboutStringRefs) &&
+        (returnFiber.mode & StrictLegacyMode || warnAboutStringRefs) &&
         // We warn in ReactElement.js if owner and self are equal for string refs
         // because these cannot be automatically converted to an arrow function
         // using a codemod. Therefore, we don't have to warn about string refs again.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -46,7 +46,7 @@ import {
 } from './ReactFiber.old';
 import {emptyRefsObject} from './ReactFiberClassComponent.old';
 import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.old';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -114,7 +114,7 @@ function coerceRef(
       // TODO: Clean this up once we turn on the string ref warning for
       // everyone, because the strict mode case will no longer be relevant
       if (
-        (returnFiber.mode & StrictMode || warnAboutStringRefs) &&
+        (returnFiber.mode & StrictModeL1 || warnAboutStringRefs) &&
         // We warn in ReactElement.js if owner and self are equal for string refs
         // because these cannot be automatically converted to an arrow function
         // using a codemod. Therefore, we don't have to warn about string refs again.

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -65,8 +65,8 @@ import {
   ConcurrentMode,
   DebugTracingMode,
   ProfileMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -424,15 +424,16 @@ export function createHostRootFiber(tag: RootTag): Fiber {
   let mode;
   if (tag === ConcurrentRoot) {
     if (enableDoubleInvokingEffects) {
-      mode = ConcurrentMode | BlockingMode | StrictModeL1 | StrictModeL2;
+      mode =
+        ConcurrentMode | BlockingMode | StrictLegacyMode | StrictEffectsMode;
     } else {
-      mode = ConcurrentMode | BlockingMode | StrictModeL1;
+      mode = ConcurrentMode | BlockingMode | StrictLegacyMode;
     }
   } else if (tag === BlockingRoot) {
     if (enableDoubleInvokingEffects) {
-      mode = BlockingMode | StrictModeL1 | StrictModeL2;
+      mode = BlockingMode | StrictLegacyMode | StrictEffectsMode;
     } else {
-      mode = BlockingMode | StrictModeL1;
+      mode = BlockingMode | StrictLegacyMode;
     }
   } else {
     mode = NoMode;
@@ -482,8 +483,8 @@ export function createFiberFromTypeAndProps(
         break;
       case REACT_STRICT_MODE_TYPE:
         fiberTag = Mode;
-        // TODO (StrictModeL2) Add support for new strict mode "level" attribute
-        mode |= StrictModeL1;
+        // TODO (StrictEffectsMode) Add support for new strict mode "level" attribute
+        mode |= StrictLegacyMode;
         break;
       case REACT_PROFILER_TYPE:
         return createFiberFromProfiler(pendingProps, mode, lanes, key);

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -65,8 +65,8 @@ import {
   ConcurrentMode,
   DebugTracingMode,
   ProfileMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -424,15 +424,16 @@ export function createHostRootFiber(tag: RootTag): Fiber {
   let mode;
   if (tag === ConcurrentRoot) {
     if (enableDoubleInvokingEffects) {
-      mode = ConcurrentMode | BlockingMode | StrictModeL1 | StrictModeL2;
+      mode =
+        ConcurrentMode | BlockingMode | StrictLegacyMode | StrictEffectsMode;
     } else {
-      mode = ConcurrentMode | BlockingMode | StrictModeL1;
+      mode = ConcurrentMode | BlockingMode | StrictLegacyMode;
     }
   } else if (tag === BlockingRoot) {
     if (enableDoubleInvokingEffects) {
-      mode = BlockingMode | StrictModeL1 | StrictModeL2;
+      mode = BlockingMode | StrictLegacyMode | StrictEffectsMode;
     } else {
-      mode = BlockingMode | StrictModeL1;
+      mode = BlockingMode | StrictLegacyMode;
     }
   } else {
     mode = NoMode;
@@ -482,8 +483,8 @@ export function createFiberFromTypeAndProps(
         break;
       case REACT_STRICT_MODE_TYPE:
         fiberTag = Mode;
-        // TODO (StrictModeL2) Add support for new strict mode "level" attribute
-        mode |= StrictModeL1;
+        // TODO (StrictEffectsMode) Add support for new strict mode "level" attribute
+        mode |= StrictLegacyMode;
         break;
       case REACT_PROFILER_TYPE:
         return createFiberFromProfiler(pendingProps, mode, lanes, key);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -125,7 +125,7 @@ import {
   ConcurrentMode,
   NoMode,
   ProfileMode,
-  StrictModeL1,
+  StrictLegacyMode,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -357,7 +357,7 @@ function updateForwardRef(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -889,7 +889,7 @@ function updateFunctionComponent(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -1068,7 +1068,7 @@ function finishClassComponent(
       nextChildren = instance.render();
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {
@@ -1478,7 +1478,7 @@ function mountIndeterminateComponent(
       }
     }
 
-    if (workInProgress.mode & StrictModeL1) {
+    if (workInProgress.mode & StrictLegacyMode) {
       ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
     }
 
@@ -1615,7 +1615,7 @@ function mountIndeterminateComponent(
 
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -125,7 +125,7 @@ import {
   ConcurrentMode,
   NoMode,
   ProfileMode,
-  StrictMode,
+  StrictModeL1,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -357,7 +357,7 @@ function updateForwardRef(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -889,7 +889,7 @@ function updateFunctionComponent(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -1068,7 +1068,7 @@ function finishClassComponent(
       nextChildren = instance.render();
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {
@@ -1478,7 +1478,7 @@ function mountIndeterminateComponent(
       }
     }
 
-    if (workInProgress.mode & StrictMode) {
+    if (workInProgress.mode & StrictModeL1) {
       ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
     }
 
@@ -1615,7 +1615,7 @@ function mountIndeterminateComponent(
 
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -125,7 +125,7 @@ import {
   ConcurrentMode,
   NoMode,
   ProfileMode,
-  StrictModeL1,
+  StrictLegacyMode,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -357,7 +357,7 @@ function updateForwardRef(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -889,7 +889,7 @@ function updateFunctionComponent(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -1068,7 +1068,7 @@ function finishClassComponent(
       nextChildren = instance.render();
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {
@@ -1478,7 +1478,7 @@ function mountIndeterminateComponent(
       }
     }
 
-    if (workInProgress.mode & StrictModeL1) {
+    if (workInProgress.mode & StrictLegacyMode) {
       ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
     }
 
@@ -1615,7 +1615,7 @@ function mountIndeterminateComponent(
 
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -125,7 +125,7 @@ import {
   ConcurrentMode,
   NoMode,
   ProfileMode,
-  StrictMode,
+  StrictModeL1,
   BlockingMode,
 } from './ReactTypeOfMode';
 import {
@@ -357,7 +357,7 @@ function updateForwardRef(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -889,7 +889,7 @@ function updateFunctionComponent(
     );
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -1068,7 +1068,7 @@ function finishClassComponent(
       nextChildren = instance.render();
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {
@@ -1478,7 +1478,7 @@ function mountIndeterminateComponent(
       }
     }
 
-    if (workInProgress.mode & StrictMode) {
+    if (workInProgress.mode & StrictModeL1) {
       ReactStrictModeWarnings.recordLegacyContextWarning(workInProgress, null);
     }
 
@@ -1615,7 +1615,7 @@ function mountIndeterminateComponent(
 
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -31,11 +31,10 @@ import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.new';
 import {
-  BlockingMode,
-  ConcurrentMode,
   DebugTracingMode,
   NoMode,
-  StrictMode,
+  StrictModeL1,
+  StrictModeL2,
 } from './ReactTypeOfMode';
 
 import {
@@ -165,7 +164,7 @@ export function applyDerivedStateFromProps(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -318,7 +317,7 @@ function checkShouldComponentUpdate(
     if (__DEV__) {
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {
@@ -655,7 +654,7 @@ function constructClassInstance(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -862,7 +861,7 @@ function mountClassInstance(
       }
     }
 
-    if (workInProgress.mode & StrictMode) {
+    if (workInProgress.mode & StrictModeL1) {
       ReactStrictModeWarnings.recordLegacyContextWarning(
         workInProgress,
         instance,
@@ -910,7 +909,7 @@ function mountClassInstance(
     if (
       __DEV__ &&
       enableDoubleInvokingEffects &&
-      (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+      (workInProgress.mode & StrictModeL2) !== NoMode
     ) {
       // Never double-invoke effects for legacy roots.
       workInProgress.flags |= MountLayoutDev | Update;
@@ -989,7 +988,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1041,7 +1040,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1056,7 +1055,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -33,8 +33,8 @@ import {resolveDefaultProps} from './ReactFiberLazyComponent.new';
 import {
   DebugTracingMode,
   NoMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
 } from './ReactTypeOfMode';
 
 import {
@@ -164,7 +164,7 @@ export function applyDerivedStateFromProps(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -317,7 +317,7 @@ function checkShouldComponentUpdate(
     if (__DEV__) {
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {
@@ -654,7 +654,7 @@ function constructClassInstance(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -861,7 +861,7 @@ function mountClassInstance(
       }
     }
 
-    if (workInProgress.mode & StrictModeL1) {
+    if (workInProgress.mode & StrictLegacyMode) {
       ReactStrictModeWarnings.recordLegacyContextWarning(
         workInProgress,
         instance,
@@ -909,7 +909,7 @@ function mountClassInstance(
     if (
       __DEV__ &&
       enableDoubleInvokingEffects &&
-      (workInProgress.mode & StrictModeL2) !== NoMode
+      (workInProgress.mode & StrictEffectsMode) !== NoMode
     ) {
       // Never double-invoke effects for legacy roots.
       workInProgress.flags |= MountLayoutDev | Update;
@@ -988,7 +988,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1040,7 +1040,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1055,7 +1055,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -33,8 +33,8 @@ import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
 import {
   DebugTracingMode,
   NoMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
 } from './ReactTypeOfMode';
 
 import {
@@ -164,7 +164,7 @@ export function applyDerivedStateFromProps(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -317,7 +317,7 @@ function checkShouldComponentUpdate(
     if (__DEV__) {
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictModeL1
+        workInProgress.mode & StrictLegacyMode
       ) {
         disableLogs();
         try {
@@ -654,7 +654,7 @@ function constructClassInstance(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictModeL1
+      workInProgress.mode & StrictLegacyMode
     ) {
       disableLogs();
       try {
@@ -861,7 +861,7 @@ function mountClassInstance(
       }
     }
 
-    if (workInProgress.mode & StrictModeL1) {
+    if (workInProgress.mode & StrictLegacyMode) {
       ReactStrictModeWarnings.recordLegacyContextWarning(
         workInProgress,
         instance,
@@ -909,7 +909,7 @@ function mountClassInstance(
     if (
       __DEV__ &&
       enableDoubleInvokingEffects &&
-      (workInProgress.mode & StrictModeL2) !== NoMode
+      (workInProgress.mode & StrictEffectsMode) !== NoMode
     ) {
       // Never double-invoke effects for legacy roots.
       workInProgress.flags |= MountLayoutDev | Update;
@@ -988,7 +988,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1040,7 +1040,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1055,7 +1055,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & StrictModeL2) !== NoMode
+        (workInProgress.mode & StrictEffectsMode) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -31,11 +31,10 @@ import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
 import {
-  BlockingMode,
-  ConcurrentMode,
   DebugTracingMode,
   NoMode,
-  StrictMode,
+  StrictModeL1,
+  StrictModeL2,
 } from './ReactTypeOfMode';
 
 import {
@@ -165,7 +164,7 @@ export function applyDerivedStateFromProps(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -318,7 +317,7 @@ function checkShouldComponentUpdate(
     if (__DEV__) {
       if (
         debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictMode
+        workInProgress.mode & StrictModeL1
       ) {
         disableLogs();
         try {
@@ -655,7 +654,7 @@ function constructClassInstance(
   if (__DEV__) {
     if (
       debugRenderPhaseSideEffectsForStrictMode &&
-      workInProgress.mode & StrictMode
+      workInProgress.mode & StrictModeL1
     ) {
       disableLogs();
       try {
@@ -862,7 +861,7 @@ function mountClassInstance(
       }
     }
 
-    if (workInProgress.mode & StrictMode) {
+    if (workInProgress.mode & StrictModeL1) {
       ReactStrictModeWarnings.recordLegacyContextWarning(
         workInProgress,
         instance,
@@ -910,7 +909,7 @@ function mountClassInstance(
     if (
       __DEV__ &&
       enableDoubleInvokingEffects &&
-      (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+      (workInProgress.mode & StrictModeL2) !== NoMode
     ) {
       // Never double-invoke effects for legacy roots.
       workInProgress.flags |= MountLayoutDev | Update;
@@ -989,7 +988,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1041,7 +1040,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;
@@ -1056,7 +1055,7 @@ function resumeMountClassInstance(
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+        (workInProgress.mode & StrictModeL2) !== NoMode
       ) {
         // Never double-invoke effects for legacy roots.
         workInProgress.flags |= MountLayoutDev | Update;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2476,7 +2476,7 @@ function ensureCorrectReturnPointer(fiber, expectedReturnFiber) {
 
 function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2510,7 +2510,7 @@ function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2535,7 +2535,7 @@ function invokePassiveEffectMountInDEV(fiber: Fiber): void {
 
 function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2579,7 +2579,7 @@ function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2476,8 +2476,8 @@ function ensureCorrectReturnPointer(fiber, expectedReturnFiber) {
 
 function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2510,8 +2510,8 @@ function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2535,8 +2535,8 @@ function invokePassiveEffectMountInDEV(fiber: Fiber): void {
 
 function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2579,8 +2579,8 @@ function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2476,7 +2476,7 @@ function ensureCorrectReturnPointer(fiber, expectedReturnFiber) {
 
 function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2510,7 +2510,7 @@ function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2535,7 +2535,7 @@ function invokePassiveEffectMountInDEV(fiber: Fiber): void {
 
 function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
@@ -2579,7 +2579,7 @@ function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2476,8 +2476,8 @@ function ensureCorrectReturnPointer(fiber, expectedReturnFiber) {
 
 function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2510,8 +2510,8 @@ function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectMountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2535,8 +2535,8 @@ function invokePassiveEffectMountInDEV(fiber: Fiber): void {
 
 function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:
@@ -2579,8 +2579,8 @@ function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
 
 function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
     switch (fiber.tag) {
       case FunctionComponent:
       case ForwardRef:

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -36,7 +36,7 @@ import {
   NoMode,
   BlockingMode,
   DebugTracingMode,
-  StrictModeL2,
+  StrictEffectsMode,
 } from './ReactTypeOfMode';
 import {
   NoLane,
@@ -510,7 +510,7 @@ export function bailoutHooks(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (workInProgress.mode & StrictModeL2) !== NoMode
+    (workInProgress.mode & StrictEffectsMode) !== NoMode
   ) {
     workInProgress.flags &= ~(
       MountPassiveDevEffect |
@@ -1424,7 +1424,7 @@ function mountEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountPassiveDevEffect | PassiveEffect | PassiveStaticEffect,
@@ -1462,7 +1462,7 @@ function mountLayoutEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1534,7 +1534,7 @@ function mountImperativeHandle<T>(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1833,7 +1833,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (currentlyRenderingFiber.mode & StrictModeL2) === NoMode
+        (currentlyRenderingFiber.mode & StrictEffectsMode) === NoMode
       ) {
         currentlyRenderingFiber.flags |= MountPassiveDevEffect | PassiveEffect;
       } else {

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -35,8 +35,8 @@ import {
 import {
   NoMode,
   BlockingMode,
-  ConcurrentMode,
   DebugTracingMode,
+  StrictModeL2,
 } from './ReactTypeOfMode';
 import {
   NoLane,
@@ -510,7 +510,7 @@ export function bailoutHooks(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (workInProgress.mode & StrictModeL2) !== NoMode
   ) {
     workInProgress.flags &= ~(
       MountPassiveDevEffect |
@@ -1424,7 +1424,7 @@ function mountEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountPassiveDevEffect | PassiveEffect | PassiveStaticEffect,
@@ -1462,7 +1462,7 @@ function mountLayoutEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1534,7 +1534,7 @@ function mountImperativeHandle<T>(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1830,7 +1830,11 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     const setId = mountState(id)[1];
 
     if ((currentlyRenderingFiber.mode & BlockingMode) === NoMode) {
-      if (__DEV__ && enableDoubleInvokingEffects) {
+      if (
+        __DEV__ &&
+        enableDoubleInvokingEffects &&
+        (currentlyRenderingFiber.mode & StrictModeL2) === NoMode
+      ) {
         currentlyRenderingFiber.flags |= MountPassiveDevEffect | PassiveEffect;
       } else {
         currentlyRenderingFiber.flags |= PassiveEffect;

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -36,7 +36,7 @@ import {
   NoMode,
   BlockingMode,
   DebugTracingMode,
-  StrictModeL2,
+  StrictEffectsMode,
 } from './ReactTypeOfMode';
 import {
   NoLane,
@@ -510,7 +510,7 @@ export function bailoutHooks(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (workInProgress.mode & StrictModeL2) !== NoMode
+    (workInProgress.mode & StrictEffectsMode) !== NoMode
   ) {
     workInProgress.flags &= ~(
       MountPassiveDevEffect |
@@ -1424,7 +1424,7 @@ function mountEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountPassiveDevEffect | PassiveEffect | PassiveStaticEffect,
@@ -1462,7 +1462,7 @@ function mountLayoutEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1534,7 +1534,7 @@ function mountImperativeHandle<T>(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
+    (currentlyRenderingFiber.mode & StrictEffectsMode) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1833,7 +1833,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
       if (
         __DEV__ &&
         enableDoubleInvokingEffects &&
-        (currentlyRenderingFiber.mode & StrictModeL2) === NoMode
+        (currentlyRenderingFiber.mode & StrictEffectsMode) === NoMode
       ) {
         currentlyRenderingFiber.flags |= MountPassiveDevEffect | PassiveEffect;
       } else {

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -35,8 +35,8 @@ import {
 import {
   NoMode,
   BlockingMode,
-  ConcurrentMode,
   DebugTracingMode,
+  StrictModeL2,
 } from './ReactTypeOfMode';
 import {
   NoLane,
@@ -510,7 +510,7 @@ export function bailoutHooks(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (workInProgress.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (workInProgress.mode & StrictModeL2) !== NoMode
   ) {
     workInProgress.flags &= ~(
       MountPassiveDevEffect |
@@ -1424,7 +1424,7 @@ function mountEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountPassiveDevEffect | PassiveEffect | PassiveStaticEffect,
@@ -1462,7 +1462,7 @@ function mountLayoutEffect(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1534,7 +1534,7 @@ function mountImperativeHandle<T>(
   if (
     __DEV__ &&
     enableDoubleInvokingEffects &&
-    (currentlyRenderingFiber.mode & (BlockingMode | ConcurrentMode)) !== NoMode
+    (currentlyRenderingFiber.mode & StrictModeL2) !== NoMode
   ) {
     return mountEffectImpl(
       MountLayoutDevEffect | UpdateEffect,
@@ -1830,7 +1830,11 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     const setId = mountState(id)[1];
 
     if ((currentlyRenderingFiber.mode & BlockingMode) === NoMode) {
-      if (__DEV__ && enableDoubleInvokingEffects) {
+      if (
+        __DEV__ &&
+        enableDoubleInvokingEffects &&
+        (currentlyRenderingFiber.mode & StrictModeL2) === NoMode
+      ) {
         currentlyRenderingFiber.flags |= MountPassiveDevEffect | PassiveEffect;
       } else {
         currentlyRenderingFiber.flags |= PassiveEffect;

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -75,7 +75,7 @@ import {
   resetCurrentFiber as resetCurrentDebugFiberInDEV,
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 import {
   SyncLane,
   InputDiscreteHydrationLane,
@@ -204,7 +204,7 @@ function findHostInstanceWithWarning(
     if (hostFiber === null) {
       return null;
     }
-    if (hostFiber.mode & StrictMode) {
+    if (hostFiber.mode & StrictModeL1) {
       const componentName = getComponentName(fiber.type) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
@@ -212,7 +212,7 @@ function findHostInstanceWithWarning(
         const previousFiber = ReactCurrentFiberCurrent;
         try {
           setCurrentDebugFiberInDEV(hostFiber);
-          if (fiber.mode & StrictMode) {
+          if (fiber.mode & StrictModeL1) {
             console.error(
               '%s is deprecated in StrictMode. ' +
                 '%s was passed an instance of %s which is inside StrictMode. ' +

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -75,7 +75,7 @@ import {
   resetCurrentFiber as resetCurrentDebugFiberInDEV,
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
   SyncLane,
   InputDiscreteHydrationLane,
@@ -204,7 +204,7 @@ function findHostInstanceWithWarning(
     if (hostFiber === null) {
       return null;
     }
-    if (hostFiber.mode & StrictModeL1) {
+    if (hostFiber.mode & StrictLegacyMode) {
       const componentName = getComponentName(fiber.type) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
@@ -212,7 +212,7 @@ function findHostInstanceWithWarning(
         const previousFiber = ReactCurrentFiberCurrent;
         try {
           setCurrentDebugFiberInDEV(hostFiber);
-          if (fiber.mode & StrictModeL1) {
+          if (fiber.mode & StrictLegacyMode) {
             console.error(
               '%s is deprecated in StrictMode. ' +
                 '%s was passed an instance of %s which is inside StrictMode. ' +

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -75,7 +75,7 @@ import {
   resetCurrentFiber as resetCurrentDebugFiberInDEV,
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 import {
   SyncLane,
   InputDiscreteHydrationLane,
@@ -204,7 +204,7 @@ function findHostInstanceWithWarning(
     if (hostFiber === null) {
       return null;
     }
-    if (hostFiber.mode & StrictMode) {
+    if (hostFiber.mode & StrictModeL1) {
       const componentName = getComponentName(fiber.type) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
@@ -212,7 +212,7 @@ function findHostInstanceWithWarning(
         const previousFiber = ReactCurrentFiberCurrent;
         try {
           setCurrentDebugFiberInDEV(hostFiber);
-          if (fiber.mode & StrictMode) {
+          if (fiber.mode & StrictModeL1) {
             console.error(
               '%s is deprecated in StrictMode. ' +
                 '%s was passed an instance of %s which is inside StrictMode. ' +

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -75,7 +75,7 @@ import {
   resetCurrentFiber as resetCurrentDebugFiberInDEV,
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
   SyncLane,
   InputDiscreteHydrationLane,
@@ -204,7 +204,7 @@ function findHostInstanceWithWarning(
     if (hostFiber === null) {
       return null;
     }
-    if (hostFiber.mode & StrictModeL1) {
+    if (hostFiber.mode & StrictLegacyMode) {
       const componentName = getComponentName(fiber.type) || 'Component';
       if (!didWarnAboutFindNodeInStrictMode[componentName]) {
         didWarnAboutFindNodeInStrictMode[componentName] = true;
@@ -212,7 +212,7 @@ function findHostInstanceWithWarning(
         const previousFiber = ReactCurrentFiberCurrent;
         try {
           setCurrentDebugFiberInDEV(hostFiber);
-          if (fiber.mode & StrictModeL1) {
+          if (fiber.mode & StrictLegacyMode) {
             console.error(
               '%s is deprecated in StrictMode. ' +
                 '%s was passed an instance of %s which is inside StrictMode. ' +

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -104,7 +104,8 @@ import {
 } from './ReactFiber.new';
 import {
   NoMode,
-  StrictMode,
+  StrictModeL1,
+  StrictModeL2,
   ProfileMode,
   BlockingMode,
   ConcurrentMode,
@@ -2561,8 +2562,8 @@ function commitDoubleInvokeEffectsInDEV(
   hasPassiveEffects: boolean,
 ) {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // Never double-invoke effects for legacy roots.
-    if ((fiber.mode & (BlockingMode | ConcurrentMode)) === NoMode) {
+    // Never double-invoke effects outside of StrictModeL2.
+    if ((fiber.mode & StrictModeL2) === NoMode) {
       return;
     }
 
@@ -2590,8 +2591,8 @@ function invokeEffectsInDev(
   invokeEffectFn: (fiber: Fiber) => void,
 ): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
 
     let current = firstChild;
     let subtreeRoot = null;
@@ -2934,7 +2935,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      (fiber.mode & StrictMode) !== NoMode &&
+      (fiber.mode & StrictModeL1) !== NoMode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -104,8 +104,8 @@ import {
 } from './ReactFiber.new';
 import {
   NoMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
   ProfileMode,
   BlockingMode,
   ConcurrentMode,
@@ -2562,8 +2562,8 @@ function commitDoubleInvokeEffectsInDEV(
   hasPassiveEffects: boolean,
 ) {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // Never double-invoke effects outside of StrictModeL2.
-    if ((fiber.mode & StrictModeL2) === NoMode) {
+    // Never double-invoke effects outside of StrictEffectsMode.
+    if ((fiber.mode & StrictEffectsMode) === NoMode) {
       return;
     }
 
@@ -2591,7 +2591,7 @@ function invokeEffectsInDev(
   invokeEffectFn: (fiber: Fiber) => void,
 ): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
 
     let current = firstChild;
@@ -2935,7 +2935,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      (fiber.mode & StrictModeL1) !== NoMode &&
+      (fiber.mode & StrictLegacyMode) !== NoMode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -104,7 +104,8 @@ import {
 } from './ReactFiber.old';
 import {
   NoMode,
-  StrictMode,
+  StrictModeL1,
+  StrictModeL2,
   ProfileMode,
   BlockingMode,
   ConcurrentMode,
@@ -2561,8 +2562,8 @@ function commitDoubleInvokeEffectsInDEV(
   hasPassiveEffects: boolean,
 ) {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // Never double-invoke effects for legacy roots.
-    if ((fiber.mode & (BlockingMode | ConcurrentMode)) === NoMode) {
+    // Never double-invoke effects outside of StrictModeL2.
+    if ((fiber.mode & StrictModeL2) === NoMode) {
       return;
     }
 
@@ -2590,8 +2591,8 @@ function invokeEffectsInDev(
   invokeEffectFn: (fiber: Fiber) => void,
 ): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check for legacy roots here.
-    // This function will not be called within legacy roots.
+    // We don't need to re-check StrictModeL2 here.
+    // This function is only called if that check has already passed.
 
     let current = firstChild;
     let subtreeRoot = null;
@@ -2934,7 +2935,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      (fiber.mode & StrictMode) !== NoMode &&
+      (fiber.mode & StrictModeL1) !== NoMode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -104,8 +104,8 @@ import {
 } from './ReactFiber.old';
 import {
   NoMode,
-  StrictModeL1,
-  StrictModeL2,
+  StrictLegacyMode,
+  StrictEffectsMode,
   ProfileMode,
   BlockingMode,
   ConcurrentMode,
@@ -2562,8 +2562,8 @@ function commitDoubleInvokeEffectsInDEV(
   hasPassiveEffects: boolean,
 ) {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // Never double-invoke effects outside of StrictModeL2.
-    if ((fiber.mode & StrictModeL2) === NoMode) {
+    // Never double-invoke effects outside of StrictEffectsMode.
+    if ((fiber.mode & StrictEffectsMode) === NoMode) {
       return;
     }
 
@@ -2591,7 +2591,7 @@ function invokeEffectsInDev(
   invokeEffectFn: (fiber: Fiber) => void,
 ): void {
   if (__DEV__ && enableDoubleInvokingEffects) {
-    // We don't need to re-check StrictModeL2 here.
+    // We don't need to re-check StrictEffectsMode here.
     // This function is only called if that check has already passed.
 
     let current = firstChild;
@@ -2935,7 +2935,7 @@ export function warnIfNotCurrentlyActingEffectsInDEV(fiber: Fiber): void {
   if (__DEV__) {
     if (
       warnsIfNotActing === true &&
-      (fiber.mode & StrictModeL1) !== NoMode &&
+      (fiber.mode & StrictLegacyMode) !== NoMode &&
       IsSomeRendererActing.current === false &&
       IsThisRendererActing.current === false
     ) {

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -14,7 +14,7 @@ import {
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
 import getComponentName from 'shared/getComponentName';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 
 type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
@@ -33,7 +33,7 @@ if (__DEV__) {
 
     let node = fiber;
     while (node !== null) {
-      if (node.mode & StrictModeL1) {
+      if (node.mode & StrictLegacyMode) {
         maybeStrictRoot = node;
       }
       node = node.return;
@@ -78,7 +78,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillMount === 'function'
     ) {
       pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
@@ -92,7 +92,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillReceiveProps === 'function'
     ) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
@@ -106,7 +106,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillUpdate === 'function'
     ) {
       pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -14,7 +14,7 @@ import {
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
 import getComponentName from 'shared/getComponentName';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 
 type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
@@ -33,7 +33,7 @@ if (__DEV__) {
 
     let node = fiber;
     while (node !== null) {
-      if (node.mode & StrictMode) {
+      if (node.mode & StrictModeL1) {
         maybeStrictRoot = node;
       }
       node = node.return;
@@ -78,7 +78,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillMount === 'function'
     ) {
       pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
@@ -92,7 +92,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillReceiveProps === 'function'
     ) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
@@ -106,7 +106,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillUpdate === 'function'
     ) {
       pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -14,7 +14,7 @@ import {
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
 import getComponentName from 'shared/getComponentName';
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 
 type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
@@ -33,7 +33,7 @@ if (__DEV__) {
 
     let node = fiber;
     while (node !== null) {
-      if (node.mode & StrictModeL1) {
+      if (node.mode & StrictLegacyMode) {
         maybeStrictRoot = node;
       }
       node = node.return;
@@ -78,7 +78,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillMount === 'function'
     ) {
       pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
@@ -92,7 +92,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillReceiveProps === 'function'
     ) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
@@ -106,7 +106,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictModeL1 &&
+      fiber.mode & StrictLegacyMode &&
       typeof instance.UNSAFE_componentWillUpdate === 'function'
     ) {
       pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -14,7 +14,7 @@ import {
   setCurrentFiber as setCurrentDebugFiberInDEV,
 } from './ReactCurrentFiber';
 import getComponentName from 'shared/getComponentName';
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 
 type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
@@ -33,7 +33,7 @@ if (__DEV__) {
 
     let node = fiber;
     while (node !== null) {
-      if (node.mode & StrictMode) {
+      if (node.mode & StrictModeL1) {
         maybeStrictRoot = node;
       }
       node = node.return;
@@ -78,7 +78,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillMount === 'function'
     ) {
       pendingUNSAFE_ComponentWillMountWarnings.push(fiber);
@@ -92,7 +92,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillReceiveProps === 'function'
     ) {
       pendingUNSAFE_ComponentWillReceivePropsWarnings.push(fiber);
@@ -106,7 +106,7 @@ if (__DEV__) {
     }
 
     if (
-      fiber.mode & StrictMode &&
+      fiber.mode & StrictModeL1 &&
       typeof instance.UNSAFE_componentWillUpdate === 'function'
     ) {
       pendingUNSAFE_ComponentWillUpdateWarnings.push(fiber);

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -9,11 +9,11 @@
 
 export type TypeOfMode = number;
 
-export const NoMode = 0b00000;
-export const StrictMode = 0b00001;
-// TODO: Remove BlockingMode and ConcurrentMode by reading from the root
-// tag instead
-export const BlockingMode = 0b00010;
-export const ConcurrentMode = 0b00100;
-export const ProfileMode = 0b01000;
-export const DebugTracingMode = 0b10000;
+export const NoMode = /*           */ 0b000000;
+// TODO: Remove BlockingMode and ConcurrentMode by reading from the root tag instead
+export const BlockingMode = /*     */ 0b000001;
+export const ConcurrentMode = /*   */ 0b000010;
+export const ProfileMode = /*      */ 0b000100;
+export const DebugTracingMode = /* */ 0b001000;
+export const StrictModeL1 = /*     */ 0b010000;
+export const StrictModeL2 = /*     */ 0b100000;

--- a/packages/react-reconciler/src/ReactTypeOfMode.js
+++ b/packages/react-reconciler/src/ReactTypeOfMode.js
@@ -9,11 +9,11 @@
 
 export type TypeOfMode = number;
 
-export const NoMode = /*           */ 0b000000;
+export const NoMode = /*            */ 0b000000;
 // TODO: Remove BlockingMode and ConcurrentMode by reading from the root tag instead
-export const BlockingMode = /*     */ 0b000001;
-export const ConcurrentMode = /*   */ 0b000010;
-export const ProfileMode = /*      */ 0b000100;
-export const DebugTracingMode = /* */ 0b001000;
-export const StrictModeL1 = /*     */ 0b010000;
-export const StrictModeL2 = /*     */ 0b100000;
+export const BlockingMode = /*      */ 0b000001;
+export const ConcurrentMode = /*    */ 0b000010;
+export const ProfileMode = /*       */ 0b000100;
+export const DebugTracingMode = /*  */ 0b001000;
+export const StrictLegacyMode = /*  */ 0b010000;
+export const StrictEffectsMode = /* */ 0b100000;

--- a/packages/react-reconciler/src/ReactUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.new.js
@@ -104,7 +104,7 @@ import {Callback, ShouldCapture, DidCapture} from './ReactFiberFlags';
 
 import {debugRenderPhaseSideEffectsForStrictMode} from 'shared/ReactFeatureFlags';
 
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
   markSkippedUpdateLanes,
   isInterleavedUpdate,
@@ -392,7 +392,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictModeL1
+            workInProgress.mode & StrictLegacyMode
           ) {
             disableLogs();
             try {
@@ -425,7 +425,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictModeL1
+            workInProgress.mode & StrictLegacyMode
           ) {
             disableLogs();
             try {

--- a/packages/react-reconciler/src/ReactUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.new.js
@@ -104,7 +104,7 @@ import {Callback, ShouldCapture, DidCapture} from './ReactFiberFlags';
 
 import {debugRenderPhaseSideEffectsForStrictMode} from 'shared/ReactFeatureFlags';
 
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 import {
   markSkippedUpdateLanes,
   isInterleavedUpdate,
@@ -392,7 +392,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictMode
+            workInProgress.mode & StrictModeL1
           ) {
             disableLogs();
             try {
@@ -425,7 +425,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictMode
+            workInProgress.mode & StrictModeL1
           ) {
             disableLogs();
             try {

--- a/packages/react-reconciler/src/ReactUpdateQueue.old.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.old.js
@@ -104,7 +104,7 @@ import {Callback, ShouldCapture, DidCapture} from './ReactFiberFlags';
 
 import {debugRenderPhaseSideEffectsForStrictMode} from 'shared/ReactFeatureFlags';
 
-import {StrictModeL1} from './ReactTypeOfMode';
+import {StrictLegacyMode} from './ReactTypeOfMode';
 import {
   markSkippedUpdateLanes,
   isInterleavedUpdate,
@@ -392,7 +392,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictModeL1
+            workInProgress.mode & StrictLegacyMode
           ) {
             disableLogs();
             try {
@@ -425,7 +425,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictModeL1
+            workInProgress.mode & StrictLegacyMode
           ) {
             disableLogs();
             try {

--- a/packages/react-reconciler/src/ReactUpdateQueue.old.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.old.js
@@ -104,7 +104,7 @@ import {Callback, ShouldCapture, DidCapture} from './ReactFiberFlags';
 
 import {debugRenderPhaseSideEffectsForStrictMode} from 'shared/ReactFeatureFlags';
 
-import {StrictMode} from './ReactTypeOfMode';
+import {StrictModeL1} from './ReactTypeOfMode';
 import {
   markSkippedUpdateLanes,
   isInterleavedUpdate,
@@ -392,7 +392,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictMode
+            workInProgress.mode & StrictModeL1
           ) {
             disableLogs();
             try {
@@ -425,7 +425,7 @@ function getStateFromUpdate<State>(
         if (__DEV__) {
           if (
             debugRenderPhaseSideEffectsForStrictMode &&
-            workInProgress.mode & StrictMode
+            workInProgress.mode & StrictModeL1
           ) {
             disableLogs();
             try {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -20,11 +20,11 @@ export const enableDebugTracing = false;
 export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
-// reducers by double invoking them in StrictModeL1.
+// reducers by double invoking them in StrictLegacyMode.
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 
 // Helps identify code that is not safe for planned Offscreen API and Suspense semantics;
-// this feature flag only impacts StrictModeL2.
+// this feature flag only impacts StrictEffectsMode.
 export const enableDoubleInvokingEffects = false;
 
 // To preserve the "Pause on caught exceptions" behavior of the debugger, we

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -20,8 +20,12 @@ export const enableDebugTracing = false;
 export const enableSchedulingProfiler = __PROFILE__ && __EXPERIMENTAL__;
 
 // Helps identify side effects in render-phase lifecycle hooks and setState
-// reducers by double invoking them in Strict Mode.
+// reducers by double invoking them in StrictModeL1.
 export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
+
+// Helps identify code that is not safe for planned Offscreen API and Suspense semantics;
+// this feature flag only impacts StrictModeL2.
+export const enableDoubleInvokingEffects = false;
 
 // To preserve the "Pause on caught exceptions" behavior of the debugger, we
 // replay the begin phase of a failed component inside invokeGuardedCallback.
@@ -138,8 +142,6 @@ export const deferRenderPhaseUpdateToNextBatch = true;
 export const decoupleUpdatePriorityFromScheduler = false;
 
 export const enableDiscreteEventFlushingChange = false;
-
-export const enableDoubleInvokingEffects = false;
 
 export const enableUseRefAccessWarning = false;
 


### PR DESCRIPTION
### PR Stack
- [x] **#20844: Add concept of StrictMode levels 1 & 2 (no public API yet)**
- [x] #20847: Separate strict effects mode feature flags
- [x] #20849: Add StrictMode level prop and createRoot unstable_strictModeLevel option

---

## Strict mode level 0 (aka loose or sloppy mode)
This isn't really a mode so much as it's the absence of any strict modes.

## Strict mode level 1 (aka legacy mode)
The exported `<React.StrictMode>` tag remains the same and opts legacy subtrees into strict mode level one (`mode == StrictLegacyMode`). This mode enables DEV-only double rendering, double component lifecycles, string ref warnings, legacy context warnings, etc. The primary purpose of this mode is to help detected render phase side effects. No new behavior. Roots created with experimental `createRoot` and `createBlockingRoot` APIs will also (for now) continue to default to strict mode level 1.

## Strict mode level 2 (aka strict effects mode)
In a subsequent commit I will add support for a `"level"` attribute on the `<React.StrictMode>` tag (as well as a new option supported by `createRoot`). This will be the way to opt into strict mode level 2 (`mode == StrictEffectsMode`). This mode will enable DEV-only double invoking of effects on initial mount (see #19523). This will simulate future Offscreen API semantics for trees being mounted, then hidden, and then shown again. The primary purpose of this mode is to enable applications to prepare for compatibility with the new Offscreen API (more information to follow shortly).

## Strict mode level >= 3?
In the future we may add additional strict mode levels (TBD).

## External changes?
For now, this commit changes no public facing behavior. The only mechanism for opting into strict mode level 2 is the pre-existing `enableDoubleInvokingEffects` feature flag (only enabled within Facebook for now).