### PR TITLE
Delete a redundant statement

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -1375,7 +1375,6 @@ export function cloneChildFibers(
     );
     newChild.return = workInProgress;
   }
-  newChild.sibling = null;
 }
 
 // Reset a workInProgress child set to prepare it for a second pass.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -1375,7 +1375,6 @@ export function cloneChildFibers(
     );
     newChild.return = workInProgress;
   }
-  newChild.sibling = null;
 }
 
 // Reset a workInProgress child set to prepare it for a second pass.


### PR DESCRIPTION
At that time, the sibling of the fiber must be null, so there is no need to assign again.

[That statement appears here for the first time](https://github.com/facebook/react/commit/edaf08fcfe179b8ac9742bcb60791f42024b8d0d#diff-5ff8ad3b5184d652e6a03d44a3cc97e74c1d7ee6885408e53edaf669d760cec5R749)