### PR TITLE
SchedulerDOM falls back to globalThis if window is undefined

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,6 +208,7 @@ module.exports = {
 
   globals: {
     SharedArrayBuffer: true,
+    globalThis: true,
 
     spyOnDev: true,
     spyOnDevAndProd: true,

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -88,7 +88,6 @@ var isHostTimeoutScheduled = false;
 // Web Workers can't access window.
 // Many browsers provide a globalThis property for this reason.
 // For legacy reasons (mostly unit tests) this code prefers window if defined.
-// eslint-disable-next-line no-undef
 const globalObject = typeof window !== 'undefined' ? window : globalThis;
 
 // Capture local references to native APIs, in case a polyfill overrides them.

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -85,17 +85,23 @@ var isPerformingWork = false;
 var isHostCallbackScheduled = false;
 var isHostTimeoutScheduled = false;
 
+// Web Workers can't access window.
+// Many browsers provide a globalThis property for this reason.
+// For legacy reasons (mostly unit tests) this code prefers window if defined.
+// eslint-disable-next-line no-undef
+const globalObject = typeof window !== 'undefined' ? window : globalThis;
+
 // Capture local references to native APIs, in case a polyfill overrides them.
-const setTimeout = window.setTimeout;
-const clearTimeout = window.clearTimeout;
-const setImmediate = window.setImmediate; // IE and Node.js + jsdom
+const setTimeout = globalObject.setTimeout;
+const clearTimeout = globalObject.clearTimeout;
+const setImmediate = globalObject.setImmediate; // IE and Node.js + jsdom
 
 if (typeof console !== 'undefined') {
   // TODO: Scheduler no longer requires these methods to be polyfilled. But
   // maybe we want to continue warning if they don't exist, to preserve the
   // option to rely on it in the future?
-  const requestAnimationFrame = window.requestAnimationFrame;
-  const cancelAnimationFrame = window.cancelAnimationFrame;
+  const requestAnimationFrame = globalObject.requestAnimationFrame;
+  const cancelAnimationFrame = globalObject.cancelAnimationFrame;
 
   if (typeof requestAnimationFrame !== 'function') {
     // Using console['error'] to evade Babel and ESLint

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -29,6 +29,7 @@ module.exports = {
     SharedArrayBuffer: true,
     Int32Array: true,
     ArrayBuffer: true,
+    globalThis: true,
 
     TaskController: true,
 

--- a/scripts/rollup/validate/eslintrc.cjs2015.js
+++ b/scripts/rollup/validate/eslintrc.cjs2015.js
@@ -29,6 +29,7 @@ module.exports = {
     SharedArrayBuffer: true,
     Int32Array: true,
     ArrayBuffer: true,
+    globalThis: true,
 
     TaskController: true,
 

--- a/scripts/rollup/validate/eslintrc.esm.js
+++ b/scripts/rollup/validate/eslintrc.esm.js
@@ -29,6 +29,7 @@ module.exports = {
     SharedArrayBuffer: true,
     Int32Array: true,
     ArrayBuffer: true,
+    globalThis: true,
 
     TaskController: true,
 

--- a/scripts/rollup/validate/eslintrc.fb.js
+++ b/scripts/rollup/validate/eslintrc.fb.js
@@ -30,6 +30,7 @@ module.exports = {
     SharedArrayBuffer: true,
     Int32Array: true,
     ArrayBuffer: true,
+    globalThis: true,
 
     TaskController: true,
 

--- a/scripts/rollup/validate/eslintrc.rn.js
+++ b/scripts/rollup/validate/eslintrc.rn.js
@@ -29,6 +29,7 @@ module.exports = {
     SharedArrayBuffer: true,
     Int32Array: true,
     ArrayBuffer: true,
+    globalThis: true,
 
     TaskController: true,
 


### PR DESCRIPTION
In response to user feedback from @rickhanlonii, I recently made a small change to our scheduling profiler so that it stores lane labels in addition to numeric values (#20808).

While re-building the profiler UI to add the newly available info, I found that it throws when importing profiling data because of references to `window` (e.g. `window.setTimeout`) inside of `SchedulerDOM`. (Some of the scheduling profiler code runs in a web worker and `window` isn't defined there.)

This PR adds a fallback to [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) if `window` is not defined. It prefers `window` if available to minimize change. We could perhaps also workaround this by falling back to something else e.g. `self` but `globalThis` seemed better.

Thoughts?