### PR TITLE
Update scheduling profiler Webpack config

### DIFF
--- a/packages/react-devtools-scheduling-profiler/webpack.config.js
+++ b/packages/react-devtools-scheduling-profiler/webpack.config.js
@@ -49,6 +49,7 @@ const config = {
       react: resolve(builtModulesDir, 'react'),
       'react-dom': resolve(builtModulesDir, 'react-dom'),
       'react-refresh': resolve(builtModulesDir, 'react-refresh'),
+      scheduler: resolve(builtModulesDir, 'scheduler'),
     },
   },
   plugins: [


### PR DESCRIPTION
Use the pre-built scheduler (which includes a check for 'window' being defined in order to load the right scheduler implementation) rather than just directly importing a version of the scheduler that relies on window. Since the scheduling profiler's code runs partially in a web worker, it can't rely on window.

Alternate fix for #20865.