### PR TITLE
Fix react-devtools-scheduling-profiler tests on main

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/constants.js
+++ b/packages/react-devtools-scheduling-profiler/src/constants.js
@@ -11,6 +11,5 @@ export {
   COMFORTABLE_LINE_HEIGHT,
   COMPACT_LINE_HEIGHT,
 } from 'react-devtools-shared/src/constants.js';
-import {TotalLanes} from 'react-reconciler/src/ReactFiberLane.new';
 
-export const REACT_TOTAL_NUM_LANES = TotalLanes;
+export const REACT_TOTAL_NUM_LANES = 31;


### PR DESCRIPTION
## Overview

This [was added](https://github.com/facebook/react/pull/20808/files#diff-c4d52dc9e050446546cb98287d3a69a3b4d53ff6caf69066d090be4815f72be1R14) and landed before [my changes](https://github.com/facebook/react/pull/20872) landed, causing main to fail since the ReactFiberHostConfig isn't selected.

This PR reverts the import to fix main.

I did it this way for two reasons:
1. We probably shouldn't be deep importing from the reconciler
2. I'm not sure of the correct way to mock the host config even if we decided that we should