### PR TITLE
Import total lanes from reconciler

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/constants.js
+++ b/packages/react-devtools-scheduling-profiler/src/constants.js
@@ -11,5 +11,6 @@ export {
   COMFORTABLE_LINE_HEIGHT,
   COMPACT_LINE_HEIGHT,
 } from 'react-devtools-shared/src/constants.js';
+import {TotalLanes} from 'react-reconciler/src/ReactFiberLane.new';
 
-export const REACT_TOTAL_NUM_LANES = 31;
+export const REACT_TOTAL_NUM_LANES = TotalLanes;


### PR DESCRIPTION
## Overview

This PR attempts to re-add the changes from [here](https://github.com/facebook/react/commit/e5f6b91d294d0c1260ce5079ed0192b43ccd3e82) that were [reverted](https://github.com/facebook/react/pull/20885) to unblock main.

The test fails because we're importing from the reconciler without mocking/forking the ReactFiberHostConfig.