### PR TITLE
Nested opaque identifier

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -448,6 +448,7 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 
 export function makeOpaqueHydratingObject(
   attemptToReadValue: () => void,
+  warnOnDuplicateKey: () => void,
 ): OpaqueIDType {
   throw new Error('Not yet implemented.');
 }

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -2190,9 +2190,7 @@ describe('ReactDOMServerHooks', () => {
       expect(() => Scheduler.unstable_flushAll()).toErrorDev(
         [
           'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.',
-          'Warning: Did not expect server HTML to contain a <div> in <div>.',
         ],
-        {withoutStack: 1},
       );
     });
   });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -2187,11 +2187,9 @@ describe('ReactDOMServerHooks', () => {
 
       container.innerHTML = ReactDOMServer.renderToString(<App />);
       ReactDOM.unstable_createRoot(container, {hydrate: true}).render(<App />);
-      expect(() => Scheduler.unstable_flushAll()).toErrorDev(
-        [
-          'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.',
-        ],
-      );
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.',
+      ]);
     });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -1978,6 +1978,7 @@ describe('ReactDOMServerHooks', () => {
         container.getElementsByTagName('span')[0].getAttribute('id'),
       ).not.toBeNull();
     });
+    // @gate experimental
     it('nested makeNewFromKey generates unique ids for server string render', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
@@ -2120,6 +2121,7 @@ describe('ReactDOMServerHooks', () => {
       expect(idList).not.toContain(null);
       expect(new Set(idList).size).toEqual(idList.length);
     });
+    // @gate experimental
     it('nested makeNewFromKey generates unique ids for client render on good server markup', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
@@ -2166,6 +2168,7 @@ describe('ReactDOMServerHooks', () => {
       expect(idList).not.toContain(null);
       expect(new Set(idList).size).toEqual(idList.length);
     });
+    // @gate experimental
     it('makeNewFromKey warns on duplicate keys', async () => {
       function App() {
         const id = useOpaqueIdentifier();

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationHooks-test.js
@@ -1981,12 +1981,12 @@ describe('ReactDOMServerHooks', () => {
     it('nested makeNewFromKey generates unique ids for server string render', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
-        const nestedOne=baseId.makeNewFromKey("key1");
-        const nestedTwo=baseId.makeNewFromKey("key2");
-        const nestedOneOne=nestedOne.makeNewFromKey("key1");
-        const nestedOneTwo=nestedOne.makeNewFromKey("key2");
-        const nestedTwoOne=nestedTwo.makeNewFromKey("key1");
-        const nestedTwoTwo=nestedTwo.makeNewFromKey("key2");
+        const nestedOne = baseId.makeNewFromKey('key1');
+        const nestedTwo = baseId.makeNewFromKey('key2');
+        const nestedOneOne = nestedOne.makeNewFromKey('key1');
+        const nestedOneTwo = nestedOne.makeNewFromKey('key2');
+        const nestedTwoOne = nestedTwo.makeNewFromKey('key1');
+        const nestedTwoTwo = nestedTwo.makeNewFromKey('key2');
         return (
           <div id={baseId}>
             <div id={nestedOne}>
@@ -2000,41 +2000,41 @@ describe('ReactDOMServerHooks', () => {
           </div>
         );
       }
-  
+
       const domNode = await serverRender(<App />);
-      
+
       expect(domNode.children.length).toEqual(2);
       expect(domNode.children[0].children.length).toEqual(2);
       expect(domNode.children[1].children.length).toEqual(2);
-      expect(domNode.children[0].children[0].getAttribute('aria-labelledby')).not.toEqual(
+      expect(
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[0].children[1].getAttribute('id'));
+      expect(
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[1].children[1].getAttribute('id'));
+      const idList = [
+        domNode.getAttribute('id'),
+        domNode.children[0].getAttribute('id'),
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
         domNode.children[0].children[1].getAttribute('id'),
-      );
-      expect(domNode.children[1].children[0].getAttribute('aria-labelledby')).not.toEqual(
+        domNode.children[1].getAttribute('id'),
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
         domNode.children[1].children[1].getAttribute('id'),
-      );
-      const idList=[
-        domNode.getAttribute("id"),
-        domNode.children[0].getAttribute("id"),
-        domNode.children[0].children[0].getAttribute("aria-labelledby"),
-        domNode.children[0].children[1].getAttribute("id"),
-        domNode.children[1].getAttribute("id"),
-        domNode.children[1].children[0].getAttribute("aria-labelledby"),
-        domNode.children[1].children[1].getAttribute("id"),
       ];
       expect(idList).not.toContain(null);
-      expect((new Set(idList)).size).toEqual(idList.length);
+      expect(new Set(idList).size).toEqual(idList.length);
     });
-  
+
     // @gate experimental
     it('nested makeNewFromKey generates unique ids for server stream render', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
-        const nestedOne=baseId.makeNewFromKey("key1");
-        const nestedTwo=baseId.makeNewFromKey("key2");
-        const nestedOneOne=nestedOne.makeNewFromKey("key1");
-        const nestedOneTwo=nestedOne.makeNewFromKey("key2");
-        const nestedTwoOne=nestedTwo.makeNewFromKey("key1");
-        const nestedTwoTwo=nestedTwo.makeNewFromKey("key2");
+        const nestedOne = baseId.makeNewFromKey('key1');
+        const nestedTwo = baseId.makeNewFromKey('key2');
+        const nestedOneOne = nestedOne.makeNewFromKey('key1');
+        const nestedOneTwo = nestedOne.makeNewFromKey('key2');
+        const nestedTwoOne = nestedTwo.makeNewFromKey('key1');
+        const nestedTwoTwo = nestedTwo.makeNewFromKey('key2');
         return (
           <div id={baseId}>
             <div id={nestedOne}>
@@ -2048,41 +2048,41 @@ describe('ReactDOMServerHooks', () => {
           </div>
         );
       }
-  
+
       const domNode = await streamRender(<App />);
-      
+
       expect(domNode.children.length).toEqual(2);
       expect(domNode.children[0].children.length).toEqual(2);
       expect(domNode.children[1].children.length).toEqual(2);
-      expect(domNode.children[0].children[0].getAttribute('aria-labelledby')).not.toEqual(
+      expect(
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[0].children[1].getAttribute('id'));
+      expect(
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[1].children[1].getAttribute('id'));
+      const idList = [
+        domNode.getAttribute('id'),
+        domNode.children[0].getAttribute('id'),
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
         domNode.children[0].children[1].getAttribute('id'),
-      );
-      expect(domNode.children[1].children[0].getAttribute('aria-labelledby')).not.toEqual(
+        domNode.children[1].getAttribute('id'),
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
         domNode.children[1].children[1].getAttribute('id'),
-      );
-      const idList=[
-        domNode.getAttribute("id"),
-        domNode.children[0].getAttribute("id"),
-        domNode.children[0].children[0].getAttribute("aria-labelledby"),
-        domNode.children[0].children[1].getAttribute("id"),
-        domNode.children[1].getAttribute("id"),
-        domNode.children[1].children[0].getAttribute("aria-labelledby"),
-        domNode.children[1].children[1].getAttribute("id"),
       ];
       expect(idList).not.toContain(null);
-      expect((new Set(idList)).size).toEqual(idList.length);
+      expect(new Set(idList).size).toEqual(idList.length);
     });
-  
+
     // @gate experimental
     it('nested makeNewFromKey generates unique ids for client render', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
-        const nestedOne=baseId.makeNewFromKey("key1");
-        const nestedTwo=baseId.makeNewFromKey("key2");
-        const nestedOneOne=nestedOne.makeNewFromKey("key1");
-        const nestedOneTwo=nestedOne.makeNewFromKey("key2");
-        const nestedTwoOne=nestedTwo.makeNewFromKey("key1");
-        const nestedTwoTwo=nestedTwo.makeNewFromKey("key2");
+        const nestedOne = baseId.makeNewFromKey('key1');
+        const nestedTwo = baseId.makeNewFromKey('key2');
+        const nestedOneOne = nestedOne.makeNewFromKey('key1');
+        const nestedOneTwo = nestedOne.makeNewFromKey('key2');
+        const nestedTwoOne = nestedTwo.makeNewFromKey('key1');
+        const nestedTwoTwo = nestedTwo.makeNewFromKey('key2');
         return (
           <div id={baseId}>
             <div id={nestedOne}>
@@ -2096,39 +2096,39 @@ describe('ReactDOMServerHooks', () => {
           </div>
         );
       }
-  
+
       const domNode = await clientCleanRender(<App />);
-      
+
       expect(domNode.children.length).toEqual(2);
       expect(domNode.children[0].children.length).toEqual(2);
       expect(domNode.children[1].children.length).toEqual(2);
-      expect(domNode.children[0].children[0].getAttribute('aria-labelledby')).not.toEqual(
+      expect(
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[0].children[1].getAttribute('id'));
+      expect(
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[1].children[1].getAttribute('id'));
+      const idList = [
+        domNode.getAttribute('id'),
+        domNode.children[0].getAttribute('id'),
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
         domNode.children[0].children[1].getAttribute('id'),
-      );
-      expect(domNode.children[1].children[0].getAttribute('aria-labelledby')).not.toEqual(
+        domNode.children[1].getAttribute('id'),
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
         domNode.children[1].children[1].getAttribute('id'),
-      );
-      const idList=[
-        domNode.getAttribute("id"),
-        domNode.children[0].getAttribute("id"),
-        domNode.children[0].children[0].getAttribute("aria-labelledby"),
-        domNode.children[0].children[1].getAttribute("id"),
-        domNode.children[1].getAttribute("id"),
-        domNode.children[1].children[0].getAttribute("aria-labelledby"),
-        domNode.children[1].children[1].getAttribute("id"),
       ];
       expect(idList).not.toContain(null);
-      expect((new Set(idList)).size).toEqual(idList.length);
+      expect(new Set(idList).size).toEqual(idList.length);
     });
     it('nested makeNewFromKey generates unique ids for client render on good server markup', async () => {
       function App(props) {
         const baseId = useOpaqueIdentifier();
-        const nestedOne=baseId.makeNewFromKey("key1");
-        const nestedTwo=baseId.makeNewFromKey("key2");
-        const nestedOneOne=nestedOne.makeNewFromKey("key1");
-        const nestedOneTwo=nestedOne.makeNewFromKey("key2");
-        const nestedTwoOne=nestedTwo.makeNewFromKey("key1");
-        const nestedTwoTwo=nestedTwo.makeNewFromKey("key2");
+        const nestedOne = baseId.makeNewFromKey('key1');
+        const nestedTwo = baseId.makeNewFromKey('key2');
+        const nestedOneOne = nestedOne.makeNewFromKey('key1');
+        const nestedOneTwo = nestedOne.makeNewFromKey('key2');
+        const nestedTwoOne = nestedTwo.makeNewFromKey('key1');
+        const nestedTwoTwo = nestedTwo.makeNewFromKey('key2');
         return (
           <div id={baseId}>
             <div id={nestedOne}>
@@ -2144,37 +2144,37 @@ describe('ReactDOMServerHooks', () => {
       }
 
       const domNode = await clientRenderOnServerString(<App />);
-      
+
       expect(domNode.children.length).toEqual(2);
       expect(domNode.children[0].children.length).toEqual(2);
       expect(domNode.children[1].children.length).toEqual(2);
-      expect(domNode.children[0].children[0].getAttribute('aria-labelledby')).not.toEqual(
+      expect(
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[0].children[1].getAttribute('id'));
+      expect(
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
+      ).not.toEqual(domNode.children[1].children[1].getAttribute('id'));
+      const idList = [
+        domNode.getAttribute('id'),
+        domNode.children[0].getAttribute('id'),
+        domNode.children[0].children[0].getAttribute('aria-labelledby'),
         domNode.children[0].children[1].getAttribute('id'),
-      );
-      expect(domNode.children[1].children[0].getAttribute('aria-labelledby')).not.toEqual(
+        domNode.children[1].getAttribute('id'),
+        domNode.children[1].children[0].getAttribute('aria-labelledby'),
         domNode.children[1].children[1].getAttribute('id'),
-      );
-      const idList=[
-        domNode.getAttribute("id"),
-        domNode.children[0].getAttribute("id"),
-        domNode.children[0].children[0].getAttribute("aria-labelledby"),
-        domNode.children[0].children[1].getAttribute("id"),
-        domNode.children[1].getAttribute("id"),
-        domNode.children[1].children[0].getAttribute("aria-labelledby"),
-        domNode.children[1].children[1].getAttribute("id"),
       ];
       expect(idList).not.toContain(null);
-      expect((new Set(idList)).size).toEqual(idList.length);
+      expect(new Set(idList).size).toEqual(idList.length);
     });
     it('makeNewFromKey warns on duplicate keys', async () => {
       function App() {
         const id = useOpaqueIdentifier();
-        const nestedOne=id.makeNewFromKey("key1");
-        const nestedTwo=id.makeNewFromKey("key1");
-        return(
+        const nestedOne = id.makeNewFromKey('key1');
+        const nestedTwo = id.makeNewFromKey('key1');
+        return (
           <div>
-            <span id={nestedOne}/>
-            <span id={nestedTwo}/>
+            <span id={nestedOne} />
+            <span id={nestedTwo} />
           </div>
         );
       }

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1124,7 +1124,7 @@ function makeNestedOpaqueHydratingObjectFromKey(
       } else {
         keySet.add(key);
       }
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth + 1);
+      return makeNestedOpaqueHydratingObjectFromKey(warnOnDuplicateKey, this, () => key, depth + 1);
     },
     toString() {
       //$FlowFixMe: if this is null, then attemptToReadValue already threw, so we won't get here anyway
@@ -1150,7 +1150,7 @@ export function makeOpaqueHydratingObject(
       } else {
         keySet.add(key);
       }
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, 0);
+      return makeNestedOpaqueHydratingObjectFromKey(warnOnDuplicateKey, this, () => key, 0);
     },
     toString() {
       return attemptToReadValue();

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -131,12 +131,11 @@ export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
 export type RendererInspectionConfig = $ReadOnly<{||}>;
 
-export opaque type OpaqueIDType =
-    {
-      makeNewFromKey: (string) => OpaqueIDType,
-      toString: () => string | void,
-      valueOf: () => string | void,
-    };
+export opaque type OpaqueIDType = {
+  makeNewFromKey: string => OpaqueIDType,
+  toString: () => string | void,
+  valueOf: () => string | void,
+};
 
 type SelectionInformation = {|
   focusedElem: null | HTMLElement,
@@ -1013,23 +1012,22 @@ export function getInstanceFromNode(node: HTMLElement): null | Object {
   return getClosestInstanceFromNode(node) || null;
 }
 
-
 function makeNestedClientId(
   parent: OpaqueIDType,
   getValueOfKey: () => string,
-  depth: number
+  depth: number,
 ): OpaqueIDType {
   return {
-    makeNewFromKey(key : string) {
-      return makeNestedClientId(this, () => key, depth+1);
+    makeNewFromKey(key: string) {
+      return makeNestedClientId(this, () => key, depth + 1);
     },
     toString() {
       //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
       //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
@@ -1054,38 +1052,41 @@ function makeNestedClientIdInDEV(
   warnOnDuplicateKey: () => void,
   parent: OpaqueIDType,
   getValueOfKey: () => string,
-  depth: number
+  depth: number,
 ): OpaqueIDType {
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     makeNewFromKey(key: string) {
-      if(keySet.has(key)){
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
-        keySet.add(key)
+        keySet.add(key);
       }
       return makeNestedClientIdInDEV(warnOnDuplicateKey, this, () => key, 0);
     },
     toString() {
       //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
       //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
 
-export function makeClientIdInDEV(warnOnAccessInDEV: () => void, warnOnDuplicateKey: () => void): OpaqueIDType {
+export function makeClientIdInDEV(
+  warnOnAccessInDEV: () => void,
+  warnOnDuplicateKey: () => void,
+): OpaqueIDType {
   const id = 'r:' + (clientId++).toString(36);
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     makeNewFromKey(key: string) {
-      if(keySet.has(key)){
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
-        keySet.add(key)
+        keySet.add(key);
       }
       return makeNestedClientIdInDEV(warnOnDuplicateKey, this, () => key, 0);
     },
@@ -1111,27 +1112,27 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 function makeNestedOpaqueHydratingObjectFromKey(
   warnOnDuplicateKey: () => void,
   parent: OpaqueIDType,
-  getValueOfKey: () => string ,
-  depth: number
+  getValueOfKey: () => string,
+  depth: number,
 ): OpaqueIDType {
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
-    makeNewFromKey(key : string) {
-      if(keySet.has(key)){
+    makeNewFromKey(key: string) {
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
-        keySet.add(key)
+        keySet.add(key);
       }
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth+1);
+      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth + 1);
     },
     toString() {
       //$FlowFixMe: if this is null, then attemptToReadValue already threw, so we won't get here anyway
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
       //$FlowFixMe: if this is null, then attemptToReadValue already threw, so we won't get here anyway
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
@@ -1140,14 +1141,14 @@ export function makeOpaqueHydratingObject(
   attemptToReadValue: () => void,
   warnOnDuplicateKey: () => void,
 ): OpaqueIDType {
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
-    makeNewFromKey(key : string) {
-      if(keySet.has(key)){
+    makeNewFromKey(key: string) {
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
-        keySet.add(key)
+        keySet.add(key);
       }
       return makeNestedOpaqueHydratingObjectFromKey(this, () => key, 0);
     },

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1124,7 +1124,12 @@ function makeNestedOpaqueHydratingObjectFromKey(
       } else {
         keySet.add(key);
       }
-      return makeNestedOpaqueHydratingObjectFromKey(warnOnDuplicateKey, this, () => key, depth + 1);
+      return makeNestedOpaqueHydratingObjectFromKey(
+        warnOnDuplicateKey,
+        this,
+        () => key,
+        depth + 1,
+      );
     },
     toString() {
       //$FlowFixMe: if this is null, then attemptToReadValue already threw, so we won't get here anyway
@@ -1150,7 +1155,12 @@ export function makeOpaqueHydratingObject(
       } else {
         keySet.add(key);
       }
-      return makeNestedOpaqueHydratingObjectFromKey(warnOnDuplicateKey, this, () => key, 0);
+      return makeNestedOpaqueHydratingObjectFromKey(
+        warnOnDuplicateKey,
+        this,
+        () => key,
+        0,
+      );
     },
     toString() {
       return attemptToReadValue();

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -42,12 +42,11 @@ type Hook = {|
   next: Hook | null,
 |};
 
-type OpaqueIDType =
-  {
-    makeNewFromKey: (string) => OpaqueIDType,
-    toString: () => string,
-    valueOf: () => string,
-  };
+type OpaqueIDType = {
+  makeNewFromKey: string => OpaqueIDType,
+  toString: () => string,
+  valueOf: () => string,
+};
 let currentlyRenderingComponent: Object | null = null;
 let firstWorkInProgressHook: Hook | null = null;
 let workInProgressHook: Hook | null = null;
@@ -485,70 +484,81 @@ function useTransition(): [(callback: () => void) => void, boolean] {
   return [startTransition, false];
 }
 
-
-
 function makeNestedOpaqueHydratingObjectFromKey(
   parent: OpaqueIDType,
-  getValueOfKey: () => string 
+  getValueOfKey: () => string,
 ): OpaqueIDType {
-  let keys : {
-    unsorted : Array<string>,
+  const keys: {
+    unsorted: Array<string>,
     map: Map<string, number>,
-  }={
+  } = {
     unsorted: [],
     map: new Map(),
-  }
+  };
   return {
-    makeNewFromKey(key : string) {
+    makeNewFromKey(key: string) {
       keys.unsorted.push(key);
       return makeNestedOpaqueHydratingObjectFromKey(this, () => {
-        if(keys.map.size!==keys.unsorted.length){
-          keys.map=new Map();
-          keys.unsorted.sort((a : string, b : string) : number => {
-            return a.length === b.length ? a.localeCompare(b) : a.length-b.length;
+        if (keys.map.size !== keys.unsorted.length) {
+          keys.map = new Map();
+          keys.unsorted.sort((a: string, b: string): number => {
+            return a.length === b.length
+              ? a.localeCompare(b)
+              : a.length - b.length;
           });
-          for(const [index, element] of keys.unsorted.entries()){
+          keys.unsorted.forEach((element, index) => {
             keys.map.set(element, index);
-          }
+          });
         }
-        const index=keys.map.get(key);
-        invariant(typeof index==="number", "The key was not found in the index map in makeNewFromKey. This is a bug in react.")
+        const index = keys.map.get(key);
+        invariant(
+          typeof index === 'number',
+          'The key was not found in the index map in makeNewFromKey. This is a bug in react.',
+        );
         return index.toString(36);
       });
     },
     toString() {
-      return parent.toString()+":"+getValueOfKey();
+      return parent.toString() + ':' + getValueOfKey();
     },
     valueOf() {
-      return parent.valueOf()+":"+getValueOfKey();
+      return parent.valueOf() + ':' + getValueOfKey();
     },
   };
 }
 
 function useOpaqueIdentifier(): OpaqueIDType {
-  const id=(currentPartialRenderer.identifierPrefix || '') + 'R:' + (currentPartialRenderer.uniqueID++).toString(36);
-  let keys: {
+  const id =
+    (currentPartialRenderer.identifierPrefix || '') +
+    'R:' +
+    (currentPartialRenderer.uniqueID++).toString(36);
+  const keys: {
     unsorted: Array<string>,
-    map: Map<string, number>
-  }={
+    map: Map<string, number>,
+  } = {
     unsorted: [],
     map: new Map(),
-  }
-  return ({
-    makeNewFromKey(key : string) {
+  };
+  return {
+    makeNewFromKey(key: string) {
       keys.unsorted.push(key);
       return makeNestedOpaqueHydratingObjectFromKey(this, () => {
-        if(keys.map.size!==keys.unsorted.length){
-          keys.map=new Map();
-          keys.unsorted.sort((a : string, b : string) : number => {
-            return a.length === b.length ? a.localeCompare(b) : a.length-b.length;
+        if (keys.map.size !== keys.unsorted.length) {
+          keys.map = new Map();
+          keys.unsorted.sort((a: string, b: string): number => {
+            return a.length === b.length
+              ? a.localeCompare(b)
+              : a.length - b.length;
           });
-          for(const [index, element] of keys.unsorted.entries()){
+          keys.unsorted.forEach((element, index) => {
             keys.map.set(element, index);
-          }
+          });
         }
-        const index=keys.map.get(key);
-        invariant(typeof index==="number", "The key was not found in the index map in makeNewFromKey. This is a bug in react.")
+        const index = keys.map.get(key);
+        invariant(
+          typeof index === 'number',
+          'The key was not found in the index map in makeNewFromKey. This is a bug in react.',
+        );
         return index.toString(36);
       });
     },
@@ -558,7 +568,7 @@ function useOpaqueIdentifier(): OpaqueIDType {
     valueOf() {
       return id;
     },
-  });
+  };
 }
 
 function useCacheRefresh(): <T>(?() => T, ?T) => void {

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -458,6 +458,7 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 
 export function makeOpaqueHydratingObject(
   attemptToReadValue: () => void,
+  warnOnDuplicateKey: () => void,
 ): OpaqueIDType {
   throw new Error('Not yet implemented.');
 }
@@ -466,7 +467,10 @@ export function makeClientId(): OpaqueIDType {
   throw new Error('Not yet implemented');
 }
 
-export function makeClientIdInDEV(warnOnAccessInDEV: () => void): OpaqueIDType {
+export function makeClientIdInDEV(
+  warnOnAccessInDEV: () => void,
+  warnOnDuplicateKey: () => void,
+): OpaqueIDType {
   throw new Error('Not yet implemented');
 }
 

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -515,6 +515,7 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 
 export function makeOpaqueHydratingObject(
   attemptToReadValue: () => void,
+  warnOnDuplicateKey: () => void,
 ): OpaqueIDType {
   throw new Error('Not yet implemented.');
 }
@@ -523,7 +524,10 @@ export function makeClientId(): OpaqueIDType {
   throw new Error('Not yet implemented');
 }
 
-export function makeClientIdInDEV(warnOnAccessInDEV: () => void): OpaqueIDType {
+export function makeClientIdInDEV(
+  warnOnAccessInDEV: () => void,
+  warnOnDuplicateKey: () => void,
+): OpaqueIDType {
   throw new Error('Not yet implemented');
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -135,8 +135,10 @@ export type UpdateQueue<S, A> = {|
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;
+let didWarnAboutDuplicateOpaqueIdentifierKeys;
 if (__DEV__) {
   didWarnAboutUseOpaqueIdentifier = {};
+  didWarnAboutDuplicateOpaqueIdentifierKeys = {};
   didWarnAboutMismatchedHooksForComponent = new Set();
 }
 
@@ -1784,12 +1786,22 @@ function warnOnOpaqueIdentifierAccessInDEV(fiber) {
     const name = getComponentName(fiber.type) || 'Unknown';
     if (getIsRendering() && !didWarnAboutUseOpaqueIdentifier[name]) {
       console.error(
-        'The object passed back from useOpaqueIdentifier is meant to be ' +
-          'passed through to attributes only. Do not read the ' +
-          'value directly.',
+        'Warning: The object passed back from useOpaqueIdentifier and those made from it are meant to be passed through to attributes only. Do not read the value directly.',
       );
       didWarnAboutUseOpaqueIdentifier[name] = true;
     }
+  }
+}
+
+function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber){
+  if(__DEV__){
+    const name=getComponentName(fiber.type) || "Unknown";
+    if(getIsRendering() && !didWarnAboutDuplicateOpaqueIdentifierKeys[name]){
+      console.error(
+        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.'
+      );
+    }
+    didWarnAboutDuplicateOpaqueIdentifierKeys[name]=true;
   }
 }
 
@@ -1798,6 +1810,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     ? makeClientIdInDEV.bind(
         null,
         warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber),
+        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(null, currentlyRenderingFiber),
       )
     : makeClientId;
 
@@ -1821,8 +1834,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
       }
       invariant(
         false,
-        'The object passed back from useOpaqueIdentifier is meant to be ' +
-          'passed through to attributes only. Do not read the value directly.',
+        'Warning: The object passed back from useOpaqueIdentifier and those made from it are meant to be passed through to attributes only. Do not read the value directly.',
       );
     };
     const id = makeOpaqueHydratingObject(readValue);

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1793,15 +1793,15 @@ function warnOnOpaqueIdentifierAccessInDEV(fiber) {
   }
 }
 
-function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber){
-  if(__DEV__){
-    const name=getComponentName(fiber.type) || "Unknown";
-    if(getIsRendering() && !didWarnAboutDuplicateOpaqueIdentifierKeys[name]){
+function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
+  if (__DEV__) {
+    const name = getComponentName(fiber.type) || 'Unknown';
+    if (getIsRendering() && !didWarnAboutDuplicateOpaqueIdentifierKeys[name]) {
       console.error(
-        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.'
+        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.',
       );
     }
-    didWarnAboutDuplicateOpaqueIdentifierKeys[name]=true;
+    didWarnAboutDuplicateOpaqueIdentifierKeys[name] = true;
   }
 }
 
@@ -1810,7 +1810,10 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
     ? makeClientIdInDEV.bind(
         null,
         warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber),
-        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(null, currentlyRenderingFiber),
+        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+          null,
+          currentlyRenderingFiber,
+        ),
       )
     : makeClientId;
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1806,14 +1806,15 @@ function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
 }
 
 function mountOpaqueIdentifier(): OpaqueIDType | void {
+  const warnOnDuplicateKeys=warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+    null,
+    currentlyRenderingFiber,
+  );
   const makeId = __DEV__
     ? makeClientIdInDEV.bind(
         null,
         warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber),
-        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
-          null,
-          currentlyRenderingFiber,
-        ),
+        warnOnDuplicateKeys,
       )
     : makeClientId;
 
@@ -1840,7 +1841,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
         'Warning: The object passed back from useOpaqueIdentifier and those made from it are meant to be passed through to attributes only. Do not read the value directly.',
       );
     };
-    const id = makeOpaqueHydratingObject(readValue);
+    const id = makeOpaqueHydratingObject(readValue, warnOnDuplicateKeys);
 
     const setId = mountState(id)[1];
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1806,7 +1806,7 @@ function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
 }
 
 function mountOpaqueIdentifier(): OpaqueIDType | void {
-  const warnOnDuplicateKeys=warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+  const warnOnDuplicateKeys = warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
     null,
     currentlyRenderingFiber,
   );

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1793,26 +1793,27 @@ function warnOnOpaqueIdentifierAccessInDEV(fiber) {
   }
 }
 
-
-function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber){
-  if(__DEV__){
-    const name=getComponentName(fiber.type) || "Unknown";
-    if(getIsRendering() && !didWarnAboutDuplicateOpaqueIdentifierKeys[name]){
+function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
+  if (__DEV__) {
+    const name = getComponentName(fiber.type) || 'Unknown';
+    if (getIsRendering() && !didWarnAboutDuplicateOpaqueIdentifierKeys[name]) {
       console.error(
-        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.'
+        'Warning: Detected that two nested opaque identifiers with the same parent were created with identical keys. Keys must be unique.',
       );
     }
-    didWarnAboutDuplicateOpaqueIdentifierKeys[name]=true;
+    didWarnAboutDuplicateOpaqueIdentifierKeys[name] = true;
   }
 }
-
 
 function mountOpaqueIdentifier(): OpaqueIDType | void {
   const makeId = __DEV__
     ? makeClientIdInDEV.bind(
         null,
         warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber),
-        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(null, currentlyRenderingFiber),
+        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+          null,
+          currentlyRenderingFiber,
+        ),
       )
     : makeClientId;
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1806,14 +1806,15 @@ function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
 }
 
 function mountOpaqueIdentifier(): OpaqueIDType | void {
+  const warnOnDuplicateKeys=warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+    null,
+    currentlyRenderingFiber,
+  );
   const makeId = __DEV__
     ? makeClientIdInDEV.bind(
         null,
         warnOnOpaqueIdentifierAccessInDEV.bind(null, currentlyRenderingFiber),
-        warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
-          null,
-          currentlyRenderingFiber,
-        ),
+        warnOnDuplicateKeys,
       )
     : makeClientId;
 
@@ -1840,7 +1841,7 @@ function mountOpaqueIdentifier(): OpaqueIDType | void {
         'Warning: The object passed back from useOpaqueIdentifier and those made from it are meant to be passed through to attributes only. Do not read the value directly.',
       );
     };
-    const id = makeOpaqueHydratingObject(readValue);
+    const id = makeOpaqueHydratingObject(readValue, warnOnDuplicateKeys);
 
     const setId = mountState(id)[1];
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1806,7 +1806,7 @@ function warnOnDuplicateOpaqueIdentifierKeyInDEV(fiber) {
 }
 
 function mountOpaqueIdentifier(): OpaqueIDType | void {
-  const warnOnDuplicateKeys=warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
+  const warnOnDuplicateKeys = warnOnDuplicateOpaqueIdentifierKeyInDEV.bind(
     null,
     currentlyRenderingFiber,
   );

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -46,12 +46,11 @@ export type ChildSet = void; // Unused
 export type TimeoutHandle = TimeoutID;
 export type NoTimeout = -1;
 export type EventResponder = any;
-export opaque type OpaqueIDType =
-    {
-      makeNewFromKey: (string) => OpaqueIDType,
-      toString: () => string | void,
-      valueOf: () => string | void,
-    };
+export opaque type OpaqueIDType = {
+  makeNewFromKey: string => OpaqueIDType,
+  toString: () => string | void,
+  valueOf: () => string | void,
+};
 
 export type RendererInspectionConfig = $ReadOnly<{||}>;
 
@@ -306,18 +305,18 @@ export function getInstanceFromNode(mockNode: Object) {
 
 function makeNestedClientId(
   parent: OpaqueIDType,
-  getValueOfKey: () => string ,
-  depth: number
+  getValueOfKey: () => string,
+  depth: number,
 ): OpaqueIDType {
   return {
-    makeNewFromKey(key : string) {
-      return makeNestedClientId(this, () => key, depth+1);
+    makeNewFromKey(key: string) {
+      return makeNestedClientId(this, () => key, depth + 1);
     },
     toString() {
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
@@ -342,39 +341,46 @@ function makeNestedClientIdInDEV(
   warnOnDuplicateKey: () => void,
   parent: OpaqueIDType,
   getValueOfKey: () => string,
-  depth: number
+  depth: number,
 ): OpaqueIDType {
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     makeNewFromKey(key: string) {
-      if(keySet.has(key)){
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
         keySet.add(key);
       }
-      return makeNestedClientIdInDEV(warnOnDuplicateKey, this, () => key, depth+1);
+      return makeNestedClientIdInDEV(
+        warnOnDuplicateKey,
+        this,
+        () => key,
+        depth + 1,
+      );
     },
     toString() {
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
 
-
-export function makeClientIdInDEV(warnOnAccessInDEV: () => void, warnOnDuplicateKey: () => void): OpaqueIDType {
+export function makeClientIdInDEV(
+  warnOnAccessInDEV: () => void,
+  warnOnDuplicateKey: () => void,
+): OpaqueIDType {
   const id = 'c_' + (clientId++).toString(36);
-  let keySet: Set<string> = new Set();
+  const keySet: Set<string> = new Set();
   return {
     makeNewFromKey(key: string) {
-      if(keySet.has(key)){
+      if (keySet.has(key)) {
         warnOnDuplicateKey();
       } else {
-        keySet.add(key)
+        keySet.add(key);
       }
-      return makeNestedClientId(this, () => key, 0);
+      return makeNestedClientIdInDEV(this, () => key, 0);
     },
     toString() {
       warnOnAccessInDEV();
@@ -397,19 +403,19 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 
 function makeNestedOpaqueHydratingObjectFromKey(
   parent: OpaqueIDType,
-  getValueOfKey: () => string ,
-  depth: number
+  getValueOfKey: () => string,
+  depth: number,
 ): OpaqueIDType {
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
-    makeNewFromKey(key : string) {
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth+1);
+    makeNewFromKey(key: string) {
+      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth + 1);
     },
     toString() {
-      return parent.toString()+getValueOfKey()+":"+depth.toString(32);
+      return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
-      return parent.valueOf()+getValueOfKey()+":"+depth.toString(32);
+      return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
 }
@@ -419,7 +425,7 @@ export function makeOpaqueHydratingObject(
 ): OpaqueIDType {
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
-    makeNewFromKey(key : string) {
+    makeNewFromKey(key: string) {
       return makeNestedOpaqueHydratingObjectFromKey(this, () => key, 0);
     },
     toString() {

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -380,7 +380,7 @@ export function makeClientIdInDEV(
       } else {
         keySet.add(key);
       }
-      return makeNestedClientIdInDEV(this, () => key, 0);
+      return makeNestedClientIdInDEV(warnOnDuplicateKey, this, () => key, 0);
     },
     toString() {
       warnOnAccessInDEV();

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -313,9 +313,11 @@ function makeNestedClientId(
       return makeNestedClientId(this, () => key, depth + 1);
     },
     toString() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
@@ -359,9 +361,11 @@ function makeNestedClientIdInDEV(
       );
     },
     toString() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
@@ -402,19 +406,33 @@ export function isOpaqueHydratingObject(value: mixed): boolean {
 }
 
 function makeNestedOpaqueHydratingObjectFromKey(
+  warnOnDuplicateKey: () => void,
   parent: OpaqueIDType,
   getValueOfKey: () => string,
   depth: number,
 ): OpaqueIDType {
+  const keySet: Set<string> = new Set();
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
     makeNewFromKey(key: string) {
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, depth + 1);
+      if (keySet.has(key)) {
+        warnOnDuplicateKey();
+      } else {
+        keySet.add(key);
+      }
+      return makeNestedOpaqueHydratingObjectFromKey(
+        warnOnDuplicateKey,
+        this,
+        () => key,
+        depth + 1,
+      );
     },
     toString() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.toString() + getValueOfKey() + ':' + depth.toString(32);
     },
     valueOf() {
+      //$FlowFixMe toString is only ever void if attemptToReadValue throws, which means we don't get here anyway
       return parent.valueOf() + getValueOfKey() + ':' + depth.toString(32);
     },
   };
@@ -422,11 +440,23 @@ function makeNestedOpaqueHydratingObjectFromKey(
 
 export function makeOpaqueHydratingObject(
   attemptToReadValue: () => void,
+  warnOnDuplicateKey: () => void,
 ): OpaqueIDType {
+  const keySet: Set<string> = new Set();
   return {
     $$typeof: REACT_OPAQUE_ID_TYPE,
     makeNewFromKey(key: string) {
-      return makeNestedOpaqueHydratingObjectFromKey(this, () => key, 0);
+      if (keySet.has(key)) {
+        warnOnDuplicateKey();
+      } else {
+        keySet.add(key);
+      }
+      return makeNestedOpaqueHydratingObjectFromKey(
+        warnOnDuplicateKey,
+        this,
+        () => key,
+        0,
+      );
     },
     toString() {
       return attemptToReadValue();

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -374,5 +374,7 @@
   "383": "This query has received fewer parameters than the last time the same query was used. Always pass the exact number of parameters that the query needs.",
   "384": "Refreshing the cache is not supported in Server Components.",
   "385": "A mutable source was mutated while the %s component was rendering. This is not supported. Move any mutations into event handlers or effects.",
-  "386": "The current renderer does not support microtasks. This error is likely caused by a bug in React. Please file an issue."
+  "386": "The current renderer does not support microtasks. This error is likely caused by a bug in React. Please file an issue.",
+  "387": "Warning: The object passed back from useOpaqueIdentifier and those made from it are meant to be passed through to attributes only. Do not read the value directly.",
+  "388": "The key was not found in the index map in makeNewFromKey. This is a bug in react."
 }


### PR DESCRIPTION
## Summary
This is an attempt to fix https://github.com/facebook/react/issues/20822
This allows for recursive key creation from an opaque identifier returned from useOpaqueIdentifier using a new member function called `makeNewFromKey(key: string)`. The recursive nature is useful in order to be able to identify a parent and a child. 
## Test Plan
Added a bunch of integration tests, but there are still many many edge cases that are difficult to test for.
Examples:
in the client key creation, adding "a" and then "b" should not equal "ab". Adding a simple delimiter would appear to fix this, but doesn't as then inserting the delimiter causes the same problem. Testing for this requires knowledge of the code where it places delimiters (before, after, both). In code, the above bug is avoided by appending the depth. There is a delimiter as to avoid very deep depths which require multiple digits running into the same problem as a naked delimiter. so the first is "a:0b:1" and the second is "ab:0".

in the server key creation, the multiple digit problem strikes again, and so a delimiter is added between identifiers. 

Testing every corner case like this would require huge numbers of tests, and I'm not entirely sure how to go about it. Advice would be appreciated. Removing the recursiveness entirely would fix this problem but I think it is worth putting some effort into keeping it.