### PR TITLE
Land enableSetImmediate feature flag

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -9,6 +9,3 @@
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
 export const enableProfiling = __VARIANT__;
-
-// TODO: enable to fix https://github.com/facebook/react/issues/20756.
-export const enableSetImmediate = __VARIANT__;

--- a/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerDOMSetImmediate-test.js
@@ -143,7 +143,6 @@ describe('SchedulerDOMSetImmediate', () => {
     };
   }
 
-  // @gate enableSchedulerSetImmediate
   it('task that finishes before deadline', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -153,7 +152,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Task']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('task with continuation', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -179,7 +177,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Continuation']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('multiple tasks', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -192,7 +189,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'A', 'B']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('multiple tasks with a yield in between', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -213,7 +209,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'B']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('cancels tasks', () => {
     const task = scheduleCallback(NormalPriority, () => {
       runtime.log('Task');
@@ -223,7 +218,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog([]);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('throws when a task errors then continues in a new event', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('Oops!');
@@ -241,7 +235,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'Yay']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('schedule new task after queue has emptied', () => {
     scheduleCallback(NormalPriority, () => {
       runtime.log('A');
@@ -259,7 +252,6 @@ describe('SchedulerDOMSetImmediate', () => {
     runtime.assertLog(['setImmediate Callback', 'B']);
   });
 
-  // @gate enableSchedulerSetImmediate
   it('schedule new task after a cancellation', () => {
     const handle = scheduleCallback(NormalPriority, () => {
       runtime.log('A');

--- a/packages/scheduler/src/forks/SchedulerDOM.js
+++ b/packages/scheduler/src/forks/SchedulerDOM.js
@@ -11,7 +11,6 @@
 import {
   enableSchedulerDebugging,
   enableProfiling,
-  enableSetImmediate,
 } from '../SchedulerFeatureFlags';
 
 import {push, pop, peek} from '../SchedulerMinHeap';
@@ -553,7 +552,7 @@ const performWorkUntilDeadline = () => {
 };
 
 let schedulePerformWorkUntilDeadline;
-if (enableSetImmediate && typeof setImmediate === 'function') {
+if (typeof setImmediate === 'function') {
   // Node.js and old IE.
   // There's a few reasons for why we prefer setImmediate.
   //

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -10,7 +10,6 @@ export const {
   enableIsInputPending,
   enableSchedulerDebugging,
   enableProfiling: enableProfilingFeatureFlag,
-  enableSetImmediate,
 } = require('SchedulerFeatureFlags');
 
 export const enableProfiling = __PROFILE__ && enableProfilingFeatureFlag;

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -55,7 +55,6 @@ function getTestFlags() {
   // These are required on demand because some of our tests mutate them. We try
   // not to but there are exceptions.
   const featureFlags = require('shared/ReactFeatureFlags');
-  const schedulerFeatureFlags = require('scheduler/src/SchedulerFeatureFlags');
 
   // TODO: This is a heuristic to detect the release channel by checking a flag
   // that is known to only be enabled in www. What we should do instead is set
@@ -90,10 +89,6 @@ function getTestFlags() {
       // tests, Jest doesn't expose the API correctly. Fix then remove
       // this override.
       enableCache: __EXPERIMENTAL__,
-
-      // This is from SchedulerFeatureFlags. Needed because there's no equivalent
-      // of ReactFeatureFlags-www.dynamic for it. Remove when enableSetImmediate is gone.
-      enableSchedulerSetImmediate: schedulerFeatureFlags.enableSetImmediate,
     },
     {
       get(flags, flagName) {


### PR DESCRIPTION
It's been on for a few days, let's remove the flag.

Fixes https://github.com/facebook/react/issues/20756, will go out in 17.1.0.