### PR TITLE
Handle case where hook callback is a CallExpression

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1436,6 +1436,40 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const delay = true ? 10 : 20;
+          const local = 'Hello';
+          useEffect(debounce(() => {
+            console.log(local);
+          }, delay), [local, delay]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const delay = true ? 10 : 20;
+          const local = 'Hello';
+          const callLater = useCallback((callback) => setTimeout(callback, delay), [delay]);
+          useEffect(callLater(() => {
+            console.log(local);
+          }), [callLater, local]);
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
+        import { debounce } from 'lodash';
+        function MyComponent() {
+          const local = 'Hello';
+          const callLater = useCallback(debounce(() => {
+            console.log(local)
+          }, 200), [local]);
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -6996,9 +7030,54 @@ const tests = {
       errors: [
         {
           message:
-            'React Hook useEffect received a function whose dependencies ' +
-            'are unknown. Pass an inline function instead.',
-          suggestions: [],
+            `React Hook useEffect has a missing dependency: 'delay'. ` +
+            `Either include it or remove the dependency array.`,
+        },
+        {
+          message:
+            `React Hook useEffect has a missing dependency: 'local'. ` +
+            `Either include it or remove the dependency array.`,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const delay = true ? 1 : 2;
+          const local = {};
+          const callLater = (callback) => setTimeout(callback, delay)
+          useEffect(callLater(() => {
+            console.log(local);
+          }), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            `React Hook useEffect has a missing dependency: 'delay'. ` +
+            `Either include it or remove the dependency array.`,
+        },
+        {
+          message:
+            `React Hook useEffect has a missing dependency: 'local'. ` +
+            `Either include it or remove the dependency array.`,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent() {
+          const local = true ? 'Hello' : 'World';
+          const myCallback = useCallback(debounce(() => {
+            console.log(local)
+          }, 200), []);
+        }
+      `,
+      errors: [
+        {
+          message:
+            `React Hook useCallback has a missing dependency: 'local'. ` +
+            `Either include it or remove the dependency array.`,
         },
       ],
     },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Fix https://github.com/facebook/react/issues/20904

```
const myCallback = useCallback(debounce(() => {}, 200), [])
```
is now linted in the same way as this (equivalent code) would be
```
const myCallback = useMemo(() => debounce(() => {}, 200), [])
```
* Check the function wrapper (`debounce` in this example) - if it's declared outside the component scope, it's safe
* Check the function args - inline callbacks are checked as though they were the callback themselves, variables are checked for presence in dependency array

## Test Plan
Best demonstration is the unit tests
