### PR TITLE
Use update lane priority to set pending updates on roots

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -597,6 +597,27 @@ export function scheduleUpdateOnFiber(
         flushSyncCallbackQueue();
       }
     }
+  } else if (decoupleUpdatePriorityFromScheduler) {
+    const updateLanePriority = getCurrentUpdateLanePriority();
+
+    // Schedule a discrete update but only if it's not Sync.
+    if (
+      (executionContext & DiscreteEventContext) !== NoContext &&
+      // Only updates at user-blocking priority or greater are considered
+      // discrete, even inside a discrete event.
+      updateLanePriority === InputDiscreteLanePriority
+    ) {
+      // This is the result of a discrete event. Track the lowest priority
+      // discrete update per root so we can flush them early, if needed.
+      if (rootsWithPendingDiscreteUpdates === null) {
+        rootsWithPendingDiscreteUpdates = new Set([root]);
+      } else {
+        rootsWithPendingDiscreteUpdates.add(root);
+      }
+    }
+    // Schedule other updates after in case the callback is sync.
+    ensureRootIsScheduled(root, eventTime);
+    schedulePendingInteractions(root, lane);
   } else {
     // Schedule a discrete update but only if it's not Sync.
     if (

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -597,6 +597,27 @@ export function scheduleUpdateOnFiber(
         flushSyncCallbackQueue();
       }
     }
+  } else if (decoupleUpdatePriorityFromScheduler) {
+    const updateLanePriority = getCurrentUpdateLanePriority();
+
+    // Schedule a discrete update but only if it's not Sync.
+    if (
+      (executionContext & DiscreteEventContext) !== NoContext &&
+      // Only updates at user-blocking priority or greater are considered
+      // discrete, even inside a discrete event.
+      updateLanePriority === InputDiscreteLanePriority
+    ) {
+      // This is the result of a discrete event. Track the lowest priority
+      // discrete update per root so we can flush them early, if needed.
+      if (rootsWithPendingDiscreteUpdates === null) {
+        rootsWithPendingDiscreteUpdates = new Set([root]);
+      } else {
+        rootsWithPendingDiscreteUpdates.add(root);
+      }
+    }
+    // Schedule other updates after in case the callback is sync.
+    ensureRootIsScheduled(root, eventTime);
+    schedulePendingInteractions(root, lane);
   } else {
     // Schedule a discrete update but only if it's not Sync.
     if (


### PR DESCRIPTION
## Overview

While removing the `decoupleUpdatePriorityFromScheduler` flag, I found a bug where we were not using the update lane priority to set pending updates on roots for discrete events. This isn't a bug in the experiment because we currently double wrap with use `runWithPriority`, but when we delete the double wrapping to use just the update lane priority, we don't mark pending updates (for example, [this test](https://github.com/facebook/react/blob/b688b1abd6ec0849ce382f20244f45b398ff4766/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js#L152) and others fail).