### PR TITLE
DevTools flushes updated passive warning/error info after delay

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -1088,16 +1088,20 @@ describe('Store', () => {
       withErrorsOrWarningsIgnored(['test-only:'], () => {
         act(() => {
           ReactDOM.render(<Example />, container);
-
-          // Flush commit
-          jest.advanceTimersByTime(1);
-
-          expect(store).toMatchInlineSnapshot(`
-            [root]
-                <Example>
-          `);
-        });
+          // flush bridge operations
+          jest.runOnlyPendingTimers();
+        }, false);
       });
+
+      expect(store).toMatchInlineSnapshot(`
+        [root]
+            <Example>
+      `);
+
+      // flush count after delay
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      }, false);
 
       // After a delay, passive effects should be committed as well
       expect(store).toMatchInlineSnapshot(`

--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -14,7 +14,10 @@ import type Store from 'react-devtools-shared/src/devtools/store';
 import type {ProfilingDataFrontend} from 'react-devtools-shared/src/devtools/views/Profiler/types';
 import type {ElementType} from 'react-devtools-shared/src/types';
 
-export function act(callback: Function): void {
+export function act(
+  callback: Function,
+  recursivelyFlush: boolean = true,
+): void {
   const {act: actTestRenderer} = require('react-test-renderer');
   const {act: actDOM} = require('react-dom/test-utils');
 
@@ -24,13 +27,15 @@ export function act(callback: Function): void {
     });
   });
 
-  // Flush Bridge operations
-  while (jest.getTimerCount() > 0) {
-    actDOM(() => {
-      actTestRenderer(() => {
-        jest.runAllTimers();
+  if (recursivelyFlush) {
+    // Flush Bridge operations
+    while (jest.getTimerCount() > 0) {
+      actDOM(() => {
+        actTestRenderer(() => {
+          jest.runAllTimers();
+        });
       });
-    });
+    }
   }
 }
 


### PR DESCRIPTION
Previously this information was not flushed until the next commit, but this provides a worse user experience if the next commit is really delayed. Instead, the backend now flushes only the warning/error counts after a delay. As a safety, if there are already any pending operations in the queue, we bail.

# Before

https://user-images.githubusercontent.com/29597/110035394-9c932a00-7d09-11eb-8911-16a61c2ca2f1.mp4

# After

https://user-images.githubusercontent.com/29597/110035403-9f8e1a80-7d09-11eb-94fd-ac432dd36f96.mp4
