### PR TITLE
chore(build):  Ensure experimental builds exists on windows

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -64,7 +64,19 @@ if (process.env.CIRCLE_NODE_TOTAL) {
   // will have already removed conflicting files.
   //
   // In CI, merging is handled automatically by CircleCI's workspace feature.
-  spawnSync('rsync', ['-ar', experimentalDir + '/', stableDir + '/']);
+  const {error} = spawnSync('rsync', [
+    '-ar',
+    experimentalDir + '/',
+    stableDir + '/',
+  ]);
+  if (error !== undefined) {
+    if (error.code === 'ENOENT') {
+      throw new Error(
+        `${process.argv[1]} needs the \`rsync\` CLI installed to work.`
+      );
+    }
+    throw error;
+  }
 
   // Now restore the combined directory back to its original name
   // TODO: Currently storing artifacts as `./build2` so that it doesn't conflict


### PR DESCRIPTION
## Summary

Replace `rsync -ar` with a custom implemention that recursively copys files from `source` to `destination`

## Test Plan

- [x] `yarn build-for-devtools; yarn test-build-devtools` runnable on windows
- [x] CI green

## Context

`yarn test-build-devtools` currently throws on windows (` Could not locate module scheduler mapped as: C:\Users\eps1lon\Development\react\build2\oss-experimental\scheduler.` even after a successful (exit code 0) `yarn build-for-devtools`.

`yarn build-for-devtools` spawns `rsync` without handling errors (i.e. the return `error` property of `spawnSync` was ignored). On systems without `rsync` that means the build script is incomplete without notifying what went wrong.