### PR TITLE
Land enableDiscreteEventMicroTasks

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
@@ -43,7 +43,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   }
 
   // @gate experimental
-  // @gate enableDiscreteEventMicroTasks && enableNativeEventPriorityInference
+  // @gate enableNativeEventPriorityInference
   it('ignores discrete events on a pending removed element', async () => {
     const disableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -95,7 +95,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableDiscreteEventMicroTasks && enableNativeEventPriorityInference
+  // @gate enableNativeEventPriorityInference
   it('ignores discrete events on a pending removed event listener', async () => {
     const disableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -165,7 +165,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableDiscreteEventMicroTasks && enableNativeEventPriorityInference
+  // @gate enableNativeEventPriorityInference
   it('uses the newest discrete events on a pending changed event listener', async () => {
     const enableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -229,7 +229,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableDiscreteEventMicroTasks && enableNativeEventPriorityInference
+  // @gate enableNativeEventPriorityInference
   it('mouse over should be user-blocking but not discrete', async () => {
     const root = ReactDOM.unstable_createRoot(container);
 
@@ -260,7 +260,7 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableDiscreteEventMicroTasks && enableNativeEventPriorityInference
+  // @gate enableNativeEventPriorityInference
   it('mouse enter should be user-blocking but not discrete', async () => {
     const root = ReactDOM.unstable_createRoot(container);
 

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -67,7 +67,6 @@ import {
   enableCreateEventHandleAPI,
   enableScopeAPI,
   enableNewReconciler,
-  enableDiscreteEventMicroTasks,
 } from 'shared/ReactFeatureFlags';
 import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {listenToAllSupportedEvents} from '../events/DOMPluginEventSystem';
@@ -404,7 +403,7 @@ export const noTimeout = -1;
 // -------------------
 //     Microtasks
 // -------------------
-export const supportsMicrotasks = enableDiscreteEventMicroTasks;
+export const supportsMicrotasks = true;
 export const scheduleMicrotask: any =
   typeof queueMicrotask === 'function'
     ? queueMicrotask

--- a/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/ChangeEventPlugin-test.js
@@ -728,17 +728,10 @@ describe('ChangeEventPlugin', () => {
       expect(Scheduler).toHaveYielded([]);
       expect(input.value).toBe('initial');
 
-      // Flush callbacks.
-      // Now the click update has flushed.
-      if (gate(flags => flags.enableDiscreteEventMicroTasks)) {
-        // Flush microtask queue.
-        await null;
-        expect(Scheduler).toHaveYielded(['render: ']);
-        expect(input.value).toBe('');
-      } else {
-        expect(Scheduler).toFlushAndYield(['render: ']);
-        expect(input.value).toBe('');
-      }
+      // Flush microtask queue.
+      await null;
+      expect(Scheduler).toHaveYielded(['render: ']);
+      expect(input.value).toBe('');
     });
 
     // @gate experimental

--- a/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
+++ b/packages/react-dom/src/events/plugins/__tests__/SimpleEventPlugin-test.js
@@ -470,24 +470,15 @@ describe('SimpleEventPlugin', function() {
         'High-pri count: 7, Low-pri count: 0',
       ]);
 
-      if (gate(flags => flags.enableDiscreteEventMicroTasks)) {
-        // Flush the microtask queue
-        await null;
+      // Flush the microtask queue
+      await null;
 
-        // At the end, both counters should equal the total number of clicks
-        expect(Scheduler).toHaveYielded([
-          'High-pri count: 8, Low-pri count: 0',
-        ]);
-        expect(Scheduler).toFlushAndYield([
-          'High-pri count: 8, Low-pri count: 8',
-        ]);
-      } else {
-        // At the end, both counters should equal the total number of clicks
-        expect(Scheduler).toFlushAndYield([
-          'High-pri count: 8, Low-pri count: 0',
-          'High-pri count: 8, Low-pri count: 8',
-        ]);
-      }
+      // At the end, both counters should equal the total number of clicks
+      expect(Scheduler).toHaveYielded(['High-pri count: 8, Low-pri count: 0']);
+      expect(Scheduler).toFlushAndYield([
+        'High-pri count: 8, Low-pri count: 8',
+      ]);
+
       expect(button.textContent).toEqual('High-pri count: 8, Low-pri count: 8');
     });
   });

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -27,10 +27,7 @@ import {
   LegacyRoot,
 } from 'react-reconciler/src/ReactRootTags';
 
-import {
-  enableNativeEventPriorityInference,
-  enableDiscreteEventMicroTasks,
-} from 'shared/ReactFeatureFlags';
+import {enableNativeEventPriorityInference} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import enqueueTask from 'shared/enqueueTask';
 const {IsSomeRendererActing} = ReactSharedInternals;
@@ -376,7 +373,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     cancelTimeout: clearTimeout,
     noTimeout: -1,
 
-    supportsMicrotasks: enableDiscreteEventMicroTasks,
+    supportsMicrotasks: true,
     scheduleMicrotask:
       typeof queueMicrotask === 'function'
         ? queueMicrotask

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -150,8 +150,6 @@ export const enableRecursiveCommitTraversal = false;
 
 export const disableSchedulerTimeoutInWorkLoop = false;
 
-export const enableDiscreteEventMicroTasks = false;
-
 export const enableSyncMicroTasks = false;
 
 export const enableNativeEventPriorityInference = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -56,7 +56,6 @@ export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
-export const enableDiscreteEventMicroTasks = false;
 export const enableSyncMicroTasks = false;
 export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -55,7 +55,6 @@ export const enableUseRefAccessWarning = __VARIANT__;
 
 export const enableProfilerNestedUpdateScheduledHook = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
-export const enableDiscreteEventMicroTasks = __VARIANT__;
 export const enableSyncMicroTasks = __VARIANT__;
 export const enableNativeEventPriorityInference = __VARIANT__;
 export const enableLazyContextPropagation = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -31,7 +31,6 @@ export const {
   enableUseRefAccessWarning,
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
-  enableDiscreteEventMicroTasks,
   enableSyncMicroTasks,
   enableNativeEventPriorityInference,
   enableLazyContextPropagation,


### PR DESCRIPTION
## Overview

After running an experiment, we're ready to land this change to move discrete events from being flushed concurrently in a macro task to being flushed synchronously in a microtask. This will move concurrent semantics closer to matching legacy root synchronous semantics, while still making discrete updates flush on a separate stack.