### PR TITLE
Land enableNativeEventPriorityInference

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMNativeEventHeuristic-test.js
@@ -43,7 +43,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   }
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('ignores discrete events on a pending removed element', async () => {
     const disableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -95,7 +94,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('ignores discrete events on a pending removed event listener', async () => {
     const disableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -165,7 +163,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('uses the newest discrete events on a pending changed event listener', async () => {
     const enableButtonRef = React.createRef();
     const submitButtonRef = React.createRef();
@@ -229,7 +226,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('mouse over should be user-blocking but not discrete', async () => {
     const root = ReactDOM.unstable_createRoot(container);
 
@@ -260,7 +256,6 @@ describe('ReactDOMNativeEventHeuristic-test', () => {
   });
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('mouse enter should be user-blocking but not discrete', async () => {
     const root = ReactDOM.unstable_createRoot(container);
 

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -438,8 +438,6 @@ export function getEventPriority(domEventName: DOMEventName): * {
       // Eventually this mechanism will be replaced by a check
       // of the current priority on the native scheduler.
       const schedulerPriority = getCurrentPriorityLevel();
-      // TODO: Inline schedulerPriorityToLanePriority into this file
-      // when we delete the enableNativeEventPriorityInference flag.
       return schedulerPriorityToLanePriority(schedulerPriority);
     }
     default:

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -8,7 +8,10 @@
  */
 
 import type {AnyNativeEvent} from '../events/PluginModuleType';
-import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
+import type {
+  FiberRoot,
+  ReactPriorityLevel,
+} from 'react-reconciler/src/ReactInternalTypes';
 import type {Container, SuspenseInstance} from '../client/ReactDOMHostConfig';
 import type {DOMEventName} from '../events/DOMEventNames';
 
@@ -50,7 +53,6 @@ import {
   DefaultLanePriority as DefaultLanePriority_old,
   getCurrentUpdateLanePriority as getCurrentUpdateLanePriority_old,
   setCurrentUpdateLanePriority as setCurrentUpdateLanePriority_old,
-  schedulerPriorityToLanePriority as schedulerPriorityToLanePriority_old,
 } from 'react-reconciler/src/ReactFiberLane.old';
 import {
   InputDiscreteLanePriority as InputDiscreteLanePriority_new,
@@ -58,10 +60,20 @@ import {
   DefaultLanePriority as DefaultLanePriority_new,
   getCurrentUpdateLanePriority as getCurrentUpdateLanePriority_new,
   setCurrentUpdateLanePriority as setCurrentUpdateLanePriority_new,
-  schedulerPriorityToLanePriority as schedulerPriorityToLanePriority_new,
+  SyncLanePriority,
+  IdleLanePriority,
+  NoLanePriority,
 } from 'react-reconciler/src/ReactFiberLane.new';
 import {getCurrentPriorityLevel as getCurrentPriorityLevel_old} from 'react-reconciler/src/SchedulerWithReactIntegration.old';
-import {getCurrentPriorityLevel as getCurrentPriorityLevel_new} from 'react-reconciler/src/SchedulerWithReactIntegration.new';
+import {
+  getCurrentPriorityLevel as getCurrentPriorityLevel_new,
+  IdlePriority as IdleSchedulerPriority,
+  ImmediatePriority as ImmediateSchedulerPriority,
+  LowPriority as LowSchedulerPriority,
+  NormalPriority as NormalSchedulerPriority,
+  UserBlockingPriority as UserBlockingSchedulerPriority,
+} from 'react-reconciler/src/SchedulerWithReactIntegration.new';
+import type {LanePriority} from 'react-reconciler/src/ReactFiberLane.new';
 
 const InputDiscreteLanePriority = enableNewReconciler
   ? InputDiscreteLanePriority_new
@@ -78,12 +90,28 @@ const getCurrentUpdateLanePriority = enableNewReconciler
 const setCurrentUpdateLanePriority = enableNewReconciler
   ? setCurrentUpdateLanePriority_new
   : setCurrentUpdateLanePriority_old;
-const schedulerPriorityToLanePriority = enableNewReconciler
-  ? schedulerPriorityToLanePriority_new
-  : schedulerPriorityToLanePriority_old;
 const getCurrentPriorityLevel = enableNewReconciler
   ? getCurrentPriorityLevel_new
   : getCurrentPriorityLevel_old;
+
+function schedulerPriorityToLanePriority(
+  schedulerPriorityLevel: ReactPriorityLevel,
+): LanePriority {
+  switch (schedulerPriorityLevel) {
+    case ImmediateSchedulerPriority:
+      return SyncLanePriority;
+    case UserBlockingSchedulerPriority:
+      return InputContinuousLanePriority;
+    case NormalSchedulerPriority:
+    case LowSchedulerPriority:
+      // TODO: Handle LowSchedulerPriority, somehow. Maybe the same lane as hydration.
+      return DefaultLanePriority;
+    case IdleSchedulerPriority:
+      return IdleLanePriority;
+    default:
+      return NoLanePriority;
+  }
+}
 
 // TODO: can we stop exporting these?
 export let _enabled = true;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -27,7 +27,6 @@ import {
   LegacyRoot,
 } from 'react-reconciler/src/ReactRootTags';
 
-import {enableNativeEventPriorityInference} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import enqueueTask from 'shared/enqueueTask';
 const {IsSomeRendererActing} = ReactSharedInternals;
@@ -934,19 +933,12 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
     discreteUpdates: NoopRenderer.discreteUpdates,
 
     idleUpdates<T>(fn: () => T): T {
-      if (enableNativeEventPriorityInference) {
-        const prevEventPriority = currentEventPriority;
-        currentEventPriority = NoopRenderer.IdleEventPriority;
-        try {
-          fn();
-        } finally {
-          currentEventPriority = prevEventPriority;
-        }
-      } else {
-        return Scheduler.unstable_runWithPriority(
-          Scheduler.unstable_IdlePriority,
-          fn,
-        );
+      const prevEventPriority = currentEventPriority;
+      currentEventPriority = NoopRenderer.IdleEventPriority;
+      try {
+        fn();
+      } finally {
+        currentEventPriority = prevEventPriority;
       }
     },
 

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -42,7 +42,6 @@ import {
   ImmediatePriority as ImmediateSchedulerPriority,
   UserBlockingPriority as UserBlockingSchedulerPriority,
   NormalPriority as NormalSchedulerPriority,
-  LowPriority as LowSchedulerPriority,
   IdlePriority as IdleSchedulerPriority,
   NoPriority as NoSchedulerPriority,
 } from './SchedulerWithReactIntegration.new';
@@ -272,25 +271,6 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
       // This shouldn't be reachable, but as a fallback, return the entire bitmask.
       return_highestLanePriority = DefaultLanePriority;
       return lanes;
-  }
-}
-
-export function schedulerPriorityToLanePriority(
-  schedulerPriorityLevel: ReactPriorityLevel,
-): LanePriority {
-  switch (schedulerPriorityLevel) {
-    case ImmediateSchedulerPriority:
-      return SyncLanePriority;
-    case UserBlockingSchedulerPriority:
-      return InputContinuousLanePriority;
-    case NormalSchedulerPriority:
-    case LowSchedulerPriority:
-      // TODO: Handle LowSchedulerPriority, somehow. Maybe the same lane as hydration.
-      return DefaultLanePriority;
-    case IdleSchedulerPriority:
-      return IdleLanePriority;
-    default:
-      return NoLanePriority;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -42,7 +42,6 @@ import {
   ImmediatePriority as ImmediateSchedulerPriority,
   UserBlockingPriority as UserBlockingSchedulerPriority,
   NormalPriority as NormalSchedulerPriority,
-  LowPriority as LowSchedulerPriority,
   IdlePriority as IdleSchedulerPriority,
   NoPriority as NoSchedulerPriority,
 } from './SchedulerWithReactIntegration.old';
@@ -272,25 +271,6 @@ function getHighestPriorityLanes(lanes: Lanes | Lane): Lanes {
       // This shouldn't be reachable, but as a fallback, return the entire bitmask.
       return_highestLanePriority = DefaultLanePriority;
       return lanes;
-  }
-}
-
-export function schedulerPriorityToLanePriority(
-  schedulerPriorityLevel: ReactPriorityLevel,
-): LanePriority {
-  switch (schedulerPriorityLevel) {
-    case ImmediateSchedulerPriority:
-      return SyncLanePriority;
-    case UserBlockingSchedulerPriority:
-      return InputContinuousLanePriority;
-    case NormalSchedulerPriority:
-    case LowSchedulerPriority:
-      // TODO: Handle LowSchedulerPriority, somehow. Maybe the same lane as hydration.
-      return DefaultLanePriority;
-    case IdleSchedulerPriority:
-      return IdleLanePriority;
-    default:
-      return NoLanePriority;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -32,7 +32,6 @@ import {
   disableSchedulerTimeoutInWorkLoop,
   enableStrictEffects,
   skipUnmountedBoundaries,
-  enableNativeEventPriorityInference,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
@@ -168,7 +167,6 @@ import {
   markRootExpired,
   markDiscreteUpdatesExpired,
   markRootFinished,
-  schedulerPriorityToLanePriority,
   lanePriorityToSchedulerPriority,
   higherLanePriority,
 } from './ReactFiberLane.new';
@@ -456,15 +454,8 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     const currentLanePriority = getCurrentUpdateLanePriority();
     lane = findUpdateLane(currentLanePriority);
   } else {
-    if (enableNativeEventPriorityInference) {
-      const eventLanePriority = getCurrentEventPriority();
-      lane = findUpdateLane(eventLanePriority);
-    } else {
-      const schedulerLanePriority = schedulerPriorityToLanePriority(
-        schedulerPriority,
-      );
-      lane = findUpdateLane(schedulerLanePriority);
-    }
+    const eventLanePriority = getCurrentEventPriority();
+    lane = findUpdateLane(eventLanePriority);
   }
 
   return lane;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -32,7 +32,6 @@ import {
   disableSchedulerTimeoutInWorkLoop,
   enableStrictEffects,
   skipUnmountedBoundaries,
-  enableNativeEventPriorityInference,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import invariant from 'shared/invariant';
@@ -168,7 +167,6 @@ import {
   markRootExpired,
   markDiscreteUpdatesExpired,
   markRootFinished,
-  schedulerPriorityToLanePriority,
   lanePriorityToSchedulerPriority,
   higherLanePriority,
 } from './ReactFiberLane.old';
@@ -456,15 +454,8 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     const currentLanePriority = getCurrentUpdateLanePriority();
     lane = findUpdateLane(currentLanePriority);
   } else {
-    if (enableNativeEventPriorityInference) {
-      const eventLanePriority = getCurrentEventPriority();
-      lane = findUpdateLane(eventLanePriority);
-    } else {
-      const schedulerLanePriority = schedulerPriorityToLanePriority(
-        schedulerPriority,
-      );
-      lane = findUpdateLane(schedulerLanePriority);
-    }
+    const eventLanePriority = getCurrentEventPriority();
+    lane = findUpdateLane(eventLanePriority);
   }
 
   return lane;

--- a/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
@@ -341,7 +341,6 @@ describe('useMutableSourceHydration', () => {
   });
 
   // @gate experimental
-  // @gate enableNativeEventPriorityInference
   it('should detect a tear during a higher priority interruption', () => {
     const source = createSource('one');
     const mutableSource = createMutableSource(source, param => param.version);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -152,6 +152,4 @@ export const disableSchedulerTimeoutInWorkLoop = false;
 
 export const enableSyncMicroTasks = false;
 
-export const enableNativeEventPriorityInference = false;
-
 export const enableLazyContextPropagation = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -58,7 +58,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -57,7 +57,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableSyncMicroTasks = false;
-export const enableNativeEventPriorityInference = false;
 export const enableLazyContextPropagation = false;
 
 // Flow magic to verify the exports of this file match the original version.

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -56,5 +56,4 @@ export const enableUseRefAccessWarning = __VARIANT__;
 export const enableProfilerNestedUpdateScheduledHook = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
 export const enableSyncMicroTasks = __VARIANT__;
-export const enableNativeEventPriorityInference = __VARIANT__;
 export const enableLazyContextPropagation = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -32,7 +32,6 @@ export const {
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
   enableSyncMicroTasks,
-  enableNativeEventPriorityInference,
   enableLazyContextPropagation,
 } = dynamicFeatureFlags;
 


### PR DESCRIPTION
## Overview

After a successful experiment, this diff lands a change that updates native events that fire outside of the React event system so that they use the event type to schedule updates at the correct priority, which would match the priority and behvior used by React if the event was fired in our event system.

See https://github.com/facebook/react/pull/20748 for more info.