### PR TITLE
Remove scheduler priority from hydration

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -16,10 +16,8 @@ import type {LanePriority} from 'react-reconciler/src/ReactFiberLane.old';
 
 import {enableSelectiveHydration} from 'shared/ReactFeatureFlags';
 import {
-  unstable_runWithPriority as runWithPriority,
   unstable_scheduleCallback as scheduleCallback,
   unstable_NormalPriority as NormalPriority,
-  unstable_getCurrentPriorityLevel as getCurrentPriorityLevel,
 } from 'scheduler';
 import {
   getNearestMountedFiber,
@@ -111,7 +109,6 @@ const queuedPointerCaptures: Map<number, QueuedReplayableEvent> = new Map();
 type QueuedHydrationTarget = {|
   blockedOn: null | Container | SuspenseInstance,
   target: Node,
-  priority: number,
   lanePriority: LanePriority,
 |};
 const queuedExplicitHydrationTargets: Array<QueuedHydrationTarget> = [];
@@ -394,9 +391,7 @@ function attemptExplicitHydrationTarget(
           // Increase its priority.
           queuedTarget.blockedOn = instance;
           attemptHydrationAtPriority(queuedTarget.lanePriority, () => {
-            runWithPriority(queuedTarget.priority, () => {
-              attemptHydrationAtCurrentPriority(nearestMounted);
-            });
+            attemptHydrationAtCurrentPriority(nearestMounted);
           });
 
           return;
@@ -417,17 +412,17 @@ function attemptExplicitHydrationTarget(
 
 export function queueExplicitHydrationTarget(target: Node): void {
   if (enableSelectiveHydration) {
-    const schedulerPriority = getCurrentPriorityLevel();
     const updateLanePriority = getCurrentUpdatePriority();
     const queuedTarget: QueuedHydrationTarget = {
       blockedOn: null,
       target: target,
-      priority: schedulerPriority,
       lanePriority: updateLanePriority,
     };
     let i = 0;
     for (; i < queuedExplicitHydrationTargets.length; i++) {
-      if (schedulerPriority <= queuedExplicitHydrationTargets[i].priority) {
+      if (
+        updateLanePriority <= queuedExplicitHydrationTargets[i].lanePriority
+      ) {
         break;
       }
     }


### PR DESCRIPTION
## Overview

Now that we landed the update lane priority, this diff removed the double wrapping in `attemptExplicitHydrationTarget` to use the update lane priority only.