### PR TITLE
Cleaned up unused PassiveUnmountPendingDev DEV flag

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -77,7 +77,6 @@ import {
   MutationMask,
   LayoutMask,
   PassiveMask,
-  PassiveUnmountPendingDev,
 } from './ReactFiberFlags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
@@ -2341,14 +2340,6 @@ function commitPassiveUnmountEffects_complete() {
 }
 
 function commitPassiveUnmountOnFiber(finishedWork: Fiber): void {
-  if (__DEV__) {
-    finishedWork.flags &= ~PassiveUnmountPendingDev;
-    const alternate = finishedWork.alternate;
-    if (alternate !== null) {
-      alternate.flags &= ~PassiveUnmountPendingDev;
-    }
-  }
-
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -77,7 +77,6 @@ import {
   MutationMask,
   LayoutMask,
   PassiveMask,
-  PassiveUnmountPendingDev,
 } from './ReactFiberFlags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
@@ -2341,14 +2340,6 @@ function commitPassiveUnmountEffects_complete() {
 }
 
 function commitPassiveUnmountOnFiber(finishedWork: Fiber): void {
-  if (__DEV__) {
-    finishedWork.flags &= ~PassiveUnmountPendingDev;
-    const alternate = finishedWork.alternate;
-    if (alternate !== null) {
-      alternate.flags &= ~PassiveUnmountPendingDev;
-    }
-  }
-
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -12,51 +12,49 @@ import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 export type Flags = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoFlags = /*                      */ 0b0000000000000000000000;
-export const PerformedWork = /*                */ 0b0000000000000000000001;
+export const NoFlags = /*                      */ 0b000000000000000000000;
+export const PerformedWork = /*                */ 0b000000000000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*                    */ 0b0000000000000000000010;
-export const Update = /*                       */ 0b0000000000000000000100;
+export const Placement = /*                    */ 0b000000000000000000010;
+export const Update = /*                       */ 0b000000000000000000100;
 export const PlacementAndUpdate = /*           */ Placement | Update;
-export const Deletion = /*                     */ 0b0000000000000000001000;
-export const ChildDeletion = /*                */ 0b0000000000000000010000;
-export const ContentReset = /*                 */ 0b0000000000000000100000;
-export const Callback = /*                     */ 0b0000000000000001000000;
-export const DidCapture = /*                   */ 0b0000000000000010000000;
-export const Ref = /*                          */ 0b0000000000000100000000;
-export const Snapshot = /*                     */ 0b0000000000001000000000;
-export const Passive = /*                      */ 0b0000000000010000000000;
-export const Hydrating = /*                    */ 0b0000000000100000000000;
+export const Deletion = /*                     */ 0b000000000000000001000;
+export const ChildDeletion = /*                */ 0b000000000000000010000;
+export const ContentReset = /*                 */ 0b000000000000000100000;
+export const Callback = /*                     */ 0b000000000000001000000;
+export const DidCapture = /*                   */ 0b000000000000010000000;
+export const Ref = /*                          */ 0b000000000000100000000;
+export const Snapshot = /*                     */ 0b000000000001000000000;
+export const Passive = /*                      */ 0b000000000010000000000;
+export const Hydrating = /*                    */ 0b000000000100000000000;
 export const HydratingAndUpdate = /*           */ Hydrating | Update;
-export const Visibility = /*                   */ 0b0000000001000000000000;
+export const Visibility = /*                   */ 0b000000001000000000000;
 
 export const LifecycleEffectMask = Passive | Update | Callback | Ref | Snapshot;
 
 // Union of all commit flags (flags with the lifetime of a particular commit)
-export const HostEffectMask = /*               */ 0b0000000001111111111111;
+export const HostEffectMask = /*               */ 0b000000001111111111111;
 
 // These are not really side effects, but we still reuse this field.
-export const Incomplete = /*                   */ 0b0000000010000000000000;
-export const ShouldCapture = /*                */ 0b0000000100000000000000;
-// TODO (effects) Remove this bit once the new reconciler is synced to the old.
-export const PassiveUnmountPendingDev = /*     */ 0b0000001000000000000000;
-export const ForceUpdateForLegacySuspense = /* */ 0b0000010000000000000000;
-export const DidPropagateContext = /*          */ 0b0000100000000000000000;
-export const NeedsPropagation = /*             */ 0b0001000000000000000000;
+export const Incomplete = /*                   */ 0b000000010000000000000;
+export const ShouldCapture = /*                */ 0b000000100000000000000;
+export const ForceUpdateForLegacySuspense = /* */ 0b000001000000000000000;
+export const DidPropagateContext = /*          */ 0b000010000000000000000;
+export const NeedsPropagation = /*             */ 0b000100000000000000000;
 
 // Static tags describe aspects of a fiber that are not specific to a render,
 // e.g. a fiber uses a passive effect (even if there are no updates on this particular render).
 // This enables us to defer more work in the unmount case,
 // since we can defer traversing the tree during layout to look for Passive effects,
 // and instead rely on the static flag as a signal that there may be cleanup work.
-export const PassiveStatic = /*                */ 0b0010000000000000000000;
+export const PassiveStatic = /*                */ 0b001000000000000000000;
 
 // These flags allow us to traverse to fibers that have effects on mount
 // without traversing the entire tree after every commit for
 // double invoking
-export const MountLayoutDev = /*               */ 0b0100000000000000000000;
-export const MountPassiveDev = /*              */ 0b1000000000000000000000;
+export const MountLayoutDev = /*               */ 0b010000000000000000000;
+export const MountPassiveDev = /*              */ 0b100000000000000000000;
 
 // Groups of flags that are used in the commit phase to skip over trees that
 // don't contain effects, by checking subtreeFlags.


### PR DESCRIPTION
This flag was added in #18617 to avoid warning about state updates for unmounted components with pending passive cleanups. We don't need the flag any more so this PR cleans it up.

Noticed this while working on the new Suspense effects semantics.