### PR TITLE
[Fizz/Flight] Allow the streaming config to decide how to precompute or compute chunks

### DIFF
--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -7,11 +7,16 @@
  * @flow
  */
 
-import type {Destination} from 'react-server/src/ReactServerStreamConfig';
+import type {
+  Destination,
+  Chunk,
+  PrecomputedChunk,
+} from 'react-server/src/ReactServerStreamConfig';
 
 import {
   writeChunk,
-  convertStringToBuffer,
+  stringToChunk,
+  stringToPrecomputedChunk,
 } from 'react-server/src/ReactServerStreamConfig';
 
 import invariant from 'shared/invariant';
@@ -71,10 +76,10 @@ export function createSuspenseBoundaryID(
   return responseState.nextSuspenseID++;
 }
 
-const RAW_TEXT = convertStringToBuffer('RCTRawText');
+const RAW_TEXT = stringToPrecomputedChunk('RCTRawText');
 
 export function pushTextInstance(
-  target: Array<Uint8Array>,
+  target: Array<Chunk | PrecomputedChunk>,
   text: string,
 ): void {
   target.push(
@@ -87,20 +92,20 @@ export function pushTextInstance(
 }
 
 export function pushStartInstance(
-  target: Array<Uint8Array>,
+  target: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
 ): void {
   target.push(
     INSTANCE,
-    convertStringToBuffer(type),
+    stringToChunk(type),
     END, // Null terminated type string
     // TODO: props
   );
 }
 
 export function pushEndInstance(
-  target: Array<Uint8Array>,
+  target: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
 ): void {

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -27,15 +27,18 @@ const ReactNoopFlightServer = ReactFlightServer({
     callback();
   },
   beginWriting(destination: Destination): void {},
-  writeChunk(destination: Destination, buffer: Uint8Array): void {
-    destination.push(Buffer.from((buffer: any)).toString('utf8'));
+  writeChunk(destination: Destination, chunk: string): void {
+    destination.push(chunk);
   },
   completeWriting(destination: Destination): void {},
   close(destination: Destination): void {},
   closeWithError(destination: Destination, error: mixed): void {},
   flushBuffered(destination: Destination): void {},
-  convertStringToBuffer(content: string): Uint8Array {
-    return Buffer.from(content, 'utf8');
+  stringToChunk(content: string): string {
+    return content;
+  },
+  stringToPrecomputedChunk(content: string): string {
+    return content;
   },
   isModuleReference(reference: Object): boolean {
     return reference.$$typeof === Symbol.for('react.module.reference');

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -8,7 +8,11 @@
  */
 
 import type {Dispatcher as DispatcherType} from 'react-reconciler/src/ReactInternalTypes';
-import type {Destination} from './ReactServerStreamConfig';
+import type {
+  Destination,
+  Chunk,
+  PrecomputedChunk,
+} from './ReactServerStreamConfig';
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {
   SuspenseBoundaryID,
@@ -78,7 +82,7 @@ type Segment = {
   parentFlushed: boolean, // typically a segment will be flushed by its parent, except if its parent was already flushed
   id: number, // starts as 0 and is lazily assigned if the parent flushes early
   +index: number, // the index within the parent's chunks or 0 at the root
-  +chunks: Array<Uint8Array>,
+  +chunks: Array<Chunk | PrecomputedChunk>,
   +children: Array<Segment>,
   // If this segment represents a fallback, this is the content that will replace that fallback.
   +boundary: null | SuspenseBoundary,

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -66,11 +66,11 @@ ByteSize
 
 import type {Request, ReactModel} from 'react-server/src/ReactFlightServer';
 
-import {convertStringToBuffer} from './ReactServerStreamConfig';
+import {stringToChunk} from './ReactServerStreamConfig';
 
-export type {Destination} from './ReactServerStreamConfig';
+import type {Chunk} from './ReactServerStreamConfig';
 
-export type Chunk = Uint8Array;
+export type {Destination, Chunk} from './ReactServerStreamConfig';
 
 const stringify = JSON.stringify;
 
@@ -86,7 +86,7 @@ export function processErrorChunk(
 ): Chunk {
   const errorInfo = {message, stack};
   const row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
-  return convertStringToBuffer(row);
+  return stringToChunk(row);
 }
 
 export function processModelChunk(
@@ -96,7 +96,7 @@ export function processModelChunk(
 ): Chunk {
   const json = stringify(model, request.toJSON);
   const row = serializeRowHeader('J', id) + json + '\n';
-  return convertStringToBuffer(row);
+  return stringToChunk(row);
 }
 
 export function processModuleChunk(
@@ -106,7 +106,7 @@ export function processModuleChunk(
 ): Chunk {
   const json = stringify(moduleMetaData);
   const row = serializeRowHeader('M', id) + json + '\n';
-  return convertStringToBuffer(row);
+  return stringToChunk(row);
 }
 
 export function processSymbolChunk(
@@ -116,7 +116,7 @@ export function processSymbolChunk(
 ): Chunk {
   const json = stringify(name);
   const row = serializeRowHeader('S', id) + json + '\n';
-  return convertStringToBuffer(row);
+  return stringToChunk(row);
 }
 
 export {

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -9,6 +9,9 @@
 
 export type Destination = ReadableStreamController;
 
+export type PrecomputedChunk = Uint8Array;
+export type Chunk = Uint8Array;
+
 export function scheduleWork(callback: () => void) {
   callback();
 }
@@ -22,9 +25,9 @@ export function beginWriting(destination: Destination) {}
 
 export function writeChunk(
   destination: Destination,
-  buffer: Uint8Array,
+  chunk: PrecomputedChunk | Chunk,
 ): boolean {
-  destination.enqueue(buffer);
+  destination.enqueue(chunk);
   return destination.desiredSize > 0;
 }
 
@@ -36,7 +39,11 @@ export function close(destination: Destination) {
 
 const textEncoder = new TextEncoder();
 
-export function convertStringToBuffer(content: string): Uint8Array {
+export function stringToChunk(content: string): Chunk {
+  return textEncoder.encode(content);
+}
+
+export function stringToPrecomputedChunk(content: string): PrecomputedChunk {
   return textEncoder.encode(content);
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -18,6 +18,9 @@ type MightBeFlushable = {
 
 export type Destination = Writable & MightBeFlushable;
 
+export type PrecomputedChunk = Uint8Array;
+export type Chunk = string;
+
 export function scheduleWork(callback: () => void) {
   setImmediate(callback);
 }
@@ -44,9 +47,9 @@ export function beginWriting(destination: Destination) {
 
 export function writeChunk(
   destination: Destination,
-  buffer: Uint8Array,
+  chunk: Chunk | PrecomputedChunk,
 ): boolean {
-  const nodeBuffer = ((buffer: any): Buffer); // close enough
+  const nodeBuffer = ((chunk: any): Buffer | string); // close enough
   return destination.write(nodeBuffer);
 }
 
@@ -61,7 +64,11 @@ export function close(destination: Destination) {
   destination.end();
 }
 
-export function convertStringToBuffer(content: string): Uint8Array {
+export function stringToChunk(content: string): Chunk {
+  return content;
+}
+
+export function stringToPrecomputedChunk(content: string): PrecomputedChunk {
   return Buffer.from(content, 'utf8');
 }
 

--- a/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.custom.js
@@ -26,6 +26,9 @@
 declare var $$$hostConfig: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
 
+export opaque type PrecomputedChunk = mixed; // eslint-disable-line no-undef
+export opaque type Chunk = mixed; // eslint-disable-line no-undef
+
 export const scheduleWork = $$$hostConfig.scheduleWork;
 export const beginWriting = $$$hostConfig.beginWriting;
 export const writeChunk = $$$hostConfig.writeChunk;
@@ -33,4 +36,5 @@ export const completeWriting = $$$hostConfig.completeWriting;
 export const flushBuffered = $$$hostConfig.flushBuffered;
 export const close = $$$hostConfig.close;
 export const closeWithError = $$$hostConfig.closeWithError;
-export const convertStringToBuffer = $$$hostConfig.convertStringToBuffer;
+export const stringToChunk = $$$hostConfig.stringToChunk;
+export const stringToPrecomputedChunk = $$$hostConfig.stringToPrecomputedChunk;

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -94,7 +94,13 @@ module.exports = [
       'react-server-native-relay',
       'react-server-native-relay/server',
     ],
-    paths: ['react-native-renderer', 'react-server-native-relay'],
+    paths: [
+      'react-native-renderer',
+      'react-server-native-relay',
+      // this is included here so that it's not included in the main native check
+      // remove this when it's added to the main native renderer.
+      'react-native-renderer/src/server',
+    ],
     isFlowTyped: true,
     isServerSupported: true,
   },


### PR DESCRIPTION
Some legacy environments can not encode non-strings. Those would specify both as strings. We'll do something special for binary data there.

Some environments have to encode strings (like web streams). Those would encode both as Uint8Array.

Some environments (like Node) can do either. It can be beneficial to leave things as strings in case the native stream can do something smart with it.

We might do some optimizations in the core assuming Uint8Array - e.g. caching or reusing. For those cases, we'll add new host configs.