### PR TITLE
Make Fabric noop when setJSResponder is called

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -16,13 +16,7 @@ const ReactFabricGlobalResponderHandler = {
     const isFabric = !!fromOrTo.stateNode.canonical._internalInstanceHandle;
 
     if (isFabric) {
-      if (from) {
-        nativeFabricUIManager.setIsJSResponder(from.stateNode.node, false);
-      }
-
-      if (to) {
-        nativeFabricUIManager.setIsJSResponder(to.stateNode.node, true);
-      }
+      // Noop for now until setJSResponder/clearJSResponder are supported in Fabric
     } else {
       if (to !== null) {
         const tag = to.stateNode.canonical._nativeTag;

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -176,7 +176,6 @@ const RCTFabricUIManager = {
     );
     success(1, 1, 100, 100);
   }),
-  setIsJSResponder: jest.fn(),
 };
 
 global.nativeFabricUIManager = RCTFabricUIManager;

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -179,7 +179,6 @@ declare var nativeFabricUIManager: {
     locationY: number,
     callback: (Fiber) => void,
   ) => void,
-  setIsJSResponder: (node: Node, isJsResponder: boolean) => void,
   ...
 };
 


### PR DESCRIPTION
Revert 'Fabric-compatible implementation of  feature', make Fabric noop when setJSResponder is called

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

setIsJSResponder is not the correct API to use on the fabric side, we need the option to pass blockNativeResponder: false

## Test Plan

yarn lint & yarn test & yarn flow fabric

