### PR TITLE
Sync ReactNativeTypes from RN repo to React

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -97,6 +97,7 @@ function findHostInstance_DEPRECATED<TElementType: ElementType>(
     // Fabric
     return (hostInstance: any).canonical;
   }
+  // $FlowFixMe
   return hostInstance;
 }
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -13,7 +13,6 @@ import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
-  NativeMethods,
   ViewConfig,
   TouchedViewDataAtPoint,
 } from './ReactNativeTypes';
@@ -185,9 +184,6 @@ class ReactFabricHostComponent {
     return;
   }
 }
-
-// eslint-disable-next-line no-unused-expressions
-(ReactFabricHostComponent.prototype: NativeMethods);
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMutation';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -13,7 +13,6 @@ import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
-  NativeMethods,
   ViewConfig,
 } from './ReactNativeTypes';
 import type {Instance} from './ReactNativeHostConfig';
@@ -125,8 +124,5 @@ class ReactNativeFiberHostComponent {
     }
   }
 }
-
-// eslint-disable-next-line no-unused-expressions
-(ReactNativeFiberHostComponent.prototype: NativeMethods);
 
 export default ReactNativeFiberHostComponent;

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -96,6 +96,7 @@ function findHostInstance_DEPRECATED(
     // Fabric
     return (hostInstance: any).canonical;
   }
+  // $FlowFixMe inexact ReactNativeFiberHostComponent is incompatible with exact $ReadOnly
   return hostInstance;
 }
 

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -94,7 +94,7 @@ export type PartialViewConfig = $ReadOnly<{
   validAttributes?: PartialAttributeConfiguration,
 }>;
 
-export type NativeMethods = {
+export type NativeMethods = {|
   blur(): void,
   focus(): void,
   measure(callback: MeasureOnSuccessCallback): void,
@@ -105,8 +105,7 @@ export type NativeMethods = {
     onFail?: () => void,
   ): void,
   setNativeProps(nativeProps: {...}): void,
-  ...
-};
+|};
 
 export type HostComponent<T> = AbstractComponent<T, $ReadOnly<NativeMethods>>;
 


### PR DESCRIPTION

## Summary

Syncs over changes RN edited directly.

The same as https://github.com/facebook/react/pull/21012 but with some $FlowFixMes and some Flow casts removed. 

This might not be the right approach, I'll need some feedback.

## Test Plan

yarn flow fabric && yarn flow native && yarn lint && yarn test