### PR TITLE
[Fizz] Expose a method to abort a pending request

### DIFF
--- a/fixtures/fizz-ssr-browser/index.html
+++ b/fixtures/fizz-ssr-browser/index.html
@@ -20,7 +20,7 @@
     <script src="../../build/node_modules/react-dom/umd/react-dom-unstable-fizz.browser.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <script type="text/babel">
-      let stream = ReactDOMFizzServer.renderToReadableStream(<body>Success</body>);
+      let {stream} = ReactDOMFizzServer.renderToReadableStream(<body>Success</body>);
       let response = new Response(stream, {
         headers: {'Content-Type': 'text/html'},
       });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -50,7 +50,7 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should call renderToReadableStream', async () => {
-    const stream = ReactDOMFizzServer.renderToReadableStream(
+    const {stream} = ReactDOMFizzServer.renderToReadableStream(
       <div>hello world</div>,
     );
     const result = await readResult(stream);
@@ -59,7 +59,7 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should error the stream when an error is thrown at the root', async () => {
-    const stream = ReactDOMFizzServer.renderToReadableStream(
+    const {stream} = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Throw />
       </div>,
@@ -78,7 +78,7 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should error the stream when an error is thrown inside a fallback', async () => {
-    const stream = ReactDOMFizzServer.renderToReadableStream(
+    const {stream} = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Suspense fallback={<Throw />}>
           <InfiniteSuspend />
@@ -99,13 +99,29 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
-    const stream = ReactDOMFizzServer.renderToReadableStream(
+    const {stream} = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <Throw />
         </Suspense>
       </div>,
     );
+
+    const result = await readResult(stream);
+    expect(result).toContain('Loading');
+  });
+
+  // @gate experimental
+  it('should be able to complete by aborting even if the promise never resolves', async () => {
+    const {abort, stream} = ReactDOMFizzServer.renderToReadableStream(
+      <div>
+        <Suspense fallback={<div>Loading</div>}>
+          <InfiniteSuspend />
+        </Suspense>
+      </div>,
+    );
+
+    abort();
 
     const result = await readResult(stream);
     expect(result).toContain('Loading');

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -13,11 +13,17 @@ import {
   createRequest,
   startWork,
   startFlowing,
+  abort,
 } from 'react-server/src/ReactFizzServer';
 
-function renderToReadableStream(children: ReactNodeList): ReadableStream {
+type Controls = {
+  stream: ReadableStream,
+  abort(): void,
+};
+
+function renderToReadableStream(children: ReactNodeList): Controls {
   let request;
-  return new ReadableStream({
+  const stream = new ReadableStream({
     start(controller) {
       request = createRequest(children, controller);
       startWork(request);
@@ -27,6 +33,12 @@ function renderToReadableStream(children: ReactNodeList): ReadableStream {
     },
     cancel(reason) {},
   });
+  return {
+    stream,
+    abort() {
+      abort(request);
+    },
+  };
 }
 
 export {renderToReadableStream};

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -14,19 +14,31 @@ import {
   createRequest,
   startWork,
   startFlowing,
+  abort,
 } from 'react-server/src/ReactFizzServer';
 
 function createDrainHandler(destination, request) {
   return () => startFlowing(request);
 }
 
+type Controls = {
+  // Cancel any pending I/O and put anything remaining into
+  // client rendered mode.
+  abort(): void,
+};
+
 function pipeToNodeWritable(
   children: ReactNodeList,
   destination: Writable,
-): void {
+): Controls {
   const request = createRequest(children, destination);
   destination.on('drain', createDrainHandler(destination, request));
   startWork(request);
+  return {
+    abort() {
+      abort(request);
+    },
+  };
 }
 
 export {pipeToNodeWritable};

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -216,6 +216,9 @@ function render(children: React$Element<any>): Destination {
     placeholders: new Map(),
     segments: new Map(),
     stack: [],
+    abort() {
+      ReactNoopServer.abort(request);
+    },
   };
   const request = ReactNoopServer.createRequest(children, destination);
   ReactNoopServer.startWork(request);


### PR DESCRIPTION
This introduces a Set of SuspendedWork to the data structures. This is basically like an AbortSignal. In fact, it should probably be coupled with an actual AbortSignal at the same places.

For work inside a fallback, the abortSet is associated with the boundary that it's a fallback for. This lets the boundary cancel the fallback if the boundary completes.

For all other work, the abortSet is associated with the whole request. This lets you cancel this work for the whole request. If a pending boundary is canceled, then its fallback is canceled too.

I expose this method as an explicit separate control both for the Node and Browser API.

This can be used to implement for example timeout semantics.

There's a subtle difference between this API and just closing the stream. It lets the stream continue emitting whatever is still queued to flush. It also emits a signal to the client that these fallbacks should be client rendered instead of waiting for the server.