### PR TITLE
[Fizz] Use identifierPrefix to avoid conflicts within the same response

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -16,9 +16,12 @@ import {
   abort,
 } from 'react-server/src/ReactFizzServer';
 
+import {createResponseState} from './ReactDOMServerFormatConfig';
+
 type Options = {
-  signal?: AbortSignal,
+  identifierPrefix?: string,
   progressiveChunkSize?: number,
+  signal?: AbortSignal,
 };
 
 function renderToReadableStream(
@@ -39,6 +42,7 @@ function renderToReadableStream(
       request = createRequest(
         children,
         controller,
+        createResponseState(options ? options.identifierPrefix : undefined),
         options ? options.progressiveChunkSize : undefined,
       );
       startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -17,11 +17,14 @@ import {
   abort,
 } from 'react-server/src/ReactFizzServer';
 
+import {createResponseState} from './ReactDOMServerFormatConfig';
+
 function createDrainHandler(destination, request) {
   return () => startFlowing(request);
 }
 
 type Options = {
+  identifierPrefix?: string,
   progressiveChunkSize?: number,
 };
 
@@ -39,6 +42,7 @@ function pipeToNodeWritable(
   const request = createRequest(
     children,
     destination,
+    createResponseState(options ? options.identifierPrefix : undefined),
     options ? options.progressiveChunkSize : undefined,
   );
   let hasStartedFlowing = false;

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -145,6 +145,7 @@ function formatID(id: number): Uint8Array {
 // display. It's never visible to users.
 export function writePlaceholder(
   destination: Destination,
+  responseState: ResponseState,
   id: number,
 ): boolean {
   writeChunk(destination, PLACEHOLDER);
@@ -179,6 +180,7 @@ export function writeEndSuspenseBoundary(destination: Destination): boolean {
 
 export function writeStartSegment(
   destination: Destination,
+  responseState: ResponseState,
   id: number,
 ): boolean {
   writeChunk(destination, SEGMENT);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -77,9 +77,6 @@ const ReactNoopServer = ReactFizzServer({
   closeWithError(destination: Destination, error: mixed): void {},
   flushBuffered(destination: Destination): void {},
 
-  createResponseState(): null {
-    return null;
-  },
   createSuspenseBoundaryID(): SuspenseInstance {
     // The ID is a pointer to the boundary itself.
     return {state: 'pending', children: []};
@@ -114,7 +111,11 @@ const ReactNoopServer = ReactFizzServer({
     target.push(POP);
   },
 
-  writePlaceholder(destination: Destination, id: number): boolean {
+  writePlaceholder(
+    destination: Destination,
+    responseState: ResponseState,
+    id: number,
+  ): boolean {
     const parent = destination.stack[destination.stack.length - 1];
     destination.placeholders.set(id, {
       parent: parent,
@@ -153,7 +154,11 @@ const ReactNoopServer = ReactFizzServer({
     destination.stack.pop();
   },
 
-  writeStartSegment(destination: Destination, id: number): boolean {
+  writeStartSegment(
+    destination: Destination,
+    responseState: ResponseState,
+    id: number,
+  ): boolean {
     const segment = {
       children: [],
     };
@@ -227,6 +232,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
   const request = ReactNoopServer.createRequest(
     children,
     destination,
+    null,
     options ? options.progressiveChunkSize : undefined,
   );
   ReactNoopServer.startWork(request);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -44,7 +44,6 @@ import {
   pushStartInstance,
   pushEndInstance,
   createSuspenseBoundaryID,
-  createResponseState,
 } from './ReactServerFormatConfig';
 import {REACT_ELEMENT_TYPE, REACT_SUSPENSE_TYPE} from 'shared/ReactSymbols';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -133,13 +132,14 @@ const DEFAULT_PROGRESSIVE_CHUNK_SIZE = 12800;
 export function createRequest(
   children: ReactNodeList,
   destination: Destination,
+  responseState: ResponseState,
   progressiveChunkSize: number = DEFAULT_PROGRESSIVE_CHUNK_SIZE,
 ): Request {
   const pingedWork = [];
   const abortSet: Set<SuspendedWork> = new Set();
   const request = {
     destination,
-    responseState: createResponseState(),
+    responseState,
     progressiveChunkSize,
     status: BUFFERING,
     nextSegmentId: 0,
@@ -590,7 +590,7 @@ function flushSubtree(
       // We're emitting a placeholder for this segment to be filled in later.
       // Therefore we'll need to assign it an ID - to refer to it by.
       const segmentID = (segment.id = request.nextSegmentId++);
-      return writePlaceholder(destination, segmentID);
+      return writePlaceholder(destination, request.responseState, segmentID);
     }
     case COMPLETED: {
       segment.status = FLUSHED;
@@ -712,7 +712,7 @@ function flushSegmentContainer(
   destination: Destination,
   segment: Segment,
 ): boolean {
-  writeStartSegment(destination, segment.id);
+  writeStartSegment(destination, request.responseState, segment.id);
   flushSegment(request, destination, segment);
   return writeEndSegment(destination);
 }

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -28,7 +28,6 @@ export opaque type Destination = mixed; // eslint-disable-line no-undef
 export opaque type ResponseState = mixed;
 export opaque type SuspenseBoundaryID = mixed;
 
-export const createResponseState = $$$hostConfig.createResponseState;
 export const createSuspenseBoundaryID = $$$hostConfig.createSuspenseBoundaryID;
 export const pushEmpty = $$$hostConfig.pushEmpty;
 export const pushTextInstance = $$$hostConfig.pushTextInstance;


### PR DESCRIPTION
identifierPrefix as an option exists to avoid useOpaqueIdentifier conflicting when different renders are used within one HTML response.

This lets this be configured for the DOM renderer specifically since it's DOM specific whether they will conflict across trees or not.

Added a test that uses two streams/containers that pipe into the same document.