### PR TITLE
[Fizz] Expose callbacks in options for when various stages of the content is done

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -336,7 +336,6 @@ describe('ReactDOMFizzServer', () => {
       writable.write(chunk, encoding, next);
     };
 
-    writable.write('<div id="container-A">');
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
         <Suspense fallback={<Text text="Loading A..." />}>
@@ -346,13 +345,17 @@ describe('ReactDOMFizzServer', () => {
           </div>
         </Suspense>,
         writableA,
-        {identifierPrefix: 'A_'},
+        {
+          identifierPrefix: 'A_',
+          onReadyToStream() {
+            writableA.write('<div id="container-A">');
+            startWriting();
+            writableA.write('</div>');
+          },
+        },
       );
-      startWriting();
     });
-    writable.write('</div>');
 
-    writable.write('<div id="container-B">');
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
         <Suspense fallback={<Text text="Loading B..." />}>
@@ -362,11 +365,16 @@ describe('ReactDOMFizzServer', () => {
           </div>
         </Suspense>,
         writableB,
-        {identifierPrefix: 'B_'},
+        {
+          identifierPrefix: 'B_',
+          onReadyToStream() {
+            writableB.write('<div id="container-B">');
+            startWriting();
+            writableB.write('</div>');
+          },
+        },
       );
-      startWriting();
     });
-    writable.write('</div>');
 
     expect(getVisibleChildren(container)).toEqual([
       <div id="container-A">Loading A...</div>,

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -77,7 +77,7 @@ describe('ReactDOMFizzServer', () => {
         </Suspense>
       </div>,
       {
-        onComplete() {
+        onCompleteAll() {
           isComplete = true;
         },
       },

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -60,10 +60,16 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should error the stream when an error is thrown at the root', async () => {
+    const reportedErrors = [];
     const stream = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Throw />
       </div>,
+      {
+        onError(x) {
+          reportedErrors.push(x);
+        },
+      },
     );
 
     let caughtError = null;
@@ -75,16 +81,23 @@ describe('ReactDOMFizzServer', () => {
     }
     expect(caughtError).toBe(theError);
     expect(result).toBe('');
+    expect(reportedErrors).toEqual([theError]);
   });
 
   // @gate experimental
   it('should error the stream when an error is thrown inside a fallback', async () => {
+    const reportedErrors = [];
     const stream = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Suspense fallback={<Throw />}>
           <InfiniteSuspend />
         </Suspense>
       </div>,
+      {
+        onError(x) {
+          reportedErrors.push(x);
+        },
+      },
     );
 
     let caughtError = null;
@@ -96,20 +109,28 @@ describe('ReactDOMFizzServer', () => {
     }
     expect(caughtError).toBe(theError);
     expect(result).toBe('');
+    expect(reportedErrors).toEqual([theError]);
   });
 
   // @gate experimental
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
+    const reportedErrors = [];
     const stream = ReactDOMFizzServer.renderToReadableStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <Throw />
         </Suspense>
       </div>,
+      {
+        onError(x) {
+          reportedErrors.push(x);
+        },
+      },
     );
 
     const result = await readResult(stream);
     expect(result).toContain('Loading');
+    expect(reportedErrors).toEqual([theError]);
   });
 
   // @gate experimental

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -107,7 +107,7 @@ describe('ReactDOMFizzServer', () => {
       </div>,
       writable,
       {
-        onComplete() {
+        onCompleteAll() {
           isComplete = true;
         },
       },

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -87,6 +87,54 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // @gate experimental
+  it('emits all HTML as one unit if we wait until the end to start', async () => {
+    let hasLoaded = false;
+    let resolve;
+    const promise = new Promise(r => (resolve = r));
+    function Wait() {
+      if (!hasLoaded) {
+        throw promise;
+      }
+      return 'Done';
+    }
+    let isComplete = false;
+    const {writable, output} = getTestWritable();
+    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      <div>
+        <Suspense fallback="Loading">
+          <Wait />
+        </Suspense>
+      </div>,
+      writable,
+      {
+        onComplete() {
+          isComplete = true;
+        },
+      },
+    );
+    await jest.runAllTimers();
+    expect(output.result).toBe('');
+    expect(isComplete).toBe(false);
+    // Resolve the loading.
+    hasLoaded = true;
+    await resolve();
+
+    await jest.runAllTimers();
+
+    expect(output.result).toBe('');
+    expect(isComplete).toBe(true);
+
+    // First we write our header.
+    output.result +=
+      '<!doctype html><html><head><title>test</title><head><body>';
+    // Then React starts writing.
+    startWriting();
+    expect(output.result).toBe(
+      '<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!--/$--></div>',
+    );
+  });
+
+  // @gate experimental
   it('should error the stream when an error is thrown at the root', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -23,7 +23,7 @@ type Options = {
   progressiveChunkSize?: number,
   signal?: AbortSignal,
   onReadyToStream?: () => void,
-  onComplete?: () => void,
+  onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 };
 
@@ -48,7 +48,7 @@ function renderToReadableStream(
         createResponseState(options ? options.identifierPrefix : undefined),
         options ? options.progressiveChunkSize : undefined,
         options ? options.onError : undefined,
-        options ? options.onComplete : undefined,
+        options ? options.onCompleteAll : undefined,
         options ? options.onReadyToStream : undefined,
       );
       startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -22,6 +22,7 @@ type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
   signal?: AbortSignal,
+  onError?: (error: mixed) => void,
 };
 
 function renderToReadableStream(
@@ -44,6 +45,7 @@ function renderToReadableStream(
         controller,
         createResponseState(options ? options.identifierPrefix : undefined),
         options ? options.progressiveChunkSize : undefined,
+        options ? options.onError : undefined,
       );
       startWork(request);
     },

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -22,6 +22,7 @@ type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
   signal?: AbortSignal,
+  onReadyToStream?: () => void,
   onComplete?: () => void,
   onError?: (error: mixed) => void,
 };
@@ -48,6 +49,7 @@ function renderToReadableStream(
         options ? options.progressiveChunkSize : undefined,
         options ? options.onError : undefined,
         options ? options.onComplete : undefined,
+        options ? options.onReadyToStream : undefined,
       );
       startWork(request);
     },

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -26,6 +26,7 @@ function createDrainHandler(destination, request) {
 type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
+  onReadyToStream?: () => void,
   onComplete?: () => void,
   onError?: (error: mixed) => void,
 };
@@ -48,6 +49,7 @@ function pipeToNodeWritable(
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
     options ? options.onComplete : undefined,
+    options ? options.onReadyToStream : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -27,7 +27,7 @@ type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
   onReadyToStream?: () => void,
-  onComplete?: () => void,
+  onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 };
 
@@ -48,7 +48,7 @@ function pipeToNodeWritable(
     createResponseState(options ? options.identifierPrefix : undefined),
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
-    options ? options.onComplete : undefined,
+    options ? options.onCompleteAll : undefined,
     options ? options.onReadyToStream : undefined,
   );
   let hasStartedFlowing = false;

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -26,6 +26,7 @@ function createDrainHandler(destination, request) {
 type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
+  onComplete?: () => void,
   onError?: (error: mixed) => void,
 };
 
@@ -46,6 +47,7 @@ function pipeToNodeWritable(
     createResponseState(options ? options.identifierPrefix : undefined),
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
+    options ? options.onComplete : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -26,6 +26,7 @@ function createDrainHandler(destination, request) {
 type Options = {
   identifierPrefix?: string,
   progressiveChunkSize?: number,
+  onError?: (error: mixed) => void,
 };
 
 type Controls = {
@@ -44,6 +45,7 @@ function pipeToNodeWritable(
     destination,
     createResponseState(options ? options.identifierPrefix : undefined),
     options ? options.progressiveChunkSize : undefined,
+    options ? options.onError : undefined,
   );
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -217,6 +217,7 @@ const ReactNoopServer = ReactFizzServer({
 
 type Options = {
   progressiveChunkSize?: number,
+  onReadyToStream?: () => void,
   onComplete?: () => void,
   onError?: (error: mixed) => void,
 };
@@ -238,6 +239,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
     options ? options.onComplete : undefined,
+    options ? options.onReadyToStream : undefined,
   );
   ReactNoopServer.startWork(request);
   ReactNoopServer.startFlowing(request);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -217,6 +217,7 @@ const ReactNoopServer = ReactFizzServer({
 
 type Options = {
   progressiveChunkSize?: number,
+  onComplete?: () => void,
   onError?: (error: mixed) => void,
 };
 
@@ -236,6 +237,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
     null,
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
+    options ? options.onComplete : undefined,
   );
   ReactNoopServer.startWork(request);
   ReactNoopServer.startFlowing(request);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -217,6 +217,7 @@ const ReactNoopServer = ReactFizzServer({
 
 type Options = {
   progressiveChunkSize?: number,
+  onError?: (error: mixed) => void,
 };
 
 function render(children: React$Element<any>, options?: Options): Destination {
@@ -234,6 +235,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
     destination,
     null,
     options ? options.progressiveChunkSize : undefined,
+    options ? options.onError : undefined,
   );
   ReactNoopServer.startWork(request);
   ReactNoopServer.startFlowing(request);

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -218,7 +218,7 @@ const ReactNoopServer = ReactFizzServer({
 type Options = {
   progressiveChunkSize?: number,
   onReadyToStream?: () => void,
-  onComplete?: () => void,
+  onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 };
 
@@ -238,7 +238,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
     null,
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
-    options ? options.onComplete : undefined,
+    options ? options.onCompleteAll : undefined,
     options ? options.onReadyToStream : undefined,
   );
   ReactNoopServer.startWork(request);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -115,6 +115,10 @@ type Request = {
   // onComplete is called when all pending work is done but it may not have flushed yet.
   // This is a good time to start writing if you want only HTML and no intermediate steps.
   onComplete: () => void,
+  // onReadyToStream is called when there is at least a root fallback ready to show.
+  // Typically you don't need this callback because it's best practice to always have a
+  // root fallback ready so there's no need to wait.
+  onReadyToStream: () => void,
 };
 
 // This is a default heuristic for how to split up the HTML content into progressive
@@ -141,6 +145,7 @@ export function createRequest(
   progressiveChunkSize: number = DEFAULT_PROGRESSIVE_CHUNK_SIZE,
   onError: (error: mixed) => void = noop,
   onComplete: () => void = noop,
+  onReadyToStream: () => void = noop,
 ): Request {
   const pingedWork = [];
   const abortSet: Set<SuspendedWork> = new Set();
@@ -160,6 +165,7 @@ export function createRequest(
     partialBoundaries: [],
     onError,
     onComplete,
+    onReadyToStream,
   };
   // This segment represents the root fallback.
   const rootSegment = createPendingSegment(request, 0, null);
@@ -481,13 +487,16 @@ function finishedWork(
   segment: Segment,
 ) {
   if (boundary === null) {
-    request.pendingRootWork--;
     if (segment.parentFlushed) {
       invariant(
         request.completedRootSegment === null,
         'There can only be one root segment. This is a bug in React.',
       );
       request.completedRootSegment = segment;
+    }
+    request.pendingRootWork--;
+    if (request.pendingRootWork === 0) {
+      request.onReadyToStream();
     }
   } else {
     boundary.pendingWork--;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -112,9 +112,9 @@ type Request = {
   partialBoundaries: Array<SuspenseBoundary>, // Partially completed boundaries that can flush its segments early.
   // onError is called when an error happens anywhere in the tree. It might recover.
   onError: (error: mixed) => void,
-  // onComplete is called when all pending work is done but it may not have flushed yet.
+  // onCompleteAll is called when all pending work is done but it may not have flushed yet.
   // This is a good time to start writing if you want only HTML and no intermediate steps.
-  onComplete: () => void,
+  onCompleteAll: () => void,
   // onReadyToStream is called when there is at least a root fallback ready to show.
   // Typically you don't need this callback because it's best practice to always have a
   // root fallback ready so there's no need to wait.
@@ -144,7 +144,7 @@ export function createRequest(
   responseState: ResponseState,
   progressiveChunkSize: number = DEFAULT_PROGRESSIVE_CHUNK_SIZE,
   onError: (error: mixed) => void = noop,
-  onComplete: () => void = noop,
+  onCompleteAll: () => void = noop,
   onReadyToStream: () => void = noop,
 ): Request {
   const pingedWork = [];
@@ -164,7 +164,7 @@ export function createRequest(
     completedBoundaries: [],
     partialBoundaries: [],
     onError,
-    onComplete,
+    onCompleteAll,
     onReadyToStream,
   };
   // This segment represents the root fallback.
@@ -429,7 +429,7 @@ function erroredWork(
 
   request.allPendingWork--;
   if (request.allPendingWork === 0) {
-    request.onComplete();
+    request.onCompleteAll();
   }
 }
 
@@ -476,7 +476,7 @@ function abortWork(suspendedWork: SuspendedWork): void {
     }
 
     if (request.allPendingWork === 0) {
-      request.onComplete();
+      request.onCompleteAll();
     }
   }
 }
@@ -537,7 +537,7 @@ function finishedWork(
   if (request.allPendingWork === 0) {
     // This needs to be called at the very end so that we can synchronously write the result
     // in the callback if needed.
-    request.onComplete();
+    request.onCompleteAll();
   }
 }
 


### PR DESCRIPTION
__onError__ is called when an error happens anywhere in the tree. It can be called multiple times if it's not a fatal error. This can be used for logging or setting a status code of a request.

__onCompleteAll__ is called when all pending work is done but it may not have flushed yet. If you don't want to incrementally stream the content, you can wait to call startWriting until this point. That way we only emit the final HTML.

__onReadyToStream__ is called when there is at least a root fallback ready to show. You typically don't need this callback because you can just startWriting immediately if you don't expect to need to change the status code or anything.

Another strategy for deciding when to call startWriting is just a timer based approach that starts writing after some timeout.

In the future we can also add callbacks for when certain priority levels are complete. So you can for example wait until all the high pri content is done.