### PR TITLE
Fail build on deep requires in npm packages

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -582,6 +582,17 @@ async function createBundle(bundle, bundleType) {
       const containsThisModule = pkg => id === pkg || id.startsWith(pkg + '/');
       const isProvidedByDependency = externals.some(containsThisModule);
       if (!shouldBundleDependencies && isProvidedByDependency) {
+        if (id.indexOf('/src/') !== -1) {
+          throw Error(
+            'You are trying to import ' +
+              id +
+              ' but ' +
+              externals.find(containsThisModule) +
+              ' is one of npm dependencies, ' +
+              'so it will not contain that source file. You probably want ' +
+              'to create a new bundle entry point for it instead.'
+          );
+        }
         return true;
       }
       return !!peerGlobals[id];


### PR DESCRIPTION
This is to make it easier to spot when you need a solution like https://github.com/facebook/react/pull/21062.

Verified by importing from `react-reconciler/src/ReactEventPriorities` in the noop renderer instead of `react-reconciler/constants`. Previously this would leave a `require('react-reconciler/src/ReactEventPriorities')` call, but now it fails the build with an instruction.

Let's see if this actually builds.