### PR TITLE
Make opaque EventPriority type a Lane internally

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -23,6 +23,7 @@ import * as Scheduler from 'scheduler/unstable_mock';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 import {
   DefaultEventPriority,
+  IdleEventPriority,
   ConcurrentRoot,
   LegacyRoot,
 } from 'react-reconciler/constants';
@@ -909,7 +910,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
     idleUpdates<T>(fn: () => T): T {
       const prevEventPriority = currentEventPriority;
-      currentEventPriority = NoopRenderer.IdleEventPriority;
+      currentEventPriority = IdleEventPriority;
       try {
         fn();
       } finally {

--- a/packages/react-reconciler/src/ReactEventPriorities.new.js
+++ b/packages/react-reconciler/src/ReactEventPriorities.new.js
@@ -8,8 +8,8 @@
  */
 
 export {
-  SyncLanePriority as DiscreteEventPriority,
-  InputContinuousLanePriority as ContinuousEventPriority,
-  DefaultLanePriority as DefaultEventPriority,
-  IdleLanePriority as IdleEventPriority,
+  SyncLane as DiscreteEventPriority,
+  InputContinuousLane as ContinuousEventPriority,
+  DefaultLane as DefaultEventPriority,
+  IdleLane as IdleEventPriority,
 } from './ReactFiberLane.new';

--- a/packages/react-reconciler/src/ReactEventPriorities.old.js
+++ b/packages/react-reconciler/src/ReactEventPriorities.old.js
@@ -8,8 +8,8 @@
  */
 
 export {
-  SyncLanePriority as DiscreteEventPriority,
-  InputContinuousLanePriority as ContinuousEventPriority,
-  DefaultLanePriority as DefaultEventPriority,
-  IdleLanePriority as IdleEventPriority,
+  SyncLane as DiscreteEventPriority,
+  InputContinuousLane as ContinuousEventPriority,
+  DefaultLane as DefaultEventPriority,
+  IdleLane as IdleEventPriority,
 } from './ReactFiberLane.old';

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -118,7 +118,7 @@ export const SelectiveHydrationLane: Lane = /*          */ 0b0001000000000000000
 const NonIdleLanes = /*                                 */ 0b0001111111111111111111111111111;
 
 export const IdleHydrationLane: Lane = /*               */ 0b0010000000000000000000000000000;
-const IdleLane: Lanes = /*                              */ 0b0100000000000000000000000000000;
+export const IdleLane: Lanes = /*                       */ 0b0100000000000000000000000000000;
 
 export const OffscreenLane: Lane = /*                   */ 0b1000000000000000000000000000000;
 

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -118,7 +118,7 @@ export const SelectiveHydrationLane: Lane = /*          */ 0b0001000000000000000
 const NonIdleLanes = /*                                 */ 0b0001111111111111111111111111111;
 
 export const IdleHydrationLane: Lane = /*               */ 0b0010000000000000000000000000000;
-const IdleLane: Lanes = /*                              */ 0b0100000000000000000000000000000;
+export const IdleLane: Lanes = /*                       */ 0b0100000000000000000000000000000;
 
 export const OffscreenLane: Lane = /*                   */ 0b1000000000000000000000000000000;
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -93,16 +93,6 @@ import {
 } from './ReactFiberHotReloading.new';
 import {markRenderScheduled} from './SchedulingProfiler';
 
-// Ideally host configs would import these constants from the reconciler
-// entry point, but we can't do this because of a circular dependency.
-// They are used by third-party renderers so they need to stay up to date.
-export {
-  SyncLanePriority as DiscreteEventPriority,
-  InputContinuousLanePriority as ContinuousEventPriority,
-  DefaultLanePriority as DefaultEventPriority,
-  IdleLanePriority as IdleEventPriority,
-} from './ReactFiberLane.new';
-
 export {registerMutableSourceForHydration} from './ReactMutableSource.new';
 export {createPortal} from './ReactPortal';
 export {

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -93,16 +93,6 @@ import {
 } from './ReactFiberHotReloading.old';
 import {markRenderScheduled} from './SchedulingProfiler';
 
-// Ideally host configs would import these constants from the reconciler
-// entry point, but we can't do this because of a circular dependency.
-// They are used by third-party renderers so they need to stay up to date.
-export {
-  SyncLanePriority as DiscreteEventPriority,
-  InputContinuousLanePriority as ContinuousEventPriority,
-  DefaultLanePriority as DefaultEventPriority,
-  IdleLanePriority as IdleEventPriority,
-} from './ReactFiberLane.old';
-
 export {registerMutableSourceForHydration} from './ReactMutableSource.old';
 export {createPortal} from './ReactPortal';
 export {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -436,8 +436,11 @@ export function requestUpdateLane(fiber: Fiber): Lane {
 
   // This update originated outside React. Ask the host environement for an
   // appropriate priority, based on the type of event.
-  const eventLanePriority = getCurrentEventPriority();
-  return findUpdateLane(eventLanePriority);
+  //
+  // The opaque type returned by the host config is internally a lane, so we can
+  // use that directly.
+  const eventLane = getCurrentEventPriority();
+  return eventLane;
 }
 
 function requestRetryLane(fiber: Fiber) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -436,8 +436,11 @@ export function requestUpdateLane(fiber: Fiber): Lane {
 
   // This update originated outside React. Ask the host environement for an
   // appropriate priority, based on the type of event.
-  const eventLanePriority = getCurrentEventPriority();
-  return findUpdateLane(eventLanePriority);
+  //
+  // The opaque type returned by the host config is internally a lane, so we can
+  // use that directly.
+  const eventLane = getCurrentEventPriority();
+  return eventLane;
 }
 
 function requestRetryLane(fiber: Fiber) {

--- a/packages/react-reconciler/src/ReactReconcilerConstants.js
+++ b/packages/react-reconciler/src/ReactReconcilerConstants.js
@@ -14,5 +14,6 @@ export {
   DiscreteEventPriority,
   ContinuousEventPriority,
   DefaultEventPriority,
+  IdleEventPriority,
 } from './ReactEventPriorities';
 export {ConcurrentRoot, LegacyRoot} from './ReactRootTags';


### PR DESCRIPTION
Instead of LanePriority, we can use a Lane and skip the extra conversion. Eventually I want to get rid of LanePriority completely.