### PR TITLE
Make time-slicing opt-in

### DIFF
--- a/packages/create-subscription/src/__tests__/createSubscription-test.js
+++ b/packages/create-subscription/src/__tests__/createSubscription-test.js
@@ -268,6 +268,7 @@ describe('createSubscription', () => {
     expect(Scheduler).toFlushAndYield(['b-1']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('should ignore values emitted by a new subscribable until the commit phase', () => {
     const log = [];
 
@@ -325,7 +326,13 @@ describe('createSubscription', () => {
     expect(log).toEqual(['Parent.componentDidMount']);
 
     // Start React update, but don't finish
-    ReactNoop.render(<Parent observed={observableB} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Parent observed={observableB} />);
+      });
+    } else {
+      ReactNoop.render(<Parent observed={observableB} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Subscriber: b-0']);
     expect(log).toEqual(['Parent.componentDidMount']);
 
@@ -355,6 +362,7 @@ describe('createSubscription', () => {
     ]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('should not drop values emitted between updates', () => {
     const log = [];
 
@@ -412,7 +420,13 @@ describe('createSubscription', () => {
     expect(log).toEqual(['Parent.componentDidMount']);
 
     // Start React update, but don't finish
-    ReactNoop.render(<Parent observed={observableB} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Parent observed={observableB} />);
+      });
+    } else {
+      ReactNoop.render(<Parent observed={observableB} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Subscriber: b-0']);
     expect(log).toEqual(['Parent.componentDidMount']);
 

--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -360,6 +360,7 @@ describe('ReactART', () => {
     expect(onClick2).toBeCalled();
   });
 
+  // @gate !enableSyncDefaultUpdates
   it('can concurrently render with a "primary" renderer while sharing context', () => {
     const CurrentRendererContext = React.createContext(null);
 

--- a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
@@ -1934,7 +1934,13 @@ describe('DOMPluginEventSystem', () => {
             log.length = 0;
 
             // Increase counter
-            root.render(<Test counter={1} />);
+            if (gate(flags => flags.enableSyncDefaultUpdates)) {
+              React.unstable_startTransition(() => {
+                root.render(<Test counter={1} />);
+              });
+            } else {
+              root.render(<Test counter={1} />);
+            }
             // Yield before committing
             expect(Scheduler).toFlushAndYieldThrough(['Test']);
 

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -60,7 +60,7 @@ export const DefaultLane: Lanes = /*                    */ 0b0000000000000000000
 
 const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000000100000;
 const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111111000000;
-export const TransitionLane1: Lane = /*                 */ 0b0000000000000000000000001000000;
+const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000001000000;
 const TransitionLane2: Lane = /*                        */ 0b0000000000000000000000010000000;
 const TransitionLane3: Lane = /*                        */ 0b0000000000000000000000100000000;
 const TransitionLane4: Lane = /*                        */ 0b0000000000000000000001000000000;

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -52,7 +52,7 @@ export const NoLane: Lane = /*                          */ 0b0000000000000000000
 
 export const SyncLane: Lane = /*                        */ 0b0000000000000000000000000000001;
 
-const InputContinuousHydrationLane: Lane = /*           */ 0b0000000000000000000000000000010;
+export const InputContinuousHydrationLane: Lane = /*    */ 0b0000000000000000000000000000010;
 export const InputContinuousLane: Lanes = /*            */ 0b0000000000000000000000000000100;
 
 export const DefaultHydrationLane: Lane = /*            */ 0b0000000000000000000000000001000;
@@ -60,7 +60,7 @@ export const DefaultLane: Lanes = /*                    */ 0b0000000000000000000
 
 const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000000100000;
 const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111111000000;
-const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000001000000;
+export const TransitionLane1: Lane = /*                 */ 0b0000000000000000000000001000000;
 const TransitionLane2: Lane = /*                        */ 0b0000000000000000000000010000000;
 const TransitionLane3: Lane = /*                        */ 0b0000000000000000000000100000000;
 const TransitionLane4: Lane = /*                        */ 0b0000000000000000000001000000000;

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -60,7 +60,7 @@ export const DefaultLane: Lanes = /*                    */ 0b0000000000000000000
 
 const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000000100000;
 const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111111000000;
-export const TransitionLane1: Lane = /*                 */ 0b0000000000000000000000001000000;
+const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000001000000;
 const TransitionLane2: Lane = /*                        */ 0b0000000000000000000000010000000;
 const TransitionLane3: Lane = /*                        */ 0b0000000000000000000000100000000;
 const TransitionLane4: Lane = /*                        */ 0b0000000000000000000001000000000;

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -52,7 +52,7 @@ export const NoLane: Lane = /*                          */ 0b0000000000000000000
 
 export const SyncLane: Lane = /*                        */ 0b0000000000000000000000000000001;
 
-const InputContinuousHydrationLane: Lane = /*           */ 0b0000000000000000000000000000010;
+export const InputContinuousHydrationLane: Lane = /*    */ 0b0000000000000000000000000000010;
 export const InputContinuousLane: Lanes = /*            */ 0b0000000000000000000000000000100;
 
 export const DefaultHydrationLane: Lane = /*            */ 0b0000000000000000000000000001000;
@@ -60,7 +60,7 @@ export const DefaultLane: Lanes = /*                    */ 0b0000000000000000000
 
 const TransitionHydrationLane: Lane = /*                */ 0b0000000000000000000000000100000;
 const TransitionLanes: Lanes = /*                       */ 0b0000000001111111111111111000000;
-const TransitionLane1: Lane = /*                        */ 0b0000000000000000000000001000000;
+export const TransitionLane1: Lane = /*                 */ 0b0000000000000000000000001000000;
 const TransitionLane2: Lane = /*                        */ 0b0000000000000000000000010000000;
 const TransitionLane3: Lane = /*                        */ 0b0000000000000000000000100000000;
 const TransitionLane4: Lane = /*                        */ 0b0000000000000000000001000000000;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -32,6 +32,7 @@ import {
   disableSchedulerTimeoutInWorkLoop,
   enableStrictEffects,
   skipUnmountedBoundaries,
+  enableSyncDefaultUpdates,
   enableUpdaterTracking,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -138,6 +139,10 @@ import {
   NoLanes,
   NoLane,
   SyncLane,
+  DefaultLane,
+  DefaultHydrationLane,
+  InputContinuousLane,
+  InputContinuousHydrationLane,
   NoTimestamp,
   claimNextTransitionLane,
   claimNextRetryLane,
@@ -433,6 +438,13 @@ export function requestUpdateLane(fiber: Fiber): Lane {
   // TODO: Move this type conversion to the event priority module.
   const updateLane: Lane = (getCurrentUpdatePriority(): any);
   if (updateLane !== NoLane) {
+    if (
+      enableSyncDefaultUpdates &&
+      (updateLane === InputContinuousLane ||
+        updateLane === InputContinuousHydrationLane)
+    ) {
+      return DefaultLane;
+    }
     return updateLane;
   }
 
@@ -695,7 +707,16 @@ function ensureRootIsScheduled(root: FiberRoot, currentTime: number) {
 
   // Schedule a new callback.
   let newCallbackNode;
-  if (newCallbackPriority === SyncLane) {
+  if (
+    enableSyncDefaultUpdates &&
+    (newCallbackPriority === DefaultLane ||
+      newCallbackPriority === DefaultHydrationLane)
+  ) {
+    newCallbackNode = scheduleCallback(
+      ImmediateSchedulerPriority,
+      performSyncWorkOnRoot.bind(null, root),
+    );
+  } else if (newCallbackPriority === SyncLane) {
     // Special case: Sync React callbacks are scheduled on a special
     // internal queue
     scheduleSyncCallback(performSyncWorkOnRoot.bind(null, root));
@@ -1030,7 +1051,11 @@ function performSyncWorkOnRoot(root) {
   const finishedWork: Fiber = (root.current.alternate: any);
   root.finishedWork = finishedWork;
   root.finishedLanes = lanes;
-  commitRoot(root);
+  if (enableSyncDefaultUpdates && includesSomeLane(lanes, DefaultLane)) {
+    finishConcurrentRender(root, exitStatus, lanes);
+  } else {
+    commitRoot(root);
+  }
 
   // Before exiting, make sure there's a callback scheduled for the next
   // pending level.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1051,7 +1051,7 @@ function performSyncWorkOnRoot(root) {
   const finishedWork: Fiber = (root.current.alternate: any);
   root.finishedWork = finishedWork;
   root.finishedLanes = lanes;
-  if (enableSyncDefaultUpdates && includesSomeLane(lanes, DefaultLane)) {
+  if (enableSyncDefaultUpdates && !includesSomeLane(lanes, SyncLane)) {
     finishConcurrentRender(root, exitStatus, lanes);
   } else {
     commitRoot(root);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -455,6 +455,13 @@ export function requestUpdateLane(fiber: Fiber): Lane {
   // use that directly.
   // TODO: Move this type conversion to the event priority module.
   const eventLane: Lane = (getCurrentEventPriority(): any);
+  if (
+    enableSyncDefaultUpdates &&
+    (eventLane === InputContinuousLane ||
+      eventLane === InputContinuousHydrationLane)
+  ) {
+    return DefaultLane;
+  }
   return eventLane;
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -32,6 +32,7 @@ import {
   disableSchedulerTimeoutInWorkLoop,
   enableStrictEffects,
   skipUnmountedBoundaries,
+  enableSyncDefaultUpdates,
   enableUpdaterTracking,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -138,6 +139,10 @@ import {
   NoLanes,
   NoLane,
   SyncLane,
+  DefaultLane,
+  DefaultHydrationLane,
+  InputContinuousLane,
+  InputContinuousHydrationLane,
   NoTimestamp,
   claimNextTransitionLane,
   claimNextRetryLane,
@@ -433,6 +438,13 @@ export function requestUpdateLane(fiber: Fiber): Lane {
   // TODO: Move this type conversion to the event priority module.
   const updateLane: Lane = (getCurrentUpdatePriority(): any);
   if (updateLane !== NoLane) {
+    if (
+      enableSyncDefaultUpdates &&
+      (updateLane === InputContinuousLane ||
+        updateLane === InputContinuousHydrationLane)
+    ) {
+      return DefaultLane;
+    }
     return updateLane;
   }
 
@@ -695,7 +707,16 @@ function ensureRootIsScheduled(root: FiberRoot, currentTime: number) {
 
   // Schedule a new callback.
   let newCallbackNode;
-  if (newCallbackPriority === SyncLane) {
+  if (
+    enableSyncDefaultUpdates &&
+    (newCallbackPriority === DefaultLane ||
+      newCallbackPriority === DefaultHydrationLane)
+  ) {
+    newCallbackNode = scheduleCallback(
+      ImmediateSchedulerPriority,
+      performSyncWorkOnRoot.bind(null, root),
+    );
+  } else if (newCallbackPriority === SyncLane) {
     // Special case: Sync React callbacks are scheduled on a special
     // internal queue
     scheduleSyncCallback(performSyncWorkOnRoot.bind(null, root));
@@ -1030,7 +1051,11 @@ function performSyncWorkOnRoot(root) {
   const finishedWork: Fiber = (root.current.alternate: any);
   root.finishedWork = finishedWork;
   root.finishedLanes = lanes;
-  commitRoot(root);
+  if (enableSyncDefaultUpdates && includesSomeLane(lanes, DefaultLane)) {
+    finishConcurrentRender(root, exitStatus, lanes);
+  } else {
+    commitRoot(root);
+  }
 
   // Before exiting, make sure there's a callback scheduled for the next
   // pending level.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1051,7 +1051,7 @@ function performSyncWorkOnRoot(root) {
   const finishedWork: Fiber = (root.current.alternate: any);
   root.finishedWork = finishedWork;
   root.finishedLanes = lanes;
-  if (enableSyncDefaultUpdates && includesSomeLane(lanes, DefaultLane)) {
+  if (enableSyncDefaultUpdates && !includesSomeLane(lanes, SyncLane)) {
     finishConcurrentRender(root, exitStatus, lanes);
   } else {
     commitRoot(root);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -455,6 +455,13 @@ export function requestUpdateLane(fiber: Fiber): Lane {
   // use that directly.
   // TODO: Move this type conversion to the event priority module.
   const eventLane: Lane = (getCurrentEventPriority(): any);
+  if (
+    enableSyncDefaultUpdates &&
+    (eventLane === InputContinuousLane ||
+      eventLane === InputContinuousHydrationLane)
+  ) {
+    return DefaultLane;
+  }
   return eventLane;
 }
 

--- a/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
@@ -45,6 +45,7 @@ describe('ReactSuspenseList', () => {
     return Component;
   }
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('appends rendering tasks to the end of the priority queue', async () => {
     const A = createAsyncText('A');
     const B = createAsyncText('B');
@@ -63,7 +64,13 @@ describe('ReactSuspenseList', () => {
     root.render(<App show={false} />);
     expect(Scheduler).toFlushAndYield([]);
 
-    root.render(<App show={true} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        root.render(<App show={true} />);
+      });
+    } else {
+      root.render(<App show={true} />);
+    }
     expect(Scheduler).toFlushAndYield([
       'Suspend! [A]',
       'Suspend! [B]',

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -50,6 +50,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushWithoutYielding();
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('should render a simple component, in steps if needed', () => {
     function Bar() {
       Scheduler.unstable_yieldValue('Bar');
@@ -65,7 +66,17 @@ describe('ReactIncremental', () => {
       return [<Bar key="a" isBar={true} />, <Bar key="b" isBar={true} />];
     }
 
-    ReactNoop.render(<Foo />, () => Scheduler.unstable_yieldValue('callback'));
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />, () =>
+          Scheduler.unstable_yieldValue('callback'),
+        );
+      });
+    } else {
+      ReactNoop.render(<Foo />, () =>
+        Scheduler.unstable_yieldValue('callback'),
+      );
+    }
     // Do one step of work.
     expect(ReactNoop.flushNextYield()).toEqual(['Foo']);
 
@@ -132,6 +143,7 @@ describe('ReactIncremental', () => {
     ]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('can cancel partially rendered work and restart', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -152,13 +164,26 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Foo text="foo" />);
     expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'Bar']);
 
-    ReactNoop.render(<Foo text="bar" />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo text="bar" />);
+      });
+    } else {
+      ReactNoop.render(<Foo text="bar" />);
+    }
     // Flush part of the work
     expect(Scheduler).toFlushAndYieldThrough(['Foo', 'Bar']);
 
     // This will abort the previous work and restart
     ReactNoop.flushSync(() => ReactNoop.render(null));
-    ReactNoop.render(<Foo text="baz" />);
+
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo text="baz" />);
+      });
+    } else {
+      ReactNoop.render(<Foo text="baz" />);
+    }
 
     // Flush part of the new work
     expect(Scheduler).toFlushAndYieldThrough(['Foo', 'Bar']);
@@ -167,6 +192,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['Bar']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('should call callbacks even if updates are aborted', () => {
     let inst;
 
@@ -192,26 +218,50 @@ describe('ReactIncremental', () => {
     ReactNoop.render(<Foo />);
     expect(Scheduler).toFlushWithoutYielding();
 
-    inst.setState(
-      () => {
-        Scheduler.unstable_yieldValue('setState1');
-        return {text: 'bar'};
-      },
-      () => Scheduler.unstable_yieldValue('callback1'),
-    );
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        inst.setState(
+          () => {
+            Scheduler.unstable_yieldValue('setState1');
+            return {text: 'bar'};
+          },
+          () => Scheduler.unstable_yieldValue('callback1'),
+        );
+      });
+    } else {
+      inst.setState(
+        () => {
+          Scheduler.unstable_yieldValue('setState1');
+          return {text: 'bar'};
+        },
+        () => Scheduler.unstable_yieldValue('callback1'),
+      );
+    }
 
     // Flush part of the work
     expect(Scheduler).toFlushAndYieldThrough(['setState1']);
 
     // This will abort the previous work and restart
     ReactNoop.flushSync(() => ReactNoop.render(<Foo />));
-    inst.setState(
-      () => {
-        Scheduler.unstable_yieldValue('setState2');
-        return {text2: 'baz'};
-      },
-      () => Scheduler.unstable_yieldValue('callback2'),
-    );
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        inst.setState(
+          () => {
+            Scheduler.unstable_yieldValue('setState2');
+            return {text2: 'baz'};
+          },
+          () => Scheduler.unstable_yieldValue('callback2'),
+        );
+      });
+    } else {
+      inst.setState(
+        () => {
+          Scheduler.unstable_yieldValue('setState2');
+          return {text2: 'baz'};
+        },
+        () => Scheduler.unstable_yieldValue('callback2'),
+      );
+    }
 
     // Flush the rest of the work which now includes the low priority
     expect(Scheduler).toFlushAndYield([
@@ -1714,6 +1764,7 @@ describe('ReactIncremental', () => {
     expect(instance.state.n).toEqual(3);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('merges and masks context', () => {
     class Intl extends React.Component {
       static childContextTypes = {
@@ -1838,15 +1889,27 @@ describe('ReactIncremental', () => {
       'ShowLocale {"locale":"de"}',
       'ShowBoth {"locale":"de"}',
     ]);
-
-    ReactNoop.render(
-      <Intl locale="sv">
-        <ShowLocale />
-        <div>
-          <ShowBoth />
-        </div>
-      </Intl>,
-    );
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(
+          <Intl locale="sv">
+            <ShowLocale />
+            <div>
+              <ShowBoth />
+            </div>
+          </Intl>,
+        );
+      });
+    } else {
+      ReactNoop.render(
+        <Intl locale="sv">
+          <ShowLocale />
+          <div>
+            <ShowBoth />
+          </div>
+        </Intl>,
+      );
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Intl {}']);
 
     ReactNoop.render(
@@ -1994,18 +2057,35 @@ describe('ReactIncremental', () => {
       }
     }
 
-    ReactNoop.render(
-      <Intl locale="fr">
-        <ShowLocale />
-        <LegacyHiddenDiv mode="hidden">
-          <ShowLocale />
-          <Intl locale="ru">
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(
+          <Intl locale="fr">
             <ShowLocale />
-          </Intl>
-        </LegacyHiddenDiv>
-        <ShowLocale />
-      </Intl>,
-    );
+            <LegacyHiddenDiv mode="hidden">
+              <ShowLocale />
+              <Intl locale="ru">
+                <ShowLocale />
+              </Intl>
+            </LegacyHiddenDiv>
+            <ShowLocale />
+          </Intl>,
+        );
+      });
+    } else {
+      ReactNoop.render(
+        <Intl locale="fr">
+          <ShowLocale />
+          <LegacyHiddenDiv mode="hidden">
+            <ShowLocale />
+            <Intl locale="ru">
+              <ShowLocale />
+            </Intl>
+          </LegacyHiddenDiv>
+          <ShowLocale />
+        </Intl>,
+      );
+    }
     expect(Scheduler).toFlushAndYieldThrough([
       'Intl {}',
       'ShowLocale {"locale":"fr"}',
@@ -2748,6 +2828,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['count:1, name:not brian']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('does not interrupt for update at same priority', () => {
     function Parent(props) {
       Scheduler.unstable_yieldValue('Parent: ' + props.step);
@@ -2759,7 +2840,13 @@ describe('ReactIncremental', () => {
       return null;
     }
 
-    ReactNoop.render(<Parent step={1} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Parent step={1} />);
+      });
+    } else {
+      ReactNoop.render(<Parent step={1} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at same priority
@@ -2768,6 +2855,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['Child: 1', 'Parent: 2', 'Child: 2']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('does not interrupt for update at lower priority', () => {
     function Parent(props) {
       Scheduler.unstable_yieldValue('Parent: ' + props.step);
@@ -2779,7 +2867,13 @@ describe('ReactIncremental', () => {
       return null;
     }
 
-    ReactNoop.render(<Parent step={1} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Parent step={1} />);
+      });
+    } else {
+      ReactNoop.render(<Parent step={1} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at lower priority
@@ -2789,6 +2883,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['Child: 1', 'Parent: 2', 'Child: 2']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('does interrupt for update at higher priority', () => {
     function Parent(props) {
       Scheduler.unstable_yieldValue('Parent: ' + props.step);
@@ -2800,7 +2895,13 @@ describe('ReactIncremental', () => {
       return null;
     }
 
-    ReactNoop.render(<Parent step={1} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Parent step={1} />);
+      });
+    } else {
+      ReactNoop.render(<Parent step={1} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough(['Parent: 1']);
 
     // Interrupt at higher priority

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -34,6 +34,7 @@ describe('ReactIncrementalReflection', () => {
     return {type: 'span', children: [], prop, hidden: false};
   }
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('handles isMounted even when the initial render is deferred', () => {
     const instances = [];
 
@@ -63,7 +64,13 @@ describe('ReactIncrementalReflection', () => {
       return <Component />;
     }
 
-    ReactNoop.render(<Foo />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />);
+      });
+    } else {
+      ReactNoop.render(<Foo />);
+    }
 
     // Render part way through but don't yet commit the updates.
     expect(Scheduler).toFlushAndYieldThrough(['componentWillMount: false']);
@@ -81,6 +88,7 @@ describe('ReactIncrementalReflection', () => {
     expect(instances[0]._isMounted()).toBe(true);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('handles isMounted when an unmount is deferred', () => {
     const instances = [];
 
@@ -121,7 +129,13 @@ describe('ReactIncrementalReflection', () => {
 
     expect(instances[0]._isMounted()).toBe(true);
 
-    ReactNoop.render(<Foo mount={false} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo mount={false} />);
+      });
+    } else {
+      ReactNoop.render(<Foo mount={false} />);
+    }
     // Render part way through but don't yet commit the updates so it is not
     // fully unmounted yet.
     expect(Scheduler).toFlushAndYieldThrough(['Other']);
@@ -134,6 +148,7 @@ describe('ReactIncrementalReflection', () => {
     expect(instances[0]._isMounted()).toBe(false);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('finds no node before insertion and correct node before deletion', () => {
     let classInstance = null;
 
@@ -204,7 +219,13 @@ describe('ReactIncrementalReflection', () => {
       return [<Component key="a" step={props.step} />, <Sibling key="b" />];
     }
 
-    ReactNoop.render(<Foo step={0} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={0} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={0} />);
+    }
     // Flush past Component but don't complete rendering everything yet.
     expect(Scheduler).toFlushAndYieldThrough([
       ['componentWillMount', null],
@@ -246,7 +267,13 @@ describe('ReactIncrementalReflection', () => {
 
     // The next step will render a new host node but won't get committed yet.
     // We expect this to mutate the original Fiber.
-    ReactNoop.render(<Foo step={2} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={2} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={2} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough([
       ['componentWillUpdate', hostSpan],
       'render',
@@ -267,7 +294,13 @@ describe('ReactIncrementalReflection', () => {
     expect(ReactNoop.findInstance(classInstance)).toBe(hostDiv);
 
     // Render to null but don't commit it yet.
-    ReactNoop.render(<Foo step={3} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={3} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={3} />);
+    }
     expect(Scheduler).toFlushAndYieldThrough([
       ['componentWillUpdate', hostDiv],
       'render',

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -85,6 +85,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span prop={5} />);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('works on deferred roots in the order they were scheduled', () => {
     const {useEffect} = React;
     function Text({text}) {
@@ -107,8 +108,15 @@ describe('ReactIncrementalScheduling', () => {
 
     // Schedule deferred work in the reverse order
     ReactNoop.act(() => {
-      ReactNoop.renderToRootWithID(<Text text="c:2" />, 'c');
-      ReactNoop.renderToRootWithID(<Text text="b:2" />, 'b');
+      if (gate(flags => flags.enableSyncDefaultUpdates)) {
+        React.unstable_startTransition(() => {
+          ReactNoop.renderToRootWithID(<Text text="c:2" />, 'c');
+          ReactNoop.renderToRootWithID(<Text text="b:2" />, 'b');
+        });
+      } else {
+        ReactNoop.renderToRootWithID(<Text text="c:2" />, 'c');
+        ReactNoop.renderToRootWithID(<Text text="b:2" />, 'b');
+      }
       // Ensure it starts in the order it was scheduled
       expect(Scheduler).toFlushAndYieldThrough(['c:2']);
 
@@ -117,7 +125,13 @@ describe('ReactIncrementalScheduling', () => {
       expect(ReactNoop.getChildrenAsJSX('c')).toEqual('c:2');
       // Schedule last bit of work, it will get processed the last
 
-      ReactNoop.renderToRootWithID(<Text text="a:2" />, 'a');
+      if (gate(flags => flags.enableSyncDefaultUpdates)) {
+        React.unstable_startTransition(() => {
+          ReactNoop.renderToRootWithID(<Text text="a:2" />, 'a');
+        });
+      } else {
+        ReactNoop.renderToRootWithID(<Text text="a:2" />, 'a');
+      }
 
       // Keep performing work in the order it was scheduled
       expect(Scheduler).toFlushAndYieldThrough(['b:2']);
@@ -132,6 +146,7 @@ describe('ReactIncrementalScheduling', () => {
     });
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('schedules sync updates when inside componentDidMount/Update', () => {
     let instance;
 
@@ -170,7 +185,13 @@ describe('ReactIncrementalScheduling', () => {
       }
     }
 
-    ReactNoop.render(<Foo />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />);
+      });
+    } else {
+      ReactNoop.render(<Foo />);
+    }
     // Render without committing
     expect(Scheduler).toFlushAndYieldThrough(['render: 0']);
 
@@ -184,7 +205,13 @@ describe('ReactIncrementalScheduling', () => {
       'componentDidUpdate: 1',
     ]);
 
-    instance.setState({tick: 2});
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        instance.setState({tick: 2});
+      });
+    } else {
+      instance.setState({tick: 2});
+    }
     expect(Scheduler).toFlushAndYieldThrough(['render: 2']);
     expect(ReactNoop.flushNextYield()).toEqual([
       'componentDidUpdate: 2',
@@ -197,6 +224,7 @@ describe('ReactIncrementalScheduling', () => {
     ]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('can opt-in to async scheduling inside componentDidMount/Update', () => {
     let instance;
     class Foo extends React.Component {
@@ -255,20 +283,39 @@ describe('ReactIncrementalScheduling', () => {
 
     // Increment the tick to 2. This will trigger an update inside cDU. Flush
     // the first update without flushing the second one.
-    instance.setState({tick: 2});
-    expect(Scheduler).toFlushAndYieldThrough([
-      'render: 2',
-      'componentDidUpdate: 2',
-      'componentDidUpdate (before setState): 2',
-      'componentDidUpdate (after setState): 2',
-    ]);
-    expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        instance.setState({tick: 2});
+      });
 
-    // Now flush the cDU update.
-    expect(Scheduler).toFlushAndYield(['render: 3', 'componentDidUpdate: 3']);
-    expect(ReactNoop).toMatchRenderedOutput(<span prop={3} />);
+      // TODO: why does this flush sync?
+      expect(Scheduler).toFlushAndYieldThrough([
+        'render: 2',
+        'componentDidUpdate: 2',
+        'componentDidUpdate (before setState): 2',
+        'componentDidUpdate (after setState): 2',
+        'render: 3',
+        'componentDidUpdate: 3',
+      ]);
+      expect(ReactNoop).toMatchRenderedOutput(<span prop={3} />);
+    } else {
+      instance.setState({tick: 2});
+
+      expect(Scheduler).toFlushAndYieldThrough([
+        'render: 2',
+        'componentDidUpdate: 2',
+        'componentDidUpdate (before setState): 2',
+        'componentDidUpdate (after setState): 2',
+      ]);
+      expect(ReactNoop).toMatchRenderedOutput(<span prop={2} />);
+
+      // Now flush the cDU update.
+      expect(Scheduler).toFlushAndYield(['render: 3', 'componentDidUpdate: 3']);
+      expect(ReactNoop).toMatchRenderedOutput(<span prop={3} />);
+    }
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('performs Task work even after time runs out', () => {
     class Foo extends React.Component {
       state = {step: 1};
@@ -286,7 +333,14 @@ describe('ReactIncrementalScheduling', () => {
         return <span prop={this.state.step} />;
       }
     }
-    ReactNoop.render(<Foo />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />);
+      });
+    } else {
+      ReactNoop.render(<Foo />);
+    }
+
     // This should be just enough to complete all the work, but not enough to
     // commit it.
     expect(Scheduler).toFlushAndYieldThrough(['Foo']);

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -384,6 +384,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildren('portalContainer')).toEqual([]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('does not update child nodes if a flush is aborted', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -409,7 +410,13 @@ describe('ReactIncrementalSideEffects', () => {
       div(div(span('Hello'), span('Hello')), span('Yo')),
     ]);
 
-    ReactNoop.render(<Foo text="World" />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo text="World" />);
+      });
+    } else {
+      ReactNoop.render(<Foo text="World" />);
+    }
 
     // Flush some of the work without committing
     expect(Scheduler).toFlushAndYieldThrough(['Foo', 'Bar']);
@@ -633,12 +640,19 @@ describe('ReactIncrementalSideEffects', () => {
     );
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('can update a completed tree before it has a chance to commit', () => {
     function Foo(props) {
       Scheduler.unstable_yieldValue('Foo');
       return <span prop={props.step} />;
     }
-    ReactNoop.render(<Foo step={1} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={1} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={1} />);
+    }
     // This should be just enough to complete the tree without committing it
     expect(Scheduler).toFlushAndYieldThrough(['Foo']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(null);
@@ -647,13 +661,26 @@ describe('ReactIncrementalSideEffects', () => {
     ReactNoop.flushNextYield();
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={1} />);
 
-    ReactNoop.render(<Foo step={2} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={2} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={2} />);
+    }
     // This should be just enough to complete the tree without committing it
     expect(Scheduler).toFlushAndYieldThrough(['Foo']);
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={1} />);
     // This time, before we commit the tree, we update the root component with
     // new props
-    ReactNoop.render(<Foo step={3} />);
+
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo step={3} />);
+      });
+    } else {
+      ReactNoop.render(<Foo step={3} />);
+    }
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={1} />);
     // Now let's commit. We already had a commit that was pending, which will
     // render 2.

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -1475,6 +1475,7 @@ describe('ReactLazy', () => {
   });
 
   // @gate enableLazyElements
+  // @gate experimental || !enableSyncDefaultUpdates
   it('mount and reorder lazy elements', async () => {
     class Child extends React.Component {
       componentDidMount() {
@@ -1534,7 +1535,13 @@ describe('ReactLazy', () => {
     expect(root).toMatchRenderedOutput('AB');
 
     // Swap the position of A and B
-    root.update(<Parent swap={true} />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        root.update(<Parent swap={true} />);
+      });
+    } else {
+      root.update(<Parent swap={true} />);
+    }
     expect(Scheduler).toFlushAndYield(['Init B2', 'Loading...']);
     await lazyChildB2;
     // We need to flush to trigger the second one to load.

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -828,6 +828,7 @@ describe('ReactNewContext', () => {
       );
     });
 
+    // @gate experimental || !enableSyncDefaultUpdates
     it('warns if multiple renderers concurrently render the same context', () => {
       spyOnDev(console, 'error');
       const Context = React.createContext(0);
@@ -846,7 +847,13 @@ describe('ReactNewContext', () => {
         );
       }
 
-      ReactNoop.render(<App value={1} />);
+      if (gate(flags => flags.enableSyncDefaultUpdates)) {
+        React.unstable_startTransition(() => {
+          ReactNoop.render(<App value={1} />);
+        });
+      } else {
+        ReactNoop.render(<App value={1} />);
+      }
       // Render past the Provider, but don't commit yet
       expect(Scheduler).toFlushAndYieldThrough(['Foo']);
 

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -88,6 +88,7 @@ describe('ReactSchedulerIntegration', () => {
     ]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('requests a paint after committing', () => {
     const scheduleCallback = Scheduler.unstable_scheduleCallback;
 
@@ -100,7 +101,13 @@ describe('ReactSchedulerIntegration', () => {
     scheduleCallback(NormalPriority, () => Scheduler.unstable_yieldValue('C'));
 
     // Schedule a React render. React will request a paint after committing it.
-    root.render('Update');
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        root.render('Update');
+      });
+    } else {
+      root.render('Update');
+    }
 
     // Advance time just to be sure the next tasks have lower priority
     Scheduler.unstable_advanceTime(2000);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -1274,7 +1274,13 @@ describe('ReactSuspenseList', () => {
     }
 
     // This render is only CPU bound. Nothing suspends.
-    ReactNoop.render(<Foo />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />);
+      });
+    } else {
+      ReactNoop.render(<Foo />);
+    }
 
     expect(Scheduler).toFlushAndYieldThrough(['A']);
 
@@ -1452,7 +1458,13 @@ describe('ReactSuspenseList', () => {
     }
 
     // This render is only CPU bound. Nothing suspends.
-    ReactNoop.render(<Foo />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<Foo />);
+      });
+    } else {
+      ReactNoop.render(<Foo />);
+    }
 
     expect(Scheduler).toFlushAndYieldThrough(['A']);
 
@@ -2449,7 +2461,13 @@ describe('ReactSuspenseList', () => {
 
     await ReactNoop.act(async () => {
       // Add a few items at the end.
-      updateLowPri(true);
+      if (gate(flags => flags.enableSyncDefaultUpdates)) {
+        React.unstable_startTransition(() => {
+          updateLowPri(true);
+        });
+      } else {
+        updateLowPri(true);
+      }
 
       // Flush partially through.
       expect(Scheduler).toFlushAndYieldThrough(['B', 'C']);
@@ -2586,7 +2604,13 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<App />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<App />);
+      });
+    } else {
+      ReactNoop.render(<App />);
+    }
 
     expect(Scheduler).toFlushAndYieldThrough([
       'App',
@@ -2653,7 +2677,13 @@ describe('ReactSuspenseList', () => {
       );
     }
 
-    ReactNoop.render(<App />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        ReactNoop.render(<App />);
+      });
+    } else {
+      ReactNoop.render(<App />);
+    }
 
     expect(Scheduler).toFlushAndYieldThrough([
       'App',

--- a/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
@@ -452,7 +452,11 @@ describe('updaters', () => {
     };
     const LowPriorityUpdater = () => {
       const [count, setCount] = React.useState(0);
-      triggerLowPriorityUpdate = () => setCount(prevCount => prevCount + 1);
+      triggerLowPriorityUpdate = () => {
+        React.unstable_startTransition(() => {
+          setCount(prevCount => prevCount + 1);
+        });
+      };
       Scheduler.unstable_yieldValue(`LowPriorityUpdater ${count}`);
       return <Yield value={`LowPriority ${count}`} />;
     };

--- a/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfiler-test.internal.js
@@ -13,12 +13,19 @@
 // This test is *.internal so that it can import this shared file.
 import ReactVersion from 'shared/ReactVersion';
 
+// Hard-coding because importing will not work with bundle tests and to
+// avoid leaking exports for lanes that are only imported in this test.
+const ReactFiberLane = {
+  SyncLane: /*        */ 0b0000000000000000000000000000001,
+  DefaultLane: /*     */ 0b0000000000000000000000000010000,
+  TransitionLane1: /* */ 0b0000000000000000000000001000000,
+};
+
 describe('SchedulingProfiler', () => {
   let React;
   let ReactTestRenderer;
   let ReactNoop;
   let Scheduler;
-  let ReactFiberLane;
 
   let clearedMarks;
   let featureDetectionMarkName = null;
@@ -82,11 +89,6 @@ describe('SchedulingProfiler', () => {
 
     const SchedulingProfiler = require('react-reconciler/src/SchedulingProfiler');
     formatLanes = SchedulingProfiler.formatLanes;
-
-    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFiberLane = ReactFeatureFlags.enableNewReconciler
-      ? require('react-reconciler/src/ReactFiberLane.new')
-      : require('react-reconciler/src/ReactFiberLane.old');
   });
 
   afterEach(() => {

--- a/packages/react-reconciler/src/__tests__/SchedulingProfilerLabels-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfilerLabels-test.internal.js
@@ -168,10 +168,18 @@ describe('SchedulingProfiler labels', () => {
       event.initEvent('mouseover', true, true);
       dispatchAndSetCurrentEvent(targetRef.current, event);
     });
-    expect(clearedMarks).toContain(
-      `--schedule-state-update-${formatLanes(
-        ReactFiberLane.InputContinuousLane,
-      )}-App`,
-    );
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      expect(clearedMarks).toContain(
+        `--schedule-state-update-${formatLanes(
+          ReactFiberLane.DefaultLane,
+        )}-App`,
+      );
+    } else {
+      expect(clearedMarks).toContain(
+        `--schedule-state-update-${formatLanes(
+          ReactFiberLane.InputContinuousLane,
+        )}-App`,
+      );
+    }
   });
 });

--- a/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
@@ -262,7 +262,13 @@ describe('useMutableSourceHydration', () => {
     });
     expect(() => {
       act(() => {
-        root.render(<TestComponent />);
+        if (gate(flags => flags.enableSyncDefaultUpdates)) {
+          React.unstable_startTransition(() => {
+            root.render(<TestComponent />);
+          });
+        } else {
+          root.render(<TestComponent />);
+        }
         expect(Scheduler).toFlushAndYieldThrough(['a:one']);
         source.value = 'two';
       });
@@ -316,22 +322,43 @@ describe('useMutableSourceHydration', () => {
     });
     expect(() => {
       act(() => {
-        root.render(
-          <>
-            <Component
-              label="0"
-              getSnapshot={getSnapshotA}
-              mutableSource={mutableSource}
-              subscribe={subscribeA}
-            />
-            <Component
-              label="1"
-              getSnapshot={getSnapshotB}
-              mutableSource={mutableSource}
-              subscribe={subscribeB}
-            />
-          </>,
-        );
+        if (gate(flags => flags.enableSyncDefaultUpdates)) {
+          React.unstable_startTransition(() => {
+            root.render(
+              <>
+                <Component
+                  label="0"
+                  getSnapshot={getSnapshotA}
+                  mutableSource={mutableSource}
+                  subscribe={subscribeA}
+                />
+                <Component
+                  label="1"
+                  getSnapshot={getSnapshotB}
+                  mutableSource={mutableSource}
+                  subscribe={subscribeB}
+                />
+              </>,
+            );
+          });
+        } else {
+          root.render(
+            <>
+              <Component
+                label="0"
+                getSnapshot={getSnapshotA}
+                mutableSource={mutableSource}
+                subscribe={subscribeA}
+              />
+              <Component
+                label="1"
+                getSnapshot={getSnapshotB}
+                mutableSource={mutableSource}
+                subscribe={subscribeB}
+              />
+            </>,
+          );
+        }
         expect(Scheduler).toFlushAndYieldThrough(['0:a:one']);
         source.valueB = 'b:two';
       });
@@ -386,7 +413,13 @@ describe('useMutableSourceHydration', () => {
 
     expect(() => {
       act(() => {
-        root.render(<TestComponent flag={1} />);
+        if (gate(flags => flags.enableSyncDefaultUpdates)) {
+          React.unstable_startTransition(() => {
+            root.render(<TestComponent flag={1} />);
+          });
+        } else {
+          root.render(<TestComponent flag={1} />);
+        }
         expect(Scheduler).toFlushAndYieldThrough([1]);
 
         // Render an update which will be higher priority than the hydration.

--- a/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSourceHydration-test.js
@@ -371,6 +371,7 @@ describe('useMutableSourceHydration', () => {
   });
 
   // @gate experimental
+  // @gate !enableSyncDefaultUpdates
   it('should detect a tear during a higher priority interruption', () => {
     const source = createSource('one');
     const mutableSource = createMutableSource(source, param => param.version);

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererAsync-test.js
@@ -73,6 +73,7 @@ describe('ReactTestRendererAsync', () => {
     expect(renderer.toJSON()).toEqual(['A:2', 'B:2', 'C:2']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('flushThrough flushes until the expected values is yielded', () => {
     function Child(props) {
       Scheduler.unstable_yieldValue(props.children);
@@ -87,9 +88,19 @@ describe('ReactTestRendererAsync', () => {
         </>
       );
     }
-    const renderer = ReactTestRenderer.create(<Parent step={1} />, {
-      unstable_isConcurrent: true,
-    });
+
+    let renderer;
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        renderer = ReactTestRenderer.create(<Parent step={1} />, {
+          unstable_isConcurrent: true,
+        });
+      });
+    } else {
+      renderer = ReactTestRenderer.create(<Parent step={1} />, {
+        unstable_isConcurrent: true,
+      });
+    }
 
     // Flush the first two siblings
     expect(Scheduler).toFlushAndYieldThrough(['A:1', 'B:1']);
@@ -101,6 +112,7 @@ describe('ReactTestRendererAsync', () => {
     expect(renderer.toJSON()).toEqual(['A:1', 'B:1', 'C:1']);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('supports high priority interruptions', () => {
     function Child(props) {
       Scheduler.unstable_yieldValue(props.children);
@@ -124,9 +136,18 @@ describe('ReactTestRendererAsync', () => {
       }
     }
 
-    const renderer = ReactTestRenderer.create(<Example step={1} />, {
-      unstable_isConcurrent: true,
-    });
+    let renderer;
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        renderer = ReactTestRenderer.create(<Example step={1} />, {
+          unstable_isConcurrent: true,
+        });
+      });
+    } else {
+      renderer = ReactTestRenderer.create(<Example step={1} />, {
+        unstable_isConcurrent: true,
+      });
+    }
 
     // Flush the some of the changes, but don't commit
     expect(Scheduler).toFlushAndYieldThrough(['A:1']);

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -150,12 +150,8 @@ describe('ReactDOMTracing', () => {
             );
             expect(Scheduler).toFlushAndYieldThrough(['Child', 'Child:mount']);
             expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-            if (gate(flags => flags.enableSyncDefaultUpdates)) {
-              // TODO: why is this 3?
-              expect(onRender).toHaveBeenCalledTimes(3);
-            } else {
-              expect(onRender).toHaveBeenCalledTimes(2);
-            }
+
+            expect(onRender).toHaveBeenCalledTimes(2);
             expect(onRender).toHaveLastRenderedWithInteractions(
               new Set([interaction]),
             );

--- a/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
+++ b/packages/react/src/__tests__/ReactDOMTracing-test.internal.js
@@ -123,11 +123,21 @@ describe('ReactDOMTracing', () => {
         SchedulerTracing.unstable_trace('initialization', 0, () => {
           interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
           act(() => {
-            root.render(
-              <React.Profiler id="test" onRender={onRender}>
-                <App />
-              </React.Profiler>,
-            );
+            if (gate(flags => flags.enableSyncDefaultUpdates)) {
+              React.unstable_startTransition(() => {
+                root.render(
+                  <React.Profiler id="test" onRender={onRender}>
+                    <App />
+                  </React.Profiler>,
+                );
+              });
+            } else {
+              root.render(
+                <React.Profiler id="test" onRender={onRender}>
+                  <App />
+                </React.Profiler>,
+              );
+            }
             expect(onInteractionTraced).toHaveBeenCalledTimes(1);
             expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
               interaction,
@@ -140,7 +150,12 @@ describe('ReactDOMTracing', () => {
             );
             expect(Scheduler).toFlushAndYieldThrough(['Child', 'Child:mount']);
             expect(onInteractionScheduledWorkCompleted).not.toHaveBeenCalled();
-            expect(onRender).toHaveBeenCalledTimes(2);
+            if (gate(flags => flags.enableSyncDefaultUpdates)) {
+              // TODO: why is this 3?
+              expect(onRender).toHaveBeenCalledTimes(3);
+            } else {
+              expect(onRender).toHaveBeenCalledTimes(2);
+            }
             expect(onRender).toHaveLastRenderedWithInteractions(
               new Set([interaction]),
             );
@@ -275,11 +290,21 @@ describe('ReactDOMTracing', () => {
         SchedulerTracing.unstable_trace('initialization', 0, () => {
           interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
           act(() => {
-            root.render(
-              <React.Profiler id="test" onRender={onRender}>
-                <App />
-              </React.Profiler>,
-            );
+            if (gate(flags => flags.enableSyncDefaultUpdates)) {
+              React.unstable_startTransition(() => {
+                root.render(
+                  <React.Profiler id="test" onRender={onRender}>
+                    <App />
+                  </React.Profiler>,
+                );
+              });
+            } else {
+              root.render(
+                <React.Profiler id="test" onRender={onRender}>
+                  <App />
+                </React.Profiler>,
+              );
+            }
             expect(onInteractionTraced).toHaveBeenCalledTimes(1);
             expect(onInteractionTraced).toHaveBeenLastNotifiedOfInteraction(
               interaction,
@@ -307,16 +332,13 @@ describe('ReactDOMTracing', () => {
         expect(
           onInteractionScheduledWorkCompleted,
         ).toHaveBeenLastNotifiedOfInteraction(interaction);
-        if (gate(flags => flags.enableUseJSStackToTrackPassiveDurations)) {
-          expect(onRender).toHaveBeenCalledTimes(3);
-        } else {
-          // TODO: This is 4 instead of 3 because this update was scheduled at
-          // idle priority, and idle updates are slightly higher priority than
-          // offscreen work. So it takes two render passes to finish it. Profiler
-          // calls `onRender` for the first render even though everything
-          // bails out.
-          expect(onRender).toHaveBeenCalledTimes(4);
-        }
+
+        // TODO: This is 4 instead of 3 because this update was scheduled at
+        // idle priority, and idle updates are slightly higher priority than
+        // offscreen work. So it takes two render passes to finish it. Profiler
+        // calls `onRender` for the first render even though everything
+        // bails out.
+        expect(onRender).toHaveBeenCalledTimes(4);
         expect(onRender).toHaveLastRenderedWithInteractions(
           new Set([interaction]),
         );
@@ -503,7 +525,13 @@ describe('ReactDOMTracing', () => {
               scheduleUpdateWithHidden(),
             );
           });
-          scheduleUpdate();
+          if (gate(flags => flags.enableSyncDefaultUpdates)) {
+            React.unstable_startTransition(() => {
+              scheduleUpdate();
+            });
+          } else {
+            scheduleUpdate();
+          }
           expect(interaction).not.toBeNull();
           expect(onRender).toHaveBeenCalledTimes(1);
           expect(onInteractionTraced).toHaveBeenCalledTimes(1);
@@ -580,7 +608,13 @@ describe('ReactDOMTracing', () => {
           SchedulerTracing.unstable_trace('initialization', 0, () => {
             interaction = Array.from(SchedulerTracing.unstable_getCurrent())[0];
             // This render is only CPU bound. Nothing suspends.
-            root.render(<App />);
+            if (gate(flags => flags.enableSyncDefaultUpdates)) {
+              React.unstable_startTransition(() => {
+                root.render(<App />);
+              });
+            } else {
+              root.render(<App />);
+            }
           });
 
           expect(Scheduler).toFlushAndYieldThrough(['A']);

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -178,6 +178,7 @@ describe('ReactProfiler DevTools integration', () => {
     ]);
   });
 
+  // @gate experimental || !enableSyncDefaultUpdates
   it('regression test: #17159', () => {
     function Text({text}) {
       Scheduler.unstable_yieldValue(text);
@@ -195,7 +196,13 @@ describe('ReactProfiler DevTools integration', () => {
     // for updates.
     Scheduler.unstable_advanceTime(10000);
     // Schedule an update.
-    root.update(<Text text="B" />);
+    if (gate(flags => flags.enableSyncDefaultUpdates)) {
+      React.unstable_startTransition(() => {
+        root.update(<Text text="B" />);
+      });
+    } else {
+      root.update(<Text text="B" />);
+    }
 
     // Update B should not instantly expire.
     expect(Scheduler).toFlushAndYieldThrough([]);

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -170,3 +170,5 @@ export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 
 export const enableLazyContextPropagation = false;
+
+export const enableSyncDefaultUpdates = true;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -60,6 +60,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -60,7 +60,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -59,6 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = false;
+export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -59,3 +59,4 @@ export const deletedTreeCleanUpLevel = __VARIANT__ ? 3 : 1;
 export const enableProfilerNestedUpdateScheduledHook = __VARIANT__;
 export const disableSchedulerTimeoutInWorkLoop = __VARIANT__;
 export const enableLazyContextPropagation = __VARIANT__;
+export const enableSyncDefaultUpdates = __VARIANT__;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -34,6 +34,7 @@ export const {
   disableSchedulerTimeoutInWorkLoop,
   enableLazyContextPropagation,
   deletedTreeCleanUpLevel,
+  enableSyncDefaultUpdates,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -92,9 +93,6 @@ export const warnUnstableRenderSubtreeIntoContainer = false;
 export const enableNewReconciler = __VARIANT__;
 
 export const enableRecursiveCommitTraversal = false;
-
-// WWW is on the new sync behavior by default unless overridden by roots.
-export const enableSyncDefaultUpdates = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -93,6 +93,9 @@ export const enableNewReconciler = __VARIANT__;
 
 export const enableRecursiveCommitTraversal = false;
 
+// WWW is on the new sync behavior by default unless overridden by roots.
+export const enableSyncDefaultUpdates = __VARIANT__;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;


### PR DESCRIPTION
## Overview

This PR adds a new flag to synchronously flush updates in a task by default.

This has the practical effect of **making time-slicing optional in the next major version**.

### Motivation

As we've iterated on concurrent features like `Suspense` and `startTransition`, we've seen the benefits of [Time-slicing](https://reactjs.org/blog/2018/03/01/sneak-peek-beyond-react-16.html) not only in those APIs, but also for time-slicing updates by default as shown in the talk above. Time slicing allows React to yield to other work while rendering and allow higher priority tasks such as user interactions, network events, or other renders to be processed. Based on this research, time-slicing by default is the future of React.

However, time-slicing can cause issues with existing code that was not written with yielding in mind. For example, by yielding to other work, we allow for the possibility that external sources of information read during render are updated. This can cause tearing - where part of the UI displays an old value and another part shows a new value. This isn't a React specific bug - it's the logical consequence of concurrency.

We've introduced warnings and dev-behavior to StrictMode to help users catch these types of issues, however there is still a large part of the community that is not ready for the new behavior by default. If we were to keep time-slicing on by default for all updates, then most users would need to convert their entire app to support concurrency all at once before upgrading to the next major version of React. 

### Changes
This PR updates the default behavior of React in the next major version to flush updates synchronously in a task, similar to how the current behavior works. This means users will not use time-slicing by default when upgrading to the concurrent root, and their app will continue to synchronously render (almost) the same as before.

To opt-in to time-slicing, users can incrementally adopt concurrent features such are `Suspense` (which will concurrently re-try rendering with time-slicing) or `startTransition` (which will render updates concurrently with time-slicing). This strategy allows users to begin to use concurrent features in subtrees of their app, while working to adopt `StrictMode` globally and prepare for the future of React with time-slicing by default.
