### PR TITLE
Remove server side lower casing warning

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -1228,15 +1228,7 @@ describe('ReactDOMComponent', () => {
         }
       }
 
-      let returnedValue;
-
-      expect(() => {
-        returnedValue = ReactDOMServer.renderToString(<Container />);
-      }).toErrorDev(
-        '<BR /> is using incorrect casing. ' +
-          'Use PascalCase for React components, ' +
-          'or lowercase for HTML elements.',
-      );
+      const returnedValue = ReactDOMServer.renderToString(<Container />);
       expect(returnedValue).not.toContain('</BR>');
     });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -795,35 +795,25 @@ describe('ReactDOMServer', () => {
     }
   });
 
-  it('warns about lowercase html but not in svg tags', () => {
+  it('does not warn about lowercase html especially not in svg tags', () => {
     function CompositeG(props) {
       // Make sure namespace passes through composites
       return <g>{props.children}</g>;
     }
-    expect(() =>
-      ReactDOMServer.renderToStaticMarkup(
-        <div>
-          <inPUT />
-          <svg>
-            <CompositeG>
-              <linearGradient />
-              <foreignObject>
-                {/* back to HTML */}
-                <iFrame />
-              </foreignObject>
-            </CompositeG>
-          </svg>
-        </div>,
-      ),
-    ).toErrorDev([
-      'Warning: <inPUT /> is using incorrect casing. ' +
-        'Use PascalCase for React components, ' +
-        'or lowercase for HTML elements.',
-      // linearGradient doesn't warn
-      'Warning: <iFrame /> is using incorrect casing. ' +
-        'Use PascalCase for React components, ' +
-        'or lowercase for HTML elements.',
-    ]);
+    ReactDOMServer.renderToStaticMarkup(
+      <div>
+        <inPUT />
+        <svg>
+          <CompositeG>
+            <linearGradient />
+            <foreignObject>
+              {/* back to HTML */}
+              <iFrame />
+            </foreignObject>
+          </CompositeG>
+        </svg>
+      </div>,
+    );
   });
 
   it('should warn about contentEditable and children', () => {


### PR DESCRIPTION
It's the only thing (outside selected value which has its own complexities with suspense) that's contextual. It's not worth adding a host config at runtime for this. So I'm removing it for parity.

We have this warning on the client. We don't have other warnings like ancestor nesting on the server anyway. We can instead warn for those in the hydration phase if we need to.