### PR TITLE
React Fabric: Support passing nativeViewTag to getInspectorDataForViewAtPoint callback, for React DevTools compat

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -192,7 +192,8 @@ if (__DEV__) {
             internalInstanceHandle.stateNode.canonical._internalInstanceHandle;
 
           // Note: this is deprecated and we want to remove it ASAP. Keeping it here for React DevTools compatibility for now.
-          const nativeViewTag = internalInstanceHandle.stateNode.canonical._nativeTag;
+          const nativeViewTag =
+            internalInstanceHandle.stateNode.canonical._nativeTag;
 
           nativeFabricUIManager.measure(
             internalInstanceHandle.stateNode.node,

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -198,7 +198,7 @@ if (__DEV__) {
             internalInstanceHandle.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
               const inspectorData = getInspectorDataForInstance(
-                getClosestInstanceFromNode(closestInstance),
+                closestInstance,
               );
               callback({
                 ...inspectorData,

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -190,13 +190,21 @@ if (__DEV__) {
 
           closestInstance =
             internalInstanceHandle.stateNode.canonical._internalInstanceHandle;
+
+          // Note: this is deprecated and we want to remove it ASAP. Keeping it here for React DevTools compatibility for now.
+          const nativeViewTag = internalInstanceHandle.stateNode.canonical._nativeTag;
+
           nativeFabricUIManager.measure(
             internalInstanceHandle.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
+              const inspectorData = getInspectorDataForInstance(
+                getClosestInstanceFromNode(closestInstance),
+              );
               callback({
+                ...inspectorData,
                 pointerY: locationY,
                 frame: {left: pageX, top: pageY, width, height},
-                ...getInspectorDataForInstance(closestInstance),
+                touchedViewTag: nativeViewTag,
               });
             },
           );


### PR DESCRIPTION
React Fabric: Support passing nativeViewTag to getInspectorDataForViewAtPoint callback, for React DevTools compat

## Summary

React DevTools needs a React Tag to highlight a component. Fabric tries not to expose this, but we can expose it "temporarily" ;) for React DevTools compat.

React DevTools will need to be refactored in the future to take a HostComponent instance.

## Test Plan

yarn flow fabric && yarn flow native && yarn lint && yarn test

Test inspector in Fabric, on iOS and Android (videos coming in a bit)