### PR TITLE
Add @noinline directive to getBumpedLaneForHydration

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -786,6 +786,12 @@ export function markRootEntangled(root: FiberRoot, entangledLanes: Lanes) {
   }
 }
 
+/**
+ * This function gets inlined in a way that breaks `lane`;
+ * it gets combined with another variable (`nextFallbackChildren`) in `updateSuspenseComponent`.
+ * Longer term, this should be fixed on the Closure side.
+ * @noinline
+ */
 export function getBumpedLaneForHydration(
   root: FiberRoot,
   renderLanes: Lanes,

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -786,6 +786,12 @@ export function markRootEntangled(root: FiberRoot, entangledLanes: Lanes) {
   }
 }
 
+/**
+ * This function gets inlined in a way that breaks `lane`;
+ * it gets combined with another variable (`nextFallbackChildren`) in `updateSuspenseComponent`.
+ * Longer term, this should be fixed on the Closure side.
+ * @noinline
+ */
 export function getBumpedLaneForHydration(
   root: FiberRoot,
   renderLanes: Lanes,


### PR DESCRIPTION
**Edit**: Moving this back into draft for now; see this comment https://github.com/facebook/react/pull/21081#issuecomment-806257915

---

During compilation, `getBumpedLaneForHydration` was being inlined in a way that breaks the local `lane` variable (making it possible for that variable to have an `undefined` value – which would not be a possible value for it to have, given the way the code was written).

As part of being inlined, `lane` is also being combined with another variable (`nextFallbackChildren`) in `updateSuspenseComponent` which can be undefined if `props.fallback` is undefined (an uncommon case, but one that is supported):

<img width="411" alt="Screen Shot 2021-03-24 at 7 20 47 PM" src="https://user-images.githubusercontent.com/29597/112397141-e3a48780-8cd7-11eb-9fae-6424e6be066b.png">

I think this should fix the problem temporarily. I'll look at the CI-generated artifact to confirm before landing.

Longer term, this should be fixed on the Closure side presumably. I'll try to create a repro for them.