### PR TITLE
[Fizz] Add separator comment between text nodes

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -55,7 +55,7 @@ describe('ReactDOMFizzServer', () => {
       <div>hello world</div>,
     );
     const result = await readResult(stream);
-    expect(result).toBe('<div>hello world</div>');
+    expect(result).toMatchInlineSnapshot(`"<div>hello world<!-- --></div>"`);
   });
 
   // @gate experimental
@@ -93,7 +93,9 @@ describe('ReactDOMFizzServer', () => {
     expect(isComplete).toBe(true);
 
     const result = await readResult(stream);
-    expect(result).toBe('<div><!--$-->Done<!--/$--></div>');
+    expect(result).toMatchInlineSnapshot(
+      `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
+    );
   });
 
   // @gate experimental

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -65,7 +65,9 @@ describe('ReactDOMFizzServer', () => {
     );
     startWriting();
     jest.runAllTimers();
-    expect(output.result).toBe('<div>hello world</div>');
+    expect(output.result).toMatchInlineSnapshot(
+      `"<div>hello world<!-- --></div>"`,
+    );
   });
 
   // @gate experimental
@@ -81,8 +83,8 @@ describe('ReactDOMFizzServer', () => {
       '<!doctype html><html><head><title>test</title><head><body>';
     // Then React starts writing.
     startWriting();
-    expect(output.result).toBe(
-      '<!doctype html><html><head><title>test</title><head><body><div>hello world</div>',
+    expect(output.result).toMatchInlineSnapshot(
+      `"<!doctype html><html><head><title>test</title><head><body><div>hello world<!-- --></div>"`,
     );
   });
 
@@ -129,8 +131,8 @@ describe('ReactDOMFizzServer', () => {
       '<!doctype html><html><head><title>test</title><head><body>';
     // Then React starts writing.
     startWriting();
-    expect(output.result).toBe(
-      '<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!--/$--></div>',
+    expect(output.result).toMatchInlineSnapshot(
+      `"<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!-- --><!--/$--></div>"`,
     );
   });
 

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -104,6 +104,8 @@ export function pushEmpty(
   }
 }
 
+const textSeparator = stringToPrecomputedChunk('<!-- -->');
+
 export function pushTextInstance(
   target: Array<Chunk | PrecomputedChunk>,
   text: string,
@@ -113,7 +115,12 @@ export function pushTextInstance(
   if (assignID !== null) {
     pushDummyNodeWithID(target, responseState, assignID);
   }
-  target.push(stringToChunk(encodeHTMLTextNode(text)));
+  if (text === '') {
+    // Empty text doesn't have a DOM node representation and the hydration is aware of this.
+    return;
+  }
+  // TODO: Avoid adding a text separator in common cases.
+  target.push(stringToChunk(encodeHTMLTextNode(text)), textSeparator);
 }
 
 const startTag1 = stringToPrecomputedChunk('<');


### PR DESCRIPTION
This is needed to avoid mutating the DOM during hydration.

This *always* adds it even when it's just text children. We need to avoid this overhead but it's a somewhat tricky problem to solve so we defer the optimization to later. This is also related to https://github.com/facebook/react/issues/13342 which is similarly difficult.

The thing that makes this difficult in Fizz is that there might be a segment that is currently suspended that may or may not render text nodes. Before or After this text node. Or there can be consecutive suspended components that resolve in various order.

We also want the result to be deterministic so if we can't always optimize it away, regardless of if/when those things resolve, then we should always insert it.

We could possible do the determination when segments resolve but then they need pointers to their parents and siblings.

I think there's a way to solve this by determining whether to emit a separator is done at the flush stage. It adds more computation there and unfortunately we'd need data structures that likely affects all "renderers".

Dropping the determinism constraint might also be an option (id-generation isn't atm).