### PR TITLE
[Fast Refresh] Add more built-in Hooks to the list

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -230,6 +230,10 @@ export default function(babel, opts = {}) {
       case 'React.useImperativeHandle':
       case 'useDebugValue':
       case 'React.useDebugValue':
+      case 'useTransition':
+      case 'React.useTransition':
+      case 'useDeferredValue':
+      case 'React.useDeferredValue':
         return true;
       default:
         return false;


### PR DESCRIPTION
This isn't really important, just doing it for consistency. These won't show up in the array we're collecting that's used for traversing custom Hooks, which we do to compose a signature.