### PR TITLE
[Fizz] Add FormatContext and Refactor Work

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -16,7 +16,10 @@ import {
   abort,
 } from 'react-server/src/ReactFizzServer';
 
-import {createResponseState} from './ReactDOMServerFormatConfig';
+import {
+  createResponseState,
+  createRootFormatContext,
+} from './ReactDOMServerFormatConfig';
 
 type Options = {
   identifierPrefix?: string,
@@ -46,6 +49,7 @@ function renderToReadableStream(
         children,
         controller,
         createResponseState(options ? options.identifierPrefix : undefined),
+        createRootFormatContext(), // We call this here in case we need options to initialize it.
         options ? options.progressiveChunkSize : undefined,
         options ? options.onError : undefined,
         options ? options.onCompleteAll : undefined,

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -17,7 +17,10 @@ import {
   abort,
 } from 'react-server/src/ReactFizzServer';
 
-import {createResponseState} from './ReactDOMServerFormatConfig';
+import {
+  createResponseState,
+  createRootFormatContext,
+} from './ReactDOMServerFormatConfig';
 
 function createDrainHandler(destination, request) {
   return () => startFlowing(request);
@@ -46,6 +49,7 @@ function pipeToNodeWritable(
     children,
     destination,
     createResponseState(options ? options.identifierPrefix : undefined),
+    createRootFormatContext(), // We call this here in case we need options to initialize it.
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
     options ? options.onCompleteAll : undefined,

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -66,6 +66,33 @@ export function createResponseState(): ResponseState {
   };
 }
 
+// isInAParentText
+export type FormatContext = boolean;
+
+export function createRootFormatContext(): FormatContext {
+  return false;
+}
+
+export function getChildFormatContext(
+  parentContext: FormatContext,
+  type: string,
+  props: Object,
+): FormatContext {
+  const prevIsInAParentText = parentContext;
+  const isInAParentText =
+    type === 'AndroidTextInput' || // Android
+    type === 'RCTMultilineTextInputView' || // iOS
+    type === 'RCTSinglelineTextInputView' || // iOS
+    type === 'RCTText' ||
+    type === 'RCTVirtualText';
+
+  if (prevIsInAParentText !== isInAParentText) {
+    return isInAParentText;
+  } else {
+    return parentContext;
+  }
+}
+
 // This object is used to lazily reuse the ID of the first generated node, or assign one.
 // This is very specific to DOM where we can't assign an ID to.
 export type SuspenseBoundaryID = number;

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -82,6 +82,10 @@ const ReactNoopServer = ReactFizzServer({
     return {state: 'pending', children: []};
   },
 
+  getChildFormatContext(): null {
+    return null;
+  },
+
   pushTextInstance(target: Array<Uint8Array>, text: string): void {
     const textInstance: TextInstance = {
       text,
@@ -235,6 +239,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
   const request = ReactNoopServer.createRequest(
     children,
     destination,
+    null,
     null,
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -26,8 +26,10 @@
 declare var $$$hostConfig: any;
 export opaque type Destination = mixed; // eslint-disable-line no-undef
 export opaque type ResponseState = mixed;
+export opaque type FormatContext = mixed;
 export opaque type SuspenseBoundaryID = mixed;
 
+export const getChildFormatContext = $$$hostConfig.getChildFormatContext;
 export const createSuspenseBoundaryID = $$$hostConfig.createSuspenseBoundaryID;
 export const pushEmpty = $$$hostConfig.pushEmpty;
 export const pushTextInstance = $$$hostConfig.pushTextInstance;


### PR DESCRIPTION
I'll need the equivalent of HostContext for keeping track of which namespace we're rendering in and some other things. There are also some contextual things already and we need to add some more for "New" Context and Legacy Context.

There are a couple of ways we could deal with Context. We could pass it on the stack to every function (that's what I was doing before). We could store it on something "thread local" in module scope like how "New" Context works.

In Fizz we don't need to yield in the middle of rendering so we can use the stack and we only need one "thread local". However, we might need to be able to switch between various contexts and pick up a context. That's what SuspendedWork is. A heap allocation for where to pick back up.

There's also a downside to passing everything recursively in the stack. 1) We use extra stack memory which risks running out. 2) We have to write to the stack for each call. Typically the same thing over and over. 3) We also have to save/restore it every time we context switch. 

So instead, I opted to just keep the "SuspendedWork" as the place where these contextual things are stored and we can temporarily override them along the stack where we need to. It's just one extra hidden class check I think to get it from there rather than the stack so should be strictly faster.

The "New" Context implementation does need restore/reset but that's a separate later issue and dependent on implementation details.

I also took this opportunity to synchronously render the content of Suspense boundaries since we can cheaply take advantage of already being in the right context.

_Note: We could actually implement Fiber like this too. We'd just create SuspendedWork if we run out of time same as what we do when we suspend. In other words, it would use a recursive stack up until a point and then create a continuation there._