### PR TITLE
Use `act` in fuzz tester to flush expired work

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.js
@@ -562,6 +562,12 @@ ${formatActions(actions)}
         ['b', flush(7)],
         ['c', toggle(0)],
       );
+
+      simulateMultipleRoots(
+        ['c', step(1)],
+        ['c', expire(5000)],
+        ['b', toggle(1)],
+      );
     });
 
     it('generative tests', () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalTriangle-test.js
@@ -432,7 +432,9 @@ describe('ReactIncrementalTriangle', () => {
         assertConsistentTree(activeLeafIndices);
       }
       // Flush remaining work
-      Scheduler.unstable_flushAllWithoutAsserting();
+      ReactNoop.act(() => {
+        Scheduler.unstable_flushAllWithoutAsserting();
+      });
       assertConsistentTree(activeLeafIndices, expectedCounterAtEnd);
     }
 


### PR DESCRIPTION
Expired work gets scheduled in a microtask now, so we need to use `act` to flush it.