### PR TITLE
Delete enableDiscreteEventFlushingChange

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -155,8 +155,6 @@ export const enableLegacyFBSupport = false;
 // new behavior.
 export const deferRenderPhaseUpdateToNextBatch = true;
 
-export const enableDiscreteEventFlushingChange = false;
-
 export const enableUseRefAccessWarning = false;
 
 export const enableRecursiveCommitTraversal = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -50,7 +50,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = true;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = false;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -49,7 +49,6 @@ export const deletedTreeCleanUpLevel = 1;
 
 export const enableNewReconciler = false;
 export const deferRenderPhaseUpdateToNextBatch = true;
-export const enableDiscreteEventFlushingChange = true;
 
 export const enableStrictEffects = false;
 export const createRootStrictEffectsByDefault = false;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -83,8 +83,6 @@ export const disableTextareaChildren = __EXPERIMENTAL__;
 
 export const warnUnstableRenderSubtreeIntoContainer = false;
 
-export const enableDiscreteEventFlushingChange = true;
-
 // Enable forked reconciler. Piggy-backing on the "variant" global so that we
 // don't have to add another test dimension. The build system will compile this
 // to the correct value.


### PR DESCRIPTION
This flag was meant to avoid flushing discrete updates unnecessarily, if multiple discrete events were dispatched in response to the same platform event.

But since we now flush all discrete events at the end of the task, in a microtask, it no longer has any effect.
