### PR TITLE
RFC: flushSync should flush passive effects if they were the result of a sync update

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1148,6 +1148,14 @@ export function unbatchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
 }
 
 export function flushSync<A, R>(fn: A => R, a: A): R {
+  if (includesSomeLane(pendingPassiveEffectsLanes, SyncLane)) {
+    // If there are pending passive effects with sync priority, flush them now,
+    // so the callback can observe the result.
+    if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
+      flushPassiveEffects();
+    }
+  }
+
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1148,6 +1148,14 @@ export function unbatchedUpdates<A, R>(fn: (a: A) => R, a: A): R {
 }
 
 export function flushSync<A, R>(fn: A => R, a: A): R {
+  if (includesSomeLane(pendingPassiveEffectsLanes, SyncLane)) {
+    // If there are pending passive effects with sync priority, flush them now,
+    // so the callback can observe the result.
+    if ((executionContext & (RenderContext | CommitContext)) === NoContext) {
+      flushPassiveEffects();
+    }
+  }
+
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
 


### PR DESCRIPTION
If there are pending passive effects that were the result of a sync/discrete update, `flushSync()` should flush them, so the caller can observe the result.

We can skip passive effects that don't have sync/discrete priority.

This would replace the need for `flushDiscreteUpdates()`, which is identical to `flushSync()` except for this.