### PR TITLE
Remove redundant setUpdatePriority call

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -49,7 +49,6 @@ import {
   markRootMutableRead,
 } from './ReactFiberLane.new';
 import {
-  DefaultEventPriority,
   ContinuousEventPriority,
   getCurrentUpdatePriority,
   setCurrentUpdatePriority,
@@ -1711,11 +1710,6 @@ function startTransition(setPending, callback) {
   );
 
   setPending(true);
-
-  // TODO: Can remove this. Was only necessary because we used to give
-  // different behavior to transitions without a config object. Now they are
-  // all treated the same.
-  setCurrentUpdatePriority(DefaultEventPriority);
 
   const prevTransition = ReactCurrentBatchConfig.transition;
   ReactCurrentBatchConfig.transition = 1;

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -49,7 +49,6 @@ import {
   markRootMutableRead,
 } from './ReactFiberLane.old';
 import {
-  DefaultEventPriority,
   ContinuousEventPriority,
   getCurrentUpdatePriority,
   setCurrentUpdatePriority,
@@ -1711,11 +1710,6 @@ function startTransition(setPending, callback) {
   );
 
   setPending(true);
-
-  // TODO: Can remove this. Was only necessary because we used to give
-  // different behavior to transitions without a config object. Now they are
-  // all treated the same.
-  setCurrentUpdatePriority(DefaultEventPriority);
 
   const prevTransition = ReactCurrentBatchConfig.transition;
   ReactCurrentBatchConfig.transition = 1;


### PR DESCRIPTION
See removed TODO comment. This call is no longer necessary because we use the dispatcher to track whether we're inside a transition, not the event priority.