### PR TITLE
[Fizz/Flight] Log all errors to console.error by default on the server

### DIFF
--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -156,10 +156,15 @@ describe('ReactFlight', () => {
       return <div ref={ref} />;
     }
 
-    const event = ReactNoopFlightServer.render(<EventHandlerProp />);
-    const fn = ReactNoopFlightServer.render(<FunctionProp />);
-    const symbol = ReactNoopFlightServer.render(<SymbolProp />);
-    const refs = ReactNoopFlightServer.render(<RefProp />);
+    const options = {
+      onError() {
+        // ignore
+      },
+    };
+    const event = ReactNoopFlightServer.render(<EventHandlerProp />, options);
+    const fn = ReactNoopFlightServer.render(<FunctionProp />, options);
+    const symbol = ReactNoopFlightServer.render(<SymbolProp />, options);
+    const refs = ReactNoopFlightServer.render(<RefProp />, options);
 
     function Client({transport}) {
       return ReactNoopFlightClient.read(transport);
@@ -213,7 +218,11 @@ describe('ReactFlight', () => {
       );
     }
 
-    const data = ReactNoopFlightServer.render(<Server />);
+    const data = ReactNoopFlightServer.render(<Server />, {
+      onError(x) {
+        // ignore
+      },
+    });
 
     function Client({transport}) {
       return ReactNoopFlightClient.read(transport);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -142,13 +142,17 @@ type Request = {
 // 500 * 1024 / 8 * .8 * 0.5 / 2
 const DEFAULT_PROGRESSIVE_CHUNK_SIZE = 12800;
 
+function defaultErrorHandler(error: mixed) {
+  console['error'](error); // Don't transform to our wrapper
+}
+
 export function createRequest(
   children: ReactNodeList,
   destination: Destination,
   responseState: ResponseState,
   rootContext: FormatContext,
   progressiveChunkSize: number = DEFAULT_PROGRESSIVE_CHUNK_SIZE,
-  onError: (error: mixed) => void = noop,
+  onError: (error: mixed) => void = defaultErrorHandler,
   onCompleteAll: () => void = noop,
   onReadyToStream: () => void = noop,
 ): Request {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,7 +91,9 @@ export type Request = {
 
 const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 
-function defaultErrorHandler() {}
+function defaultErrorHandler(error: mixed) {
+  console['error'](error); // Don't transform to our wrapper
+}
 
 export function createRequest(
   model: ReactModel,


### PR DESCRIPTION
Builds on #21129 and #21056.

It can be tricky to discover server errors, especially errors in React itself or where we gracefully fallback or hand off to the client.

In ReactDOM client, we log all errors to the console even if they're handled by an error boundary. You have to attach a global onerror listener and preventDefault on that to silence those errors.

On the server you can pass an onError callback. I went with an approach where if you don't pass an onError callback we log to the console by default. But if you do, then we don't. So it's up to you to ensure that you log them somehow if you implement this callback.

In the future we might attach component stacks to both the onError callback and these logs, but we don't have components stacks neither in Flight nor Fizz yet.