### PR TITLE
Don't import star from ReactDOM

### DIFF
--- a/packages/react-dom/src/client/ReactDOMOption.js
+++ b/packages/react-dom/src/client/ReactDOMOption.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import * as React from 'react';
+import {Children} from 'react';
 import {getToStringValue, toString} from './ToStringValue';
 
 let didWarnSelectedSetOnOption = false;
@@ -21,7 +21,7 @@ function flattenChildren(children) {
   // Note that this would throw on non-element objects.
   // Elements are stringified (which is normally irrelevant
   // but matters for <fbt>).
-  React.Children.forEach(children, function(child) {
+  Children.forEach(children, function(child) {
     if (child == null) {
       return;
     }
@@ -45,7 +45,7 @@ export function validateProps(element: Element, props: Object) {
     // TODO: this seems like it could cause a DEV-only throw for hydration
     // if children contains a non-element object. We should try to avoid that.
     if (typeof props.children === 'object' && props.children !== null) {
-      React.Children.forEach(props.children, function(child) {
+      Children.forEach(props.children, function(child) {
         if (child == null) {
           return;
         }


### PR DESCRIPTION
Another one. Ideally we should remove the use of Children here and have a more specific implementation so we can extract Children helpers.