### PR TITLE
Support nesting of React.startTransition and ReactDOM.flushSync

### DIFF
--- a/packages/react-reconciler/src/ReactEventPriorities.old.js
+++ b/packages/react-reconciler/src/ReactEventPriorities.old.js
@@ -7,10 +7,11 @@
  * @flow
  */
 
-import type {Lane, Lanes} from './ReactFiberLane.old';
+import type {Lanes} from './ReactFiberLane.old';
+
+import ReactSharedInternals from 'shared/ReactSharedInternals';
 
 import {
-  NoLane,
   SyncLane,
   InputContinuousLane,
   DefaultLane,
@@ -19,30 +20,41 @@ import {
   includesNonIdleWork,
 } from './ReactFiberLane.old';
 
-export opaque type EventPriority = Lane;
+const {ReactCurrentBatchConfig} = ReactSharedInternals;
+
+export opaque type EventPriority = number;
 
 export const DiscreteEventPriority: EventPriority = SyncLane;
 export const ContinuousEventPriority: EventPriority = InputContinuousLane;
 export const DefaultEventPriority: EventPriority = DefaultLane;
 export const IdleEventPriority: EventPriority = IdleLane;
 
-let currentUpdatePriority: EventPriority = NoLane;
+// This should stay in sync with the isomorphic package (ReactStartTransition).
+// Intentionally not using a shared module, because this crosses a package
+// boundary: importing from a shared module would give a false sense of
+// DRYness, because it's theoretically possible for for the renderer and
+// the isomorphic package to be out of sync. We don't fully support that, but we
+// should try (within reason) to be resilient.
+//
+// The value is an arbitrary transition lane. I picked a lane in the middle of
+// the bitmask because it's unlikely to change meaning.
+export const TransitionEventPriority = 0b0000000000000001000000000000000;
 
 export function getCurrentUpdatePriority(): EventPriority {
-  return currentUpdatePriority;
+  return ReactCurrentBatchConfig.transition;
 }
 
 export function setCurrentUpdatePriority(newPriority: EventPriority) {
-  currentUpdatePriority = newPriority;
+  ReactCurrentBatchConfig.transition = newPriority;
 }
 
 export function runWithPriority<T>(priority: EventPriority, fn: () => T): T {
-  const previousPriority = currentUpdatePriority;
+  const previousPriority = ReactCurrentBatchConfig.transition;
   try {
-    currentUpdatePriority = priority;
+    ReactCurrentBatchConfig.transition = priority;
     return fn();
   } finally {
-    currentUpdatePriority = previousPriority;
+    ReactCurrentBatchConfig.transition = previousPriority;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -50,6 +50,7 @@ import {
 } from './ReactFiberLane.new';
 import {
   ContinuousEventPriority,
+  TransitionEventPriority,
   getCurrentUpdatePriority,
   setCurrentUpdatePriority,
   higherEventPriority,
@@ -1664,8 +1665,9 @@ function updateMemo<T>(
 function mountDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = mountState(value);
   mountEffect(() => {
+    // TODO: Replace with setCurrentUpdatePriority
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1678,8 +1680,9 @@ function mountDeferredValue<T>(value: T): T {
 function updateDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = updateState(value);
   updateEffect(() => {
+    // TODO: Replace with setCurrentUpdatePriority
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1693,7 +1696,7 @@ function rerenderDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = rerenderState(value);
   updateEffect(() => {
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1711,8 +1714,9 @@ function startTransition(setPending, callback) {
 
   setPending(true);
 
+  // TODO: Replace with setCurrentUpdatePriority
   const prevTransition = ReactCurrentBatchConfig.transition;
-  ReactCurrentBatchConfig.transition = 1;
+  ReactCurrentBatchConfig.transition = TransitionEventPriority;
   try {
     setPending(false);
     callback();

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -50,6 +50,7 @@ import {
 } from './ReactFiberLane.old';
 import {
   ContinuousEventPriority,
+  TransitionEventPriority,
   getCurrentUpdatePriority,
   setCurrentUpdatePriority,
   higherEventPriority,
@@ -1664,8 +1665,9 @@ function updateMemo<T>(
 function mountDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = mountState(value);
   mountEffect(() => {
+    // TODO: Replace with setCurrentUpdatePriority
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1678,8 +1680,9 @@ function mountDeferredValue<T>(value: T): T {
 function updateDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = updateState(value);
   updateEffect(() => {
+    // TODO: Replace with setCurrentUpdatePriority
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1693,7 +1696,7 @@ function rerenderDeferredValue<T>(value: T): T {
   const [prevValue, setValue] = rerenderState(value);
   updateEffect(() => {
     const prevTransition = ReactCurrentBatchConfig.transition;
-    ReactCurrentBatchConfig.transition = 1;
+    ReactCurrentBatchConfig.transition = TransitionEventPriority;
     try {
       setValue(value);
     } finally {
@@ -1711,8 +1714,9 @@ function startTransition(setPending, callback) {
 
   setPending(true);
 
+  // TODO: Replace with setCurrentUpdatePriority
   const prevTransition = ReactCurrentBatchConfig.transition;
-  ReactCurrentBatchConfig.transition = 1;
+  ReactCurrentBatchConfig.transition = TransitionEventPriority;
   try {
     setPending(false);
     callback();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -148,6 +148,7 @@ import {
   includesNonIdleWork,
   includesOnlyRetries,
   includesOnlyTransitions,
+  isTransitionLane,
   getNextLanes,
   markStarvedLanesAsExpired,
   getLanesToRetrySynchronouslyOnError,
@@ -170,7 +171,6 @@ import {
   higherEventPriority,
   lanesToEventPriority,
 } from './ReactEventPriorities.old';
-import {requestCurrentTransition, NoTransition} from './ReactFiberTransition';
 import {beginWork as originalBeginWork} from './ReactFiberBeginWork.old';
 import {completeWork} from './ReactFiberCompleteWork.old';
 import {unwindWork, unwindInterruptedWork} from './ReactFiberUnwindWork.old';
@@ -401,8 +401,14 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     return pickArbitraryLane(workInProgressRootRenderLanes);
   }
 
-  const isTransition = requestCurrentTransition() !== NoTransition;
-  if (isTransition) {
+  // The opaque type returned by the host config is internally a lane.
+  // TODO: Move this type conversion to the event priority module.
+  const eventPriority: Lane = (getCurrentUpdatePriority(): any);
+
+  // Check if this is a transition. These are special because unlike other
+  // priorities, we don't assign the same lane to all transitions. We assign
+  // one of multiple possible lanes, so that transitions can run in parallel.
+  if (isTransitionLane(eventPriority)) {
     // The algorithm for assigning an update to a lane should be stable for all
     // updates at the same priority within the same event. To do this, the
     // inputs to the algorithm must be the same.
@@ -417,25 +423,21 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     return currentEventTransitionLane;
   }
 
-  // Updates originating inside certain React methods, like flushSync, have
-  // their priority set by tracking it with a context variable.
-  //
-  // The opaque type returned by the host config is internally a lane, so we can
-  // use that directly.
-  // TODO: Move this type conversion to the event priority module.
-  const updateLane: Lane = (getCurrentUpdatePriority(): any);
-  if (updateLane !== NoLane) {
-    return updateLane;
+  if (eventPriority !== NoLane) {
+    // If this isn't a transition, and an event priority is set, we can use the
+    // event priority as a lane directly. (Again, the EventPriority type is
+    // opaque to avoid leaking the Lane type, but *pssst* it's really a Lane.)
+    return eventPriority;
   }
 
-  // This update originated outside React. Ask the host environement for an
-  // appropriate priority, based on the type of event.
+  // This update originated outside React, so no priority was set. Ask the host
+  // environement for an appropriate priority, based on the type of event.
   //
   // The opaque type returned by the host config is internally a lane, so we can
   // use that directly.
   // TODO: Move this type conversion to the event priority module.
-  const eventLane: Lane = (getCurrentEventPriority(): any);
-  return eventLane;
+  const hostEventPriority: Lane = (getCurrentEventPriority(): any);
+  return hostEventPriority;
 }
 
 function requestRetryLane(fiber: Fiber) {

--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -3,6 +3,7 @@ let ReactNoop;
 let Scheduler;
 let useState;
 let useEffect;
+let startTransition;
 
 describe('ReactFlushSync', () => {
   beforeEach(() => {
@@ -13,6 +14,7 @@ describe('ReactFlushSync', () => {
     Scheduler = require('scheduler');
     useState = React.useState;
     useEffect = React.useEffect;
+    startTransition = React.unstable_startTransition;
   });
 
   function Text({text}) {
@@ -52,6 +54,47 @@ describe('ReactFlushSync', () => {
       // Now flush it.
       expect(Scheduler).toFlushUntilNextPaint(['1, 1']);
     });
+    expect(root).toMatchRenderedOutput('1, 1');
+  });
+
+  // @gate experimental
+  test('nested with startTransition', async () => {
+    let setSyncState;
+    let setState;
+    function App() {
+      const [syncState, _setSyncState] = useState(0);
+      const [state, _setState] = useState(0);
+      setSyncState = _setSyncState;
+      setState = _setState;
+      return <Text text={`${syncState}, ${state}`} />;
+    }
+
+    const root = ReactNoop.createRoot();
+    await ReactNoop.act(async () => {
+      root.render(<App />);
+    });
+    expect(Scheduler).toHaveYielded(['0, 0']);
+    expect(root).toMatchRenderedOutput('0, 0');
+
+    await ReactNoop.act(async () => {
+      ReactNoop.flushSync(() => {
+        startTransition(() => {
+          // This should be async even though flushSync is on the stack, because
+          // startTransition is closer.
+          setState(1);
+          ReactNoop.flushSync(() => {
+            // This should be async even though startTransition is on the stack,
+            // because flushSync is closer.
+            setSyncState(1);
+          });
+        });
+      });
+      // Only the sync update should have flushed
+      expect(Scheduler).toHaveYielded(['1, 0']);
+      expect(root).toMatchRenderedOutput('1, 0');
+    });
+    // Now the async update has flushed, too.
+    expect(Scheduler).toHaveYielded(['1, 1']);
     expect(root).toMatchRenderedOutput('1, 1');
   });
 });

--- a/packages/react/src/ReactCurrentBatchConfig.js
+++ b/packages/react/src/ReactCurrentBatchConfig.js
@@ -12,6 +12,8 @@
  * should suspend for if it needs to.
  */
 const ReactCurrentBatchConfig = {
+  // TODO: This now is used to track other types of event priorities, too, not
+  // just transitions. Consider renaming.
   transition: (0: number),
 };
 

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -9,9 +9,20 @@
 
 import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 
+// This should stay in sync with the reconciler (ReactEventPriorities).
+// Intentionally not using a shared module, because this crosses a package
+// boundary: importing from a shared module would give a false sense of
+// DRYness, because it's theoretically possible for for the renderer and
+// the isomorphic package to be out of sync. We don't fully support that, but we
+// should try (within reason) to be resilient.
+//
+// The value is an arbitrary transition lane. I picked a lane in the middle of
+// the bitmask because it's unlikely to change meaning.
+const TransitionEventPriority = 0b0000000000000001000000000000000;
+
 export function startTransition(scope: () => void) {
   const prevTransition = ReactCurrentBatchConfig.transition;
-  ReactCurrentBatchConfig.transition = 1;
+  ReactCurrentBatchConfig.transition = TransitionEventPriority;
   try {
     scope();
   } finally {


### PR DESCRIPTION
Currently we track event priorities in two different places:

- For transitions, we use the ReactCurrentBatchConfig object, which lives in the secret internals object of the isomorphic package. This is how the hook-less `startTransition` works.
- For other types of events, we use a module-level variable in ReactEventPriorities, which is owned by the renderer.

The problem with this approach is if both priorities are set, we don't know which one takes precedence. For example, what happens if wrap an update in both `ReactDOM.flushSync` and `React.startTransition`?

The desired behavior is that we use the priority of whichever wrapper is closer on the stack. So if `flushSync` is called inside of `startTransition`, then we should use sync priority; if it's the other way around, we should use transition priority.

To implement this, I updated the ReactEventPriorities module to track priority on the ReactCurrentBatchConfig object instead of in a module- level variable. Now when multiple event wrappers are nested, the innermost wrapper wins.