### PR TITLE
[perf] Improve SchedulerMinHeap implementation

### DIFF
--- a/packages/scheduler/src/SchedulerMinHeap.js
+++ b/packages/scheduler/src/SchedulerMinHeap.js
@@ -20,70 +20,69 @@ export function push(heap: Heap, node: Node): void {
 }
 
 export function peek(heap: Heap): Node | null {
-  const first = heap[0];
-  return first === undefined ? null : first;
+  return heap.length === 0 ? null : heap[0];
 }
 
 export function pop(heap: Heap): Node | null {
-  const first = heap[0];
-  if (first !== undefined) {
-    const last = heap.pop();
-    if (last !== first) {
-      heap[0] = last;
-      siftDown(heap, last, 0);
-    }
-    return first;
-  } else {
+  if (heap.length === 0) {
     return null;
   }
+  const first = heap[0];
+
+  const last = heap.pop();
+
+  if (last !== first) {
+    heap[0] = last;
+    siftDown(heap, last, 0);
+  }
+
+  return first;
 }
 
 function siftUp(heap, node, i) {
   let index = i;
-  while (true) {
+
+  while (index > 0) {
     const parentIndex = (index - 1) >>> 1;
     const parent = heap[parentIndex];
-    if (parent !== undefined && compare(parent, node) > 0) {
-      // The parent is larger. Swap positions.
-      heap[parentIndex] = node;
-      heap[index] = parent;
-      index = parentIndex;
-    } else {
-      // The parent is smaller. Exit.
-      return;
+
+    if (compare(parent, node) < 0) {
+      break;
     }
+    swap(heap, parentIndex, index);
+    index = parentIndex;
   }
 }
 
 function siftDown(heap, node, i) {
   let index = i;
-  const length = heap.length;
-  while (index < length) {
-    const leftIndex = (index + 1) * 2 - 1;
-    const left = heap[leftIndex];
-    const rightIndex = leftIndex + 1;
-    const right = heap[rightIndex];
+  const halfLength = heap.length >>> 1;
 
-    // If the left or right node is smaller, swap with the smaller of those.
-    if (left !== undefined && compare(left, node) < 0) {
-      if (right !== undefined && compare(right, left) < 0) {
-        heap[index] = right;
-        heap[rightIndex] = node;
-        index = rightIndex;
-      } else {
-        heap[index] = left;
-        heap[leftIndex] = node;
-        index = leftIndex;
-      }
-    } else if (right !== undefined && compare(right, node) < 0) {
-      heap[index] = right;
-      heap[rightIndex] = node;
-      index = rightIndex;
-    } else {
-      // Neither child is smaller. Exit.
-      return;
+  while (index < halfLength) {
+    let bestIndex = index * 2 + 1;
+    const rightIndex = index * 2 + 2;
+
+    // If the right node is smaller, swap with the smaller of those.
+    if (
+      heap.length > rightIndex &&
+      compare(heap[rightIndex], heap[bestIndex]) < 0
+    ) {
+      bestIndex = rightIndex;
     }
+
+    if (compare(node, heap[bestIndex]) < 0) {
+      break;
+    }
+
+    swap(heap, bestIndex, index);
+    index = bestIndex;
   }
+}
+
+function swap(heap, left, right) {
+  const item = heap[left];
+  heap[left] = heap[right];
+  heap[right] = item;
 }
 
 function compare(a, b) {

--- a/packages/scheduler/src/SchedulerMinHeap.js
+++ b/packages/scheduler/src/SchedulerMinHeap.js
@@ -28,61 +28,61 @@ export function pop(heap: Heap): Node | null {
     return null;
   }
   const first = heap[0];
-
   const last = heap.pop();
-
   if (last !== first) {
     heap[0] = last;
     siftDown(heap, last, 0);
   }
-
   return first;
 }
 
 function siftUp(heap, node, i) {
   let index = i;
-
   while (index > 0) {
     const parentIndex = (index - 1) >>> 1;
     const parent = heap[parentIndex];
-
-    if (compare(parent, node) < 0) {
-      break;
+    if (compare(parent, node) > 0) {
+      // The parent is larger. Swap positions.
+      heap[parentIndex] = node;
+      heap[index] = parent;
+      index = parentIndex;
+    } else {
+      // The parent is smaller. Exit.
+      return;
     }
-    swap(heap, parentIndex, index);
-    index = parentIndex;
   }
 }
 
 function siftDown(heap, node, i) {
   let index = i;
-  const halfLength = heap.length >>> 1;
-
+  const length = heap.length;
+  const halfLength = length >>> 1;
   while (index < halfLength) {
-    let bestIndex = index * 2 + 1;
-    const rightIndex = index * 2 + 2;
+    const leftIndex = (index + 1) * 2 - 1;
+    const left = heap[leftIndex];
+    const rightIndex = leftIndex + 1;
+    const right = heap[rightIndex];
 
-    // If the right node is smaller, swap with the smaller of those.
-    if (
-      heap.length > rightIndex &&
-      compare(heap[rightIndex], heap[bestIndex]) < 0
-    ) {
-      bestIndex = rightIndex;
+    // If the left or right node is smaller, swap with the smaller of those.
+    if (compare(left, node) < 0) {
+      if (rightIndex < length && compare(right, left) < 0) {
+        heap[index] = right;
+        heap[rightIndex] = node;
+        index = rightIndex;
+      } else {
+        heap[index] = left;
+        heap[leftIndex] = node;
+        index = leftIndex;
+      }
+    } else if (rightIndex < length && compare(right, node) < 0) {
+      heap[index] = right;
+      heap[rightIndex] = node;
+      index = rightIndex;
+    } else {
+      // Neither child is smaller. Exit.
+      return;
     }
-
-    if (compare(node, heap[bestIndex]) < 0) {
-      break;
-    }
-
-    swap(heap, bestIndex, index);
-    index = bestIndex;
   }
-}
-
-function swap(heap, left, right) {
-  const item = heap[left];
-  heap[left] = heap[right];
-  heap[right] = item;
 }
 
 function compare(a, b) {


### PR DESCRIPTION
Migrated to a new algorithm that does not go beyond the array, thus de-optimization of this piece of code is not happening

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I investigated the package scheduler and observed that the current implementation MinHeap reading beyond the length of the array. MinHeap is hot type code and I had decided to improve the current implementation

Result
```
❯ node -v
v14.15.5

❯ node bench.js
master branche - small number of elements x 17,740 ops/sec ±1.50% (85 runs sampled)
master branche - large number of elements x 1,430 ops/sec ±1.10% (71 runs sampled)

current branche - small number of elements x 441,482 ops/sec ±0.60% (95 runs sampled)
current branche - large number of elements x 14,038 ops/sec ±1.17% (91 runs sampled)
```

Proofs why it's work that

> reading array[42] when array.length === 5. In this case, the array index 42 is out of bounds, the property is not present on the array itself, and so the JavaScript engine has to perform expensive prototype chain lookups. Once a load has run into this situation, V8 remembers that “this load needs to deal with special cases”, and it will never be as fast again as it was before reading out-of-bounds.

url - [https://v8.dev/blog/elements-kinds#avoid-reading-beyond-the-length-of-the-array](https://v8.dev/blog/elements-kinds#avoid-reading-beyond-the-length-of-the-array)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
