### PR TITLE
Remove my deadname from AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -608,7 +608,6 @@ Ludovico Fischer <livrerie@gmail.com>
 Luigy Leon <luichi.19@gmail.com>
 Luke Belliveau <luke.belliveau@gmail.com>
 Luke Horvat <lukehorvat@gmail.com>
-Lutz Rosema <terabaud@gmail.com>
 MICHAEL JACKSON <mjijackson@gmail.com>
 MIKAMI Yoshiyuki <yoshuki@saikyoline.jp>
 Maciej Kasprzyk <kapustka.maciek@gmail.com>


### PR DESCRIPTION

## Summary

The AUTHORS contains my name assigned at birth. I prefer to have it removed from the list as I prefer my deadname to not be public. About a year ago, I changed the .mailmap so the `git shortlog -se` script would generate a list with my correct name; I'd be ok with that. But as the contributions I made to react was only a small documentation fix in the past, it's also ok for me to remove me completely.