### PR TITLE
[Fizz] Implement all the DOM attributes and special cases

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -428,7 +428,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     function AsyncCol({className}) {
-      return <col className={readText(className)}>{[]}</col>;
+      return <col className={readText(className)} />;
     }
 
     function AsyncPath({id}) {

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -1168,6 +1168,20 @@ export function pushStartInstance(
           'probably not intentional.',
       );
     }
+
+    if (
+      formatContext.insertionMode !== SVG_MODE &&
+      formatContext.insertionMode !== MATHML_MODE
+    ) {
+      if (type.toLowerCase() !== type) {
+        console.error(
+          '<%s /> is using incorrect casing. ' +
+            'Use PascalCase for React components, ' +
+            'or lowercase for HTML elements.',
+          type,
+        );
+      }
+    }
   }
 
   switch (type) {

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -7,6 +7,10 @@
  * @flow
  */
 
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+import {enableFilterEmptyStringAttributesDOM} from 'shared/ReactFeatureFlags';
+
 import type {
   Destination,
   Chunk,
@@ -19,8 +23,24 @@ import {
   stringToPrecomputedChunk,
 } from 'react-server/src/ReactServerStreamConfig';
 
+import {
+  getPropertyInfo,
+  isAttributeNameSafe,
+  BOOLEAN,
+  OVERLOADED_BOOLEAN,
+  NUMERIC,
+  POSITIVE_NUMERIC,
+} from '../shared/DOMProperty';
+
+import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
+import {validateProperties as validateInputProperties} from '../shared/ReactDOMNullInputValuePropHook';
+import {validateProperties as validateUnknownProperties} from '../shared/ReactDOMUnknownPropertyHook';
+
 import escapeTextForBrowser from './escapeTextForBrowser';
 import invariant from 'shared/invariant';
+import sanitizeURL from '../shared/sanitizeURL';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 // Per response, global state that is not contextual to the rendering subtree.
 export type ResponseState = {
@@ -142,10 +162,6 @@ export function createSuspenseBoundaryID(
   return {formattedID: null};
 }
 
-function encodeHTMLIDAttribute(value: string): string {
-  return escapeTextForBrowser(value);
-}
-
 function encodeHTMLTextNode(text: string): string {
   return escapeTextForBrowser(text);
 }
@@ -202,11 +218,614 @@ export function pushTextInstance(
   target.push(stringToChunk(encodeHTMLTextNode(text)), textSeparator);
 }
 
-const startTag1 = stringToPrecomputedChunk('<');
-const startTag2 = stringToPrecomputedChunk('>');
+function pushStyle(
+  target: Array<Chunk | PrecomputedChunk>,
+  responseState: ResponseState,
+  style: mixed,
+): void {
+  invariant(
+    typeof style === 'object',
+    'The `style` prop expects a mapping from style properties to values, ' +
+      "not a string. For example, style={{marginRight: spacing + 'em'}} when " +
+      'using JSX.',
+  );
+  // TODO
+}
+
+const attributeSeparator = stringToPrecomputedChunk(' ');
+const attributeAssign = stringToPrecomputedChunk('="');
+const attributeEnd = stringToPrecomputedChunk('"');
+const attributeEmptyString = stringToPrecomputedChunk('=""');
+
+function pushAttribute(
+  target: Array<Chunk | PrecomputedChunk>,
+  responseState: ResponseState,
+  name: string,
+  value: string | boolean | number | Function | Object, // not null or undefined
+): void {
+  switch (name) {
+    case 'style': {
+      pushStyle(target, responseState, value);
+      return;
+    }
+    case 'defaultValue':
+    case 'defaultChecked': // These shouldn't be set as attributes on generic HTML elements.
+    case 'innerHTML': // Must use dangerouslySetInnerHTML instead.
+    case 'suppressContentEditableWarning':
+    case 'suppressHydrationWarning':
+      // Ignored. These are built-in to React on the client.
+      return;
+  }
+  if (
+    // shouldIgnoreAttribute
+    // We have already filtered out null/undefined and reserved words.
+    name.length > 2 &&
+    (name[0] === 'o' || name[0] === 'O') &&
+    (name[1] === 'n' || name[1] === 'N')
+  ) {
+    return;
+  }
+
+  const propertyInfo = getPropertyInfo(name);
+  if (propertyInfo !== null) {
+    // shouldRemoveAttribute
+    switch (typeof value) {
+      case 'function':
+      // $FlowIssue symbol is perfectly valid here
+      case 'symbol': // eslint-disable-line
+        return;
+      case 'boolean': {
+        if (!propertyInfo.acceptsBooleans) {
+          return;
+        }
+      }
+    }
+    if (enableFilterEmptyStringAttributesDOM) {
+      if (propertyInfo.removeEmptyString && value === '') {
+        if (__DEV__) {
+          if (name === 'src') {
+            console.error(
+              'An empty string ("") was passed to the %s attribute. ' +
+                'This may cause the browser to download the whole page again over the network. ' +
+                'To fix this, either do not render the element at all ' +
+                'or pass null to %s instead of an empty string.',
+              name,
+              name,
+            );
+          } else {
+            console.error(
+              'An empty string ("") was passed to the %s attribute. ' +
+                'To fix this, either do not render the element at all ' +
+                'or pass null to %s instead of an empty string.',
+              name,
+              name,
+            );
+          }
+        }
+        return;
+      }
+    }
+
+    const attributeName = propertyInfo.attributeName;
+    const attributeNameChunk = stringToChunk(attributeName); // TODO: If it's known we can cache the chunk.
+
+    switch (propertyInfo.type) {
+      case BOOLEAN:
+        if (value) {
+          target.push(
+            attributeSeparator,
+            attributeNameChunk,
+            attributeEmptyString,
+          );
+        }
+        return;
+      case OVERLOADED_BOOLEAN:
+        if (value === true) {
+          target.push(
+            attributeSeparator,
+            attributeNameChunk,
+            attributeEmptyString,
+          );
+        } else if (value === false) {
+          // Ignored
+        } else {
+          target.push(
+            attributeSeparator,
+            attributeNameChunk,
+            attributeAssign,
+            escapeTextForBrowser(value),
+            attributeEnd,
+          );
+        }
+        return;
+      case NUMERIC:
+        if (!isNaN(value)) {
+          target.push(
+            attributeSeparator,
+            attributeNameChunk,
+            attributeAssign,
+            escapeTextForBrowser(value),
+            attributeEnd,
+          );
+        }
+        break;
+      case POSITIVE_NUMERIC:
+        if (!isNaN(value) && (value: any) >= 1) {
+          target.push(
+            attributeSeparator,
+            attributeNameChunk,
+            attributeAssign,
+            escapeTextForBrowser(value),
+            attributeEnd,
+          );
+        }
+        break;
+      default:
+        if (propertyInfo.sanitizeURL) {
+          value = '' + (value: any);
+          sanitizeURL(value);
+        }
+        target.push(
+          attributeSeparator,
+          attributeNameChunk,
+          attributeAssign,
+          escapeTextForBrowser(value),
+          attributeEnd,
+        );
+    }
+  } else if (isAttributeNameSafe(name)) {
+    // shouldRemoveAttribute
+    switch (typeof value) {
+      case 'function':
+      // $FlowIssue symbol is perfectly valid here
+      case 'symbol': // eslint-disable-line
+        return;
+      case 'boolean': {
+        const prefix = name.toLowerCase().slice(0, 5);
+        if (prefix !== 'data-' && prefix !== 'aria-') {
+          return;
+        }
+      }
+    }
+    target.push(
+      attributeSeparator,
+      stringToChunk(name),
+      attributeAssign,
+      escapeTextForBrowser(value),
+      attributeEnd,
+    );
+  }
+}
+
+const endOfStartTag = stringToPrecomputedChunk('>');
+const endOfStartTagSelfClosing = stringToPrecomputedChunk('/>');
 
 const idAttr = stringToPrecomputedChunk(' id="');
 const attrEnd = stringToPrecomputedChunk('"');
+
+function pushID(
+  target: Array<Chunk | PrecomputedChunk>,
+  responseState: ResponseState,
+  assignID: SuspenseBoundaryID,
+  existingID: mixed,
+): void {
+  if (
+    existingID !== null &&
+    existingID !== undefined &&
+    (typeof existingID === 'string' || typeof existingID === 'object')
+  ) {
+    // We can reuse the existing ID for our purposes.
+    assignID.formattedID = stringToPrecomputedChunk(
+      escapeTextForBrowser(existingID),
+    );
+  } else {
+    const encodedID = assignAnID(responseState, assignID);
+    target.push(idAttr, encodedID, attrEnd);
+  }
+}
+
+function pushInnerHTML(
+  target: Array<Chunk | PrecomputedChunk>,
+  innerHTML,
+  children,
+) {
+  if (innerHTML != null) {
+    invariant(
+      children == null,
+      'Can only set one of `children` or `props.dangerouslySetInnerHTML`.',
+    );
+
+    invariant(
+      typeof innerHTML === 'object' && '__html' in innerHTML,
+      '`props.dangerouslySetInnerHTML` must be in the form `{__html: ...}`. ' +
+        'Please visit https://reactjs.org/link/dangerously-set-inner-html ' +
+        'for more information.',
+    );
+    const html = innerHTML.__html;
+    target.push(stringToChunk(html));
+  }
+}
+
+function pushStartSelect(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag('select'));
+
+  let children = null;
+  let innerHTML = null;
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+          children = propValue;
+          break;
+        case 'dangerouslySetInnerHTML':
+          // TODO: This doesn't really make sense for select since it can't use the controlled
+          // value in the innerHTML.
+          innerHTML = propValue;
+          break;
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
+  return children;
+}
+
+function pushStartOption(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag('option'));
+
+  let children = null;
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+          children = propValue;
+          break;
+        case 'dangerouslySetInnerHTML':
+          invariant(
+            false,
+            '`dangerouslySetInnerHTML` does not work on <option>.',
+          );
+        // eslint-disable-next-line-no-fallthrough
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  return children;
+}
+
+function pushInput(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag('input'));
+
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+        case 'dangerouslySetInnerHTML':
+          invariant(
+            false,
+            '%s is a self-closing tag and must neither have `children` nor ' +
+              'use `dangerouslySetInnerHTML`.',
+            'input',
+          );
+        // eslint-disable-next-line-no-fallthrough
+        case 'defaultChecked':
+          pushAttribute(target, responseState, 'checked', propValue);
+          break;
+        case 'defaultValue':
+          pushAttribute(target, responseState, 'value', propValue);
+          break;
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTagSelfClosing);
+  return null;
+}
+
+function pushStartTextArea(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag('textarea'));
+
+  let children = null;
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+          children = propValue;
+          break;
+        case 'dangerouslySetInnerHTML':
+          invariant(
+            false,
+            '`dangerouslySetInnerHTML` does not make sense on <textarea>.',
+          );
+        // eslint-disable-next-line-no-fallthrough
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  return children;
+}
+
+function pushSelfClosing(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  tag: string,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag(tag));
+
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+        case 'dangerouslySetInnerHTML':
+          invariant(
+            false,
+            '%s is a self-closing tag and must neither have `children` nor ' +
+              'use `dangerouslySetInnerHTML`.',
+            tag,
+          );
+        // eslint-disable-next-line-no-fallthrough
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTagSelfClosing);
+  return null;
+}
+
+function pushStartMenuItem(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag('menuitem'));
+
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+        case 'dangerouslySetInnerHTML':
+          invariant(
+            false,
+            'menuitems cannot have `children` nor `dangerouslySetInnerHTML`.',
+          );
+        // eslint-disable-next-line-no-fallthrough
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  return null;
+}
+
+function pushStartGenericElement(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  tag: string,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag(tag));
+
+  let children = null;
+  let innerHTML = null;
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+          children = propValue;
+          break;
+        case 'dangerouslySetInnerHTML':
+          innerHTML = propValue;
+          break;
+        default:
+          pushAttribute(target, responseState, propKey, propValue);
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
+  return children;
+}
+
+function pushStartCustomElement(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  tag: string,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  target.push(startChunkForTag(tag));
+
+  let children = null;
+  let innerHTML = null;
+  for (const propKey in props) {
+    if (hasOwnProperty.call(props, propKey)) {
+      const propValue = props[propKey];
+      if (propValue == null) {
+        continue;
+      }
+      switch (propKey) {
+        case 'children':
+          children = propValue;
+          break;
+        case 'dangerouslySetInnerHTML':
+          innerHTML = propValue;
+          break;
+        case 'style':
+          pushStyle(target, responseState, propValue);
+          break;
+        case 'suppressContentEditableWarning':
+        case 'suppressHydrationWarning':
+          // Ignored. These are built-in to React on the client.
+          break;
+        default:
+          if (isAttributeNameSafe(propKey)) {
+            target.push(
+              attributeSeparator,
+              stringToChunk(propKey),
+              attributeAssign,
+              escapeTextForBrowser(propValue),
+              attributeEnd,
+            );
+          }
+          break;
+      }
+    }
+  }
+  if (assignID !== null) {
+    pushID(target, responseState, assignID, props.id);
+  }
+
+  target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
+  return children;
+}
+
+const leadingNewline = stringToPrecomputedChunk('\n');
+
+function pushStartPreformattedElement(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  tag: string,
+  responseState: ResponseState,
+  assignID: null | SuspenseBoundaryID,
+): ReactNodeList {
+  const children = pushStartGenericElement(
+    target,
+    props,
+    tag,
+    responseState,
+    assignID,
+  );
+
+  if (typeof children === 'string' && children[0] === '\n') {
+    // text/html ignores the first character in these tags if it's a newline
+    // Prefer to break application/xml over text/html (for now) by adding
+    // a newline specifically to get eaten by the parser. (Alternately for
+    // textareas, replacing "^\n" with "\r\n" doesn't get eaten, and the first
+    // \r is normalized out by HTMLTextAreaElement#value.)
+    // See: <http://www.w3.org/TR/html-polyglot/#newlines-in-textarea-and-pre>
+    // See: <http://www.w3.org/TR/html5/syntax.html#element-restrictions>
+    // See: <http://www.w3.org/TR/html5/syntax.html#newlines>
+    // See: Parsing of "textarea" "listing" and "pre" elements
+    //  from <http://www.w3.org/TR/html5/syntax.html#parsing-main-inbody>
+    // TODO: This doesn't deal with the case where the child is an array
+    // or component that returns a string.
+    target.push(leadingNewline);
+  }
+
+  return children;
+}
+
+// We accept any tag to be rendered but since this gets injected into arbitrary
+// HTML, we want to make sure that it's a safe tag.
+// http://www.w3.org/TR/REC-xml/#NT-Name
+const VALID_TAG_REGEX = /^[a-zA-Z][a-zA-Z:_\.\-\d]*$/; // Simplified subset
+const validatedTagCache = new Map();
+function startChunkForTag(tag: string): PrecomputedChunk {
+  let tagStartChunk = validatedTagCache.get(tag);
+  if (tagStartChunk === undefined) {
+    invariant(VALID_TAG_REGEX.test(tag), 'Invalid tag: %s', tag);
+    tagStartChunk = stringToPrecomputedChunk('<' + tag);
+    validatedTagCache.set(tag, tagStartChunk);
+  }
+  return tagStartChunk;
+}
 
 export function pushStartInstance(
   target: Array<Chunk | PrecomputedChunk>,
@@ -214,41 +833,105 @@ export function pushStartInstance(
   props: Object,
   responseState: ResponseState,
   assignID: null | SuspenseBoundaryID,
-): void {
-  // TODO: Figure out if it's self closing and everything else.
-  if (assignID !== null) {
-    let encodedID;
-    if (typeof props.id === 'string') {
-      // We can reuse the existing ID for our purposes.
-      encodedID = assignID.formattedID = stringToPrecomputedChunk(
-        encodeHTMLIDAttribute(props.id),
-      );
-    } else {
-      encodedID = assignAnID(responseState, assignID);
-    }
-    target.push(
-      startTag1,
-      stringToChunk(type),
-      idAttr,
-      encodedID,
-      attrEnd,
-      startTag2,
-    );
-  } else {
-    target.push(startTag1, stringToChunk(type));
-    if (props.className) {
-      target.push(
-        stringToChunk(
-          ' class="' + encodeHTMLIDAttribute(props.className) + '"',
-        ),
+): ReactNodeList {
+  if (__DEV__) {
+    validateARIAProperties(type, props);
+    validateInputProperties(type, props);
+    validateUnknownProperties(type, props, null);
+
+    if (
+      !props.suppressContentEditableWarning &&
+      props.contentEditable &&
+      props.children != null
+    ) {
+      console.error(
+        'A component is `contentEditable` and contains `children` managed by ' +
+          'React. It is now your responsibility to guarantee that none of ' +
+          'those nodes are unexpectedly modified or duplicated. This is ' +
+          'probably not intentional.',
       );
     }
-    if (props.id) {
-      target.push(
-        stringToChunk(' id="' + encodeHTMLIDAttribute(props.id) + '"'),
+  }
+
+  switch (type) {
+    // Special tags
+    case 'select':
+      return pushStartSelect(target, props, responseState, assignID);
+    case 'option':
+      return pushStartOption(target, props, responseState, assignID);
+    case 'textarea':
+      return pushStartTextArea(target, props, responseState, assignID);
+    case 'input':
+      return pushInput(target, props, responseState, assignID);
+    case 'menuitem':
+      return pushStartMenuItem(target, props, responseState, assignID);
+    // Newline eating tags
+    case 'listing':
+    case 'pre': {
+      return pushStartPreformattedElement(
+        target,
+        props,
+        type,
+        responseState,
+        assignID,
       );
     }
-    target.push(startTag2);
+    // Omitted close tags
+    case 'area':
+    case 'base':
+    case 'br':
+    case 'col':
+    case 'embed':
+    case 'hr':
+    case 'img':
+    case 'keygen':
+    case 'link':
+    case 'meta':
+    case 'param':
+    case 'source':
+    case 'track':
+    case 'wbr': {
+      return pushSelfClosing(target, props, type, responseState, assignID);
+    }
+    // These are reserved SVG and MathML elements, that are never custom elements.
+    // https://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+    case 'annotation-xml':
+    case 'color-profile':
+    case 'font-face':
+    case 'font-face-src':
+    case 'font-face-uri':
+    case 'font-face-format':
+    case 'font-face-name':
+    case 'missing-glyph': {
+      return pushStartGenericElement(
+        target,
+        props,
+        type,
+        responseState,
+        assignID,
+      );
+    }
+    default: {
+      if (type.indexOf('-') === -1 && typeof props.is !== 'string') {
+        // Generic element
+        return pushStartGenericElement(
+          target,
+          props,
+          type,
+          responseState,
+          assignID,
+        );
+      } else {
+        // Custom element
+        return pushStartCustomElement(
+          target,
+          props,
+          type,
+          responseState,
+          assignID,
+        );
+      }
+    }
   }
 }
 
@@ -260,8 +943,32 @@ export function pushEndInstance(
   type: string,
   props: Object,
 ): void {
-  // TODO: Figure out if it was self closing.
-  target.push(endTag1, stringToChunk(type), endTag2);
+  switch (type) {
+    // Omitted close tags
+    // TODO: Instead of repeating this switch we could try to pass a flag from above.
+    // That would require returning a tuple. Which might be ok if it gets inlined.
+    case 'area':
+    case 'base':
+    case 'br':
+    case 'col':
+    case 'embed':
+    case 'hr':
+    case 'img':
+    case 'input':
+    case 'keygen':
+    case 'link':
+    case 'meta':
+    case 'param':
+    case 'source':
+    case 'track':
+    case 'wbr': {
+      // No close tag needed.
+      break;
+    }
+    default: {
+      target.push(endTag1, stringToChunk(type), endTag2);
+    }
+  }
 }
 
 // Structural Nodes

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ReactNodeList} from 'shared/ReactTypes';
+
 import type {
   Destination,
   Chunk,
@@ -135,13 +137,14 @@ export function pushStartInstance(
   props: Object,
   responseState: ResponseState,
   assignID: null | SuspenseBoundaryID,
-): void {
+): ReactNodeList {
   target.push(
     INSTANCE,
     stringToChunk(type),
     END, // Null terminated type string
     // TODO: props
   );
+  return props.children;
 }
 
 export function pushEndInstance(

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -136,6 +136,7 @@ export function pushStartInstance(
   type: string,
   props: Object,
   responseState: ResponseState,
+  formatContext: FormatContext,
   assignID: null | SuspenseBoundaryID,
 ): ReactNodeList {
   target.push(

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -14,6 +14,8 @@
  * environment.
  */
 
+import type {ReactNodeList} from 'shared/ReactTypes';
+
 import ReactFizzServer from 'react-server';
 
 type Instance = {|
@@ -97,7 +99,7 @@ const ReactNoopServer = ReactFizzServer({
     target: Array<Uint8Array>,
     type: string,
     props: Object,
-  ): void {
+  ): ReactNodeList {
     const instance: Instance = {
       type: type,
       children: [],
@@ -105,6 +107,7 @@ const ReactNoopServer = ReactFizzServer({
       hidden: false,
     };
     target.push(Buffer.from(JSON.stringify(instance), 'utf8'));
+    return props.children;
   },
 
   pushEndInstance(

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -302,6 +302,11 @@ function renderNode(request: Request, task: Task, node: ReactNodeList): void {
     return;
   }
 
+  if (node === null) {
+    pushEmpty(task.blockedSegment.chunks, request.responseState, task.assignID);
+    return;
+  }
+
   if (
     typeof node !== 'object' ||
     !node ||
@@ -347,7 +352,7 @@ function renderNode(request: Request, task: Task, node: ReactNodeList): void {
     }
   } else if (typeof type === 'string') {
     const segment = task.blockedSegment;
-    pushStartInstance(
+    const children = pushStartInstance(
       segment.chunks,
       type,
       props,
@@ -358,7 +363,7 @@ function renderNode(request: Request, task: Task, node: ReactNodeList): void {
     task.assignID = null;
     const prevContext = segment.formatContext;
     segment.formatContext = getChildFormatContext(prevContext, type, props);
-    renderNode(request, task, props.children);
+    renderNode(request, task, children);
     // We expect that errors will fatal the whole task and that we don't need
     // the correct context. Therefore this is not in a finally.
     segment.formatContext = prevContext;

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -357,6 +357,7 @@ function renderNode(request: Request, task: Task, node: ReactNodeList): void {
       type,
       props,
       request.responseState,
+      segment.formatContext,
       task.assignID,
     );
     // We must have assigned it already above so we don't need this anymore.

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -385,5 +385,8 @@
   "394": "startTransition cannot be called during server rendering.",
   "395": "An ID must have been assigned before we can complete the boundary.",
   "396": "More boundaries or placeholders than we expected to ever emit.",
-  "397": "Unknown insertion mode. This is a bug in React."
+  "397": "Unknown insertion mode. This is a bug in React.",
+  "398": "`dangerouslySetInnerHTML` does not work on <option>.",
+  "399": "%s is a self-closing tag and must neither have `children` nor use `dangerouslySetInnerHTML`.",
+  "400": "menuitems cannot have `children` nor `dangerouslySetInnerHTML`."
 }


### PR DESCRIPTION
This implements all the DOM bindings parts as far as I know (except the reactroot attribute). I can't run it against our test suite yet. But I carefully ported everything I could.

There's only one breakage I decided to do. We don't force lower case HTML tags before comparing them. This means that special cases like `<select />`, `<textarea />` etc. don't work if you use a different case. We warned about this before and warn about it after, so shouldn't matter.

I did a very different structure from what we've done in the DOM bindings before though.

A problem with how we used to do it is that the logic is spread out into a lot of different concepts. This causes a lot of extra checks for each element because we check those things over and over. It also leads to unnecessary checks. A lot of the helpers check things like `== null` over and over or they overcheck because in that context it can never happen.

Instead of a bunch of `isSomething(...)` helpers. I structured it fully based on a switch over each kind of value once and from there the code flow determines what to do next.

The structure is something like this:

- type
  - propertyName
    - propertyInfo
      - value

First we switch on the type, then we loop over each property, we switch over the property name to find special cases, then we switch over the propertyInfo and finally the value type and that determines what we do.

So the goal is that we only check each of these once along that path.

All special cases are encoded along with that specific element type. This ends up needing to fork the loop. So there's a lot of duplication there. This is controversial because if you make a change to these things you have to replicate them. However, I've noticed subtle little issues because we don't consider how each special case applies to each tag. So this is actually a benefit. It's also better for perf.

Large switches might not be better than Map of Functions depending on VM but that's something we can automate if needed if it's expressed as a simple switch.