### PR TITLE
Fix [Refresh] Components resulting of HOCs composition immediately applied to render functions are ignored

### DIFF
--- a/packages/react-refresh/src/ReactFreshBabelPlugin.js
+++ b/packages/react-refresh/src/ReactFreshBabelPlugin.js
@@ -103,6 +103,21 @@ export default function(babel, opts = {}) {
             callback(inferredName, node, path);
             return true;
           }
+          case 'CallExpression': {
+            const firstArgPath = argsPath[0];
+            const innerName = inferredName + '$compose';
+            const foundInside = findInnerComponents(
+              innerName,
+              firstArgPath,
+              callback,
+            );
+            if (!foundInside) {
+              return false;
+            }
+            // const Foo = compose(hoc1, hoc2)(() => {})
+            callback(inferredName, node, path);
+            return true;
+          }
           default: {
             return false;
           }

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -345,6 +345,14 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
+  
+  it('registers composed HOCs', () => {
+    expect(
+      transform(`
+        export const A = compose(hoc1, hoc2, hoc3)(() => (<h1>Hi</h1>));
+    `),
+    ).toMatchSnapshot();
+  });
 
   it('generates signatures for function declarations calling hooks', () => {
     expect(

--- a/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
+++ b/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js
@@ -345,7 +345,7 @@ describe('ReactFreshBabelPlugin', () => {
     `),
     ).toMatchSnapshot();
   });
-  
+
   it('registers composed HOCs', () => {
     expect(
       transform(`

--- a/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
+++ b/packages/react-refresh/src/__tests__/__snapshots__/ReactFreshBabelPlugin-test.js.snap
@@ -355,6 +355,16 @@ $RefreshReg$(_c3, "A");
 $RefreshReg$(_c4, "B");
 `;
 
+exports[`ReactFreshBabelPlugin registers composed HOCs 1`] = `
+export const A = compose(hoc1, hoc2, hoc3)(_c = () => <h1>Hi</h1>);
+_c2 = A;
+
+var _c, _c2;
+
+$RefreshReg$(_c, "A$compose");
+$RefreshReg$(_c2, "A");
+`;
+
 exports[`ReactFreshBabelPlugin registers identifiers used in JSX at definition site 1`] = `
 import A from './A';
 import Store from './Store';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Fixes #21179.

## Test Plan

Run `node ./scripts/jest/jest-cli.js -i /Users/david/Code/react/packages/react-refresh/src/__tests__/ReactFreshBabelPlugin-test.js`.
