### PR TITLE
chore: Ignore build2/ when linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,9 @@ packages/react-art/npm/lib
 
 # Build products
 build/
+# TODO: Currently storing artifacts as `./build2` so that it doesn't conflict
+# with old build job. Remove once we migrate rest of build/test pipeline.
+build2/
 coverage/
 fixtures/
 scripts/bench/benchmarks/**/*.js


### PR DESCRIPTION
## Summary

Ignore files created by `yarn build-for-devtools` in `yarn lint`

## Test Plan

- [x] CI green
- [x] `git clean -fdx; yarn install; yarn build-for-devtools; yarn lint` passes (is failing on `master` (currently `782f689ca8380a715ab0c24e326fc293e5d25647`))