### PR TITLE
Warn when a function whose name starts with a capital letter is passed to useState/setState

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -677,8 +677,25 @@ function createFunctionComponentUpdateQueue(): FunctionComponentUpdateQueue {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
-  // $FlowFixMe: Flow doesn't like mixed types
-  return typeof action === 'function' ? action(state) : action;
+  if (typeof action === 'function') {
+    if (__DEV__) {
+      // $FlowFixMe: Flow doesn't like mixed types
+      const name = action.displayName || action.name || '';
+      // $FlowFixMe: Flow doesn't like mixed types
+      if (name.charAt(0) !== name.charAt(0).toLowerCase()) {
+        console.warn(
+          'You passed a function whose name starts with a capital letter. ' +
+            'If you are trying to put a class into state, keep in mind that ' +
+            'it can throw at runtime. As a workaround, you can use ' +
+            'functional updates (e.g. useState(() => InitialClass), ' +
+            'setState(() => AnotherClass)).',
+        );
+      }
+    }
+    // $FlowFixMe: Flow doesn't like mixed types
+    return action(state);
+  }
+  return action;
 }
 
 function mountReducer<S, I, A>(
@@ -1240,6 +1257,20 @@ function mountState<S>(
 ): [S, Dispatch<BasicStateAction<S>>] {
   const hook = mountWorkInProgressHook();
   if (typeof initialState === 'function') {
+    if (__DEV__) {
+      // $FlowFixMe: Flow doesn't like mixed types
+      const name = initialState.displayName || initialState.name || '';
+      // $FlowFixMe: Flow doesn't like mixed types
+      if (name.charAt(0) !== name.charAt(0).toLowerCase()) {
+        console.warn(
+          'You passed a function whose name starts with a capital letter. ' +
+            'If you are trying to put a class into state, keep in mind that ' +
+            'it can throw at runtime. As a workaround, you can use ' +
+            'functional updates (e.g. useState(() => InitialClass), ' +
+            'setState(() => AnotherClass)).',
+        );
+      }
+    }
     // $FlowFixMe: Flow doesn't like mixed types
     initialState = initialState();
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -677,8 +677,25 @@ function createFunctionComponentUpdateQueue(): FunctionComponentUpdateQueue {
 }
 
 function basicStateReducer<S>(state: S, action: BasicStateAction<S>): S {
-  // $FlowFixMe: Flow doesn't like mixed types
-  return typeof action === 'function' ? action(state) : action;
+  if (typeof action === 'function') {
+    if (__DEV__) {
+      // $FlowFixMe: Flow doesn't like mixed types
+      const name = action.displayName || action.name || '';
+      // $FlowFixMe: Flow doesn't like mixed types
+      if (name.charAt(0) !== name.charAt(0).toLowerCase()) {
+        console.warn(
+          'You passed a function whose name starts with a capital letter. ' +
+            'If you are trying to put a class into state, keep in mind that ' +
+            'it can throw at runtime. As a workaround, you can use ' +
+            'functional updates (e.g. useState(() => InitialClass), ' +
+            'setState(() => AnotherClass)).',
+        );
+      }
+    }
+    // $FlowFixMe: Flow doesn't like mixed types
+    return action(state);
+  }
+  return action;
 }
 
 function mountReducer<S, I, A>(
@@ -1240,6 +1257,20 @@ function mountState<S>(
 ): [S, Dispatch<BasicStateAction<S>>] {
   const hook = mountWorkInProgressHook();
   if (typeof initialState === 'function') {
+    if (__DEV__) {
+      // $FlowFixMe: Flow doesn't like mixed types
+      const name = initialState.displayName || initialState.name || '';
+      // $FlowFixMe: Flow doesn't like mixed types
+      if (name.charAt(0) !== name.charAt(0).toLowerCase()) {
+        console.warn(
+          'You passed a function whose name starts with a capital letter. ' +
+            'If you are trying to put a class into state, keep in mind that ' +
+            'it can throw at runtime. As a workaround, you can use ' +
+            'functional updates (e.g. useState(() => InitialClass), ' +
+            'setState(() => AnotherClass)).',
+        );
+      }
+    }
     // $FlowFixMe: Flow doesn't like mixed types
     initialState = initialState();
   }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1138,6 +1138,41 @@ describe('ReactHooks', () => {
     );
   });
 
+  if (__DEV__) {
+    it('warns when a function whose name starts with a capital letter is passed to useState', () => {
+      const {useState} = React;
+      function StartsWithCapitalLetter() {}
+      function App() {
+        useState(StartsWithCapitalLetter);
+        return null;
+      }
+      expect(() => ReactTestRenderer.create(<App />)).toWarnDev(
+        'You passed a function whose name starts with a capital letter. If you are trying to put a class into state, keep in mind that it can throw at runtime. As a workaround, you can use functional updates (e.g. useState(() => InitialClass), setState(() => AnotherClass)).',
+      );
+    });
+  }
+
+  if (__DEV__) {
+    it('warns when a function whose name starts with a capital letter is passed to setState', () => {
+      const {useEffect, useState} = React;
+      function StartsWithCapitalLetter() {}
+      function App() {
+        // eslint-disable-next-line no-unused-vars
+        const [_, setState] = useState();
+        useEffect(() => {
+          setState(StartsWithCapitalLetter);
+        }, []);
+        return null;
+      }
+      expect(() => {
+        const root = ReactTestRenderer.create(<App />);
+        root.update(<App />);
+      }).toWarnDev(
+        'You passed a function whose name starts with a capital letter. If you are trying to put a class into state, keep in mind that it can throw at runtime. As a workaround, you can use functional updates (e.g. useState(() => InitialClass), setState(() => AnotherClass)).',
+      );
+    });
+  }
+
   it('resets warning internal state when interrupted by an error', () => {
     const ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
As discussed in #21057, passing a class to `useState` and `setState` functions can be problematic because of the internal structure of those functions to check whether the user passed the state directly or using a function. As suggested in the mentioned issue, checking the name of the function (if the user passed a function to `useState` and `setState`) whether its first letter is capitalized or not and warning the user if it starts with a capital letter could be a helpful hint.

For this reason, I added a small if block which will work in the development build to check the first letter of the function name. To get the name of the function, I used the `displayName` and `name` properties. Even though these two aren't supported in all browsers, it still covers a big percentage. I searched the codebase for alternative approaches but this was the most common way. If there are alternative and better approaches to get the name of the function, we can update that logic for sure.

```js
if (__DEV__) {
  const name = initialState.displayName || initialState.name || '';
  if (name.charAt(0) !== name.charAt(0).toLowerCase()) {
    console.warn(...);
  }
}
```

I made the same changes to both `ReactFiberHooks.old.js` and `ReactFiberHooks.new.js` although I observed that `*.old.js` were the one used in my local environment. I searched for the differences between these two files but couldn't find anything. If the change is not needed in the `*.new.js` file, we can remove that part as well.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos if the pull request changes the user interface. -->
For the test strategy, I added two basic tests to `ReactHooks-test.internal.js`, for both `useState` and `setState` functions. In the tests, a function whose name starts with a capital letter is passed and the console warning is expected as a result of those function calls.

If needed, test cases for success scenarios can be added. However, as far as I observed, most of the other test cases are failing if a warning is fired in a success scenario.
