### PR TITLE
Remove textarea special case from ChildFiber

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -216,18 +216,16 @@ function coerceRef(
 }
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
-  if (returnFiber.type !== 'textarea') {
-    const childString = Object.prototype.toString.call(newChild);
-    invariant(
-      false,
-      'Objects are not valid as a React child (found: %s). ' +
-        'If you meant to render a collection of children, use an array ' +
-        'instead.',
-      childString === '[object Object]'
-        ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
-        : childString,
-    );
-  }
+  const childString = Object.prototype.toString.call(newChild);
+  invariant(
+    false,
+    'Objects are not valid as a React child (found: %s). ' +
+      'If you meant to render a collection of children, use an array ' +
+      'instead.',
+    childString === '[object Object]'
+      ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
+      : childString,
+  );
 }
 
 function warnOnFunctionType(returnFiber: Fiber) {

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -216,18 +216,16 @@ function coerceRef(
 }
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
-  if (returnFiber.type !== 'textarea') {
-    const childString = Object.prototype.toString.call(newChild);
-    invariant(
-      false,
-      'Objects are not valid as a React child (found: %s). ' +
-        'If you meant to render a collection of children, use an array ' +
-        'instead.',
-      childString === '[object Object]'
-        ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
-        : childString,
-    );
-  }
+  const childString = Object.prototype.toString.call(newChild);
+  invariant(
+    false,
+    'Objects are not valid as a React child (found: %s). ' +
+      'If you meant to render a collection of children, use an array ' +
+      'instead.',
+    childString === '[object Object]'
+      ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
+      : childString,
+  );
 }
 
 function warnOnFunctionType(returnFiber: Fiber) {


### PR DESCRIPTION
It was added in https://github.com/facebook/react/commit/7af673afc148fe2eb8a1753a901c1d46b78ea476. We don't need this toString the children in the `<textarea>` special case: https://github.com/facebook/react/blob/7af673afc148fe2eb8a1753a901c1d46b78ea476/src/renderers/dom/fiber/wrappers/ReactDOMFiberTextarea.js#L60

However, we used to then also reconcile the children because we didn't use the shouldTextContent special case for textareas:

https://github.com/facebook/react/blob/7af673afc148fe2eb8a1753a901c1d46b78ea476/src/renderers/dom/fiber/ReactDOMFiber.js#L259

But now we do:

https://github.com/facebook/react/blob/bdc23c3dba86eaa03c7accecc16e8fd997e9185e/packages/react-dom/src/client/ReactDOMHostConfig.js#L353

Therefore we don't need this anymore.