### PR TITLE
Fixed broken feature flag import for DT inline package

### DIFF
--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-devtools-inline",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Embed react-devtools within a website",
   "license": "MIT",
   "main": "./dist/backend.js",

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -33,10 +33,14 @@ module.exports = {
     react: 'react',
     // TODO: Once this package is published, remove the external
     // 'react-debug-tools': 'react-debug-tools',
-    'react-devtools-feature-flags': resolveFeatureFlags('inline'),
     'react-dom': 'react-dom',
     'react-is': 'react-is',
     scheduler: 'scheduler',
+  },
+  resolve: {
+    alias: {
+      'react-devtools-feature-flags': resolveFeatureFlags('inline'),
+    },
   },
   optimization: {
     minimize: false,

--- a/packages/react-devtools/CHANGELOG.md
+++ b/packages/react-devtools/CHANGELOG.md
@@ -9,6 +9,10 @@
   <!-- Upcoming changes go here -->
 </details>
 
+## 4.11.1 (April 11, 2021)
+#### Bugfix
+* Fixed broken import in `react-devtools-inline` for feature flags file ([bvaughn](https://github.com/bvaughn) in [#21235](https://github.com/facebook/react/issues/21235))
+
 ## 4.11.0 (April 9, 2021)
 #### Bugfix
 * `$r` should contain hooks property when it is `forwardRef` or `memo` component  ([meowtec](https://github.com/meowtec) in [#20626](https://github.com/facebook/react/pull/20626))


### PR DESCRIPTION
Resolves #21235

I accidentally put the module map in an `externals` map rather than a `resolve.alias` map. Oops.