### PR TITLE
yarn test: Default to bleeding edge configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,14 +462,14 @@ workflows:
                 - "-r=stable --env=production"
                 - "-r=experimental --env=development"
                 - "-r=experimental --env=production"
-                - "-r=www-classic --env=development"
-                - "-r=www-classic --env=production"
-                - "-r=www-classic --env=development --variant"
-                - "-r=www-classic --env=production --variant"
-                - "-r=www-modern --env=development"
-                - "-r=www-modern --env=production"
-                - "-r=www-modern --env=development --variant"
-                - "-r=www-modern --env=production --variant"
+                - "-r=www-classic --env=development --variant=false"
+                - "-r=www-classic --env=production --variant=false"
+                - "-r=www-classic --env=development --variant=true"
+                - "-r=www-classic --env=production --variant=true"
+                - "-r=www-modern --env=development --variant=false"
+                - "-r=www-modern --env=production --variant=false"
+                - "-r=www-modern --env=development --variant=true"
+                - "-r=www-modern --env=production --variant=true"
 
                 # TODO: Test more persistent configurations?
                 - '-r=stable --env=development --persistent'
@@ -497,14 +497,14 @@ workflows:
                 - "--project=devtools -r=experimental"
 
                 # TODO: Update test config to support www build tests
-                # - "-r=www-classic --env=development"
-                # - "-r=www-classic --env=production"
-                # - "-r=www-classic --env=development --variant"
-                # - "-r=www-classic --env=production --variant"
-                # - "-r=www-modern --env=development"
-                # - "-r=www-modern --env=production"
-                # - "-r=www-modern --env=development --variant"
-                # - "-r=www-modern --env=production --variant"
+                # - "-r=www-classic --env=development --variant=false"
+                # - "-r=www-classic --env=production --variant=false"
+                # - "-r=www-classic --env=development --variant=true"
+                # - "-r=www-classic --env=production --variant=true"
+                # - "-r=www-modern --env=development --variant=false"
+                # - "-r=www-modern --env=production --variant=false"
+                # - "-r=www-modern --env=development --variant=true"
+                # - "-r=www-modern --env=production --variant=true"
 
                 # TODO: Test more persistent configurations?
       - get_base_build:

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -44,7 +44,7 @@ const argv = yargs
       describe: 'Run with the given release channel.',
       requiresArg: true,
       type: 'string',
-      default: 'experimental',
+      default: 'www-modern',
       choices: ['experimental', 'stable', 'www-classic', 'www-modern'],
     },
     env: {
@@ -71,7 +71,6 @@ const argv = yargs
       describe: 'Run with www variant set to true.',
       requiresArg: false,
       type: 'boolean',
-      default: false,
     },
     build: {
       alias: 'b',
@@ -161,11 +160,18 @@ function validateOptions() {
     }
   }
 
-  if (argv.variant && !isWWWConfig()) {
-    logError(
-      'Variant is only supported for the www release channels. Update these options to continue.'
-    );
-    success = false;
+  if (isWWWConfig()) {
+    if (argv.variant === undefined) {
+      // Turn internal experiments on by default
+      argv.variant = true;
+    }
+  } else {
+    if (argv.variant) {
+      logError(
+        'Variant is only supported for the www release channels. Update these options to continue.'
+      );
+      success = false;
+    }
   }
 
   if (argv.build && argv.persistent) {


### PR DESCRIPTION
My personal workflow is to develop against the www-modern release channel, with the variant flags enabled, because it encompasses the largest set of features. Then I rely on CI to run the tests against all the other configurations.

So in practice, I almost always run

```sh
yarn test -r=www-modern --variant TEST_FILE
```

instead of

```sh
yarn test TEST_FILE
```

So, I've updated the `yarn test` command to use those options by default.

## Test plan

I logged `gate(flags => flags)` in a test file, ran it against different test commands, and inspected the output.