### PR TITLE
Prevent reading canonical property of null

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -13,7 +13,8 @@ import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateI
 const ReactFabricGlobalResponderHandler = {
   onChange: function(from: any, to: any, blockNativeResponder: boolean) {
     const fromOrTo = from || to;
-    const isFabric = !!fromOrTo.stateNode.canonical._internalInstanceHandle;
+    const fromOrToStateNode = fromOrTo && fromOrTo.stateNode;
+    const isFabric = !!(fromOrToStateNode && fromOrToStateNode.canonical._internalInstanceHandle);
 
     if (isFabric) {
       // Noop for now until setJSResponder/clearJSResponder are supported in Fabric

--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -14,7 +14,9 @@ const ReactFabricGlobalResponderHandler = {
   onChange: function(from: any, to: any, blockNativeResponder: boolean) {
     const fromOrTo = from || to;
     const fromOrToStateNode = fromOrTo && fromOrTo.stateNode;
-    const isFabric = !!(fromOrToStateNode && fromOrToStateNode.canonical._internalInstanceHandle);
+    const isFabric = !!(
+      fromOrToStateNode && fromOrToStateNode.canonical._internalInstanceHandle
+    );
 
     if (isFabric) {
       // Noop for now until setJSResponder/clearJSResponder are supported in Fabric


### PR DESCRIPTION
## Summary

If both `from` and `to` are null, this crashes.

My only question is if there's a better way to do optional chaining that is supported in the React repo? Can I use `??`?

## Test Plan

`yarn flow fabric && yarn flow native && yarn lint && yarn test`