### PR TITLE
[Fizz] Implement New Context

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -48,6 +48,10 @@ import hasOwnProperty from 'shared/hasOwnProperty';
 import sanitizeURL from '../shared/sanitizeURL';
 import isArray from 'shared/isArray';
 
+// Used to distinguish these contexts from ones used in other renderers.
+// E.g. this can be used to distinguish legacy renderers from this modern one.
+export const isPrimaryRenderer = true;
+
 // Per response, global state that is not contextual to the rendering subtree.
 export type ResponseState = {
   placeholderPrefix: PrecomputedChunk,

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -23,6 +23,8 @@ import {
 
 import invariant from 'shared/invariant';
 
+export const isPrimaryRenderer = true;
+
 // Every list of children or string is null terminated.
 const END_TAG = 0;
 // Tree node tags.

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -8,6 +8,7 @@
  */
 
 import {emptyContextObject} from './ReactFizzContext';
+import {readContext} from './ReactFizzNewContext';
 
 import {disableLegacyContext} from 'shared/ReactFeatureFlags';
 import {get as getInstance, set as setInstance} from 'shared/ReactInstanceMap';
@@ -211,9 +212,7 @@ export function constructClassInstance(
   }
 
   if (typeof contextType === 'object' && contextType !== null) {
-    // TODO: Implement Context.
-    // context = readContext((contextType: any));
-    throw new Error('Context is not yet implemented.');
+    context = readContext((contextType: any));
   } else if (!disableLegacyContext) {
     context = maskedLegacyContext;
   }
@@ -617,9 +616,7 @@ export function mountClassInstance(
 
   const contextType = ctor.contextType;
   if (typeof contextType === 'object' && contextType !== null) {
-    // TODO: Implement Context.
-    // instance.context = readContext(contextType);
-    throw new Error('Context is not yet implemented.');
+    instance.context = readContext(contextType);
   } else if (disableLegacyContext) {
     instance.context = emptyContextObject;
   } else {

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -219,7 +219,7 @@ export function pushProvider<T>(
   return newNode;
 }
 
-export function popProvider<T>(context: ReactContext<T>): void {
+export function popProvider<T>(context: ReactContext<T>): ContextSnapshot {
   const prevSnapshot = currentActiveSnapshot;
   invariant(
     prevSnapshot !== null,
@@ -263,7 +263,7 @@ export function popProvider<T>(context: ReactContext<T>): void {
       context._currentRenderer2 = rendererSigil;
     }
   }
-  currentActiveSnapshot = prevSnapshot.parent;
+  return (currentActiveSnapshot = prevSnapshot.parent);
 }
 
 export function getActiveContext(): ContextSnapshot {

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -9,10 +9,9 @@
 
 import type {ReactContext} from 'shared/ReactTypes';
 
-import invariant from 'shared/invariant';
+import {isPrimaryRenderer} from './ReactServerFormatConfig';
 
-// TODO: Move to format config.
-const isPrimaryRenderer = true;
+import invariant from 'shared/invariant';
 
 let rendererSigil;
 if (__DEV__) {

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -41,9 +41,133 @@ export const rootContextSnapshot: ContextSnapshot = null;
 // fields are currently in.
 let currentActiveSnapshot: ContextSnapshot = null;
 
+function popNode(prev: ContextNode<any>): void {
+  if (isPrimaryRenderer) {
+    prev.context._currentValue = prev.parentValue;
+  } else {
+    prev.context._currentValue2 = prev.parentValue;
+  }
+}
+
+function pushNode(next: ContextNode<any>): void {
+  if (isPrimaryRenderer) {
+    next.context._currentValue = next.value;
+  } else {
+    next.context._currentValue2 = next.value;
+  }
+}
+
+function popToNearestCommonAncestor(
+  prev: ContextNode<any>,
+  next: ContextNode<any>,
+): void {
+  if (prev === next) {
+    // We've found a shared ancestor. We don't need to pop nor reapply this one or anything above.
+  } else {
+    popNode(prev);
+    const parentPrev = prev.parent;
+    const parentNext = next.parent;
+    if (parentPrev === null) {
+      invariant(
+        parentNext === null,
+        'The stacks must reach the root at the same time. This is a bug in React.',
+      );
+    } else {
+      invariant(
+        parentNext !== null,
+        'The stacks must reach the root at the same time. This is a bug in React.',
+      );
+      popToNearestCommonAncestor(parentPrev, parentNext);
+      // On the way back, we push the new ones that weren't common.
+      pushNode(next);
+    }
+  }
+}
+
+function popAllPrevious(prev: ContextNode<any>): void {
+  popNode(prev);
+  const parentPrev = prev.parent;
+  if (parentPrev !== null) {
+    popAllPrevious(parentPrev);
+  }
+}
+
+function pushAllNext(next: ContextNode<any>): void {
+  const parentNext = next.parent;
+  if (parentNext !== null) {
+    pushAllNext(parentNext);
+  }
+  pushNode(next);
+}
+
+function popPreviousToCommonLevel(
+  prev: ContextNode<any>,
+  next: ContextNode<any>,
+): void {
+  popNode(prev);
+  const parentPrev = prev.parent;
+  invariant(
+    parentPrev !== null,
+    'The depth must equal at least at zero before reaching the root. This is a bug in React.',
+  );
+  if (parentPrev.depth === next.depth) {
+    // We found the same level. Now we just need to find a shared ancestor.
+    popToNearestCommonAncestor(parentPrev, next);
+  } else {
+    // We must still be deeper.
+    popPreviousToCommonLevel(parentPrev, next);
+  }
+}
+
+function popNextToCommonLevel(
+  prev: ContextNode<any>,
+  next: ContextNode<any>,
+): void {
+  const parentNext = next.parent;
+  invariant(
+    parentNext !== null,
+    'The depth must equal at least at zero before reaching the root. This is a bug in React.',
+  );
+  if (prev.depth === parentNext.depth) {
+    // We found the same level. Now we just need to find a shared ancestor.
+    popToNearestCommonAncestor(prev, parentNext);
+  } else {
+    // We must still be deeper.
+    popNextToCommonLevel(prev, parentNext);
+  }
+  pushNode(next);
+}
+
 // Perform context switching to the new snapshot.
+// To make it cheap to read many contexts, while not suspending, we make the switch eagerly by
+// updating all the context's current values. That way reads, always just read the current value.
+// At the cost of updating contexts even if they're never read by this subtree.
 export function switchContext(newSnapshot: ContextSnapshot): void {
-  // TODO: Switch the context.
+  // The basic algorithm we need to do is to pop back any contexts that are no longer on the stack.
+  // We also need to update any new contexts that are now on the stack with the deepest value.
+  // The easiest way to update new contexts is to just reapply them in reverse order from the
+  // perspective of the backpointers. To avoid allocating a lot when switching, we use the stack
+  // for that. Therefore this algorithm is recursive.
+  // 1) First we pop which ever snapshot tree was deepest. Popping old contexts as we go.
+  // 2) Then we find the nearest common ancestor from there. Popping old contexts as we go.
+  // 3) Then we reapply new contexts on the way back up the stack.
+  const prev = currentActiveSnapshot;
+  const next = newSnapshot;
+  if (prev !== next) {
+    if (prev === null) {
+      // $FlowFixMe: This has to be non-null since it's not equal to prev.
+      pushAllNext(next);
+    } else if (next === null) {
+      popAllPrevious(prev);
+    } else if (prev.depth === next.depth) {
+      popToNearestCommonAncestor(prev, next);
+    } else if (prev.depth > next.depth) {
+      popPreviousToCommonLevel(prev, next);
+    } else {
+      popNextToCommonLevel(prev, next);
+    }
+    currentActiveSnapshot = next;
+  }
 }
 
 export function pushProvider<T>(

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactContext} from 'shared/ReactTypes';
+
+import invariant from 'shared/invariant';
+
+// TODO: Move to format config.
+const isPrimaryRenderer = true;
+
+let rendererSigil;
+if (__DEV__) {
+  // Use this to detect multiple renderers using the same context
+  rendererSigil = {};
+}
+
+// Used to store the parent path of all context overrides in a shared linked list.
+// Forming a reverse tree.
+type ContextNode<T> = {
+  parent: null | ContextNode<any>,
+  depth: number, // Short hand to compute the depth of the tree at this node.
+  context: ReactContext<T>,
+  parentValue: T,
+  value: T,
+};
+
+// The structure of a context snapshot is an implementation of this file.
+// Currently, it's implemented as tracking the current active node.
+export opaque type ContextSnapshot = null | ContextNode<any>;
+
+export const rootContextSnapshot: ContextSnapshot = null;
+
+// We assume that this runtime owns the "current" field on all ReactContext instances.
+// This global (actually thread local) state represents what state all those "current",
+// fields are currently in.
+let currentActiveSnapshot: ContextSnapshot = null;
+
+// Perform context switching to the new snapshot.
+export function switchContext(newSnapshot: ContextSnapshot): void {
+  // TODO: Switch the context.
+}
+
+export function pushProvider<T>(
+  context: ReactContext<T>,
+  nextValue: T,
+): ContextSnapshot {
+  let prevValue;
+  if (isPrimaryRenderer) {
+    prevValue = context._currentValue;
+    context._currentValue = nextValue;
+    if (__DEV__) {
+      if (
+        context._currentRenderer !== undefined &&
+        context._currentRenderer !== null &&
+        context._currentRenderer !== rendererSigil
+      ) {
+        console.error(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+      context._currentRenderer = rendererSigil;
+    }
+  } else {
+    prevValue = context._currentValue2;
+    context._currentValue2 = nextValue;
+    if (__DEV__) {
+      if (
+        context._currentRenderer2 !== undefined &&
+        context._currentRenderer2 !== null &&
+        context._currentRenderer2 !== rendererSigil
+      ) {
+        console.error(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+      context._currentRenderer2 = rendererSigil;
+    }
+  }
+  const prevNode = currentActiveSnapshot;
+  const newNode: ContextNode<T> = {
+    parent: prevNode,
+    depth: prevNode === null ? 0 : prevNode.depth + 1,
+    context: context,
+    parentValue: prevValue,
+    value: nextValue,
+  };
+  currentActiveSnapshot = newNode;
+  return newNode;
+}
+
+export function popProvider<T>(context: ReactContext<T>): void {
+  const prevSnapshot = currentActiveSnapshot;
+  invariant(
+    prevSnapshot !== null,
+    'Tried to pop a Context at the root of the app. This is a bug in React.',
+  );
+  if (__DEV__) {
+    if (prevSnapshot.context !== context) {
+      console.error(
+        'The parent context is not the expected context. This is probably a bug in React.',
+      );
+    }
+  }
+  if (isPrimaryRenderer) {
+    prevSnapshot.context._currentValue = prevSnapshot.parentValue;
+    if (__DEV__) {
+      if (
+        context._currentRenderer !== undefined &&
+        context._currentRenderer !== null &&
+        context._currentRenderer !== rendererSigil
+      ) {
+        console.error(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+      context._currentRenderer = rendererSigil;
+    }
+  } else {
+    prevSnapshot.context._currentValue2 = prevSnapshot.parentValue;
+    if (__DEV__) {
+      if (
+        context._currentRenderer2 !== undefined &&
+        context._currentRenderer2 !== null &&
+        context._currentRenderer2 !== rendererSigil
+      ) {
+        console.error(
+          'Detected multiple renderers concurrently rendering the ' +
+            'same context provider. This is currently unsupported.',
+        );
+      }
+      context._currentRenderer2 = rendererSigil;
+    }
+  }
+  currentActiveSnapshot = prevSnapshot.parent;
+}
+
+export function getActiveContext(): ContextSnapshot {
+  return currentActiveSnapshot;
+}

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -269,3 +269,10 @@ export function popProvider<T>(context: ReactContext<T>): ContextSnapshot {
 export function getActiveContext(): ContextSnapshot {
   return currentActiveSnapshot;
 }
+
+export function readContext<T>(context: ReactContext<T>): T {
+  const value = isPrimaryRenderer
+    ? context._currentValue
+    : context._currentValue2;
+  return value;
+}

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -66,6 +66,8 @@ import {
   rootContextSnapshot,
   switchContext,
   getActiveContext,
+  pushProvider,
+  popProvider,
 } from './ReactFizzNewContext';
 
 import {
@@ -748,7 +750,23 @@ function renderContextProvider(
   type: ReactProviderType<any>,
   props: Object,
 ): void {
-  throw new Error('Not yet implemented element type.');
+  const context = type._context;
+  const value = props.value;
+  const children = props.children;
+  let prevSnapshot;
+  if (__DEV__) {
+    prevSnapshot = task.context;
+  }
+  task.context = pushProvider(context, value);
+  renderNodeDestructive(request, task, children);
+  task.context = popProvider(context);
+  if (__DEV__) {
+    if (prevSnapshot !== task.context) {
+      console.error(
+        'Popping the context provider did not return back to the original snapshot. This is a bug in React.',
+      );
+    }
+  }
 }
 
 function renderLazyComponent(

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -29,6 +29,8 @@ export opaque type ResponseState = mixed;
 export opaque type FormatContext = mixed;
 export opaque type SuspenseBoundaryID = mixed;
 
+export const isPrimaryRenderer = false;
+
 export const getChildFormatContext = $$$hostConfig.getChildFormatContext;
 export const createSuspenseBoundaryID = $$$hostConfig.createSuspenseBoundaryID;
 export const pushEmpty = $$$hostConfig.pushEmpty;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -388,5 +388,8 @@
   "397": "Unknown insertion mode. This is a bug in React.",
   "398": "`dangerouslySetInnerHTML` does not work on <option>.",
   "399": "%s is a self-closing tag and must neither have `children` nor use `dangerouslySetInnerHTML`.",
-  "400": "menuitems cannot have `children` nor `dangerouslySetInnerHTML`."
+  "400": "menuitems cannot have `children` nor `dangerouslySetInnerHTML`.",
+  "401": "The stacks must reach the root at the same time. This is a bug in React.",
+  "402": "The depth must equal at least at zero before reaching the root. This is a bug in React.",
+  "403": "Tried to pop a Context at the root of the app. This is a bug in React."
 }


### PR DESCRIPTION
Fizz is a bit different than either Fiber or the partial renderer in terms of scenarios and tradeoffs. Unlike the partial renderer, we don't just always resume where we previously left off. We can suspend in different sibling trees. Unlike Fiber, we never have to restart with new props and we don't otherwise need the tree we've already past.

We could use a model similar to partial renderer's use of threads, where each context has N number of concurrent threads and a thread is allocated for each suspended task. But that would require a large and growing array for each Context which probably doesn't end up paying for itself.

We could use a Map of contexts associated with each provider. This requires a lot of cloning at the point of each provider. Effectively what legacy context does.

We could also store a loop up list of all parent providers that we backtrack any time we read a Context. That comes at the cost of reading being slower.

The general tradeoffs that we want to favor is making reading cheap so that mostly global dependency injection things are very cheap. We also generally favor rendering at full perf once something is unsuspended. Even though there are many possible suspended points, if you're preload a lot of data then you hopefully can just render straight through large sections without suspending at all.

The approach that I actually went with is similar to the Fiber approach in that we update the `_currentValue` field on each context and then reading is as cheap as just reading that value.

I also store a linked list of the stack of context providers that we're currently in. This gets heap allocated each time we visit a provider. If we need to spawn a new task, this node is what gets stored on the Task.

When we resume work on a task, we switch context by popping and pushing the delta between the most recently active context and the task's context. I.e. we restore where we were.

The cost of this happens at the point when we switch between tasks. It's cheap (or free) when we're resuming a single task over and over. Such as when the first few root components suspend or when you've reach the last suspended subtree which is the final one blocking completion. It's slower when you're switching back and forth between two deep and far removed siblings but at that point you're not close to reaching completion anyway.

_(This could use some more tests of various suspending and resuming scenarios that are specific to Fizz and isn't covered by existing tests. The coverage isn't great yet. But didn't want to spend too much time on it before I unblock other work on top.)_
