### PR TITLE
[Fizz] Implement useOpaqueIdentifier

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -57,8 +57,9 @@ export type ResponseState = {
   placeholderPrefix: PrecomputedChunk,
   segmentPrefix: PrecomputedChunk,
   boundaryPrefix: string,
-  opaqueIdentifierPrefix: PrecomputedChunk,
+  opaqueIdentifierPrefix: string,
   nextSuspenseID: number,
+  nextOpaqueID: number,
   sentCompleteSegmentFunction: boolean,
   sentCompleteBoundaryFunction: boolean,
   sentClientRenderFunction: boolean,
@@ -72,8 +73,9 @@ export function createResponseState(
     placeholderPrefix: stringToPrecomputedChunk(identifierPrefix + 'P:'),
     segmentPrefix: stringToPrecomputedChunk(identifierPrefix + 'S:'),
     boundaryPrefix: identifierPrefix + 'B:',
-    opaqueIdentifierPrefix: stringToPrecomputedChunk(identifierPrefix + 'R:'),
+    opaqueIdentifierPrefix: identifierPrefix + 'R:',
     nextSuspenseID: 0,
+    nextOpaqueID: 0,
     sentCompleteSegmentFunction: false,
     sentCompleteBoundaryFunction: false,
     sentClientRenderFunction: false,
@@ -170,6 +172,22 @@ export function createSuspenseBoundaryID(
   responseState: ResponseState,
 ): SuspenseBoundaryID {
   return {formattedID: null};
+}
+
+export type OpaqueIDType = string;
+
+export function makeServerID(
+  responseState: null | ResponseState,
+): OpaqueIDType {
+  invariant(
+    responseState !== null,
+    'Invalid hook call. Hooks can only be called inside of the body of a function component.',
+  );
+  // TODO: This is not deterministic since it's created during render.
+  return (
+    responseState.opaqueIdentifierPrefix +
+    (responseState.nextOpaqueID++).toString(36)
+  );
 }
 
 function encodeHTMLTextNode(text: string): string {

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -61,12 +61,14 @@ SUSPENSE_UPDATE_TO_CLIENT_RENDER[0] = SUSPENSE_UPDATE_TO_CLIENT_RENDER_TAG;
 // Per response,
 export type ResponseState = {
   nextSuspenseID: number,
+  nextOpaqueID: number,
 };
 
 // Allows us to keep track of what we've already written so we can refer back to it.
 export function createResponseState(): ResponseState {
   return {
     nextSuspenseID: 0,
+    nextOpaqueID: 0,
   };
 }
 
@@ -106,6 +108,19 @@ export function createSuspenseBoundaryID(
 ): SuspenseBoundaryID {
   // TODO: This is not deterministic since it's created during render.
   return responseState.nextSuspenseID++;
+}
+
+export type OpaqueIDType = number;
+
+export function makeServerID(
+  responseState: null | ResponseState,
+): OpaqueIDType {
+  invariant(
+    responseState !== null,
+    'Invalid hook call. Hooks can only be called inside of the body of a function component.',
+  );
+  // TODO: This is not deterministic since it's created during render.
+  return responseState.nextOpaqueID++;
 }
 
 const RAW_TEXT = stringToPrecomputedChunk('RCTRawText');

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -53,6 +53,8 @@ type Destination = {
 
 const POP = Buffer.from('/', 'utf8');
 
+let opaqueID = 0;
+
 const ReactNoopServer = ReactFizzServer({
   scheduleWork(callback: () => void) {
     callback();
@@ -82,6 +84,10 @@ const ReactNoopServer = ReactFizzServer({
   createSuspenseBoundaryID(): SuspenseInstance {
     // The ID is a pointer to the boundary itself.
     return {state: 'pending', children: []};
+  },
+
+  makeServerID(): number {
+    return opaqueID++;
   },
 
   getChildFormatContext(): null {

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -16,7 +16,11 @@ import type {
   ReactContext,
 } from 'shared/ReactTypes';
 
+import type {ResponseState, OpaqueIDType} from './ReactServerFormatConfig';
+
 import {readContext as readContextImpl} from './ReactFizzNewContext';
+
+import {makeServerID} from './ReactServerFormatConfig';
 
 import invariant from 'shared/invariant';
 import {enableCache} from 'shared/ReactFeatureFlags';
@@ -40,8 +44,6 @@ type Hook = {|
   queue: UpdateQueue<any> | null,
   next: Hook | null,
 |};
-
-type OpaqueIDType = string;
 
 let currentlyRenderingComponent: Object | null = null;
 let firstWorkInProgressHook: Hook | null = null;
@@ -474,7 +476,7 @@ function useTransition(): [(callback: () => void) => void, boolean] {
 }
 
 function useOpaqueIdentifier(): OpaqueIDType {
-  throw new Error('Not yet implemented.');
+  return makeServerID(currentResponseState);
 }
 
 function unsupportedRefresh() {
@@ -512,4 +514,11 @@ export const Dispatcher: DispatcherType = {
 if (enableCache) {
   Dispatcher.getCacheForType = getCacheForType;
   Dispatcher.useCacheRefresh = useCacheRefresh;
+}
+
+export let currentResponseState: null | ResponseState = (null: any);
+export function setCurrentResponseState(
+  responseState: null | ResponseState,
+): void {
+  currentResponseState = responseState;
 }

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -74,6 +74,8 @@ import {
   finishHooks,
   resetHooksState,
   Dispatcher,
+  currentResponseState,
+  setCurrentResponseState,
 } from './ReactFizzHooks';
 
 import {
@@ -1341,7 +1343,8 @@ function performWork(request: Request): void {
   const prevContext = getActiveContext();
   const prevDispatcher = ReactCurrentDispatcher.current;
   ReactCurrentDispatcher.current = Dispatcher;
-
+  const prevResponseState = currentResponseState;
+  setCurrentResponseState(request.responseState);
   try {
     const pingedTasks = request.pingedTasks;
     let i;
@@ -1357,6 +1360,7 @@ function performWork(request: Request): void {
     reportError(request, error);
     fatalError(request, error);
   } finally {
+    setCurrentResponseState(prevResponseState);
     ReactCurrentDispatcher.current = prevDispatcher;
     if (prevDispatcher === Dispatcher) {
       // This means that we were in a reentrant work loop. This could happen

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -28,11 +28,13 @@ export opaque type Destination = mixed; // eslint-disable-line no-undef
 export opaque type ResponseState = mixed;
 export opaque type FormatContext = mixed;
 export opaque type SuspenseBoundaryID = mixed;
+export opaque type OpaqueIDType = mixed;
 
 export const isPrimaryRenderer = false;
 
 export const getChildFormatContext = $$$hostConfig.getChildFormatContext;
 export const createSuspenseBoundaryID = $$$hostConfig.createSuspenseBoundaryID;
+export const makeServerID = $$$hostConfig.makeServerID;
 export const pushEmpty = $$$hostConfig.pushEmpty;
 export const pushTextInstance = $$$hostConfig.pushTextInstance;
 export const pushStartInstance = $$$hostConfig.pushStartInstance;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -391,5 +391,6 @@
   "400": "menuitems cannot have `children` nor `dangerouslySetInnerHTML`.",
   "401": "The stacks must reach the root at the same time. This is a bug in React.",
   "402": "The depth must equal at least at zero before reaching the root. This is a bug in React.",
-  "403": "Tried to pop a Context at the root of the app. This is a bug in React."
+  "403": "Tried to pop a Context at the root of the app. This is a bug in React.",
+  "404": "Invalid hook call. Hooks can only be called inside of the body of a function component."
 }


### PR DESCRIPTION
Builds on top of #21257.

The format of useOpaqueIdentifier varies between formats.

We need to track the responseState so that we know which one currently applies to the currently rendering component.

This should ideally be deterministic. Right now it's not, because it's created during render. This means that depending on which order things unsuspend, you get different resulting HTML.

This implements a naive number incrementation for React Native. RN doesn't have a concept of these IDs yet but it could probably use some special encoding in the protocol instead to create native IDs.