### PR TITLE
Fix DevTools test target

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -104,8 +104,9 @@ function logError(message) {
 }
 function isWWWConfig() {
   return (
-    argv.releaseChannel === 'www-classic' ||
-    argv.releaseChannel === 'www-modern'
+    (argv.releaseChannel === 'www-classic' ||
+      argv.releaseChannel === 'www-modern') &&
+    argv.project !== 'devtools'
   );
 }
 


### PR DESCRIPTION
This regressed in #21238 so that `yarn test-build-devtools` no longer ran.