### PR TITLE
[Fizz] Always insert a dummy node with an ID into fallbacks

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -419,17 +419,30 @@ function renderSuspenseBoundary(
     task.blockedSegment = parentSegment;
   }
 
+  // This injects an extra segment just to contain an empty tag with an ID.
+  // This means that we're not actually using the assignID anywhere.
+  // TODO: Rethink the assignID approach.
+  pushEmpty(boundarySegment.chunks, request.responseState, newBoundary.id);
+  const innerSegment = createPendingSegment(
+    request,
+    boundarySegment.chunks.length,
+    null,
+    boundarySegment.formatContext,
+  );
+  boundarySegment.status = COMPLETED;
+  boundarySegment.children.push(innerSegment);
+
   // We create suspended task for the fallback because we don't want to actually work
   // on it yet in case we finish the main content, so we queue for later.
   const suspendedFallbackTask = createTask(
     request,
     fallback,
     parentBoundary,
-    boundarySegment,
+    innerSegment,
     fallbackAbortSet,
     task.legacyContext,
     task.context,
-    newBoundary.id, // This is the ID we want to give this fallback so we can replace it later.
+    null,
   );
   // TODO: This should be queued at a separate lower priority queue so that we only work
   // on preparing fallbacks if we don't have any more main content to task on.


### PR DESCRIPTION
This test shows that the `assignID` approach is flawed. That approach wants to reuse an ID that already exists on the fallback if it's available, or assign one to the first element. However, because the fallback itself can suspend, we can't rely on that existing yet.

Since the fallback itself can be emitted as a partial we might have already flushed some of it but not the ID. At that point there's nothing to refer to.

This shows up in a case if you throw an error while the fallback is still suspended if that tree has been partially flushed already because there's no ID yet to refer to.

This PR just always inserts a dummy node but this really invalidates the whole approach so it needs to be cleaned up and rethought completely.