### PR TITLE
(WIP) Add a post react-devtools setup event

### DIFF
--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -51,6 +51,13 @@ function setup(hook) {
       };
     },
     send(event: string, payload: any, transferable?: Array<any>) {
+      if (window.__REACT_REPLAY_IS_RECORDING__) {
+        // Synchronously notify the record/replay driver.
+        return window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_BRIDGE__(
+          event,
+          payload,
+        );
+      }
       window.postMessage(
         {
           source: 'react-devtools-bridge',

--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -16,7 +16,12 @@ function welcome(event) {
 
   window.removeEventListener('message', welcome);
 
-  setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
+  const {bridge} = setup(window.__REACT_DEVTOOLS_GLOBAL_HOOK__);
+  window.dispatchEvent(
+    new CustomEvent('react-devtools-setup', {
+      bridge,
+    }),
+  );
 }
 
 window.addEventListener('message', welcome);
@@ -51,13 +56,6 @@ function setup(hook) {
       };
     },
     send(event: string, payload: any, transferable?: Array<any>) {
-      if (window.__REACT_REPLAY_IS_RECORDING__) {
-        // Synchronously notify the record/replay driver.
-        return window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_BRIDGE__(
-          event,
-          payload,
-        );
-      }
       window.postMessage(
         {
           source: 'react-devtools-bridge',
@@ -91,4 +89,6 @@ function setup(hook) {
       hook.nativeStyleEditorValidAttributes,
     );
   }
+
+  return {bridge};
 }

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -226,6 +226,23 @@ export default class Agent extends EventEmitter<{|
 
     setupHighlighter(bridge, this);
     setupTraceUpdates(this);
+
+    if (window.__REACT_REPLAY_IS_RECORDING__) {
+      // Hook for sending messages via record/replay evaluations.
+      window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__ = (
+        inEvent,
+        inData,
+      ) => {
+        let rv;
+        this._bridge = {
+          send(event, data) {
+            rv = {event, data};
+          },
+        };
+        this[inEvent](inData);
+        return rv;
+      };
+    }
   }
 
   get rendererInterfaces(): {[key: RendererID]: RendererInterface, ...} {

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -226,23 +226,6 @@ export default class Agent extends EventEmitter<{|
 
     setupHighlighter(bridge, this);
     setupTraceUpdates(this);
-
-    if (window.__REACT_REPLAY_IS_RECORDING__) {
-      // Hook for sending messages via record/replay evaluations.
-      window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__ = (
-        inEvent,
-        inData,
-      ) => {
-        let rv;
-        this._bridge = {
-          send(event, data) {
-            rv = {event, data};
-          },
-        };
-        this[inEvent](inData);
-        return rv;
-      };
-    }
   }
 
   get rendererInterfaces(): {[key: RendererID]: RendererInterface, ...} {


### PR DESCRIPTION
## Summary

This is a very early wip patch to see if it would be possible to avoid modifying `react_devtools_backend` in the Replay browser.

The goal is to emit a post welcome event, which Replay could listen for and do some post setup work.

e.g.

On the Replay side we could do something like:

```js
window.addEventListener(`react-devtools-setup`, ({ bridge }) => {
  window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_MESSAGE__ = (inEvent, inData) => {
      let rv;
      this._bridge = {
        send(event, data) {
         rv = { event, data };
        }
      };
      bridge[inEvent](inData);
      return rv;
  }

  bridge.send = (send, payload, transferable) => window.__RECORD_REPLAY_REACT_DEVTOOLS_SEND_BRIDGE__(event, payload); 
});
```

* This is admittedly a bit hand wavey.  
* I assume that the Replay content script can fetch `react_devtools_backend` from unpkg and wrap it in an iife
* I assume it is safe to monkeypatch `bridge.send`


I think the replay content script would look something like this:

```js
const reactDevtoolsbackend = fetch(`https://unpkg.com/browse/react-devtools-extension/firefox/build/unpacked/build/react_devtools_backend.js`)
dbgWindow.executeInGlobal(`(function reactDevtoolsBackend(window) { ${reactDevtoolsBackend} })(window))`)
```

this would require publishing `react-devtools-extension` but that feels like a necessary if others are going to depend on it.


Of course, sharing early to get others thoughts. I expect this to change a bunch before we land on something good.