### PR TITLE
Add dynamic flags to React Native

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -9,6 +9,11 @@
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.native-fb';
+import * as DynamicFeatureFlags from './ReactFeatureFlags.www-dynamic';
+
+// Re-export dynamic flags.
+const dynamicFeatureFlags: DynamicFeatureFlags = require('ReactFeatureFlags');
+export const {enableSyncDefaultUpdates} = dynamicFeatureFlags;
 
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;
@@ -60,7 +65,6 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -9,11 +9,6 @@
 
 import typeof * as FeatureFlagsType from 'shared/ReactFeatureFlags';
 import typeof * as ExportsType from './ReactFeatureFlags.native-fb';
-import * as DynamicFeatureFlags from './ReactFeatureFlags.www-dynamic';
-
-// Re-export dynamic flags.
-const dynamicFeatureFlags: DynamicFeatureFlags = require('ReactFeatureFlags');
-export const {enableSyncDefaultUpdates} = dynamicFeatureFlags;
 
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;
@@ -65,6 +60,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## Overview

This should allow RN to turn flags on/off.

They need this right now to temporarily turn off `enableSyncDefaultUpdates`.