### PR TITLE
[Fizz] Mark boundary as client rendered even if aborting fallback

### DIFF
--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1245,21 +1245,17 @@ function abortTask(task: Task): void {
   } else {
     boundary.pendingTasks--;
 
-    if (boundary.fallbackAbortableTasks.size > 0) {
-      // If this boundary was still pending then we haven't already cancelled its fallbacks.
-      // We'll need to abort the fallbacks, which will also error that parent boundary.
-      // This means that we don't have to client render this boundary because its parent
-      // will be client rendered anyway.
-      boundary.fallbackAbortableTasks.forEach(abortTask, request);
-      boundary.fallbackAbortableTasks.clear();
-    } else {
-      if (!boundary.forceClientRender) {
-        boundary.forceClientRender = true;
-        if (boundary.parentFlushed) {
-          request.clientRenderedBoundaries.push(boundary);
-        }
+    if (!boundary.forceClientRender) {
+      boundary.forceClientRender = true;
+      if (boundary.parentFlushed) {
+        request.clientRenderedBoundaries.push(boundary);
       }
     }
+
+    // If this boundary was still pending then we haven't already cancelled its fallbacks.
+    // We'll need to abort the fallbacks, which will also error that parent boundary.
+    boundary.fallbackAbortableTasks.forEach(abortTask, request);
+    boundary.fallbackAbortableTasks.clear();
 
     request.allPendingTasks--;
     if (request.allPendingTasks === 0) {


### PR DESCRIPTION
The fix in https://github.com/facebook/react/pull/21270/commits/57812696c33bbbef8164f805b5638763b9cb7582 was slightly wrong. This surfaced in a legacy test. https://github.com/facebook/react/blob/master/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js

If a task blocking a boundary is aborted, and that boundary's fallback has pending tasks, it doesn't mean that the parent will be client rendered. Because the boundary's fallback's pending tasks might themselves be inside other boundaries and not needed to complete. So we must still mark it as client rendered in that case.

We didn't need to be this conservative because the real fix was moving the allPendingTasks decrementor. As a safety for new user space calls, I made sure to move the parentFlushed check before the recursive call.