### PR TITLE
DevTools fork console patching logic

### DIFF
--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -58,6 +58,9 @@ module.exports = {
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
     }),
   ],
+  optimization: {
+    minimize: false,
+  },
   module: {
     rules: [
       {

--- a/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
@@ -29,9 +29,9 @@ import {
   SUSPENSE_LIST_SYMBOL_STRING,
 } from './ReactSymbols';
 
-// These methods are safe to import from shared;
-// there is no React-specific logic here.
-import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
+// The shared console patching code is DEV-only.
+// We can't use it since DevTools only ships production builds.
+import {disableLogs, reenableLogs} from './DevToolsConsolePatching';
 
 let prefix;
 export function describeBuiltInComponentFrame(

--- a/packages/react-devtools-shared/src/backend/DevToolsConsolePatching.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsConsolePatching.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// This is a DevTools fork of shared/ConsolePatchingDev.
+// The shared console patching code is DEV-only.
+// We can't use it since DevTools only ships production builds.
+
+// Helpers to patch console.logs to avoid logging during side-effect free
+// replaying on render function. This currently only patches the object
+// lazily which won't cover if the log function was extracted eagerly.
+// We could also eagerly patch the method.
+
+let disabledDepth = 0;
+let prevLog;
+let prevInfo;
+let prevWarn;
+let prevError;
+let prevGroup;
+let prevGroupCollapsed;
+let prevGroupEnd;
+
+function disabledLog() {}
+disabledLog.__reactDisabledLog = true;
+
+export function disableLogs(): void {
+  if (disabledDepth === 0) {
+    /* eslint-disable react-internal/no-production-logging */
+    prevLog = console.log;
+    prevInfo = console.info;
+    prevWarn = console.warn;
+    prevError = console.error;
+    prevGroup = console.group;
+    prevGroupCollapsed = console.groupCollapsed;
+    prevGroupEnd = console.groupEnd;
+    // https://github.com/facebook/react/issues/19099
+    const props = {
+      configurable: true,
+      enumerable: true,
+      value: disabledLog,
+      writable: true,
+    };
+    // $FlowFixMe Flow thinks console is immutable.
+    Object.defineProperties(console, {
+      info: props,
+      log: props,
+      warn: props,
+      error: props,
+      group: props,
+      groupCollapsed: props,
+      groupEnd: props,
+    });
+    /* eslint-enable react-internal/no-production-logging */
+  }
+  disabledDepth++;
+}
+
+export function reenableLogs(): void {
+  disabledDepth--;
+  if (disabledDepth === 0) {
+    /* eslint-disable react-internal/no-production-logging */
+    const props = {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    };
+    // $FlowFixMe Flow thinks console is immutable.
+    Object.defineProperties(console, {
+      log: {...props, value: prevLog},
+      info: {...props, value: prevInfo},
+      warn: {...props, value: prevWarn},
+      error: {...props, value: prevError},
+      group: {...props, value: prevGroup},
+      groupCollapsed: {...props, value: prevGroupCollapsed},
+      groupEnd: {...props, value: prevGroupEnd},
+    });
+    /* eslint-enable react-internal/no-production-logging */
+  }
+  if (disabledDepth < 0) {
+    console.error(
+      'disabledDepth fell below zero. ' +
+        'This is a bug in React. Please file an issue.',
+    );
+  }
+}


### PR DESCRIPTION
React has its own [component stack generation code](https://github.com/facebook/react/blob/master/packages/shared/ReactComponentStackFrame.js) that DevTools [embeds a fork of](https://github.com/facebook/react/blob/master/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js), but both of them use [a shared helper for disabling console logs](https://github.com/facebook/react/blob/c1a53ad2b2f29f30412c682b42bdd6ac3227eafa/packages/shared/ConsolePatchingDev.js#L27-L28). This shared helper is DEV only though, because it was intended for use with React DEV-only warnings and we didn't want to unnecessarily add bytes to production builds.

But DevTools itself always ships as a _production build_– even when it's used to debug DEV bundles of product apps (with third party DEV-only warnings). That means this helper was always a noop.

The `resolveCurrentDispatcher` method was [changed recently](https://github.com/facebook/react/pull/20604/files) to replace the thrown error with a call to `console.error`. This newly logged error ended up slipping through and being user visible because of the above issue.

This PR updates DevTools to also fork the console patching logic (to remove the DEV-only guard).

Note that I didn't spot this earlier because my test harness ([`react-devtools-shell`](https://github.com/facebook/react/tree/master/packages/react-devtools-shell)) always runs in DEV mode. 🤡 