### PR TITLE
improved test coverage with findRenderedComponentWithType test

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -503,4 +503,17 @@ describe('ReactTestUtils', () => {
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(mockArgs.length).toEqual(0);
   });
+
+  it('should find rendered component with type in document', () => {
+    class MyComponent extends React.Component {
+      render() {
+        return true;
+      }
+    }
+
+    const instance = ReactTestUtils.renderIntoDocument(<MyComponent/>);
+    const renderedComponentType = ReactTestUtils.findRenderedComponentWithType(instance, MyComponent);
+
+    expect(renderedComponentType).toBe(instance);
+  })
 });


### PR DESCRIPTION
## Summary
I wanted make my first contribution to an open source project by adding a simple test to improve test coverage. 
ReactTestUtils.js was missing coverage on lines 292-294.

## Test Plan
Added a new test to verify that the findRenderedComponentWithType method was indeed finding the rendered component with the given type.

`yarn test reactutils-test --coverage`
Was able to compare test results and verify that the test was passed in addition to improving test coverage.

