### PR TITLE
Update DevTools Error strings to support GitHub fuzzy search

### DIFF
--- a/packages/react-devtools-shared/src/devtools/ProfilerStore.js
+++ b/packages/react-devtools-shared/src/devtools/ProfilerStore.js
@@ -113,7 +113,7 @@ export default class ProfilerStore extends EventEmitter<{|
     }
 
     throw Error(
-      `Could not find commit data for root "${rootID}" and commit ${commitIndex}`,
+      `Could not find commit data for root "${rootID}" and commit "${commitIndex}"`,
     );
   }
 

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -794,7 +794,7 @@ export default class Store extends EventEmitter<{|
 
           if (this._idToElement.has(id)) {
             throw Error(
-              `Cannot add node ${id} because a node with that id is already in the Store.`,
+              `Cannot add node "${id}" because a node with that id is already in the Store.`,
             );
           }
 
@@ -857,7 +857,7 @@ export default class Store extends EventEmitter<{|
 
             if (!this._idToElement.has(parentID)) {
               throw Error(
-                `Cannot add child ${id} to parent ${parentID} because parent node was not found in the Store.`,
+                `Cannot add child "${id}" to parent "${parentID}" because parent node was not found in the Store.`,
               );
             }
 
@@ -909,7 +909,7 @@ export default class Store extends EventEmitter<{|
 
             if (!this._idToElement.has(id)) {
               throw Error(
-                `Cannot remove node ${id} because no matching node was found in the Store.`,
+                `Cannot remove node "${id}" because no matching node was found in the Store.`,
               );
             }
 
@@ -918,7 +918,7 @@ export default class Store extends EventEmitter<{|
             const element = ((this._idToElement.get(id): any): Element);
             const {children, ownerID, parentID, weight} = element;
             if (children.length > 0) {
-              throw new Error(`Node ${id} was removed before its children.`);
+              throw new Error(`Node "${id}" was removed before its children.`);
             }
 
             this._idToElement.delete(id);
@@ -941,7 +941,7 @@ export default class Store extends EventEmitter<{|
               parentElement = ((this._idToElement.get(parentID): any): Element);
               if (parentElement === undefined) {
                 throw Error(
-                  `Cannot remove node ${id} from parent ${parentID} because no matching node was found in the Store.`,
+                  `Cannot remove node "${id}" from parent "${parentID}" because no matching node was found in the Store.`,
                 );
               }
               const index = parentElement.children.indexOf(id);
@@ -1002,7 +1002,7 @@ export default class Store extends EventEmitter<{|
 
           if (!this._idToElement.has(id)) {
             throw Error(
-              `Cannot reorder children for node ${id} because no matching node was found in the Store.`,
+              `Cannot reorder children for node "${id}" because no matching node was found in the Store.`,
             );
           }
 
@@ -1055,7 +1055,7 @@ export default class Store extends EventEmitter<{|
           haveErrorsOrWarningsChanged = true;
           break;
         default:
-          throw Error(`Unsupported Bridge operation ${operation}`);
+          throw Error(`Unsupported Bridge operation "${operation}"`);
       }
     }
 

--- a/packages/react-devtools-shared/src/devtools/utils.js
+++ b/packages/react-devtools-shared/src/devtools/utils.js
@@ -114,7 +114,7 @@ export function printStore(
         const element = store.getElementAtIndex(i);
 
         if (element == null) {
-          throw Error(`Could not find element at index ${i}`);
+          throw Error(`Could not find element at index "${i}"`);
         }
 
         const printedSelectedMarker = printSelectedMarker(i);
@@ -131,7 +131,7 @@ export function printStore(
     // Make sure the pretty-printed test align with the Store's reported number of total rows.
     if (rootWeight !== store.numElements) {
       throw Error(
-        `Inconsistent Store state. Individual root weights (${rootWeight}) do not match total weight (${store.numElements})`,
+        `Inconsistent Store state. Individual root weights ("${rootWeight}") do not match total weight ("${store.numElements}")`,
       );
     }
 

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/githubAPI.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/githubAPI.js
@@ -18,7 +18,7 @@ export async function searchGitHubIssues(
   message: string,
 ): Promise<GitHubIssue | null> {
   // Remove Fiber IDs from error message (as those will be unique).
-  message = message.replace(/"[0-9]+"/, '');
+  message = message.replace(/"[0-9]+"/g, '');
 
   const filters = [
     'in:title',

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -116,7 +116,7 @@ export function getCommitTree({
   }
 
   throw Error(
-    `getCommitTree(): Unable to reconstruct tree for root "${rootID}" and commit ${commitIndex}`,
+    `getCommitTree(): Unable to reconstruct tree for root "${rootID}" and commit "${commitIndex}"`,
   );
 }
 
@@ -194,9 +194,7 @@ function updateTree(
 
         if (nodes.has(id)) {
           throw new Error(
-            'Commit tree already contains fiber ' +
-              id +
-              '. This is a bug in React DevTools.',
+            `Commit tree already contains fiber "${id}". This is a bug in React DevTools.`,
           );
         }
 
@@ -269,9 +267,7 @@ function updateTree(
 
           if (!nodes.has(id)) {
             throw new Error(
-              'Commit tree does not contain fiber ' +
-                id +
-                '. This is a bug in React DevTools.',
+              `Commit tree does not contain fiber "${id}". This is a bug in React DevTools.`,
             );
           }
 
@@ -350,7 +346,7 @@ function updateTree(
         break;
 
       default:
-        throw Error(`Unsupported Bridge operation ${operation}`);
+        throw Error(`Unsupported Bridge operation "${operation}"`);
     }
   }
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/utils.js
@@ -53,12 +53,16 @@ export function prepareProfilingDataFrontendFromBackendAndStore(
       }) => {
         const operations = operationsByRootID.get(rootID);
         if (operations == null) {
-          throw Error(`Could not find profiling operations for root ${rootID}`);
+          throw Error(
+            `Could not find profiling operations for root "${rootID}"`,
+          );
         }
 
         const snapshots = snapshotsByRootID.get(rootID);
         if (snapshots == null) {
-          throw Error(`Could not find profiling snapshots for root ${rootID}`);
+          throw Error(
+            `Could not find profiling snapshots for root "${rootID}"`,
+          );
         }
 
         // Do not filter empty commits from the profiler data!

--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -77,7 +77,7 @@ export function inspectElement({
         // If the Element is still in the Store, we can eagerly remove it from the Map.
         inspectedElementMap.delete(element);
 
-        throw Error(`Element ${id} not found`);
+        throw Error(`Element "${id}" not found`);
 
       case 'full-data':
         const fullData = ((data: any): InspectElementFullData);
@@ -127,6 +127,6 @@ export function inspectElement({
         break;
     }
 
-    throw Error(`Unable to inspect element with id ${id}`);
+    throw Error(`Unable to inspect element with id "${id}"`);
   });
 }

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -241,7 +241,7 @@ export function printOperationsArray(operations: Array<number>) {
         );
         break;
       default:
-        throw Error(`Unsupported Bridge operation ${operation}`);
+        throw Error(`Unsupported Bridge operation "${operation}"`);
     }
   }
 


### PR DESCRIPTION
#21279 added GitHub issue search to link users to pre-existing errors. This search attempts to strip things like ids or indices from the error string before searching:
https://github.com/facebook/react/blob/af1a4cbf7adf2acae6f869e397198752d150e29a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/githubAPI.js#L17-L21

I noticed a bug #21313 was filed that didn't match a pre-existing bug #20431 and realized this was because there were no ""s around the Fiber id. This PR updates all DevTools errors to put ""s around dynamic parts of DevTools errors to better support the matching logic.