### PR TITLE
Turn off enableSyncDefaultUpdates in test renderer

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -59,7 +59,7 @@ export const enableUseRefAccessWarning = false;
 export const enableRecursiveCommitTraversal = false;
 export const disableSchedulerTimeoutInWorkLoop = false;
 export const enableLazyContextPropagation = false;
-export const enableSyncDefaultUpdates = true;
+export const enableSyncDefaultUpdates = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## Overview

This is failing the sync so let's turn it off and follow up after we have the root config option.