### PR TITLE
Continuous updates should interrupt transitions

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -39,6 +39,7 @@ import {
   enableCache,
   enableSchedulingProfiler,
   enableUpdaterTracking,
+  enableSyncDefaultUpdates,
 } from 'shared/ReactFeatureFlags';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook.old';
 
@@ -263,14 +264,23 @@ export function getNextLanes(root: FiberRoot, wipLanes: Lanes): Lanes {
       // Default priority updates should not interrupt transition updates. The
       // only difference between default updates and transition updates is that
       // default updates do not support refresh transitions.
-      // TODO: This applies to sync default updates, too. Which is probably what
-      // we want for default priority events, but not for continuous priority
-      // events like hover.
       (nextLane === DefaultLane && (wipLane & TransitionLanes) !== NoLanes)
     ) {
       // Keep working on the existing in-progress tree. Do not interrupt.
       return wipLanes;
     }
+  }
+
+  if (
+    // TODO: Check for root override, once that lands
+    enableSyncDefaultUpdates &&
+    (nextLanes & InputContinuousLane) !== NoLanes
+  ) {
+    // When updates are sync by default, we entangle continous priority updates
+    // and default updates, so they render in the same batch. The only reason
+    // they use separate lanes is because continuous updates should interrupt
+    // transitions, but default updates should not.
+    nextLanes |= pendingLanes & DefaultLane;
   }
 
   // Check for entangled lanes and add them to the batch.
@@ -465,6 +475,19 @@ export function includesOnlyRetries(lanes: Lanes) {
 }
 export function includesOnlyTransitions(lanes: Lanes) {
   return (lanes & TransitionLanes) === lanes;
+}
+
+export function shouldTimeSlice(root: FiberRoot, lanes: Lanes) {
+  if (!enableSyncDefaultUpdates) {
+    return true;
+  }
+  const SyncDefaultLanes =
+    InputContinuousHydrationLane |
+    InputContinuousLane |
+    DefaultHydrationLane |
+    DefaultLane;
+  // TODO: Check for root override, once that lands
+  return (lanes & SyncDefaultLanes) === NoLanes;
 }
 
 export function isTransitionLane(lane: Lane) {

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -1405,18 +1405,6 @@ describe('ReactHooksWithNoopRenderer', () => {
         ReactNoop.unstable_runWithPriority(ContinuousEventPriority, () => {
           setParentState(false);
         });
-        if (gate(flags => flags.enableSyncDefaultUpdates)) {
-          // TODO: Default updates do not interrupt transition updates, to
-          // prevent starvation. However, when sync default updates are enabled,
-          // continuous updates are treated like default updates. In this case,
-          // we probably don't want this behavior; continuous should be allowed
-          // to interrupt.
-          expect(Scheduler).toFlushUntilNextPaint([
-            'Child two render',
-            'Child one commit',
-            'Child two commit',
-          ]);
-        }
         expect(Scheduler).toFlushUntilNextPaint([
           'Parent false render',
           'Parent false commit',

--- a/packages/react-reconciler/src/__tests__/SchedulingProfilerLabels-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/SchedulingProfilerLabels-test.internal.js
@@ -168,18 +168,10 @@ describe('SchedulingProfiler labels', () => {
       event.initEvent('mouseover', true, true);
       dispatchAndSetCurrentEvent(targetRef.current, event);
     });
-    if (gate(flags => flags.enableSyncDefaultUpdates)) {
-      expect(clearedMarks).toContain(
-        `--schedule-state-update-${formatLanes(
-          ReactFiberLane.DefaultLane,
-        )}-App`,
-      );
-    } else {
-      expect(clearedMarks).toContain(
-        `--schedule-state-update-${formatLanes(
-          ReactFiberLane.InputContinuousLane,
-        )}-App`,
-      );
-    }
+    expect(clearedMarks).toContain(
+      `--schedule-state-update-${formatLanes(
+        ReactFiberLane.InputContinuousLane,
+      )}-App`,
+    );
   });
 });


### PR DESCRIPTION
Discovered this quirk while working on #21322. Previously, when sync default updates are enabled, continuous updates are treated like default updates. We implemented this by assigning DefaultLane to continuous updates. However, an unintended consequence of that approach is that continuous updates would no longer interrupt transitions, because default updates are not supposed to interrupt transitions.

To fix this, I changed the implementation to always assign separate lanes for default and continuous updates. Then I entangle the lanes together.