### PR TITLE
Move scheduler to host configs

### DIFF
--- a/packages/jest-mock-scheduler/package.json
+++ b/packages/jest-mock-scheduler/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://reactjs.org/",
   "peerDependencies": {
     "jest": "^23.0.1 || ^24.0.0 || ^25.1.0",
-    "scheduler": "^0.20.0"
+    "scheduler": "^0.20.1"
   },
   "files": [
     "LICENSE",

--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -8,6 +8,7 @@
 import Transform from 'art/core/transform';
 import Mode from 'art/modes/current';
 import invariant from 'shared/invariant';
+import * as SchedulerPackage from 'scheduler';
 
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 
@@ -469,3 +470,5 @@ export function preparePortalMount(portalInstance: any): void {
 export function detachDeletedInstance(node: Instance): void {
   // noop
 }
+
+export const Scheduler = SchedulerPackage;

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -16,6 +16,7 @@ import type {
 } from 'react-reconciler/src/ReactTestSelectors';
 import type {RootType} from './ReactDOMRoot';
 import type {ReactScopeInstance} from 'shared/ReactTypes';
+import * as SchedulerPackage from 'scheduler';
 
 import {
   precacheFiberNode,
@@ -1219,3 +1220,5 @@ export function setupIntersectionObserver(
     },
   };
 }
+
+export const Scheduler = SchedulerPackage;

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -40,7 +40,7 @@ import {
   LowPriority as LowSchedulerPriority,
   NormalPriority as NormalSchedulerPriority,
   UserBlockingPriority as UserBlockingSchedulerPriority,
-} from 'react-reconciler/src/Scheduler';
+} from 'scheduler';
 import {
   DiscreteEventPriority,
   ContinuousEventPriority,

--- a/packages/react-native-renderer/package.json
+++ b/packages/react-native-renderer/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "scheduler": "^0.11.0"
+    "scheduler": "^0.20.1"
   },
   "peerDependencies": {
     "react": "^17.0.0"

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -33,6 +33,7 @@ import {
   TextInputState,
   deepFreezeAndThrowOnMutationInDev,
 } from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
+import * as SchedulerPackage from 'scheduler';
 
 const {
   createNode,
@@ -479,3 +480,8 @@ export function preparePortalMount(portalInstance: Instance): void {
 export function detachDeletedInstance(node: Instance): void {
   // noop
 }
+
+export const Scheduler =
+  typeof global.nativeRuntimeScheduler !== 'undefined'
+    ? global.nativeRuntimeScheduler
+    : SchedulerPackage;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -27,6 +27,7 @@ import {
 import ReactNativeFiberHostComponent from './ReactNativeFiberHostComponent';
 
 import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+import * as SchedulerPackage from 'scheduler';
 
 const {get: getViewConfigForType} = ReactNativeViewConfigRegistry;
 
@@ -536,3 +537,5 @@ export function preparePortalMount(portalInstance: Instance): void {
 export function detachDeletedInstance(node: Instance): void {
   // noop
 }
+
+export const Scheduler = SchedulerPackage;

--- a/packages/react-noop-renderer/src/ReactNoop.js
+++ b/packages/react-noop-renderer/src/ReactNoop.js
@@ -49,6 +49,7 @@ export const {
   getRoot,
   // TODO: Remove this after callers migrate to alternatives.
   unstable_runWithPriority,
+  Scheduler,
 } = createReactNoop(
   ReactFiberReconciler, // reconciler
   true, // useMutation

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -20,6 +20,7 @@ import type {ReactNodeList, Thenable} from 'shared/ReactTypes';
 import type {RootTag} from 'react-reconciler/src/ReactRootTags';
 
 import * as Scheduler from 'scheduler/unstable_mock';
+import * as SchedulerPackage from 'scheduler';
 import {REACT_FRAGMENT_TYPE, REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
 import isArray from 'shared/isArray';
 import {
@@ -399,6 +400,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       return currentEventPriority;
     },
 
+    Scheduler: SchedulerPackage,
     now: Scheduler.unstable_now,
 
     isPrimaryRenderer: true,

--- a/packages/react-reconciler/README.md
+++ b/packages/react-reconciler/README.md
@@ -210,6 +210,10 @@ Set this to true to indicate that your renderer supports `scheduleMicrotask`. We
 
 Optional. You can proxy this to `queueMicrotask` or its equivalent in your environment.
 
+#### `Scheduler`
+
+The scheduler to be used by React. In most cases this is the `scheduler` package, but this can also be used to provide a native scheduler.
+
 #### `isPrimaryRenderer`
 
 This is a property (not a function) that should be set to `true` if your renderer is the main one on the page. For example, if you're writing a renderer for the Terminal, it makes sense to set it to `true`, but if your renderer is used *on top of* React DOM or some other existing renderer, set it to `false`.

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -54,7 +54,8 @@ import {
 } from './ReactWorkTags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 
-import {isDevToolsPresent} from './ReactFiberDevToolsHook.new';
+const isDevToolsPresent =
+  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
 import {
   resolveClassForHotReloading,
   resolveFunctionForHotReloading,

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -54,7 +54,8 @@ import {
 } from './ReactWorkTags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 
-import {isDevToolsPresent} from './ReactFiberDevToolsHook.old';
+const isDevToolsPresent =
+  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined';
 import {
   resolveClassForHotReloading,
   resolveFunctionForHotReloading,

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -41,7 +41,6 @@ import {
   enableUpdaterTracking,
   enableSyncDefaultUpdates,
 } from 'shared/ReactFeatureFlags';
-import {isDevToolsPresent} from './ReactFiberDevToolsHook.new';
 
 // Lane values below should be kept in sync with getLabelsForLanes(), used by react-devtools-scheduling-profiler.
 // If those values are changed that package should be rebuilt and redeployed.
@@ -781,9 +780,6 @@ export function addFiberToLanesMap(
   if (!enableUpdaterTracking) {
     return;
   }
-  if (!isDevToolsPresent) {
-    return;
-  }
   const pendingUpdatersLaneMap = root.pendingUpdatersLaneMap;
   while (lanes > 0) {
     const index = laneToIndex(lanes);
@@ -798,9 +794,6 @@ export function addFiberToLanesMap(
 
 export function movePendingFibersToMemoized(root: FiberRoot, lanes: Lanes) {
   if (!enableUpdaterTracking) {
-    return;
-  }
-  if (!isDevToolsPresent) {
     return;
   }
   const pendingUpdatersLaneMap = root.pendingUpdatersLaneMap;

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -41,7 +41,6 @@ import {
   enableUpdaterTracking,
   enableSyncDefaultUpdates,
 } from 'shared/ReactFeatureFlags';
-import {isDevToolsPresent} from './ReactFiberDevToolsHook.old';
 
 // Lane values below should be kept in sync with getLabelsForLanes(), used by react-devtools-scheduling-profiler.
 // If those values are changed that package should be rebuilt and redeployed.
@@ -781,9 +780,6 @@ export function addFiberToLanesMap(
   if (!enableUpdaterTracking) {
     return;
   }
-  if (!isDevToolsPresent) {
-    return;
-  }
   const pendingUpdatersLaneMap = root.pendingUpdatersLaneMap;
   while (lanes > 0) {
     const index = laneToIndex(lanes);
@@ -798,9 +794,6 @@ export function addFiberToLanesMap(
 
 export function movePendingFibersToMemoized(root: FiberRoot, lanes: Lanes) {
   if (!enableUpdaterTracking) {
-    return;
-  }
-  if (!isDevToolsPresent) {
     return;
   }
   const pendingUpdatersLaneMap = root.pendingUpdatersLaneMap;

--- a/packages/react-reconciler/src/Scheduler.js
+++ b/packages/react-reconciler/src/Scheduler.js
@@ -11,7 +11,7 @@
 // Scheduler dependency. Notice that we're intentionally not using named imports
 // because Rollup would use dynamic dispatch for CommonJS interop named imports.
 // When we switch to ESM, we can delete this module.
-import * as Scheduler from 'scheduler';
+import {Scheduler} from './ReactFiberHostConfig';
 import {__interactionsRef} from 'scheduler/tracing';
 import {enableSchedulerTracing} from 'shared/ReactFeatureFlags';
 import invariant from 'shared/invariant';

--- a/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactFiberHostContext-test.internal.js
@@ -14,11 +14,13 @@ let React;
 let ReactFiberReconciler;
 let ConcurrentRoot;
 let DefaultEventPriority;
+let Scheduler;
 
 describe('ReactFiberHostContext', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
+    Scheduler = require('scheduler');
     ReactFiberReconciler = require('react-reconciler');
     ConcurrentRoot = require('react-reconciler/src/ReactRootTags')
       .ConcurrentRoot;
@@ -62,6 +64,7 @@ describe('ReactFiberHostContext', () => {
         return DefaultEventPriority;
       },
       supportsMutation: true,
+      Scheduler,
     });
 
     const container = Renderer.createContainer(
@@ -122,6 +125,7 @@ describe('ReactFiberHostContext', () => {
         return DefaultEventPriority;
       },
       supportsMutation: true,
+      Scheduler,
     });
 
     const container = Renderer.createContainer(

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -81,6 +81,7 @@ export const detachDeletedInstance = $$$hostConfig.detachDeletedInstance;
 // -------------------
 export const supportsMicrotasks = $$$hostConfig.supportsMicrotasks;
 export const scheduleMicrotask = $$$hostConfig.scheduleMicrotask;
+export const Scheduler = $$$hostConfig.Scheduler;
 
 // -------------------
 //      Test selectors

--- a/packages/react-server-dom-relay/package.json
+++ b/packages/react-server-dom-relay/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "scheduler": "^0.11.0"
+    "scheduler": "^0.20.1"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/packages/react-server-native-relay/package.json
+++ b/packages/react-server-native-relay/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "scheduler": "^0.11.0"
+    "scheduler": "^0.20.1"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -10,6 +10,7 @@
 import {REACT_OPAQUE_ID_TYPE} from 'shared/ReactSymbols';
 import isArray from 'shared/isArray';
 import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+import * as SchedulerPackage from 'scheduler';
 
 export type Type = string;
 export type Props = Object;
@@ -358,3 +359,5 @@ export function getInstanceFromScope(scopeInstance: Object): null | Object {
 export function detachDeletedInstance(node: Instance): void {
   // noop
 }
+
+export const Scheduler = SchedulerPackage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12319,14 +12319,6 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.11.0:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.3.tgz#b5769b90cf8b1464f3f3cfcafe8e3cd7555a2d6b"
-  integrity sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.13.0:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"


### PR DESCRIPTION
## WIP

**TODO: Working with RN to confirm this works**

This PR imports the scheduler from the host configs instead of the package directly. This will allow React Native and other custom renderers to provide a native renderer, if provided.