### PR TITLE
[Fizz] Escape style values

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -321,7 +321,9 @@ function pushStyle(
           valueChunk = stringToChunk('' + styleValue);
         }
       } else {
-        valueChunk = stringToChunk(('' + styleValue).trim());
+        valueChunk = stringToChunk(
+          escapeTextForBrowser(('' + styleValue).trim()),
+        );
       }
     }
     if (isFirst) {


### PR DESCRIPTION
I missed this case. When it's numeric, we don't have to escape it. We already escape it if it's a custom CSS property.

This is covered by the legacy tests.