### PR TITLE
[Fizz] Switch the isPrimaryRender flag based on the stream config

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -23,6 +23,7 @@ import {
   writeChunk,
   stringToChunk,
   stringToPrecomputedChunk,
+  isPrimaryStreamConfig,
 } from 'react-server/src/ReactServerStreamConfig';
 
 import {
@@ -50,7 +51,7 @@ import isArray from 'shared/isArray';
 
 // Used to distinguish these contexts from ones used in other renderers.
 // E.g. this can be used to distinguish legacy renderers from this modern one.
-export const isPrimaryRenderer = true;
+export const isPrimaryRenderer = isPrimaryStreamConfig;
 
 // Per response, global state that is not contextual to the rendering subtree.
 export type ResponseState = {

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -12,6 +12,8 @@ export type Destination = ReadableStreamController;
 export type PrecomputedChunk = Uint8Array;
 export type Chunk = Uint8Array;
 
+export const isPrimaryStreamConfig = true;
+
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -21,6 +21,8 @@ export type Destination = Writable & MightBeFlushable;
 export type PrecomputedChunk = Uint8Array;
 export type Chunk = string;
 
+export const isPrimaryStreamConfig = true;
+
 export function scheduleWork(callback: () => void) {
   setImmediate(callback);
 }


### PR DESCRIPTION
It's possible for Fizz and Fiber to co-exist for example. If they both end up using the same context field then that can clash.

It's also possible for e.g. DOM and ART to co-exist on the server.

Or Legacy Fizz DOM and Modern Fizz DOM.

Instead of protecting against every possible clash, I just took the most common one. E.g. renderToString clashing with either Fiber or Modern Fizz.

I flip it in the legacy stream config so that renderToString use the secondary Context fields. https://github.com/facebook/react/pull/21276