### PR TITLE
Remove unnecessary type cast

### DIFF
--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -9,6 +9,7 @@
 
 import type {Container} from './ReactDOMHostConfig';
 import type {RootType} from './ReactDOMRoot';
+import type {FiberRoot} from 'react-reconciler/src/ReactInternalTypes';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {
@@ -184,10 +185,8 @@ function legacyRenderSubtreeIntoContainer(
     warnOnInvalidCallback(callback === undefined ? null : callback, 'render');
   }
 
-  // TODO: Without `any` type, Flow says "Property cannot be accessed on any
-  // member of intersection type." Whyyyyyy.
-  let root: RootType = (container._reactRootContainer: any);
-  let fiberRoot;
+  let root = container._reactRootContainer;
+  let fiberRoot: FiberRoot;
   if (!root) {
     // Initial mount
     root = container._reactRootContainer = legacyCreateRootFromDOMContainer(


### PR DESCRIPTION
## Summary
<details>
<summary>Increases type coverage from 82.50% to 82.66% :muscle: ... </summary>

... just because we got rid of one expression.

```bash
$ git checkout master
$ npx flow coverage packages/react-dom/src/client/ReactDOMLegacy.js
Covered: 82.50% (429 of 520 expressions)

$ git checkout eps1lon/chore/root-coverage
$ npx flow coverage packages/react-dom/src/client/ReactDOMLegacy.js 
Covered: 82.66% (429 of 519 expressions)
```
</details>

TODO comment was added in 1b55ad2a4b24b06ce34f77a943396228641d74a1. The flow bug was likely fixed during an update to flow since the type didn't change in the meantime.

## Test Plan

- [x] CI green
