### PR TITLE
[Fizz] Allow dangerouslySetInnerHTML in <option>

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -691,6 +691,7 @@ function pushStartOption(
   let children = null;
   let value = null;
   let selected = null;
+  let innerHTML = null;
   for (const propKey in props) {
     if (hasOwnProperty.call(props, propKey)) {
       const propValue = props[propKey];
@@ -716,10 +717,8 @@ function pushStartOption(
           }
           break;
         case 'dangerouslySetInnerHTML':
-          invariant(
-            false,
-            '`dangerouslySetInnerHTML` does not work on <option>.',
-          );
+          innerHTML = propValue;
+          break;
         // eslint-disable-next-line-no-fallthrough
         case 'value':
           value = propValue;
@@ -760,6 +759,7 @@ function pushStartOption(
   }
 
   target.push(endOfStartTag);
+  pushInnerHTML(target, innerHTML, children);
   return children;
 }
 


### PR DESCRIPTION
I didn't think this was valid because if you don't provide a `value` for the option, we don't know whether to select it or not. However it's arguably valid if you do provide the value attribute.

We should probably have a warning if you provide dangerouslySetInnerHTML and don't provide a value attribute though. Both server and client.