### PR TITLE
Added test fixture for scheduling profiler

### DIFF
--- a/fixtures/devtools/scheduling-profiler/.gitignore
+++ b/fixtures/devtools/scheduling-profiler/.gitignore
@@ -1,0 +1,1 @@
+dependencies

--- a/fixtures/devtools/scheduling-profiler/README.md
+++ b/fixtures/devtools/scheduling-profiler/README.md
@@ -1,0 +1,15 @@
+# Test fixture for `packages/react-devtools-scheduling-profiler`
+
+1. First, run the fixture:
+```sh
+# In the root directory
+# Download the latest *experimental* React build
+scripts/release/download-experimental-build.js
+
+# Run this fixtures
+fixtures/devtools/scheduling-profiler/run.js
+```
+
+2. Then open [localhost:8000/](http://localhost:8000/) and use the Performance tab in Chrome to reload-and-profile.
+3. Now stop profiling and export JSON.
+4. Lastly, open [react-scheduling-profiler.vercel.app](https://react-scheduling-profiler.vercel.app/) and upload the performance JSON data you just recorded.

--- a/fixtures/devtools/scheduling-profiler/app.js
+++ b/fixtures/devtools/scheduling-profiler/app.js
@@ -1,0 +1,14 @@
+const {createElement, useLayoutEffect, useState} = React;
+const {unstable_createRoot: createRoot} = ReactDOM;
+
+function App() {
+  const [isMounted, setIsMounted] = useState(false);
+  useLayoutEffect(() => {
+    setIsMounted(true);
+  }, []);
+  return createElement('div', null, `isMounted? ${isMounted}`);
+}
+
+const container = document.getElementById('container');
+const root = createRoot(container);
+root.render(createElement(App));

--- a/fixtures/devtools/scheduling-profiler/index.html
+++ b/fixtures/devtools/scheduling-profiler/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Scheduling Profiler Fixture</title>
+
+    <script src="./scheduler.js"></script>
+    <script src="./react.js"></script>
+    <script src="./react-dom.js"></script>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/fixtures/devtools/scheduling-profiler/run.js
+++ b/fixtures/devtools/scheduling-profiler/run.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmdirSync,
+} = require('fs');
+const {join} = require('path');
+const http = require('http');
+
+const DEPENDENCIES = [
+  ['scheduler/umd/scheduler.development.js', 'scheduler.js'],
+  ['react/umd/react.development.js', 'react.js'],
+  ['react-dom/umd/react-dom.development.js', 'react-dom.js'],
+];
+
+const BUILD_DIRECTORY = '../../../build/node_modules/';
+const DEPENDENCIES_DIRECTORY = 'dependencies';
+
+function initDependencies() {
+  if (existsSync(DEPENDENCIES_DIRECTORY)) {
+    rmdirSync(DEPENDENCIES_DIRECTORY, {recursive: true});
+  }
+  mkdirSync(DEPENDENCIES_DIRECTORY);
+
+  DEPENDENCIES.forEach(([from, to]) => {
+    const fromPath = join(__dirname, BUILD_DIRECTORY, from);
+    const toPath = join(__dirname, DEPENDENCIES_DIRECTORY, to);
+    console.log(`Copying ${fromPath} => ${toPath}`);
+    copyFileSync(fromPath, toPath);
+  });
+}
+
+function initServer() {
+  const host = 'localhost';
+  const port = 8000;
+
+  const requestListener = function(request, response) {
+    let contents;
+    switch (request.url) {
+      case '/react.js':
+      case '/react-dom.js':
+      case '/scheduler.js':
+        response.setHeader('Content-Type', 'text/javascript');
+        response.writeHead(200);
+        contents = readFileSync(
+          join(__dirname, DEPENDENCIES_DIRECTORY, request.url)
+        );
+        response.end(contents);
+        break;
+      case '/app.js':
+        response.setHeader('Content-Type', 'text/javascript');
+        response.writeHead(200);
+        contents = readFileSync(join(__dirname, 'app.js'));
+        response.end(contents);
+        break;
+      case '/index.html':
+      default:
+        response.setHeader('Content-Type', 'text/html');
+        response.writeHead(200);
+        contents = readFileSync(join(__dirname, 'index.html'));
+        response.end(contents);
+        break;
+    }
+  };
+
+  const server = http.createServer(requestListener);
+  server.listen(port, host, () => {
+    console.log(`Server is running on http://${host}:${port}`);
+  });
+}
+
+initDependencies();
+initServer();


### PR DESCRIPTION
Related to #21379

Adds a test fixture for the ["scheduling profiler"](https://github.com/facebook/react/tree/master/packages/react-devtools-scheduling-profiler) (live at [react-scheduling-profiler.vercel.app](https://react-scheduling-profiler.vercel.app)).

Right now the fixture shows that the experimental OSS release works:
![Screen Shot 2021-04-30 at 1 23 12 PM](https://user-images.githubusercontent.com/29597/116735484-909baf80-a9bc-11eb-955b-62d234c3761b.png)

But the Facebook internal version does not:
![Screen Shot 2021-04-30 at 2 22 51 PM](https://user-images.githubusercontent.com/29597/116737846-b7a7b080-a9bf-11eb-91a9-8439e93c3741.png)

Digging into the Facebook data closer, the marks aren't even being logged.

On an on-demand server though, these marks are being logged:
![Screen Shot 2021-04-30 at 2 43 39 PM](https://user-images.githubusercontent.com/29597/116740089-8381bf00-a9c2-11eb-94f5-45c5532a00c9.png)
