### PR TITLE
createRoot API is no longer strict by default

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -97,16 +97,10 @@ describe('ReactTestUtils.act()', () => {
     });
 
     // @gate experimental
-    it('warns in concurrent mode', () => {
-      expect(() => {
-        const root = ReactDOM.unstable_createRoot(
-          document.createElement('div'),
-        );
-        root.render(<App />);
-        Scheduler.unstable_flushAll();
-      }).toErrorDev([
-        'An update to App ran an effect, but was not wrapped in act(...)',
-      ]);
+    it('does not warn in concurrent mode', () => {
+      const root = ReactDOM.unstable_createRoot(document.createElement('div'));
+      root.render(<App />);
+      Scheduler.unstable_flushAll();
     });
   });
 });

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -27,7 +27,6 @@ export type RootOptions = {
     mutableSources?: Array<MutableSource<any>>,
     ...
   },
-  unstable_strictModeLevel?: number,
   unstable_concurrentUpdatesByDefault?: boolean,
   ...
 };
@@ -123,10 +122,6 @@ function createRootImpl(
       options.hydrationOptions != null &&
       options.hydrationOptions.mutableSources) ||
     null;
-  const strictModeLevelOverride =
-    options != null && options.unstable_strictModeLevel != null
-      ? options.unstable_strictModeLevel
-      : null;
 
   let concurrentUpdatesByDefaultOverride = null;
   if (allowConcurrentByDefault) {
@@ -141,7 +136,6 @@ function createRootImpl(
     tag,
     hydrate,
     hydrationCallbacks,
-    strictModeLevelOverride,
     concurrentUpdatesByDefaultOverride,
   );
   markContainerAsRoot(root.current, container);

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -207,7 +207,7 @@ function render(
   if (!root) {
     // TODO (bvaughn): If we decide to keep the wrapper component,
     // We could create a wrapper for containerTag as well to reduce special casing.
-    root = createContainer(containerTag, LegacyRoot, false, null, null, null);
+    root = createContainer(containerTag, LegacyRoot, false, null, null);
     roots.set(containerTag, root);
   }
   updateContainer(element, root, null, callback);

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -203,7 +203,7 @@ function render(
   if (!root) {
     // TODO (bvaughn): If we decide to keep the wrapper component,
     // We could create a wrapper for containerTag as well to reduce special casing.
-    root = createContainer(containerTag, LegacyRoot, false, null, null, null);
+    root = createContainer(containerTag, LegacyRoot, false, null, null);
     roots.set(containerTag, root);
   }
   updateContainer(element, root, null, callback);

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -722,7 +722,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       if (!root) {
         const container = {rootID: rootID, pendingChildren: [], children: []};
         rootContainers.set(rootID, container);
-        root = NoopRenderer.createContainer(container, tag, false, null, null);
+        root = NoopRenderer.createContainer(container, tag, false, null);
         roots.set(rootID, root);
       }
       return root.current.stateNode.containerInfo;
@@ -739,7 +739,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         container,
         ConcurrentRoot,
         false,
-        null,
         null,
       );
       return {
@@ -766,7 +765,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         container,
         LegacyRoot,
         false,
-        null,
         null,
       );
       return {

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -422,25 +422,13 @@ export function resetWorkInProgress(workInProgress: Fiber, renderLanes: Lanes) {
 
 export function createHostRootFiber(
   tag: RootTag,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): Fiber {
   let mode;
   if (tag === ConcurrentRoot) {
     mode = ConcurrentMode;
-    if (strictModeLevelOverride !== null) {
-      if (strictModeLevelOverride >= 1) {
-        mode |= StrictLegacyMode;
-      }
-      if (enableStrictEffects) {
-        if (strictModeLevelOverride >= 2) {
-          mode |= StrictEffectsMode;
-        }
-      }
-    } else {
-      if (enableStrictEffects && createRootStrictEffectsByDefault) {
-        mode |= StrictLegacyMode | StrictEffectsMode;
-      }
+    if (enableStrictEffects && createRootStrictEffectsByDefault) {
+      mode |= StrictLegacyMode | StrictEffectsMode;
     }
     if (
       // We only use this flag for our repo tests to check both behaviors.

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -440,8 +440,6 @@ export function createHostRootFiber(
     } else {
       if (enableStrictEffects && createRootStrictEffectsByDefault) {
         mode |= StrictLegacyMode | StrictEffectsMode;
-      } else {
-        mode |= StrictLegacyMode;
       }
     }
     if (

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -422,25 +422,13 @@ export function resetWorkInProgress(workInProgress: Fiber, renderLanes: Lanes) {
 
 export function createHostRootFiber(
   tag: RootTag,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): Fiber {
   let mode;
   if (tag === ConcurrentRoot) {
     mode = ConcurrentMode;
-    if (strictModeLevelOverride !== null) {
-      if (strictModeLevelOverride >= 1) {
-        mode |= StrictLegacyMode;
-      }
-      if (enableStrictEffects) {
-        if (strictModeLevelOverride >= 2) {
-          mode |= StrictEffectsMode;
-        }
-      }
-    } else {
-      if (enableStrictEffects && createRootStrictEffectsByDefault) {
-        mode |= StrictLegacyMode | StrictEffectsMode;
-      }
+    if (enableStrictEffects && createRootStrictEffectsByDefault) {
+      mode |= StrictLegacyMode | StrictEffectsMode;
     }
     if (
       // We only use this flag for our repo tests to check both behaviors.

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -440,8 +440,6 @@ export function createHostRootFiber(
     } else {
       if (enableStrictEffects && createRootStrictEffectsByDefault) {
         mode |= StrictLegacyMode | StrictEffectsMode;
-      } else {
-        mode |= StrictLegacyMode;
       }
     }
     if (

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -248,7 +248,6 @@ export function createContainer(
   tag: RootTag,
   hydrate: boolean,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): OpaqueRoot {
   return createFiberRoot(
@@ -256,7 +255,6 @@ export function createContainer(
     tag,
     hydrate,
     hydrationCallbacks,
-    strictModeLevelOverride,
     concurrentUpdatesByDefaultOverride,
   );
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -248,7 +248,6 @@ export function createContainer(
   tag: RootTag,
   hydrate: boolean,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): OpaqueRoot {
   return createFiberRoot(
@@ -256,7 +255,6 @@ export function createContainer(
     tag,
     hydrate,
     hydrationCallbacks,
-    strictModeLevelOverride,
     concurrentUpdatesByDefaultOverride,
   );
 }

--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -98,7 +98,6 @@ export function createFiberRoot(
   tag: RootTag,
   hydrate: boolean,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): FiberRoot {
   const root: FiberRoot = (new FiberRootNode(containerInfo, tag, hydrate): any);
@@ -110,7 +109,6 @@ export function createFiberRoot(
   // stateNode is any.
   const uninitializedFiber = createHostRootFiber(
     tag,
-    strictModeLevelOverride,
     concurrentUpdatesByDefaultOverride,
   );
   root.current = uninitializedFiber;

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -98,7 +98,6 @@ export function createFiberRoot(
   tag: RootTag,
   hydrate: boolean,
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
-  strictModeLevelOverride: null | number,
   concurrentUpdatesByDefaultOverride: null | boolean,
 ): FiberRoot {
   const root: FiberRoot = (new FiberRootNode(containerInfo, tag, hydrate): any);
@@ -110,7 +109,6 @@ export function createFiberRoot(
   // stateNode is any.
   const uninitializedFiber = createHostRootFiber(
     tag,
-    strictModeLevelOverride,
     concurrentUpdatesByDefaultOverride,
   );
   root.current = uninitializedFiber;

--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -282,7 +282,6 @@ describe('DebugTracing', () => {
     expect(logs).toEqual([
       `group: ⚛️ render (${DEFAULT_LANE_STRING})`,
       `log: ⚛️ Example updated state (${DEFAULT_LANE_STRING})`,
-      `log: ⚛️ Example updated state (${DEFAULT_LANE_STRING})`,
       `groupEnd: ⚛️ render (${DEFAULT_LANE_STRING})`,
     ]);
   });
@@ -366,7 +365,6 @@ describe('DebugTracing', () => {
     expect(logs).toEqual([
       `group: ⚛️ render (${DEFAULT_LANE_STRING})`,
       `log: ⚛️ Example updated state (${DEFAULT_LANE_STRING})`,
-      `log: ⚛️ Example updated state (${DEFAULT_LANE_STRING})`, // debugRenderPhaseSideEffectsForStrictMode
       `groupEnd: ⚛️ render (${DEFAULT_LANE_STRING})`,
     ]);
   });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -517,11 +517,7 @@ describe('ReactHooksWithNoopRenderer', () => {
           </>,
         );
         expect(() =>
-          expect(Scheduler).toFlushAndYield(
-            __DEV__
-              ? ['Foo [0]', 'Bar', 'Foo [2]']
-              : ['Foo [0]', 'Bar', 'Foo [1]'],
-          ),
+          expect(Scheduler).toFlushAndYield(['Foo [0]', 'Bar', 'Foo [1]']),
         ).toErrorDev([
           'Cannot update a component (`Foo`) while rendering a ' +
             'different component (`Bar`). To locate the bad setState() call inside `Bar`',
@@ -536,11 +532,7 @@ describe('ReactHooksWithNoopRenderer', () => {
             <Bar triggerUpdate={true} />
           </>,
         );
-        expect(Scheduler).toFlushAndYield(
-          __DEV__
-            ? ['Foo [2]', 'Bar', 'Foo [4]']
-            : ['Foo [1]', 'Bar', 'Foo [2]'],
-        );
+        expect(Scheduler).toFlushAndYield(['Foo [1]', 'Bar', 'Foo [2]']);
       });
     });
 
@@ -1762,16 +1754,11 @@ describe('ReactHooksWithNoopRenderer', () => {
         return <Text text={'Count: ' + count} />;
       }
 
-      // we explicitly wait for missing act() warnings here since
-      // it's a lot harder to simulate this condition inside an act scope
-      expect(() => {
-        ReactNoop.render(<Counter count={0} />, () =>
-          Scheduler.unstable_yieldValue('Sync effect'),
-        );
-        expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
-        expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
-      }).toErrorDev(['An update to Counter ran an effect']);
-
+      ReactNoop.render(<Counter count={0} />, () =>
+        Scheduler.unstable_yieldValue('Sync effect'),
+      );
+      expect(Scheduler).toFlushAndYieldThrough(['Count: 0', 'Sync effect']);
+      expect(ReactNoop.getChildren()).toEqual([span('Count: 0')]);
       // A flush sync doesn't cause the passive effects to fire.
       // So we haven't added the other update yet.
       act(() => {

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -1863,18 +1863,11 @@ describe('ReactIncremental', () => {
         </div>
       </Intl>,
     );
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'Intl {}',
-        'ShowLocale {"locale":"fr"}',
-        'ShowBoth {"locale":"fr"}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Intl, ShowBoth, ShowLocale',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'Intl {}',
+      'ShowLocale {"locale":"fr"}',
+      'ShowBoth {"locale":"fr"}',
+    ]);
 
     ReactNoop.render(
       <Intl locale="de">
@@ -1921,28 +1914,21 @@ describe('ReactIncremental', () => {
         <ShowBoth />
       </Intl>,
     );
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'ShowLocale {"locale":"sv"}',
-        'ShowBoth {"locale":"sv"}',
-        'Intl {}',
-        'ShowLocale {"locale":"en"}',
-        'Router {}',
-        'Indirection {}',
-        'ShowLocale {"locale":"en"}',
-        'ShowRoute {"route":"/about"}',
-        'ShowNeither {}',
-        'Intl {}',
-        'ShowBoth {"locale":"ru","route":"/about"}',
-        'ShowBoth {"locale":"en","route":"/about"}',
-        'ShowBoth {"locale":"en"}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Router, ShowRoute',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'ShowLocale {"locale":"sv"}',
+      'ShowBoth {"locale":"sv"}',
+      'Intl {}',
+      'ShowLocale {"locale":"en"}',
+      'Router {}',
+      'Indirection {}',
+      'ShowLocale {"locale":"en"}',
+      'ShowRoute {"route":"/about"}',
+      'ShowNeither {}',
+      'Intl {}',
+      'ShowBoth {"locale":"ru","route":"/about"}',
+      'ShowBoth {"locale":"en","route":"/about"}',
+      'ShowBoth {"locale":"en"}',
+    ]);
   });
 
   it('does not leak own context into context provider', () => {
@@ -1968,19 +1954,12 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<Recurse />);
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'Recurse {}',
-        'Recurse {"n":2}',
-        'Recurse {"n":1}',
-        'Recurse {"n":0}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Recurse',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'Recurse {}',
+      'Recurse {"n":2}',
+      'Recurse {"n":1}',
+      'Recurse {"n":0}',
+    ]);
   });
 
   if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
@@ -2020,10 +1999,6 @@ describe('ReactIncremental', () => {
           "If you can't use a class try assigning the prototype on the function as a workaround. " +
           '`Recurse.prototype = React.Component.prototype`. ' +
           "Don't use an arrow function since it cannot be called with `new` by React.",
-        'Legacy context API has been detected within a strict-mode tree.\n\n' +
-          'The old API will be supported in all 16.x releases, but applications ' +
-          'using it should migrate to the new version.\n\n' +
-          'Please update the following components: Recurse',
       ]);
     });
   }
@@ -2092,18 +2067,11 @@ describe('ReactIncremental', () => {
       'ShowLocale {"locale":"fr"}',
     ]);
 
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'ShowLocale {"locale":"fr"}',
-        'Intl {}',
-        'ShowLocale {"locale":"ru"}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Intl, ShowLocale',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'ShowLocale {"locale":"fr"}',
+      'Intl {}',
+      'ShowLocale {"locale":"ru"}',
+    ]);
   });
 
   it('reads context when setState is below the provider', () => {
@@ -2186,21 +2154,14 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Intl>,
     );
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'Intl:read {}',
-        'Intl:provide {"locale":"fr"}',
-        'IndirectionFn {}',
-        'IndirectionClass {}',
-        'ShowLocaleClass:read {"locale":"fr"}',
-        'ShowLocaleFn:read {"locale":"fr"}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'Intl:read {}',
+      'Intl:provide {"locale":"fr"}',
+      'IndirectionFn {}',
+      'IndirectionClass {}',
+      'ShowLocaleClass:read {"locale":"fr"}',
+      'ShowLocaleFn:read {"locale":"fr"}',
+    ]);
 
     statefulInst.setState({x: 1});
     expect(Scheduler).toFlushWithoutYielding();
@@ -2287,21 +2248,14 @@ describe('ReactIncremental', () => {
         </IndirectionFn>
       </Stateful>,
     );
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'Intl:read {}',
-        'Intl:provide {"locale":"fr"}',
-        'IndirectionFn {}',
-        'IndirectionClass {}',
-        'ShowLocaleClass:read {"locale":"fr"}',
-        'ShowLocaleFn:read {"locale":"fr"}',
-      ]),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Intl, ShowLocaleClass, ShowLocaleFn',
-    );
+    expect(Scheduler).toFlushAndYield([
+      'Intl:read {}',
+      'Intl:provide {"locale":"fr"}',
+      'IndirectionFn {}',
+      'IndirectionClass {}',
+      'ShowLocaleClass:read {"locale":"fr"}',
+      'ShowLocaleFn:read {"locale":"fr"}',
+    ]);
 
     statefulInst.setState({locale: 'gr'});
     expect(Scheduler).toFlushAndYield([
@@ -2356,12 +2310,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Child',
-    );
+    expect(Scheduler).toFlushWithoutYielding();
 
     // Trigger an update in the middle of the tree
     instance.setState({});
@@ -2407,12 +2356,7 @@ describe('ReactIncremental', () => {
 
     // Init
     ReactNoop.render(<Root />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: ContextProvider',
-    );
+    expect(Scheduler).toFlushWithoutYielding();
 
     // Trigger an update in the middle of the tree
     // This is necessary to reproduce the error as it currently exists.
@@ -2454,27 +2398,16 @@ describe('ReactIncremental', () => {
     }
 
     ReactNoop.render(<MyComponent />);
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([
-        'render',
-        'componentDidMount',
-        'shouldComponentUpdate',
-        'render',
-        'componentDidUpdate',
-        'shouldComponentUpdate',
-        'render',
-        'componentDidUpdate',
-      ]),
-    ).toErrorDev(
-      [
-        'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
-        'Legacy context API has been detected within a strict-mode tree.\n\n' +
-          'The old API will be supported in all 16.x releases, but applications ' +
-          'using it should migrate to the new version.\n\n' +
-          'Please update the following components: MyComponent',
-      ],
-      {withoutStack: 1},
-    );
+    expect(Scheduler).toFlushAndYield([
+      'render',
+      'componentDidMount',
+      'shouldComponentUpdate',
+      'render',
+      'componentDidUpdate',
+      'shouldComponentUpdate',
+      'render',
+      'componentDidUpdate',
+    ]);
   });
 
   xit('should reuse memoized work if pointers are updated before calling lifecycles', () => {
@@ -2604,12 +2537,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushAndYield(['count:0'])).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Child, TopContextProvider',
-    );
+    expect(Scheduler).toFlushAndYield(['count:0']);
     instance.updateCount();
     expect(Scheduler).toFlushAndYield(['count:1']);
   });
@@ -2664,12 +2592,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushAndYield(['count:0'])).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
-    );
+    expect(Scheduler).toFlushAndYield(['count:0']);
     instance.updateCount();
     expect(Scheduler).toFlushAndYield(['count:1']);
   });
@@ -2733,12 +2656,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() => expect(Scheduler).toFlushAndYield(['count:0'])).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
-    );
+    expect(Scheduler).toFlushAndYield(['count:0']);
     instance.updateCount();
     expect(Scheduler).toFlushWithoutYielding();
   });
@@ -2814,14 +2732,7 @@ describe('ReactIncremental', () => {
       </TopContextProvider>,
     );
 
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(['count:0, name:brian']),
-    ).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but applications ' +
-        'using it should migrate to the new version.\n\n' +
-        'Please update the following components: Child, MiddleContextProvider, TopContextProvider',
-    );
+    expect(Scheduler).toFlushAndYield(['count:0, name:brian']);
     topInstance.updateCount();
     expect(Scheduler).toFlushWithoutYielding();
     middleInstance.updateName('not brian');
@@ -2933,7 +2844,11 @@ describe('ReactIncremental', () => {
           return this.state.didError ? null : <Thing />;
         }
       }
-      ReactNoop.render(<Boundary />);
+      ReactNoop.render(
+        <React.StrictMode>
+          <Boundary />
+        </React.StrictMode>,
+      );
       expect(() => {
         expect(Scheduler).toFlushWithoutYielding();
       }).toErrorDev([

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -1286,12 +1286,7 @@ describe('ReactIncrementalErrorHandling', () => {
         <Connector />
       </Provider>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-      'Legacy context API has been detected within a strict-mode tree.\n\n' +
-        'The old API will be supported in all 16.x releases, but ' +
-        'applications using it should migrate to the new version.\n\n' +
-        'Please update the following components: Connector, Provider',
-    );
+    expect(Scheduler).toFlushWithoutYielding();
 
     // If the context stack does not unwind, span will get 'abcde'
     expect(ReactNoop.getChildren()).toEqual([span('a')]);
@@ -1843,10 +1838,6 @@ describe('ReactIncrementalErrorHandling', () => {
           "If you can't use a class try assigning the prototype on the function as a workaround. " +
           '`Provider.prototype = React.Component.prototype`. ' +
           "Don't use an arrow function since it cannot be called with `new` by React.",
-        'Legacy context API has been detected within a strict-mode tree.\n\n' +
-          'The old API will be supported in all 16.x releases, but ' +
-          'applications using it should migrate to the new version.\n\n' +
-          'Please update the following components: Provider',
       ]);
     });
   }

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalReflection-test.js
@@ -78,12 +78,7 @@ describe('ReactIncrementalReflection', () => {
     expect(instances[0]._isMounted()).toBe(false);
 
     // Render the rest and commit the updates.
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(['componentDidMount: true']),
-    ).toErrorDev(
-      'Using UNSAFE_componentWillMount in strict mode is not recommended',
-      {withoutStack: true},
-    );
+    expect(Scheduler).toFlushAndYield(['componentDidMount: true']);
 
     expect(instances[0]._isMounted()).toBe(true);
   });
@@ -120,12 +115,7 @@ describe('ReactIncrementalReflection', () => {
     }
 
     ReactNoop.render(<Foo mount={true} />);
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(['Component']),
-    ).toErrorDev(
-      'Using UNSAFE_componentWillMount in strict mode is not recommended',
-      {withoutStack: true},
-    );
+    expect(Scheduler).toFlushAndYield(['Component']);
 
     expect(instances[0]._isMounted()).toBe(true);
 
@@ -238,15 +228,7 @@ describe('ReactIncrementalReflection', () => {
     // not find any host nodes in it.
     expect(findInstance(classInstance)).toBe(null);
 
-    expect(() =>
-      expect(Scheduler).toFlushAndYield([['componentDidMount', span()]]),
-    ).toErrorDev(
-      [
-        'Using UNSAFE_componentWillMount in strict mode is not recommended',
-        'Using UNSAFE_componentWillUpdate in strict mode is not recommended',
-      ],
-      {withoutStack: true},
-    );
+    expect(Scheduler).toFlushAndYield([['componentDidMount', span()]]);
 
     const hostSpan = classInstance.span;
     expect(hostSpan).toBeDefined();

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -1308,9 +1308,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
-      'Warning: A string ref, "bar", has been found within a strict mode tree.',
-    );
+    expect(Scheduler).toFlushWithoutYielding();
 
     expect(fooInstance.refs.bar.test).toEqual('test');
   });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -402,12 +402,7 @@ describe('ReactIncrementalUpdates', () => {
       }
     }
     ReactNoop.render(<Foo />);
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(['render']),
-    ).toErrorDev(
-      'Using UNSAFE_componentWillReceiveProps in strict mode is not recommended',
-      {withoutStack: true},
-    );
+    expect(Scheduler).toFlushAndYield(['render']);
 
     ReactNoop.flushSync(() => {
       instance.setState({a: 'a'});

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -953,14 +953,7 @@ describe('ReactNewContext', () => {
           </App>
         </LegacyProvider>,
       );
-      expect(() => {
-        expect(Scheduler).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
-      }).toErrorDev(
-        'Legacy context API has been detected within a strict-mode tree.\n\n' +
-          'The old API will be supported in all 16.x releases, but applications ' +
-          'using it should migrate to the new version.\n\n' +
-          'Please update the following components: LegacyProvider',
-      );
+      expect(Scheduler).toFlushAndYield(['LegacyProvider', 'App', 'Child']);
       expect(ReactNoop.getChildren()).toEqual([span('Child')]);
 
       // Update App with same value (should bail out)
@@ -1244,8 +1237,6 @@ describe('ReactNewContext', () => {
 
       ReactNoop.render(<Cls />);
       expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
-        'Context can only be read while React is rendering',
-        // A second warning comes from to setStates being added to the queue.
         'Context can only be read while React is rendering',
         'Cannot update during an existing state transition',
       ]);

--- a/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
@@ -1836,9 +1836,14 @@ describe('useMutableSource', () => {
           return null;
         }
 
+        // TODO The mechanism for this type of detection relies on StrictMode double rendering.
         expect(() => {
           act(() => {
-            ReactNoop.render(<MutateDuringRead />);
+            ReactNoop.render(
+              <React.StrictMode>
+                <MutateDuringRead />
+              </React.StrictMode>,
+            );
           });
         }).toThrow(
           'A mutable source was mutated while the MutateDuringRead component ' +

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -58,7 +58,6 @@ const {IsSomeRendererActing} = ReactSharedInternals;
 type TestRendererOptions = {
   createNodeMock: (element: React$Element<any>) => any,
   unstable_isConcurrent: boolean,
-  unstable_strictModeLevel: number,
   unstable_concurrentUpdatesByDefault: boolean,
   ...
 };
@@ -437,7 +436,6 @@ function propsMatch(props: Object, filter: Object): boolean {
 function create(element: React$Element<any>, options: TestRendererOptions) {
   let createNodeMock = defaultTestOptions.createNodeMock;
   let isConcurrent = false;
-  let strictModeLevel = null;
   let concurrentUpdatesByDefault = null;
   if (typeof options === 'object' && options !== null) {
     if (typeof options.createNodeMock === 'function') {
@@ -445,9 +443,6 @@ function create(element: React$Element<any>, options: TestRendererOptions) {
     }
     if (options.unstable_isConcurrent === true) {
       isConcurrent = true;
-    }
-    if (options.unstable_strictModeLevel !== undefined) {
-      strictModeLevel = options.unstable_strictModeLevel;
     }
     if (allowConcurrentByDefault) {
       if (options.unstable_concurrentUpdatesByDefault !== undefined) {
@@ -466,7 +461,6 @@ function create(element: React$Element<any>, options: TestRendererOptions) {
     isConcurrent ? ConcurrentRoot : LegacyRoot,
     false,
     null,
-    strictModeLevel,
     concurrentUpdatesByDefault,
   );
   invariant(root != null, 'something went wrong');

--- a/packages/react/src/__tests__/ReactStrictMode-test.internal.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.internal.js
@@ -50,34 +50,11 @@ describe('ReactStrictMode', () => {
     }
 
     // @gate experimental
-    it('should support overriding default via createRoot option', () => {
+    it('should default to not strict', () => {
       act(() => {
         const container = document.createElement('div');
-        const root = ReactDOM.createRoot(container, {
-          unstable_strictModeLevel: 0,
-        });
+        const root = ReactDOM.createRoot(container);
         root.render(<Component label="A" />);
-      });
-
-      expect(log).toEqual([
-        'A: render',
-        'A: useLayoutEffect mount',
-        'A: useEffect mount',
-      ]);
-    });
-
-    // @gate experimental
-    it('should disable strict mode if level 0 is specified', () => {
-      act(() => {
-        const container = document.createElement('div');
-        const root = ReactDOM.createRoot(container, {
-          unstable_strictModeLevel: 0,
-        });
-        root.render(
-          <React.StrictMode unstable_level={0}>
-            <Component label="A" />
-          </React.StrictMode>,
-        );
       });
 
       expect(log).toEqual([
@@ -156,9 +133,7 @@ describe('ReactStrictMode', () => {
       it('should allow level to be increased with nesting', () => {
         act(() => {
           const container = document.createElement('div');
-          const root = ReactDOM.createRoot(container, {
-            unstable_strictModeLevel: 0,
-          });
+          const root = ReactDOM.createRoot(container);
           root.render(
             <>
               <Component label="A" />
@@ -197,9 +172,7 @@ describe('ReactStrictMode', () => {
       it('should not allow level to be decreased with nesting', () => {
         act(() => {
           const container = document.createElement('div');
-          const root = ReactDOM.createRoot(container, {
-            unstable_strictModeLevel: 2,
-          });
+          const root = ReactDOM.createRoot(container);
           root.render(
             <>
               <Component label="A" />
@@ -217,23 +190,10 @@ describe('ReactStrictMode', () => {
 
         expect(log).toEqual([
           'A: render',
-          'A: render',
           'B: render',
           'B: render',
           'C: render',
           'C: render',
-          'A: useLayoutEffect mount',
-          'B: useLayoutEffect mount',
-          'C: useLayoutEffect mount',
-          'A: useEffect mount',
-          'B: useEffect mount',
-          'C: useEffect mount',
-          'A: useLayoutEffect unmount',
-          'B: useLayoutEffect unmount',
-          'C: useLayoutEffect unmount',
-          'A: useEffect unmount',
-          'B: useEffect unmount',
-          'C: useEffect unmount',
           'A: useLayoutEffect mount',
           'B: useLayoutEffect mount',
           'C: useLayoutEffect mount',

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -363,8 +363,15 @@ describe('Concurrent Mode', () => {
   });
 
   // @gate experimental
-  it('should warn about unsafe legacy lifecycle methods anywhere in the tree', () => {
-    class AsyncRoot extends React.Component {
+  it('should warn about unsafe legacy lifecycle methods anywhere in a StrictMode tree', () => {
+    function StrictRoot() {
+      return (
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      );
+    }
+    class App extends React.Component {
       UNSAFE_componentWillMount() {}
       UNSAFE_componentWillUpdate() {}
       render() {
@@ -399,7 +406,7 @@ describe('Concurrent Mode', () => {
 
     const container = document.createElement('div');
     const root = ReactDOM.unstable_createRoot(container);
-    root.render(<AsyncRoot />);
+    root.render(<StrictRoot />);
     expect(() => Scheduler.unstable_flushAll()).toErrorDev(
       [
         /* eslint-disable max-len */
@@ -407,7 +414,7 @@ describe('Concurrent Mode', () => {
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 
-Please update the following components: AsyncRoot`,
+Please update the following components: App`,
         `Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://reactjs.org/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
@@ -418,20 +425,27 @@ Please update the following components: Bar, Foo`,
 
 * Move data fetching code or side effects to componentDidUpdate.
 
-Please update the following components: AsyncRoot`,
+Please update the following components: App`,
         /* eslint-enable max-len */
       ],
       {withoutStack: true},
     );
 
     // Dedupe
-    root.render(<AsyncRoot />);
+    root.render(<App />);
     Scheduler.unstable_flushAll();
   });
 
   // @gate experimental
   it('should coalesce warnings by lifecycle name', () => {
-    class AsyncRoot extends React.Component {
+    function StrictRoot() {
+      return (
+        <React.StrictMode>
+          <App />
+        </React.StrictMode>
+      );
+    }
+    class App extends React.Component {
       UNSAFE_componentWillMount() {}
       UNSAFE_componentWillUpdate() {}
       render() {
@@ -455,7 +469,7 @@ Please update the following components: AsyncRoot`,
 
     const container = document.createElement('div');
     const root = ReactDOM.unstable_createRoot(container);
-    root.render(<AsyncRoot />);
+    root.render(<StrictRoot />);
 
     expect(() => {
       expect(() => Scheduler.unstable_flushAll()).toErrorDev(
@@ -465,7 +479,7 @@ Please update the following components: AsyncRoot`,
 
 * Move code with side effects to componentDidMount, and set initial state in the constructor.
 
-Please update the following components: AsyncRoot`,
+Please update the following components: App`,
           `Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. See https://reactjs.org/link/unsafe-component-lifecycles for details.
 
 * Move data fetching code or side effects to componentDidUpdate.
@@ -476,7 +490,7 @@ Please update the following components: Child`,
 
 * Move data fetching code or side effects to componentDidUpdate.
 
-Please update the following components: AsyncRoot`,
+Please update the following components: App`,
           /* eslint-enable max-len */
         ],
         {withoutStack: true},
@@ -508,16 +522,14 @@ Please update the following components: Parent`,
       {withoutStack: true},
     );
     // Dedupe
-    root.render(<AsyncRoot />);
+    root.render(<StrictRoot />);
     Scheduler.unstable_flushAll();
   });
 
   // @gate experimental
   it('should warn about components not present during the initial render', () => {
-    class AsyncRoot extends React.Component {
-      render() {
-        return this.props.foo ? <Foo /> : <Bar />;
-      }
+    function StrictRoot({foo}) {
+      return <React.StrictMode>{foo ? <Foo /> : <Bar />}</React.StrictMode>;
     }
     class Foo extends React.Component {
       UNSAFE_componentWillMount() {}
@@ -534,7 +546,7 @@ Please update the following components: Parent`,
 
     const container = document.createElement('div');
     const root = ReactDOM.unstable_createRoot(container);
-    root.render(<AsyncRoot foo={true} />);
+    root.render(<StrictRoot foo={true} />);
     expect(() =>
       Scheduler.unstable_flushAll(),
     ).toErrorDev(
@@ -542,7 +554,7 @@ Please update the following components: Parent`,
       {withoutStack: true},
     );
 
-    root.render(<AsyncRoot foo={false} />);
+    root.render(<StrictRoot foo={false} />);
     expect(() =>
       Scheduler.unstable_flushAll(),
     ).toErrorDev(
@@ -551,9 +563,9 @@ Please update the following components: Parent`,
     );
 
     // Dedupe
-    root.render(<AsyncRoot foo={true} />);
+    root.render(<StrictRoot foo={true} />);
     Scheduler.unstable_flushAll();
-    root.render(<AsyncRoot foo={false} />);
+    root.render(<StrictRoot foo={false} />);
     Scheduler.unstable_flushAll();
   });
 

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -287,11 +287,11 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 2 : 1);
+    expect(renderCount).toBe(1);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 4 : 2);
+    expect(renderCount).toBe(2);
   });
 
   it('should bailout if forwardRef is wrapped in memo', () => {
@@ -310,13 +310,13 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 2 : 1);
+    expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 2 : 1);
+    expect(renderCount).toBe(1);
 
     const differentRef = React.createRef();
 
@@ -324,14 +324,14 @@ describe('forwardRef', () => {
       <RefForwardingComponent ref={differentRef} optional="foo" />,
     );
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 4 : 2);
+    expect(renderCount).toBe(2);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="bar" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 6 : 3);
+    expect(renderCount).toBe(3);
   });
 
   it('should custom memo comparisons to compose', () => {
@@ -351,19 +351,19 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="0" c="1" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 2 : 1);
+    expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     // Changing either a or b rerenders
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="1" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 4 : 2);
+    expect(renderCount).toBe(2);
 
     // Changing c doesn't rerender
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="2" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 4 : 2);
+    expect(renderCount).toBe(2);
 
     const ComposedMemo = React.memo(
       RefForwardingComponent,
@@ -372,29 +372,29 @@ describe('forwardRef', () => {
 
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="0" c="0" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 6 : 3);
+    expect(renderCount).toBe(3);
 
     // Changing just b no longer updates
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="1" c="0" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 6 : 3);
+    expect(renderCount).toBe(3);
 
     // Changing just a and c updates
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="2" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 8 : 4);
+    expect(renderCount).toBe(4);
 
     // Changing just c does not update
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="3" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 8 : 4);
+    expect(renderCount).toBe(4);
 
     // Changing ref still rerenders
     const differentRef = React.createRef();
 
     ReactNoop.render(<ComposedMemo ref={differentRef} a="2" b="2" c="3" />);
     expect(Scheduler).toFlushWithoutYielding();
-    expect(renderCount).toBe(__DEV__ ? 10 : 5);
+    expect(renderCount).toBe(5);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');


### PR DESCRIPTION
Backs out some of the changes from #20849.

This PR has been split into three commits to simplify the review process:
* The `createRoot` API no longer defaults to strict mode <sup>1</sup>
* The `unstable_strictLevel` option has also been removed for now
* Tests have been updated accordingly

<sup>1</sup> Support was left in place for defaulting a root into "strict effects mode" if the `createRootStrictEffectsByDefault` feature flag is enabled, but this feature flag is only enabled within Facebook behind a GK.