### PR TITLE
DevTools Store emits errors before throwing

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -26,7 +26,6 @@ import SettingsModal from 'react-devtools-shared/src/devtools/views/Settings/Set
 import SettingsModalContextToggle from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContextToggle';
 import {SettingsModalContextController} from 'react-devtools-shared/src/devtools/views/Settings/SettingsModalContext';
 import portaledContent from '../portaledContent';
-import Store from '../../store';
 
 import styles from './Profiler.css';
 
@@ -188,10 +187,4 @@ const RecordingInProgress = () => (
   </div>
 );
 
-function onErrorRetry(store: Store) {
-  // If an error happened in the Profiler,
-  // we should clear data on retry (or it will just happen again).
-  store.profilerStore.profilingData = null;
-}
-
-export default portaledContent(Profiler, onErrorRetry);
+export default portaledContent(Profiler);

--- a/packages/react-devtools-shared/src/devtools/views/portaledContent.js
+++ b/packages/react-devtools-shared/src/devtools/views/portaledContent.js
@@ -12,19 +12,17 @@ import {useContext} from 'react';
 import {createPortal} from 'react-dom';
 import ErrorBoundary from './ErrorBoundary';
 import {StoreContext} from './context';
-import Store from '../store';
 
 export type Props = {portalContainer?: Element, ...};
 
 export default function portaledContent(
   Component: React$StatelessFunctionalComponent<any>,
-  onErrorRetry?: (store: Store) => void,
 ): React$StatelessFunctionalComponent<any> {
   return function PortaledContent({portalContainer, ...rest}: Props) {
     const store = useContext(StoreContext);
 
     const children = (
-      <ErrorBoundary store={store} onRetry={onErrorRetry}>
+      <ErrorBoundary store={store}>
         <Component {...rest} />
       </ErrorBoundary>
     );


### PR DESCRIPTION
The Store should never throw an error without also emitting an event. Otherwise Store errors will be invisible to users, but the downstream errors they cause will be reported as bugs. (For example, #21402)

Emitting an error event allows the ErrorBoundary to show the original error. Note that this _may_ result in a slight uptick of errors being reported in the short term _but_ should make bug reports more actionable.

(The store still throws as well since throwing is valuable for local development and for unit testing the Store itself.)

For example, the underlying cause of #21402 is now shown in the error overlay:
![Screenshot of error boundary showing an error thrown by the Store](https://user-images.githubusercontent.com/29597/117021979-d78fea80-acc5-11eb-9bd6-c5e32d2cdca2.png)
