### PR TITLE
Enable setJSResponder/setIsJSResponder for React Native Fabric

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -19,7 +19,15 @@ const ReactFabricGlobalResponderHandler = {
     );
 
     if (isFabric) {
-      // Noop for now until setJSResponder/clearJSResponder are supported in Fabric
+      if (from) {
+        // equivalent to clearJSResponder
+        nativeFabricUIManager.setIsJSResponder(from.stateNode.node, false, blockNativeResponder || false);
+      }
+
+      if (to) {
+        // equivalent to setJSResponder
+        nativeFabricUIManager.setIsJSResponder(to.stateNode.node, true, blockNativeResponder || false);
+      }
     } else {
       if (to !== null) {
         const tag = to.stateNode.canonical._nativeTag;

--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -21,12 +21,20 @@ const ReactFabricGlobalResponderHandler = {
     if (isFabric) {
       if (from) {
         // equivalent to clearJSResponder
-        nativeFabricUIManager.setIsJSResponder(from.stateNode.node, false, blockNativeResponder || false);
+        nativeFabricUIManager.setIsJSResponder(
+          from.stateNode.node,
+          false,
+          blockNativeResponder || false,
+        );
       }
 
       if (to) {
         // equivalent to setJSResponder
-        nativeFabricUIManager.setIsJSResponder(to.stateNode.node, true, blockNativeResponder || false);
+        nativeFabricUIManager.setIsJSResponder(
+          to.stateNode.node,
+          true,
+          blockNativeResponder || false,
+        );
       }
     } else {
       if (to !== null) {

--- a/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
+++ b/packages/react-native-renderer/src/__mocks__/react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager.js
@@ -176,6 +176,7 @@ const RCTFabricUIManager = {
     );
     success(1, 1, 100, 100);
   }),
+  setIsJSResponder: jest.fn(),
 };
 
 global.nativeFabricUIManager = RCTFabricUIManager;

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -179,7 +179,11 @@ declare var nativeFabricUIManager: {
     locationY: number,
     callback: (Fiber) => void,
   ) => void,
-  setIsJSResponder: (node: Node, isJsResponder: boolean, blockNativeResponder: boolean) => void,
+  setIsJSResponder: (
+    node: Node,
+    isJsResponder: boolean,
+    blockNativeResponder: boolean,
+  ) => void,
   ...
 };
 

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -179,6 +179,7 @@ declare var nativeFabricUIManager: {
     locationY: number,
     callback: (Fiber) => void,
   ) => void,
+  setIsJSResponder: (node: Node, isJsResponder: boolean, blockNativeResponder: boolean) => void,
   ...
 };
 


### PR DESCRIPTION
## Summary

Reenable setJSResponder / setIsJSResponder for RN Fabric.

What could possibly go wrong?

## Test Plan

We have tested this extensively internally and will test before landing any ReactJS sync to the RN repo.