### PR TITLE
Added new GitHub issue form for React DevTools bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/devtools_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/devtools_bug_report.yml
@@ -1,0 +1,78 @@
+name: "DevTools bug report"
+description: "Report a problem with React DevTools"
+title: "[DevTools Bug]: "
+labels: ["Component: Developer Tools", "Type: Bug", "Status: Unconfirmed"]
+body:
+- type: input
+  attributes:
+    label: Website or app
+    description: |
+      Which website or app were you using when the bug happened?
+    placeholder: |
+      e.g. website URL, public GitHub repo, or Code Sandbox app
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Repro steps
+    description: |
+      What were you doing on the website or app when the bug happened? Detailed information helps maintainers reproduce and fix bugs.
+
+      Issues filed without repro steps may be closed.
+    placeholder: |
+      Example bug report:
+      1. Log in with username/password
+      2. Click "Messages" on the left menu
+      3. Open any message in the list
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: How often does this bug happen?
+    description: |
+      Following the repro steps above, how easily are you able to reproduce this bug?
+    options:
+      - Every time
+      - Often
+      - Sometimes
+      - Only once
+  validations:
+    required: true
+- type: input
+  id: automated_package
+  attributes:
+    label: DevTools package (automated)
+    description: |
+      Please do not edit this field.
+- type: input
+  id: automated_version
+  attributes:
+    label: DevTools version (automated)
+    description: |
+      Please do not edit this field.
+- type: input
+  id: automated_error_message
+  attributes:
+    label: Error message (automated)
+    description: |
+      Please do not edit this field.
+- type: textarea
+  id: automated_call_stack
+  attributes:
+    label: Error call stack (automated)
+    description: |
+      Please do not edit this field.
+    render: text
+- type: textarea
+  id: automated_component_stack
+  attributes:
+    label: Error component stack (automated)
+    description: |
+      Please do not edit this field.
+    render: text
+- type: input
+  id: automated_github_query_string
+  attributes:
+    label: GitHub query string (automated)
+    description: |
+      Please do not edit this field.

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -54,6 +54,7 @@ module.exports = {
       __EXTENSION__: false,
       __PROFILE__: false,
       __TEST__: NODE_ENV === 'test',
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-core"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
     }),

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -54,6 +54,7 @@ module.exports = {
       __EXTENSION__: false,
       __PROFILE__: false,
       __TEST__: NODE_ENV === 'test',
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-core"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
       'process.env.NODE_ENV': `"${NODE_ENV}"`,

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -51,6 +51,7 @@ module.exports = {
       __DEV__: true,
       __PROFILE__: false,
       __EXPERIMENTAL__: true,
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-extensions"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
     }),

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -58,6 +58,7 @@ module.exports = {
       __EXTENSION__: true,
       __PROFILE__: false,
       __TEST__: NODE_ENV === 'test',
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-extensions"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
       'process.env.NODE_ENV': `"${NODE_ENV}"`,

--- a/packages/react-devtools-inline/webpack.config.js
+++ b/packages/react-devtools-inline/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = {
       __EXTENSION__: false,
       __PROFILE__: false,
       __TEST__: NODE_ENV === 'test',
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-inline"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
       'process.env.NODE_ENV': `"${NODE_ENV}"`,

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ReportNewIssue.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ReportNewIssue.js
@@ -12,9 +12,14 @@ import Icon from '../Icon';
 import {searchGitHubIssuesURL} from './githubAPI';
 import styles from './shared.css';
 
-function encodeURIWrapper(string: string): string {
-  return encodeURI(string).replace(/#/g, '%23');
-}
+const LABELS = [
+  'Component: Developer Tools',
+  'Type: Bug',
+  'Status: Unconfirmed',
+];
+
+// This must match the filename in ".github/ISSUE_TEMPLATE/"
+const TEMPLATE = 'devtools_bug_report.yml';
 
 type Props = {|
   callStack: string | null,
@@ -35,44 +40,21 @@ export default function ReportNewIssue({
   const gitHubAPISearch =
     errorMessage !== null ? searchGitHubIssuesURL(errorMessage) : '(none)';
 
-  const title = `Error: "${errorMessage || ''}"`;
-  const labels = ['Component: Developer Tools', 'Status: Unconfirmed'];
+  const title = `[DevTools Error] ${errorMessage || ''}`;
 
-  const body = `
-<!-- Please answer both questions below before submitting this issue. -->
+  const parameters = [
+    `template=${TEMPLATE}`,
+    `labels=${encodeURIComponent(LABELS.join(','))}`,
+    `title=${encodeURIComponent(title)}`,
+    `automated_package=${process.env.DEVTOOLS_PACKAGE || ''}`,
+    `automated_version=${process.env.DEVTOOLS_VERSION || ''}`,
+    `automated_error_message=${encodeURIComponent(errorMessage || '')}`,
+    `automated_call_stack=${encodeURIComponent(callStack || '')}`,
+    `automated_component_stack=${encodeURIComponent(componentStack || '')}`,
+    `automated_github_query_string=${gitHubAPISearch}`,
+  ];
 
-### Which website or app were you using when the bug happened?
-
-Please provide a link to the URL of the website (if it is public), a CodeSandbox (https://codesandbox.io/s/new) example that reproduces the bug, or a project on GitHub that we can checkout and run locally.
-
-### What were you doing on the website or app when the bug happened?
-
-If possible, please describe how to reproduce this bug on the website or app mentioned above:
-1. <!-- FILL THIS IN -->
-2. <!-- FILL THIS IN -->
-3. <!-- FILL THIS IN -->
-
-<!--------------------------------------------------->
-<!-- Please do not remove the text below this line -->
-<!--------------------------------------------------->
-
-### Generated information
-
-DevTools version: ${process.env.DEVTOOLS_VERSION || ''}
-
-Call stack:
-${callStack || '(none)'}
-
-Component stack:
-${componentStack || '(none)'}
-
-GitHub URL search query:
-${gitHubAPISearch}
-  `;
-
-  bugURL += `/issues/new?labels=${encodeURIWrapper(
-    labels.join(','),
-  )}&title=${encodeURIWrapper(title)}&body=${encodeURIWrapper(body.trim())}`;
+  bugURL += `/issues/new?${parameters.join('&')}`;
 
   return (
     <div className={styles.GitHubLinkRow}>

--- a/packages/react-devtools-shell/webpack.config.js
+++ b/packages/react-devtools-shell/webpack.config.js
@@ -52,6 +52,7 @@ const config = {
       __PROFILE__: false,
       __TEST__: NODE_ENV === 'test',
       'process.env.GITHUB_URL': `"${GITHUB_URL}"`,
+      'process.env.DEVTOOLS_PACKAGE': `"react-devtools-shell"`,
       'process.env.DEVTOOLS_VERSION': `"${DEVTOOLS_VERSION}"`,
     }),
   ],


### PR DESCRIPTION
- [x] Add a new GitHub issue [form template](https://gh-community.github.io/issue-template-feedback/structured/) for DevTools bug reports.
- [x] Update the React DevTools issue reporting flow to 

You can demo this new form in action [here](https://github.com/bvaughn/test-github-issue-template/issues/new?template=devtools_bug_report.yml&labels=Component:%20Developer%20Tools,Type:%20Bug,Status:%20Unconfirmed&title=%5BDevTools%20Error%5D%20This%20is%20an%20example%20error&automated_package=react-devtools-inline&automated_version=4.13.1-bd070eb2c4&automated_error_message=This%20is%20an%20example%20error&automated_call_stack=%20%20%20%20at%20Components%20(webpack-internal:///../react-devtools-shared/src/devtools/views/Components/Components.js:43:9)%0A%20%20%20%20at%20renderWithHooks%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:2606:157)%0A%20%20%20%20at%20mountIndeterminateComponent%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:3035:886)%0A%20%20%20%20at%20beginWork%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:3356:93)%0A%20%20%20%20at%20beginWork$1%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:4320:93)%0A%20%20%20%20at%20performUnitOfWork%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:4168:270)%0A%20%20%20%20at%20workLoopSync%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:4154:30)%0A%20%20%20%20at%20renderRootSync%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:4150:108)%0A%20%20%20%20at%20performConcurrentWorkOnRoot%20(webpack-internal:///../../build/node_modules/react-dom/cjs/react-dom.development.js:4029:126)%0A%20%20%20%20at%20workLoop%20(webpack-internal:///../../build/node_modules/scheduler/cjs/scheduler.development.js:269:38)&automated_component_stack=%0A%20%20%20%20at%20Components%20(webpack-internal:///../react-devtools-shared/src/devtools/views/Components/Components.js:43:9)%0A%20%20%20%20at%20ErrorBoundary%20(webpack-internal:///../react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js:35:5)%0A%20%20%20%20at%20PortaledContent%20(webpack-internal:///../react-devtools-shared/src/devtools/views/portaledContent.js:28:5)%0A%20%20%20%20at%20div%0A%20%20%20%20at%20div%0A%20%20%20%20at%20ProfilerContextController%20(webpack-internal:///../react-devtools-shared/src/devtools/views/Profiler/ProfilerContext.js:31:3)%0A%20%20%20%20at%20TreeContextController%20(webpack-internal:///../react-devtools-shared/src/devtools/views/Components/TreeContext.js:664:3)%0A%20%20%20%20at%20SettingsContextController%20(webpack-internal:///../react-devtools-shared/src/devtools/views/Settings/SettingsContext.js:30:3)%0A%20%20%20%20at%20ModalDialogContextController%20(webpack-internal:///../react-devtools-shared/src/devtools/views/ModalDialog.js:52:3)%0A%20%20%20%20at%20DevTools%20(webpack-internal:///../react-devtools-shared/src/devtools/views/DevTools.js:75:3)%0A%20%20%20%20at%20DevTools&automated_github_query_string=https://api.github.com/search/issues?q=This%20is%20an%20example%20error%20in%3Atitle%20is%3Aissue%20is%3Aopen%20is%3Apublic%20label%3A%22Component%3A%20Developer%20Tools%22%20repo%3Afacebook%2Freact).

### Demo
https://user-images.githubusercontent.com/29597/117450144-dac9e700-af0e-11eb-8b91-07401b21f42b.mp4
