### PR TITLE
 Define global __WWW__ = true flag during www tests

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
@@ -10,15 +10,12 @@
 'use strict';
 
 let React;
-let ReactFeatureFlags;
 let ReactNoop;
 let Scheduler;
 
 describe('ReactSuspense', () => {
   beforeEach(() => {
     jest.resetModules();
-    ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.enableSuspenseCallback = true;
 
     React = require('react');
     ReactNoop = require('react-noop-renderer');
@@ -47,30 +44,34 @@ describe('ReactSuspense', () => {
     return {promise, resolve, PromiseComp};
   }
 
-  it('check type', () => {
-    const {PromiseComp} = createThenable();
+  if (__DEV__) {
+    // @gate www
+    it('check type', () => {
+      const {PromiseComp} = createThenable();
 
-    const elementBadType = (
-      <React.Suspense suspenseCallback={1} fallback={'Waiting'}>
-        <PromiseComp />
-      </React.Suspense>
-    );
+      const elementBadType = (
+        <React.Suspense suspenseCallback={1} fallback={'Waiting'}>
+          <PromiseComp />
+        </React.Suspense>
+      );
 
-    ReactNoop.render(elementBadType);
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([
-      'Warning: Unexpected type for suspenseCallback.',
-    ]);
+      ReactNoop.render(elementBadType);
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev([
+        'Warning: Unexpected type for suspenseCallback.',
+      ]);
 
-    const elementMissingCallback = (
-      <React.Suspense fallback={'Waiting'}>
-        <PromiseComp />
-      </React.Suspense>
-    );
+      const elementMissingCallback = (
+        <React.Suspense fallback={'Waiting'}>
+          <PromiseComp />
+        </React.Suspense>
+      );
 
-    ReactNoop.render(elementMissingCallback);
-    expect(() => Scheduler.unstable_flushAll()).toErrorDev([]);
-  });
+      ReactNoop.render(elementMissingCallback);
+      expect(() => Scheduler.unstable_flushAll()).toErrorDev([]);
+    });
+  }
 
+  // @gate www
   it('1 then 0 suspense callback', async () => {
     const {promise, resolve, PromiseComp} = createThenable();
 
@@ -97,6 +98,7 @@ describe('ReactSuspense', () => {
     expect(ops).toEqual([]);
   });
 
+  // @gate www
   it('2 then 1 then 0 suspense callback', async () => {
     const {
       promise: promise1,
@@ -143,6 +145,7 @@ describe('ReactSuspense', () => {
     expect(ops).toEqual([]);
   });
 
+  // @gate www
   it('nested suspense promises are reported only for their tier', () => {
     const {promise, PromiseComp} = createThenable();
 
@@ -174,6 +177,7 @@ describe('ReactSuspense', () => {
     expect(ops2).toEqual([new Set([promise])]);
   });
 
+  // @gate www
   it('competing suspense promises', async () => {
     const {
       promise: promise1,
@@ -242,6 +246,7 @@ describe('ReactSuspense', () => {
   });
 
   if (__DEV__) {
+    // @gate www
     it('regression test for #16215 that relies on implementation details', async () => {
       // Regression test for https://github.com/facebook/react/pull/16215.
       // The bug only happens if there's an error earlier in the commit phase.
@@ -271,9 +276,6 @@ describe('ReactSuspense', () => {
           return errors[errors.length - 1];
         },
       }));
-
-      ReactFeatureFlags = require('shared/ReactFeatureFlags');
-      ReactFeatureFlags.enableSuspenseCallback = true;
 
       React = require('react');
       ReactNoop = require('react-noop-renderer');

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -56,10 +56,7 @@ function getTestFlags() {
   // not to but there are exceptions.
   const featureFlags = require('shared/ReactFeatureFlags');
 
-  // TODO: This is a heuristic to detect the release channel by checking a flag
-  // that is known to only be enabled in www. What we should do instead is set
-  // the release channel explicitly in the each test config file.
-  const www = featureFlags.enableSuspenseCallback === true;
+  const www = global.__WWW__ === true;
   const releaseChannel = www
     ? __EXPERIMENTAL__
       ? 'modern'

--- a/scripts/jest/config.source-www.js
+++ b/scripts/jest/config.source-www.js
@@ -30,7 +30,7 @@ module.exports = Object.assign({}, baseConfig, {
   ],
   setupFiles: [
     ...baseConfig.setupFiles,
-    require.resolve('./setupHostConfigs.js'),
     require.resolve('./setupTests.www.js'),
+    require.resolve('./setupHostConfigs.js'),
   ],
 });

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -19,3 +19,5 @@ jest.mock('shared/ReactFeatureFlags', () => {
 
   return wwwFlags;
 });
+
+global.__WWW__ = true;


### PR DESCRIPTION
We already do the same thing for `__PERSISTENT__`. So now this works the same and we have a more reliable flag.

I need this for some other jest set up stuff in a follow up anyway.

To test it I used the `@gate` feature in ReactSuspenseCallback and converted it from internal.