### PR TITLE
Resolve the true entry point during tests

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -286,7 +286,7 @@ describe('ReactDOMFiberAsync', () => {
       expect(ops).toEqual(['BC', 'ABCD']);
     });
 
-    // @gate experimental
+    // @gate experimental || www
     it('flushControlled flushes updates before yielding to browser', () => {
       let inst;
       class Counter extends React.Component {
@@ -326,7 +326,7 @@ describe('ReactDOMFiberAsync', () => {
       ]);
     });
 
-    // @gate experimental
+    // @gate experimental || www
     it('flushControlled does not flush until end of outermost batchedUpdates', () => {
       let inst;
       class Counter extends React.Component {
@@ -357,7 +357,7 @@ describe('ReactDOMFiberAsync', () => {
       ]);
     });
 
-    // @gate experimental
+    // @gate experimental || www
     it('flushControlled returns nothing', () => {
       // In the future, we may want to return a thenable "work" object.
       let inst;

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -571,7 +571,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.className).toBe('hi');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('blocks updates to hydrate the content first if props changed at idle priority', async () => {
     let suspend = false;
     let resolve;
@@ -1498,7 +1498,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(container.textContent).toBe('ALoading B');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('clears server boundaries when SuspenseList runs out of time hydrating', async () => {
     let suspend = false;
     let resolve;
@@ -2617,7 +2617,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.innerHTML).toBe('Hidden child');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('renders a hidden LegacyHidden component inside a Suspense boundary', async () => {
     const ref = React.createRef();
 
@@ -2646,7 +2646,7 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(span.innerHTML).toBe('Hidden child');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('renders a visible LegacyHidden component', async () => {
     const ref = React.createRef();
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -1912,7 +1912,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate www
   it('does not invoke an event on a hydrated event handle until it commits', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let suspend = false;
@@ -2077,7 +2077,7 @@ describe('ReactDOMServerPartialHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate www
   it('invokes discrete events on nested suspense boundaries in a root (createEventHandle)', async () => {
     let suspend = false;
     let isServerRendering = true;

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -812,7 +812,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('hydrates the last explicitly hydrated target at higher priority', async () => {
     function Child({text}) {
       Scheduler.unstable_yieldValue(text);
@@ -861,7 +861,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     expect(Scheduler).toFlushAndYield(['App', 'C', 'B', 'A']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('hydrates before an update even if hydration moves away from it', async () => {
     function Child({text}) {
       Scheduler.unstable_yieldValue(text);

--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -369,7 +369,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate www
   it('hydrates the target boundary synchronously during a click (createEventHandle)', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let isServerRendering = true;
@@ -438,7 +438,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate www
   it('hydrates at higher pri if sync did not work first time (createEventHandle)', async () => {
     let suspend = false;
     let isServerRendering = true;
@@ -526,7 +526,7 @@ describe('ReactDOMServerSelectiveHydration', () => {
     document.body.removeChild(container);
   });
 
-  // @gate experimental
+  // @gate www
   it('hydrates at higher pri for secondary discrete events (createEventHandle)', async () => {
     const setClick = ReactDOM.unstable_createEventHandle('click');
     let suspend = false;

--- a/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTestSelectors-test.internal.js
@@ -56,6 +56,7 @@ describe('ReactDOMTestSelectors', () => {
   });
 
   describe('findAllNodes', () => {
+    // @gate www
     it('should support searching from the document root', () => {
       function Example() {
         return (
@@ -75,6 +76,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support searching from the container', () => {
       function Example() {
         return (
@@ -94,6 +96,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support searching from a previous match if the match had a data-testname', () => {
       function Outer() {
         return (
@@ -124,6 +127,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('inner');
     });
 
+    // @gate www
     it('should not support searching from a previous match if the match did not have a data-testname', () => {
       function Outer() {
         return (
@@ -153,6 +157,7 @@ describe('ReactDOMTestSelectors', () => {
       );
     });
 
+    // @gate www
     it('should support an multiple component types in the selector array', () => {
       function Outer() {
         return (
@@ -206,6 +211,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match3');
     });
 
+    // @gate www
     it('should find multiple matches', () => {
       function Example1() {
         return (
@@ -243,6 +249,7 @@ describe('ReactDOMTestSelectors', () => {
       ]);
     });
 
+    // @gate www
     it('should ignore nested matches', () => {
       function Example() {
         return (
@@ -262,6 +269,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toEqual('match1');
     });
 
+    // @gate www
     it('should enforce the specific order of selectors', () => {
       function Outer() {
         return (
@@ -286,6 +294,7 @@ describe('ReactDOMTestSelectors', () => {
       ).toHaveLength(0);
     });
 
+    // @gate www
     it('should not search within hidden subtrees', () => {
       const ref1 = React.createRef(null);
       const ref2 = React.createRef(null);
@@ -315,6 +324,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0]).toBe(ref2.current);
     });
 
+    // @gate www
     it('should support filtering by display text', () => {
       function Example() {
         return (
@@ -337,6 +347,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support filtering by explicit accessibiliy role', () => {
       function Example() {
         return (
@@ -361,6 +372,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support filtering by explicit secondary accessibiliy role', () => {
       const ref = React.createRef();
 
@@ -385,6 +397,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0]).toBe(ref.current);
     });
 
+    // @gate www
     it('should support filtering by implicit accessibiliy role', () => {
       function Example() {
         return (
@@ -407,6 +420,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support filtering by implicit accessibiliy role with attributes qualifications', () => {
       function Example() {
         return (
@@ -429,6 +443,7 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should support searching ahead with the has() selector', () => {
       function Example() {
         return (
@@ -464,12 +479,14 @@ describe('ReactDOMTestSelectors', () => {
       expect(matches[0].id).toBe('match');
     });
 
+    // @gate www
     it('should throw if no container can be found', () => {
       expect(() => findAllNodes(document.body, [])).toThrow(
         'Could not find React container within specified host subtree.',
       );
     });
 
+    // @gate www
     it('should throw if an invalid host root is specified', () => {
       const ref = React.createRef();
       function Example() {
@@ -485,6 +502,7 @@ describe('ReactDOMTestSelectors', () => {
   });
 
   describe('getFindAllNodesFailureDescription', () => {
+    // @gate www
     it('should describe findAllNodes failures caused by the component type selector', () => {
       function Outer() {
         return <Middle />;
@@ -514,6 +532,7 @@ No matching component was found for:
       );
     });
 
+    // @gate www
     it('should return null if findAllNodes was able to find a match', () => {
       function Example() {
         return (
@@ -549,6 +568,7 @@ No matching component was found for:
       };
     }
 
+    // @gate www
     it('should return a single rect for a component that returns a single root host element', () => {
       const ref = React.createRef();
 
@@ -582,6 +602,7 @@ No matching component was found for:
       });
     });
 
+    // @gate www
     it('should return a multiple rects for multiple matches', () => {
       const outerRef = React.createRef();
       const innerRef = React.createRef();
@@ -631,6 +652,7 @@ No matching component was found for:
       });
     });
 
+    // @gate www
     it('should return a multiple rects for single match that returns a fragment', () => {
       const refA = React.createRef();
       const refB = React.createRef();
@@ -680,6 +702,7 @@ No matching component was found for:
       });
     });
 
+    // @gate www
     it('should merge overlapping rects', () => {
       const refA = React.createRef();
       const refB = React.createRef();
@@ -734,6 +757,7 @@ No matching component was found for:
       });
     });
 
+    // @gate www
     it('should merge some types of adjacent rects (if they are the same in one dimension)', () => {
       const refA = React.createRef();
       const refB = React.createRef();
@@ -833,6 +857,7 @@ No matching component was found for:
       });
     });
 
+    // @gate www
     it('should not search within hidden subtrees', () => {
       const refA = React.createRef();
       const refB = React.createRef();
@@ -889,6 +914,7 @@ No matching component was found for:
   });
 
   describe('focusWithin', () => {
+    // @gate www
     it('should return false if the specified component path has no matches', () => {
       function Example() {
         return <Child />;
@@ -909,6 +935,7 @@ No matching component was found for:
       expect(didFocus).toBe(false);
     });
 
+    // @gate www
     it('should return false if there are no focusable elements within the matched subtree', () => {
       function Example() {
         return <Child />;
@@ -926,6 +953,7 @@ No matching component was found for:
       expect(didFocus).toBe(false);
     });
 
+    // @gate www
     it('should return false if the only focusable elements are disabled', () => {
       function Example() {
         return (
@@ -943,6 +971,7 @@ No matching component was found for:
       expect(didFocus).toBe(false);
     });
 
+    // @gate www
     it('should return false if the only focusable elements are hidden', () => {
       function Example() {
         return <button hidden={true}>not clickable</button>;
@@ -956,6 +985,7 @@ No matching component was found for:
       expect(didFocus).toBe(false);
     });
 
+    // @gate www
     it('should successfully focus the first focusable element within the tree', () => {
       const secondRef = React.createRef(null);
 
@@ -1010,6 +1040,7 @@ No matching component was found for:
       expect(handleThirdFocus).not.toHaveBeenCalled();
     });
 
+    // @gate www
     it('should successfully focus the first focusable element even if application logic interferes', () => {
       const ref = React.createRef(null);
 
@@ -1039,6 +1070,7 @@ No matching component was found for:
       expect(handleFocus).toHaveBeenCalledTimes(1);
     });
 
+    // @gate www
     it('should not focus within hidden subtrees', () => {
       const secondRef = React.createRef(null);
 
@@ -1162,6 +1194,7 @@ No matching component was found for:
       window.IntersectionObserver = IntersectionObserver;
     });
 
+    // @gate www
     it('should notify a listener when the underlying instance intersection changes', () => {
       const ref = React.createRef(null);
 
@@ -1198,6 +1231,7 @@ No matching component was found for:
       expect(handleVisibilityChange).toHaveBeenCalledWith([{rect, ratio: 0.5}]);
     });
 
+    // @gate www
     it('should notify a listener of multiple targets when the underlying instance intersection changes', () => {
       const ref1 = React.createRef(null);
       const ref2 = React.createRef(null);
@@ -1274,6 +1308,7 @@ No matching component was found for:
       ]);
     });
 
+    // @gate www
     it('should stop listening when its disconnected', () => {
       const ref = React.createRef(null);
 
@@ -1308,7 +1343,7 @@ No matching component was found for:
     });
 
     // This test reuires gating because it relies on the __DEV__ only commit hook to work.
-    // @gate __DEV__
+    // @gate www && __DEV__
     it('should update which targets its listening to after a commit', () => {
       const ref1 = React.createRef(null);
       const ref2 = React.createRef(null);
@@ -1387,6 +1422,7 @@ No matching component was found for:
       ]);
     });
 
+    // @gate www
     it('should not observe components within hidden subtrees', () => {
       const ref1 = React.createRef(null);
       const ref2 = React.createRef(null);

--- a/packages/react-dom/src/__tests__/ReactUpdates-test.js
+++ b/packages/react-dom/src/__tests__/ReactUpdates-test.js
@@ -1300,7 +1300,7 @@ describe('ReactUpdates', () => {
     expect(ops).toEqual(['Foo', 'Bar', 'Baz']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('delays sync updates inside hidden subtrees in Concurrent Mode', () => {
     const container = document.createElement('div');
 

--- a/packages/react-dom/src/__tests__/ReactWrongReturnPointer-test.js
+++ b/packages/react-dom/src/__tests__/ReactWrongReturnPointer-test.js
@@ -194,7 +194,6 @@ test('warns in DEV if return pointer is inconsistent', async () => {
   );
 });
 
-// @gate experimental
 // @gate enableCache
 test('regression (#20932): return pointer is correct before entering deleted tree', async () => {
   // Based on a production bug. Designed to trigger a very specific

--- a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
@@ -1257,7 +1257,7 @@ describe('DOMPluginEventSystem', () => {
             act = ReactTestUtils.unstable_concurrentAct;
           });
 
-          // @gate experimental
+          // @gate www
           it('can render correctly with the ReactDOMServer', () => {
             const clickEvent = jest.fn();
             const setClick = ReactDOM.unstable_createEventHandle('click');
@@ -1275,7 +1275,7 @@ describe('DOMPluginEventSystem', () => {
             expect(output).toBe(`<div>Hello world</div>`);
           });
 
-          // @gate experimental
+          // @gate www
           it('can render correctly with the ReactDOMServer hydration', () => {
             const clickEvent = jest.fn();
             const spanRef = React.createRef();
@@ -1301,7 +1301,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toHaveBeenCalledTimes(1);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly work for a basic "click" listener', () => {
             let log = [];
             const clickEvent = jest.fn(event => {
@@ -1409,7 +1409,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent2).toBeCalledTimes(1);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly work for setting and clearing a basic "click" listener', () => {
             const clickEvent = jest.fn();
             const divRef = React.createRef();
@@ -1450,7 +1450,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toBeCalledTimes(0);
           });
 
-          // @gate experimental
+          // @gate www
           it('should handle the target being a text node', () => {
             const clickEvent = jest.fn();
             const buttonRef = React.createRef();
@@ -1472,7 +1472,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toBeCalledTimes(1);
           });
 
-          // @gate experimental
+          // @gate www
           it('handle propagation of click events', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -1541,7 +1541,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log[3]).toEqual(['bubble', buttonElement]);
           });
 
-          // @gate experimental
+          // @gate www
           it('handle propagation of click events mixed with onClick events', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -1601,7 +1601,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log[5]).toEqual(['bubble', buttonElement]);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly work for a basic "click" listener on the outer target', () => {
             const log = [];
             const clickEvent = jest.fn(event => {
@@ -1666,7 +1666,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toBeCalledTimes(2);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle many nested target listeners', () => {
             const buttonRef = React.createRef();
             const targetListener1 = jest.fn();
@@ -1769,7 +1769,7 @@ describe('DOMPluginEventSystem', () => {
             expect(targetListener4).toHaveBeenCalledTimes(2);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle stopPropagation correctly for target events', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -1807,7 +1807,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toHaveBeenCalledTimes(0);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle stopPropagation correctly for many target events', () => {
             const buttonRef = React.createRef();
             const targetListener1 = jest.fn(e => e.stopPropagation());
@@ -1860,7 +1860,7 @@ describe('DOMPluginEventSystem', () => {
             expect(targetListener4).toHaveBeenCalledTimes(1);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle stopPropagation for mixed capture/bubbling target listeners', () => {
             const buttonRef = React.createRef();
             const targetListener1 = jest.fn(e => e.stopPropagation());
@@ -1917,7 +1917,7 @@ describe('DOMPluginEventSystem', () => {
             expect(targetListener4).toHaveBeenCalledTimes(0);
           });
 
-          // @gate experimental
+          // @gate www
           it('should work with concurrent mode updates', async () => {
             const log = [];
             const ref = React.createRef();
@@ -1970,7 +1970,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log).toEqual([{counter: 1}]);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly work for a basic "click" window listener', () => {
             const log = [];
             const clickEvent = jest.fn(event => {
@@ -2021,7 +2021,7 @@ describe('DOMPluginEventSystem', () => {
             expect(clickEvent).toBeCalledTimes(2);
           });
 
-          // @gate experimental
+          // @gate www
           it('handle propagation of click events on the window', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -2101,7 +2101,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log[5]).toEqual(['bubble', window]);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle stopPropagation for mixed listeners', () => {
             const buttonRef = React.createRef();
             const rootListener1 = jest.fn(e => e.stopPropagation());
@@ -2152,7 +2152,7 @@ describe('DOMPluginEventSystem', () => {
             expect(rootListener2).toHaveBeenCalledTimes(0);
           });
 
-          // @gate experimental
+          // @gate www
           it('should correctly handle stopPropagation for delegated listeners', () => {
             const buttonRef = React.createRef();
             const rootListener1 = jest.fn(e => e.stopPropagation());
@@ -2198,7 +2198,7 @@ describe('DOMPluginEventSystem', () => {
             expect(rootListener4).toHaveBeenCalledTimes(0);
           });
 
-          // @gate experimental
+          // @gate www
           it('handle propagation of click events on the window and document', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -2311,7 +2311,7 @@ describe('DOMPluginEventSystem', () => {
             }
           });
 
-          // @gate experimental
+          // @gate www
           it('does not support custom user events', () => {
             // With eager listeners, supporting custom events via this API doesn't make sense
             // because we can't know a full list of them ahead of time. Let's check we throw
@@ -2323,7 +2323,7 @@ describe('DOMPluginEventSystem', () => {
             );
           });
 
-          // @gate experimental
+          // @gate www
           it('beforeblur and afterblur are called after a focused element is unmounted', () => {
             const log = [];
             // We have to persist here because we want to read relatedTarget later.
@@ -2382,7 +2382,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log).toEqual(['beforeblur', 'afterblur']);
           });
 
-          // @gate experimental
+          // @gate www
           it('beforeblur and afterblur are called after a nested focused element is unmounted', () => {
             const log = [];
             // We have to persist here because we want to read relatedTarget later.
@@ -2445,7 +2445,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log).toEqual(['beforeblur', 'afterblur']);
           });
 
-          // @gate experimental
+          // @gate www
           it('beforeblur should skip handlers from a deleted subtree after the focused element is unmounted', () => {
             const onBeforeBlur = jest.fn();
             const innerRef = React.createRef();
@@ -2499,7 +2499,7 @@ describe('DOMPluginEventSystem', () => {
             expect(onBeforeBlur).toHaveBeenCalledTimes(1);
           });
 
-          // @gate experimental
+          // @gate www
           it('beforeblur and afterblur are called after a focused element is suspended', () => {
             const log = [];
             // We have to persist here because we want to read relatedTarget later.
@@ -2585,7 +2585,7 @@ describe('DOMPluginEventSystem', () => {
             document.body.removeChild(container2);
           });
 
-          // @gate experimental
+          // @gate www
           it('beforeblur should skip handlers from a deleted subtree after the focused element is suspended', () => {
             const onBeforeBlur = jest.fn();
             const innerRef = React.createRef();
@@ -2666,7 +2666,7 @@ describe('DOMPluginEventSystem', () => {
             document.body.removeChild(container2);
           });
 
-          // @gate experimental
+          // @gate www
           it('regression: does not fire beforeblur/afterblur if target is already hidden', () => {
             const Suspense = React.Suspense;
             let suspend = false;
@@ -2728,7 +2728,7 @@ describe('DOMPluginEventSystem', () => {
             document.body.removeChild(container2);
           });
 
-          // @gate experimental
+          // @gate www
           it('handle propagation of click events between disjointed comment roots', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -2799,7 +2799,7 @@ describe('DOMPluginEventSystem', () => {
             expect(log[5]).toEqual(['bubble', buttonElement]);
           });
 
-          // @gate experimental
+          // @gate www
           it('propagates known createEventHandle events through portals without inner listeners', () => {
             const buttonRef = React.createRef();
             const divRef = React.createRef();
@@ -2870,7 +2870,7 @@ describe('DOMPluginEventSystem', () => {
               ReactDOMServer = require('react-dom/server');
             });
 
-            // @gate experimental
+            // @gate www
             it('handle propagation of click events on a scope', () => {
               const buttonRef = React.createRef();
               const log = [];
@@ -2926,7 +2926,7 @@ describe('DOMPluginEventSystem', () => {
               ]);
             });
 
-            // @gate experimental
+            // @gate www
             it('handle mixed propagation of click events on a scope', () => {
               const buttonRef = React.createRef();
               const divRef = React.createRef();
@@ -3017,7 +3017,7 @@ describe('DOMPluginEventSystem', () => {
               ]);
             });
 
-            // @gate experimental
+            // @gate www
             it('should not handle the target being a dangling text node within a scope', () => {
               const clickEvent = jest.fn();
               const buttonRef = React.createRef();
@@ -3048,7 +3048,7 @@ describe('DOMPluginEventSystem', () => {
               expect(clickEvent).toBeCalledTimes(0);
             });
 
-            // @gate experimental
+            // @gate www
             it('handle stopPropagation (inner) correctly between scopes', () => {
               const buttonRef = React.createRef();
               const outerOnClick = jest.fn();
@@ -3090,7 +3090,7 @@ describe('DOMPluginEventSystem', () => {
               expect(outerOnClick).toHaveBeenCalledTimes(0);
             });
 
-            // @gate experimental
+            // @gate www
             it('handle stopPropagation (outer) correctly between scopes', () => {
               const buttonRef = React.createRef();
               const outerOnClick = jest.fn(e => e.stopPropagation());
@@ -3132,7 +3132,7 @@ describe('DOMPluginEventSystem', () => {
               expect(outerOnClick).toHaveBeenCalledTimes(1);
             });
 
-            // @gate experimental
+            // @gate www
             it('handle stopPropagation (inner and outer) correctly between scopes', () => {
               const buttonRef = React.createRef();
               const onClick = jest.fn(e => e.stopPropagation());
@@ -3172,7 +3172,7 @@ describe('DOMPluginEventSystem', () => {
               expect(onClick).toHaveBeenCalledTimes(1);
             });
 
-            // @gate experimental
+            // @gate www
             it('should be able to register handlers for events affected by the intervention', () => {
               const rootContainer = document.createElement('div');
               container.appendChild(rootContainer);

--- a/packages/react-fetch/src/__tests__/ReactFetchNode-test.js
+++ b/packages/react-fetch/src/__tests__/ReactFetchNode-test.js
@@ -39,7 +39,7 @@ describe('ReactFetchNode', () => {
     server = null;
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can fetch text from a server component', async () => {
     serverImpl = (req, res) => {
       res.write('mango');
@@ -51,7 +51,7 @@ describe('ReactFetchNode', () => {
     expect(text).toEqual('mango');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can fetch json from a server component', async () => {
     serverImpl = (req, res) => {
       res.write(JSON.stringify({name: 'Sema'}));
@@ -63,7 +63,7 @@ describe('ReactFetchNode', () => {
     expect(json).toEqual({name: 'Sema'});
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('provides response status', async () => {
     serverImpl = (req, res) => {
       res.write(JSON.stringify({name: 'Sema'}));
@@ -79,7 +79,7 @@ describe('ReactFetchNode', () => {
     });
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('handles different paths', async () => {
     serverImpl = (req, res) => {
       switch (req.url) {
@@ -105,7 +105,7 @@ describe('ReactFetchNode', () => {
     expect(outputs).toMatchObject(['banana', 'mango', 'orange']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can produce an error', async () => {
     serverImpl = (req, res) => {};
 

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
@@ -70,7 +70,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('does not call callbacks', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -97,7 +97,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "blur" event', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -128,7 +128,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "focus" event', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -136,7 +136,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       expect(onFocus).toHaveBeenCalledTimes(1);
     });
 
-    // @gate experimental
+    // @gate www
     it('is not called if descendants of target receive focus', () => {
       componentInit();
       const target = createEventTarget(innerRef.current);
@@ -166,7 +166,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "blur" and "focus" events', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -178,7 +178,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       expect(onFocusChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is not called after "blur" and "focus" events on descendants', () => {
       componentInit();
       const target = createEventTarget(innerRef.current);
@@ -210,7 +210,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "focus" and "blur" if keyboard navigation is active', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -225,7 +225,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       expect(onFocusVisibleChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -244,7 +244,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       expect(onFocusVisibleChange).toHaveBeenCalledTimes(2);
     });
 
-    // @gate experimental
+    // @gate www
     it('is not called after "focus" and "blur" events without keyboard', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -256,7 +256,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
       expect(onFocusVisibleChange).toHaveBeenCalledTimes(0);
     });
 
-    // @gate experimental
+    // @gate www
     it('is not called after "blur" and "focus" events on descendants', () => {
       componentInit();
       const innerTarget = createEventTarget(innerRef.current);
@@ -270,7 +270,7 @@ describe.each(table)(`useFocus hasPointerEvents=%s`, hasPointerEvents => {
   });
 
   describe('nested Focus components', () => {
-    // @gate experimental
+    // @gate www
     it('propagates events in the correct order', () => {
       const events = [];
       const innerRef = React.createRef();

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocus-test.internal.js
@@ -28,7 +28,7 @@ function initializeModules(hasPointerEvents) {
 
   // TODO: This import throws outside of experimental mode. Figure out better
   // strategy for gated imports.
-  if (__EXPERIMENTAL__) {
+  if (__EXPERIMENTAL__ || global.__WWW__) {
     useFocus = require('react-interactions/events/focus').useFocus;
   }
 }

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
@@ -33,7 +33,7 @@ function initializeModules(hasPointerEvents) {
 
   // TODO: This import throws outside of experimental mode. Figure out better
   // strategy for gated imports.
-  if (__EXPERIMENTAL__) {
+  if (__EXPERIMENTAL__ || global.__WWW__) {
     useFocusWithin = require('react-interactions/events/focus').useFocusWithin;
   }
 }

--- a/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/__tests__/useFocusWithin-test.internal.js
@@ -80,7 +80,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('prevents custom events being dispatched', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -115,7 +115,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "blur" and "focus" events on focus target', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -127,7 +127,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after "blur" and "focus" events on descendants', () => {
       componentInit();
       const target = createEventTarget(innerRef.current);
@@ -139,7 +139,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is only called once when focus moves within and outside the subtree', () => {
       componentInit();
       const node = ref.current;
@@ -191,7 +191,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       Scheduler.unstable_flushAll();
     };
 
-    // @gate experimental
+    // @gate www
     it('is called after "focus" and "blur" on focus target if keyboard was used', () => {
       componentInit();
       const target = createEventTarget(ref.current);
@@ -206,7 +206,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after "focus" and "blur" on descendants if keyboard was used', () => {
       componentInit();
       const innerTarget = createEventTarget(innerRef.current);
@@ -221,7 +221,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledWith(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called if non-keyboard event is dispatched on target previously focused with keyboard', () => {
       componentInit();
       const node = ref.current;
@@ -259,7 +259,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(4);
     });
 
-    // @gate experimental
+    // @gate www
     it('is not called after "focus" and "blur" events without keyboard', () => {
       componentInit();
       const innerTarget = createEventTarget(innerRef.current);
@@ -269,7 +269,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onFocusWithinVisibleChange).toHaveBeenCalledTimes(0);
     });
 
-    // @gate experimental
+    // @gate www
     it('is only called once when focus moves within and outside the subtree', () => {
       componentInit();
       const node = ref.current;
@@ -297,7 +297,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
     });
   });
 
-  // @gate experimental
+  // @gate www
   it('should correctly handle focus visibility when typing into an input', () => {
     const onFocusWithinVisibleChange = jest.fn();
     const ref = React.createRef();
@@ -337,7 +337,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       innerRef2 = React.createRef();
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after a focused element is unmounted', () => {
       const Component = ({show}) => {
         const focusWithinRef = useFocusWithin(ref, {
@@ -369,7 +369,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       );
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after a nested focused element is unmounted', () => {
       const Component = ({show}) => {
         const focusWithinRef = useFocusWithin(ref, {
@@ -405,7 +405,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       );
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after many elements are unmounted', () => {
       const buttonRef = React.createRef();
       const inputRef = React.createRef();
@@ -440,7 +440,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(onAfterBlurWithin).toHaveBeenCalledTimes(1);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after a nested focused element is unmounted (with scope query)', () => {
       const TestScope = React.unstable_Scope;
       const testScopeQuery = (type, props) => true;
@@ -476,7 +476,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       expect(targetNodes).toEqual([targetNode]);
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after a focused suspended element is hidden', () => {
       const Suspense = React.Suspense;
       let suspend = false;
@@ -534,7 +534,7 @@ describe.each(table)(`useFocus`, hasPointerEvents => {
       resolve();
     });
 
-    // @gate experimental
+    // @gate www
     it('is called after a focused suspended element is hidden then shown', () => {
       const Suspense = React.Suspense;
       let suspend = false;

--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -43,7 +43,7 @@ describe('DebugTracing', () => {
     });
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('should not log anything for sync render without suspends or state updates', () => {
     ReactTestRenderer.create(
       <React.unstable_DebugTracingMode>
@@ -54,7 +54,7 @@ describe('DebugTracing', () => {
     expect(logs).toEqual([]);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('should not log anything for concurrent render without suspends or state updates', () => {
     ReactTestRenderer.create(
       <React.unstable_DebugTracingMode>
@@ -396,7 +396,7 @@ describe('DebugTracing', () => {
     ]);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('should not log anything outside of a unstable_DebugTracingMode subtree', () => {
     function ExampleThatCascades() {
       const [didMount, setDidMount] = React.useState(false);

--- a/packages/react-reconciler/src/__tests__/ReactCache-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCache-test.js
@@ -149,7 +149,7 @@ describe('ReactCache', () => {
     }
   }
 
-  // @gate experimental
+  // @gate experimental || www
   test('render Cache component', async () => {
     const root = ReactNoop.createRoot();
     await ReactNoop.act(async () => {
@@ -158,7 +158,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('Hi');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('mount new data', async () => {
     const root = ReactNoop.createRoot();
     await ReactNoop.act(async () => {
@@ -180,7 +180,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('root acts as implicit cache boundary', async () => {
     const root = ReactNoop.createRoot();
     await ReactNoop.act(async () => {
@@ -200,7 +200,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('multiple new Cache boundaries in the same update share the same, fresh cache', async () => {
     function App({text}) {
       return (
@@ -239,7 +239,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('AA');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test(
     'nested cache boundaries share the same cache as the root during ' +
       'the initial render',
@@ -272,7 +272,7 @@ describe('ReactCache', () => {
     },
   );
 
-  // @gate experimental
+  // @gate experimental || www
   test('new content inside an existing Cache boundary should re-use already cached data', async () => {
     function App({showMore}) {
       return (
@@ -309,7 +309,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]A [v1]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('a new Cache boundary uses fresh cache', async () => {
     // The only difference from the previous test is that the "Show More"
     // content is wrapped in a nested <Cache /> boundary
@@ -356,7 +356,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]A [v2]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('inner content uses same cache as shell if spawned by the same transition', async () => {
     const root = ReactNoop.createRoot();
 
@@ -431,7 +431,7 @@ describe('ReactCache', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('refresh a cache', async () => {
     let refresh;
     function App() {
@@ -474,7 +474,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v2]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('refresh the root cache', async () => {
     let refresh;
     function App() {
@@ -515,7 +515,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v2]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('refresh a cache with seed data', async () => {
     let refresh;
     function App() {
@@ -558,7 +558,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v2]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('refreshing a parent cache also refreshes its children', async () => {
     let refreshShell;
     function RefreshShell() {
@@ -623,7 +623,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v3]A [v3]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test(
     'refreshing a cache boundary does not refresh the other boundaries ' +
       'that mounted at the same time (i.e. the ones that share the same cache)',
@@ -696,7 +696,7 @@ describe('ReactCache', () => {
     },
   );
 
-  // @gate experimental
+  // @gate experimental || www
   test(
     'mount a new Cache boundary in a sibling while simultaneously ' +
       'resolving a Suspense boundary',
@@ -758,7 +758,7 @@ describe('ReactCache', () => {
     },
   );
 
-  // @gate experimental
+  // @gate experimental || www
   test('cache pool is cleared once transitions that depend on it commit their shell', async () => {
     function Child({text}) {
       return (
@@ -841,7 +841,7 @@ describe('ReactCache', () => {
     expect(root).toMatchRenderedOutput('A [v1]A [v1]A [v2]');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('cache pool is not cleared by arbitrary commits', async () => {
     function App() {
       return (

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -542,7 +542,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('BB');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('context is propagated through offscreen trees', async () => {
     const LegacyHidden = React.unstable_LegacyHidden;
 
@@ -588,7 +588,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('BB');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('multiple contexts are propagated across through offscreen trees', async () => {
     // Same as previous test, but with multiple context providers
     const LegacyHidden = React.unstable_LegacyHidden;
@@ -744,7 +744,6 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('BB');
   });
 
-  // @gate experimental
   // @gate enableCache
   test('nested bailouts across retries', async () => {
     // Lazy context propagation will stop propagating when it hits the first
@@ -814,7 +813,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('BB');
   });
 
-  // @gate experimental
+  // @gate experimental || www
   test('nested bailouts through offscreen trees', async () => {
     // Lazy context propagation will stop propagating when it hits the first
     // match. If we bail out again inside that tree, we must resume propagating.

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -270,7 +270,7 @@ describe('ReactIncremental', () => {
     expect(inst.state).toEqual({text: 'bar', text2: 'baz'});
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can deprioritize unfinished work and resume it later', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -316,7 +316,7 @@ describe('ReactIncremental', () => {
     expect(Scheduler).toFlushAndYield(['Middle', 'Middle']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can deprioritize a tree from without dropping work', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -1999,7 +1999,7 @@ describe('ReactIncremental', () => {
     });
   }
 
-  // @gate experimental
+  // @gate experimental || www
   it('provides context when reusing work', () => {
     class Intl extends React.Component {
       static childContextTypes = {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js
@@ -308,7 +308,7 @@ describe('ReactIncrementalErrorHandling', () => {
     expect(ReactNoop.getChildren()).toEqual([span('Everything is fine.')]);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('does not include offscreen work when retrying after an error', () => {
     function App(props) {
       if (props.isBroken) {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -424,7 +424,7 @@ describe('ReactIncrementalSideEffects', () => {
     ]);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('preserves a previously rendered node when deprioritized', () => {
     function Middle(props) {
       Scheduler.unstable_yieldValue('Middle');
@@ -475,7 +475,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can reuse side-effects after being preempted', () => {
     function Bar(props) {
       Scheduler.unstable_yieldValue('Bar');
@@ -555,7 +555,7 @@ describe('ReactIncrementalSideEffects', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('can reuse side-effects after being preempted, if shouldComponentUpdate is false', () => {
     class Bar extends React.Component {
       shouldComponentUpdate(nextProps) {
@@ -690,7 +690,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ReactNoop.getChildrenAsJSX()).toEqual(<span prop={3} />);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('updates a child even though the old props is empty', () => {
     function Foo(props) {
       return (
@@ -930,7 +930,7 @@ describe('ReactIncrementalSideEffects', () => {
     expect(ops).toEqual(['Bar', 'Baz', 'Bar', 'Bar']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('deprioritizes setStates that happens within a deprioritized tree', () => {
     const barInstances = [];
 

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -667,7 +667,7 @@ describe('ReactNewContext', () => {
         expect(ReactNoop.getChildren()).toEqual([span(2), span(2)]);
       });
 
-      // @gate experimental
+      // @gate experimental || www
       it("context consumer doesn't bail out inside hidden subtree", () => {
         const Context = React.createContext('dark');
         const Consumer = getConsumer(Context);

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -24,7 +24,7 @@ describe('ReactOffscreen', () => {
     return <span prop={props.text} />;
   }
 
-  // @gate experimental
+  // @gate experimental || www
   it('unstable-defer-without-hiding should never toggle the visibility of its children', async () => {
     function App({mode}) {
       return (
@@ -83,7 +83,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('does not defer in legacy mode', async () => {
     let setState;
     function Foo() {
@@ -128,7 +128,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('does defer in concurrent mode', async () => {
     let setState;
     function Foo() {
@@ -174,7 +174,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // @gate experimental
+  // @gate experimental || www
   // @gate enableSuspenseLayoutEffectSemantics
   it('mounts without layout effects when hidden', async () => {
     function Child({text}) {
@@ -216,7 +216,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   // @gate enableSuspenseLayoutEffectSemantics
   it('mounts/unmounts layout effects when visibility changes (starting visible)', async () => {
     function Child({text}) {
@@ -266,7 +266,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   // @gate enableSuspenseLayoutEffectSemantics
   it('mounts/unmounts layout effects when visibility changes (starting hidden)', async () => {
     function Child({text}) {

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -120,7 +120,7 @@ describe('ReactSchedulerIntegration', () => {
     expect(Scheduler).toHaveYielded(['A', 'B', 'C']);
   });
 
-  // @gate experimental
+  // @gate experimental || www
   it('idle updates are not blocked by offscreen work', async () => {
     function Text({text}) {
       Scheduler.unstable_yieldValue(text);

--- a/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactScope-test.internal.js
@@ -39,7 +39,7 @@ describe('ReactScope', () => {
       container = null;
     });
 
-    // @gate experimental
+    // @gate www
     it('DO_NOT_USE_queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_Scope;
@@ -74,7 +74,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
-    // @gate experimental
+    // @gate www
     it('DO_NOT_USE_queryAllNodes() provides the correct host instance', () => {
       const testScopeQuery = (type, props) => type === 'div';
       const TestScope = React.unstable_Scope;
@@ -121,7 +121,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
-    // @gate experimental
+    // @gate www
     it('DO_NOT_USE_queryFirstNode() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_Scope;
@@ -156,7 +156,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
-    // @gate experimental
+    // @gate www
     it('containsNode() works as intended', () => {
       const TestScope = React.unstable_Scope;
       const scopeRef = React.createRef();
@@ -206,7 +206,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current.containsNode(emRef.current)).toBe(false);
     });
 
-    // @gate experimental
+    // @gate www
     it('scopes support server-side rendering and hydration', () => {
       const TestScope = React.unstable_Scope;
       const scopeRef = React.createRef();
@@ -237,7 +237,7 @@ describe('ReactScope', () => {
       expect(nodes).toEqual([divRef.current, spanRef.current, aRef.current]);
     });
 
-    // @gate experimental
+    // @gate www
     it('getChildContextValues() works as intended', () => {
       const TestContext = React.createContext();
       const TestScope = React.unstable_Scope;
@@ -266,7 +266,7 @@ describe('ReactScope', () => {
       expect(scopeRef.current).toBe(null);
     });
 
-    // @gate experimental
+    // @gate www
     it('correctly works with suspended boundaries that are hydrated', async () => {
       let suspend = false;
       let resolve;
@@ -341,7 +341,7 @@ describe('ReactScope', () => {
       ReactTestRenderer = require('react-test-renderer');
     });
 
-    // @gate experimental
+    // @gate www
     it('DO_NOT_USE_queryAllNodes() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_Scope;
@@ -378,7 +378,7 @@ describe('ReactScope', () => {
       expect(nodes).toEqual([aRef.current, divRef.current, spanRef.current]);
     });
 
-    // @gate experimental
+    // @gate www
     it('DO_NOT_USE_queryFirstNode() works as intended', () => {
       const testScopeQuery = (type, props) => true;
       const TestScope = React.unstable_Scope;
@@ -415,7 +415,7 @@ describe('ReactScope', () => {
       expect(node).toEqual(aRef.current);
     });
 
-    // @gate experimental
+    // @gate www
     it('containsNode() works as intended', () => {
       const TestScope = React.unstable_Scope;
       const scopeRef = React.createRef();

--- a/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
@@ -124,7 +124,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
   const resolveText = resolveMostRecentTextCache;
 
-  // @gate experimental
+  // @gate experimental || www
   it('regression: false positive for legacy suspense', async () => {
     // Wrapping in memo because regular function components go through the
     // mountIndeterminateComponent path, which acts like there's no `current`

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -81,11 +81,6 @@ function getTestFlags() {
 
       ...featureFlags,
       ...environmentFlags,
-
-      // FIXME: www-classic has enableCache on, but when running the source
-      // tests, Jest doesn't expose the API correctly. Fix then remove
-      // this override.
-      enableCache: __EXPERIMENTAL__,
     },
     {
       get(flags, flagName) {

--- a/scripts/jest/config.source-persistent.js
+++ b/scripts/jest/config.source-persistent.js
@@ -2,28 +2,7 @@
 
 const baseConfig = require('./config.base');
 
-const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL;
-
-// Default to building in experimental mode. If the release channel is set via
-// an environment variable, then check if it's "experimental".
-const __EXPERIMENTAL__ =
-  typeof RELEASE_CHANNEL === 'string'
-    ? RELEASE_CHANNEL === 'experimental'
-    : true;
-
-const preferredExtension = __EXPERIMENTAL__ ? '.js' : '.stable.js';
-
-const moduleNameMapper = {};
-moduleNameMapper[
-  '^react$'
-] = `<rootDir>/packages/react/index${preferredExtension}`;
-moduleNameMapper[
-  '^react-dom$'
-] = `<rootDir>/packages/react-dom/index${preferredExtension}`;
-
 module.exports = Object.assign({}, baseConfig, {
-  // Prefer the stable forks for tests.
-  moduleNameMapper,
   modulePathIgnorePatterns: [
     ...baseConfig.modulePathIgnorePatterns,
     'packages/react-devtools-shared',

--- a/scripts/jest/config.source-www.js
+++ b/scripts/jest/config.source-www.js
@@ -2,28 +2,7 @@
 
 const baseConfig = require('./config.base');
 
-const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL;
-
-// Default to building in experimental mode. If the release channel is set via
-// an environment variable, then check if it's "experimental".
-const __EXPERIMENTAL__ =
-  typeof RELEASE_CHANNEL === 'string'
-    ? RELEASE_CHANNEL === 'experimental'
-    : true;
-
-const preferredExtension = __EXPERIMENTAL__ ? '.js' : '.stable.js';
-
-const moduleNameMapper = {};
-moduleNameMapper[
-  '^react$'
-] = `<rootDir>/packages/react/index${preferredExtension}`;
-moduleNameMapper[
-  '^react-dom$'
-] = `<rootDir>/packages/react-dom/index${preferredExtension}`;
-
 module.exports = Object.assign({}, baseConfig, {
-  // Prefer the stable forks for tests.
-  moduleNameMapper,
   modulePathIgnorePatterns: [
     ...baseConfig.modulePathIgnorePatterns,
     'packages/react-devtools-shared',

--- a/scripts/jest/config.source.js
+++ b/scripts/jest/config.source.js
@@ -2,28 +2,7 @@
 
 const baseConfig = require('./config.base');
 
-const RELEASE_CHANNEL = process.env.RELEASE_CHANNEL;
-
-// Default to building in experimental mode. If the release channel is set via
-// an environment variable, then check if it's "experimental".
-const __EXPERIMENTAL__ =
-  typeof RELEASE_CHANNEL === 'string'
-    ? RELEASE_CHANNEL === 'experimental'
-    : true;
-
-const preferredExtension = __EXPERIMENTAL__ ? '.js' : '.stable.js';
-
-const moduleNameMapper = {};
-moduleNameMapper[
-  '^react$'
-] = `<rootDir>/packages/react/index${preferredExtension}`;
-moduleNameMapper[
-  '^react-dom$'
-] = `<rootDir>/packages/react-dom/index${preferredExtension}`;
-
 module.exports = Object.assign({}, baseConfig, {
-  // Prefer the stable forks for tests.
-  moduleNameMapper,
   modulePathIgnorePatterns: [
     ...baseConfig.modulePathIgnorePatterns,
     'packages/react-devtools-shared',

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -1,6 +1,49 @@
 'use strict';
 
+const fs = require('fs');
 const inlinedHostConfigs = require('../shared/inlinedHostConfigs');
+
+function resolveEntryFork(resolvedEntry, isFBBundle) {
+  // Pick which entry point fork to use:
+  // .modern.fb.js
+  // .classic.fb.js
+  // .fb.js
+  // .stable.js
+  // .experimental.js
+  // .js
+
+  if (isFBBundle) {
+    const resolvedFBEntry = resolvedEntry.replace(
+      '.js',
+      __EXPERIMENTAL__ ? '.modern.fb.js' : '.classic.fb.js'
+    );
+    if (fs.existsSync(resolvedFBEntry)) {
+      return resolvedFBEntry;
+    }
+    const resolvedGenericFBEntry = resolvedEntry.replace('.js', '.fb.js');
+    if (fs.existsSync(resolvedGenericFBEntry)) {
+      return resolvedGenericFBEntry;
+    }
+    // Even if it's a FB bundle we fallthrough to pick stable or experimental if we don't have an FB fork.
+  }
+  const resolvedForkedEntry = resolvedEntry.replace(
+    '.js',
+    __EXPERIMENTAL__ ? '.experimental.js' : '.stable.js'
+  );
+  if (fs.existsSync(resolvedForkedEntry)) {
+    return resolvedForkedEntry;
+  }
+  // Just use the plain .js one.
+  return resolvedEntry;
+}
+
+jest.mock('react', () => {
+  const resolvedEntryPoint = resolveEntryFork(
+    require.resolve('react'),
+    global.__WWW__
+  );
+  return jest.requireActual(resolvedEntryPoint);
+});
 
 jest.mock('react-reconciler/src/ReactFiberReconciler', () => {
   return jest.requireActual(
@@ -85,7 +128,11 @@ inlinedHostConfigs.forEach(rendererInfo => {
   rendererInfo.entryPoints.forEach(entryPoint => {
     jest.mock(entryPoint, () => {
       mockAllConfigs(rendererInfo);
-      return jest.requireActual(entryPoint);
+      const resolvedEntryPoint = resolveEntryFork(
+        require.resolve(entryPoint),
+        global.__WWW__
+      );
+      return jest.requireActual(resolvedEntryPoint);
     });
   });
 });

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -13,6 +13,11 @@ function resolveEntryFork(resolvedEntry, isFBBundle) {
   // .js
 
   if (isFBBundle) {
+    if (__EXPERIMENTAL__) {
+      // We can't currently use the true modern entry point because too many tests fail.
+      // TODO: Fix tests to not use ReactDOM.render or gate them. Then we can remove this.
+      return resolvedEntry;
+    }
     const resolvedFBEntry = resolvedEntry.replace(
       '.js',
       __EXPERIMENTAL__ ? '.modern.fb.js' : '.classic.fb.js'


### PR DESCRIPTION
The config.build maps these to the build artifacts. But the source tests map either to `.js` which includes all entry points or `.stable.js`. My change makes it so that we resolve to `.experimental.js` or `.classic.fb.js` entry points. 

That means the tests that the Cache now works for a lot of www-classic tests for example.

This way the source tests, test the same entry point configuration. This helps us test the correct entry point and forces us to write tests that uses the broadest API available.

__I had to disable www-modern's entry point for now until we convert more tests to use the createRoot API instead. It doesn't make sense to gate all the tests. Especially since that's the default test mode atm.__

_(My main motivation is that I need to clean some of this up because I need to add some substantially more complicated mappings to solve the `react-dom/server` entry point which will map to several different builds at the same time. So I need to use the mocks to select the configuration for source tests.)_
