### PR TITLE
DevTools: Fix Fiber leak caused by Refresh hot reloading

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
+++ b/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+describe('Fast Refresh', () => {
+  let React;
+  let ReactDOM;
+  let ReactFreshRuntime;
+  let act;
+  let babel;
+  let container;
+  let exportsObj;
+  let freshPlugin;
+  let store;
+  let withErrorsOrWarningsIgnored;
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  beforeEach(() => {
+    exportsObj = undefined;
+    container = document.createElement('div');
+
+    babel = require('@babel/core');
+    freshPlugin = require('react-refresh/babel');
+
+    store = global.store;
+
+    React = require('react');
+
+    ReactFreshRuntime = require('react-refresh/runtime');
+    ReactFreshRuntime.injectIntoGlobalHook(global);
+
+    ReactDOM = require('react-dom');
+
+    const utils = require('./utils');
+    act = utils.act;
+    withErrorsOrWarningsIgnored = utils.withErrorsOrWarningsIgnored;
+  });
+
+  function execute(source) {
+    const compiled = babel.transform(source, {
+      babelrc: false,
+      presets: ['@babel/react'],
+      plugins: [
+        [freshPlugin, {skipEnvCheck: true}],
+        '@babel/plugin-transform-modules-commonjs',
+        '@babel/plugin-transform-destructuring',
+      ].filter(Boolean),
+    }).code;
+    exportsObj = {};
+    // eslint-disable-next-line no-new-func
+    new Function(
+      'global',
+      'React',
+      'exports',
+      '$RefreshReg$',
+      '$RefreshSig$',
+      compiled,
+    )(global, React, exportsObj, $RefreshReg$, $RefreshSig$);
+    // Module systems will register exports as a fallback.
+    // This is useful for cases when e.g. a class is exported,
+    // and we don't want to propagate the update beyond this module.
+    $RefreshReg$(exportsObj.default, 'exports.default');
+    return exportsObj.default;
+  }
+
+  function render(source) {
+    const Component = execute(source);
+    act(() => {
+      ReactDOM.render(<Component />, container);
+    });
+    // Module initialization shouldn't be counted as a hot update.
+    expect(ReactFreshRuntime.performReactRefresh()).toBe(null);
+  }
+
+  function patch(source) {
+    const prevExports = exportsObj;
+    execute(source);
+    const nextExports = exportsObj;
+
+    // Check if exported families have changed.
+    // (In a real module system we'd do this for *all* exports.)
+    // For example, this can happen if you convert a class to a function.
+    // Or if you wrap something in a HOC.
+    const didExportsChange =
+      ReactFreshRuntime.getFamilyByType(prevExports.default) !==
+      ReactFreshRuntime.getFamilyByType(nextExports.default);
+    if (didExportsChange) {
+      // In a real module system, we would propagate such updates upwards,
+      // and re-execute modules that imported this one. (Just like if we edited them.)
+      // This makes adding/removing/renaming exports re-render references to them.
+      // Here, we'll just force a re-render using the newer type to emulate this.
+      const NextComponent = nextExports.default;
+      act(() => {
+        ReactDOM.render(<NextComponent />, container);
+      });
+    }
+    act(() => {
+      const result = ReactFreshRuntime.performReactRefresh();
+      if (!didExportsChange) {
+        // Normally we expect that some components got updated in our tests.
+        expect(result).not.toBe(null);
+      } else {
+        // However, we have tests where we convert functions to classes,
+        // and in those cases it's expected nothing would get updated.
+        // (Instead, the export change branch above would take care of it.)
+      }
+    });
+    expect(ReactFreshRuntime._getMountedRootCount()).toBe(1);
+  }
+
+  function $RefreshReg$(type, id) {
+    ReactFreshRuntime.register(type, id);
+  }
+
+  function $RefreshSig$() {
+    return ReactFreshRuntime.createSignatureFunctionForTransform();
+  }
+
+  it('should not break the DevTools store', () => {
+    render(`
+      function Parent() {
+        return <Child key="A" />;
+      };
+
+      function Child() {
+        return null;
+      };
+
+      export default Parent;
+    `);
+
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <Parent>
+            <Child key="A">
+    `);
+
+    patch(`
+      function Parent() {
+        return <Child key="B" />;
+      };
+
+      function Child() {
+        return null;
+      };
+
+      export default Parent;
+    `);
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <Parent>
+            <Child key="B">
+    `);
+  });
+
+  it('should not break when there are warnings in between patching', () => {
+    withErrorsOrWarningsIgnored(['Expected warning during render'], () => {
+      render(`
+      const {useState} = React;
+
+      export default function Component() {
+        const [state, setState] = useState(1);
+
+        console.warn("Expected warning during render");
+
+        return <div />;
+      }
+    `);
+    });
+    expect(store).toMatchInlineSnapshot(`
+      ✕ 0, ⚠ 1
+      [root]
+          <Component> ⚠
+    `);
+
+    let element = container.firstChild;
+
+    withErrorsOrWarningsIgnored(['Expected warning during render'], () => {
+      patch(`
+      const {useState} = React;
+
+      export default function Component() {
+        const [state, setState] = useState(1);
+
+        console.warn("Expected warning during render");
+
+        return <div id="one" />;
+      }
+    `);
+    });
+
+    // This is the same component type, so the warning count carries over.
+    expect(store).toMatchInlineSnapshot(`
+      ✕ 0, ⚠ 2
+      [root]
+          <Component> ⚠
+    `);
+
+    // State is preserved; this verifies that Fast Refresh is wired up.
+    expect(container.firstChild).toBe(element);
+    element = container.firstChild;
+
+    withErrorsOrWarningsIgnored(['Expected warning during render'], () => {
+      patch(`
+      const {useEffect, useState} = React;
+
+      export default function Component() {
+        const [state, setState] = useState(3);
+        useEffect(() => {});
+
+        console.warn("Expected warning during render");
+
+        return <div id="one" />;
+      }
+    `);
+    });
+
+    // This is a new component type, so the warning count has been reset.
+    expect(store).toMatchInlineSnapshot(`
+      ✕ 0, ⚠ 1
+      [root]
+          <Component> ⚠
+    `);
+
+    // State is reset because hooks changed.
+    expect(container.firstChild).not.toBe(element);
+  });
+});

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -1007,6 +1007,11 @@ export function attach(
   const getProfilingData = () => {
     throw new Error('getProfilingData not supported by this renderer');
   };
+  const handleClonedForForceRemount = () => {
+    throw new Error(
+      'handleClonedForForceRemount not supported by this renderer',
+    );
+  };
   const handleCommitFiberRoot = () => {
     throw new Error('handleCommitFiberRoot not supported by this renderer');
   };
@@ -1084,6 +1089,7 @@ export function attach(
     getOwnersList,
     getPathForElement,
     getProfilingData,
+    handleClonedForForceRemount,
     handleCommitFiberRoot,
     handleCommitFiberUnmount,
     handlePostCommitFiberRoot,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -323,6 +323,7 @@ export type RendererInterface = {
   getProfilingData(): ProfilingDataBackend,
   getOwnersList: (id: number) => Array<SerializedElement> | null,
   getPathForElement: (id: number) => Array<PathFrame> | null,
+  handleClonedForForceRemount: (oldFiber: Fiber, newFiber: Fiber) => void,
   handleCommitFiberRoot: (fiber: Object, commitPriority?: number) => void,
   handleCommitFiberUnmount: (fiber: Object) => void,
   handlePostCommitFiberRoot: (fiber: Object) => void,
@@ -395,6 +396,13 @@ export type DevToolsHook = {
     commitPriority?: number,
     // Added in v16.9 to support Fast Refresh
     didError?: boolean,
+  ) => void,
+
+  // Added in v17.x to improve Fast Refresh + DevTools integration
+  onClonedForForceRemount: (
+    rendererID: RendererID,
+    oldFiber: Fiber,
+    newFiber: Fiber,
   ) => void,
   ...
 };

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -261,6 +261,13 @@ export function installHook(target: any): DevToolsHook | null {
     return roots[rendererID];
   }
 
+  function onClonedForForceRemount(rendererID, oldFiber, newFiber) {
+    const rendererInterface = rendererInterfaces.get(rendererID);
+    if (rendererInterface != null) {
+      rendererInterface.handleClonedForForceRemount(oldFiber, newFiber);
+    }
+  }
+
   function onCommitFiberUnmount(rendererID, fiber) {
     const rendererInterface = rendererInterfaces.get(rendererID);
     if (rendererInterface != null) {
@@ -306,6 +313,7 @@ export function installHook(target: any): DevToolsHook | null {
 
     // Fast Refresh for web relies on this.
     renderers,
+    onClonedForForceRemount,
 
     emit,
     getFiberRoots,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -33,6 +33,10 @@ import type {UpdateQueue} from './ReactUpdateQueue.new';
 import checkPropTypes from 'shared/checkPropTypes';
 
 import {
+  isDevToolsPresent,
+  onClonedForForceRemount,
+} from './ReactFiberDevToolsHook.new';
+import {
   IndeterminateComponent,
   FunctionComponent,
   ClassComponent,
@@ -3194,19 +3198,21 @@ function beginWork(
 
   if (__DEV__) {
     if (workInProgress._debugNeedsRemount && current !== null) {
-      // This will restart the begin phase with a new fiber.
-      return remountFiber(
-        current,
-        workInProgress,
-        createFiberFromTypeAndProps(
-          workInProgress.type,
-          workInProgress.key,
-          workInProgress.pendingProps,
-          workInProgress._debugOwner || null,
-          workInProgress.mode,
-          workInProgress.lanes,
-        ),
+      const clonedWorkInProgress = createFiberFromTypeAndProps(
+        workInProgress.type,
+        workInProgress.key,
+        workInProgress.pendingProps,
+        workInProgress._debugOwner || null,
+        workInProgress.mode,
+        workInProgress.lanes,
       );
+
+      if (isDevToolsPresent) {
+        onClonedForForceRemount(workInProgress, clonedWorkInProgress);
+      }
+
+      // This will restart the begin phase with a new fiber.
+      return remountFiber(current, workInProgress, clonedWorkInProgress);
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -33,6 +33,10 @@ import type {UpdateQueue} from './ReactUpdateQueue.old';
 import checkPropTypes from 'shared/checkPropTypes';
 
 import {
+  isDevToolsPresent,
+  onClonedForForceRemount,
+} from './ReactFiberDevToolsHook.old';
+import {
   IndeterminateComponent,
   FunctionComponent,
   ClassComponent,
@@ -3194,19 +3198,21 @@ function beginWork(
 
   if (__DEV__) {
     if (workInProgress._debugNeedsRemount && current !== null) {
-      // This will restart the begin phase with a new fiber.
-      return remountFiber(
-        current,
-        workInProgress,
-        createFiberFromTypeAndProps(
-          workInProgress.type,
-          workInProgress.key,
-          workInProgress.pendingProps,
-          workInProgress._debugOwner || null,
-          workInProgress.mode,
-          workInProgress.lanes,
-        ),
+      const clonedWorkInProgress = createFiberFromTypeAndProps(
+        workInProgress.type,
+        workInProgress.key,
+        workInProgress.pendingProps,
+        workInProgress._debugOwner || null,
+        workInProgress.mode,
+        workInProgress.lanes,
       );
+
+      if (isDevToolsPresent) {
+        onClonedForForceRemount(workInProgress, clonedWorkInProgress);
+      }
+
+      // This will restart the begin phase with a new fiber.
+      return remountFiber(current, workInProgress, clonedWorkInProgress);
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -166,3 +166,28 @@ export function onCommitUnmount(fiber: Fiber) {
     }
   }
 }
+
+export function onClonedForForceRemount(
+  oldWorkInProgress: Fiber,
+  newWorkInProgress: Fiber,
+) {
+  if (
+    injectedHook &&
+    typeof injectedHook.onClonedForForceRemount === 'function'
+  ) {
+    try {
+      injectedHook.onClonedForForceRemount(
+        rendererID,
+        oldWorkInProgress,
+        newWorkInProgress,
+      );
+    } catch (err) {
+      if (__DEV__) {
+        if (!hasLoggedError) {
+          hasLoggedError = true;
+          console.error('React instrumentation encountered an error: %s', err);
+        }
+      }
+    }
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
@@ -166,3 +166,28 @@ export function onCommitUnmount(fiber: Fiber) {
     }
   }
 }
+
+export function onClonedForForceRemount(
+  oldWorkInProgress: Fiber,
+  newWorkInProgress: Fiber,
+) {
+  if (
+    injectedHook &&
+    typeof injectedHook.onClonedForForceRemount === 'function'
+  ) {
+    try {
+      injectedHook.onClonedForForceRemount(
+        rendererID,
+        oldWorkInProgress,
+        newWorkInProgress,
+      );
+    } catch (err) {
+      if (__DEV__) {
+        if (!hasLoggedError) {
+          hasLoggedError = true;
+          console.error('React instrumentation encountered an error: %s', err);
+        }
+      }
+    }
+  }
+}

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -318,6 +318,7 @@ function scheduleFibersWithFamiliesRecursively(
     if (needsRemount) {
       fiber._debugNeedsRemount = true;
     }
+
     if (needsRemount || needsRender) {
       scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
     }

--- a/packages/react-reconciler/src/ReactFiberHotReloading.old.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.old.js
@@ -318,6 +318,7 @@ function scheduleFibersWithFamiliesRecursively(
     if (needsRemount) {
       fiber._debugNeedsRemount = true;
     }
+
     if (needsRemount || needsRender) {
       scheduleUpdateOnFiber(fiber, SyncLane, NoTimestamp);
     }


### PR DESCRIPTION
Resolves #21469 as well as #21436 and #21442 (I think)

Posting for discussion purposes with @gaearon 

The general idea is to add a new hook that Fast Refresh can use to _inform_ DevTools when a force remount is scheduled. Then DevTools can clean up any Fibers that would have otherwise been linked by the clone-and-splice operation on the tree.

Added some basic integration tests for Fast Refresh + DevTools, including one that fails without this fix:
![Screen Shot 2021-05-13 at 4 49 45 PM](https://user-images.githubusercontent.com/29597/118187024-69a59a80-b40c-11eb-9e87-ccbcb839eefb.png)
