### PR TITLE
fix: eslint-plugin-react-hooks - report hooks used within underscored non-component functions

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -337,6 +337,11 @@ const tests = {
         const [myState, setMyState] = useState(null);
       }
     `,
+    `
+      function _Component() {
+        useState();
+      }
+    `,
   ],
   invalid: [
     {
@@ -380,7 +385,7 @@ const tests = {
     },
     {
       code: `
-        // This is a false positive (it's valid) that unfortunately 
+        // This is a false positive (it's valid) that unfortunately
         // we cannot avoid. Prefer to rename it to not start with "use"
         class Foo extends Component {
           render() {
@@ -886,6 +891,26 @@ const tests = {
         (class {i() { useState(); }});
       `,
       errors: [classError('useState')],
+    },
+    {
+      code: `
+        function Component() {
+          function _internalFunction() {
+            useState();
+          }
+        }
+      `,
+      errors: [functionError('useState', '_internalFunction')],
+    },
+    {
+      code: `
+        function _Component() {
+          function _internalFunction() {
+            useState();
+          }
+        }
+      `,
+      errors: [functionError('useState', '_internalFunction')],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -47,7 +47,13 @@ function isHook(node) {
 
 function isComponentName(node) {
   if (node.type === 'Identifier') {
-    return !/^[a-z]/.test(node.name);
+    if (node.name[0] === '_') {
+      // _Foo is a valid component name, but _foo is not
+      // so we have to ignore the underscore
+      return !/^[a-z]/.test(node.name[1]);
+    } else {
+      return !/^[a-z]/.test(node.name[0]);
+    }
   } else {
     return false;
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The rule previously only considered a function as not a component function if it started with a lowercase character.
However this is incorrect if you have a function name like `_myfunction`.

This PR adds checks to report against underscored non component functions like `_myfunction`

## Test Plan

- `yarn flow`
- `yarn lint`
- `yarn test eslint-plugin`
- `yarn test --prod eslint-plugin`