### PR TITLE
Fix unwindInterruptedWork bug

### DIFF
--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -163,8 +163,8 @@ function unwindWork(workInProgress: Fiber, renderLanes: Lanes) {
 function unwindInterruptedWork(interruptedWork: Fiber, renderLanes: Lanes) {
   switch (interruptedWork.tag) {
     case ClassComponent: {
-      const childContextTypes = interruptedWork.type.childContextTypes;
-      if (childContextTypes !== null && childContextTypes !== undefined) {
+      const Component = interruptedWork.type;
+      if (isLegacyContextProvider(Component)) {
         popLegacyContext(interruptedWork);
       }
       break;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
@@ -163,8 +163,8 @@ function unwindWork(workInProgress: Fiber, renderLanes: Lanes) {
 function unwindInterruptedWork(interruptedWork: Fiber, renderLanes: Lanes) {
   switch (interruptedWork.tag) {
     case ClassComponent: {
-      const childContextTypes = interruptedWork.type.childContextTypes;
-      if (childContextTypes !== null && childContextTypes !== undefined) {
+      const Component = interruptedWork.type;
+      if (isLegacyContextProvider(Component)) {
         popLegacyContext(interruptedWork);
       }
       break;


### PR DESCRIPTION
In the function unwindInterruptedWork, when the flag disableLegacyContext is true, it is possible that an error occurs in the stack.