### PR TITLE
AppRoutes moved into separate file as TODO item

### DIFF
--- a/fixtures/blocks/src/server/App.js
+++ b/fixtures/blocks/src/server/App.js
@@ -8,19 +8,10 @@
 
 import * as React from 'react';
 import {matchRoute} from './ServerRouter';
-import FeedPage from './FeedPage';
-import ProfilePage from './ProfilePage';
+import AppRoutes from './AppRoutes';
 
 // TODO: Replace with asset reference.
 import Shell from '../client/Shell';
-
-// TODO: Router component?
-const AppRoutes = {
-  '/': props => <FeedPage {...props} key="home" />,
-  '/profile/:userId/*': props => (
-    <ProfilePage {...props} key={`profile-${props.userId}`} />
-  ),
-};
 
 export default function App(props) {
   const match = matchRoute(props, AppRoutes);

--- a/fixtures/blocks/src/server/AppRoutes.js
+++ b/fixtures/blocks/src/server/AppRoutes.js
@@ -1,7 +1,7 @@
 import FeedPage from './FeedPage';
 import ProfilePage from './ProfilePage';
 
-const AppRoutes =  {
+const AppRoutes = {
   '/': props => <FeedPage {...props} key="home" />,
   '/profile/:userId/*': props => (
     <ProfilePage {...props} key={`profile-${props.userId}`} />

--- a/fixtures/blocks/src/server/AppRoutes.js
+++ b/fixtures/blocks/src/server/AppRoutes.js
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import FeedPage from './FeedPage';
 import ProfilePage from './ProfilePage';
 

--- a/fixtures/blocks/src/server/AppRoutes.js
+++ b/fixtures/blocks/src/server/AppRoutes.js
@@ -1,0 +1,11 @@
+import FeedPage from './FeedPage';
+import ProfilePage from './ProfilePage';
+
+const AppRoutes =  {
+  '/': props => <FeedPage {...props} key="home" />,
+  '/profile/:userId/*': props => (
+    <ProfilePage {...props} key={`profile-${props.userId}`} />
+  ),
+};
+
+export default AppRoutes;


### PR DESCRIPTION
## Summary

In fixtures/blocks, there is a TODO item as moving AppRoutes into separate file. I think it is because server/App.js should be decoupled from pages and we should have a separate file for having all screens with their route definitions as a better architecture.

## Test Plan
The blocks app should run without any error to make sure that all imports in both newly created file(AppRoutes.js) and main file(App.js) are correct.

