### PR TITLE
Enable the StrictEffects flag for OSS builds

### DIFF
--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -25,7 +25,7 @@ export const debugRenderPhaseSideEffectsForStrictMode = __DEV__;
 
 // Helps identify code that is not safe for planned Offscreen API and Suspense semantics;
 // this feature flag only impacts StrictEffectsMode.
-export const enableStrictEffects = false;
+export const enableStrictEffects = true;
 
 // If TRUE, trees rendered with createRoot will be StrictEffectsMode.
 // If FALSE, these trees will be StrictLegacyMode.


### PR DESCRIPTION
Seems like an omission. Are there more we should enable? Also, is it ok to land this to main now, or do we still plan to cut minors from main?

TODO:

- [ ] Fix tests (why do they double-call with `render`?)
- [ ] Figure out the DEV thing
- [ ] What about enableSuspenseLayoutEffectSemantics?