### PR TITLE
Fix Fizz exported types

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -21,7 +21,7 @@ import {
   createRootFormatContext,
 } from './ReactDOMServerFormatConfig';
 
-type Options = {
+type Options = {|
   identifierPrefix?: string,
   namespaceURI?: string,
   progressiveChunkSize?: number,
@@ -29,7 +29,7 @@ type Options = {
   onReadyToStream?: () => void,
   onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
-};
+|};
 
 function renderToReadableStream(
   children: ReactNodeList,

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -26,20 +26,21 @@ function createDrainHandler(destination, request) {
   return () => startFlowing(request);
 }
 
-type Options = {
+type Options = {|
   identifierPrefix?: string,
   namespaceURI?: string,
   progressiveChunkSize?: number,
   onReadyToStream?: () => void,
   onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
-};
+|};
 
-type Controls = {
+type Controls = {|
   // Cancel any pending I/O and put anything remaining into
   // client rendered mode.
   abort(): void,
-};
+  startWriting(): void,
+|};
 
 function pipeToNodeWritable(
   children: ReactNodeList,


### PR DESCRIPTION
I noticed that this was missing while writing docs. These aren't tested since our tests don't use Flow. I also noticed we don't use exact objects by default which would've caught this oversight.