### PR TITLE
Use ReactVersions module as package allowlist

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -50,7 +50,6 @@ const experimentalPackages = [
   'react-fs',
   'react-pg',
   'react-server-dom-webpack',
-  'react-server',
 ];
 
 // TODO: Export a map of every package and its version.

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -11,6 +11,7 @@ const {join} = require('path');
 const createLogger = require('progress-estimator');
 const prompt = require('prompt-promise');
 const theme = require('./theme');
+const {stablePackages, experimentalPackages} = require('../../ReactVersions');
 
 // https://www.npmjs.com/package/progress-estimator#configuration
 const logger = createLogger({
@@ -132,42 +133,11 @@ const getCommitFromCurrentBuild = async () => {
 };
 
 const getPublicPackages = isExperimental => {
-  // TODO: Use ReactVersions.js as source of truth.
+  const packageNames = Object.keys(stablePackages);
   if (isExperimental) {
-    return [
-      'create-subscription',
-      'eslint-plugin-react-hooks',
-      'jest-react',
-      'react',
-      'react-art',
-      'react-dom',
-      'react-is',
-      'react-reconciler',
-      'react-refresh',
-      'react-test-renderer',
-      'use-subscription',
-      'scheduler',
-      'react-fetch',
-      'react-fs',
-      'react-pg',
-      'react-server-dom-webpack',
-    ];
-  } else {
-    return [
-      'create-subscription',
-      'eslint-plugin-react-hooks',
-      'jest-react',
-      'react',
-      'react-art',
-      'react-dom',
-      'react-is',
-      'react-reconciler',
-      'react-refresh',
-      'react-test-renderer',
-      'use-subscription',
-      'scheduler',
-    ];
+    packageNames.push(...experimentalPackages);
   }
+  return packageNames;
 };
 
 const handleError = error => {


### PR DESCRIPTION
Instead of keeping a separate allowlist in sync, we use ReactVersions.js as the source of truth for which packages get published.