### PR TITLE
Support `@latest` in prepare-release-from-ci 

### DIFF
--- a/scripts/release/prepare-release-from-ci.js
+++ b/scripts/release/prepare-release-from-ci.js
@@ -23,7 +23,8 @@ const run = async () => {
       await testPackagingFixture(params);
     }
 
-    await printPrereleaseSummary(params, false);
+    const isLatestRelease = params.releaseChannel === 'latest';
+    await printPrereleaseSummary(params, isLatestRelease);
   } catch (error) {
     handleError(error);
   }

--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -39,10 +39,13 @@ const run = async ({build, cwd, releaseChannel}) => {
     await exec(`rm -rf ./build/node_modules`, {cwd});
   }
   let sourceDir;
+  // TODO: Rename release channel to `next`
   if (releaseChannel === 'stable') {
     sourceDir = 'oss-stable';
   } else if (releaseChannel === 'experimental') {
     sourceDir = 'oss-experimental';
+  } else if (releaseChannel === 'latest') {
+    sourceDir = 'oss-stable-semver';
   } else {
     console.error('Internal error: Invalid release channel: ' + releaseChannel);
     process.exit(releaseChannel);

--- a/scripts/release/shared-commands/parse-params.js
+++ b/scripts/release/shared-commands/parse-params.js
@@ -32,7 +32,7 @@ const paramDefinitions = [
     name: 'releaseChannel',
     alias: 'r',
     type: String,
-    description: 'Release channel (stable or experimental)',
+    description: 'Release channel (stable, experimental, or latest)',
   },
 ];
 
@@ -40,9 +40,13 @@ module.exports = async () => {
   const params = commandLineArgs(paramDefinitions);
 
   const channel = params.releaseChannel;
-  if (channel !== 'experimental' && channel !== 'stable') {
+  if (
+    channel !== 'experimental' &&
+    channel !== 'stable' &&
+    channel !== 'latest'
+  ) {
     console.error(
-      theme.error`Invalid release channel (-r) "${channel}". Must be "stable" or "experimental".`
+      theme.error`Invalid release channel (-r) "${channel}". Must be "stable", "experimental", or "latest".`
     );
     process.exit(1);
   }


### PR DESCRIPTION
Since we track these versions in source, we can build `@latest` releases in CI and store them as artifacts.

Then when it's time to release, and the build has been verified, we use `prepare-release-from-ci` (the same script we use for `@next` and `@experimental`) to fetch the already built and versioned packages.