### PR TITLE
Make enableSuspenseLayoutEffectSemantics static for www

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,7 +26,6 @@ export const {
   enableDebugTracing,
   skipUnmountedBoundaries,
   createRootStrictEffectsByDefault,
-  enableSuspenseLayoutEffectSemantics,
   enableUseRefAccessWarning,
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
@@ -37,6 +36,8 @@ export const {
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
 // It's not used anywhere in production yet.
+
+export const enableSuspenseLayoutEffectSemantics = true;
 
 export const enableStrictEffects =
   __DEV__ && dynamicFeatureFlags.enableStrictEffects;


### PR DESCRIPTION
This feature is now enabled for the OSS release and the GK has been ramped up to 80% within FB (so the next step is to make it a static flag there as well).