### PR TITLE
[Fizz] Always call flush() if it exists

### DIFF
--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -11,8 +11,6 @@ import type {Writable} from 'stream';
 
 type MightBeFlushable = {
   flush?: () => void,
-  // Legacy
-  flushHeaders?: () => void,
   ...
 };
 
@@ -31,12 +29,9 @@ export function flushBuffered(destination: Destination) {
   // If we don't have any more data to send right now.
   // Flush whatever is in the buffer to the wire.
   if (typeof destination.flush === 'function') {
-    // http.createServer response have flush(), but it has a different meaning and
-    // is deprecated in favor of flushHeaders(). Detect to avoid a warning.
-    if (typeof destination.flushHeaders !== 'function') {
-      // By convention the Zlib streams provide a flush function for this purpose.
-      destination.flush();
-    }
+    // By convention the Zlib streams provide a flush function for this purpose.
+    // For Express, compression middleware adds this method.
+    destination.flush();
   }
 }
 


### PR DESCRIPTION
I was trying to make things better with https://github.com/facebook/react/pull/17289 but I shot myself in the foot.

The problem is that Express `res` objects have no `flush` method but do have `flushHeaders`. Which is fine. Unless you add `compression` middleware. Which monkepatches `flush` onto the object. But we don't call it. So it never flushes.

Let's always call `flush` if it exists. If it fires a deprecation with `http.createServer`, that's fine.