### PR TITLE
Fix typo in comment (environement → environment)

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -427,7 +427,7 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     return updateLane;
   }
 
-  // This update originated outside React. Ask the host environement for an
+  // This update originated outside React. Ask the host environment for an
   // appropriate priority, based on the type of event.
   //
   // The opaque type returned by the host config is internally a lane, so we can

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -427,7 +427,7 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     return updateLane;
   }
 
-  // This update originated outside React. Ask the host environement for an
+  // This update originated outside React. Ask the host environment for an
   // appropriate priority, based on the type of event.
   //
   // The opaque type returned by the host config is internally a lane, so we can


### PR DESCRIPTION
## Summary

Fixed minor typo in comment.

environement → environment
