### PR TITLE
Propagate errors while resolving lazy() default export

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -56,8 +56,8 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     const pending: PendingPayload = (payload: any);
     pending._status = Pending;
     pending._result = thenable;
-    thenable.then(
-      moduleObject => {
+    thenable
+      .then(moduleObject => {
         if (payload._status === Pending) {
           const defaultExport = moduleObject.default;
           if (__DEV__) {
@@ -77,16 +77,17 @@ function lazyInitializer<T>(payload: Payload<T>): T {
           resolved._status = Resolved;
           resolved._result = defaultExport;
         }
-      },
-      error => {
+      })
+      // Use .catch so that errors while resolving the default
+      // import also propagate to the error handler.
+      .catch(error => {
         if (payload._status === Pending) {
           // Transition to the next state.
           const rejected: RejectedPayload = (payload: any);
           rejected._status = Rejected;
           rejected._result = error;
         }
-      },
-    );
+      });
   }
   if (payload._status === Resolved) {
     return payload._result;

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -56,8 +56,8 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     const pending: PendingPayload = (payload: any);
     pending._status = Pending;
     pending._result = thenable;
-    thenable
-      .then(moduleObject => {
+    thenable.then(
+      moduleObject => {
         if (payload._status === Pending) {
           const defaultExport = moduleObject.default;
           if (__DEV__) {
@@ -77,17 +77,16 @@ function lazyInitializer<T>(payload: Payload<T>): T {
           resolved._status = Resolved;
           resolved._result = defaultExport;
         }
-      })
-      // Use .catch so that errors while resolving the default
-      // import also propagate to the error handler.
-      .catch(error => {
+      },
+      error => {
         if (payload._status === Pending) {
           // Transition to the next state.
           const rejected: RejectedPayload = (payload: any);
           rejected._status = Rejected;
           rejected._result = error;
         }
-      });
+      },
+    );
   }
   if (payload._status === Resolved) {
     return payload._result;

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -68,6 +68,19 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     thenable.then(moduleObject => {
       if (payload._status === Pending) {
         let defaultExport;
+        if (__DEV__) {
+          if (moduleObject === undefined) {
+            console.error(
+              'lazy: Expected the result of a dynamic import() call. ' +
+                'Instead received: %s\n\nYour code should look like: \n  ' +
+                // Break up imports to avoid accidentally parsing them as dependencies.
+                'const MyComponent = lazy(() => imp' +
+                "ort('./MyComponent'))\n\n" +
+                'Did you accidentally put curly braces around the import?',
+              moduleObject,
+            );
+          }
+        }
         try {
           defaultExport = moduleObject.default;
         } catch (e) {


### PR DESCRIPTION
I think this might fix https://github.com/facebook/react/issues/18768. I haven't tested yet. Basically, the problem is that the Promise has resolved but we never record that because the handler that's meant to change the status throws.

<s>My fix is to make the error handler catch that. I could also change the `then` branch itself but didn't want to touch the common case.</s> I changed it to just catch this part specifically with a try/catch.