### PR TITLE
Fix Issue with Undefined Lazy Imports By Refactoring Lazy Initialization Order

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -178,13 +178,13 @@ describe('ReactLazy', () => {
 
     await Promise.resolve();
 
+    expect(Scheduler).toFlushAndThrow('Element type is invalid');
     if (__DEV__) {
-      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledTimes(3);
       expect(console.error.calls.argsFor(0)[0]).toContain(
         'Expected the result of a dynamic import() call',
       );
     }
-    expect(Scheduler).toFlushAndThrow('Element type is invalid');
   });
 
   it('throws if promise rejects', async () => {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -59,6 +59,19 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     thenable.then(
       moduleObject => {
         if (payload._status === Pending) {
+          if (__DEV__) {
+            if (moduleObject === undefined) {
+              console.error(
+                'lazy: Expected the result of a dynamic import() call. ' +
+                  'Instead received: %s\n\nYour code should look like: \n  ' +
+                  // Break up imports to avoid accidentally parsing them as dependencies.
+                  'const MyComponent = lazy(() => imp' +
+                  "ort('./MyComponent'))\n\n" +
+                  'Did you accidentally put curly braces around the import?',
+                moduleObject,
+              );
+            }
+          }
           const defaultExport = moduleObject.default;
           if (__DEV__) {
             if (defaultExport === undefined) {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -59,7 +59,7 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     // end up fixing it if the resolution was a concurrency bug.
     thenable.then(
       moduleObject => {
-        if (payload._status === Pending) {
+        if (payload._status === Pending || payload._status === Uninitialized) {
           // Transition to the next state.
           const resolved: ResolvedPayload<T> = (payload: any);
           resolved._status = Resolved;
@@ -67,7 +67,7 @@ function lazyInitializer<T>(payload: Payload<T>): T {
         }
       },
       error => {
-        if (payload._status === Pending) {
+        if (payload._status === Pending || payload._status === Uninitialized) {
           // Transition to the next state.
           const rejected: RejectedPayload = (payload: any);
           rejected._status = Rejected;

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -98,9 +98,8 @@ function lazyInitializer<T>(payload: Payload<T>): T {
         );
       }
     }
-    const defaultExport = moduleObject.default;
     if (__DEV__) {
-      if (defaultExport === undefined) {
+      if (!('default' in moduleObject)) {
         console.error(
           'lazy: Expected the result of a dynamic import() call. ' +
             'Instead received: %s\n\nYour code should look like: \n  ' +
@@ -111,7 +110,7 @@ function lazyInitializer<T>(payload: Payload<T>): T {
         );
       }
     }
-    return defaultExport;
+    return moduleObject.default;
   } else {
     throw payload._result;
   }


### PR DESCRIPTION
This is an alternative to #21639 which might fix #18768. Needs unit tests.

We should be pretty careful about using try/catch. It doesn't come without caveats:

- Browsers have been known to deopt them. This is getting less of an issue but not sure it's non-zero issue.
- It breaks debugging using break on uncaught exceptions.
- Even relying on it suggests an anti-pattern because you're likely executing in some outside execution context that doesn't have the right stacks or component stacks.
- We support suspense almost everywhere during the render. This means that technically anything that catches must know whether to forward it or not.
- It's often easiest to avoid it and instead just letting the general purpose system deal with it.

In general the lazy protocol is pretty simple. You just call the function and it either throws, suspends or gives you the value. It also works recursively. And since that is all happen directly on the same stack you have the full JS stack and component stack for how you got there. For example the ctor part can suspend or throw. You can also throw in the .then function potentially if it's a non-standard thenable which we support for the purpose of higher performance sync resolution.

To fix the outer resolution I simply moved the timing of when we set the flag. This is generally how you'd solve these kinds of bugs. Moving the timing of the mutation. So now we just keep it as uninitialized until we've called the thenable and so we know it's a thenable. So when we set the value, we know it'll suspend the next time we call it. This also lets this call throw and it'll also rethrow at the same place every time similar to how if the ctor throws. So you always get the right stack.

The other thing I changed is that when we resolve the `.default` property in the resolving path, we don't have the right stack so it'll be tricky to debug it. Sure, this generally happens inside React so it's not a very useful stack anyway. Therefore I instead moved this resolution to when the lazy value is read. That way it just works. It's a tiny bit slower during the reread perhaps but in general the reconciler diffs the lazy wrapper and not the resolved value anyway. It's also how this whole suspense thing is supposed to work in general. Any "transform" of a value is applied during "render" after you read it. The underlying lazy thing (that is also what React "sees" in the promise passed to React) is the module object itself. Maybe it's unfortunate that this created a memory dependency on the whole module but it's supposed to be in the module cache anyway.

Another thing I noticed is that we warn for `undefined` values but it's not invalid to import undefined from another module. E.g. Flight creates lazy values that return undefined all the time. It's not useful as an Element Type which is the previous only usage, but now it's allowed as a Node too where undefined is allowed.

```
const lazyNode = React.lazy(() => import(...));

<div>{lazyNode}</div>
```

I changed the early warning to check for `in`. We can also check for `undefined` if we want specifically for element types to give a better error message but that should be checked in the reconciler where we know how we'll use it.