### PR TITLE
Update next React version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,7 +532,7 @@ workflows:
             - setup
           commit_sha: << pipeline.parameters.prerelease_commit_sha >>
           release_channel: stable
-          dist_tag: next
+          dist_tag: "next, alpha"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:
@@ -564,7 +564,7 @@ workflows:
             - setup
           commit_sha: << pipeline.git.revision >>
           release_channel: stable
-          dist_tag: next
+          dist_tag: "next, alpha"
       - publish_prerelease:
           name: Publish to Experimental channel
           requires:

--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -12,20 +12,17 @@
 // The @next channel appends additional information, with the scheme
 // <version>-<label>-<commit_sha>, e.g.:
 //
-//   18.0.0-next-a1c2d3e4
-//
-// (TODO: ^ this isn't enabled quite yet. We still use <version>-<commit_sha>.)
+//   18.0.0-alpha-a1c2d3e4
 //
 // The @experimental channel doesn't include a version, only a sha, e.g.:
 //
 //   0.0.0-experimental-a1c2d3e4
 
-// TODO: Main includes breaking changes. Bump this to 18.0.0.
-const ReactVersion = '17.0.3';
+const ReactVersion = '18.0.0';
 
 // The label used by the @next channel. Represents the upcoming release's
 // stability. Could be "alpha", "beta", "rc", etc.
-const nextChannelLabel = 'next';
+const nextChannelLabel = 'alpha';
 
 const stablePackages = {
   'create-subscription': ReactVersion,
@@ -52,7 +49,6 @@ const experimentalPackages = [
   'react-server-dom-webpack',
 ];
 
-// TODO: Export a map of every package and its version.
 module.exports = {
   ReactVersion,
   nextChannelLabel,

--- a/scripts/release/publish-commands/validate-tags.js
+++ b/scripts/release/publish-commands/validate-tags.js
@@ -19,7 +19,7 @@ const run = async ({cwd, packages, tags}) => {
   );
   const {version} = await readJson(packageJSONPath);
   const isExperimentalVersion = version.indexOf('experimental') !== -1;
-  if (version.indexOf('0.0.0') === 0) {
+  if (version.indexOf('-') === 0) {
     if (tags.includes('latest')) {
       if (isExperimentalVersion) {
         console.log(

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -12,6 +12,7 @@ const {
   ReactVersion,
   stablePackages,
   experimentalPackages,
+  nextChannelLabel,
 } = require('../../ReactVersions');
 
 // Runs the build script for both stable and experimental release channels,
@@ -90,10 +91,12 @@ function processStable(buildDir) {
     const defaultVersionIfNotFound = '0.0.0' + '-' + sha;
     const versionsMap = new Map();
     for (const moduleName in stablePackages) {
-      // TODO: Use version declared in ReactVersions module instead of 0.0.0.
-      // const version = stablePackages[moduleName];
-      // versionsMap.set(moduleName, version + '-' + nextChannelLabel + '-' + sha);
-      versionsMap.set(moduleName, defaultVersionIfNotFound);
+      const version = stablePackages[moduleName];
+      versionsMap.set(
+        moduleName,
+        version + '-' + nextChannelLabel + '-' + sha,
+        defaultVersionIfNotFound
+      );
     }
     updatePackageVersions(
       buildDir + '/node_modules',
@@ -220,19 +223,21 @@ function updatePackageVersions(
 
       if (packageInfo.dependencies) {
         for (const dep of Object.keys(packageInfo.dependencies)) {
-          if (versionsMap.has(dep)) {
+          const depVersion = versionsMap.get(dep);
+          if (depVersion !== undefined) {
             packageInfo.dependencies[dep] = pinToExactVersion
-              ? version
-              : '^' + version;
+              ? depVersion
+              : '^' + depVersion;
           }
         }
       }
       if (packageInfo.peerDependencies) {
         for (const dep of Object.keys(packageInfo.peerDependencies)) {
-          if (versionsMap.has(dep)) {
+          const depVersion = versionsMap.get(dep);
+          if (depVersion !== undefined) {
             packageInfo.peerDependencies[dep] = pinToExactVersion
-              ? version
-              : '^' + version;
+              ? depVersion
+              : '^' + depVersion;
           }
         }
       }


### PR DESCRIPTION
This does not mean that a release of 18.0 is imminent, only that the main branch includes breaking changes.

Also updates the versioning scheme of the `@next` channel to include the upcoming semver number, as well as the word "alpha" to indicate the
stability of the release.

- Before: `0.0.0-<sha>`
- After: `18.0.0-alpha-<sha>`