### PR TITLE
Revert "Make enableSuspenseLayoutEffectSemantics static for www (#21617)"

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -26,6 +26,7 @@ export const {
   enableDebugTracing,
   skipUnmountedBoundaries,
   createRootStrictEffectsByDefault,
+  enableSuspenseLayoutEffectSemantics,
   enableUseRefAccessWarning,
   disableNativeComponentFrames,
   disableSchedulerTimeoutInWorkLoop,
@@ -36,8 +37,6 @@ export const {
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
 // It's not used anywhere in production yet.
-
-export const enableSuspenseLayoutEffectSemantics = true;
 
 export const enableStrictEffects =
   __DEV__ && dynamicFeatureFlags.enableStrictEffects;


### PR DESCRIPTION
This reverts commit 39f00748922cf40e06cd08d0c81f8b28fc8503fa.

I'm not sure this was actually fully rolled out so not sure I can sync this.