### PR TITLE
Move guarded callback closer to usage

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -342,24 +342,6 @@ function safelyCallDestroy(
   }
 }
 
-function safelyCallBeforeInstanceBlur(fiber: Fiber) {
-  if (__DEV__) {
-    setCurrentDebugFiberInDEV(fiber);
-    invokeGuardedCallback(null, beforeActiveInstanceBlur, null, fiber);
-    if (hasCaughtError()) {
-      const error = clearCaughtError();
-      captureCommitPhaseError(fiber, fiber.return, error);
-    }
-    resetCurrentDebugFiberInDEV();
-  } else {
-    try {
-      beforeActiveInstanceBlur(fiber);
-    } catch (error) {
-      captureCommitPhaseError(fiber, fiber.return, error);
-    }
-  }
-}
-
 let focusedInstanceHandle: null | Fiber = null;
 let shouldFireAfterActiveInstanceBlur: boolean = false;
 
@@ -428,7 +410,7 @@ function commitBeforeMutationEffects_complete() {
           doesFiberContain(fiber, focusedInstanceHandle)
         ) {
           shouldFireAfterActiveInstanceBlur = true;
-          safelyCallBeforeInstanceBlur(fiber);
+          beforeActiveInstanceBlur(fiber);
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2208,25 +2208,27 @@ function commitMutationEffects_begin(root: FiberRoot) {
 function commitMutationEffects_complete(root: FiberRoot) {
   while (nextEffect !== null) {
     const fiber = nextEffect;
-    if (__DEV__) {
-      setCurrentDebugFiberInDEV(fiber);
-      invokeGuardedCallback(
-        null,
-        commitMutationEffectsOnFiber,
-        null,
-        fiber,
-        root,
-      );
-      if (hasCaughtError()) {
-        const error = clearCaughtError();
-        captureCommitPhaseError(fiber, fiber.return, error);
-      }
-      resetCurrentDebugFiberInDEV();
-    } else {
-      try {
-        commitMutationEffectsOnFiber(fiber, root);
-      } catch (error) {
-        captureCommitPhaseError(fiber, fiber.return, error);
+    if (fiber.flags !== NoFlags) {
+      if (__DEV__) {
+        setCurrentDebugFiberInDEV(fiber);
+        invokeGuardedCallback(
+          null,
+          commitMutationEffectsOnFiber,
+          null,
+          fiber,
+          root,
+        );
+        if (hasCaughtError()) {
+          const error = clearCaughtError();
+          captureCommitPhaseError(fiber, fiber.return, error);
+        }
+        resetCurrentDebugFiberInDEV();
+      } else {
+        try {
+          commitMutationEffectsOnFiber(fiber, root);
+        } catch (error) {
+          captureCommitPhaseError(fiber, fiber.return, error);
+        }
       }
     }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -342,6 +342,24 @@ function safelyCallDestroy(
   }
 }
 
+function safelyCallBeforeInstanceBlur(fiber: Fiber) {
+  if (__DEV__) {
+    setCurrentDebugFiberInDEV(fiber);
+    invokeGuardedCallback(null, beforeActiveInstanceBlur, null, fiber);
+    if (hasCaughtError()) {
+      const error = clearCaughtError();
+      captureCommitPhaseError(fiber, fiber.return, error);
+    }
+    resetCurrentDebugFiberInDEV();
+  } else {
+    try {
+      beforeActiveInstanceBlur(fiber);
+    } catch (error) {
+      captureCommitPhaseError(fiber, fiber.return, error);
+    }
+  }
+}
+
 let focusedInstanceHandle: null | Fiber = null;
 let shouldFireAfterActiveInstanceBlur: boolean = false;
 
@@ -395,24 +413,46 @@ function commitBeforeMutationEffects_begin() {
 function commitBeforeMutationEffects_complete() {
   while (nextEffect !== null) {
     const fiber = nextEffect;
-    if (__DEV__) {
-      setCurrentDebugFiberInDEV(fiber);
-      invokeGuardedCallback(
-        null,
-        commitBeforeMutationEffectsOnFiber,
-        null,
-        fiber,
-      );
-      if (hasCaughtError()) {
-        const error = clearCaughtError();
-        captureCommitPhaseError(fiber, fiber.return, error);
+    const flags = fiber.flags;
+
+    if (enableCreateEventHandleAPI) {
+      if (
+        !shouldFireAfterActiveInstanceBlur &&
+        focusedInstanceHandle !== null
+      ) {
+        // Check to see if the focused element was inside of a hidden (Suspense) subtree.
+        // TODO: Move this out of the hot path using a dedicated effect tag.
+        if (
+          fiber.tag === SuspenseComponent &&
+          isSuspenseBoundaryBeingHidden(fiber.alternate, fiber) &&
+          doesFiberContain(fiber, focusedInstanceHandle)
+        ) {
+          shouldFireAfterActiveInstanceBlur = true;
+          safelyCallBeforeInstanceBlur(fiber);
+        }
       }
-      resetCurrentDebugFiberInDEV();
-    } else {
-      try {
-        commitBeforeMutationEffectsOnFiber(fiber);
-      } catch (error) {
-        captureCommitPhaseError(fiber, fiber.return, error);
+    }
+
+    if ((flags & Snapshot) !== NoFlags) {
+      if (__DEV__) {
+        setCurrentDebugFiberInDEV(fiber);
+        invokeGuardedCallback(
+          null,
+          commitBeforeMutationEffectsOnFiber,
+          null,
+          fiber,
+        );
+        if (hasCaughtError()) {
+          const error = clearCaughtError();
+          captureCommitPhaseError(fiber, fiber.return, error);
+        }
+        resetCurrentDebugFiberInDEV();
+      } else {
+        try {
+          commitBeforeMutationEffectsOnFiber(fiber);
+        } catch (error) {
+          captureCommitPhaseError(fiber, fiber.return, error);
+        }
       }
     }
 
@@ -428,113 +468,94 @@ function commitBeforeMutationEffects_complete() {
 }
 
 function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
-  const current = finishedWork.alternate;
-  const flags = finishedWork.flags;
+  setCurrentDebugFiberInDEV(finishedWork);
 
-  if (enableCreateEventHandleAPI) {
-    if (!shouldFireAfterActiveInstanceBlur && focusedInstanceHandle !== null) {
-      // Check to see if the focused element was inside of a hidden (Suspense) subtree.
-      // TODO: Move this out of the hot path using a dedicated effect tag.
-      if (
-        finishedWork.tag === SuspenseComponent &&
-        isSuspenseBoundaryBeingHidden(current, finishedWork) &&
-        doesFiberContain(finishedWork, focusedInstanceHandle)
-      ) {
-        shouldFireAfterActiveInstanceBlur = true;
-        beforeActiveInstanceBlur(finishedWork);
-      }
+  switch (finishedWork.tag) {
+    case FunctionComponent:
+    case ForwardRef:
+    case SimpleMemoComponent: {
+      break;
     }
-  }
-
-  if ((flags & Snapshot) !== NoFlags) {
-    setCurrentDebugFiberInDEV(finishedWork);
-
-    switch (finishedWork.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        break;
-      }
-      case ClassComponent: {
-        if (current !== null) {
-          const prevProps = current.memoizedProps;
-          const prevState = current.memoizedState;
-          const instance = finishedWork.stateNode;
-          // We could update instance props and state here,
-          // but instead we rely on them being set during last render.
-          // TODO: revisit this when we implement resuming.
-          if (__DEV__) {
-            if (
-              finishedWork.type === finishedWork.elementType &&
-              !didWarnAboutReassigningProps
-            ) {
-              if (instance.props !== finishedWork.memoizedProps) {
-                console.error(
-                  'Expected %s props to match memoized props before ' +
-                    'getSnapshotBeforeUpdate. ' +
-                    'This might either be because of a bug in React, or because ' +
-                    'a component reassigns its own `this.props`. ' +
-                    'Please file an issue.',
-                  getComponentNameFromFiber(finishedWork) || 'instance',
-                );
-              }
-              if (instance.state !== finishedWork.memoizedState) {
-                console.error(
-                  'Expected %s state to match memoized state before ' +
-                    'getSnapshotBeforeUpdate. ' +
-                    'This might either be because of a bug in React, or because ' +
-                    'a component reassigns its own `this.state`. ' +
-                    'Please file an issue.',
-                  getComponentNameFromFiber(finishedWork) || 'instance',
-                );
-              }
-            }
-          }
-          const snapshot = instance.getSnapshotBeforeUpdate(
-            finishedWork.elementType === finishedWork.type
-              ? prevProps
-              : resolveDefaultProps(finishedWork.type, prevProps),
-            prevState,
-          );
-          if (__DEV__) {
-            const didWarnSet = ((didWarnAboutUndefinedSnapshotBeforeUpdate: any): Set<mixed>);
-            if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
-              didWarnSet.add(finishedWork.type);
+    case ClassComponent: {
+      const current = finishedWork.alternate;
+      if (current !== null) {
+        const prevProps = current.memoizedProps;
+        const prevState = current.memoizedState;
+        const instance = finishedWork.stateNode;
+        // We could update instance props and state here,
+        // but instead we rely on them being set during last render.
+        // TODO: revisit this when we implement resuming.
+        if (__DEV__) {
+          if (
+            finishedWork.type === finishedWork.elementType &&
+            !didWarnAboutReassigningProps
+          ) {
+            if (instance.props !== finishedWork.memoizedProps) {
               console.error(
-                '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
-                  'must be returned. You have returned undefined.',
-                getComponentNameFromFiber(finishedWork),
+                'Expected %s props to match memoized props before ' +
+                  'getSnapshotBeforeUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.props`. ' +
+                  'Please file an issue.',
+                getComponentNameFromFiber(finishedWork) || 'instance',
+              );
+            }
+            if (instance.state !== finishedWork.memoizedState) {
+              console.error(
+                'Expected %s state to match memoized state before ' +
+                  'getSnapshotBeforeUpdate. ' +
+                  'This might either be because of a bug in React, or because ' +
+                  'a component reassigns its own `this.state`. ' +
+                  'Please file an issue.',
+                getComponentNameFromFiber(finishedWork) || 'instance',
               );
             }
           }
-          instance.__reactInternalSnapshotBeforeUpdate = snapshot;
         }
-        break;
-      }
-      case HostRoot: {
-        if (supportsMutation) {
-          const root = finishedWork.stateNode;
-          clearContainer(root.containerInfo);
-        }
-        break;
-      }
-      case HostComponent:
-      case HostText:
-      case HostPortal:
-      case IncompleteClassComponent:
-        // Nothing to do for these component types
-        break;
-      default: {
-        invariant(
-          false,
-          'This unit of work tag should not have side-effects. This error is ' +
-            'likely caused by a bug in React. Please file an issue.',
+        const snapshot = instance.getSnapshotBeforeUpdate(
+          finishedWork.elementType === finishedWork.type
+            ? prevProps
+            : resolveDefaultProps(finishedWork.type, prevProps),
+          prevState,
         );
+        if (__DEV__) {
+          const didWarnSet = ((didWarnAboutUndefinedSnapshotBeforeUpdate: any): Set<mixed>);
+          if (snapshot === undefined && !didWarnSet.has(finishedWork.type)) {
+            didWarnSet.add(finishedWork.type);
+            console.error(
+              '%s.getSnapshotBeforeUpdate(): A snapshot value (or null) ' +
+                'must be returned. You have returned undefined.',
+              getComponentNameFromFiber(finishedWork),
+            );
+          }
+        }
+        instance.__reactInternalSnapshotBeforeUpdate = snapshot;
       }
+      break;
     }
-
-    resetCurrentDebugFiberInDEV();
+    case HostRoot: {
+      if (supportsMutation) {
+        const root = finishedWork.stateNode;
+        clearContainer(root.containerInfo);
+      }
+      break;
+    }
+    case HostComponent:
+    case HostText:
+    case HostPortal:
+    case IncompleteClassComponent:
+      // Nothing to do for these component types
+      break;
+    default: {
+      invariant(
+        false,
+        'This unit of work tag should not have side-effects. This error is ' +
+          'likely caused by a bug in React. Please file an issue.',
+      );
+    }
   }
+
+  resetCurrentDebugFiberInDEV();
 }
 
 function commitBeforeMutationEffectsDeletion(deletion: Fiber) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -342,24 +342,6 @@ function safelyCallDestroy(
   }
 }
 
-function safelyCallBeforeInstanceBlur(fiber: Fiber) {
-  if (__DEV__) {
-    setCurrentDebugFiberInDEV(fiber);
-    invokeGuardedCallback(null, beforeActiveInstanceBlur, null, fiber);
-    if (hasCaughtError()) {
-      const error = clearCaughtError();
-      captureCommitPhaseError(fiber, fiber.return, error);
-    }
-    resetCurrentDebugFiberInDEV();
-  } else {
-    try {
-      beforeActiveInstanceBlur(fiber);
-    } catch (error) {
-      captureCommitPhaseError(fiber, fiber.return, error);
-    }
-  }
-}
-
 let focusedInstanceHandle: null | Fiber = null;
 let shouldFireAfterActiveInstanceBlur: boolean = false;
 
@@ -428,7 +410,7 @@ function commitBeforeMutationEffects_complete() {
           doesFiberContain(fiber, focusedInstanceHandle)
         ) {
           shouldFireAfterActiveInstanceBlur = true;
-          safelyCallBeforeInstanceBlur(fiber);
+          beforeActiveInstanceBlur(fiber);
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -19,6 +19,7 @@ import {
   warnAboutDeprecatedLifecycles,
   enableSuspenseServerRenderer,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
+  enableCreateEventHandleAPI,
   enableProfilerTimer,
   enableProfilerCommitHooks,
   enableProfilerNestedUpdatePhase,
@@ -1854,8 +1855,10 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The next phase is the mutation phase, where we mutate the host tree.
     commitMutationEffects(root, finishedWork, lanes);
 
-    if (shouldFireAfterActiveInstanceBlur) {
-      afterActiveInstanceBlur();
+    if (enableCreateEventHandleAPI) {
+      if (shouldFireAfterActiveInstanceBlur) {
+        afterActiveInstanceBlur();
+      }
     }
     resetAfterCommit(root.containerInfo);
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -19,6 +19,7 @@ import {
   warnAboutDeprecatedLifecycles,
   enableSuspenseServerRenderer,
   replayFailedUnitOfWorkWithInvokeGuardedCallback,
+  enableCreateEventHandleAPI,
   enableProfilerTimer,
   enableProfilerCommitHooks,
   enableProfilerNestedUpdatePhase,
@@ -1854,8 +1855,10 @@ function commitRootImpl(root, renderPriorityLevel) {
     // The next phase is the mutation phase, where we mutate the host tree.
     commitMutationEffects(root, finishedWork, lanes);
 
-    if (shouldFireAfterActiveInstanceBlur) {
-      afterActiveInstanceBlur();
+    if (enableCreateEventHandleAPI) {
+      if (shouldFireAfterActiveInstanceBlur) {
+        afterActiveInstanceBlur();
+      }
     }
     resetAfterCommit(root.containerInfo);
 


### PR DESCRIPTION
Based on https://github.com/facebook/react/pull/21657.

Changes:

- https://github.com/facebook/react/commit/161be62e202c1ed7dac4d2428bb0d6b35dd5b7c6?w=1: Pulls out all the code outside of `(flags & Snapshot) !== NoFlags` check out of the inner function. Leaves the inner function in guarded callback. The `beforeActiveInstanceBlur` stuff might need guarding in theory (though I'm not sure we're consistent about it now), so I wrapped it separately just to be safe.
- https://github.com/facebook/react/commit/d1e7f28d8382f86f9272f8658b34c20834d171a3?w=1: Prod change: don't run the inner function if `flags` are `NoFlags`. I read `fiber.flags` but should be ok because it's read inside right after anyway. All code inside only runs on non-zero flags so this should be safe.
- https://github.com/facebook/react/pull/21658/commits/626cd53f8327670280d7748b333edca61328d7c3: Though I added this safeguard in the first commit, I decided to remove it. The only thing that host method does is dispatch an event. So it's not expected to throw. We also already _don't_ guard it in another place. So if it used to throw, we would've likely known. Let's just not bother and keep the code simple.

Why: so that we spend less time in DEV in these guarded callbacks that don't do anything. In particular, if Fiber has no effects.