### PR TITLE
Add a DOCTYPE to the stream if the <html> tag is rendered at the root

### DIFF
--- a/fixtures/fizz-ssr-browser/index.html
+++ b/fixtures/fizz-ssr-browser/index.html
@@ -21,9 +21,14 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <script type="text/babel">
       let controller = new AbortController();
-      let stream = ReactDOMFizzServer.renderToReadableStream(<body>Success</body>, {
-        signal: controller.signal,
-      });
+      let stream = ReactDOMFizzServer.renderToReadableStream(
+        <html>
+          <body>Success</body>
+        </html>,
+        {
+          signal: controller.signal,
+        }
+      );
       let response = new Response(stream, {
         headers: {'Content-Type': 'text/html'},
       });

--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -28,8 +28,6 @@ export default function render(url, res) {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;
         res.setHeader('Content-type', 'text/html');
-        // There's no way to render a doctype in React so prepend manually.
-        res.write('<!DOCTYPE html>');
         startWriting();
       },
       onError(x) {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -59,6 +59,19 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // @gate experimental
+  it('should emit DOCTYPE at the root of the document', async () => {
+    const stream = ReactDOMFizzServer.renderToReadableStream(
+      <html>
+        <body>hello world</body>
+      </html>,
+    );
+    const result = await readResult(stream);
+    expect(result).toMatchInlineSnapshot(
+      `"<!DOCTYPE html><html><body>hello world</body></html>"`,
+    );
+  });
+
+  // @gate experimental
   it('emits all HTML as one unit if we wait until the end to start', async () => {
     let hasLoaded = false;
     let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -69,6 +69,22 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // @gate experimental
+  it('should emit DOCTYPE at the root of the document', () => {
+    const {writable, output} = getTestWritable();
+    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      <html>
+        <body>hello world</body>
+      </html>,
+      writable,
+    );
+    startWriting();
+    jest.runAllTimers();
+    expect(output.result).toMatchInlineSnapshot(
+      `"<!DOCTYPE html><html><body>hello world</body></html>"`,
+    );
+  });
+
+  // @gate experimental
   it('should start writing after startWriting', () => {
     const {writable, output} = getTestWritable();
     const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -49,6 +49,7 @@ describe('rendering React components at document', () => {
       }
 
       const markup = ReactDOMServer.renderToString(<Root hello="world" />);
+      expect(markup).not.toContain('DOCTYPE');
       const testDocument = getTestDocument(markup);
       const body = testDocument.body;
 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -64,7 +64,7 @@ function renderToStringImpl(
       generateStaticMarkup,
       options ? options.identifierPrefix : undefined,
     ),
-    createRootFormatContext(undefined),
+    createRootFormatContext(),
     Infinity,
     onError,
     undefined,

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
@@ -79,7 +79,7 @@ function renderToNodeStreamImpl(
     children,
     destination,
     createResponseState(false, options ? options.identifierPrefix : undefined),
-    createRootFormatContext(undefined),
+    createRootFormatContext(),
     Infinity,
     onError,
     onCompleteAll,

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {SuspenseBoundaryID} from './ReactDOMServerFormatConfig';
+import type {
+  SuspenseBoundaryID,
+  FormatContext,
+} from './ReactDOMServerFormatConfig';
 
 import {
   createResponseState as createResponseStateImpl,
@@ -16,6 +19,7 @@ import {
   writeStartClientRenderedSuspenseBoundary as writeStartClientRenderedSuspenseBoundaryImpl,
   writeEndCompletedSuspenseBoundary as writeEndCompletedSuspenseBoundaryImpl,
   writeEndClientRenderedSuspenseBoundary as writeEndClientRenderedSuspenseBoundaryImpl,
+  HTML_MODE,
 } from './ReactDOMServerFormatConfig';
 
 import type {
@@ -62,6 +66,13 @@ export function createResponseState(
   };
 }
 
+export function createRootFormatContext(): FormatContext {
+  return {
+    insertionMode: HTML_MODE, // We skip the root mode because we don't want to emit the DOCTYPE in legacy mode.
+    selectedValue: null,
+  };
+}
+
 export type {
   FormatContext,
   SuspenseBoundaryID,
@@ -69,7 +80,6 @@ export type {
 } from './ReactDOMServerFormatConfig';
 
 export {
-  createRootFormatContext,
   getChildFormatContext,
   createSuspenseBoundaryID,
   makeServerID,


### PR DESCRIPTION
This makes it a lot easier to render the whole document using React without needing to patch into the stream.

We expect that currently people will still have to patch into the stream to do advanced things but eventually the goal is that you shouldn't need to once we have enough escape hatches to inject into the stream.

I couldn't update the `/ssr2/` fixture yet since that installs a public version rather than installs React from source builds.