### PR TITLE
[Fizz/Flight] Don't use default args

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -42,12 +42,12 @@ type Controls = {|
   startWriting(): void,
 |};
 
-function pipeToNodeWritable(
+function createRequestImpl(
   children: ReactNodeList,
   destination: Writable,
-  options?: Options,
-): Controls {
-  const request = createRequest(
+  options: void | Options,
+) {
+  return createRequest(
     children,
     destination,
     createResponseState(options ? options.identifierPrefix : undefined),
@@ -57,6 +57,14 @@ function pipeToNodeWritable(
     options ? options.onCompleteAll : undefined,
     options ? options.onReadyToStream : undefined,
   );
+}
+
+function pipeToNodeWritable(
+  children: ReactNodeList,
+  destination: Writable,
+  options?: Options,
+): Controls {
+  const request = createRequestImpl(children, destination, options);
   let hasStartedFlowing = false;
   startWork(request);
   return {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -222,17 +222,20 @@ export function createRequest(
   destination: Destination,
   responseState: ResponseState,
   rootFormatContext: FormatContext,
-  progressiveChunkSize: number = DEFAULT_PROGRESSIVE_CHUNK_SIZE,
-  onError: (error: mixed) => void = defaultErrorHandler,
-  onCompleteAll: () => void = noop,
-  onReadyToStream: () => void = noop,
+  progressiveChunkSize: void | number,
+  onError: void | ((error: mixed) => void),
+  onCompleteAll: void | (() => void),
+  onReadyToStream: void | (() => void),
 ): Request {
   const pingedTasks = [];
   const abortSet: Set<Task> = new Set();
   const request = {
     destination,
     responseState,
-    progressiveChunkSize,
+    progressiveChunkSize:
+      progressiveChunkSize === undefined
+        ? DEFAULT_PROGRESSIVE_CHUNK_SIZE
+        : progressiveChunkSize,
     status: BUFFERING,
     nextSegmentId: 0,
     allPendingTasks: 0,
@@ -243,9 +246,9 @@ export function createRequest(
     clientRenderedBoundaries: [],
     completedBoundaries: [],
     partialBoundaries: [],
-    onError,
-    onCompleteAll,
-    onReadyToStream,
+    onError: onError === undefined ? defaultErrorHandler : onError,
+    onCompleteAll: onCompleteAll === undefined ? noop : onCompleteAll,
+    onReadyToStream: onReadyToStream === undefined ? noop : onReadyToStream,
   };
   // This segment represents the root fallback.
   const rootSegment = createPendingSegment(request, 0, null, rootFormatContext);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -98,7 +98,7 @@ export function createRequest(
   model: ReactModel,
   destination: Destination,
   bundlerConfig: BundlerConfig,
-  onError: (error: mixed) => void = defaultErrorHandler,
+  onError: void | ((error: mixed) => void),
 ): Request {
   const pingedSegments = [];
   const request = {
@@ -113,7 +113,7 @@ export function createRequest(
     completedErrorChunks: [],
     writtenSymbols: new Map(),
     writtenModules: new Map(),
-    onError,
+    onError: onError === undefined ? defaultErrorHandler : onError,
     flowing: false,
     toJSON: function(key: string, value: ReactModel): ReactJSONValue {
       return resolveModelToJSON(request, this, key, value);


### PR DESCRIPTION
These don't compile very nicely because they end up checking the argument length instead of undefinedness for some reason.