### PR TITLE
Use the server src files as entry points for the builds/tests

### DIFF
--- a/fixtures/fizz-ssr-browser/index.html
+++ b/fixtures/fizz-ssr-browser/index.html
@@ -17,11 +17,11 @@
       </p>
     </div>
     <script src="../../build/node_modules/react/umd/react.development.js"></script>
-    <script src="../../build/node_modules/react-dom/umd/react-dom-unstable-fizz.browser.development.js"></script>
+    <script src="../../build/node_modules/react-dom/umd/react-dom-server.browser.development.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <script type="text/babel">
       let controller = new AbortController();
-      let stream = ReactDOMFizzServer.renderToReadableStream(
+      let stream = ReactDOMServer.renderToReadableStream(
         <html>
           <body>Success</body>
         </html>,

--- a/fixtures/ssr/src/index.js
+++ b/fixtures/ssr/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {unstable_createRoot as createRoot} from 'react-dom';
+import {createRoot} from 'react-dom';
 
 import App from './components/App';
 

--- a/packages/react-dom/npm/server.browser.js
+++ b/packages/react-dom/npm/server.browser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-server.browser.production.min.js');
+  module.exports = require('./cjs/react-dom-server-legacy.browser.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-server.browser.development.js');
+  module.exports = require('./cjs/react-dom-server-legacy.browser.development.js');
 }

--- a/packages/react-dom/npm/server.node.js
+++ b/packages/react-dom/npm/server.node.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-server.node.production.min.js');
+  module.exports = require('./cjs/react-dom-server-legacy.node.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-server.node.development.js');
+  module.exports = require('./cjs/react-dom-server-legacy.node.development.js');
 }

--- a/packages/react-dom/npm/unstable-fizz.browser.js
+++ b/packages/react-dom/npm/unstable-fizz.browser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-unstable-fizz.browser.production.min.js');
+  module.exports = require('./cjs/react-dom-server.browser.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-unstable-fizz.browser.development.js');
+  module.exports = require('./cjs/react-dom-server.browser.development.js');
 }

--- a/packages/react-dom/npm/unstable-fizz.node.js
+++ b/packages/react-dom/npm/unstable-fizz.node.js
@@ -1,7 +1,7 @@
 'use strict';
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./cjs/react-dom-unstable-fizz.node.production.min.js');
+  module.exports = require('./cjs/react-dom-server.node.production.min.js');
 } else {
-  module.exports = require('./cjs/react-dom-unstable-fizz.node.development.js');
+  module.exports = require('./cjs/react-dom-server.node.development.js');
 }

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.classic.fb.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.classic.fb.js
@@ -13,4 +13,4 @@ export {
   renderToNodeStream,
   renderToStaticNodeStream,
   version,
-} from './src/server/ReactDOMServerLegacyPartialRendererBrowser';
+} from './ReactDOMServerLegacyPartialRendererBrowser';

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -263,15 +263,17 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/unstable-fizz.browser',
-    global: 'ReactDOMFizzServer',
+    entry: 'react-dom/src/server/ReactDOMFizzServerBrowser',
+    name: 'react-dom-server.browser',
+    global: 'ReactDOMServer',
     externals: ['react'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/unstable-fizz.node',
-    global: 'ReactDOMFizzServer',
+    entry: 'react-dom/src/server/ReactDOMFizzServerNode',
+    name: 'react-dom-server.node',
+    global: 'ReactDOMServer',
     externals: ['react'],
   },
   {

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -234,7 +234,8 @@ const bundles = [
       ? [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD]
       : [UMD_DEV, UMD_PROD, NODE_DEV, NODE_PROD, FB_WWW_DEV, FB_WWW_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/server.browser',
+    entry: 'react-dom/src/server/ReactDOMLegacyServerBrowser',
+    name: 'react-dom-server-legacy.browser',
     global: 'ReactDOMServer',
     externals: ['react'],
     babel: opts =>
@@ -247,7 +248,8 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/server.node',
+    entry: 'react-dom/src/server/ReactDOMLegacyServerNode',
+    name: 'react-dom-server-legacy.node',
     externals: ['react', 'stream'],
     babel: opts =>
       Object.assign({}, opts, {
@@ -263,21 +265,21 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-dom/unstable-fizz.browser',
     global: 'ReactDOMFizzServer',
-    externals: ['react', 'react-dom/server'],
+    externals: ['react'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-dom/unstable-fizz.node',
     global: 'ReactDOMFizzServer',
-    externals: ['react', 'react-dom/server'],
+    externals: ['react'],
   },
   {
     bundleTypes: __EXPERIMENTAL__ ? [FB_WWW_DEV, FB_WWW_PROD] : [],
     moduleType: RENDERER,
     entry: 'react-server-dom-relay/src/ReactDOMServerFB',
     global: 'ReactDOMServer',
-    externals: ['react', 'react-dom/server'],
+    externals: ['react'],
   },
 
   /******* React Server DOM Webpack Writer *******/
@@ -286,14 +288,14 @@ const bundles = [
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/writer.browser.server',
     global: 'ReactServerDOMWriter',
-    externals: ['react', 'react-dom/server'],
+    externals: ['react'],
   },
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
     entry: 'react-server-dom-webpack/writer.node.server',
     global: 'ReactServerDOMWriter',
-    externals: ['react', 'react-dom/server'],
+    externals: ['react'],
   },
 
   /******* React Server DOM Webpack Reader *******/
@@ -340,7 +342,6 @@ const bundles = [
     global: 'ReactFlightDOMRelayServer', // TODO: Rename to Writer
     externals: [
       'react',
-      'react-dom/server',
       'ReactFlightDOMRelayServerIntegration',
       'JSResourceReference',
     ],
@@ -785,7 +786,7 @@ deepFreeze(bundleTypes);
 deepFreeze(moduleTypes);
 
 function getOriginalFilename(bundle, bundleType) {
-  let name = bundle.entry;
+  let name = bundle.name || bundle.entry;
   const globalName = bundle.global;
   // we do this to replace / to -, for react-dom/server
   name = name.replace('/index.', '.').replace('/', '-');

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -55,7 +55,10 @@ module.exports = [
   },
   {
     shortName: 'dom-legacy',
-    entryPoints: ['react-dom/server.browser', 'react-dom/server.node'],
+    entryPoints: [
+      'react-dom/src/server/ReactDOMLegacyServerBrowser', // react-dom/server.browser
+      'react-dom/src/server/ReactDOMLegacyServerNode', // react-dom/server.node
+    ],
     paths: [
       'react-dom',
       'react-dom/server',

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -12,7 +12,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/testing',
-      'react-dom/unstable-fizz.node',
+      'react-dom/src/server/ReactDOMFizzServerNode',
       'react-server-dom-webpack/writer.node.server',
       'react-server-dom-webpack',
     ],
@@ -36,7 +36,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/testing',
-      'react-dom/unstable-fizz.browser',
+      'react-dom/src/server/ReactDOMFizzServerBrowser',
       'react-server-dom-webpack/writer.browser.server',
       'react-server-dom-webpack',
     ],


### PR DESCRIPTION
We need one top level entry point to target two builds so we can't have the top level one be the entry point for the build configs.

To do this I added "name" field so we can customize the build output's name a bit more freely.

The next step is actually merging the top level entry points.