### PR TITLE
Remove unstable_createRoot from internal builds

### DIFF
--- a/fixtures/blocks/src/index.js
+++ b/fixtures/blocks/src/index.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import {unstable_createRoot as createRoot} from 'react-dom';
+import {createRoot} from 'react-dom';
 import './index.css';
 import Router from './Router';
 

--- a/fixtures/concurrent/time-slicing/src/index.js
+++ b/fixtures/concurrent/time-slicing/src/index.js
@@ -1,5 +1,5 @@
 import React, {PureComponent, unstable_startTransition} from 'react';
-import {unstable_createRoot} from 'react-dom';
+import {createRoot} from 'react-dom';
 import _ from 'lodash';
 import Charts from './Charts';
 import Clock from './Clock';
@@ -142,5 +142,5 @@ class App extends PureComponent {
 }
 
 const container = document.getElementById('root');
-const root = unstable_createRoot(container);
+const root = createRoot(container);
 root.render(<App />);

--- a/fixtures/devtools/scheduling-profiler/app.js
+++ b/fixtures/devtools/scheduling-profiler/app.js
@@ -1,5 +1,5 @@
 const {createElement, useLayoutEffect, useState} = React;
-const {unstable_createRoot: createRoot} = ReactDOM;
+const {createRoot} = ReactDOM;
 
 function App() {
   const [isMounted, setIsMounted] = useState(false);

--- a/fixtures/dom/src/__tests__/wrong-act-test.js
+++ b/fixtures/dom/src/__tests__/wrong-act-test.js
@@ -189,7 +189,7 @@ it("doesn't warn if you use nested acts from different renderers", () => {
 
 if (__EXPERIMENTAL__) {
   it('warns when using createRoot() + .render', () => {
-    const root = ReactDOM.unstable_createRoot(document.createElement('div'));
+    const root = ReactDOM.createRoot(document.createElement('div'));
     expect(() => {
       TestRenderer.act(() => {
         root.render(<App />);

--- a/packages/react-dom/index.classic.fb.js
+++ b/packages/react-dom/index.classic.fb.js
@@ -22,7 +22,6 @@ export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   createPortal,
   createRoot,
-  createRoot as unstable_createRoot, // TODO Remove once callsites use createRoot
   hydrateRoot,
   findDOMNode,
   flushSync,

--- a/packages/react-dom/index.js
+++ b/packages/react-dom/index.js
@@ -13,7 +13,6 @@ export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   createPortal,
   createRoot,
-  createRoot as unstable_createRoot,
   hydrateRoot,
   findDOMNode,
   flushSync,

--- a/packages/react-dom/index.modern.fb.js
+++ b/packages/react-dom/index.modern.fb.js
@@ -11,7 +11,6 @@ export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   createPortal,
   createRoot,
-  createRoot as unstable_createRoot, // TODO Remove once callsites use createRoot
   hydrateRoot,
   flushSync,
   unstable_batchedUpdates,


### PR DESCRIPTION
These callsites were already removed as far as I can tell.
