### PR TITLE
Next/experimental release versions include commit date

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -14,9 +14,9 @@
 //
 //   18.0.0-alpha-a1c2d3e4
 //
-// The @experimental channel doesn't include a version, only a sha, e.g.:
+// The @experimental channel doesn't include a version, only a date and a sha, e.g.:
 //
-//   0.0.0-experimental-a1c2d3e4
+//   0.0.0-experimental-241c4467e-20200129
 
 const ReactVersion = '18.0.0';
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -87,7 +87,7 @@ Stable releases should always be created from the "next" channel. This encourage
 To prepare a stable release, choose a "next" version and run the [`prepare-release-from-npm`](#prepare-release-from-npm) script <sup>1</sup>:
 
 ```sh
-scripts/release/prepare-release-from-npm.js --version=0.0.0-241c4467e
+scripts/release/prepare-release-from-npm.js --version=0.0.0-241c4467e-20200129
 ```
 
 This script will prompt you to select stable version numbers for each of the packages. It will update the package JSON versions (and dependencies) based on the numbers you select.
@@ -165,9 +165,9 @@ This script prompts for new (stable) release versions for each public package an
 "Next" releases have already been tested but it is still a good idea to **manually test and verify a release** before publishing to ensure that e.g. version numbers are correct. Upon completion, this script prints manual testing instructions.
 
 #### Example usage
-To promote the "next" release `0.0.0-241c4467e` (aka commit [241c4467e](https://github.com/facebook/react/commit/241c4467e)) to stable:
+To promote the "next" release `0.0.0-241c4467e-20200129` (aka commit [241c4467e](https://github.com/facebook/react/commit/241c4467e)) to stable:
 ```sh
-scripts/release/prepare-release-from-npm.js --version=0.0.0-241c4467e
+scripts/release/prepare-release-from-npm.js --version=0.0.0-241c4467e-20200129
 ```
 
 ## `publish`

--- a/scripts/release/prepare-release-from-npm-commands/parse-params.js
+++ b/scripts/release/prepare-release-from-npm-commands/parse-params.js
@@ -29,7 +29,8 @@ const paramDefinitions = [
   {
     name: 'version',
     type: String,
-    description: 'Version of published "next" release (e.g. 0.0.0-ddaf2b07c)',
+    description:
+      'Version of published "next" release (e.g. 0.0.0-0e526bcec-20210202)',
   },
 ];
 

--- a/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
+++ b/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
@@ -47,7 +47,7 @@ const run = async ({cwd, packages, version}, versionsMap) => {
           // (e.g. scheduler@^0.11.0 becomes scheduler@^0.12.0 when we release scheduler 0.12.0).
           // Otherwise we leave the constraint alone (e.g. react@^16.0.0 doesn't change between releases).
           // Note that in both cases, we must update the target package JSON,
-          // since "next" releases are all locked to the version (e.g. 0.0.0-ddaf2b07c).
+          // since "next" releases are all locked to the version (e.g. 0.0.0-0e526bcec-20210202).
           if (
             sourceDependencyVersion ===
             sourceDependencyConstraint.replace(/^[\^\~]/, '')
@@ -69,7 +69,7 @@ const run = async ({cwd, packages, version}, versionsMap) => {
   // Update all package JSON versions and their dependencies/peerDependencies.
   // This must be done in a way that respects semver constraints (e.g. 16.7.0, ^16.7.0, ^16.0.0).
   // To do this, we use the dependencies defined in the source package JSONs,
-  // because the "next" dependencies have already been flattened to an exact match (e.g. 0.0.0-ddaf2b07c).
+  // because the "next" dependencies have already been flattened to an exact match (e.g. 0.0.0-0e526bcec-20210202).
   for (let i = 0; i < packages.length; i++) {
     const packageName = packages[i];
     const packageJSONPath = join(nodeModulesPath, packageName, 'package.json');

--- a/scripts/release/snapshot-test.js
+++ b/scripts/release/snapshot-test.js
@@ -6,7 +6,7 @@ const {exec, spawn} = require('child-process-promise');
 const {join} = require('path');
 const {readFileSync} = require('fs');
 const theme = require('./theme');
-const {logPromise, printDiff} = require('./utils');
+const {getDateStringForCommit, logPromise, printDiff} = require('./utils');
 
 const cwd = join(__dirname, '..', '..');
 
@@ -37,6 +37,8 @@ const run = async () => {
     );
     await promise;
 
+    const dateString = await getDateStringForCommit(COMMIT);
+
     // Upgrade the above build top a known React version.
     // Note that using the --local flag skips NPM checkout.
     // This isn't totally necessary but is useful if we want to test an unpublished "next" build.
@@ -44,7 +46,7 @@ const run = async () => {
       'node',
       [
         './scripts/release/prepare-release-from-npm.js',
-        `--version=0.0.0-${COMMIT}`,
+        `--version=0.0.0-${COMMIT}-${dateString}`,
         '--local',
       ],
       defaultOptions

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -49,9 +49,9 @@ const execRead = async (command, options) => {
 };
 
 const extractCommitFromVersionNumber = version => {
-  // Support stable version format e.g. "0.0.0-0e526bcec"
-  // and experimental version format e.g. "0.0.0-experimental-0e526bcec"
-  const match = version.match(/0\.0\.0\-([a-z]+\-){0,1}(.+)/);
+  // Support stable version format e.g. "0.0.0-0e526bcec-20210202"
+  // and experimental version format e.g. "0.0.0-experimental-0e526bcec-20210202"
+  const match = version.match(/0\.0\.0\-([a-z]+\-){0,1}([^-]+).+/);
   if (match === null) {
     throw Error(`Could not extra commit from version "${version}"`);
   }
@@ -74,9 +74,10 @@ const getBuildInfo = async () => {
   });
   const commit = await execRead('git show -s --format=%h', {cwd});
   const checksum = await getChecksumForCurrentRevision(cwd);
+  const dateString = await getDateStringForCommit(commit);
   const version = isExperimental
-    ? `0.0.0-experimental-${commit}`
-    : `0.0.0-${commit}`;
+    ? `0.0.0-experimental-${commit}-${dateString}`
+    : `0.0.0-${commit}-${dateString}`;
 
   // Only available for Circle CI builds.
   // https://circleci.com/docs/2.0/env-vars/
@@ -88,8 +89,8 @@ const getBuildInfo = async () => {
     join(cwd, 'packages', 'react', 'package.json')
   );
   const reactVersion = isExperimental
-    ? `${packageJSON.version}-experimental-${commit}`
-    : `${packageJSON.version}-${commit}`;
+    ? `${packageJSON.version}-experimental-${commit}-${dateString}`
+    : `${packageJSON.version}-${commit}-${dateString}`;
 
   return {branch, buildNumber, checksum, commit, reactVersion, version};
 };
@@ -101,6 +102,19 @@ const getChecksumForCurrentRevision = async cwd => {
     files: {exclude: ['.DS_Store']},
   });
   return hashedPackages.hash.slice(0, 7);
+};
+
+const getDateStringForCommit = async commit => {
+  let dateString = await execRead(
+    `git show -s --format=%cd --date=format:%Y%m%d ${commit}`
+  );
+
+  // On CI environment, this string is wrapped with quotes '...'s
+  if (dateString.startsWith("'")) {
+    dateString = dateString.substr(1, 8);
+  }
+
+  return dateString;
 };
 
 const getCommitFromCurrentBuild = async () => {
@@ -194,10 +208,10 @@ const splitCommaParams = array => {
 // This method is used by both local Node release scripts and Circle CI bash scripts.
 // It updates version numbers in package JSONs (both the version field and dependencies),
 // As well as the embedded renderer version in "packages/shared/ReactVersion".
-// Canaries version numbers use the format of 0.0.0-<sha> to be easily recognized (e.g. 0.0.0-01974a867).
+// Canaries version numbers use the format of 0.0.0-<sha>-<date> to be easily recognized (e.g. 0.0.0-01974a867-20200129).
 // A separate "React version" is used for the embedded renderer version to support DevTools,
 // since it needs to distinguish between different version ranges of React.
-// It is based on the version of React in the local package.json (e.g. 16.12.0-01974a867).
+// It is based on the version of React in the local package.json (e.g. 16.12.0-01974a867-20200129).
 // Both numbers will be replaced if the "next" release is promoted to a stable release.
 const updateVersionsForNext = async (cwd, reactVersion, version) => {
   const isExperimental = reactVersion.includes('experimental');
@@ -258,6 +272,7 @@ module.exports = {
   getBuildInfo,
   getChecksumForCurrentRevision,
   getCommitFromCurrentBuild,
+  getDateStringForCommit,
   getPublicPackages,
   handleError,
   logPromise,


### PR DESCRIPTION
Change format of @next and @experimental release versions from `<number>-<sha>` to `<number>-<sha>-<date>` to make them more human readable. This format still preserves the ability for us to easily map a version number to the changes it contains, while also being able to more easily know at a glance  how recent a release is.

Note that the date used is the date of the commit (not the current date).
![Screen Shot 2021-06-23 at 12 00 10 PM](https://user-images.githubusercontent.com/29597/123130265-a48eeb00-d41a-11eb-858c-03eb6891c560.png)

![Screen Shot 2021-06-23 at 1 49 01 PM](https://user-images.githubusercontent.com/29597/123144575-cb085280-d429-11eb-8fd1-925b73c8003f.png)

- [x] Build release locally (via `scripts/release/build-release-locally.js`) and verify version number in packages contains the date of the commit (e.g. `0.0.0-68053d940-20210623`) and the version embedded as the `ReactVersion` const does as well (e.g. `17.0.3-68053d940-20210623`).
- [x] Prepare release in CI (via `scripts/release/prepare-release-from-ci.js`) and verify version number in packages contains the date of the commit (`0.0.0-68053d940-20210623` or `0.0.0-experimental-68053d940-20210623`).
- [x] Dry run promote a local (or CI) build to prepare for stable release.