### PR TITLE
Improved `additionalHooks` with the ability to specify `callbackIndex` (backwards-compatible)

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -64,6 +64,18 @@ This option accepts a regex to match the names of custom Hooks that have depende
 }
 ```
 
+Alternatively, you can specify `additionalHooks` as a dictionary, providing the `callbackIndex` parameter.
+You might need that if you have custom Hooks that have some extra parameters preceding the callback.
+
+```js
+    "react-hooks/exhaustive-deps": ["warn", {
+      "additionalHooks": {
+        "useMyCustomHook": {"callbackIndex": 0}
+        "useMyOtherCustomHook": {"callbackIndex": 1}
+      }
+    }]
+```
+
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
 
 ## Valid and Invalid Examples

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -3557,6 +3557,101 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomEffect0(() => {
+            console.log(props.foo);
+          }, []);
+          useCustomEffect1(bar, () => {
+            console.log(props.foo);
+          }, []);
+          useCustomEffect2(bar, qux, () => {
+            console.log(props.foo);
+          }, []);
+        }
+      `,
+      options: [
+        {
+          additionalHooks: {
+            useCustomEffect0: {},
+            useCustomEffect1: {callbackIndex: 1},
+            useCustomEffect2: {callbackIndex: 2},
+          },
+        },
+      ],
+      errors: [
+        {
+          message:
+            "React Hook useCustomEffect0 has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomEffect0(() => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                  useCustomEffect1(bar, () => {
+                    console.log(props.foo);
+                  }, []);
+                  useCustomEffect2(bar, qux, () => {
+                    console.log(props.foo);
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message:
+            "React Hook useCustomEffect1 has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomEffect0(() => {
+                    console.log(props.foo);
+                  }, []);
+                  useCustomEffect1(bar, () => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                  useCustomEffect2(bar, qux, () => {
+                    console.log(props.foo);
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+        {
+          message:
+            "React Hook useCustomEffect2 has a missing dependency: 'props.foo'. " +
+            'Either include it or remove the dependency array.',
+          suggestions: [
+            {
+              desc: 'Update the dependencies array to be: [props.foo]',
+              output: normalizeIndent`
+                function MyComponent(props) {
+                  useCustomEffect0(() => {
+                    console.log(props.foo);
+                  }, []);
+                  useCustomEffect1(bar, () => {
+                    console.log(props.foo);
+                  }, []);
+                  useCustomEffect2(bar, qux, () => {
+                    console.log(props.foo);
+                  }, [props.foo]);
+                }
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
         function MyComponent() {
           const local = {};
           useEffect(() => {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -27,7 +27,7 @@ export default {
         enableDangerousAutofixThisMayCauseInfiniteLoops: false,
         properties: {
           additionalHooks: {
-            type: 'string',
+            type: ['string', 'object'],
           },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
@@ -42,7 +42,9 @@ export default {
       context.options &&
       context.options[0] &&
       context.options[0].additionalHooks
-        ? new RegExp(context.options[0].additionalHooks)
+        ? typeof context.options[0].additionalHooks === 'string'
+          ? new RegExp(context.options[0].additionalHooks)
+          : context.options[0].additionalHooks
         : undefined;
 
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
@@ -1722,7 +1724,12 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
             throw error;
           }
         }
-        return options.additionalHooks.test(name) ? 0 : -1;
+        if (options.additionalHooks instanceof RegExp) {
+          return options.additionalHooks.test(name) ? 0 : -1;
+        } else {
+          const params = options.additionalHooks[name];
+          return params ? params.callbackIndex || 0 : -1;
+        }
       } else {
         return -1;
       }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -27,7 +27,17 @@ export default {
         enableDangerousAutofixThisMayCauseInfiniteLoops: false,
         properties: {
           additionalHooks: {
-            type: ['string', 'object'],
+            anyOf: [
+              {type: 'string'},
+              {
+                type: 'object',
+                additionalProperties: {
+                  type: 'object',
+                  additionalProperties: false,
+                  properties: {callbackIndex: {type: 'number'}},
+                },
+              },
+            ],
           },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',


### PR DESCRIPTION
## Summary

Hi there. We develop a state management library and we have a custom hook with dependencies that has additional arguments _preceding_ the callback, something like:

```js
useSelect(store, () => ..., [deps])
```

We want to get it linted with the `exhaustive-deps` rule. But the current `additionalHooks` implementation assumes that custom hooks are always like `useEffect` — and it is even explicitly mentioned in the source code:

```js
// What's the index of callback that needs to be analyzed for a given Hook?
// -1 if it's not a Hook we care about (e.g. useState).
// 0 for useEffect/useMemo/useCallback(fn).
// 1 for useImperativeHandle(ref, fn).
// For additionally configured Hooks, assume that they're like useEffect (0).                <---- THIS
```

But with a very small change (just ~10 LOC to the checking code) we can add a mechanism for configuring the callback index (not breaking the backward compatibility with the existing regex-based configuration — it is still there):

```js
    "react-hooks/exhaustive-deps": ["warn", {
      "additionalHooks": {
        "useMyCustomHook": {"callbackIndex": 0}
        "useMyOtherCustomHook": {"callbackIndex": 1}
      }
    }]
```

P.S. Yeah, of course we recognize that we can just put the `useCallback` on top of every call to our custom hook and thus "avoid" the very need of creating a custom hook with dependencies. But here's the rationale against it: in _100%_ cases we need memoization and dependency-checking of the callback passed to our custom hook — it's kind of _really_ mandatory in our case. And there is a massive codebase that relies on our custom hook, so having users to wrap the callback in `useCallback` by hand would create a significant code bloat and make it prone to errors. In the end we would have had to create a custom linter rule that checks that the callback is always memoized... so we decided that it's better to hide the memoization in the implementation of our custom hook itself, passing the dependencies down to it, and then use the `additionalHooks` thing for linting it.

## Test Plan

I've added a test case to `ESLintRuleExhaustiveDeps-test.js`, that should suffice (?)