### PR TITLE
Revert "Remove invokeGuardedCallback from commit phase"

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOM-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOM-test.js
@@ -408,6 +408,49 @@ describe('ReactDOM', () => {
     }
   });
 
+  it('throws in DEV if jsdom is destroyed by the time setState() is called', () => {
+    class App extends React.Component {
+      state = {x: 1};
+      componentDidUpdate() {}
+      render() {
+        return <div />;
+      }
+    }
+    const container = document.createElement('div');
+    const instance = ReactDOM.render(<App />, container);
+    const documentDescriptor = Object.getOwnPropertyDescriptor(
+      global,
+      'document',
+    );
+    try {
+      // Emulate jsdom environment cleanup.
+      // This is roughly what happens if the test finished and then
+      // an asynchronous callback tried to setState() after this.
+      delete global.document;
+
+      // The error we're interested in is thrown by invokeGuardedCallback, which
+      // in DEV is used 1) to replay a failed begin phase, or 2) when calling
+      // lifecycle methods. We're triggering the second case here.
+      const fn = () => instance.setState({x: 2});
+      if (__DEV__) {
+        expect(fn).toThrow(
+          'The `document` global was defined when React was initialized, but is not ' +
+            'defined anymore. This can happen in a test environment if a component ' +
+            'schedules an update from an asynchronous callback, but the test has already ' +
+            'finished running. To solve this, you can either unmount the component at ' +
+            'the end of your test (and ensure that any asynchronous operations get ' +
+            'canceled in `componentWillUnmount`), or you can change the test itself ' +
+            'to be asynchronous.',
+        );
+      } else {
+        expect(fn).not.toThrow();
+      }
+    } finally {
+      // Don't break other tests.
+      Object.defineProperty(global, 'document', documentDescriptor);
+    }
+  });
+
   it('reports stacks with re-entrant renderToString() calls on the client', () => {
     function Child2(props) {
       return <span ariaTypo3="no">{props.children}</span>;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
@@ -244,4 +244,69 @@ describe('ReactSuspense', () => {
     expect(ops1).toEqual([]);
     expect(ops2).toEqual([]);
   });
+
+  if (__DEV__) {
+    // @gate www
+    it('regression test for #16215 that relies on implementation details', async () => {
+      // Regression test for https://github.com/facebook/react/pull/16215.
+      // The bug only happens if there's an error earlier in the commit phase.
+      // The first error is the one that gets thrown, so to observe the later
+      // error, I've mocked the ReactErrorUtils module.
+      //
+      // If this test starts failing because the implementation details change,
+      // you can probably just delete it. It's not worth the hassle.
+      jest.resetModules();
+
+      const errors = [];
+      let hasCaughtError = false;
+      jest.mock('shared/ReactErrorUtils', () => ({
+        invokeGuardedCallback(name, fn, context, ...args) {
+          try {
+            return fn.call(context, ...args);
+          } catch (error) {
+            hasCaughtError = true;
+            errors.push(error);
+          }
+        },
+        hasCaughtError() {
+          return hasCaughtError;
+        },
+        clearCaughtError() {
+          hasCaughtError = false;
+          return errors[errors.length - 1];
+        },
+      }));
+
+      React = require('react');
+      ReactNoop = require('react-noop-renderer');
+      Scheduler = require('scheduler');
+
+      const {useEffect} = React;
+      const {PromiseComp} = createThenable();
+      function App() {
+        useEffect(() => {
+          Scheduler.unstable_yieldValue('Passive Effect');
+        });
+        return (
+          <React.Suspense
+            suspenseCallback={() => {
+              throw Error('Oops!');
+            }}
+            fallback="Loading...">
+            <PromiseComp />
+          </React.Suspense>
+        );
+      }
+      const root = ReactNoop.createRoot();
+      await ReactNoop.act(async () => {
+        root.render(<App />);
+        expect(Scheduler).toFlushAndThrow('Oops!');
+      });
+
+      // Should have only received a single error. Before the bug fix, there was
+      // also a second error related to the Suspense update queue.
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toEqual('Oops!');
+    });
+  }
 });


### PR DESCRIPTION
Reverts facebook/react#21666

Closes https://github.com/facebook/react/issues/21712

~Just want to confirm if facebook/react#21666 actually changed how errors in effects are handled inside Error boundaries.~ Confirmed: https://codesandbox.io/s/react-18-error-boundaries-8khik