### PR TITLE
Add tests for invokeGuardedCallback

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -13,6 +13,7 @@ describe('ReactDOMConsoleErrorReporting', () => {
   let ReactDOM;
 
   let ErrorBoundary;
+  let NoError;
   let container;
   let windowOnError;
 
@@ -33,6 +34,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
         }
         return this.props.children;
       }
+    };
+    NoError = function() {
+      return <h1>OK</h1>;
     };
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -125,6 +129,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
           ],
         ]);
       }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+        ]);
+      }
     });
 
     it('logs render errors without an error boundary', () => {
@@ -176,6 +194,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
               message: 'Boom',
             }),
           ],
+        ]);
+      }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
         ]);
       }
     });
@@ -234,6 +266,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
           ],
         ]);
       }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+        ]);
+      }
     });
 
     // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
@@ -289,6 +335,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
               message: 'Boom',
             }),
           ],
+        ]);
+      }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
         ]);
       }
     });
@@ -351,6 +411,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
           ],
         ]);
       }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+        ]);
+      }
     });
 
     // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
@@ -406,6 +480,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
               message: 'Boom',
             }),
           ],
+        ]);
+      }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
         ]);
       }
     });
@@ -466,6 +554,20 @@ describe('ReactDOMConsoleErrorReporting', () => {
               message: 'Boom',
             }),
           ],
+        ]);
+      }
+
+      // Check next render doesn't throw.
+      windowOnError.mockReset();
+      console.error.calls.reset();
+      act(() => {
+        ReactDOM.render(<NoError />, container);
+      });
+      expect(container.textContent).toBe('OK');
+      expect(windowOnError.mock.calls).toEqual([]);
+      if (__DEV__) {
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
         ]);
       }
     });

--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -235,5 +235,239 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
       }
     });
+
+    // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
+    xit('logs layout effect errors without an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        React.useLayoutEffect(() => {
+          throw Error('Boom');
+        }, []);
+        return null;
+      }
+
+      expect(() => {
+        act(() => {
+          ReactDOM.render(<Foo />, container);
+        });
+      }).toThrow('Boom');
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+
+    // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
+    xit('logs layout effect errors with an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        React.useLayoutEffect(() => {
+          throw Error('Boom');
+        }, []);
+        return null;
+      }
+
+      act(() => {
+        ReactDOM.render(
+          <ErrorBoundary>
+            <Foo />
+          </ErrorBoundary>,
+          container,
+        );
+      });
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported by jsdom due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+
+    // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
+    xit('logs passive effect errors without an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        React.useEffect(() => {
+          throw Error('Boom');
+        }, []);
+        return null;
+      }
+
+      expect(() => {
+        act(() => {
+          ReactDOM.render(<Foo />, container);
+        });
+      }).toThrow('Boom');
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+
+    // TODO: this is broken due to https://github.com/facebook/react/issues/21712.
+    xit('logs passive effect errors with an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        React.useEffect(() => {
+          throw Error('Boom');
+        }, []);
+        return null;
+      }
+
+      act(() => {
+        ReactDOM.render(
+          <ErrorBoundary>
+            <Foo />
+          </ErrorBoundary>,
+          container,
+        );
+      });
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported by jsdom due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -79,31 +79,31 @@ describe('ReactDOMConsoleErrorReporting', () => {
 
       if (__DEV__) {
         expect(windowOnError.mock.calls).toEqual([
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // This one is jsdom-only. Real browser deduplicates it.
-          // (In DEV, we have a nested event due to guarded callback.)
           [
+            // This one is jsdom-only. Real browser deduplicates it.
+            // (In DEV, we have a nested event due to guarded callback.)
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // This one is jsdom-only. Real browser deduplicates it.
-          // (In DEV, we have a nested event due to guarded callback.)
           [
+            // This one is jsdom-only. Real browser deduplicates it.
+            // (In DEV, we have a nested event due to guarded callback.)
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
@@ -111,17 +111,17 @@ describe('ReactDOMConsoleErrorReporting', () => {
           ],
         ]);
       } else {
-        // Reported because we're in a browser click event:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported because we're in a browser click event:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
@@ -158,24 +158,37 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          [
+            // TODO: This is duplicated only with createRoot. Why?
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // TODO: This is duplicated only with createRoot. Why?
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -225,24 +238,43 @@ describe('ReactDOMConsoleErrorReporting', () => {
       });
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          [
+            // TODO: This is duplicated only with createRoot. Why?
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+          [
+            // TODO: This is duplicated only with createRoot. Why?
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          [
+            // TODO: This is duplicated only with createRoot. Why?
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -255,6 +287,12 @@ describe('ReactDOMConsoleErrorReporting', () => {
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [
             // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          [
+            // TODO: This is duplicated only with createRoot. Why?
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -294,24 +332,24 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -365,24 +403,24 @@ describe('ReactDOMConsoleErrorReporting', () => {
       });
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -434,24 +472,24 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -505,24 +543,24 @@ describe('ReactDOMConsoleErrorReporting', () => {
       });
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -585,15 +623,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
 
       if (__DEV__) {
         expect(windowOnError.mock.calls).toEqual([
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // This one is jsdom-only. Real browser deduplicates it.
-          // (In DEV, we have a nested event due to guarded callback.)
           [
+            // This one is jsdom-only. Real browser deduplicates it.
+            // (In DEV, we have a nested event due to guarded callback.)
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -601,16 +639,16 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // This one is jsdom-only. Real browser deduplicates it.
-          // (In DEV, we have a nested event due to guarded callback.)
           [
+            // This one is jsdom-only. Real browser deduplicates it.
+            // (In DEV, we have a nested event due to guarded callback.)
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
@@ -618,17 +656,17 @@ describe('ReactDOMConsoleErrorReporting', () => {
           ],
         ]);
       } else {
-        // Reported because we're in a browser click event:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported because we're in a browser click event:
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
-          // Reported because we're in a browser click event:
           [
+            // Reported because we're in a browser click event:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
@@ -666,9 +704,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -676,15 +714,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -736,9 +774,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
       });
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -746,15 +784,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -807,9 +845,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -817,15 +855,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -881,9 +919,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
       });
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -891,15 +929,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -952,9 +990,9 @@ describe('ReactDOMConsoleErrorReporting', () => {
       }).toThrow('Boom');
 
       if (__DEV__) {
-        // Reported due to guarded callback:
         expect(windowOnError.mock.calls).toEqual([
           [
+            // Reported due to guarded callback:
             expect.objectContaining({
               message: 'Boom',
             }),
@@ -962,15 +1000,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported due to the guarded callback:
           [
+            // Reported due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),
@@ -1036,15 +1074,15 @@ describe('ReactDOMConsoleErrorReporting', () => {
         ]);
         expect(console.error.calls.all().map(c => c.args)).toEqual([
           [expect.stringContaining('ReactDOM.render is no longer supported')],
-          // Reported by jsdom due to the guarded callback:
           [
+            // Reported by jsdom due to the guarded callback:
             expect.stringContaining('Error: Uncaught [Error: Boom]'),
             expect.objectContaining({
               message: 'Boom',
             }),
           ],
-          // Addendum by React:
           [
+            // Addendum by React:
             expect.stringContaining(
               'The above error occurred in the <Foo> component',
             ),

--- a/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMConsoleErrorReporting-test.js
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+describe('ReactDOMConsoleErrorReporting', () => {
+  let act;
+  let React;
+  let ReactDOM;
+
+  let ErrorBoundary;
+  let container;
+  let windowOnError;
+
+  beforeEach(() => {
+    jest.resetModules();
+    act = require('jest-react').act;
+    React = require('react');
+    ReactDOM = require('react-dom');
+
+    ErrorBoundary = class extends React.Component {
+      state = {error: null};
+      static getDerivedStateFromError(error) {
+        return {error};
+      }
+      render() {
+        if (this.state.error) {
+          return <h1>Caught: {this.state.error.message}</h1>;
+        }
+        return this.props.children;
+      }
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    windowOnError = jest.fn();
+    window.addEventListener('error', windowOnError);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    window.removeEventListener('error', windowOnError);
+  });
+
+  describe('ReactDOM.render', () => {
+    it('logs errors during event handlers', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        return (
+          <button
+            onClick={() => {
+              throw Error('Boom');
+            }}>
+            click me
+          </button>
+        );
+      }
+
+      act(() => {
+        ReactDOM.render(<Foo />, container);
+      });
+
+      act(() => {
+        container.firstChild.dispatchEvent(
+          new MouseEvent('click', {
+            bubbles: true,
+          }),
+        );
+      });
+
+      if (__DEV__) {
+        expect(windowOnError.mock.calls).toEqual([
+          // Reported because we're in a browser click event:
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // This one is jsdom-only. Real browser deduplicates it.
+          // (In DEV, we have a nested event due to guarded callback.)
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported because we're in a browser click event:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // This one is jsdom-only. Real browser deduplicates it.
+          // (In DEV, we have a nested event due to guarded callback.)
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      } else {
+        // Reported because we're in a browser click event:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          // Reported because we're in a browser click event:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+
+    it('logs render errors without an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        throw Error('Boom');
+      }
+
+      expect(() => {
+        act(() => {
+          ReactDOM.render(<Foo />, container);
+        });
+      }).toThrow('Boom');
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+
+    it('logs render errors with an error boundary', () => {
+      spyOnDevAndProd(console, 'error');
+
+      function Foo() {
+        throw Error('Boom');
+      }
+
+      act(() => {
+        ReactDOM.render(
+          <ErrorBoundary>
+            <Foo />
+          </ErrorBoundary>,
+          container,
+        );
+      });
+
+      if (__DEV__) {
+        // Reported due to guarded callback:
+        expect(windowOnError.mock.calls).toEqual([
+          [
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [expect.stringContaining('ReactDOM.render is no longer supported')],
+          // Reported by jsdom due to the guarded callback:
+          [
+            expect.stringContaining('Error: Uncaught [Error: Boom]'),
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+          // Addendum by React:
+          [
+            expect.stringContaining(
+              'The above error occurred in the <Foo> component',
+            ),
+          ],
+        ]);
+      } else {
+        // The top-level error was caught with try/catch, and there's no guarded callback,
+        // so in production we don't see an error event.
+        expect(windowOnError.mock.calls).toEqual([]);
+        expect(console.error.calls.all().map(c => c.args)).toEqual([
+          [
+            // Reported by React with no extra message:
+            expect.objectContaining({
+              message: 'Boom',
+            }),
+          ],
+        ]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
- [x] Add render tests
- [x] Add skipped failing tests for effects
- [x] Strengthen tests to verify we don't keep rethrowing old errors
- [x] Port all tests to `createRoot` too, add TODOs for known mismatches