### PR TITLE
Pass Jest useStderr flag when debugging

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -261,6 +261,9 @@ function getCommandArgs() {
   if (argv.debug) {
     args.unshift('--inspect-brk');
     args.push('--runInBand');
+
+    // Prevent console logs from being hidden until test completes.
+    args.push('--useStderr');
   }
 
   // CI Environments have limited workers.


### PR DESCRIPTION
This prevents it from buffering and suppressing all console logs until a test has completed running (When debugging in Chrome). This is super annoying default behavior.