### PR TITLE
DevTools: Fix Settings dialog scroll/size bug in Firefox

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.css
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsModal.css
@@ -22,7 +22,7 @@
   box-shadow: 0 2px 4px var(--color-shadow);
   border-radius: 0.25rem;
   overflow: auto;
-  width: 400px;
+  width: 410px;
   max-width: 100%;
 }
 

--- a/packages/react-devtools-shared/src/devtools/views/TabBar.css
+++ b/packages/react-devtools-shared/src/devtools/views/TabBar.css
@@ -10,6 +10,9 @@
   user-select: none;
   color: var(--color-text);
 
+  /* Hide radio buttons for Firefox too */
+  position:  relative;
+
   /* Electron drag area */
   -webkit-app-region: no-drag;
 }
@@ -48,6 +51,9 @@
   width: 0;
   margin: 0;
   opacity: 0;
+
+  /* Hide radio buttons for Firefox too */
+  position:  absolute;
 }
 
 .IconSizeNavigation,


### PR DESCRIPTION
Resolves #21718

The reason for the difference between Firefox and Chrome is that the (supposedly hidden) `<input type=radio>` buttons used for the Tab bar accessibility isn't 0 width for Firefox. In addition to this, there was a bit too much content in the tab bar and it was crowding tabs, so I made it a little wider as well.