### PR TITLE
Simplify `discreteUpdates`

### DIFF
--- a/packages/react-dom/src/events/ReactDOMUpdateBatching.js
+++ b/packages/react-dom/src/events/ReactDOMUpdateBatching.js
@@ -24,10 +24,11 @@ let discreteUpdatesImpl = function(fn, a, b, c, d) {
   return fn(a, b, c, d);
 };
 let flushDiscreteUpdatesImpl = function() {};
-let batchedEventUpdatesImpl = batchedUpdatesImpl;
+// TODO: Remove references to batchedEventUpdates
+// let batchedEventUpdatesImpl = batchedUpdatesImpl;
 
 let isInsideEventHandler = false;
-let isBatchingEventUpdates = false;
+// let isBatchingEventUpdates = false;
 
 function finishEventHandler() {
   // Here we wait until all updates have propagated, which is important
@@ -46,48 +47,27 @@ function finishEventHandler() {
   }
 }
 
-export function batchedUpdates(fn, bookkeeping) {
+export function batchedUpdates(fn, a, b) {
   if (isInsideEventHandler) {
     // If we are currently inside another batch, we need to wait until it
     // fully completes before restoring state.
-    return fn(bookkeeping);
+    return fn(a, b);
   }
   isInsideEventHandler = true;
   try {
-    return batchedUpdatesImpl(fn, bookkeeping);
+    return batchedUpdatesImpl(fn, a, b);
   } finally {
     isInsideEventHandler = false;
     finishEventHandler();
   }
 }
 
-export function batchedEventUpdates(fn, a, b) {
-  if (isBatchingEventUpdates) {
-    // If we are currently inside another batch, we need to wait until it
-    // fully completes before restoring state.
-    return fn(a, b);
-  }
-  isBatchingEventUpdates = true;
-  try {
-    return batchedEventUpdatesImpl(fn, a, b);
-  } finally {
-    isBatchingEventUpdates = false;
-    finishEventHandler();
-  }
-}
+// TODO: Remove references to batchedEventUpdates
+export const batchedEventUpdates = batchedUpdates;
 
 // TODO: Replace with flushSync
 export function discreteUpdates(fn, a, b, c, d) {
-  const prevIsInsideEventHandler = isInsideEventHandler;
-  isInsideEventHandler = true;
-  try {
-    return discreteUpdatesImpl(fn, a, b, c, d);
-  } finally {
-    isInsideEventHandler = prevIsInsideEventHandler;
-    if (!isInsideEventHandler) {
-      finishEventHandler();
-    }
-  }
+  return discreteUpdatesImpl(fn, a, b, c, d);
 }
 
 export function setBatchingImplementation(
@@ -99,5 +79,6 @@ export function setBatchingImplementation(
   batchedUpdatesImpl = _batchedUpdatesImpl;
   discreteUpdatesImpl = _discreteUpdatesImpl;
   flushDiscreteUpdatesImpl = _flushDiscreteUpdatesImpl;
-  batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
+  // TODO: Remove references to batchedEventUpdates
+  // batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
 }


### PR DESCRIPTION
Now that discrete updates are flushed synchronously in a microtask, the `discreteUpdates` method used by our event system is only an optimization to save us from having to check `window.event.type` on every update. So we should be able to remove the extra logic.

Assuming this lands successfully, we can remove `batchedEventUpdates` and probably inline `discreteUpdates` into the renderer, like we do for continuous updates.