### PR TITLE
Delete batchedEventUpdates

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -21,7 +21,6 @@ import {createRoot, hydrateRoot, isValidContainer} from './ReactDOMRoot';
 import {createEventHandle} from './ReactDOMEventHandle';
 
 import {
-  batchedEventUpdates,
   batchedUpdates,
   discreteUpdates,
   flushDiscreteUpdates,
@@ -102,7 +101,6 @@ setBatchingImplementation(
   batchedUpdates,
   discreteUpdates,
   flushDiscreteUpdates,
-  batchedEventUpdates,
 );
 
 function createPortal(

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -43,7 +43,7 @@ import {
   getEventHandlerListeners,
 } from '../client/ReactDOMComponentTree';
 import {COMMENT_NODE} from '../shared/HTMLNodeType';
-import {batchedEventUpdates} from './ReactDOMUpdateBatching';
+import {batchedUpdates} from './ReactDOMUpdateBatching';
 import getListener from './getListener';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
 
@@ -630,7 +630,7 @@ export function dispatchEventForPluginEventSystem(
     }
   }
 
-  batchedEventUpdates(() =>
+  batchedUpdates(() =>
     dispatchEventsForPlugins(
       domEventName,
       eventSystemFlags,

--- a/packages/react-dom/src/events/ReactDOMUpdateBatching.js
+++ b/packages/react-dom/src/events/ReactDOMUpdateBatching.js
@@ -24,11 +24,8 @@ let discreteUpdatesImpl = function(fn, a, b, c, d) {
   return fn(a, b, c, d);
 };
 let flushDiscreteUpdatesImpl = function() {};
-// TODO: Remove references to batchedEventUpdates
-// let batchedEventUpdatesImpl = batchedUpdatesImpl;
 
 let isInsideEventHandler = false;
-// let isBatchingEventUpdates = false;
 
 function finishEventHandler() {
   // Here we wait until all updates have propagated, which is important
@@ -62,9 +59,6 @@ export function batchedUpdates(fn, a, b) {
   }
 }
 
-// TODO: Remove references to batchedEventUpdates
-export const batchedEventUpdates = batchedUpdates;
-
 // TODO: Replace with flushSync
 export function discreteUpdates(fn, a, b, c, d) {
   return discreteUpdatesImpl(fn, a, b, c, d);
@@ -74,11 +68,8 @@ export function setBatchingImplementation(
   _batchedUpdatesImpl,
   _discreteUpdatesImpl,
   _flushDiscreteUpdatesImpl,
-  _batchedEventUpdatesImpl,
 ) {
   batchedUpdatesImpl = _batchedUpdatesImpl;
   discreteUpdatesImpl = _discreteUpdatesImpl;
   flushDiscreteUpdatesImpl = _flushDiscreteUpdatesImpl;
-  // TODO: Remove references to batchedEventUpdates
-  // batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
 }

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -16,7 +16,6 @@ import './ReactFabricInjection';
 import {
   findHostInstance,
   findHostInstanceWithWarning,
-  batchedEventUpdates,
   batchedUpdates as batchedUpdatesImpl,
   discreteUpdates,
   createContainer,
@@ -246,11 +245,7 @@ function createPortal(
   return createPortalImpl(children, containerTag, null, key);
 }
 
-setBatchingImplementation(
-  batchedUpdatesImpl,
-  discreteUpdates,
-  batchedEventUpdates,
-);
+setBatchingImplementation(batchedUpdatesImpl, discreteUpdates);
 
 const roots = new Map();
 

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -17,7 +17,6 @@ import {
   findHostInstance,
   findHostInstanceWithWarning,
   batchedUpdates as batchedUpdatesImpl,
-  batchedEventUpdates,
   discreteUpdates,
   createContainer,
   updateContainer,
@@ -237,11 +236,7 @@ function createPortal(
   return createPortalImpl(children, containerTag, null, key);
 }
 
-setBatchingImplementation(
-  batchedUpdatesImpl,
-  discreteUpdates,
-  batchedEventUpdates,
-);
+setBatchingImplementation(batchedUpdatesImpl, discreteUpdates);
 
 function computeComponentStackForErrorReporting(reactTag: number): string {
   const fiber = getClosestInstanceFromNode(reactTag);

--- a/packages/react-native-renderer/src/legacy-events/ReactGenericBatching.js
+++ b/packages/react-native-renderer/src/legacy-events/ReactGenericBatching.js
@@ -18,10 +18,8 @@ let batchedUpdatesImpl = function(fn, bookkeeping) {
 let discreteUpdatesImpl = function(fn, a, b, c, d) {
   return fn(a, b, c, d);
 };
-let batchedEventUpdatesImpl = batchedUpdatesImpl;
 
 let isInsideEventHandler = false;
-let isBatchingEventUpdates = false;
 
 export function batchedUpdates(fn, bookkeeping) {
   if (isInsideEventHandler) {
@@ -34,20 +32,6 @@ export function batchedUpdates(fn, bookkeeping) {
     return batchedUpdatesImpl(fn, bookkeeping);
   } finally {
     isInsideEventHandler = false;
-  }
-}
-
-export function batchedEventUpdates(fn, a, b) {
-  if (isBatchingEventUpdates) {
-    // If we are currently inside another batch, we need to wait until it
-    // fully completes before restoring state.
-    return fn(a, b);
-  }
-  isBatchingEventUpdates = true;
-  try {
-    return batchedEventUpdatesImpl(fn, a, b);
-  } finally {
-    isBatchingEventUpdates = false;
   }
 }
 
@@ -64,9 +48,7 @@ export function discreteUpdates(fn, a, b, c, d) {
 export function setBatchingImplementation(
   _batchedUpdatesImpl,
   _discreteUpdatesImpl,
-  _batchedEventUpdatesImpl,
 ) {
   batchedUpdatesImpl = _batchedUpdatesImpl;
   discreteUpdatesImpl = _discreteUpdatesImpl;
-  batchedEventUpdatesImpl = _batchedEventUpdatesImpl;
 }

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -17,7 +17,6 @@ import {enableNewReconciler} from 'shared/ReactFeatureFlags';
 import {
   createContainer as createContainer_old,
   updateContainer as updateContainer_old,
-  batchedEventUpdates as batchedEventUpdates_old,
   batchedUpdates as batchedUpdates_old,
   unbatchedUpdates as unbatchedUpdates_old,
   deferredUpdates as deferredUpdates_old,
@@ -56,7 +55,6 @@ import {
 import {
   createContainer as createContainer_new,
   updateContainer as updateContainer_new,
-  batchedEventUpdates as batchedEventUpdates_new,
   batchedUpdates as batchedUpdates_new,
   unbatchedUpdates as unbatchedUpdates_new,
   deferredUpdates as deferredUpdates_new,
@@ -98,9 +96,6 @@ export const createContainer = enableNewReconciler
 export const updateContainer = enableNewReconciler
   ? updateContainer_new
   : updateContainer_old;
-export const batchedEventUpdates = enableNewReconciler
-  ? batchedEventUpdates_new
-  : batchedEventUpdates_old;
 export const batchedUpdates = enableNewReconciler
   ? batchedUpdates_new
   : batchedUpdates_old;

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -51,7 +51,6 @@ import {
   requestUpdateLane,
   scheduleUpdateOnFiber,
   flushRoot,
-  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   flushSync,
@@ -327,7 +326,6 @@ export function updateContainer(
 }
 
 export {
-  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   deferredUpdates,

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -51,7 +51,6 @@ import {
   requestUpdateLane,
   scheduleUpdateOnFiber,
   flushRoot,
-  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   flushSync,
@@ -327,7 +326,6 @@ export function updateContainer(
 }
 
 export {
-  batchedEventUpdates,
   batchedUpdates,
   unbatchedUpdates,
   deferredUpdates,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -246,13 +246,12 @@ const {
 
 type ExecutionContext = number;
 
-export const NoContext = /*             */ 0b000000;
-const BatchedContext = /*               */ 0b000001;
-const EventContext = /*                 */ 0b000010;
-const LegacyUnbatchedContext = /*       */ 0b000100;
-const RenderContext = /*                */ 0b001000;
-const CommitContext = /*                */ 0b010000;
-export const RetryAfterError = /*       */ 0b100000;
+export const NoContext = /*             */ 0b00000;
+const BatchedContext = /*               */ 0b00001;
+const LegacyUnbatchedContext = /*       */ 0b00010;
+const RenderContext = /*                */ 0b00100;
+const CommitContext = /*                */ 0b01000;
+export const RetryAfterError = /*       */ 0b10000;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5;
 const RootIncomplete = 0;
@@ -1089,22 +1088,6 @@ export function deferredUpdates<A>(fn: () => A): A {
 export function batchedUpdates<A, R>(fn: A => R, a: A): R {
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
-  try {
-    return fn(a);
-  } finally {
-    executionContext = prevExecutionContext;
-    // If there were legacy sync updates, flush them at the end of the outer
-    // most batchedUpdates-like method.
-    if (executionContext === NoContext) {
-      resetRenderTimer();
-      flushSyncCallbacksOnlyInLegacyMode();
-    }
-  }
-}
-
-export function batchedEventUpdates<A, R>(fn: A => R, a: A): R {
-  const prevExecutionContext = executionContext;
-  executionContext |= EventContext;
   try {
     return fn(a);
   } finally {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -246,13 +246,12 @@ const {
 
 type ExecutionContext = number;
 
-export const NoContext = /*             */ 0b000000;
-const BatchedContext = /*               */ 0b000001;
-const EventContext = /*                 */ 0b000010;
-const LegacyUnbatchedContext = /*       */ 0b000100;
-const RenderContext = /*                */ 0b001000;
-const CommitContext = /*                */ 0b010000;
-export const RetryAfterError = /*       */ 0b100000;
+export const NoContext = /*             */ 0b00000;
+const BatchedContext = /*               */ 0b00001;
+const LegacyUnbatchedContext = /*       */ 0b00010;
+const RenderContext = /*                */ 0b00100;
+const CommitContext = /*                */ 0b01000;
+export const RetryAfterError = /*       */ 0b10000;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5;
 const RootIncomplete = 0;
@@ -1089,22 +1088,6 @@ export function deferredUpdates<A>(fn: () => A): A {
 export function batchedUpdates<A, R>(fn: A => R, a: A): R {
   const prevExecutionContext = executionContext;
   executionContext |= BatchedContext;
-  try {
-    return fn(a);
-  } finally {
-    executionContext = prevExecutionContext;
-    // If there were legacy sync updates, flush them at the end of the outer
-    // most batchedUpdates-like method.
-    if (executionContext === NoContext) {
-      resetRenderTimer();
-      flushSyncCallbacksOnlyInLegacyMode();
-    }
-  }
-}
-
-export function batchedEventUpdates<A, R>(fn: A => R, a: A): R {
-  const prevExecutionContext = executionContext;
-  executionContext |= EventContext;
   try {
     return fn(a);
   } finally {


### PR DESCRIPTION
No longer used anywhere. https://github.com/facebook/react/pull/21773 replaced it with `batchedUpdates`.

Context here: https://github.com/facebook/react/pull/21773#issuecomment-871643183

> ...we don't bother to prevent overflushing anymore, because flushDiscreteUpdates doesn't exist conceptually, because we either do it at the end of the event (in a microtask or in finishEventHandler) or with flushSync. Instead of the previous mechanism, which was do it at the beginning of every discrete event, even if it's nested.
> 
> That's why I could remove batchedEventUpdates, too, which was added here originally to prevent overflushing: #15687