### PR TITLE
Install nested packages from Yarn cache before running build tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,9 @@ jobs:
           at: .
       - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
+      - run:
+          name: Install nested packages from Yarn cache
+          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run: yarn test --build <<parameters.args>> --ci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:


### PR DESCRIPTION
Unblocks #21641

We cache the root `node_modules` directory on Circle CI and restore it before e.g. running tests. We don't cache nested `node_modules` folders though, instead choosing to re-install (from the local Yarn cache) after restoring the root cache. We were not doing this for the `yarn_test_build` targets though which caused problems if there were dependency differences between packages.

This PR addresses that.