### PR TITLE
DevTools show error icon when hook name parsing fails

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -26,7 +26,6 @@ import {
   inspectElement,
 } from 'react-devtools-shared/src/inspectedElementCache';
 import {loadHookNames} from 'react-devtools-shared/src/hookNamesCache';
-import {ElementTypeFunction} from 'react-devtools-shared/src/types';
 import LoadHookNamesFunctionContext from 'react-devtools-shared/src/devtools/views/Components/LoadHookNamesFunctionContext';
 import {SettingsContext} from '../Settings/SettingsContext';
 
@@ -112,7 +111,6 @@ export function InspectedElementContextController({children}: Props) {
       if (parseHookNames) {
         if (
           inspectedElement !== null &&
-          inspectedElement.type === ElementTypeFunction &&
           inspectedElement.hooks !== null &&
           loadHookNamesFunction !== null
         ) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.css
@@ -82,3 +82,7 @@
 .HookName {
   color: var(--color-component-name);
 }
+
+.ToggleError {
+  color: var(--color-error-text);
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
@@ -64,6 +64,17 @@ export function InspectedElementHooksTree({
     toggleParseHookNames();
   };
 
+  const hookParsingFailed = parseHookNames && hookNames === null;
+
+  let toggleTitle;
+  if (hookParsingFailed) {
+    toggleTitle = 'Hook parsing failed';
+  } else if (parseHookNames) {
+    toggleTitle = 'Parsing hook names ...';
+  } else {
+    toggleTitle = 'Parse hook names (may be slow)';
+  }
+
   const handleCopy = () => copy(serializeHooksForCopy(hooks));
 
   if (hooks === null) {
@@ -73,16 +84,13 @@ export function InspectedElementHooksTree({
       <div className={styles.HooksTreeView}>
         <div className={styles.HeaderRow}>
           <div className={styles.Header}>hooks</div>
-          {enableHookNameParsing && !parseHookNames && (
+          {enableHookNameParsing && (!parseHookNames || hookParsingFailed) && (
             <Toggle
+              className={hookParsingFailed ? styles.ToggleError : null}
               isChecked={parseHookNamesOptimistic}
-              isDisabled={parseHookNamesOptimistic}
+              isDisabled={parseHookNamesOptimistic || hookParsingFailed}
               onChange={handleChange}
-              title={
-                parseHookNames
-                  ? 'Parse hook names'
-                  : 'Parse hook names (may be slow)'
-              }>
+              title={toggleTitle}>
               <ButtonIcon type="parse-hook-names" />
             </Toggle>
           )}


### PR DESCRIPTION
Resolves #21817

![hooknameerrorbadgeKapture 2021-07-07 at 16 06 08](https://user-images.githubusercontent.com/29597/124821917-45ae9300-df3d-11eb-9f3f-fdec9c187730.gif)
