### PR TITLE
Reset inspected element cache in the event of an error

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -102,8 +102,8 @@ export function InspectedElementContextController({children}: Props) {
   }
 
   // Don't load a stale element from the backend; it wastes bridge bandwidth.
-  let inspectedElement = null;
   let hookNames: HookNames | null = null;
+  let inspectedElement = null;
   if (!elementHasChanged && element !== null) {
     inspectedElement = inspectElement(element, state.path, store, bridge);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorBoundary.js
@@ -8,11 +8,14 @@
  */
 
 import * as React from 'react';
-import {useCallback, useContext} from 'react';
+import {
+  useCallback,
+  useContext,
+  unstable_useCacheRefresh as useCacheRefresh,
+} from 'react';
 import ErrorBoundary from '../ErrorBoundary';
 import {TreeStateContext} from './TreeContext';
-import {StoreContext} from '../context';
-import {getClearElementCallback} from '../../../inspectedElementCache';
+import {clearCacheBecauseOfError} from '../../../inspectedElementCache';
 import styles from './InspectedElementErrorBoundary.css';
 
 type WrapperProps = {|
@@ -26,22 +29,10 @@ export default function InspectedElementErrorBoundaryWrapper({
   // This seems best since an error inspecting one element isn't likely to be relevant to another element.
   const {selectedElementID} = useContext(TreeStateContext);
 
-  // Note that getClearElementCallback(), like useContext(), must be called during render.
-  const store = useContext(StoreContext);
-  const selectedElement =
-    selectedElementID !== null ? store.getElementByID(selectedElementID) : null;
-  const clearElementCallback = useCallback(
-    () =>
-      selectedElement !== null
-        ? getClearElementCallback(selectedElement)
-        : null,
-    [selectedElement],
-  );
+  const refresh = useCacheRefresh();
   const handleDsmiss = useCallback(() => {
-    if (clearElementCallback !== null) {
-      clearElementCallback();
-    }
-  }, [clearElementCallback]);
+    clearCacheBecauseOfError(refresh);
+  }, [refresh]);
 
   return (
     <div className={styles.Wrapper}>

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorBoundary.js
@@ -8,9 +8,11 @@
  */
 
 import * as React from 'react';
-import {useContext} from 'react';
+import {useCallback, useContext} from 'react';
 import ErrorBoundary from '../ErrorBoundary';
 import {TreeStateContext} from './TreeContext';
+import {StoreContext} from '../context';
+import {getClearElementCallback} from '../../../inspectedElementCache';
 import styles from './InspectedElementErrorBoundary.css';
 
 type WrapperProps = {|
@@ -23,9 +25,30 @@ export default function InspectedElementErrorBoundaryWrapper({
   // Key on the selected element ID so that changing the selected element automatically hides the boundary.
   // This seems best since an error inspecting one element isn't likely to be relevant to another element.
   const {selectedElementID} = useContext(TreeStateContext);
+
+  // Note that getClearElementCallback(), like useContext(), must be called during render.
+  const store = useContext(StoreContext);
+  const selectedElement =
+    selectedElementID !== null ? store.getElementByID(selectedElementID) : null;
+  const clearElementCallback = useCallback(
+    () =>
+      selectedElement !== null
+        ? getClearElementCallback(selectedElement)
+        : null,
+    [selectedElement],
+  );
+  const handleDsmiss = useCallback(() => {
+    if (clearElementCallback !== null) {
+      clearElementCallback();
+    }
+  }, [clearElementCallback]);
+
   return (
     <div className={styles.Wrapper}>
-      <ErrorBoundary key={selectedElementID} canDismiss={true}>
+      <ErrorBoundary
+        key={selectedElementID}
+        canDismiss={true}
+        onBeforeDismissCallback={handleDsmiss}>
         {children}
       </ErrorBoundary>
     </div>

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -17,6 +17,7 @@ import SuspendingErrorView from './SuspendingErrorView';
 type Props = {|
   children: React$Node,
   canDismiss?: boolean,
+  onBeforeDismissCallback?: () => void,
   store?: Store,
 |};
 
@@ -118,6 +119,11 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   _dismissError = () => {
+    const onBeforeDismissCallback = this.props.onBeforeDismissCallback;
+    if (typeof onBeforeDismissCallback === 'function') {
+      onBeforeDismissCallback();
+    }
+
     this.setState(InitialState);
   };
 

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -63,6 +63,19 @@ function getRecordMap(): WeakMap<Element, Record<InspectedElementFrontend>> {
   return getCacheForType(createMap);
 }
 
+/**
+ * Removes inspected element metadata from the cache.
+ *
+ * This function should only be called during render (since it reads from Context)
+ * and the callback it returns should be called prior to render.
+ */
+export function getClearElementCallback(element: Element): () => void {
+  const map = getRecordMap();
+  return function clearElementCallback(): void {
+    map.delete(element);
+  };
+}
+
 function createCacheSeed(
   element: Element,
   inspectedElement: InspectedElementFrontend,

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -63,19 +63,6 @@ function getRecordMap(): WeakMap<Element, Record<InspectedElementFrontend>> {
   return getCacheForType(createMap);
 }
 
-/**
- * Removes inspected element metadata from the cache.
- *
- * This function should only be called during render (since it reads from Context)
- * and the callback it returns should be called prior to render.
- */
-export function getClearElementCallback(element: Element): () => void {
-  const map = getRecordMap();
-  return function clearElementCallback(): void {
-    map.delete(element);
-  };
-}
-
 function createCacheSeed(
   element: Element,
   inspectedElement: InspectedElementFrontend,
@@ -202,4 +189,11 @@ export function checkForUpdate({
       },
     );
   }
+}
+
+export function clearCacheBecauseOfError(refresh: RefreshFunction): void {
+  startTransition(() => {
+    const map = createMap();
+    refresh(createMap, map);
+  });
 }


### PR DESCRIPTION
This prevents React from immediately erroring again when re-rendering (since the previous error would have been stored in the Suspense cache)

Resolves #21819