### PR TITLE
DevTools: Don't load source files contaning only unnamed hooks

### DIFF
--- a/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/ComponentWithExternalUseEffect.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/ComponentWithExternalUseEffect.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const {useState} = require('react');
+const {useCustom} = require('./useCustom');
+
+function Component(props) {
+  const [count] = useState(0);
+  useCustom();
+  return count;
+}
+
+module.exports = {Component};

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/useCustom.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/useCustom.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const {useEffect} = require('react');
+
+function useCustom() {
+  useEffect(() => {
+    // ...
+  }, []);
+}
+
+module.exports = {useCustom};

--- a/packages/react-devtools-extensions/src/astUtils.js
+++ b/packages/react-devtools-extensions/src/astUtils.js
@@ -292,13 +292,6 @@ function isHookName(name: string): boolean {
   return /^use[A-Z0-9].*$/.test(name);
 }
 
-// Determines whether incoming hook is a primitive hook that gets assigned to variables.
-export function isNonDeclarativePrimitiveHook(hook: HooksNode) {
-  return ['Effect', 'ImperativeHandle', 'LayoutEffect', 'DebugValue'].includes(
-    hook.name,
-  );
-}
-
 // Check if the AST Node COULD be a React Hook
 function isPotentialHookDeclaration(path: NodePath): boolean {
   // The array potentialHooksFound will contain all potential hook declaration cases we support


### PR DESCRIPTION
Filter these out earlier and avoid the extra processing.

Resolves #21834