### PR TITLE
DevTools: Show numbers of children by hover or select element

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -190,6 +190,7 @@ export default function Element({data, index, style}: Props) {
             }
           />
         )}
+        {isHovered || isSelected ? `[${element.children.length}]`: null}
       </div>
     </div>
   );


### PR DESCRIPTION
For knowing numbers of children by hover or select element

<img width="266" alt="Screen Shot 2021-07-09 at 01 12 18" src="https://user-images.githubusercontent.com/1549069/124988320-17bb7280-e053-11eb-8afe-501d9a0ceecc.png">
