### PR TITLE
Suspense layout effects: Failing test case

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let TestUtils;
+
+describe('ReactSuspenseEffectsSemanticsDOM', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    TestUtils = require('react-dom/test-utils');
+  });
+
+  it('should not cause a cycle when combined with a render phase update', () => {
+    let scheduleSuspendingUpdate;
+
+    function App() {
+      const [value, setValue] = React.useState(true);
+
+      scheduleSuspendingUpdate = () => setValue(!value);
+
+      return (
+        <>
+          <React.Suspense fallback="Loading...">
+            <ComponentThatCausesBug value={value} />
+            <ComponentThatSuspendsOnUpdate shouldSuspend={!value} />
+          </React.Suspense>
+        </>
+      );
+    }
+
+    function ComponentThatCausesBug({value}) {
+      const [mirroredValue, setMirroredValue] = React.useState(value);
+      if (mirroredValue !== value) {
+        setMirroredValue(value);
+      }
+
+      // eslint-disable-next-line no-unused-vars
+      const [_, setRef] = React.useState(null);
+
+      return <div ref={setRef} />;
+    }
+
+    const promise = Promise.resolve();
+
+    function ComponentThatSuspendsOnUpdate({shouldSuspend}) {
+      if (shouldSuspend) {
+        // Fake Suspend
+        throw promise;
+      }
+      return null;
+    }
+
+    TestUtils.act(() => {
+      const root = ReactDOM.createRoot(document.createElement('div'));
+      root.render(<App />);
+    });
+
+    TestUtils.act(() => {
+      scheduleSuspendingUpdate();
+    });
+  });
+});


### PR DESCRIPTION
The key components to this are:
1. State updater function as a `ref` setter.
2. Render-phase update, e.g. mirrored props-to-state ([not a generally recommended patter](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#anti-pattern-unconditionally-copying-props-to-state)).
3. Suspend in an update ([also not a common or recommended pattern](https://github.com/reactwg/react-18/discussions/31)).

This causes a cycle:
1. Ref gets set to null by React, which schedules a state update (because ref is `useState`)
2. Component schedules more work during the render phase (b'c of the mirrored value in state)
3. Repeat...

The reason `enableSuspenseLayoutEffectSemantics` is related to this issue is because React doesn't otherwise reset refs to `null` when an update suspends. (Note that React does eventually set the ref to null when the component unmounts, but since the component doesn't render again after, there's no render-phase update to cycle.)