### PR TITLE
Fix DevTools console announcement being suppressed by Fast Refresh

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -69,8 +69,13 @@ export function injectInternals(internals: Object): boolean {
       console.error('React instrumentation encountered an error: %s.', err);
     }
   }
-  // DevTools exists
-  return true;
+  if (hook.checkDCE) {
+    // This is the real DevTools.
+    return true;
+  } else {
+    // This is likely a hook installed by Fast Refresh runtime.
+    return false;
+  }
 }
 
 export function onScheduleRoot(root: FiberRoot, children: ReactNodeList) {

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
@@ -69,8 +69,13 @@ export function injectInternals(internals: Object): boolean {
       console.error('React instrumentation encountered an error: %s.', err);
     }
   }
-  // DevTools exists
-  return true;
+  if (hook.checkDCE) {
+    // This is the real DevTools.
+    return true;
+  } else {
+    // This is likely a hook installed by Fast Refresh runtime.
+    return false;
+  }
 }
 
 export function onScheduleRoot(root: FiberRoot, children: ReactNodeList) {


### PR DESCRIPTION
We show a console message in DEV for supported browsers that encourages you to install React DevTools. This isn't new: we've been showing this message for many years.

However, we've accidentally regressed because both DevTools and Fast Refresh Runtime install a global hook. So if you don't have the browser extension but you _do_ have Fast Refresh, we mistakingly detect it as you having the browser extension, and don't show the message. This should fix it to correctly detect whether you have React DevTools again.

I used `checkDCE` because:

1. We already rely on this field in the bundles themselves, so it's not adding a new dependency, and we probably won't remove it (unlike some implementation detail like `on` or `emit`).
2. There is no reason for it to ever exist in the Fast Refresh hook shim since it's only needed for real DevTools.
3. It doesn't require updating the Fast Refresh runtime to take effect.