### PR TITLE
Adjust Error stack columns numbers by 1

### DIFF
--- a/packages/react-devtools-extensions/src/astUtils.js
+++ b/packages/react-devtools-extensions/src/astUtils.js
@@ -40,6 +40,17 @@ function checkNodeLocation(
     return false;
   }
 
+  // Column numbers are representated differently between tools/engines.
+  // Error.prototype.stack columns are 1-based (like most IDEs) but ASTs are 0-based.
+  //
+  // In practice this will probably never matter,
+  // because this code matches the 1-based Error stack location for the hook Identifier (e.g. useState)
+  // with the larger 0-based VariableDeclarator (e.g. [foo, setFoo] = useState())
+  // so the ranges should always overlap.
+  //
+  // For more info see https://github.com/facebook/react/pull/21833#discussion_r666831276
+  column -= 1;
+
   if (
     (line === start.line && column < start.column) ||
     (line === end.line && column > end.column)

--- a/packages/react-devtools-extensions/src/parseHookNames.js
+++ b/packages/react-devtools-extensions/src/parseHookNames.js
@@ -378,6 +378,7 @@ function findHookNames(
         line: lineNumber,
 
         // Column numbers are representated differently between tools/engines.
+        // Error.prototype.stack columns are 1-based (like most IDEs) but ASTs are 0-based.
         // For more info see https://github.com/facebook/react/issues/21792#issuecomment-873171991
         column: columnNumber - 1,
       });
@@ -476,6 +477,7 @@ async function parseSourceAST(
         line: lineNumber,
 
         // Column numbers are representated differently between tools/engines.
+        // Error.prototype.stack columns are 1-based (like most IDEs) but ASTs are 0-based.
         // For more info see https://github.com/facebook/react/issues/21792#issuecomment-873171991
         column: columnNumber - 1,
       });


### PR DESCRIPTION
Follow up for https://github.com/facebook/react/pull/21833#discussion_r666831276. Resolves #21792.

This change accounts for differences between error stacks (1-based) and ASTs (0-based). In practice this change should not make an observable difference.

In practice, the change should never matter, because we are matching the 1-based Error stack location for the hook `Identifier` (e.g. `useState`) against the larger 0-based `VariableDeclarator` (e.g. `[foo, setFoo] = useState()`) so the ranges will always overlap. Because of this, I don't think it's possible to write an integration test that would fail without this change.