### PR TITLE
[Bugfix] Don't hide/unhide unless visibility changes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -9,7 +9,11 @@
 
 import type {Fiber} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.old';
-import type {ReactScopeInstance, ReactContext} from 'shared/ReactTypes';
+import type {
+  ReactScopeInstance,
+  ReactContext,
+  Wakeable,
+} from 'shared/ReactTypes';
 import type {FiberRoot} from './ReactInternalTypes';
 import type {
   Instance,
@@ -60,6 +64,7 @@ import {
   Ref,
   RefStatic,
   Update,
+  Visibility,
   NoFlags,
   DidCapture,
   Snapshot,
@@ -320,7 +325,7 @@ if (supportsMutation) {
         // down its children. Instead, we'll get insertions from each child in
         // the portal directly.
       } else if (node.tag === SuspenseComponent) {
-        if ((node.flags & Update) !== NoFlags) {
+        if ((node.flags & Visibility) !== NoFlags) {
           // Need to toggle the visibility of the primary children.
           const newIsHidden = node.memoizedState !== null;
           if (newIsHidden) {
@@ -405,7 +410,7 @@ if (supportsMutation) {
         // down its children. Instead, we'll get insertions from each child in
         // the portal directly.
       } else if (node.tag === SuspenseComponent) {
-        if ((node.flags & Update) !== NoFlags) {
+        if ((node.flags & Visibility) !== NoFlags) {
           // Need to toggle the visibility of the primary children.
           const newIsHidden = node.memoizedState !== null;
           if (newIsHidden) {
@@ -1084,32 +1089,40 @@ function completeWork(
         }
       }
 
-      if (supportsPersistence) {
-        // TODO: Only schedule updates if not prevDidTimeout.
-        if (nextDidTimeout) {
-          // If this boundary just timed out, schedule an effect to attach a
-          // retry listener to the promise. This flag is also used to hide the
-          // primary children.
-          workInProgress.flags |= Update;
-        }
+      const wakeables: Set<Wakeable> | null = (workInProgress.updateQueue: any);
+      if (wakeables !== null) {
+        // Schedule an effect to attach a retry listener to the promise.
+        // TODO: Move to passive phase
+        workInProgress.flags |= Update;
       }
+
       if (supportsMutation) {
-        // TODO: Only schedule updates if these values are non equal, i.e. it changed.
-        if (nextDidTimeout || prevDidTimeout) {
-          // If this boundary just timed out, schedule an effect to attach a
-          // retry listener to the promise. This flag is also used to hide the
-          // primary children. In mutation mode, we also need the flag to
-          // *unhide* children that were previously hidden, so check if this
-          // is currently timed out, too.
-          workInProgress.flags |= Update;
+        if (nextDidTimeout !== prevDidTimeout) {
+          // In mutation mode, visibility is toggled by mutating the nearest
+          // host nodes whenever they switch from hidden -> visible or vice
+          // versa. We don't need to switch when the boundary updates but its
+          // visibility hasn't changed.
+          workInProgress.flags |= Visibility;
         }
       }
+      if (supportsPersistence) {
+        if (nextDidTimeout) {
+          // In persistent mode, visibility is toggled by cloning the nearest
+          // host nodes in the complete phase whenever the boundary is hidden.
+          // TODO: The plan is to add a transparent host wrapper (no layout)
+          // around the primary children and hide that node. Then we don't need
+          // to do the funky cloning business.
+          workInProgress.flags |= Visibility;
+        }
+      }
+
       if (
         enableSuspenseCallback &&
         workInProgress.updateQueue !== null &&
         workInProgress.memoizedProps.suspenseCallback != null
       ) {
         // Always notify the callback
+        // TODO: Move to passive phase
         workInProgress.flags |= Update;
       }
       bubbleProperties(workInProgress);
@@ -1396,7 +1409,7 @@ function completeWork(
           prevIsHidden !== nextIsHidden &&
           newProps.mode !== 'unstable-defer-without-hiding'
         ) {
-          workInProgress.flags |= Update;
+          workInProgress.flags |= Visibility;
         }
       }
 

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -82,7 +82,7 @@ export const MutationMask =
   Ref |
   Hydrating |
   Visibility;
-export const LayoutMask = Update | Callback | Ref;
+export const LayoutMask = Update | Callback | Ref | Visibility;
 
 // TODO: Split into PassiveMountMask and PassiveUnmountMask
 export const PassiveMask = Passive | ChildDeletion;

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let React;
+let ReactDOM;
+let act;
+
+describe('ReactSuspenseEffectsSemanticsDOM', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactDOM = require('react-dom');
+    act = require('jest-react').act;
+  });
+
+  it('should not cause a cycle when combined with a render phase update', () => {
+    let scheduleSuspendingUpdate;
+
+    function App() {
+      const [value, setValue] = React.useState(true);
+
+      scheduleSuspendingUpdate = () => setValue(!value);
+
+      return (
+        <>
+          <React.Suspense fallback="Loading...">
+            <ComponentThatCausesBug value={value} />
+            <ComponentThatSuspendsOnUpdate shouldSuspend={!value} />
+          </React.Suspense>
+        </>
+      );
+    }
+
+    function ComponentThatCausesBug({value}) {
+      const [mirroredValue, setMirroredValue] = React.useState(value);
+      if (mirroredValue !== value) {
+        setMirroredValue(value);
+      }
+
+      // eslint-disable-next-line no-unused-vars
+      const [_, setRef] = React.useState(null);
+
+      return <div ref={setRef} />;
+    }
+
+    const promise = Promise.resolve();
+
+    function ComponentThatSuspendsOnUpdate({shouldSuspend}) {
+      if (shouldSuspend) {
+        // Fake Suspend
+        throw promise;
+      }
+      return null;
+    }
+
+    act(() => {
+      const root = ReactDOM.createRoot(document.createElement('div'));
+      root.render(<App />);
+    });
+
+    act(() => {
+      scheduleSuspendingUpdate();
+    });
+  });
+});


### PR DESCRIPTION
Instead of the Update flag, which is also used for other side-effects, like refs.

I originally added the Visibility flag for this purpose in #20043 but it got reverted last winter when we were bisecting the effects refactor.

Fixes #21853
Fixes #21876