### PR TITLE
devtools: Add `ref` to inspect element view

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2518,4 +2518,79 @@ describe('InspectedElement', () => {
       );
     });
   });
+
+  describe('refs', () => {
+    it('has no ref by default', async () => {
+      const container = document.createElement('div');
+      function Example() {
+        return <div />;
+      }
+      await utils.actAsync(() => legacyRender(<Example />, container));
+
+      const inspectedElement = await inspectElementAtIndex(0);
+      expect(inspectedElement.ref).toEqual(null);
+    });
+
+    it('supports useRef on host components', async () => {
+      const container = document.createElement('div');
+      const ForwardRefComponent = React.forwardRef((props, ref) => (
+        <div ref={ref} />
+      ));
+      function Example() {
+        const ref = React.useRef(null);
+        return <ForwardRefComponent ref={ref} />;
+      }
+      await utils.actAsync(() => legacyRender(<Example />, container));
+
+      const inspectedElement = await inspectElementAtIndex(1);
+      expect(inspectedElement.ref).toMatchInlineSnapshot(`
+        Object {
+          "current": Dehydrated {
+            "preview_short": <div />,
+            "preview_long": <div />,
+          },
+        }
+      `);
+    });
+
+    it('supports useRef on class components', async () => {
+      const container = document.createElement('div');
+      class ClassComponent extends React.Component {
+        render() {
+          return null;
+        }
+      }
+      function Example() {
+        const ref = React.useRef(null);
+        return <ClassComponent ref={ref} />;
+      }
+      await utils.actAsync(() => legacyRender(<Example />, container));
+
+      const inspectedElement = await inspectElementAtIndex(1);
+      expect(inspectedElement.ref).toEqual({current: expect.any(Object)});
+    });
+
+    it('supports ref callbacks', async () => {
+      const container = document.createElement('div');
+      const ForwardRefComponent = React.forwardRef((props, ref) => (
+        <div ref={ref} />
+      ));
+      function Example() {
+        const ref = () => {};
+        return <ForwardRefComponent ref={ref} />;
+      }
+      await utils.actAsync(() => legacyRender(<Example />, container));
+
+      const inspectedElement = await inspectElementAtIndex(1);
+      expect(inspectedElement.ref).toMatchInlineSnapshot(`
+        Object {
+          "inspectable": false,
+          "name": "ref",
+          "preview_long": "ƒ ref() {}",
+          "preview_short": "ƒ ref() {}",
+          "type": "function",
+        }
+      `);
+    });
+  });
 });

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -820,6 +820,9 @@ export function attach(
 
       key: key != null ? key : null,
 
+      // TODO: Support in legacy versions?
+      ref: null,
+
       // Inspectable properties.
       context,
       hooks: null,

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2980,6 +2980,7 @@ export function attach(
       memoizedProps,
       memoizedState,
       dependencies,
+      ref,
       tag,
       type,
     } = fiber;
@@ -3173,6 +3174,8 @@ export function attach(
       hasLegacyContext,
 
       key: key != null ? key : null,
+
+      ref,
 
       displayName: getDisplayNameForFiber(fiber),
       type: elementType,
@@ -3440,6 +3443,10 @@ export function attach(
     cleanedInspectedElement.state = cleanForBridge(
       cleanedInspectedElement.state,
       createIsPathAllowed('state', null),
+    );
+    cleanedInspectedElement.ref = cleanForBridge(
+      cleanedInspectedElement.ref,
+      createIsPathAllowed('ref', null),
     );
 
     return {

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -246,6 +246,7 @@ export type InspectedElement = {|
   props: Object | null,
   state: Object | null,
   key: number | string | null,
+  ref: Object | Function | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
 

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -210,6 +210,7 @@ export function convertInspectedElementBackendToFrontend(
     key,
     errors,
     warnings,
+    ref,
   } = inspectedElementBackend;
 
   const inspectedElement: InspectedElementFrontend = {
@@ -252,6 +253,7 @@ export function convertInspectedElementBackendToFrontend(
     state: hydrateHelper(state),
     errors,
     warnings,
+    ref: hydrateHelper(ref),
   };
 
   return inspectedElement;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementRefTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementRefTree.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {copy} from 'clipboard-js';
+import * as React from 'react';
+import Button from '../Button';
+import ButtonIcon from '../ButtonIcon';
+import KeyValue from './KeyValue';
+import {serializeDataForCopy} from '../utils';
+import Store from '../../store';
+import styles from './InspectedElementSharedStyles.css';
+
+import type {InspectedElement} from './types';
+import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+import type {Element} from 'react-devtools-shared/src/devtools/views/Components/types';
+
+type Props = {|
+  bridge: FrontendBridge,
+  element: Element,
+  inspectedElement: InspectedElement,
+  store: Store,
+|};
+
+export default function InspectedElementPropsTree({
+  bridge,
+  element,
+  inspectedElement,
+  store,
+}: Props) {
+  const {ref} = inspectedElement;
+
+  if (ref === null) {
+    return null;
+  }
+
+  const handleCopy = () => copy(serializeDataForCopy({ref}));
+
+  return (
+    <div className={styles.InspectedElementTree}>
+      <div className={styles.HeaderRow}>
+        <div className={styles.Header}>Ref</div>
+        <Button onClick={handleCopy} title="Copy to clipboard">
+          <ButtonIcon type="copy" />
+        </Button>
+      </div>
+      <KeyValue
+        key="value"
+        alphaSort={true}
+        bridge={bridge}
+        canDeletePaths={false}
+        canEditValues={false}
+        canRenamePaths={false}
+        depth={1}
+        element={element}
+        hidden={false}
+        inspectedElement={inspectedElement}
+        name={'ref'}
+        path={['value']}
+        pathRoot="ref"
+        store={store}
+        value={ref}
+      />
+    </div>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementView.js
@@ -22,6 +22,7 @@ import InspectedElementContextTree from './InspectedElementContextTree';
 import InspectedElementErrorsAndWarningsTree from './InspectedElementErrorsAndWarningsTree';
 import InspectedElementHooksTree from './InspectedElementHooksTree';
 import InspectedElementPropsTree from './InspectedElementPropsTree';
+import InspectedElementRefTree from './InspectedElementRefTree';
 import InspectedElementStateTree from './InspectedElementStateTree';
 import InspectedElementSuspenseToggle from './InspectedElementSuspenseToggle';
 import NativeStyleEditor from './NativeStyleEditor';
@@ -125,6 +126,13 @@ export default function InspectedElementView({
         />
 
         <InspectedElementErrorsAndWarningsTree
+          bridge={bridge}
+          element={element}
+          inspectedElement={inspectedElement}
+          store={store}
+        />
+
+        <InspectedElementRefTree
           bridge={bridge}
           element={element}
           inspectedElement={inspectedElement}

--- a/packages/react-devtools-shared/src/devtools/views/Components/types.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/types.js
@@ -96,6 +96,7 @@ export type InspectedElement = {|
   props: Object | null,
   state: Object | null,
   key: number | string | null,
+  ref: Object | Function | null,
   errors: Array<[string, number]>,
   warnings: Array<[string, number]>,
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -510,7 +510,11 @@ export function getDataType(data: Object): DataType {
     return 'react_element';
   }
 
-  if (typeof HTMLElement !== 'undefined' && data instanceof HTMLElement) {
+  if (
+    (typeof HTMLElement !== 'undefined' && data instanceof HTMLElement) ||
+    // cross-realm HTMLElement?
+    /^\[object HTML.+Element\]$/.test(Object.prototype.toString.call(data))
+  ) {
     return 'html_element';
   }
 

--- a/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/InspectableElements.js
@@ -18,6 +18,7 @@ import EdgeCaseObjects from './EdgeCaseObjects.js';
 import NestedProps from './NestedProps';
 import SimpleValues from './SimpleValues';
 import SymbolKeys from './SymbolKeys';
+import Refs from './Refs';
 
 // TODO Add Immutable JS example
 
@@ -34,6 +35,7 @@ export default function InspectableElements() {
       <EdgeCaseObjects />
       <CircularReferences />
       <SymbolKeys />
+      <Refs />
     </Fragment>
   );
 }

--- a/packages/react-devtools-shell/src/app/InspectableElements/Refs.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/Refs.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+
+const ForwardRefComponent = React.forwardRef(function ForwardRefComponent(
+  props,
+  ref,
+) {
+  return <div ref={ref} />;
+});
+
+class ClassComponent extends React.Component {
+  render() {
+    return null;
+  }
+}
+
+export default function Refs() {
+  const hostRef = React.useRef(null);
+  const classComponentRef = React.useRef(null);
+  const forwardRefComponentRef = React.useRef(null);
+
+  return (
+    <React.Fragment>
+      <div data-testid="has-no-ref" />
+      <div ref={hostRef} />
+      <div ref={() => {}} />
+      <ClassComponent ref={classComponentRef} />
+      <ForwardRefComponent ref={forwardRefComponentRef} />
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION

## Summary

Displays the `ref` of an inspected element if the element has one.

The UI feels a bit lost since we only have a single value in this new section. Ideally we'd have the `key` in the view too so we could create a "Misc" view. 

On the other hand, the `ref` will eventually be just another prop (if I understood https://github.com/reactjs/rfcs/pull/107 correctly) so it'll merge with the props view eventually.

## Test Plan

- [x] Tested in shell
- [ ] CI green
