### PR TITLE
Add comment support to `@gate` pragma

### DIFF
--- a/scripts/babel/__tests__/transform-test-gate-pragma-test.js
+++ b/scripts/babel/__tests__/transform-test-gate-pragma-test.js
@@ -160,6 +160,11 @@ describe('transform-test-gate-pragma', () => {
   test('single quoted strings', () => {
     expect(shouldPass).toBe(true);
   });
+
+  // @gate flagThatIsOn // This is a comment
+  test('line comment', () => {
+    expect(shouldPass).toBe(true);
+  });
 });
 
 describe('transform test-gate-pragma: actual runtime', () => {

--- a/scripts/babel/transform-test-gate-pragma.js
+++ b/scripts/babel/transform-test-gate-pragma.js
@@ -93,6 +93,10 @@ function transform(babel) {
           tokens.push({type: next2});
           i += 2;
           continue;
+        case '//':
+          // This is the beginning of a line comment. The rest of the line
+          // is ignored.
+          return tokens;
       }
 
       switch (char) {


### PR DESCRIPTION
So you can more easily comment on why a test is gated.