### PR TITLE
[DevTools] Disable sizeBot on DevTools Rull Request

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -113,6 +113,17 @@ function row(result) {
     return;
   }
 
+  // Disable sizeBot in a Devtools Pull Request. Because that doesn't affect production bundle size.
+  const commitFiles = [
+    ...danger.git.created_files,
+    ...danger.git.deleted_files,
+    ...danger.git.modified_files,
+  ];
+  if (
+    commitFiles.every(filename => filename.includes('packages/react-devtools'))
+  )
+    return;
+
   const resultsMap = new Map();
 
   // Find all the head (current) artifacts paths.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -113,10 +113,6 @@ function row(result) {
     return;
   }
 
-  // Disable sizeBot in a Devtools PR like bellow title. Because that doesn't affect production bundle size.
-  // [Fix DevTools console announcement being suppressed by Fast Refresh #21864](https://github.com/facebook/react/pull/21864)
-  if (new RegExp('devtools?', 'i').test(danger.github.pr.title)) return;
-
   const resultsMap = new Map();
 
   // Find all the head (current) artifacts paths.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -113,6 +113,10 @@ function row(result) {
     return;
   }
 
+  // Disable sizeBot in a Devtools PR like bellow title. Because that doesn't affect production bundle size.
+  // [Fix DevTools console announcement being suppressed by Fast Refresh #21864](https://github.com/facebook/react/pull/21864)
+  if (new RegExp('devtools?', 'i').test(danger.github.pr.title)) return;
+
   const resultsMap = new Map();
 
   // Find all the head (current) artifacts paths.


### PR DESCRIPTION
Because DevTools code doesn't affect production bundle size.
Meaningless sizeBot comment give us frastration within Pull Request discussion.