### PR TITLE
Clean up flushSync flow types

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -132,7 +132,7 @@ describe('ReactDOMFiberAsync', () => {
   it('flushSync logs an error if already performing work', () => {
     class Component extends React.Component {
       componentDidUpdate() {
-        ReactDOM.flushSync(() => {});
+        ReactDOM.flushSync();
       }
       render() {
         return null;

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -913,10 +913,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
       }
     },
 
-    flushSync(fn: () => mixed) {
-      NoopRenderer.flushSync(fn);
-    },
-
+    flushSync: NoopRenderer.flushSync,
     flushPassiveEffects: NoopRenderer.flushPassiveEffects,
 
     // Logs the current state of the tree.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1093,10 +1093,13 @@ export function discreteUpdates<A, B, C, D, R>(
   }
 }
 
-export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
-  fn: A => R,
-  a: A,
-): R {
+// Overload the definition to the two valid signatures.
+// Warning, this opts-out of checking the function body.
+declare function flushSyncWithoutWarningIfAlreadyRendering<R>(fn: () => R): R;
+// eslint-disable-next-line no-redeclare
+declare function flushSyncWithoutWarningIfAlreadyRendering(): void;
+// eslint-disable-next-line no-redeclare
+export function flushSyncWithoutWarningIfAlreadyRendering(fn) {
   // In legacy mode, we flush pending passive effects at the beginning of the
   // next event, not at the end of the previous one.
   if (
@@ -1116,9 +1119,9 @@ export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
     ReactCurrentBatchConfig.transition = 0;
     setCurrentUpdatePriority(DiscreteEventPriority);
     if (fn) {
-      return fn(a);
+      return fn();
     } else {
-      return (undefined: $FlowFixMe);
+      return undefined;
     }
   } finally {
     setCurrentUpdatePriority(previousPriority);
@@ -1133,7 +1136,13 @@ export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
   }
 }
 
-export function flushSync<A, R>(fn: A => R, a: A): R {
+// Overload the definition to the two valid signatures.
+// Warning, this opts-out of checking the function body.
+declare function flushSync<R>(fn: () => R): R;
+// eslint-disable-next-line no-redeclare
+declare function flushSync(): void;
+// eslint-disable-next-line no-redeclare
+export function flushSync(fn) {
   if (__DEV__) {
     if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
       console.error(
@@ -1143,7 +1152,7 @@ export function flushSync<A, R>(fn: A => R, a: A): R {
       );
     }
   }
-  return flushSyncWithoutWarningIfAlreadyRendering(fn, a);
+  return flushSyncWithoutWarningIfAlreadyRendering(fn);
 }
 
 export function flushControlled(fn: () => mixed): void {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1093,10 +1093,13 @@ export function discreteUpdates<A, B, C, D, R>(
   }
 }
 
-export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
-  fn: A => R,
-  a: A,
-): R {
+// Overload the definition to the two valid signatures.
+// Warning, this opts-out of checking the function body.
+declare function flushSyncWithoutWarningIfAlreadyRendering<R>(fn: () => R): R;
+// eslint-disable-next-line no-redeclare
+declare function flushSyncWithoutWarningIfAlreadyRendering(): void;
+// eslint-disable-next-line no-redeclare
+export function flushSyncWithoutWarningIfAlreadyRendering(fn) {
   // In legacy mode, we flush pending passive effects at the beginning of the
   // next event, not at the end of the previous one.
   if (
@@ -1116,9 +1119,9 @@ export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
     ReactCurrentBatchConfig.transition = 0;
     setCurrentUpdatePriority(DiscreteEventPriority);
     if (fn) {
-      return fn(a);
+      return fn();
     } else {
-      return (undefined: $FlowFixMe);
+      return undefined;
     }
   } finally {
     setCurrentUpdatePriority(previousPriority);
@@ -1133,7 +1136,13 @@ export function flushSyncWithoutWarningIfAlreadyRendering<A, R>(
   }
 }
 
-export function flushSync<A, R>(fn: A => R, a: A): R {
+// Overload the definition to the two valid signatures.
+// Warning, this opts-out of checking the function body.
+declare function flushSync<R>(fn: () => R): R;
+// eslint-disable-next-line no-redeclare
+declare function flushSync(): void;
+// eslint-disable-next-line no-redeclare
+export function flushSync(fn) {
   if (__DEV__) {
     if ((executionContext & (RenderContext | CommitContext)) !== NoContext) {
       console.error(
@@ -1143,7 +1152,7 @@ export function flushSync<A, R>(fn: A => R, a: A): R {
       );
     }
   }
-  return flushSyncWithoutWarningIfAlreadyRendering(fn, a);
+  return flushSyncWithoutWarningIfAlreadyRendering(fn);
 }
 
 export function flushControlled(fn: () => mixed): void {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -536,9 +536,7 @@ function create(element: React$Element<any>, options: TestRendererOptions) {
       return getPublicRootInstance(root);
     },
 
-    unstable_flushSync<T>(fn: () => T): T {
-      return flushSync(fn);
-    },
+    unstable_flushSync: flushSync,
   };
 
   Object.defineProperty(


### PR DESCRIPTION
## Overview

Makes the callback function optional and cleans up the type to make it consistent and correct everywhere.