### PR TITLE
Refactor "reappear" logic into its own traversal

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -501,30 +501,18 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     await rejectText('Result', new Error('Failed to load: Result'));
 
-    gate(flags => {
-      if (flags.enableSuspenseLayoutEffectSemantics) {
-        expect(Scheduler).toFlushAndYield([
-          'Error! [Result]',
+    expect(Scheduler).toFlushAndYield([
+      'Error! [Result]',
 
-          // React retries one more time
-          'Error! [Result]',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([]);
-      } else {
-        expect(Scheduler).toFlushAndYield([
-          'Error! [Result]',
+      // React retries one more time
+      'Error! [Result]',
 
-          // React retries one more time
-          'Error! [Result]',
-
-          // Errored again on retry. Now handle it.
-          'Caught error: Failed to load: Result',
-        ]);
-        expect(ReactNoop.getChildren()).toEqual([
-          span('Caught error: Failed to load: Result'),
-        ]);
-      }
-    });
+      // Errored again on retry. Now handle it.
+      'Caught error: Failed to load: Result',
+    ]);
+    expect(ReactNoop.getChildren()).toEqual([
+      span('Caught error: Failed to load: Result'),
+    ]);
   });
 
   // @gate enableCache


### PR DESCRIPTION
When a Suspense boundary switches to its fallback state — or similarly, when an Offscreen boundary switches from visible to hidden — we unmount all its layout effects. When it resolves — or when Offscreen switches back to visible — we mount them again. This "reappearing" logic currently happens in the same commit phase traversal where we perform normal layout effects.

I've changed it so that the "reappear" logic happens in its own recursive traversal that is separate from the commit phase one.

In the next step, I will do the same for the "disappear" logic that currently lives in the `hideOrUnhideAllChildren` function.

There are a few reasons to model it this way, related to future Offscreen features that we have planned. For example, we intend to provide an imperative API to "appear" and "reappear" all the effects within an Offscreen boundary. This API would be called from outside the commit phase, during an arbitrary event. Which means it can't rely on the regular commit phase — it's not part of a commit. This isn't the only motivation but it illustrates why the separation makes sense.