### PR TITLE
react-devtools: set icon on macos

### DIFF
--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -9,6 +9,7 @@
 
 const {app, BrowserWindow} = require('electron'); // Module to create native browser window.
 const {join} = require('path');
+const os = require('os');
 
 const argv = require('minimist')(process.argv.slice(2));
 const projectRoots = argv._;
@@ -31,6 +32,11 @@ app.on('ready', function() {
       nodeIntegration: true,
     },
   });
+
+  // set dock icon for macos
+  if (os.platform() === 'darwin') {
+    app.dock.setIcon(join(__dirname, 'icons/icon128.png'));
+  }
 
   // https://stackoverflow.com/questions/32402327/
   mainWindow.webContents.on('new-window', function(event, url) {


### PR DESCRIPTION
## Summary

Running `react-devtools` on MacOS shows the default electron icon in the dock.

## Test Plan
```bash
cd packages/react-devtools/
yarn start
```
Observe that the dock icon is now the correct react icon.
