### PR TITLE
break up import keyword

### DIFF
--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -88,7 +88,8 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     if (__DEV__) {
       if (moduleObject === undefined) {
         console.error(
-          'lazy: Expected the result of a dynamic import() call. ' +
+          'lazy: Expected the result of a dynamic imp' +
+            'ort() call. ' +
             'Instead received: %s\n\nYour code should look like: \n  ' +
             // Break up imports to avoid accidentally parsing them as dependencies.
             'const MyComponent = lazy(() => imp' +
@@ -101,7 +102,8 @@ function lazyInitializer<T>(payload: Payload<T>): T {
     if (__DEV__) {
       if (!('default' in moduleObject)) {
         console.error(
-          'lazy: Expected the result of a dynamic import() call. ' +
+          'lazy: Expected the result of a dynamic imp' +
+            'ort() call. ' +
             'Instead received: %s\n\nYour code should look like: \n  ' +
             // Break up imports to avoid accidentally parsing them as dependencies.
             'const MyComponent = lazy(() => imp' +


### PR DESCRIPTION
## Summary

Break up import keyword to avoid being accidentally parsed as dynamic import statement in external code.

Related discussioin issue: https://github.com/facebook/react/issues/21910