### PR TITLE
Clean-up: Move visibility toggling logic from Suspense fiber to Offscreen fiber

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2121,34 +2121,12 @@ function commitMutationEffectsOnFiber(finishedWork: Fiber, root: FiberRoot) {
       case SuspenseComponent: {
         const newState: OffscreenState | null = finishedWork.memoizedState;
         const isHidden = newState !== null;
-        const current = finishedWork.alternate;
-        const wasHidden = current !== null && current.memoizedState !== null;
-        const offscreenBoundary: Fiber = (finishedWork.child: any);
-
         if (isHidden) {
+          const current = finishedWork.alternate;
+          const wasHidden = current !== null && current.memoizedState !== null;
           if (!wasHidden) {
+            // TODO: Move to passive phase
             markCommitTimeOfFallback();
-            if (supportsMutation) {
-              hideOrUnhideAllChildren(offscreenBoundary, true);
-            }
-            if (
-              enableSuspenseLayoutEffectSemantics &&
-              (offscreenBoundary.mode & ConcurrentMode) !== NoMode
-            ) {
-              let offscreenChild = offscreenBoundary.child;
-              while (offscreenChild !== null) {
-                nextEffect = offscreenChild;
-                disappearLayoutEffects_begin(offscreenChild);
-                offscreenChild = offscreenChild.sibling;
-              }
-            }
-          }
-        } else {
-          if (wasHidden) {
-            if (supportsMutation) {
-              hideOrUnhideAllChildren(offscreenBoundary, false);
-            }
-            // TODO: Move re-appear call here for symmetry?
           }
         }
         break;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2121,34 +2121,12 @@ function commitMutationEffectsOnFiber(finishedWork: Fiber, root: FiberRoot) {
       case SuspenseComponent: {
         const newState: OffscreenState | null = finishedWork.memoizedState;
         const isHidden = newState !== null;
-        const current = finishedWork.alternate;
-        const wasHidden = current !== null && current.memoizedState !== null;
-        const offscreenBoundary: Fiber = (finishedWork.child: any);
-
         if (isHidden) {
+          const current = finishedWork.alternate;
+          const wasHidden = current !== null && current.memoizedState !== null;
           if (!wasHidden) {
+            // TODO: Move to passive phase
             markCommitTimeOfFallback();
-            if (supportsMutation) {
-              hideOrUnhideAllChildren(offscreenBoundary, true);
-            }
-            if (
-              enableSuspenseLayoutEffectSemantics &&
-              (offscreenBoundary.mode & ConcurrentMode) !== NoMode
-            ) {
-              let offscreenChild = offscreenBoundary.child;
-              while (offscreenChild !== null) {
-                nextEffect = offscreenChild;
-                disappearLayoutEffects_begin(offscreenChild);
-                offscreenChild = offscreenChild.sibling;
-              }
-            }
-          }
-        } else {
-          if (wasHidden) {
-            if (supportsMutation) {
-              hideOrUnhideAllChildren(offscreenBoundary, false);
-            }
-            // TODO: Move re-appear call here for symmetry?
           }
         }
         break;

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -201,10 +201,14 @@ describe('ReactOffscreen', () => {
     });
     // No layout effect.
     expect(Scheduler).toHaveYielded(['Child']);
-    // TODO: Offscreen does not yet hide/unhide children correctly. Until we do,
-    // it should only be used inside a host component wrapper whose visibility
-    // is toggled simultaneously.
-    expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    if (gate(flags => flags.persistent)) {
+      expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
+    } else {
+      // TODO: Offscreen does not yet hide/unhide children correctly in mutation
+      // mode. Until we do, it should only be used inside a host component
+      // wrapper whose visibility is toggled simultaneously.
+      expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    }
 
     // Unhide the tree. The layout effect is mounted.
     await act(async () => {
@@ -251,10 +255,14 @@ describe('ReactOffscreen', () => {
       );
     });
     expect(Scheduler).toHaveYielded(['Unmount layout', 'Child']);
-    // TODO: Offscreen does not yet hide/unhide children correctly. Until we do,
-    // it should only be used inside a host component wrapper whose visibility
-    // is toggled simultaneously.
-    expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    if (gate(flags => flags.persistent)) {
+      expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
+    } else {
+      // TODO: Offscreen does not yet hide/unhide children correctly in mutation
+      // mode. Until we do, it should only be used inside a host component
+      // wrapper whose visibility is toggled simultaneously.
+      expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    }
 
     // Unhide the tree. The layout effect is re-mounted.
     await act(async () => {
@@ -291,10 +299,14 @@ describe('ReactOffscreen', () => {
       );
     });
     expect(Scheduler).toHaveYielded(['Child']);
-    // TODO: Offscreen does not yet hide/unhide children correctly. Until we do,
-    // it should only be used inside a host component wrapper whose visibility
-    // is toggled simultaneously.
-    expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    if (gate(flags => flags.persistent)) {
+      expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
+    } else {
+      // TODO: Offscreen does not yet hide/unhide children correctly in mutation
+      // mode. Until we do, it should only be used inside a host component
+      // wrapper whose visibility is toggled simultaneously.
+      expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    }
 
     // Show the tree. The layout effect is mounted.
     await act(async () => {
@@ -316,9 +328,13 @@ describe('ReactOffscreen', () => {
       );
     });
     expect(Scheduler).toHaveYielded(['Unmount layout', 'Child']);
-    // TODO: Offscreen does not yet hide/unhide children correctly. Until we do,
-    // it should only be used inside a host component wrapper whose visibility
-    // is toggled simultaneously.
-    expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    if (gate(flags => flags.persistent)) {
+      expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
+    } else {
+      // TODO: Offscreen does not yet hide/unhide children correctly in mutation
+      // mode. Until we do, it should only be used inside a host component
+      // wrapper whose visibility is toggled simultaneously.
+      expect(root).toMatchRenderedOutput(<span prop="Child" />);
+    }
   });
 });


### PR DESCRIPTION
Much of the visibility-toggling logic is shared between the Suspense and Offscreen types, but there is some duplicated code that exists in both. Specifically, when a Suspense fiber's state switches from suspended to resolved, we schedule an effect on the parent Suspense fiber, rather than the inner Offscreen fiber. Then in the commit phase, the Suspense fiber is responsible for committing the visibility effect on Offscreen.

There two main reasons we implemented it this way, neither of which apply any more:

- The inner Offscreen fiber that wraps around the Suspense children used to be conditionally added only when the boundary was in its fallback state. So when toggling back to visible, there was no inner fiber to handle the visibility effect. This is no longer the case — the primary children are always wrapped in an Offscreen fiber.
- When the Suspense fiber is in its fallback state, the inner Offscreen fiber does not have a complete phase, because we bail out of rendering that tree. In the old effects list implementation, that meant the Offscreen fiber did not get added to the effect list, so it didn't have a commit phase. In the new recursive effects implementation, there's no list to maintain. Marking a flag on the inner fiber is sufficient to schedule a commit effect.

Given that these are no relevant, I was able to remove a lot of old code and shift more of the logic out of the Suspense implementation and into the Offscreen implementation so that it is shared by both. (Being able to share the implementation like this was in fact one of the reasons we stopped conditionally removing the inner Offscreen fiber.)

As a bonus, this happens to fix a TODO in the Offscreen implementation for persistent (Fabric) mode, where newly inserted nodes inside an already hidden tree must also be hidden. Though we'll still need to make this work in mutation (DOM) mode, too.