### PR TITLE
Fix global reference to Promise

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -392,7 +392,7 @@ export const scheduleTimeout: any =
 export const cancelTimeout: any =
   typeof clearTimeout === 'function' ? clearTimeout : (undefined: any);
 export const noTimeout = -1;
-const localPromise = Promise;
+const localPromise = typeof Promise === 'function' ? Promise : undefined;
 
 // -------------------
 //     Microtasks


### PR DESCRIPTION
Referencing Promise without a type check will throw in environments where Promise is not defined.

We will follow up with a lint rule that restricts access to all globals except in dedicated module indirections.