### PR TITLE
Add default for current act queue

### DIFF
--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -22,7 +22,9 @@ const ReactSharedInternals = {
 
 if (__DEV__) {
   ReactSharedInternals.ReactDebugCurrentFrame = ReactDebugCurrentFrame;
-  ReactSharedInternals.ReactCurrentActQueue = ReactCurrentActQueue;
+  ReactSharedInternals.ReactCurrentActQueue = ReactCurrentActQueue || {
+    current: null,
+  };
 }
 
 export default ReactSharedInternals;


### PR DESCRIPTION
## Overview

If you're depending on an older version of React than the renderer uses, we'll crash on `ReactCurrentActQueue is undefined`. 

For example, OSS React Native builds use the sync'd renderer but the latest OSS React version. This is a simple fix to default ReactCurrentActQueue so it doesn't error. Another fix would be to feature flag this to non-React Native OSS builds, but that seem heavy handed.