### PR TITLE
Scheduling profiler: Improve native events UI

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/content-views/FlamechartView.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/FlamechartView.js
@@ -32,9 +32,9 @@ import {
 } from './utils/positioning';
 import {
   COLORS,
-  FLAMECHART_FONT_SIZE,
+  FONT_SIZE,
   FLAMECHART_FRAME_HEIGHT,
-  FLAMECHART_TEXT_PADDING,
+  TEXT_PADDING,
   COLOR_HOVER_DIM_DELTA,
   BORDER_SIZE,
 } from './constants';
@@ -157,7 +157,7 @@ class FlamechartStackLayerView extends View {
 
     context.textAlign = 'left';
     context.textBaseline = 'middle';
-    context.font = `${FLAMECHART_FONT_SIZE}px sans-serif`;
+    context.font = `${FONT_SIZE}px sans-serif`;
 
     const scaleFactor = positioningScaleFactor(_intrinsicSize.width, frame);
 
@@ -195,15 +195,15 @@ class FlamechartStackLayerView extends View {
         drawableRect.size.height,
       );
 
-      if (width > FLAMECHART_TEXT_PADDING * 2) {
+      if (width > TEXT_PADDING * 2) {
         const trimmedName = trimFlamechartText(
           context,
           name,
-          width - FLAMECHART_TEXT_PADDING * 2 + (x < 0 ? x : 0),
+          width - TEXT_PADDING * 2 + (x < 0 ? x : 0),
         );
 
         if (trimmedName !== null) {
-          context.fillStyle = COLORS.FLAME_GRAPH_LABEL;
+          context.fillStyle = COLORS.TEXT_COLOR;
 
           // Prevent text from being drawn outside `viewableArea`
           const textOverflowsViewableArea = !rectEqualToRect(
@@ -225,7 +225,7 @@ class FlamechartStackLayerView extends View {
 
           context.fillText(
             trimmedName,
-            nodeRect.origin.x + FLAMECHART_TEXT_PADDING - (x < 0 ? x : 0),
+            nodeRect.origin.x + TEXT_PADDING - (x < 0 ? x : 0),
             nodeRect.origin.y + FLAMECHART_FRAME_HEIGHT / 2,
           );
 

--- a/packages/react-devtools-scheduling-profiler/src/content-views/ReactEventsView.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/ReactEventsView.js
@@ -25,13 +25,13 @@ import {
 } from '../view-base';
 import {
   COLORS,
-  EVENT_ROW_PADDING,
-  EVENT_DIAMETER,
+  TOP_ROW_PADDING,
+  REACT_EVENT_DIAMETER,
   BORDER_SIZE,
 } from './constants';
 
 const EVENT_ROW_HEIGHT_FIXED =
-  EVENT_ROW_PADDING + EVENT_DIAMETER + EVENT_ROW_PADDING;
+  TOP_ROW_PADDING + REACT_EVENT_DIAMETER + TOP_ROW_PADDING;
 
 function isSuspenseEvent(event: ReactEvent): boolean %checks {
   return (
@@ -85,13 +85,13 @@ export class ReactEventsView extends View {
     const {timestamp, type} = event;
 
     const x = timestampToPosition(timestamp, scaleFactor, frame);
-    const radius = EVENT_DIAMETER / 2;
+    const radius = REACT_EVENT_DIAMETER / 2;
     const eventRect: Rect = {
       origin: {
         x: x - radius,
         y: baseY,
       },
-      size: {width: EVENT_DIAMETER, height: EVENT_DIAMETER},
+      size: {width: REACT_EVENT_DIAMETER, height: REACT_EVENT_DIAMETER},
     };
     if (!rectIntersectsRect(eventRect, rect)) {
       return; // Not in view
@@ -156,7 +156,7 @@ export class ReactEventsView extends View {
     );
 
     // Draw events
-    const baseY = frame.origin.y + EVENT_ROW_PADDING;
+    const baseY = frame.origin.y + TOP_ROW_PADDING;
     const scaleFactor = positioningScaleFactor(
       this._intrinsicSize.width,
       frame,
@@ -246,7 +246,7 @@ export class ReactEventsView extends View {
     );
     const hoverTimestamp = positionToTimestamp(location.x, scaleFactor, frame);
     const eventTimestampAllowance = widthToDuration(
-      EVENT_DIAMETER / 2,
+      REACT_EVENT_DIAMETER / 2,
       scaleFactor,
     );
 

--- a/packages/react-devtools-scheduling-profiler/src/content-views/ReactMeasuresView.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/ReactMeasuresView.js
@@ -54,7 +54,7 @@ export class ReactMeasuresView extends View {
 
   _performPreflightComputations() {
     this._lanesToRender = [];
-    this._laneToMeasures = new Map<ReactLane, ReactMeasure[]>();
+    this._laneToMeasures = new Map();
 
     for (let lane: ReactLane = 0; lane < REACT_TOTAL_NUM_LANES; lane++) {
       const measuresForLane = getMeasuresForLane(

--- a/packages/react-devtools-scheduling-profiler/src/content-views/TimeAxisMarkersView.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/TimeAxisMarkersView.js
@@ -25,7 +25,7 @@ import {
   COLORS,
   INTERVAL_TIMES,
   LABEL_SIZE,
-  MARKER_FONT_SIZE,
+  FONT_SIZE,
   MARKER_HEIGHT,
   MARKER_TEXT_PADDING,
   MARKER_TICK_HEIGHT,
@@ -129,7 +129,7 @@ export class TimeAxisMarkersView extends View {
       context.fillStyle = COLORS.TIME_MARKER_LABEL;
       context.textAlign = 'right';
       context.textBaseline = 'middle';
-      context.font = `${MARKER_FONT_SIZE}px sans-serif`;
+      context.font = `${FONT_SIZE}px sans-serif`;
       context.fillText(
         `${markerLabel}ms`,
         x - MARKER_TEXT_PADDING,

--- a/packages/react-devtools-scheduling-profiler/src/content-views/UserTimingMarksView.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/UserTimingMarksView.js
@@ -25,13 +25,13 @@ import {
 } from '../view-base';
 import {
   COLORS,
-  EVENT_ROW_PADDING,
+  TOP_ROW_PADDING,
   USER_TIMING_MARK_SIZE,
   BORDER_SIZE,
 } from './constants';
 
 const ROW_HEIGHT_FIXED =
-  EVENT_ROW_PADDING + USER_TIMING_MARK_SIZE + EVENT_ROW_PADDING;
+  TOP_ROW_PADDING + USER_TIMING_MARK_SIZE + TOP_ROW_PADDING;
 
 export class UserTimingMarksView extends View {
   _marks: UserTimingMark[];
@@ -125,7 +125,7 @@ export class UserTimingMarksView extends View {
     );
 
     // Draw marks
-    const baseY = frame.origin.y + EVENT_ROW_PADDING;
+    const baseY = frame.origin.y + TOP_ROW_PADDING;
     const scaleFactor = positioningScaleFactor(
       this._intrinsicSize.width,
       frame,

--- a/packages/react-devtools-scheduling-profiler/src/content-views/constants.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/constants.js
@@ -8,12 +8,19 @@
  */
 
 export const LABEL_SIZE = 80;
-export const LABEL_FONT_SIZE = 11;
 export const MARKER_HEIGHT = 20;
 export const MARKER_TICK_HEIGHT = 8;
-export const MARKER_FONT_SIZE = 10;
+export const FONT_SIZE = 10;
 export const MARKER_TEXT_PADDING = 8;
 export const COLOR_HOVER_DIM_DELTA = 5;
+export const TOP_ROW_PADDING = 4;
+export const NATIVE_EVENT_HEIGHT = 14;
+export const REACT_EVENT_DIAMETER = 6;
+export const USER_TIMING_MARK_SIZE = 8;
+export const REACT_MEASURE_HEIGHT = 9;
+export const BORDER_SIZE = 1;
+export const FLAMECHART_FRAME_HEIGHT = 14;
+export const TEXT_PADDING = 3;
 
 export const INTERVAL_TIMES = [
   1,
@@ -31,22 +38,14 @@ export const INTERVAL_TIMES = [
 ];
 export const MIN_INTERVAL_SIZE_PX = 70;
 
-export const EVENT_ROW_PADDING = 4;
-export const EVENT_DIAMETER = 6;
-export const USER_TIMING_MARK_SIZE = 8;
-export const REACT_MEASURE_HEIGHT = 9;
-export const BORDER_SIZE = 1;
-
-export const FLAMECHART_FONT_SIZE = 10;
-export const FLAMECHART_FRAME_HEIGHT = 16;
-export const FLAMECHART_TEXT_PADDING = 3;
-
 // TODO Replace this with "export let" vars
 export let COLORS = {
   BACKGROUND: '',
-  FLAME_GRAPH_LABEL: '',
   NATIVE_EVENT: '',
   NATIVE_EVENT_HOVER: '',
+  NATIVE_EVENT_WARNING: '',
+  NATIVE_EVENT_WARNING_HOVER: '',
+  NATIVE_EVENT_WARNING_TEXT: '',
   PRIORITY_BACKGROUND: '',
   PRIORITY_BORDER: '',
   PRIORITY_LABEL: '',
@@ -75,6 +74,7 @@ export let COLORS = {
   REACT_SUSPEND: '',
   REACT_SUSPEND_HOVER: '',
   REACT_WORK_BORDER: '',
+  TEXT_COLOR: '',
   TIME_MARKER_LABEL: '',
 };
 
@@ -83,14 +83,20 @@ export function updateColorsToMatchTheme(): void {
 
   COLORS = {
     BACKGROUND: computedStyle.getPropertyValue('--color-background'),
-    FLAME_GRAPH_LABEL: computedStyle.getPropertyValue(
-      '--color-scheduling-profiler-flame-graph-label',
-    ),
     NATIVE_EVENT: computedStyle.getPropertyValue(
       '--color-scheduling-profiler-native-event',
     ),
     NATIVE_EVENT_HOVER: computedStyle.getPropertyValue(
       '--color-scheduling-profiler-native-event-hover',
+    ),
+    NATIVE_EVENT_WARNING: computedStyle.getPropertyValue(
+      '--color-scheduling-profiler-native-event-warning',
+    ),
+    NATIVE_EVENT_WARNING_HOVER: computedStyle.getPropertyValue(
+      '--color-scheduling-profiler-native-event-warning-hover',
+    ),
+    NATIVE_EVENT_WARNING_TEXT: computedStyle.getPropertyValue(
+      '--color-scheduling-profiler-native-event-warning-text',
     ),
     PRIORITY_BACKGROUND: computedStyle.getPropertyValue(
       '--color-scheduling-profiler-priority-background',
@@ -171,6 +177,9 @@ export function updateColorsToMatchTheme(): void {
     ),
     REACT_WORK_BORDER: computedStyle.getPropertyValue(
       '--color-scheduling-profiler-react-work-border',
+    ),
+    TEXT_COLOR: computedStyle.getPropertyValue(
+      '--color-scheduling-profiler-text-color',
     ),
     TIME_MARKER_LABEL: computedStyle.getPropertyValue('--color-text'),
   };

--- a/packages/react-devtools-scheduling-profiler/src/types.js
+++ b/packages/react-devtools-scheduling-profiler/src/types.js
@@ -22,7 +22,9 @@ export type Milliseconds = number;
 export type ReactLane = number;
 
 export type NativeEvent = {|
+  +depth: number,
   +duration: Milliseconds,
+  highlight: boolean,
   +timestamp: Milliseconds,
   +type: string,
 |};

--- a/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Settings/SettingsContext.js
@@ -418,7 +418,7 @@ export function updateThemeVariables(
   updateStyleHelper(theme, 'color-search-match-current', documentElements);
   updateStyleHelper(
     theme,
-    'color-scheduling-profiler-flame-graph-label',
+    'color-scheduling-profiler-text-color',
     documentElements,
   );
   updateStyleHelper(
@@ -429,6 +429,21 @@ export function updateThemeVariables(
   updateStyleHelper(
     theme,
     'color-scheduling-profiler-native-event-hover',
+    documentElements,
+  );
+  updateStyleHelper(
+    theme,
+    'color-scheduling-profiler-native-event-warning',
+    documentElements,
+  );
+  updateStyleHelper(
+    theme,
+    'color-scheduling-profiler-native-event-warning-hover',
+    documentElements,
+  );
+  updateStyleHelper(
+    theme,
+    'color-scheduling-profiler-native-event-warning-text',
     documentElements,
   );
   updateStyleHelper(

--- a/packages/react-devtools-shared/src/devtools/views/root.css
+++ b/packages/react-devtools-shared/src/devtools/views/root.css
@@ -78,9 +78,11 @@
   --light-color-record-hover: #3578e5;
   --light-color-record-inactive: #0088fa;
   --light-color-resize-bar: #cccccc;
-  --light-color-scheduling-profiler-flame-graph-label: #000000;
-  --light-color-scheduling-profiler-native-event: #aaaaaa;
-  --light-color-scheduling-profiler-native-event-hover: #888888;
+  --light-color-scheduling-profiler-native-event: #ccc;
+  --light-color-scheduling-profiler-native-event-hover: #aaa;
+  --light-color-scheduling-profiler-native-event-warning: #ee1638;
+  --light-color-scheduling-profiler-native-event-warning-hover: #da1030;
+  --light-color-scheduling-profiler-native-event-warning-text: #fff;
   --light-color-scheduling-profiler-priority-background: #f6f6f6;
   --light-color-scheduling-profiler-priority-border: #eeeeee;
   --light-color-scheduling-profiler-user-timing: #c9cacd;
@@ -106,6 +108,7 @@
   --light-color-scheduling-profiler-react-schedule-cascading-hover:#ed0030;
   --light-color-scheduling-profiler-react-suspend: #a6e59f;
   --light-color-scheduling-profiler-react-suspend-hover:#13bc00;
+  --light-color-scheduling-profiler-text-color: #000000;
   --light-color-scheduling-profiler-react-work-border:#ffffff;
   --light-color-scroll-thumb: #c2c2c2;
   --light-color-scroll-track: #fafafa;
@@ -200,9 +203,11 @@
   --dark-color-record-hover: #a2e9fc;
   --dark-color-record-inactive: #61dafb;
   --dark-color-resize-bar: #3d424a;
-  --dark-color-scheduling-profiler-flame-graph-label: #000000;
-  --dark-color-scheduling-profiler-native-event: #aaaaaa;
-  --dark-color-scheduling-profiler-native-event-hover: #888888;
+  --dark-color-scheduling-profiler-native-event: #b2b2b2;
+  --dark-color-scheduling-profiler-native-event-hover: #949494;
+  --dark-color-scheduling-profiler-native-event-warning: #ee1638;
+  --dark-color-scheduling-profiler-native-event-warning-hover: #da1030;
+  --dark-color-scheduling-profiler-native-event-warning-text: #fff;
   --dark-color-scheduling-profiler-priority-background: #1d2129;
   --dark-color-scheduling-profiler-priority-border: #282c34;
   --dark-color-scheduling-profiler-user-timing: #c9cacd;
@@ -228,6 +233,7 @@
   --dark-color-scheduling-profiler-react-schedule-cascading-hover:#ed0030;
   --dark-color-scheduling-profiler-react-suspend: #a6e59f;
   --dark-color-scheduling-profiler-react-suspend-hover:#13bc00;
+  --dark-color-scheduling-profiler-text-color: #000000;
   --dark-color-scheduling-profiler-react-work-border:#ffffff;
   --dark-color-scroll-thumb: #afb3b9;
   --dark-color-scroll-track: #313640;


### PR DESCRIPTION
Native events sometimes overlap. In this case, separate them vertically so they're easier to see:
![Video showing stacked event rendering](https://user-images.githubusercontent.com/29597/127070201-aa1d3b0b-e52c-4767-9655-c19f2abb0534.gif)

Also highlight events that have synchronous updates inside of them:
![Video showing an event handler with a synchronous update in it](https://user-images.githubusercontent.com/29597/127070190-fad9b4b5-3e11-4afe-9ea8-66dfefc07a8c.gif)

(We may want to relax this highlighting later to not warn about event handlers that are still fast enough.)