### PR TITLE
Devtools: Fix setting modal closes when deleting component filter

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -239,7 +239,7 @@ export function useModalDismissSignal(
       ownerDocument = ((modalRef.current: any): HTMLDivElement).ownerDocument;
       ownerDocument.addEventListener('keydown', handleDocumentKeyDown);
       if (dismissOnClickOutside) {
-        ownerDocument.addEventListener('click', handleDocumentClick);
+        ownerDocument.addEventListener('click', handleDocumentClick, true);
       }
     }, 0);
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When deleting the last element in component filters the setting modal closes. this PR fixes this

<img src="https://user-images.githubusercontent.com/59608551/127568480-5210f281-2f37-4388-baf3-ac81008cd8eb.gif" alt="bug" width="500px">

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

When deleting the last element in component filters the setting modal shouldn't close.

<img src="https://user-images.githubusercontent.com/59608551/127568697-12c28e3e-bf43-47dd-ac69-8b88457b01b3.gif" alt="bug" width="500px">



