### PR TITLE
[DevTools] Fix: highlight updates with memoized components

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2179,7 +2179,9 @@ export function attach(
         if (
           elementType === ElementTypeFunction ||
           elementType === ElementTypeClass ||
-          elementType === ElementTypeContext
+          elementType === ElementTypeContext ||
+          elementType === ElementTypeMemo ||
+          elementType === ElementTypeForwardRef
         ) {
           // Otherwise if this is a traced ancestor, flag for the nearest host descendant(s).
           traceNearestHostComponentUpdate = didFiberRender(


### PR DESCRIPTION
closes: #20696

example app - https://codesandbox.io/s/exwey?file=/src/App.js
remove `<script src="http://localhost:8097"></script>` from index.html to look at actual behavior


# Actual behavior:
Only memorized components with equals function highlights
https://user-images.githubusercontent.com/15823482/127928757-1c3abba6-7de5-4f76-8bcb-f2cff8abcc21.mov

# Expected result:
All memorized components should highlights
https://user-images.githubusercontent.com/15823482/127928379-b4a41936-4128-4e2a-9ceb-b32a7b29e4e3.mov


