### PR TITLE
Switch on enableProfilerChangedHookIndices flag for OSS devtools builds

### DIFF
--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
@@ -13,7 +13,7 @@
  * It should always be imported from "react-devtools-feature-flags".
  ************************************************************************/
 
-export const enableProfilerChangedHookIndices = false;
+export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = false;
 
 /************************************************************************


### PR DESCRIPTION
## Summary

Follow-up on thread of #20998. That PR added functionality behind an FB-only flag —namely showing which hooks (indices) changed on profiles that capture the reasons behind re-render. This functionality is useful beyond just Facebook. This diff enables it for OSS builds, so that everyone else can use it too.

## Test Plan

Built the extension and conforirmed hook indeces appear under **"Why did this render?"** in the profiler (on both Chrome and Firefox). ✅

<img width="1173" alt="Screen Shot 2021-08-02 at 7 33 44 PM" src="https://user-images.githubusercontent.com/1285131/127940299-d269e8ee-0c96-4493-a8b4-a23a5d59185c.png">
<img width="1250" alt="Screen Shot 2021-08-02 at 7 45 18 PM" src="https://user-images.githubusercontent.com/1285131/127940584-134bfb9e-eed2-416e-8c24-cea137f5e7b7.png">

Ran the test suite, just in case. ✅