### PR TITLE
[Fabric] Add `flex: 1` to Offscreen view container

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -453,6 +453,9 @@ export function getOffscreenContainerProps(
   } else {
     return {
       children,
+      style: {
+        flex: 1,
+      },
     };
   }
 }


### PR DESCRIPTION
Without this style property, the layout of the children is messed up.

The goal is for the container view to have no layout at all. It should be a completely transparent wrapper, except for when we set `display: none` to hide its contents. On the web, the equivalent (at least in the spec) is `display: contents`.

After some initial testing, this seems to be close enough to the desired behavior that we can ship it. We'll try rolling it out behind a flag.