### PR TITLE
[README.md] Visualizing a codebase

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -1,0 +1,16 @@
+name: Diagram
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+jobs:
+  get_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Update diagram
+        uses: githubocto/repo-visualizer@main
+        with:
+          excluded_paths: ".circleci,.codesandbox,.github"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ This example will render "Hello Taylor" into a container on the page.
 
 You'll notice that we used an HTML-like syntax; [we call it JSX](https://reactjs.org/docs/introducing-jsx.html). JSX is not required to use React, but it makes code more readable, and writing it feels like writing HTML. If you're using React as a `<script>` tag, read [this section](https://reactjs.org/docs/add-react-to-a-website.html#optional-try-react-with-jsx) on integrating JSX; otherwise, the [recommended JavaScript toolchains](https://reactjs.org/docs/create-a-new-react-app.html) handle it automatically.
 
+## [Diagram](https://octo.github.com/projects/repo-visualization)
+
+![Visualization of the codebase](./diagram.svg)
+
 ## Contributing
 
 The main purpose of this repository is to continue evolving React core, making it faster and easier to use. Development of React happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Read below to learn how you can take part in improving React.


### PR DESCRIPTION
Added codebase visualized digram to README.md.
This is new Github feature announceed bellow offical blog post.

https://octo.github.com/projects/repo-visualization  

After merge the PR, will appeared following codebase diagram.  

<img width="1051" alt="Screen Shot 2021-08-06 at 2 44 23" src="https://user-images.githubusercontent.com/5501268/128396778-cdf3edb7-6ee5-400f-b4f7-89de07d74991.png">
