### PR TITLE
Scheduling Profiler: Improve warnings and add unit tests

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/SchedulingProfiler.css
+++ b/packages/react-devtools-scheduling-profiler/src/SchedulingProfiler.css
@@ -54,6 +54,7 @@
 .WelcomeInstructionsListItemLink {
   color: var(--color-link);
   margin-left: 0.25rem;
+  margin-right: 0.25rem;
 }
 
 .ImportButtonLabel {

--- a/packages/react-devtools-scheduling-profiler/src/SchedulingProfiler.js
+++ b/packages/react-devtools-scheduling-profiler/src/SchedulingProfiler.js
@@ -86,7 +86,7 @@ const Welcome = ({onFileSelect}: {|onFileSelect: (file: File) => void|}) => (
         target="_blank">
         profiling build of ReactDOM
       </a>
-      .
+      (version 18 or newer).
     </li>
     <li className={styles.WelcomeInstructionsListItem}>
       Open the "Performance" tab in Chrome and record some performance data.

--- a/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
@@ -1116,7 +1116,7 @@ describe(preprocessData, () => {
             ({type}) => type === 'schedule-state-update',
           );
           expect(event.warning).toMatchInlineSnapshot(
-            `"A nested update was scheduled during layout. These updates require React to re-render synchronously before the browser can paint."`,
+            `"A big nested update was scheduled during layout. Nested updates require React to re-render synchronously before the browser can paint. Consider delaying this update by moving it to a passive effect (useEffect)."`,
           );
         }
       });
@@ -1177,7 +1177,7 @@ describe(preprocessData, () => {
             ({type}) => type === 'schedule-force-update',
           );
           expect(event.warning).toMatchInlineSnapshot(
-            `"A nested update was scheduled during layout. These updates require React to re-render synchronously before the browser can paint."`,
+            `"A big nested update was scheduled during layout. Nested updates require React to re-render synchronously before the browser can paint. Consider delaying this update by moving it to a passive effect (useEffect)."`,
           );
         }
       });

--- a/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
@@ -60,6 +60,7 @@ describe(getLanesFromTransportDecimalBitmask, () => {
 describe(preprocessData, () => {
   let React;
   let ReactDOM;
+  let Scheduler;
 
   let act;
   let clearedMarks;
@@ -135,6 +136,26 @@ describe(preprocessData, () => {
     });
   }
 
+  function createNativeEventEntry(type, duration) {
+    return createUserTimingEntry({
+      cat: 'devtools.timeline',
+      name: 'EventDispatch',
+      args: {data: {type}},
+      dur: duration,
+      tdur: duration,
+    });
+  }
+
+  function creactCpuProfilerSample() {
+    return createUserTimingEntry({
+      args: {data: {startTime: ++startTime}},
+      cat: 'disabled-by-default-v8.cpu_profiler',
+      id: '0x1',
+      name: 'Profile',
+      ph: 'P',
+    });
+  }
+
   function createBoilerplateEntries() {
     return [
       createProfilerVersionEntry(),
@@ -144,13 +165,7 @@ describe(preprocessData, () => {
   }
 
   function createUserTimingData(sampleMarks) {
-    const cpuProfilerSample = createUserTimingEntry({
-      args: {data: {startTime: ++startTime}},
-      cat: 'disabled-by-default-v8.cpu_profiler',
-      id: '0x1',
-      name: 'Profile',
-      ph: 'P',
-    });
+    const cpuProfilerSample = creactCpuProfilerSample();
 
     const randomSample = createUserTimingEntry({
       dur: 100,
@@ -168,7 +183,7 @@ describe(preprocessData, () => {
         pid: ++pid,
         tid: ++tid,
         ts: ++startTime,
-        args: {data: {navigationId: 'fake-navigation-id'}},
+        args: {data: {}},
         cat: 'blink.user_timing',
         name: markName,
         ph: 'R',
@@ -185,6 +200,7 @@ describe(preprocessData, () => {
 
     React = require('react');
     ReactDOM = require('react-dom');
+    Scheduler = require('scheduler');
 
     const TestUtils = require('react-dom/test-utils');
     act = TestUtils.act;
@@ -219,13 +235,7 @@ describe(preprocessData, () => {
   });
 
   it('should return empty data given a timeline with no React scheduling profiling marks', () => {
-    const cpuProfilerSample = createUserTimingEntry({
-      args: {data: {startTime: ++startTime}},
-      cat: 'disabled-by-default-v8.cpu_profiler',
-      id: '0x1',
-      name: 'Profile',
-      ph: 'P',
-    });
+    const cpuProfilerSample = creactCpuProfilerSample();
     const randomSample = createUserTimingEntry({
       dur: 100,
       tdur: 200,
@@ -292,13 +302,7 @@ describe(preprocessData, () => {
   });
 
   it('should process legacy data format (before lane labels were added)', () => {
-    const cpuProfilerSample = createUserTimingEntry({
-      args: {data: {startTime: ++startTime}},
-      cat: 'disabled-by-default-v8.cpu_profiler',
-      id: '0x1',
-      name: 'Profile',
-      ph: 'P',
-    });
+    const cpuProfilerSample = creactCpuProfilerSample();
 
     if (gate(flags => flags.enableSchedulingProfiler)) {
       // Data below is hard-coded based on an older profile sample.
@@ -336,102 +340,102 @@ describe(preprocessData, () => {
         }),
       ]);
       expect(data).toMatchInlineSnapshot(`
-      Object {
-        "componentMeasures": Array [],
-        "duration": 0.011,
-        "flamechart": Array [],
-        "laneToLabelMap": Map {
-          0 => "Sync",
-          1 => "InputContinuousHydration",
-          2 => "InputContinuous",
-          3 => "DefaultHydration",
-          4 => "Default",
-          5 => "TransitionHydration",
-          6 => "Transition",
-          7 => "Transition",
-          8 => "Transition",
-          9 => "Transition",
-          10 => "Transition",
-          11 => "Transition",
-          12 => "Transition",
-          13 => "Transition",
-          14 => "Transition",
-          15 => "Transition",
-          16 => "Transition",
-          17 => "Transition",
-          18 => "Transition",
-          19 => "Transition",
-          20 => "Transition",
-          21 => "Transition",
-          22 => "Retry",
-          23 => "Retry",
-          24 => "Retry",
-          25 => "Retry",
-          26 => "Retry",
-          27 => "SelectiveHydration",
-          28 => "IdleHydration",
-          29 => "Idle",
-          30 => "Offscreen",
-        },
-        "measures": Array [
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.004999999999999999,
-            "lanes": Array [
-              9,
-            ],
-            "timestamp": 0.006,
-            "type": "render-idle",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.001,
-            "lanes": Array [
-              9,
-            ],
-            "timestamp": 0.006,
-            "type": "render",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.002999999999999999,
-            "lanes": Array [
-              9,
-            ],
-            "timestamp": 0.008,
-            "type": "commit",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 1,
-            "duration": 0.0010000000000000009,
-            "lanes": Array [
-              9,
-            ],
-            "timestamp": 0.009,
-            "type": "layout-effects",
-          },
-        ],
-        "nativeEvents": Array [],
-        "otherUserTimingMarks": Array [],
-        "reactVersion": "17.0.3",
-        "schedulingEvents": Array [
-          Object {
-            "lanes": Array [
-              9,
-            ],
-            "timestamp": 0.005,
-            "type": "schedule-render",
-            "warning": null,
-          },
-        ],
-        "startTime": 1,
-        "suspenseEvents": Array [],
-      }
-    `);
+              Object {
+                "componentMeasures": Array [],
+                "duration": 0.011,
+                "flamechart": Array [],
+                "laneToLabelMap": Map {
+                  0 => "Sync",
+                  1 => "InputContinuousHydration",
+                  2 => "InputContinuous",
+                  3 => "DefaultHydration",
+                  4 => "Default",
+                  5 => "TransitionHydration",
+                  6 => "Transition",
+                  7 => "Transition",
+                  8 => "Transition",
+                  9 => "Transition",
+                  10 => "Transition",
+                  11 => "Transition",
+                  12 => "Transition",
+                  13 => "Transition",
+                  14 => "Transition",
+                  15 => "Transition",
+                  16 => "Transition",
+                  17 => "Transition",
+                  18 => "Transition",
+                  19 => "Transition",
+                  20 => "Transition",
+                  21 => "Transition",
+                  22 => "Retry",
+                  23 => "Retry",
+                  24 => "Retry",
+                  25 => "Retry",
+                  26 => "Retry",
+                  27 => "SelectiveHydration",
+                  28 => "IdleHydration",
+                  29 => "Idle",
+                  30 => "Offscreen",
+                },
+                "measures": Array [
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.004999999999999999,
+                    "lanes": Array [
+                      9,
+                    ],
+                    "timestamp": 0.006,
+                    "type": "render-idle",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.001,
+                    "lanes": Array [
+                      9,
+                    ],
+                    "timestamp": 0.006,
+                    "type": "render",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.002999999999999999,
+                    "lanes": Array [
+                      9,
+                    ],
+                    "timestamp": 0.008,
+                    "type": "commit",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 1,
+                    "duration": 0.0010000000000000009,
+                    "lanes": Array [
+                      9,
+                    ],
+                    "timestamp": 0.009,
+                    "type": "layout-effects",
+                  },
+                ],
+                "nativeEvents": Array [],
+                "otherUserTimingMarks": Array [],
+                "reactVersion": "17.0.3",
+                "schedulingEvents": Array [
+                  Object {
+                    "lanes": Array [
+                      9,
+                    ],
+                    "timestamp": 0.005,
+                    "type": "schedule-render",
+                    "warning": null,
+                  },
+                ],
+                "startTime": 1,
+                "suspenseEvents": Array [],
+              }
+          `);
     }
   });
 
@@ -444,107 +448,107 @@ describe(preprocessData, () => {
         ...createUserTimingData(clearedMarks),
       ]);
       expect(data).toMatchInlineSnapshot(`
-      Object {
-        "componentMeasures": Array [],
-        "duration": 0.013,
-        "flamechart": Array [],
-        "laneToLabelMap": Map {
-          0 => "Sync",
-          1 => "InputContinuousHydration",
-          2 => "InputContinuous",
-          3 => "DefaultHydration",
-          4 => "Default",
-          5 => "TransitionHydration",
-          6 => "Transition",
-          7 => "Transition",
-          8 => "Transition",
-          9 => "Transition",
-          10 => "Transition",
-          11 => "Transition",
-          12 => "Transition",
-          13 => "Transition",
-          14 => "Transition",
-          15 => "Transition",
-          16 => "Transition",
-          17 => "Transition",
-          18 => "Transition",
-          19 => "Transition",
-          20 => "Transition",
-          21 => "Transition",
-          22 => "Retry",
-          23 => "Retry",
-          24 => "Retry",
-          25 => "Retry",
-          26 => "Retry",
-          27 => "SelectiveHydration",
-          28 => "IdleHydration",
-          29 => "Idle",
-          30 => "Offscreen",
-        },
-        "measures": Array [
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.008,
-            "lanes": Array [
-              0,
-            ],
-            "timestamp": 0.005,
-            "type": "render-idle",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.001,
-            "lanes": Array [
-              0,
-            ],
-            "timestamp": 0.005,
-            "type": "render",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.005999999999999999,
-            "lanes": Array [
-              0,
-            ],
-            "timestamp": 0.007,
-            "type": "commit",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 1,
-            "duration": 0.0010000000000000009,
-            "lanes": Array [
-              0,
-            ],
-            "timestamp": 0.011,
-            "type": "layout-effects",
-          },
-        ],
-        "nativeEvents": Array [],
-        "otherUserTimingMarks": Array [
-          Object {
-            "name": "__v3",
-            "timestamp": 0.003,
-          },
-        ],
-        "reactVersion": "17.0.3",
-        "schedulingEvents": Array [
-          Object {
-            "lanes": Array [
-              0,
-            ],
-            "timestamp": 0.004,
-            "type": "schedule-render",
-            "warning": null,
-          },
-        ],
-        "startTime": 4,
-        "suspenseEvents": Array [],
-      }
-    `);
+              Object {
+                "componentMeasures": Array [],
+                "duration": 0.013,
+                "flamechart": Array [],
+                "laneToLabelMap": Map {
+                  0 => "Sync",
+                  1 => "InputContinuousHydration",
+                  2 => "InputContinuous",
+                  3 => "DefaultHydration",
+                  4 => "Default",
+                  5 => "TransitionHydration",
+                  6 => "Transition",
+                  7 => "Transition",
+                  8 => "Transition",
+                  9 => "Transition",
+                  10 => "Transition",
+                  11 => "Transition",
+                  12 => "Transition",
+                  13 => "Transition",
+                  14 => "Transition",
+                  15 => "Transition",
+                  16 => "Transition",
+                  17 => "Transition",
+                  18 => "Transition",
+                  19 => "Transition",
+                  20 => "Transition",
+                  21 => "Transition",
+                  22 => "Retry",
+                  23 => "Retry",
+                  24 => "Retry",
+                  25 => "Retry",
+                  26 => "Retry",
+                  27 => "SelectiveHydration",
+                  28 => "IdleHydration",
+                  29 => "Idle",
+                  30 => "Offscreen",
+                },
+                "measures": Array [
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.008,
+                    "lanes": Array [
+                      0,
+                    ],
+                    "timestamp": 0.005,
+                    "type": "render-idle",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.001,
+                    "lanes": Array [
+                      0,
+                    ],
+                    "timestamp": 0.005,
+                    "type": "render",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.005999999999999999,
+                    "lanes": Array [
+                      0,
+                    ],
+                    "timestamp": 0.007,
+                    "type": "commit",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 1,
+                    "duration": 0.0010000000000000009,
+                    "lanes": Array [
+                      0,
+                    ],
+                    "timestamp": 0.011,
+                    "type": "layout-effects",
+                  },
+                ],
+                "nativeEvents": Array [],
+                "otherUserTimingMarks": Array [
+                  Object {
+                    "name": "__v3",
+                    "timestamp": 0.003,
+                  },
+                ],
+                "reactVersion": "17.0.3",
+                "schedulingEvents": Array [
+                  Object {
+                    "lanes": Array [
+                      0,
+                    ],
+                    "timestamp": 0.004,
+                    "type": "schedule-render",
+                    "warning": null,
+                  },
+                ],
+                "startTime": 4,
+                "suspenseEvents": Array [],
+              }
+          `);
     }
   });
 
@@ -568,189 +572,189 @@ describe(preprocessData, () => {
         ...createUserTimingData(clearedMarks),
       ]);
       expect(data).toMatchInlineSnapshot(`
-      Object {
-        "componentMeasures": Array [
-          Object {
-            "componentName": "App",
-            "duration": 0.001,
-            "timestamp": 0.006,
-            "warning": null,
-          },
-          Object {
-            "componentName": "App",
-            "duration": 0.0010000000000000009,
-            "timestamp": 0.02,
-            "warning": null,
-          },
-        ],
-        "duration": 0.031,
-        "flamechart": Array [],
-        "laneToLabelMap": Map {
-          0 => "Sync",
-          1 => "InputContinuousHydration",
-          2 => "InputContinuous",
-          3 => "DefaultHydration",
-          4 => "Default",
-          5 => "TransitionHydration",
-          6 => "Transition",
-          7 => "Transition",
-          8 => "Transition",
-          9 => "Transition",
-          10 => "Transition",
-          11 => "Transition",
-          12 => "Transition",
-          13 => "Transition",
-          14 => "Transition",
-          15 => "Transition",
-          16 => "Transition",
-          17 => "Transition",
-          18 => "Transition",
-          19 => "Transition",
-          20 => "Transition",
-          21 => "Transition",
-          22 => "Retry",
-          23 => "Retry",
-          24 => "Retry",
-          25 => "Retry",
-          26 => "Retry",
-          27 => "SelectiveHydration",
-          28 => "IdleHydration",
-          29 => "Idle",
-          30 => "Offscreen",
-        },
-        "measures": Array [
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.009999999999999998,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.005,
-            "type": "render-idle",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.003,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.005,
-            "type": "render",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.006,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.009,
-            "type": "commit",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 1,
-            "duration": 0.0010000000000000009,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.013,
-            "type": "layout-effects",
-          },
-          Object {
-            "batchUID": 0,
-            "depth": 0,
-            "duration": 0.0019999999999999983,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.016,
-            "type": "passive-effects",
-          },
-          Object {
-            "batchUID": 1,
-            "depth": 0,
-            "duration": 0.010000000000000002,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.019,
-            "type": "render-idle",
-          },
-          Object {
-            "batchUID": 1,
-            "depth": 0,
-            "duration": 0.002999999999999999,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.019,
-            "type": "render",
-          },
-          Object {
-            "batchUID": 1,
-            "depth": 0,
-            "duration": 0.006000000000000002,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.023,
-            "type": "commit",
-          },
-          Object {
-            "batchUID": 1,
-            "depth": 1,
-            "duration": 0.0010000000000000009,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.027,
-            "type": "layout-effects",
-          },
-          Object {
-            "batchUID": 1,
-            "depth": 0,
-            "duration": 0.0010000000000000009,
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.03,
-            "type": "passive-effects",
-          },
-        ],
-        "nativeEvents": Array [],
-        "otherUserTimingMarks": Array [
-          Object {
-            "name": "__v3",
-            "timestamp": 0.003,
-          },
-        ],
-        "reactVersion": "17.0.3",
-        "schedulingEvents": Array [
-          Object {
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.004,
-            "type": "schedule-render",
-            "warning": null,
-          },
-          Object {
-            "componentName": "App",
-            "lanes": Array [
-              4,
-            ],
-            "timestamp": 0.017,
-            "type": "schedule-state-update",
-            "warning": null,
-          },
-        ],
-        "startTime": 4,
-        "suspenseEvents": Array [],
-      }
-    `);
+              Object {
+                "componentMeasures": Array [
+                  Object {
+                    "componentName": "App",
+                    "duration": 0.001,
+                    "timestamp": 0.006,
+                    "warning": null,
+                  },
+                  Object {
+                    "componentName": "App",
+                    "duration": 0.0010000000000000009,
+                    "timestamp": 0.02,
+                    "warning": null,
+                  },
+                ],
+                "duration": 0.031,
+                "flamechart": Array [],
+                "laneToLabelMap": Map {
+                  0 => "Sync",
+                  1 => "InputContinuousHydration",
+                  2 => "InputContinuous",
+                  3 => "DefaultHydration",
+                  4 => "Default",
+                  5 => "TransitionHydration",
+                  6 => "Transition",
+                  7 => "Transition",
+                  8 => "Transition",
+                  9 => "Transition",
+                  10 => "Transition",
+                  11 => "Transition",
+                  12 => "Transition",
+                  13 => "Transition",
+                  14 => "Transition",
+                  15 => "Transition",
+                  16 => "Transition",
+                  17 => "Transition",
+                  18 => "Transition",
+                  19 => "Transition",
+                  20 => "Transition",
+                  21 => "Transition",
+                  22 => "Retry",
+                  23 => "Retry",
+                  24 => "Retry",
+                  25 => "Retry",
+                  26 => "Retry",
+                  27 => "SelectiveHydration",
+                  28 => "IdleHydration",
+                  29 => "Idle",
+                  30 => "Offscreen",
+                },
+                "measures": Array [
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.009999999999999998,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.005,
+                    "type": "render-idle",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.003,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.005,
+                    "type": "render",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.006,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.009,
+                    "type": "commit",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 1,
+                    "duration": 0.0010000000000000009,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.013,
+                    "type": "layout-effects",
+                  },
+                  Object {
+                    "batchUID": 0,
+                    "depth": 0,
+                    "duration": 0.0019999999999999983,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.016,
+                    "type": "passive-effects",
+                  },
+                  Object {
+                    "batchUID": 1,
+                    "depth": 0,
+                    "duration": 0.010000000000000002,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.019,
+                    "type": "render-idle",
+                  },
+                  Object {
+                    "batchUID": 1,
+                    "depth": 0,
+                    "duration": 0.002999999999999999,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.019,
+                    "type": "render",
+                  },
+                  Object {
+                    "batchUID": 1,
+                    "depth": 0,
+                    "duration": 0.006000000000000002,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.023,
+                    "type": "commit",
+                  },
+                  Object {
+                    "batchUID": 1,
+                    "depth": 1,
+                    "duration": 0.0010000000000000009,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.027,
+                    "type": "layout-effects",
+                  },
+                  Object {
+                    "batchUID": 1,
+                    "depth": 0,
+                    "duration": 0.0010000000000000009,
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.03,
+                    "type": "passive-effects",
+                  },
+                ],
+                "nativeEvents": Array [],
+                "otherUserTimingMarks": Array [
+                  Object {
+                    "name": "__v3",
+                    "timestamp": 0.003,
+                  },
+                ],
+                "reactVersion": "17.0.3",
+                "schedulingEvents": Array [
+                  Object {
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.004,
+                    "type": "schedule-render",
+                    "warning": null,
+                  },
+                  Object {
+                    "componentName": "App",
+                    "lanes": Array [
+                      4,
+                    ],
+                    "timestamp": 0.017,
+                    "type": "schedule-state-update",
+                    "warning": null,
+                  },
+                ],
+                "startTime": 4,
+                "suspenseEvents": Array [],
+              }
+          `);
     }
   });
 
@@ -831,6 +835,157 @@ describe(preprocessData, () => {
         },
       ]
     `);
+  });
+
+  describe('warnings', () => {
+    describe('long event handlers', () => {
+      it('should not warn when React scedules a (sync) update inside of a short event handler', () => {
+        function App() {
+          return null;
+        }
+
+        if (gate(flags => flags.enableSchedulingProfiler)) {
+          const testMarks = [
+            creactCpuProfilerSample(),
+            ...createBoilerplateEntries(),
+            createNativeEventEntry('click', 5),
+          ];
+
+          clearedMarks.splice(0);
+
+          ReactDOM.render(<App />, document.createElement('div'));
+
+          testMarks.push(...createUserTimingData(clearedMarks));
+
+          const data = preprocessData(testMarks);
+          const event = data.nativeEvents.find(({type}) => type === 'click');
+          expect(event.warning).toBe(null);
+        }
+      });
+
+      it('should not warn about long events if the cause was non-React JavaScript', () => {
+        function App() {
+          return null;
+        }
+
+        if (gate(flags => flags.enableSchedulingProfiler)) {
+          const testMarks = [
+            creactCpuProfilerSample(),
+            ...createBoilerplateEntries(),
+            createNativeEventEntry('click', 25000),
+          ];
+
+          startTime += 2000;
+
+          clearedMarks.splice(0);
+
+          ReactDOM.render(<App />, document.createElement('div'));
+
+          testMarks.push(...createUserTimingData(clearedMarks));
+
+          const data = preprocessData(testMarks);
+          const event = data.nativeEvents.find(({type}) => type === 'click');
+          expect(event.warning).toBe(null);
+        }
+      });
+
+      it('should warn when React scedules a long (sync) update inside of an event', () => {
+        function App() {
+          return null;
+        }
+
+        if (gate(flags => flags.enableSchedulingProfiler)) {
+          const testMarks = [
+            creactCpuProfilerSample(),
+            ...createBoilerplateEntries(),
+            createNativeEventEntry('click', 25000),
+          ];
+
+          clearedMarks.splice(0);
+
+          ReactDOM.render(<App />, document.createElement('div'));
+
+          clearedMarks.forEach(markName => {
+            if (markName === '--render-stop') {
+              // Fake a long running render
+              startTime += 20000;
+            }
+
+            testMarks.push({
+              pid: ++pid,
+              tid: ++tid,
+              ts: ++startTime,
+              args: {data: {}},
+              cat: 'blink.user_timing',
+              name: markName,
+              ph: 'R',
+            });
+          });
+
+          const data = preprocessData(testMarks);
+          const event = data.nativeEvents.find(({type}) => type === 'click');
+          expect(event.warning).toMatchInlineSnapshot(
+            `"An event handler scheduled a big update with React. Consider using the Transition API to defer some of this work."`,
+          );
+        }
+      });
+
+      it('should not warn when React finishes a previously long (async) update with a short (sync) update inside of an event', () => {
+        function Yield({id, value}) {
+          Scheduler.unstable_yieldValue(`${id}:${value}`);
+          return null;
+        }
+
+        if (gate(flags => flags.enableSchedulingProfiler)) {
+          const testMarks = [
+            creactCpuProfilerSample(),
+            ...createBoilerplateEntries(),
+          ];
+
+          // Advance the clock by some arbitrary amount.
+          startTime += 50000;
+
+          const root = ReactDOM.createRoot(document.createElement('div'));
+
+          React.startTransition(() => {
+            // Start rendering an async update (but don't finish).
+            root.render(
+              <>
+                <Yield id="A" value={1} />
+                <Yield id="B" value={1} />
+              </>,
+            );
+            expect(Scheduler).toFlushAndYieldThrough(['A:1']);
+
+            testMarks.push(...createUserTimingData(clearedMarks));
+            clearedMarks.splice(0);
+
+            // Advance the clock some more to make the pending React update seem long.
+            startTime += 20000;
+
+            // Fake a long "click" event in the middle
+            // and schedule a sync update that will also flush the previous work.
+            testMarks.push(createNativeEventEntry('click', 25000));
+            ReactDOM.flushSync(() => {
+              root.render(
+                <>
+                  <Yield id="A" value={2} />
+                  <Yield id="B" value={2} />
+                </>,
+              );
+            });
+          });
+
+          expect(Scheduler).toHaveYielded(['A:2', 'B:2']);
+
+          testMarks.push(...createUserTimingData(clearedMarks));
+
+          const data = preprocessData(testMarks);
+          const event = data.nativeEvents.find(({type}) => type === 'click');
+          expect(event.warning).toBe(null);
+        }
+      });
+    });
   });
 
   // TODO: Add test for flamechart parsing

--- a/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
@@ -57,7 +57,9 @@ const WARNING_STRINGS = {
   LONG_EVENT_HANDLER:
     'An event handler scheduled a big update with React. Consider using the Transition API to defer some of this work.',
   NESTED_UPDATE:
-    'A nested update was scheduled during layout. These updates require React to re-render synchronously before the browser can paint.',
+    'A big nested update was scheduled during layout. ' +
+    'Nested updates require React to re-render synchronously before the browser can paint. ' +
+    'Consider delaying this update by moving it to a passive effect (useEffect).',
   SUSPEND_DURING_UPATE:
     'A component suspended during an update which caused a fallback to be shown. ' +
     "Consider using the Transition API to avoid hiding components after they've been mounted.",

--- a/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
+++ b/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
@@ -23,6 +23,8 @@ function unmemoizedGetBatchRange(
 
   let i = 0;
 
+  // TODO (scheduling profiler) Use a binary search since the measures array is sorted.
+
   // Find the first measure in the current batch.
   for (i; i < measures.length; i++) {
     const measure = measures[i];

--- a/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
+++ b/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
@@ -27,10 +27,7 @@ function unmemoizedGetBatchRange(
   for (i; i < measures.length; i++) {
     const measure = measures[i];
     if (measure.batchUID === batchUID) {
-      if (minStartTime == null) {
-        startTime = measure.timestamp;
-        break;
-      } else if (measure.timestamp >= minStartTime) {
+      if (minStartTime == null || measure.timestamp >= minStartTime) {
         startTime = measure.timestamp;
         break;
       }

--- a/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
+++ b/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
@@ -14,23 +14,26 @@ import type {BatchUID, Milliseconds, ReactProfilerData} from '../types';
 function unmemoizedGetBatchRange(
   batchUID: BatchUID,
   data: ReactProfilerData,
-  minStartTime?: number = 0,
+  minStartTime?: ?number,
 ): [Milliseconds, Milliseconds] {
   const {measures} = data;
 
-  let startTime = minStartTime;
+  let startTime = 0;
   let stopTime = Infinity;
 
   let i = 0;
-
-  // TODO (scheduling profiler) Use a binary search since the measures array is sorted.
 
   // Find the first measure in the current batch.
   for (i; i < measures.length; i++) {
     const measure = measures[i];
     if (measure.batchUID === batchUID) {
-      startTime = Math.max(startTime, measure.timestamp);
-      break;
+      if (minStartTime == null) {
+        startTime = measure.timestamp;
+        break;
+      } else if (measure.timestamp >= minStartTime) {
+        startTime = measure.timestamp;
+        break;
+      }
     }
   }
 

--- a/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
+++ b/packages/react-devtools-scheduling-profiler/src/utils/getBatchRange.js
@@ -14,26 +14,30 @@ import type {BatchUID, Milliseconds, ReactProfilerData} from '../types';
 function unmemoizedGetBatchRange(
   batchUID: BatchUID,
   data: ReactProfilerData,
+  minStartTime?: number = 0,
 ): [Milliseconds, Milliseconds] {
   const {measures} = data;
 
-  let startTime = 0;
+  let startTime = minStartTime;
   let stopTime = Infinity;
 
   let i = 0;
 
+  // Find the first measure in the current batch.
   for (i; i < measures.length; i++) {
     const measure = measures[i];
     if (measure.batchUID === batchUID) {
-      startTime = measure.timestamp;
+      startTime = Math.max(startTime, measure.timestamp);
       break;
     }
   }
 
+  // Find the last measure in the current batch.
   for (i; i < measures.length; i++) {
     const measure = measures[i];
-    stopTime = measure.timestamp;
-    if (measure.batchUID !== batchUID) {
+    if (measure.batchUID === batchUID) {
+      stopTime = measure.timestamp;
+    } else {
       break;
     }
   }


### PR DESCRIPTION
- [x] Update scheduling profiler usage instructions to mentioned v18+ requirement.
- [x] Improve long-event warnings (by moving to post-processing) and avoid false positives
  - [x] Add basic unit tests for this

Don't warn if the React work in the update was short:
<img width="664" alt="Screen Shot: Don't warn if the React work in the update was short" src="https://user-images.githubusercontent.com/29597/128419399-e755018e-6f30-44f9-9dd5-e80c39839e59.png">

Even if the event was long because of non-React work:
<img width="663" alt="Screen Shot: Even if the event was long because of non-React work" src="https://user-images.githubusercontent.com/29597/128419776-dace6d03-41d0-46da-8e04-cd9d5686940f.png">

Only warn if React significantly delayed the event:
<img width="664" alt="Screen Shot: Only warn if React significantly delayed the event" src="https://user-images.githubusercontent.com/29597/128419400-ad2b8e6f-5455-4a14-92de-0d2160246151.png">

- [x] Improve long nested-update warning (by moving to post-processing) and avoid false positives
  - [x] Also improved the wording here to mention passive effects
  - [x] Add basic unit tests for this

Don't warn if the nested update was short (these are required for controlled components after all):
<img width="665" alt="Screen Shot: Don't warn if the nested update was short" src="https://user-images.githubusercontent.com/29597/128541078-dff5b3de-d03d-49f9-bcec-f42b5cae9c94.png">

Warn if the nested update was long and delayed paint:
<img width="664" alt="Screen Shot: Warn if the nested update was long and delayed paint"  src="https://user-images.githubusercontent.com/29597/128541444-3c5ba253-e916-4e58-a017-18bb2e44c09a.png">

- [x] Improve Suspense-during-update warning detection to avoid false negatives (by moving to post-processing)
  - [x] Also fixed a bug here (our previous check was wrong)
  - [x] Add basic unit tests for this

Don't warn if a component suspends during a transition:
<img width="664" alt="Screen Shot: Don't warn if a component suspends during a transition" src="https://user-images.githubusercontent.com/29597/128550794-e2ca04dd-45eb-4b65-88a6-391576e45a40.png">

Warn if a component suspends during an update (outside of a transition):
<img width="666" alt="Screen Shot: Warn if a component suspends during an update (outside of a transition)" src="https://user-images.githubusercontent.com/29597/128550833-0aa142cc-2af7-4bfb-89c1-09d08e0ed00f.png">
