### PR TITLE
Ignore meta content attribute escaping to prevent invalid URLs 

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -381,7 +381,11 @@ function createOpenTagMarkup(
         markup = createMarkupForCustomAttribute(propKey, propValue);
       }
     } else {
-      markup = createMarkupForProperty(propKey, propValue);
+      if (tagVerbatim === 'meta' && propKey === 'content') {
+        markup = 'content="' + propValue + '"';
+      } else {
+        markup = createMarkupForProperty(propKey, propValue);
+      }
     }
     if (markup) {
       ret += ' ' + markup;

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -381,7 +381,7 @@ function createOpenTagMarkup(
         markup = createMarkupForCustomAttribute(propKey, propValue);
       }
     } else {
-      if (tagVerbatim === 'meta' && propKey === 'content') {
+      if (tagVerbatim === 'meta' && propKey === 'content' && propValue) {
         markup = 'content="' + propValue + '"';
       } else {
         markup = createMarkupForProperty(propKey, propValue);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
React automatically escapes HTML. Unfortunately for `<meta />` tags, escaping characters like `&` to `&amp;` could break URLs. There are a lot of issues and there is no easy solution (at least for raw `Next.js` hosted on Vercel). I know, escaping HTML is important, but it should not break URLs, which developers are not able to fix easily. 

This change is ignoring escaping `content` of `<meta />` attribute.

That means this tag
`<meta property='og:image' content='https://example.com?query1=one&query2=two' />` will not become `<meta property='og:image' content='https://example.com?query1=one&amp;query2=two' />`, but stays the same. (Encoding the URL will make it [fail](https://user-images.githubusercontent.com/3165635/46868650-52076f00-ce29-11e8-892f-cfbf924bba82.png))

Also it prevents duplicating escaping `<meta property='og:image' content='https://example.com?query1=one&amp;query2=two' />` to become `<meta property='og:image' content='https://example.com?query1=one&amp;amp;query2=two' />`.

Altough we have `dangerouslySetInnerHTML`, there is no such way to change it for attributes (eg `content` in `<meta />`), if it is not supported by `<React.Fragment />` for inserting `innerHTML`.

## Some related issues
https://github.com/facebook/react/issues/13838
https://github.com/vercel/next.js/issues/2006
https://github.com/garmeeh/next-seo/issues/678


## Test Plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
