### PR TITLE
Devtools/function context change

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
+++ b/packages/react-devtools-shared/src/__tests__/__snapshots__/profilingCache-test.js.snap
@@ -2485,7 +2485,7 @@ Object {
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 0 1`] = `
 Object {
   "changeDescriptions": Map {
-    3 => Object {
+    4 => Object {
       "context": null,
       "didHooksChange": false,
       "isFirstMount": true,
@@ -2499,11 +2499,13 @@ Object {
     1 => 0,
     2 => 0,
     3 => 0,
+    4 => 0,
   },
   "fiberSelfDurations": Map {
     1 => 0,
     2 => 0,
     3 => 0,
+    4 => 0,
   },
   "passiveEffectDuration": 0,
   "priorityLevel": "Immediate",
@@ -2523,8 +2525,8 @@ Object {
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 1 1`] = `
 Object {
   "changeDescriptions": Map {
-    3 => Object {
-      "context": null,
+    4 => Object {
+      "context": false,
       "didHooksChange": false,
       "isFirstMount": false,
       "props": Array [
@@ -2536,11 +2538,13 @@ Object {
   "duration": 0,
   "effectDuration": null,
   "fiberActualDurations": Map {
+    4 => 0,
     3 => 0,
     2 => 0,
     1 => 0,
   },
   "fiberSelfDurations": Map {
+    4 => 0,
     3 => 0,
     2 => 0,
     1 => 0,
@@ -2563,8 +2567,8 @@ Object {
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 2 1`] = `
 Object {
   "changeDescriptions": Map {
-    3 => Object {
-      "context": null,
+    4 => Object {
+      "context": false,
       "didHooksChange": true,
       "isFirstMount": false,
       "props": Array [],
@@ -2574,10 +2578,10 @@ Object {
   "duration": 0,
   "effectDuration": null,
   "fiberActualDurations": Map {
-    3 => 0,
+    4 => 0,
   },
   "fiberSelfDurations": Map {
-    3 => 0,
+    4 => 0,
   },
   "passiveEffectDuration": null,
   "priorityLevel": "Immediate",
@@ -2586,7 +2590,7 @@ Object {
     Object {
       "displayName": "Component",
       "hocDisplayNames": null,
-      "id": 3,
+      "id": 4,
       "key": null,
       "type": 5,
     },
@@ -2597,8 +2601,8 @@ Object {
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 3 1`] = `
 Object {
   "changeDescriptions": Map {
-    3 => Object {
-      "context": null,
+    4 => Object {
+      "context": false,
       "didHooksChange": true,
       "isFirstMount": false,
       "props": Array [],
@@ -2608,10 +2612,10 @@ Object {
   "duration": 0,
   "effectDuration": null,
   "fiberActualDurations": Map {
-    3 => 0,
+    4 => 0,
   },
   "fiberSelfDurations": Map {
-    3 => 0,
+    4 => 0,
   },
   "passiveEffectDuration": null,
   "priorityLevel": "Immediate",
@@ -2620,7 +2624,7 @@ Object {
     Object {
       "displayName": "Component",
       "hocDisplayNames": null,
-      "id": 3,
+      "id": 4,
       "key": null,
       "type": 5,
     },
@@ -2631,8 +2635,8 @@ Object {
 exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 4 1`] = `
 Object {
   "changeDescriptions": Map {
-    3 => Object {
-      "context": null,
+    4 => Object {
+      "context": true,
       "didHooksChange": false,
       "isFirstMount": false,
       "props": Array [],
@@ -2642,11 +2646,53 @@ Object {
   "duration": 0,
   "effectDuration": null,
   "fiberActualDurations": Map {
+    4 => 0,
     3 => 0,
     2 => 0,
     1 => 0,
   },
   "fiberSelfDurations": Map {
+    4 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "passiveEffectDuration": null,
+  "priorityLevel": "Immediate",
+  "timestamp": 0,
+  "updaters": Array [
+    Object {
+      "displayName": "Anonymous",
+      "hocDisplayNames": null,
+      "id": 1,
+      "key": null,
+      "type": 11,
+    },
+  ],
+}
+`;
+
+exports[`ProfilingCache should properly detect changed hooks: CommitDetails commitIndex: 5 1`] = `
+Object {
+  "changeDescriptions": Map {
+    4 => Object {
+      "context": true,
+      "didHooksChange": false,
+      "isFirstMount": false,
+      "props": Array [],
+      "state": null,
+    },
+  },
+  "duration": 0,
+  "effectDuration": null,
+  "fiberActualDurations": Map {
+    4 => 0,
+    3 => 0,
+    2 => 0,
+    1 => 0,
+  },
+  "fiberSelfDurations": Map {
+    4 => 0,
     3 => 0,
     2 => 0,
     1 => 0,
@@ -2674,7 +2720,7 @@ Object {
         Object {
           "changeDescriptions": Array [
             Array [
-              3,
+              4,
               Object {
                 "context": null,
                 "didHooksChange": false,
@@ -2699,6 +2745,10 @@ Object {
               3,
               0,
             ],
+            Array [
+              4,
+              0,
+            ],
           ],
           "fiberSelfDurations": Array [
             Array [
@@ -2711,6 +2761,10 @@ Object {
             ],
             Array [
               3,
+              0,
+            ],
+            Array [
+              4,
               0,
             ],
           ],
@@ -2730,9 +2784,9 @@ Object {
         Object {
           "changeDescriptions": Array [
             Array [
-              3,
+              4,
               Object {
-                "context": null,
+                "context": false,
                 "didHooksChange": false,
                 "isFirstMount": false,
                 "props": Array [
@@ -2745,6 +2799,10 @@ Object {
           "duration": 0,
           "effectDuration": null,
           "fiberActualDurations": Array [
+            Array [
+              4,
+              0,
+            ],
             Array [
               3,
               0,
@@ -2759,6 +2817,10 @@ Object {
             ],
           ],
           "fiberSelfDurations": Array [
+            Array [
+              4,
+              0,
+            ],
             Array [
               3,
               0,
@@ -2788,9 +2850,9 @@ Object {
         Object {
           "changeDescriptions": Array [
             Array [
-              3,
+              4,
               Object {
-                "context": null,
+                "context": false,
                 "didHooksChange": true,
                 "isFirstMount": false,
                 "props": Array [],
@@ -2802,13 +2864,13 @@ Object {
           "effectDuration": null,
           "fiberActualDurations": Array [
             Array [
-              3,
+              4,
               0,
             ],
           ],
           "fiberSelfDurations": Array [
             Array [
-              3,
+              4,
               0,
             ],
           ],
@@ -2819,7 +2881,7 @@ Object {
             Object {
               "displayName": "Component",
               "hocDisplayNames": null,
-              "id": 3,
+              "id": 4,
               "key": null,
               "type": 5,
             },
@@ -2828,9 +2890,9 @@ Object {
         Object {
           "changeDescriptions": Array [
             Array [
-              3,
+              4,
               Object {
-                "context": null,
+                "context": false,
                 "didHooksChange": true,
                 "isFirstMount": false,
                 "props": Array [],
@@ -2842,13 +2904,13 @@ Object {
           "effectDuration": null,
           "fiberActualDurations": Array [
             Array [
-              3,
+              4,
               0,
             ],
           ],
           "fiberSelfDurations": Array [
             Array [
-              3,
+              4,
               0,
             ],
           ],
@@ -2859,7 +2921,7 @@ Object {
             Object {
               "displayName": "Component",
               "hocDisplayNames": null,
-              "id": 3,
+              "id": 4,
               "key": null,
               "type": 5,
             },
@@ -2868,9 +2930,9 @@ Object {
         Object {
           "changeDescriptions": Array [
             Array [
-              3,
+              4,
               Object {
-                "context": null,
+                "context": true,
                 "didHooksChange": false,
                 "isFirstMount": false,
                 "props": Array [],
@@ -2881,6 +2943,10 @@ Object {
           "duration": 0,
           "effectDuration": null,
           "fiberActualDurations": Array [
+            Array [
+              4,
+              0,
+            ],
             Array [
               3,
               0,
@@ -2895,6 +2961,74 @@ Object {
             ],
           ],
           "fiberSelfDurations": Array [
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "passiveEffectDuration": null,
+          "priorityLevel": "Immediate",
+          "timestamp": 0,
+          "updaters": Array [
+            Object {
+              "displayName": "Anonymous",
+              "hocDisplayNames": null,
+              "id": 1,
+              "key": null,
+              "type": 11,
+            },
+          ],
+        },
+        Object {
+          "changeDescriptions": Array [
+            Array [
+              4,
+              Object {
+                "context": true,
+                "didHooksChange": false,
+                "isFirstMount": false,
+                "props": Array [],
+                "state": null,
+              },
+            ],
+          ],
+          "duration": 0,
+          "effectDuration": null,
+          "fiberActualDurations": Array [
+            Array [
+              4,
+              0,
+            ],
+            Array [
+              3,
+              0,
+            ],
+            Array [
+              2,
+              0,
+            ],
+            Array [
+              1,
+              0,
+            ],
+          ],
+          "fiberSelfDurations": Array [
+            Array [
+              4,
+              0,
+            ],
             Array [
               3,
               0,
@@ -2973,13 +3107,28 @@ Object {
           0,
           1,
           3,
-          5,
           2,
+          2,
+          0,
+          1,
+          0,
+          4,
+          3,
+          0,
+          1,
+          4,
+          5,
+          3,
           0,
           2,
           0,
           4,
-          3,
+          4,
+          0,
+        ],
+        Array [
+          1,
+          1,
           0,
         ],
         Array [

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1279,7 +1279,7 @@ export function attach(
       case ElementTypeFunction:
         const dependencies = fiber.dependencies;
         if (dependencies && dependencies.firstContext) {
-          modernContext = dependencies.firstContext.memoizedValue;
+          modernContext = dependencies.firstContext;
         }
 
         return [legacyContext, modernContext];
@@ -1327,7 +1327,19 @@ export function attach(
           break;
         case ElementTypeFunction:
           if (nextModernContext !== NO_CONTEXT) {
-            return !is(prevModernContext, nextModernContext);
+            let prevContext = prevModernContext;
+            let nextContext = nextModernContext;
+
+            while (prevContext && nextContext) {
+              if (!is(prevContext.memoizedValue, nextContext.memoizedValue)) {
+                return true;
+              }
+
+              prevContext = prevContext.next;
+              nextContext = nextContext.next;
+            }
+
+            return false;
           }
           break;
         default:

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -960,6 +960,7 @@ export function attach(
 
     return false;
   }
+
   // NOTICE Keep in sync with shouldFilterFiber() and other get*ForFiber methods
   function getElementTypeForFiber(fiber: Fiber): ElementType {
     const {type, tag} = fiber;
@@ -1236,6 +1237,7 @@ export function attach(
 
   function updateContextsForFiber(fiber: Fiber) {
     switch (getElementTypeForFiber(fiber)) {
+      case ElementTypeFunction:
       case ElementTypeClass:
         if (idToContextsMap !== null) {
           const id = getFiberIDThrows(fiber);
@@ -1254,11 +1256,12 @@ export function attach(
   const NO_CONTEXT = {};
 
   function getContextsForFiber(fiber: Fiber): [Object, any] | null {
+    let legacyContext = NO_CONTEXT;
+    let modernContext = NO_CONTEXT;
+
     switch (getElementTypeForFiber(fiber)) {
       case ElementTypeClass:
         const instance = fiber.stateNode;
-        let legacyContext = NO_CONTEXT;
-        let modernContext = NO_CONTEXT;
         if (instance != null) {
           if (
             instance.constructor &&
@@ -1272,6 +1275,13 @@ export function attach(
             }
           }
         }
+        return [legacyContext, modernContext];
+      case ElementTypeFunction:
+        const dependencies = fiber.dependencies;
+        if (dependencies && dependencies.firstContext) {
+          modernContext = dependencies.firstContext.memoizedValue;
+        }
+
         return [legacyContext, modernContext];
       default:
         return null;
@@ -1291,31 +1301,38 @@ export function attach(
   }
 
   function getContextChangedKeys(fiber: Fiber): null | boolean | Array<string> {
-    switch (getElementTypeForFiber(fiber)) {
-      case ElementTypeClass:
-        if (idToContextsMap !== null) {
-          const id = getFiberIDThrows(fiber);
-          const prevContexts = idToContextsMap.has(id)
-            ? idToContextsMap.get(id)
-            : null;
-          const nextContexts = getContextsForFiber(fiber);
+    if (idToContextsMap !== null) {
+      const id = getFiberIDThrows(fiber);
+      const prevContexts = idToContextsMap.has(id)
+        ? idToContextsMap.get(id)
+        : null;
+      const nextContexts = getContextsForFiber(fiber);
 
-          if (prevContexts == null || nextContexts == null) {
-            return null;
+      if (prevContexts == null || nextContexts == null) {
+        return null;
+      }
+
+      const [prevLegacyContext, prevModernContext] = prevContexts;
+      const [nextLegacyContext, nextModernContext] = nextContexts;
+
+      switch (getElementTypeForFiber(fiber)) {
+        case ElementTypeClass:
+          if (prevContexts && nextContexts) {
+            if (nextLegacyContext !== NO_CONTEXT) {
+              return getChangedKeys(prevLegacyContext, nextLegacyContext);
+            } else if (nextModernContext !== NO_CONTEXT) {
+              return prevModernContext !== nextModernContext;
+            }
           }
-
-          const [prevLegacyContext, prevModernContext] = prevContexts;
-          const [nextLegacyContext, nextModernContext] = nextContexts;
-
-          if (nextLegacyContext !== NO_CONTEXT) {
-            return getChangedKeys(prevLegacyContext, nextLegacyContext);
-          } else if (nextModernContext !== NO_CONTEXT) {
-            return prevModernContext !== nextModernContext;
+          break;
+        case ElementTypeFunction:
+          if (nextModernContext !== NO_CONTEXT) {
+            return !is(prevModernContext, nextModernContext);
           }
-        }
-        break;
-      default:
-        break;
+          break;
+        default:
+          break;
+      }
     }
     return null;
   }
@@ -2859,6 +2876,7 @@ export function attach(
     // Otherwise B has to be current branch.
     return alternate;
   }
+
   // END copied code
 
   function prepareViewAttributeSource(
@@ -3860,6 +3878,7 @@ export function attach(
   // Map of id and its force error status: true (error), false (toggled off),
   // null (do nothing)
   const forceErrorForFiberIDs = new Map();
+
   function shouldErrorFiberAccordingToMap(fiber) {
     if (typeof setErrorHandler !== 'function') {
       throw new Error(
@@ -3924,6 +3943,7 @@ export function attach(
   }
 
   const forceFallbackForSuspenseIDs = new Set();
+
   function shouldSuspendFiberAccordingToSet(fiber) {
     const maybeID = getFiberIDUnsafe(((fiber: any): Fiber));
     return maybeID !== null && forceFallbackForSuspenseIDs.has(maybeID);


### PR DESCRIPTION
## Summary

Show if a function component rendered due to context changes. Fixes: https://github.com/facebook/react/issues/21736

I also added some additional usecases for verifying context change behavior in the `react-devtools-shell` test app - https://github.com/facebook/react/commit/ed07e58288bba3c80f4290eb7c8f592fe70ec701. Happy to remove this if it shouldn't be merged in.

On the test plan, only manual testing has been performed. I plan to add tests, but wanted to send out a PR first to get some eyes on the implementation.

## Test Plan

1. Given a function component consuming contexts `string` and `string2`,
when `string` changes,
the function component was rendered due to *Context changed*

https://user-images.githubusercontent.com/34072411/128655236-53a70429-c2bf-4f77-bdfd-141875a51564.mp4

2. Given a function component consuming context `string` and `string2`,
when `string2` changes,
the function component was rendered due to *Context changed*.

https://user-images.githubusercontent.com/34072411/128655259-c5e6b3a4-5a1f-4aad-8501-d61a539c7b8b.mp4

3. Given a function component consuming context and has internal state,
when internal state changes and context does not,
the function component was rendered due to *Hooks changed*.

https://user-images.githubusercontent.com/34072411/128655492-dd4a9dcc-0681-436c-bd76-42f312d7322c.mp4

