### PR TITLE
Scheduling Profiler: Inline snapshots

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/EventTooltip.css
+++ b/packages/react-devtools-scheduling-profiler/src/EventTooltip.css
@@ -11,7 +11,6 @@
   user-select: none;
   pointer-events: none;
   background-color: var(--color-tooltip-background);
-  border: 1px solid var(border);
   box-shadow: 1px 1px 2px var(--color-shadow);
   color: var(--color-tooltip-text);
   font-size: 11px;
@@ -72,4 +71,8 @@
 .InfoText,
 .WarningText {
   color: var(--color-warning-text-color);
+}
+
+.Image {
+  border: 1px solid var(--color-border);
 }

--- a/packages/react-devtools-scheduling-profiler/src/EventTooltip.js
+++ b/packages/react-devtools-scheduling-profiler/src/EventTooltip.js
@@ -315,6 +315,7 @@ const TooltipSnapshot = ({
   return (
     <div className={styles.Tooltip} ref={tooltipRef}>
       <img
+        className={styles.Image}
         src={snapshot.imageSource}
         style={{width: snapshot.width / 2, height: snapshot.height / 2}}
       />

--- a/packages/react-devtools-scheduling-profiler/src/content-views/constants.js
+++ b/packages/react-devtools-scheduling-profiler/src/content-views/constants.js
@@ -23,7 +23,7 @@ export const REACT_MEASURE_HEIGHT = 14;
 export const BORDER_SIZE = 1;
 export const FLAMECHART_FRAME_HEIGHT = 14;
 export const TEXT_PADDING = 3;
-export const SNAPSHOT_HEIGHT = 50;
+export const SNAPSHOT_HEIGHT = 35;
 
 export const INTERVAL_TIMES = [
   1,


### PR DESCRIPTION
Iterated a little bit on the snapshot UI to add borders and improve the UX when scrolling (so the hovered tooltip image now updates)

https://user-images.githubusercontent.com/29597/129425551-021179f9-4d42-4ee9-86ea-9188ede28f95.mp4

The motion is really fluid:

https://user-images.githubusercontent.com/29597/129426583-d4959eee-153e-46b7-be6b-2f068998cd2b.mp4
