### PR TITLE
Handle suspending un-captured with a soft error

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -35,11 +35,9 @@ function initModules() {
   };
 }
 
-const {
-  itThrowsWhenRendering,
-  resetModules,
-  serverRender,
-} = ReactDOMServerIntegrationUtils(initModules);
+const {resetModules, serverRender} = ReactDOMServerIntegrationUtils(
+  initModules,
+);
 
 describe('ReactDOMServerSuspense', () => {
   beforeEach(() => {
@@ -169,36 +167,14 @@ describe('ReactDOMServerSuspense', () => {
     expect(divB).toBe(divB2);
   });
 
-  // TODO: Remove this in favor of @gate pragma
-  if (__EXPERIMENTAL__) {
-    itThrowsWhenRendering(
-      'a suspending component outside a Suspense node',
-      async render => {
-        await render(
-          <div>
-            <React.Suspense />
-            <AsyncText text="Children" />
-            <React.Suspense />
-          </div>,
-          1,
-        );
-      },
-      'Add a <Suspense fallback=...> component higher in the tree',
+  it('should render null when a promise is thrown with no boundary', async () => {
+    const c = await serverRender(
+      <div>
+        <AsyncText text="Children" />
+      </div>,
     );
-
-    itThrowsWhenRendering(
-      'a suspending component without a Suspense above',
-      async render => {
-        await render(
-          <div>
-            <AsyncText text="Children" />
-          </div>,
-          1,
-        );
-      },
-      'Add a <Suspense fallback=...> component higher in the tree',
-    );
-  }
+    expect(c).toEqual(null);
+  });
 
   it('does not get confused by throwing null', () => {
     function Bad() {

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -53,10 +53,7 @@ function renderToStringImpl(
     },
   };
 
-  let readyToStream = false;
-  function onReadyToStream() {
-    readyToStream = true;
-  }
+  function onReadyToStream() {}
   const request = createRequest(
     children,
     destination,
@@ -78,13 +75,6 @@ function renderToStringImpl(
   if (didFatal) {
     throw fatalError;
   }
-  invariant(
-    readyToStream,
-    'A React component suspended while rendering, but no fallback UI was specified.\n' +
-      '\n' +
-      'Add a <Suspense fallback=...> component higher in the tree to ' +
-      'provide a loading indicator or placeholder to display.',
-  );
   return result;
 }
 

--- a/packages/react-dom/src/server/ReactPartialRenderer.js
+++ b/packages/react-dom/src/server/ReactPartialRenderer.js
@@ -971,14 +971,10 @@ class ReactDOMServerRenderer {
         } catch (err) {
           if (err != null && typeof err.then === 'function') {
             if (enableSuspenseServerRenderer) {
-              invariant(
-                this.suspenseDepth > 0,
-                // TODO: include component name. This is a bit tricky with current factoring.
-                'A React component suspended while rendering, but no fallback UI was specified.\n' +
-                  '\n' +
-                  'Add a <Suspense fallback=...> component higher in the tree to ' +
-                  'provide a loading indicator or placeholder to display.',
-              );
+              if (this.suspenseDepth === 0) {
+                // We suspended up to the root without a boundary.
+                return null;
+              }
               suspended = true;
             } else {
               invariant(false, 'ReactDOMServer does not yet support Suspense.');

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -67,6 +67,7 @@ import {
   isAlreadyFailedLegacyErrorBoundary,
   pingSuspendedRoot,
   restorePendingUpdaters,
+  renderDidSuspendUncaptured,
 } from './ReactFiberWorkLoop.new';
 import {propagateParentContextChangesToDeferredTree} from './ReactFiberNewContext.new';
 import {logCapturedError} from './ReactFiberErrorLogger';
@@ -422,15 +423,16 @@ function throwException(
       // boundary.
       workInProgress = workInProgress.return;
     } while (workInProgress !== null);
-    // No boundary was found. Fallthrough to error mode.
-    // TODO: Use invariant so the message is stripped in prod?
-    value = new Error(
-      (getComponentNameFromFiber(sourceFiber) || 'A React component') +
-        ' suspended while rendering, but no fallback UI was specified.\n' +
-        '\n' +
-        'Add a <Suspense fallback=...> component higher in the tree to ' +
-        'provide a loading indicator or placeholder to display.',
-    );
+    // No boundary was found. Log an error, and mark root suspended.
+    if (__DEV__) {
+      console.error(
+        '%s suspended while rendering, but no suspense boundary was specified. Add a Suspense component to specify a fallback.',
+        getComponentNameFromFiber(sourceFiber) || 'A React component',
+      );
+    }
+    attachPingListener(root, wakeable, rootRenderLanes);
+    renderDidSuspendUncaptured();
+    return;
   }
 
   // We didn't find a boundary that could handle this type of exception. Start

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -1003,11 +1003,20 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   });
 
   // @gate enableCache
-  it('throws a helpful error when an update is suspends without a placeholder', () => {
+  it('logs an error when an update suspends without a boundary', async () => {
     ReactNoop.render(<AsyncText text="Async" />);
-    expect(Scheduler).toFlushAndThrow(
-      'AsyncText suspended while rendering, but no fallback UI was specified.',
+    expect(() => {
+      expect(Scheduler).toFlushAndYield(['Suspend! [Async]']);
+      expect(ReactNoop.getChildren()).toEqual([]);
+    }).toErrorDev(
+      'Warning: AsyncText suspended while rendering, but no suspense boundary was specified. Add a Suspense component to specify a fallback.',
+      {withoutStack: true},
     );
+
+    await resolveText('Async');
+
+    expect(Scheduler).toFlushAndYield(['Async']);
+    expect(ReactNoop.getChildren()).toEqual([span('Async')]);
   });
 
   // @gate enableCache


### PR DESCRIPTION
## Overview

Currently, if a tree suspends and it's not caught by a boundary we throw an exception.

Instead, we want to log an error and infinitely delay waiting for the data, similar to what a transition would do. On the server, renderToString will render `null`, and the streaming APIs will wait until the content resolves to start streaming.
