### PR TITLE
Revert "Show a soft error when a text string or number is supplied as a child to non text wrappers"

### DIFF
--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -22,6 +22,8 @@ import type {
 import {mountSafeCallback_NOT_REALLY_SAFE} from './NativeMethodsMixinUtils';
 import {create, diff} from './ReactNativeAttributePayload';
 
+import invariant from 'shared/invariant';
+
 import {dispatchEvent} from './ReactFabricEventEmitter';
 
 import {
@@ -262,11 +264,10 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  if (__DEV__) {
-    if (!hostContext.isInAParentText) {
-      console.error('Text strings must be rendered within a <Text> component.');
-    }
-  }
+  invariant(
+    hostContext.isInAParentText,
+    'Text strings must be rendered within a <Text> component.',
+  );
 
   const tag = nextReactTag;
   nextReactTag += 2;

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -147,11 +147,11 @@ export function createTextInstance(
   hostContext: HostContext,
   internalInstanceHandle: Object,
 ): TextInstance {
-  if (__DEV__) {
-    if (!hostContext.isInAParentText) {
-      console.error('Text strings must be rendered within a <Text> component.');
-    }
-  }
+  invariant(
+    hostContext.isInAParentText,
+    'Text strings must be rendered within a <Text> component.',
+  );
+
   const tag = allocateTag();
 
   UIManager.createView(

--- a/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactFabric-test.internal.js
@@ -524,7 +524,7 @@ describe('ReactFabric', () => {
     });
   });
 
-  it('should console error for text not inside of a <Text> ancestor', () => {
+  it('should throw for text not inside of a <Text> ancestor', () => {
     const ScrollView = createReactNativeComponentClass('RCTScrollView', () => ({
       validAttributes: {},
       uiViewClassName: 'RCTScrollView',
@@ -542,7 +542,7 @@ describe('ReactFabric', () => {
       act(() => {
         ReactFabric.render(<View>this should warn</View>, 11);
       });
-    }).toErrorDev(['Text strings must be rendered within a <Text> component.']);
+    }).toThrow('Text strings must be rendered within a <Text> component.');
 
     expect(() => {
       act(() => {
@@ -553,7 +553,7 @@ describe('ReactFabric', () => {
           11,
         );
       });
-    }).toErrorDev(['Text strings must be rendered within a <Text> component.']);
+    }).toThrow('Text strings must be rendered within a <Text> component.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -473,7 +473,7 @@ describe('ReactNative', () => {
     );
   });
 
-  it('should console error for text not inside of a <Text> ancestor', () => {
+  it('should throw for text not inside of a <Text> ancestor', () => {
     const ScrollView = createReactNativeComponentClass('RCTScrollView', () => ({
       validAttributes: {},
       uiViewClassName: 'RCTScrollView',
@@ -487,9 +487,9 @@ describe('ReactNative', () => {
       uiViewClassName: 'RCTView',
     }));
 
-    expect(() =>
-      ReactNative.render(<View>this should warn</View>, 11),
-    ).toErrorDev(['Text strings must be rendered within a <Text> component.']);
+    expect(() => ReactNative.render(<View>this should warn</View>, 11)).toThrow(
+      'Text strings must be rendered within a <Text> component.',
+    );
 
     expect(() =>
       ReactNative.render(
@@ -498,7 +498,7 @@ describe('ReactNative', () => {
         </Text>,
         11,
       ),
-    ).toErrorDev(['Text strings must be rendered within a <Text> component.']);
+    ).toThrow('Text strings must be rendered within a <Text> component.');
   });
 
   it('should not throw for text inside of an indirect <Text> ancestor', () => {


### PR DESCRIPTION
I am going to make this change only for Fabric.

Reverts facebook/react#21953

