### PR TITLE
[DevTools] Using array destructuring without assigning first variable does not error

### DIFF
--- a/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/ComponentWithUseState.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__untransformed__/ComponentWithUseState.js
@@ -14,6 +14,7 @@ function Component(props) {
   const [foo] = useState(true);
   const bar = useState(true);
   const [baz] = React.useState(true);
+  const [, forceUpdate] = useState();
   return `${foo}-${bar}-${baz}`;
 }
 

--- a/packages/react-devtools-extensions/src/__tests__/parseHookNames-test.js
+++ b/packages/react-devtools-extensions/src/__tests__/parseHookNames-test.js
@@ -95,7 +95,7 @@ describe('parseHookNames', () => {
     const Component = require('./__source__/__untransformed__/ComponentWithUseState')
       .Component;
     const hookNames = await getHookNamesForComponent(Component);
-    expectHookNamesToEqual(hookNames, ['foo', 'bar', 'baz']);
+    expectHookNamesToEqual(hookNames, ['foo', 'bar', 'baz', null]);
   });
 
   it('should parse names for useReducer()', async () => {

--- a/packages/react-devtools-extensions/src/astUtils.js
+++ b/packages/react-devtools-extensions/src/astUtils.js
@@ -271,7 +271,7 @@ function getHookVariableName(
   const nodeType = hook.node.id.type;
   switch (nodeType) {
     case AST_NODE_TYPES.ARRAY_PATTERN:
-      return !isCustomHook ? hook.node.id.elements[0].name : null;
+      return !isCustomHook ? hook.node.id.elements[0]?.name ?? null : null;
 
     case AST_NODE_TYPES.IDENTIFIER:
       return hook.node.id.name;


### PR DESCRIPTION
## Summary

Before this commit, if a hook returned an array the was destructured, but without assigning a variable to the first element in the array, this would produce an error. This was detected via internal testing.

This commit fixes that and adds regression tests.


## Test Plan

- yarn flow
- yarn test
- yarn test-build-devtools
- added new regression tests 
- named hooks still work on manual test of browser extension on a few different apps (code sandbox, create-react-app, internally).

