### PR TITLE
Set up test infra for dynamic Scheduler flags

### DIFF
--- a/packages/scheduler/src/SchedulerFeatureFlags.js
+++ b/packages/scheduler/src/SchedulerFeatureFlags.js
@@ -8,4 +8,4 @@
 
 export const enableSchedulerDebugging = false;
 export const enableIsInputPending = false;
-export const enableProfiling = __VARIANT__;
+export const enableProfiling = false;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www-dynamic.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// In www, these flags are controlled by GKs. Because most GKs have some
+// population running in either mode, we should run our tests that way, too,
+//
+// Use __VARIANT__ to simulate a GK. The tests will be run twice: once
+// with the __VARIANT__ set to `true`, and once set to `false`.
+
+export const enableIsInputPending = __VARIANT__;
+export const enableSchedulerDebugging = __VARIANT__;
+export const enableProfiling = __VARIANT__;

--- a/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
+++ b/packages/scheduler/src/forks/SchedulerFeatureFlags.www.js
@@ -6,10 +6,13 @@
  *
  */
 
+const dynamicFeatureFlags = require('SchedulerFeatureFlags');
+
+// Re-export dynamic flags from the www version.
 export const {
   enableIsInputPending,
   enableSchedulerDebugging,
   enableProfiling: enableProfilingFeatureFlag,
-} = require('SchedulerFeatureFlags');
+} = dynamicFeatureFlags;
 
 export const enableProfiling = __PROFILE__ && enableProfilingFeatureFlag;

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -57,6 +57,7 @@ function getTestFlags() {
   // These are required on demand because some of our tests mutate them. We try
   // not to but there are exceptions.
   const featureFlags = require('shared/ReactFeatureFlags');
+  const schedulerFeatureFlags = require('scheduler/src/SchedulerFeatureFlags');
 
   const www = global.__WWW__ === true;
   const releaseChannel = www
@@ -81,6 +82,11 @@ function getTestFlags() {
       source: !process.env.IS_BUILD,
       www,
 
+      // If there's a naming conflict between scheduler and React feature flags, the
+      // React ones take precedence.
+      // TODO: Maybe we should error on conflicts? Or we could namespace
+      // the flags
+      ...schedulerFeatureFlags,
       ...featureFlags,
       ...environmentFlags,
     },

--- a/scripts/jest/setupTests.www.js
+++ b/scripts/jest/setupTests.www.js
@@ -19,4 +19,19 @@ jest.mock('shared/ReactFeatureFlags', () => {
   return wwwFlags;
 });
 
+jest.mock('scheduler/src/SchedulerFeatureFlags', () => {
+  const schedulerSrcPath = process.cwd() + '/packages/scheduler';
+  jest.mock(
+    'SchedulerFeatureFlags',
+    () =>
+      jest.requireActual(
+        schedulerSrcPath + '/src/forks/SchedulerFeatureFlags.www-dynamic'
+      ),
+    {virtual: true}
+  );
+  return jest.requireActual(
+    schedulerSrcPath + '/src/forks/SchedulerFeatureFlags.www'
+  );
+});
+
 global.__WWW__ = true;


### PR DESCRIPTION
I copied the set up we use for React.

In the www-variant test job, the Scheduler `__VARIANT__` flags will be `true`. When writing a test, we can read the value of the flag with the `gate` pragma and method.

(Since these packages are currently released in lockstep, maybe we should remove SchedulerFeatureFlags and use ReactFeatureFlags for both.)