### PR TITLE
Replace react-virtualized-auto-sizer with ResizeObserver

### DIFF
--- a/packages/react-devtools-extensions/main.html
+++ b/packages/react-devtools-extensions/main.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html>
+<html style="height: 100vh; width: 100vw;">
     <head>
         <meta charset="utf-8">
         <script src="./build/main.js"></script>
     </head>
-    <body>
+    <body style="height: 100vh; width: 100vw;">
     </body>
 </html>

--- a/packages/react-devtools-extensions/panel.html
+++ b/packages/react-devtools-extensions/panel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="display: flex">
+<html style="display: flex; height: 100vh; width: 100vw;">
     <head>
         <meta charset="utf8">
         <style>
@@ -24,7 +24,7 @@
             }
         </style>
     </head>
-    <body>
+    <body style="height: 100vh; width: 100vw;">
         <!-- main react mount point -->
         <div id="container">Unable to find React on the page.</div>
         <script src="./build/panel.js"></script>

--- a/packages/react-devtools-scheduling-profiler/package.json
+++ b/packages/react-devtools-scheduling-profiler/package.json
@@ -9,8 +9,8 @@
     "memoize-one": "^5.1.1",
     "nullthrows": "^1.1.1",
     "pretty-ms": "^7.0.0",
-    "react-virtualized-auto-sizer": "^1.0.6",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "resize-observer-polyfill": "1.5.1"
   },
   "devDependencies": {
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.1",

--- a/packages/react-devtools-scheduling-profiler/src/CanvasPage.js
+++ b/packages/react-devtools-scheduling-profiler/src/CanvasPage.js
@@ -25,7 +25,7 @@ import {
   useState,
   useCallback,
 } from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import AutoSizer from 'react-devtools-shared/src/devtools/views/AutoSizer';
 import {copy} from 'clipboard-js';
 import prettyMilliseconds from 'pretty-ms';
 

--- a/packages/react-devtools-shared/package.json
+++ b/packages/react-devtools-shared/package.json
@@ -17,7 +17,7 @@
     "local-storage-fallback": "^4.1.1",
     "lodash.throttle": "^4.1.1",
     "memoize-one": "^3.1.1",
-    "react-virtualized-auto-sizer": "^1.0.6",
+    "resize-observer-polyfill": "1.5.1",
     "semver": "^6.3.0"
   }
 }

--- a/packages/react-devtools-shared/src/devtools/views/AutoSizer.css
+++ b/packages/react-devtools-shared/src/devtools/views/AutoSizer.css
@@ -1,0 +1,5 @@
+.AutoSizer {
+  width: 100%;
+  height: 100%;
+  flex: 1 1 100%;
+}

--- a/packages/react-devtools-shared/src/devtools/views/AutoSizer.js
+++ b/packages/react-devtools-shared/src/devtools/views/AutoSizer.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import * as React from 'react';
+import useResizeObserver from './useResizeObserver';
+
+import styles from './AutoSizer.css';
+
+type SizeState = {|
+  height: number,
+  width: number,
+|};
+
+type Props = {|
+  children: SizeState => React$Element<*>,
+|};
+
+// TODO Deprecate
+export default function AutoSizer({children}: Props) {
+  const {ref, width, height} = useResizeObserver();
+
+  return (
+    <div ref={ref} className={styles.AutoSizer}>
+      {children({height, width})}
+    </div>
+  );
+}

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.css
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.css
@@ -27,9 +27,9 @@
 }
 
 .AutoSizerWrapper {
+  flex: 1 1 auto;
   width: 100%;
   overflow: hidden;
-  flex: 1 0 auto;
 }
 .AutoSizerWrapper:focus {
   outline: none;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitFlamegraph.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import {forwardRef, useCallback, useContext, useMemo, useState} from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import AutoSizer from 'react-devtools-shared/src/devtools/views/AutoSizer';
 import {FixedSizeList} from 'react-window';
 import {ProfilerContext} from './ProfilerContext';
 import NoCommitData from './NoCommitData';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitRanked.js
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import {useCallback, useContext, useMemo, useState} from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import AutoSizer from 'react-devtools-shared/src/devtools/views/AutoSizer';
 import {FixedSizeList} from 'react-window';
 import {ProfilerContext} from './ProfilerContext';
 import NoCommitData from './NoCommitData';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
@@ -11,7 +11,7 @@ import type {CommitDataFrontend} from './types';
 
 import * as React from 'react';
 import {useEffect, useMemo, useRef, useState} from 'react';
-import AutoSizer from 'react-virtualized-auto-sizer';
+import AutoSizer from 'react-devtools-shared/src/devtools/views/AutoSizer';
 import {FixedSizeList} from 'react-window';
 import SnapshotCommitListItem from './SnapshotCommitListItem';
 import {minBarWidth} from './constants';

--- a/packages/react-devtools-shared/src/devtools/views/useResizeObserver.js
+++ b/packages/react-devtools-shared/src/devtools/views/useResizeObserver.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {useEffect, useState} from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+
+type SizeState = {|
+  height: number,
+  width: number,
+|};
+
+type RefSetterFunction = (current: HTMLElement | null) => void;
+
+function safeStateUpdater(setSizeState, width, height) {
+  setSizeState(prevState => {
+    if (prevState.height === height && prevState.width === width) {
+      return prevState;
+    } else {
+      return {height, width};
+    }
+  });
+}
+
+export default function useResizeObserver(): {|
+  ref: RefSetterFunction,
+  height: number,
+  width: number,
+|} {
+  const [sizeState, setSizeState] = useState<SizeState>({
+    height: 0,
+    width: 0,
+  });
+
+  const [element, setRef] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (element != null) {
+      const rect = element.getBoundingClientRect();
+      safeStateUpdater(setSizeState, rect.width, rect.height);
+
+      const resizeObserver = new ResizeObserver(entries => {
+        if (!Array.isArray(entries) || entries.length === 0) {
+          return;
+        }
+
+        if (__DEV__) {
+          if (entries.length > 1) {
+            console.warn(
+              'useResizeObserver() expects only one observed entry.',
+            );
+          }
+        }
+
+        // Flow doesn't know about new contentBoxSize property
+        const entry = (entries[0]: any);
+        if (entry.contentBoxSize) {
+          // https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+          const contentBoxSize = Array.isArray(entry.contentBoxSize)
+            ? entry.contentBoxSize[0]
+            : entry.contentBoxSize;
+
+          // https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentBoxSize#value
+          const writingMode = getComputedStyle(element)['writing-mode'];
+          if (writingMode.startsWith('horizontal')) {
+            safeStateUpdater(
+              setSizeState,
+              contentBoxSize.inlineSize,
+              contentBoxSize.blockSize,
+            );
+          } else {
+            safeStateUpdater(
+              setSizeState,
+              contentBoxSize.blockSize,
+              contentBoxSize.inlineSize,
+            );
+          }
+        } else {
+          const contentRect = entry.contentRect;
+          safeStateUpdater(setSizeState, contentRect.width, contentRect.height);
+        }
+      });
+
+      resizeObserver.observe(element);
+      return () => {
+        resizeObserver.unobserve(element);
+      };
+    }
+  }, [element]);
+
+  return {ref: setRef, height: sizeState.height, width: sizeState.width};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12941,11 +12941,6 @@ react-timer-mixin@^0.13.4:
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
-react-virtualized-auto-sizer@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz#66c5b1c9278064c5ef1699ed40a29c11518f97ca"
-  integrity sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==
-
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -13353,6 +13348,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves #22122

Note that the code currently committed _fixes_ the issue for Chrome, and supports standalone and inline packages, but fails on Firefox because `ResizeObserver` callbacks never seem to get fired.

I'm going to leave this for the moment and try a potential alternate fix.