### PR TITLE
DevTools: update error indices when elements are added/removed

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -2172,8 +2172,8 @@ describe('TreeListContext', () => {
       expect(state).toMatchInlineSnapshot(`
         ✕ 1, ⚠ 0
         [root]
-        →    <Child>
-             <ErrorOnce key="error"> ✕
+             <Child>
+        →    <ErrorOnce key="error"> ✕
       `);
     });
 

--- a/packages/react-devtools-shared/src/__tests__/treeContext-test.js
+++ b/packages/react-devtools-shared/src/__tests__/treeContext-test.js
@@ -2119,6 +2119,64 @@ describe('TreeListContext', () => {
       `);
     });
 
+    it('should update correctly when elements are added/removed', () => {
+      const container = document.createElement('div');
+      let errored = false;
+      function ErrorOnce() {
+        if (!errored) {
+          errored = true;
+          console.error('test-only:one-time-error');
+        }
+        return null;
+      }
+      withErrorsOrWarningsIgnored(['test-only:'], () =>
+        utils.act(() =>
+          legacyRender(
+            <React.Fragment>
+              <ErrorOnce key="error" />
+            </React.Fragment>,
+            container,
+          ),
+        ),
+      );
+
+      let renderer;
+      utils.act(() => (renderer = TestRenderer.create(<Contexts />)));
+      expect(state).toMatchInlineSnapshot(`
+        ✕ 1, ⚠ 0
+        [root]
+             <ErrorOnce key="error"> ✕
+      `);
+
+      withErrorsOrWarningsIgnored(['test-only:'], () =>
+        utils.act(() =>
+          legacyRender(
+            <React.Fragment>
+              <Child />
+              <ErrorOnce key="error" />
+            </React.Fragment>,
+            container,
+          ),
+        ),
+      );
+
+      utils.act(() => renderer.update(<Contexts />));
+      expect(state).toMatchInlineSnapshot(`
+        ✕ 1, ⚠ 0
+        [root]
+             <Child>
+             <ErrorOnce key="error"> ✕
+      `);
+
+      selectNextErrorOrWarning();
+      expect(state).toMatchInlineSnapshot(`
+        ✕ 1, ⚠ 0
+        [root]
+        →    <Child>
+             <ErrorOnce key="error"> ✕
+      `);
+    });
+
     it('should update select and auto-expand parts components within hidden parts of the tree', () => {
       const Wrapper = ({children}) => children;
 

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1189,10 +1189,13 @@ export default class Store extends EventEmitter<{|
 
     const indicesOfCachedErrorsOrWarningsAreStale =
       !haveErrorsOrWarningsChanged &&
-      (addedElementIDs.length > 0 || removedElementIDs.length > 0);
+      (addedElementIDs.length > 0 || removedElementIDs.size > 0);
     if (indicesOfCachedErrorsOrWarningsAreStale) {
       this._cachedErrorAndWarningTuples.forEach(entry => {
-        entry.index = this.getIndexOfElementID(entry.id);
+        const index = this.getIndexOfElementID(entry.id);
+        if (index !== null) {
+          entry.index = index;
+        }
       });
     }
 

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -1187,6 +1187,15 @@ export default class Store extends EventEmitter<{|
       console.groupEnd();
     }
 
+    const indicesOfCachedErrorsOrWarningsAreStale =
+      !haveErrorsOrWarningsChanged &&
+      (addedElementIDs.length > 0 || removedElementIDs.length > 0);
+    if (indicesOfCachedErrorsOrWarningsAreStale) {
+      this._cachedErrorAndWarningTuples.forEach(entry => {
+        entry.index = this.getIndexOfElementID(entry.id);
+      });
+    }
+
     this.emit('mutated', [addedElementIDs, removedElementIDs]);
   };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/22143

First commit has the current behavior. Second commit the fix (making it easier to spot the change in behavior).

## Test Plan

- [x] tested behavior in shell
- [x] CI green (failure is unrelated and probably just needs a restart)
