### PR TITLE
[DevTools] Keep query params in extracted source map urls

### DIFF
--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index-map/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/fb-sources-extended/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index-map/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentUsingHooksIndirectly.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentUsingHooksIndirectly.js
@@ -42,4 +42,4 @@ function useIsDarkMode() {
   }, []);
   return [isDarkMode, () => {}];
 }
-//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map
+//# sourceMappingURL=ComponentUsingHooksIndirectly.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithCustomHook.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithCustomHook.js
@@ -48,4 +48,4 @@ function useFoo() {
     foo: true
   };
 }
-//# sourceMappingURL=ComponentWithCustomHook.js.map
+//# sourceMappingURL=ComponentWithCustomHook.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithExternalCustomHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithExternalCustomHooks.js
@@ -23,4 +23,4 @@ function Component() {
   const theme = (0, _useTheme.default)();
   return /*#__PURE__*/_react.default.createElement("div", null, "theme: ", theme);
 }
-//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map
+//# sourceMappingURL=ComponentWithExternalCustomHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithMultipleHooksPerLine.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithMultipleHooksPerLine.js
@@ -27,4 +27,4 @@ function Component() {
 
   return a + b + c + d;
 }
-//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map
+//# sourceMappingURL=ComponentWithMultipleHooksPerLine.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithNestedHooks.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ComponentWithNestedHooks.js
@@ -25,4 +25,4 @@ function Component(props) {
 module.exports = {
   Component
 };
-//# sourceMappingURL=ComponentWithNestedHooks.js.map
+//# sourceMappingURL=ComponentWithNestedHooks.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ContainingStringSourceMappingURL.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ContainingStringSourceMappingURL.js
@@ -26,4 +26,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=ContainingStringSourceMappingURL.js.map
+//# sourceMappingURL=ContainingStringSourceMappingURL.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/Example.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/Example.js
@@ -25,4 +25,4 @@ function Component() {
     onClick: () => setCount(count + 1)
   }, "Click me"));
 }
-//# sourceMappingURL=Example.js.map
+//# sourceMappingURL=Example.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/InlineRequire.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/InlineRequire.js
@@ -18,4 +18,4 @@ function Component() {
 
   return count;
 }
-//# sourceMappingURL=InlineRequire.js.map
+//# sourceMappingURL=InlineRequire.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ToDoList.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/ToDoList.js
@@ -103,4 +103,4 @@ function List(props) {
     toggleItem: toggleItem
   }))));
 }
-//# sourceMappingURL=ToDoList.js.map
+//# sourceMappingURL=ToDoList.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index-map/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/index.js
@@ -86,4 +86,4 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=index.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/react-sources-extended/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/useTheme.js
+++ b/packages/react-devtools-extensions/src/__tests__/__source__/__compiled__/external/useTheme.js
@@ -24,4 +24,4 @@ function useTheme() {
   (0, _react.useDebugValue)(theme);
   return theme;
 }
-//# sourceMappingURL=useTheme.js.map
+//# sourceMappingURL=useTheme.js.map?foo=bar&param=some_value

--- a/packages/react-devtools-extensions/src/__tests__/parseHookNames-test.js
+++ b/packages/react-devtools-extensions/src/__tests__/parseHookNames-test.js
@@ -57,7 +57,15 @@ describe('parseHookNames', () => {
     };
 
     fetchMock.mockIf(/.+$/, request => {
-      return requireText(request.url, 'utf8');
+      const url = request.url;
+      const isLoadingExternalSourceMap = /external\/.*\.map/.test(url);
+      if (isLoadingExternalSourceMap) {
+        // Assert that url contains correct query params
+        expect(url.includes('?foo=bar&param=some_value')).toBe(true);
+        const fileSystemPath = url.split('?')[0];
+        return requireText(fileSystemPath, 'utf8');
+      }
+      return requireText(url, 'utf8');
     });
   });
 

--- a/packages/react-devtools-extensions/src/__tests__/updateMockSourceMaps.js
+++ b/packages/react-devtools-extensions/src/__tests__/updateMockSourceMaps.js
@@ -97,7 +97,8 @@ function compile(fileName) {
   // Generate compiled output with external source maps
   writeFileSync(
     resolve(externalDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(
@@ -167,7 +168,8 @@ function compile(fileName) {
   // Generate compiled output using external source maps using index map format
   writeFileSync(
     resolve(externalIndexMapDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(
@@ -242,7 +244,8 @@ function compile(fileName) {
   );
   writeFileSync(
     resolve(externalFbSourcesExtendedDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(
@@ -260,7 +263,8 @@ function compile(fileName) {
   );
   writeFileSync(
     resolve(externalFbSourcesIndexMapExtendedDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(
@@ -279,7 +283,8 @@ function compile(fileName) {
   );
   writeFileSync(
     resolve(externalReactSourcesExtendedDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(
@@ -297,7 +302,8 @@ function compile(fileName) {
   );
   writeFileSync(
     resolve(externalReactSourcesIndexMapExtendedDir, fileName),
-    transformed.code + `\n//# sourceMappingURL=${fileName}.map`,
+    transformed.code +
+      `\n//# sourceMappingURL=${fileName}.map?foo=bar&param=some_value`,
     'utf8',
   );
   writeFileSync(


### PR DESCRIPTION
## Summary

Our current logic for extracting source map urls assumed that the url contained no query params (e.g. `?foo=bar`), and when extracting the url we would cut off the query params. I noticed this during internal testing, since removing the query params would cause loading source maps to fail.

This commit fixes that behavior by ensuring that our regex captures the full url, including query params.

## Test Plan

- yarn flow
- yarn test
- yarn test-build-devtools
- added new regression tests 
- named hooks still work on manual test of browser extension on a few different apps (code sandbox, create-react-app, internally).

