### PR TITLE
[Blocks Fixture] fix broken fixture ServerComponent app

### DIFF
--- a/fixtures/blocks/src/server/PostList.js
+++ b/fixtures/blocks/src/server/PostList.js
@@ -7,7 +7,7 @@
 /* eslint-disable import/first */
 
 import * as React from 'react';
-import {Suspense, unstable_SuspenseList as SuspenseList} from 'react';
+import {Suspense, SuspenseList} from 'react';
 import {preload} from 'react-fetch';
 import PostGlimmer from './PostGlimmer';
 import Post from './Post';


### PR DESCRIPTION
## Summary

- https://github.com/facebook/react/pull/20315

Since removed 'react/unstable-cache' entry point by above PR, **Blocks not working** with error on the next line. 


`import {createCache, CacheProvider} from 'react/unstable-cache';`

## Test Plan
I've planning adding test by [Cypress](https://www.cypress.io/).

- https://github.com/facebook/react/issues/22152

## Screen Capture

https://user-images.githubusercontent.com/5501268/130332689-196ac1e9-2d06-4065-a6ff-ab210e0b5445.mov