### PR TITLE
Yarn replace-fork should not silently error

### DIFF
--- a/scripts/merge-fork/replace-fork.js
+++ b/scripts/merge-fork/replace-fork.js
@@ -22,7 +22,15 @@ async function main() {
   await Promise.all(oldFilenames.map(unforkFile));
 
   // Use ESLint to autofix imports
-  spawnSync('yarn', ['linc', '--fix']);
+  const spawn = spawnSync('yarn', ['linc', '--fix'], {
+    stdio: ['inherit', 'inherit', 'pipe'],
+  });
+  if (spawn.stderr.toString() !== '') {
+    spawnSync('git', ['checkout', '.']);
+
+    console.log(Error(spawn.stderr));
+    process.exitCode = 1;
+  }
 }
 
 async function unforkFile(oldFilename) {


### PR DESCRIPTION
If the Yarn `replace-fork` script fails while running the lint sub-command, catch and report the error. (Previously this error was being swallowed and causing CI to incorrectly report a different problem.)

Relates to #21998, #22151