### PR TITLE
add more detailed error handling if profiling data does not have any React marks

### DIFF
--- a/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/__tests__/preprocessData-test.internal.js
@@ -234,6 +234,29 @@ describe('preprocessData', () => {
     await expect(async () => preprocessData([randomSample])).rejects.toThrow();
   });
 
+  it('should throw given a timeline without an explicit profiler version mark nor any other React marks', async () => {
+    const cpuProfilerSample = creactCpuProfilerSample();
+
+    await expect(
+      async () => await preprocessData([cpuProfilerSample]),
+    ).rejects.toThrow(
+      'Please provide profiling data from an React application',
+    );
+  });
+
+  it('should throw given a timeline with React scheduling marks, but without an explicit profiler version mark', async () => {
+    const cpuProfilerSample = creactCpuProfilerSample();
+    const scheduleRenderSample = createUserTimingEntry({
+      cat: 'blink.user_timing',
+      name: '--schedule-render-512-',
+    });
+    const samples = [cpuProfilerSample, scheduleRenderSample];
+
+    await expect(async () => await preprocessData(samples)).rejects.toThrow(
+      'This version of profiling data is not supported',
+    );
+  });
+
   it('should return empty data given a timeline with no React scheduling profiling marks', async () => {
     const cpuProfilerSample = creactCpuProfilerSample();
     const randomSample = createUserTimingEntry({

--- a/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
@@ -916,6 +916,10 @@ export default async function preprocessData(
       profilerData.schedulingEvents.length === 0 &&
       profilerData.batchUIDToMeasuresMap.size === 0
     ) {
+      // No profiler version could indicate data was logged using an older build of React,
+      // before an explicitly profiler version was included in the logging data.
+      // But it could also indicate that the website was either not using React, or using a production build.
+      // The easiest way to check for this case is to see if the data contains any scheduled updates or render work.
       throw new InvalidProfileError(
         'No React marks were found in the provided profile.' +
           ' Please provide profiling data from an React application running in development or profiling mode.',

--- a/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-scheduling-profiler/src/import-worker/preprocessData.js
@@ -912,6 +912,16 @@ export default async function preprocessData(
   timeline.forEach(event => processTimelineEvent(event, profilerData, state));
 
   if (profilerVersion === null) {
+    if (
+      profilerData.schedulingEvents.length === 0 &&
+      profilerData.batchUIDToMeasuresMap.size === 0
+    ) {
+      throw new InvalidProfileError(
+        'No React marks were found in the provided profile.' +
+          ' Please provide profiling data from an React application running in development or profiling mode.',
+      );
+    }
+
     throw new InvalidProfileError(
       `This version of profiling data is not supported by the current profiler.`,
     );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Improve error messaging when an invalid performance trace is imported into the scheduling profiler.

Context is explained in this issue: https://github.com/facebook/react/issues/22106

## Test Plan

Updated unit tests to check for the additional error handling case.
