### PR TITLE
Added performance timings to DevTools named hooks parsing

### DIFF
--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -10,6 +10,9 @@
 // Flip this flag to true to enable verbose console debug logging.
 export const __DEBUG__ = false;
 
+// Flip this flag to true to enable performance.mark() and performance.measure() timings.
+export const __PERFORMANCE_PROFILE__ = false;
+
 export const TREE_OPERATION_ADD = 1;
 export const TREE_OPERATION_REMOVE = 2;
 export const TREE_OPERATION_REORDER_CHILDREN = 3;


### PR DESCRIPTION
This can be turned on or off (statically) via a new `__PERFORMANCE_PROFILE__` flag in `react-devtools-shared/src/constants`. For now, it's _disabled_, but it's useful to turn on when performance profiling.

When enabled, the flag will generate measures like:

<img width="1056" alt="Screen Shot 2021-08-25 at 10 57 31 AM" src="https://user-images.githubusercontent.com/29597/130844703-c445eb72-ffc5-46c1-bf99-5f1107d0cd2a.png">

<img width="756" alt="Screen Shot 2021-08-25 at 10 59 50 AM" src="https://user-images.githubusercontent.com/29597/130844720-3c250f2f-7506-48bc-97a7-13c5dff03134.png">
