### PR TITLE
[DevTools] Throw error in console without interfering with logs

### DIFF
--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -222,6 +222,9 @@ export function patch({
               }
             } catch (error) {
               // Don't let a DevTools or React internal error interfere with logging.
+              setTimeout(() => {
+                throw error;
+              }, 0);
             } finally {
               break;
             }


### PR DESCRIPTION
This PR uses `setTimeout` to throw an error outside the overridden console method so DevTools and React internal errors will still throw without interfering with logging