### PR TITLE
Add consoleManagedByDevToolsDuringStrictMode feature flag in React Reconciler

### DIFF
--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -37,7 +37,7 @@ import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
 import {
   enableSchedulingProfiler,
-  enableConsoleLogsInDoubleRender,
+  consoleManagedByDevToolsDuringStrictMode,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
@@ -723,7 +723,7 @@ export function getIsStrictModeForDevtools() {
 export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
   isStrictMode = newIsStrictMode;
 
-  if (enableConsoleLogsInDoubleRender) {
+  if (consoleManagedByDevToolsDuringStrictMode) {
     // We're in a test because Scheduler.unstable_yieldValue only exists
     // in SchedulerMock. To reduce the noise in strict mode tests,
     // suppress warnings and disable scheduler yielding during the double render

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -35,7 +35,10 @@ import {
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
-import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
+import {
+  enableSchedulingProfiler,
+  enableConsoleLogsInDoubleRender,
+} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -107,6 +110,7 @@ export {
 
 import * as Scheduler from './Scheduler';
 import {setSuppressWarning} from 'shared/consoleWithStackDev';
+import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
 type OpaqueRoot = FiberRoot;
 
@@ -717,14 +721,23 @@ export function getIsStrictModeForDevtools() {
 }
 
 export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
-  // We're in a test because Scheduler.unstable_yieldValue only exists
-  // in SchedulerMock. To reduce the noise in strict mode tests,
-  // suppress warnings and disable scheduler yielding during the double render
-  if (typeof Scheduler.unstable_yieldValue === 'function') {
-    Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
-    setSuppressWarning(newIsStrictMode);
-  }
   isStrictMode = newIsStrictMode;
+
+  if (enableConsoleLogsInDoubleRender) {
+    // We're in a test because Scheduler.unstable_yieldValue only exists
+    // in SchedulerMock. To reduce the noise in strict mode tests,
+    // suppress warnings and disable scheduler yielding during the double render
+    if (typeof Scheduler.unstable_yieldValue === 'function') {
+      Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
+      setSuppressWarning(newIsStrictMode);
+    }
+  } else {
+    if (newIsStrictMode) {
+      disableLogs();
+    } else {
+      reenableLogs();
+    }
+  }
 }
 
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -37,7 +37,7 @@ import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
 import {
   enableSchedulingProfiler,
-  enableConsoleLogsInDoubleRender,
+  consoleManagedByDevToolsDuringStrictMode,
 } from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
@@ -723,7 +723,7 @@ export function getIsStrictModeForDevtools() {
 export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
   isStrictMode = newIsStrictMode;
 
-  if (enableConsoleLogsInDoubleRender) {
+  if (consoleManagedByDevToolsDuringStrictMode) {
     // We're in a test because Scheduler.unstable_yieldValue only exists
     // in SchedulerMock. To reduce the noise in strict mode tests,
     // suppress warnings and disable scheduler yielding during the double render

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -35,7 +35,10 @@ import {
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
-import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
+import {
+  enableSchedulingProfiler,
+  enableConsoleLogsInDoubleRender,
+} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -107,6 +110,7 @@ export {
 
 import * as Scheduler from './Scheduler';
 import {setSuppressWarning} from 'shared/consoleWithStackDev';
+import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
 type OpaqueRoot = FiberRoot;
 
@@ -717,14 +721,23 @@ export function getIsStrictModeForDevtools() {
 }
 
 export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
-  // We're in a test because Scheduler.unstable_yieldValue only exists
-  // in SchedulerMock. To reduce the noise in strict mode tests,
-  // suppress warnings and disable scheduler yielding during the double render
-  if (typeof Scheduler.unstable_yieldValue === 'function') {
-    Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
-    setSuppressWarning(newIsStrictMode);
-  }
   isStrictMode = newIsStrictMode;
+
+  if (enableConsoleLogsInDoubleRender) {
+    // We're in a test because Scheduler.unstable_yieldValue only exists
+    // in SchedulerMock. To reduce the noise in strict mode tests,
+    // suppress warnings and disable scheduler yielding during the double render
+    if (typeof Scheduler.unstable_yieldValue === 'function') {
+      Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
+      setSuppressWarning(newIsStrictMode);
+    }
+  } else {
+    if (newIsStrictMode) {
+      disableLogs();
+    } else {
+      reenableLogs();
+    }
+  }
 }
 
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -12,6 +12,7 @@
 let React;
 let ReactDOM;
 let ReactDOMServer;
+let ReactFeatureFlags;
 let Scheduler;
 let PropTypes;
 
@@ -893,7 +894,17 @@ describe('context legacy', () => {
     ReactDOM.render(<Root />, container);
   });
 
-  describe('logging', () => {
+  describe('enable console logs logging', () => {
+    beforeEach(() => {
+      jest.resetModules();
+
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      React = require('react');
+      ReactDOM = require('react-dom');
+
+      ReactFeatureFlags.enableConsoleLogsInDoubleRender = true;
+    });
+
     it('does not disable logs for class double render', () => {
       spyOnDevAndProd(console, 'log');
 
@@ -1078,6 +1089,208 @@ describe('context legacy', () => {
 
       expect(count).toBe(__DEV__ ? 2 : 1);
       expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+  });
+
+  describe('disable console logs logging', () => {
+    beforeEach(() => {
+      jest.resetModules();
+
+      ReactFeatureFlags = require('shared/ReactFeatureFlags');
+      React = require('react');
+      ReactDOM = require('react-dom');
+
+      ReactFeatureFlags.enableConsoleLogsInDoubleRender = false;
+    });
+
+    it('disable logs for class double render', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let count = 0;
+      class Foo extends React.Component {
+        render() {
+          count++;
+          console.log('foo ' + count);
+          return null;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+
+    it('disables logs for class double ctor', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let count = 0;
+      class Foo extends React.Component {
+        constructor(props) {
+          super(props);
+          count++;
+          console.log('foo ' + count);
+        }
+        render() {
+          return null;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+
+    it('disable logs for class double getDerivedStateFromProps', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let count = 0;
+      class Foo extends React.Component {
+        state = {};
+        static getDerivedStateFromProps() {
+          count++;
+          console.log('foo ' + count);
+          return {};
+        }
+        render() {
+          return null;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+
+    it('disable logs for class double shouldComponentUpdate', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let count = 0;
+      class Foo extends React.Component {
+        state = {};
+        shouldComponentUpdate() {
+          count++;
+          console.log('foo ' + count);
+          return {};
+        }
+        render() {
+          return null;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+      // Trigger sCU:
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+
+    it('disable logs for class state updaters', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let inst;
+      let count = 0;
+      class Foo extends React.Component {
+        state = {};
+        render() {
+          inst = this;
+          return null;
+        }
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+      inst.setState(() => {
+        count++;
+        console.log('foo ' + count);
+        return {};
+      });
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
+      // Note: we should display the first log because otherwise
+      // there is a risk of suppressing warnings when they happen,
+      // and on the next render they'd get deduplicated and ignored.
+      expect(console.log).toBeCalledWith('foo 1');
+    });
+
+    it('disable logs for function double render', () => {
+      spyOnDevAndProd(console, 'log');
+
+      let count = 0;
+      function Foo() {
+        count++;
+        console.log('foo ' + count);
+        return null;
+      }
+
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <React.StrictMode>
+          <Foo />
+        </React.StrictMode>,
+        container,
+      );
+
+      expect(count).toBe(__DEV__ ? 2 : 1);
+      expect(console.log).toBeCalledTimes(1);
       // Note: we should display the first log because otherwise
       // there is a risk of suppressing warnings when they happen,
       // and on the next render they'd get deduplicated and ignored.

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -12,9 +12,10 @@
 let React;
 let ReactDOM;
 let ReactDOMServer;
-let ReactFeatureFlags;
 let Scheduler;
 let PropTypes;
+
+const ReactFeatureFlags = require('shared/ReactFeatureFlags');
 
 describe('ReactStrictMode', () => {
   beforeEach(() => {
@@ -894,407 +895,393 @@ describe('context legacy', () => {
     ReactDOM.render(<Root />, container);
   });
 
-  describe('enable console logs logging', () => {
+  describe('console logs logging', () => {
     beforeEach(() => {
       jest.resetModules();
-
-      ReactFeatureFlags = require('shared/ReactFeatureFlags');
       React = require('react');
       ReactDOM = require('react-dom');
-
-      ReactFeatureFlags.enableConsoleLogsInDoubleRender = true;
     });
 
-    it('does not disable logs for class double render', () => {
-      spyOnDevAndProd(console, 'log');
+    if (ReactFeatureFlags.consoleManagedByDevToolsDuringStrictMode) {
+      it('does not disable logs for class double render', () => {
+        spyOnDevAndProd(console, 'log');
 
-      let count = 0;
-      class Foo extends React.Component {
-        render() {
-          count++;
-          console.log('foo ' + count);
-          return null;
+        let count = 0;
+        class Foo extends React.Component {
+          render() {
+            count++;
+            console.log('foo ' + count);
+            return null;
+          }
         }
-      }
 
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
 
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('does not disable logs for class double ctor', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        constructor(props) {
-          super(props);
-          count++;
-          console.log('foo ' + count);
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('does not disable logs for class double getDerivedStateFromProps', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        static getDerivedStateFromProps() {
-          count++;
-          console.log('foo ' + count);
-          return {};
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('does not disable logs for class double shouldComponentUpdate', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        shouldComponentUpdate() {
-          count++;
-          console.log('foo ' + count);
-          return {};
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-      // Trigger sCU:
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('does not disable logs for class state updaters', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let inst;
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        render() {
-          inst = this;
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-      inst.setState(() => {
-        count++;
-        console.log('foo ' + count);
-        return {};
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
       });
 
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
+      it('does not disable logs for class double ctor', () => {
+        spyOnDevAndProd(console, 'log');
 
-    it('does not disable logs for function double render', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      function Foo() {
-        count++;
-        console.log('foo ' + count);
-        return null;
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-  });
-
-  describe('disable console logs logging', () => {
-    beforeEach(() => {
-      jest.resetModules();
-
-      ReactFeatureFlags = require('shared/ReactFeatureFlags');
-      React = require('react');
-      ReactDOM = require('react-dom');
-
-      ReactFeatureFlags.enableConsoleLogsInDoubleRender = false;
-    });
-
-    it('disable logs for class double render', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        render() {
-          count++;
-          console.log('foo ' + count);
-          return null;
+        let count = 0;
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            count++;
+            console.log('foo ' + count);
+          }
+          render() {
+            return null;
+          }
         }
-      }
 
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
 
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('disables logs for class double ctor', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        constructor(props) {
-          super(props);
-          count++;
-          console.log('foo ' + count);
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('disable logs for class double getDerivedStateFromProps', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        static getDerivedStateFromProps() {
-          count++;
-          console.log('foo ' + count);
-          return {};
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('disable logs for class double shouldComponentUpdate', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        shouldComponentUpdate() {
-          count++;
-          console.log('foo ' + count);
-          return {};
-        }
-        render() {
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-      // Trigger sCU:
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
-
-    it('disable logs for class state updaters', () => {
-      spyOnDevAndProd(console, 'log');
-
-      let inst;
-      let count = 0;
-      class Foo extends React.Component {
-        state = {};
-        render() {
-          inst = this;
-          return null;
-        }
-      }
-
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
-      inst.setState(() => {
-        count++;
-        console.log('foo ' + count);
-        return {};
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
       });
 
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
+      it('does not disable logs for class double getDerivedStateFromProps', () => {
+        spyOnDevAndProd(console, 'log');
 
-    it('disable logs for function double render', () => {
-      spyOnDevAndProd(console, 'log');
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          static getDerivedStateFromProps() {
+            count++;
+            console.log('foo ' + count);
+            return {};
+          }
+          render() {
+            return null;
+          }
+        }
 
-      let count = 0;
-      function Foo() {
-        count++;
-        console.log('foo ' + count);
-        return null;
-      }
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
 
-      const container = document.createElement('div');
-      ReactDOM.render(
-        <React.StrictMode>
-          <Foo />
-        </React.StrictMode>,
-        container,
-      );
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
 
-      expect(count).toBe(__DEV__ ? 2 : 1);
-      expect(console.log).toBeCalledTimes(1);
-      // Note: we should display the first log because otherwise
-      // there is a risk of suppressing warnings when they happen,
-      // and on the next render they'd get deduplicated and ignored.
-      expect(console.log).toBeCalledWith('foo 1');
-    });
+      it('does not disable logs for class double shouldComponentUpdate', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          shouldComponentUpdate() {
+            count++;
+            console.log('foo ' + count);
+            return {};
+          }
+          render() {
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+        // Trigger sCU:
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('does not disable logs for class state updaters', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let inst;
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          render() {
+            inst = this;
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+        inst.setState(() => {
+          count++;
+          console.log('foo ' + count);
+          return {};
+        });
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('does not disable logs for function double render', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        function Foo() {
+          count++;
+          console.log('foo ' + count);
+          return null;
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(__DEV__ ? 2 : 1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+    } else {
+      it('disable logs for class double render', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        class Foo extends React.Component {
+          render() {
+            count++;
+            console.log('foo ' + count);
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('disables logs for class double ctor', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            count++;
+            console.log('foo ' + count);
+          }
+          render() {
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('disable logs for class double getDerivedStateFromProps', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          static getDerivedStateFromProps() {
+            count++;
+            console.log('foo ' + count);
+            return {};
+          }
+          render() {
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('disable logs for class double shouldComponentUpdate', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          shouldComponentUpdate() {
+            count++;
+            console.log('foo ' + count);
+            return {};
+          }
+          render() {
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+        // Trigger sCU:
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('disable logs for class state updaters', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let inst;
+        let count = 0;
+        class Foo extends React.Component {
+          state = {};
+          render() {
+            inst = this;
+            return null;
+          }
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+        inst.setState(() => {
+          count++;
+          console.log('foo ' + count);
+          return {};
+        });
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+
+      it('disable logs for function double render', () => {
+        spyOnDevAndProd(console, 'log');
+
+        let count = 0;
+        function Foo() {
+          count++;
+          console.log('foo ' + count);
+          return null;
+        }
+
+        const container = document.createElement('div');
+        ReactDOM.render(
+          <React.StrictMode>
+            <Foo />
+          </React.StrictMode>,
+          container,
+        );
+
+        expect(count).toBe(__DEV__ ? 2 : 1);
+        expect(console.log).toBeCalledTimes(1);
+        // Note: we should display the first log because otherwise
+        // there is a risk of suppressing warnings when they happen,
+        // and on the next render they'd get deduplicated and ignored.
+        expect(console.log).toBeCalledWith('foo 1');
+      });
+    }
   });
 });

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -175,3 +175,5 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 
 export const enablePersistentOffscreenHostContainer = false;
+
+export const enableConsoleLogsInDoubleRender = false;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -176,4 +176,4 @@ export const allowConcurrentByDefault = false;
 
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = false;
+export const consoleManagedByDevToolsDuringStrictMode = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -69,7 +69,7 @@ export const enableLazyContextPropagation = false;
 export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 
-export const enableConsoleLogsInDoubleRender = false;
+export const consoleManagedByDevToolsDuringStrictMode = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -69,6 +69,8 @@ export const enableLazyContextPropagation = false;
 export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 
+export const enableConsoleLogsInDoubleRender = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = false;
+export const consoleManagedByDevToolsDuringStrictMode = false;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = false;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = false;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -61,7 +61,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -61,6 +61,8 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -60,4 +60,4 @@ export const enableSyncDefaultUpdates = __VARIANT__;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -59,3 +59,5 @@ export const enableLazyContextPropagation = __VARIANT__;
 export const enableSyncDefaultUpdates = __VARIANT__;
 export const allowConcurrentByDefault = true;
 export const enablePersistentOffscreenHostContainer = false;
+
+export const enableConsoleLogsInDoubleRender = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -97,6 +97,8 @@ export const deletedTreeCleanUpLevel = 3;
 
 export const enablePersistentOffscreenHostContainer = false;
 
+export const enableConsoleLogsInDoubleRender = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -97,7 +97,7 @@ export const deletedTreeCleanUpLevel = 3;
 
 export const enablePersistentOffscreenHostContainer = false;
 
-export const enableConsoleLogsInDoubleRender = true;
+export const consoleManagedByDevToolsDuringStrictMode = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Right now we don't have support to read the React DevTools settings before initial render on React Native. This PR adds a React feature flag to always disable double logging console logs on React Native until React Native adds support for synchronously reading settings in the future