### PR TITLE
devtools: Don't display hook index of useContext  

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
@@ -222,7 +222,7 @@ function HookView({
 
   let name = hook.name;
   if (enableProfilerChangedHookIndices) {
-    if (!isCustomHook) {
+    if (hookID !== null) {
       name = (
         <>
           <span className={styles.PrimitiveHookNumber}>{hookID + 1}</span>

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -9,10 +9,12 @@
 
 import * as React from 'react';
 import {
+  createContext,
   forwardRef,
   Fragment,
   memo,
   useCallback,
+  useContext,
   useDebugValue,
   useEffect,
   useState,
@@ -64,8 +66,13 @@ function useDeepHookF() {
   useDebugValue('useDeepHookF');
 }
 
+const ContextA = createContext('A');
+const ContextB = createContext('B');
+
 function FunctionWithHooks(props: any, ref: React$Ref<any>) {
   const [count, updateCount] = useState(0);
+  // eslint-disable-next-line no-unused-vars
+  const contextValueA = useContext(ContextA);
 
   // eslint-disable-next-line no-unused-vars
   const [_, __] = useState(object);
@@ -84,6 +91,9 @@ function FunctionWithHooks(props: any, ref: React$Ref<any>) {
 
   // Tests nested custom hooks
   useNestedOuterHook();
+
+  // eslint-disable-next-line no-unused-vars
+  const contextValueB = useContext(ContextB);
 
   // Verify deep nesting doesn't break
   useDeepHookA();


### PR DESCRIPTION

## Summary

Resolves https://github.com/facebook/react/pull/20998#issuecomment-865491587

`useContext` will no longer display a (wrong) hook index since it has none (with regards to the hook indices displayed during profiling). This should also affect `useDebugValue` since it also has no ID.

Alternatively, we could start giving non-stateful hooks an index as well (https://github.com/facebook/react/blob/main/packages/react-debug-tools/src/ReactDebugHooks.js). But this can happen in a follow-up since the guard against `hookID` being `null` should happen anyway.

I think this makes more sense to give `useContext` a number from the perspective of a developer using React. Hooks being stateful is somewhat of an implementation detail in my opinion. It's also a bit confusing if the mental model one has doesn't differentiate between the context hook (not stateful) and the actual context (stateful).
Though I don't know why non-stateful hooks were not given an ID. Might be that the use case for the ID simply changed over time since [it was introduced](https://github.com/facebook/react/pull/14906).
There's also an argument for maintainability since `ReactDebugHooks` always needs to know what hooks (by name) are not stateful.

Before:
![context-numbering-before](https://user-images.githubusercontent.com/12292047/131214241-45daefa2-338e-4da6-903f-73c0c1c79b56.png)

After:
![context-numbering-after](https://user-images.githubusercontent.com/12292047/131214244-0b68e58b-1f81-42c7-99b3-f0d6de021015.png)


## Test Plan

- [x] Verified manually with sheel app by including context hooks
- [x] CI green