### PR TITLE
devtools: Display StrictMode by default

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -978,7 +978,8 @@ describe('Store', () => {
     );
     expect(store).toMatchInlineSnapshot(`
       [root]
-          <Child>
+        ▾ <StrictMode>
+            <Child>
     `);
   });
 

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -962,6 +962,26 @@ describe('Store', () => {
     `);
   });
 
+  it('shows "other" component types', () => {
+    const container = document.createElement('div');
+    const Child = () => null;
+
+    act(() =>
+      legacyRender(
+        <React.StrictMode>
+          <React.Fragment>
+            <Child />
+          </React.Fragment>
+        </React.StrictMode>,
+        container,
+      ),
+    );
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+          <Child>
+    `);
+  });
+
   describe('Lazy', () => {
     async function fakeImport(result) {
       return {default: result};

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -135,6 +135,38 @@ describe('Store component filters', () => {
     `);
   });
 
+  it('should support filtering "other" element types', () => {
+    const FunctionComponent = () => <div>Hi</div>;
+
+    act(() =>
+      legacyRender(
+        <React.StrictMode>
+          <React.Fragment>
+            <FunctionComponent />
+          </React.Fragment>
+        </React.StrictMode>,
+        document.createElement('div'),
+      ),
+    );
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <FunctionComponent>
+            <div>
+    `);
+
+    act(
+      () =>
+        (store.componentFilters = [
+          utils.createElementTypeFilter(Types.ElementTypeOtherOrUnknown),
+        ]),
+    );
+    expect(store).toMatchInlineSnapshot(`
+      [root]
+        ▾ <FunctionComponent>
+            <div>
+    `);
+  });
+
   it('should ignore invalid ElementTypeRoot filter', () => {
     const Component = () => <div>Hi</div>;
 

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -150,8 +150,9 @@ describe('Store component filters', () => {
     );
     expect(store).toMatchInlineSnapshot(`
       [root]
-        ▾ <FunctionComponent>
-            <div>
+        ▾ <StrictMode>
+          ▾ <FunctionComponent>
+              <div>
     `);
 
     act(

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -478,7 +478,7 @@ export function getInternalReactConstants(
             return `${resolvedContext.displayName || 'Context'}.Consumer`;
           case STRICT_MODE_NUMBER:
           case STRICT_MODE_SYMBOL_STRING:
-            return null;
+            return 'StrictMode';
           case PROFILER_NUMBER:
           case PROFILER_SYMBOL_STRING:
             return `Profiler(${fiber.memoizedProps.id})`;
@@ -923,8 +923,6 @@ export function attach(
           case CONCURRENT_MODE_NUMBER:
           case CONCURRENT_MODE_SYMBOL_STRING:
           case DEPRECATED_ASYNC_MODE_SYMBOL_STRING:
-          case STRICT_MODE_NUMBER:
-          case STRICT_MODE_SYMBOL_STRING:
             return true;
           default:
             break;


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/21974

The "other" element type filter in devtools is currently in a weird spot (from a user and implementation perspective).

The "other" element type filter filters every component for which the computed devtools element type is `ElementTypeOtherOrUnknown`. The computed devtools element type is `ElementTypeOtherOrUnknown` for the following fiber tags:
1. `HostPortal`
2. `HostText`
3. `Fragment`
and the following symbols:
1. `CONCURRENT_MODE_NUMBER`
2. `CONCURRENT_MODE_SYMBOL_STRING`
3. `DEPRECATED_ASYNC_MODE_SYMBOL_STRING`
4. `STRICT_MODE_SYMBOL_STRING`
5. `STRICT_MODE_NUMBER`

See https://github.com/facebook/react/blob/8723e772b98d1a61aa0170981483c4da1e9237c5/packages/react-devtools-shared/src/backend/renderer.js#L965-L1016

However, the function responsible for determining whether a fiber should be filtered hides all of these types by default: https://github.com/facebook/react/blob/8723e772b98d1a61aa0170981483c4da1e9237c5/packages/react-devtools-shared/src/backend/renderer.js#L899-L928

So without this change, the "other" element type filter does not have any effect as far as I can tell. This change is really just about displaying `StrictMode` as reported by https://github.com/facebook/react/issues/21974. But, looking at the implementation, it seems like more types should be subject to the filter.

I see three paths forwards to avoid future confusion:
1. Split `ElementTypeOtherOrUnknown` into two new element types. One that will be filterable and one that's always hidden
2. Apply this fix to all `ElementTypeOtherOrUnknown` (`Fragment` is currently broken due to its usage by `Suspense`)
2. Remove the "other" element filter i.e. https://github.com/facebook/react/issues/21974 is not a bug but a feature 

## Test Plan

- [x] Added tests for filtering `StrictMode`
- [x] Added `StrictMode` to parts of the shell
- [x] CI green
