### PR TITLE
Set up use-sync-external-store package

### DIFF
--- a/ReactVersions.js
+++ b/ReactVersions.js
@@ -47,6 +47,7 @@ const experimentalPackages = [
   'react-fs',
   'react-pg',
   'react-server-dom-webpack',
+  'use-sync-external-store',
 ];
 
 module.exports = {

--- a/packages/use-sync-external-store/README.md
+++ b/packages/use-sync-external-store/README.md
@@ -1,0 +1,5 @@
+# use-sync-external-store
+
+Backwards compatible shim for React's `useSyncExternalStore`. Works with any React that supports hooks.
+
+Until `useSyncExternalStore` is documented, refer to https://github.com/reactwg/react-18/discussions/86

--- a/packages/use-sync-external-store/index.js
+++ b/packages/use-sync-external-store/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export * from './src/useSyncExternalStore';

--- a/packages/use-sync-external-store/npm/index.js
+++ b/packages/use-sync-external-store/npm/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/use-sync-external-store.production.min.js');
+} else {
+  module.exports = require('./cjs/use-sync-external-store.development.js');
+}

--- a/packages/use-sync-external-store/package.json
+++ b/packages/use-sync-external-store/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "use-sync-external-store",
+  "description": "Backwards compatible shim for React's useSyncExternalStore. Works with any React that supports hooks.",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/react.git",
+    "directory": "packages/use-sync-external-store"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "build-info.json",
+    "index.js",
+    "cjs/"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0"
+  }
+}

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStore-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStore-test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('useSyncExternalStore', () => {
+  test('TODO', () => {});
+});

--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export function useSyncExternalStore() {
+  throw new Error('Not yet implemented');
+}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -684,6 +684,15 @@ const bundles = [
     externals: ['react'],
   },
 
+  /******* Shim for useSyncExternalState *******/
+  {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: ISOMORPHIC,
+    entry: 'use-sync-external-store',
+    global: 'useSyncExternalStore',
+    externals: ['react'],
+  },
+
   /******* React Scheduler (experimental) *******/
   {
     bundleTypes: [


### PR DESCRIPTION
This package will be a shim for the built-in useSyncExternalStore API (not yet implemented).