### PR TITLE
Fix typo in ReactDOMServerFormatConfig.js

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -1706,7 +1706,7 @@ export function writeEndSegment(
 //   // Clear all the existing children. This is complicated because
 //   // there can be embedded Suspense boundaries in the fallback.
 //   // This is similar to clearSuspenseBoundary in ReactDOMHostConfig.
-//   // TOOD: We could avoid this if we never emitted suspense boundaries in fallback trees.
+//   // TODO: We could avoid this if we never emitted suspense boundaries in fallback trees.
 //   // They never hydrate anyway. However, currently we support incrementally loading the fallback.
 //   const parentInstance = suspenseNode.parentNode;
 //   let node = suspenseNode.nextSibling;


### PR DESCRIPTION
Fix typo:

TOOD -> TODO