### PR TITLE
Add consoleManagedByDevToolsDuringStrictMode feature flag in DevTools

### DIFF
--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -14,6 +14,7 @@ import {format} from './utils';
 
 import {getInternalReactConstants} from './renderer';
 import {getStackByFiberInDevAndProd} from './DevToolsFiberComponentStack';
+import {consoleManagedByDevToolsDuringStrictMode} from 'react-devtools-feature-flags';
 
 const OVERRIDE_CONSOLE_METHODS = ['error', 'trace', 'warn', 'log'];
 const DIMMED_NODE_CONSOLE_COLOR = '\x1b[2m%s\x1b[0m';
@@ -237,7 +238,7 @@ export function patch({
           debugger;
         }
 
-        if (isInStrictMode) {
+        if (consoleManagedByDevToolsDuringStrictMode && isInStrictMode) {
           if (!consoleSettingsRef.hideConsoleLogsInStrictMode) {
             // Dim the text color of the double logs if we're not
             // hiding them.

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 
+export const consoleManagedByDevToolsDuringStrictMode = false;
+
 /************************************************************************
  * Do not edit the code below.
  * It ensures this fork exports the same types as the default flags file.

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
 
+export const consoleManagedByDevToolsDuringStrictMode = false;
+
 /************************************************************************
  * Do not edit the code below.
  * It ensures this fork exports the same types as the default flags file.

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
@@ -15,3 +15,5 @@
 
 export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
+
+export const consoleManagedByDevToolsDuringStrictMode = true;

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 
+export const consoleManagedByDevToolsDuringStrictMode = true;
+
 /************************************************************************
  * Do not edit the code below.
  * It ensures this fork exports the same types as the default flags file.

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = false;
 
+export const consoleManagedByDevToolsDuringStrictMode = true;
+
 /************************************************************************
  * Do not edit the code below.
  * It ensures this fork exports the same types as the default flags file.


### PR DESCRIPTION
Right now we don't have support to read the React DevTools settings before initial render on React Native. This PR adds a DevTools feature flag to always disable double logging console logs on React Native until React Native adds support for synchronously reading settings in the future

