### PR TITLE
[DevTools] Remove `dist` build folder in release script before rebuilding

### DIFF
--- a/scripts/devtools/build-and-test.js
+++ b/scripts/devtools/build-and-test.js
@@ -93,6 +93,9 @@ async function buildAndTestExtensions() {
 
 async function buildAndTestStandalonePackage() {
   const corePackagePath = join(ROOT_PATH, 'packages', 'react-devtools-core');
+  const corePackageDest = join(corePackagePath, 'dist');
+
+  await exec(`rm -rf ${corePackageDest}`);
   const buildCorePromise = exec('yarn build', {cwd: corePackagePath});
 
   await logger(
@@ -133,6 +136,9 @@ async function buildAndTestInlinePackage() {
     'packages',
     'react-devtools-inline'
   );
+  const inlinePackageDest = join(inlinePackagePath, 'dist');
+
+  await exec(`rm -rf ${inlinePackageDest}`);
   const buildPromise = exec('yarn build', {cwd: inlinePackagePath});
 
   await logger(


### PR DESCRIPTION
Previously, we weren't removing the `dist` build folder for `react-devtools-inline` and `react-devtools-core` packages before rebuilding in the release script, which caused issues like #22220. This PR updates the release script to do fix this.