### PR TITLE
[DevTools] Fix Issue in release script where commits for the last DevTools release are undefined

### DIFF
--- a/scripts/devtools/prepare-release.js
+++ b/scripts/devtools/prepare-release.js
@@ -115,8 +115,12 @@ async function getPreviousCommitSha() {
   const choices = [];
 
   const lines = await execRead(`
-    git log --max-count=5 --topo-order --pretty=format:'%H:::%s:::%as' HEAD -- ${PACKAGE_PATHS[0]}
+    git log --max-count=5 --topo-order --pretty=format:'%H:::%s:::%as' HEAD -- ${join(
+      ROOT_PATH,
+      PACKAGE_PATHS[0]
+    )}
   `);
+
   lines.split('\n').forEach((line, index) => {
     const [hash, message, date] = line.split(':::');
     choices.push({


### PR DESCRIPTION
Fixes issue in release script where commits for the last DevTools release are undefined

Before:
![image](https://user-images.githubusercontent.com/2735514/131733011-dceb51c8-bb76-4430-831c-3b793e9d9513.png)

After: 
![image](https://user-images.githubusercontent.com/2735514/131733175-366c386a-7c99-444b-959c-017e3b411807.png)

Verified that this works both from the `root` folder and the `scripts/devtools` folder