### PR TITLE
Feature/warnings for concurrent hooks in legacy mode

### DIFF
--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -372,7 +372,10 @@ describe('ReactHooksInspectionIntegration', () => {
       const memoizedValue = React.useMemo(() => 'hello', []);
       return <div>{memoizedValue}</div>;
     }
-    const renderer = ReactTestRenderer.create(<Foo />);
+    let renderer
+    act(() => {
+      renderer = ReactTestRenderer.create(<Foo />, { unstable_isConcurrent: true});
+    })
     const childFiber = renderer.root.findByType(Foo)._currentFiber();
     const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
@@ -401,7 +404,10 @@ describe('ReactHooksInspectionIntegration', () => {
       const [state] = React.useState(() => 'hello', []);
       return <div>{state}</div>;
     }
-    const renderer = ReactTestRenderer.create(<Foo />);
+    let renderer;
+    act(() => {
+      renderer = ReactTestRenderer.create(<Foo />, { unstable_isConcurrent: true});
+    })
     const childFiber = renderer.root.findByType(Foo)._currentFiber();
     const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -372,10 +372,12 @@ describe('ReactHooksInspectionIntegration', () => {
       const memoizedValue = React.useMemo(() => 'hello', []);
       return <div>{memoizedValue}</div>;
     }
-    let renderer
+    let renderer;
     act(() => {
-      renderer = ReactTestRenderer.create(<Foo />, { unstable_isConcurrent: true});
-    })
+      renderer = ReactTestRenderer.create(<Foo />, {
+        unstable_isConcurrent: true,
+      });
+    });
     const childFiber = renderer.root.findByType(Foo)._currentFiber();
     const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([
@@ -406,8 +408,10 @@ describe('ReactHooksInspectionIntegration', () => {
     }
     let renderer;
     act(() => {
-      renderer = ReactTestRenderer.create(<Foo />, { unstable_isConcurrent: true});
-    })
+      renderer = ReactTestRenderer.create(<Foo />, {
+        unstable_isConcurrent: true,
+      });
+    });
     const childFiber = renderer.root.findByType(Foo)._currentFiber();
     const tree = ReactDebugTools.inspectHooksOfFiber(childFiber);
     expect(tree).toEqual([

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -725,9 +725,12 @@ function runActTests(label, render, unmount, rerender) {
                 rerender(<App suspend={true} />);
               });
             });
-          }).toErrorDev([
-            'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
-          ], {withoutStack: true})
+          }).toErrorDev(
+            [
+              'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
+            ],
+            {withoutStack: true},
+          );
 
           if (label === 'concurrent mode') {
             // In Concurrent Mode, refresh transitions delay indefinitely.

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -718,12 +718,16 @@ function runActTests(label, render, unmount, rerender) {
           });
           expect(document.querySelector('[data-test-id=spinner]')).toBeNull();
 
-          // trigger a suspendy update with a delay
-          React.startTransition(() => {
-            act(() => {
-              rerender(<App suspend={true} />);
+          expect(() => {
+            // trigger a suspendy update with a delay
+            React.startTransition(() => {
+              act(() => {
+                rerender(<App suspend={true} />);
+              });
             });
-          });
+          }).toErrorDev([
+            'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
+          ], {withoutStack: true})
 
           if (label === 'concurrent mode') {
             // In Concurrent Mode, refresh transitions delay indefinitely.

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1673,16 +1673,17 @@ function updateMemo<T>(
 }
 
 function mountDeferredValue<T>(value: T): T {
-  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
-    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+  if (__DEV__ && (currentlyRenderingFiber.mode & ConcurrentMode) === NoMode) {
+    const name =
+      getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseDeferredValueWithoutConcurrentMode.has(name)) {
       if (__DEV__) {
-console.error(
-        'useDeferredValue can only be used inside concurrent mode. '+
-        'Use React.createRoot instead of ReactDOM.render'
-      )
-}
-      didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name)
+        console.error(
+          'useDeferredValue can only be used inside concurrent mode. ' +
+            'Use React.createRoot instead of ReactDOM.render',
+        );
+      }
+      didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name);
     }
   }
   const [prevValue, setValue] = mountState(value);
@@ -1746,16 +1747,17 @@ function startTransition(setPending, callback) {
 }
 
 function mountTransition(): [boolean, (() => void) => void] {
-  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
-    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+  if (__DEV__ && (currentlyRenderingFiber.mode & ConcurrentMode) === NoMode) {
+    const name =
+      getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseTransitionWithoutConcurrentMode.has(name)) {
       if (__DEV__) {
-console.error(
-        'useTransition can only be used inside concurrent mode. '+
-        'Use React.createRoot instead of ReactDOM.render'
-      )
-}
-      didWarnAboutUseTransitionWithoutConcurrentMode.add(name)
+        console.error(
+          'useTransition can only be used inside concurrent mode. ' +
+            'Use React.createRoot instead of ReactDOM.render',
+        );
+      }
+      didWarnAboutUseTransitionWithoutConcurrentMode.add(name);
     }
   }
   const [isPending, setPending] = mountState(false);

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1676,10 +1676,12 @@ function mountDeferredValue<T>(value: T): T {
   if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
     const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseDeferredValueWithoutConcurrentMode.has(name)) {
-      console.error(
+      if (__DEV__) {
+console.error(
         'useDeferredValue can only be used inside concurrent mode. '+
         'Use React.createRoot instead of ReactDOM.render'
       )
+}
       didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name)
     }
   }
@@ -1747,10 +1749,12 @@ function mountTransition(): [boolean, (() => void) => void] {
   if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
     const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseTransitionWithoutConcurrentMode.has(name)) {
-      console.error(
+      if (__DEV__) {
+console.error(
         'useTransition can only be used inside concurrent mode. '+
         'Use React.createRoot instead of ReactDOM.render'
       )
+}
       didWarnAboutUseTransitionWithoutConcurrentMode.add(name)
     }
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1673,16 +1673,17 @@ function updateMemo<T>(
 }
 
 function mountDeferredValue<T>(value: T): T {
-  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
-    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+  if (__DEV__ && (currentlyRenderingFiber.mode & ConcurrentMode) === NoMode) {
+    const name =
+      getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseDeferredValueWithoutConcurrentMode.has(name)) {
       if (__DEV__) {
-console.error(
-        'useDeferredValue can only be used inside concurrent mode. '+
-        'Use React.createRoot instead of ReactDOM.render'
-      )
-}
-      didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name)
+        console.error(
+          'useDeferredValue can only be used inside concurrent mode. ' +
+            'Use React.createRoot instead of ReactDOM.render',
+        );
+      }
+      didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name);
     }
   }
   const [prevValue, setValue] = mountState(value);
@@ -1746,16 +1747,17 @@ function startTransition(setPending, callback) {
 }
 
 function mountTransition(): [boolean, (() => void) => void] {
-  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
-    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+  if (__DEV__ && (currentlyRenderingFiber.mode & ConcurrentMode) === NoMode) {
+    const name =
+      getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
     if (!didWarnAboutUseTransitionWithoutConcurrentMode.has(name)) {
       if (__DEV__) {
-console.error(
-        'useTransition can only be used inside concurrent mode. '+
-        'Use React.createRoot instead of ReactDOM.render'
-      )
-}
-      didWarnAboutUseTransitionWithoutConcurrentMode.add(name)
+        console.error(
+          'useTransition can only be used inside concurrent mode. ' +
+            'Use React.createRoot instead of ReactDOM.render',
+        );
+      }
+      didWarnAboutUseTransitionWithoutConcurrentMode.add(name);
     }
   }
   const [isPending, setPending] = mountState(false);

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -136,9 +136,13 @@ export type UpdateQueue<S, A> = {|
 
 let didWarnAboutMismatchedHooksForComponent;
 let didWarnAboutUseOpaqueIdentifier;
+let didWarnAboutUseTransitionWithoutConcurrentMode;
+let didWarnAboutUseDeferredValueWithoutConcurrentMode;
 if (__DEV__) {
   didWarnAboutUseOpaqueIdentifier = {};
   didWarnAboutMismatchedHooksForComponent = new Set();
+  didWarnAboutUseTransitionWithoutConcurrentMode = new Set();
+  didWarnAboutUseDeferredValueWithoutConcurrentMode = new Set();
 }
 
 export type Hook = {|
@@ -1669,6 +1673,18 @@ function updateMemo<T>(
 }
 
 function mountDeferredValue<T>(value: T): T {
+  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
+    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+    if (!didWarnAboutUseDeferredValueWithoutConcurrentMode.has(name)) {
+      if (__DEV__) {
+console.error(
+        'useDeferredValue can only be used inside concurrent mode. '+
+        'Use React.createRoot instead of ReactDOM.render'
+      )
+}
+      didWarnAboutUseDeferredValueWithoutConcurrentMode.add(name)
+    }
+  }
   const [prevValue, setValue] = mountState(value);
   mountEffect(() => {
     const prevTransition = ReactCurrentBatchConfig.transition;
@@ -1730,6 +1746,18 @@ function startTransition(setPending, callback) {
 }
 
 function mountTransition(): [boolean, (() => void) => void] {
+  if (__DEV__ && ((currentlyRenderingFiber.mode & ConcurrentMode) === NoMode)) {
+    const name = getComponentNameFromFiber(currentlyRenderingFiber) || 'Unknown';
+    if (!didWarnAboutUseTransitionWithoutConcurrentMode.has(name)) {
+      if (__DEV__) {
+console.error(
+        'useTransition can only be used inside concurrent mode. '+
+        'Use React.createRoot instead of ReactDOM.render'
+      )
+}
+      didWarnAboutUseTransitionWithoutConcurrentMode.add(name)
+    }
+  }
   const [isPending, setPending] = mountState(false);
   // The `start` method never changes.
   const start = startTransition.bind(null, setPending);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -361,9 +361,9 @@ export function getCurrentTime() {
   return now();
 }
 
-let didWarnAboutStartTransitionWithoutConcurrentMode
+let didWarnAboutStartTransitionWithoutConcurrentMode;
 if (__DEV__) {
-  didWarnAboutStartTransitionWithoutConcurrentMode = new Set()
+  didWarnAboutStartTransitionWithoutConcurrentMode = new Set();
 }
 export function requestUpdateLane(fiber: Fiber): Lane {
   // Special cases
@@ -373,11 +373,11 @@ export function requestUpdateLane(fiber: Fiber): Lane {
       const name = getComponentNameFromFiber(fiber) || 'Unknown';
       if (!didWarnAboutStartTransitionWithoutConcurrentMode.has(name)) {
         if (__DEV__) {
-console.error(
-          'startTransition can only be used inside concurrent mode. '+
-          'Use React.createRoot instead of ReactDOM.render'
-        )
-};
+          console.error(
+            'startTransition can only be used inside concurrent mode. ' +
+              'Use React.createRoot instead of ReactDOM.render',
+          );
+        }
         didWarnAboutStartTransitionWithoutConcurrentMode.add(name);
       }
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -190,7 +190,6 @@ import {
   resetHooksAfterThrow,
   ContextOnlyDispatcher,
   getIsUpdatingOpaqueValueInRenderPhaseInDEV,
-  warnOnConcurrentHookOutsideConcurrentModeInDEV,
 } from './ReactFiberHooks.new';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -373,10 +372,12 @@ export function requestUpdateLane(fiber: Fiber): Lane {
     if (__DEV__ && requestCurrentTransition() !== NoTransition) {
       const name = getComponentNameFromFiber(fiber) || 'Unknown';
       if (!didWarnAboutStartTransitionWithoutConcurrentMode.has(name)) {
-        console.error(
+        if (__DEV__) {
+console.error(
           'startTransition can only be used inside concurrent mode. '+
           'Use React.createRoot instead of ReactDOM.render'
-        );
+        )
+};
         didWarnAboutStartTransitionWithoutConcurrentMode.add(name);
       }
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -190,6 +190,7 @@ import {
   resetHooksAfterThrow,
   ContextOnlyDispatcher,
   getIsUpdatingOpaqueValueInRenderPhaseInDEV,
+  warnOnConcurrentHookOutsideConcurrentModeInDEV,
 } from './ReactFiberHooks.new';
 import {createCapturedValue} from './ReactCapturedValue';
 import {
@@ -361,10 +362,24 @@ export function getCurrentTime() {
   return now();
 }
 
+let didWarnAboutStartTransitionWithoutConcurrentMode
+if (__DEV__) {
+  didWarnAboutStartTransitionWithoutConcurrentMode = new Set()
+}
 export function requestUpdateLane(fiber: Fiber): Lane {
   // Special cases
   const mode = fiber.mode;
   if ((mode & ConcurrentMode) === NoMode) {
+    if (__DEV__ && requestCurrentTransition() !== NoTransition) {
+      const name = getComponentNameFromFiber(fiber) || 'Unknown';
+      if (!didWarnAboutStartTransitionWithoutConcurrentMode.has(name)) {
+        console.error(
+          'startTransition can only be used inside concurrent mode. '+
+          'Use React.createRoot instead of ReactDOM.render'
+        );
+        didWarnAboutStartTransitionWithoutConcurrentMode.add(name);
+      }
+    }
     return (SyncLane: Lane);
   } else if (
     !deferRenderPhaseUpdateToNextBatch &&

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -361,10 +361,26 @@ export function getCurrentTime() {
   return now();
 }
 
+let didWarnAboutStartTransitionWithoutConcurrentMode
+if (__DEV__) {
+  didWarnAboutStartTransitionWithoutConcurrentMode = new Set()
+}
 export function requestUpdateLane(fiber: Fiber): Lane {
   // Special cases
   const mode = fiber.mode;
   if ((mode & ConcurrentMode) === NoMode) {
+    if (__DEV__ && requestCurrentTransition() !== NoTransition) {
+      const name = getComponentNameFromFiber(fiber) || 'Unknown';
+      if (!didWarnAboutStartTransitionWithoutConcurrentMode.has(name)) {
+        if (__DEV__) {
+console.error(
+          'startTransition can only be used inside concurrent mode. '+
+          'Use React.createRoot instead of ReactDOM.render'
+        )
+};
+        didWarnAboutStartTransitionWithoutConcurrentMode.add(name);
+      }
+    }
     return (SyncLane: Lane);
   } else if (
     !deferRenderPhaseUpdateToNextBatch &&

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -361,9 +361,9 @@ export function getCurrentTime() {
   return now();
 }
 
-let didWarnAboutStartTransitionWithoutConcurrentMode
+let didWarnAboutStartTransitionWithoutConcurrentMode;
 if (__DEV__) {
-  didWarnAboutStartTransitionWithoutConcurrentMode = new Set()
+  didWarnAboutStartTransitionWithoutConcurrentMode = new Set();
 }
 export function requestUpdateLane(fiber: Fiber): Lane {
   // Special cases
@@ -373,11 +373,11 @@ export function requestUpdateLane(fiber: Fiber): Lane {
       const name = getComponentNameFromFiber(fiber) || 'Unknown';
       if (!didWarnAboutStartTransitionWithoutConcurrentMode.has(name)) {
         if (__DEV__) {
-console.error(
-          'startTransition can only be used inside concurrent mode. '+
-          'Use React.createRoot instead of ReactDOM.render'
-        )
-};
+          console.error(
+            'startTransition can only be used inside concurrent mode. ' +
+              'Use React.createRoot instead of ReactDOM.render',
+          );
+        }
         didWarnAboutStartTransitionWithoutConcurrentMode.add(name);
       }
     }

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1999,7 +1999,7 @@ describe('ReactHooks', () => {
       React.useTransition({
         timeoutMs: 3000
       });
-      return <div/>
+      return <div />
     }
     const renderer = ReactTestRenderer.create(null, {unstable_isConcurrent: false});
     expect(() => {
@@ -2013,14 +2013,17 @@ describe('ReactHooks', () => {
     ])
 
     function Parent2() {
-      const [state, setState] = React.useState(5)
-      return <div onClick={() => { React.startTransition(() => {
+      /* eslint-disable no-unused-vars */
+      const [_, setState] = React.useState(5)
+      return (<div onClick={() => {
+ React.startTransition(() => {
         setState(6);
-      }); }}></div>
+      }); 
+}} />)
     }
     expect(() => {
       act(() => {
-        renderer.update(<Parent2/>)
+        renderer.update(<Parent2 />)
         renderer.root.findByType('div').props.onClick()
       })
     }).toErrorDev([
@@ -2028,7 +2031,7 @@ describe('ReactHooks', () => {
     ], {withoutStack: true})
 
     act(() => {
-      ReactTestRenderer.create(<Parent/>, {unstable_isConcurrent: true});
+      ReactTestRenderer.create(<Parent />, {unstable_isConcurrent: true});
     })
   })
 });

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1556,7 +1556,9 @@ describe('ReactHooks', () => {
         }
         let root;
         act(() => {
-          root = ReactTestRenderer.create(<App update={false} />, { unstable_isConcurrent: true});
+          root = ReactTestRenderer.create(<App update={false} />, {
+            unstable_isConcurrent: true,
+          });
         });
         expect(() => {
           try {
@@ -1605,7 +1607,9 @@ describe('ReactHooks', () => {
         }
         let root;
         act(() => {
-          root = ReactTestRenderer.create(<App update={false} />, { unstable_isConcurrent: true});
+          root = ReactTestRenderer.create(<App update={false} />, {
+            unstable_isConcurrent: true,
+          });
         });
 
         expect(() => {
@@ -1659,7 +1663,9 @@ describe('ReactHooks', () => {
         }
         let root;
         act(() => {
-          root = ReactTestRenderer.create(<App update={false} />, { unstable_isConcurrent: true});
+          root = ReactTestRenderer.create(<App update={false} />, {
+            unstable_isConcurrent: true,
+          });
         });
 
         expect(() => {
@@ -1994,44 +2000,53 @@ describe('ReactHooks', () => {
   it('Warns when using useTransition, startTransition or useDeferredValue in legacy mode', () => {
     function Parent() {
       React.useDeferredValue(5, {
-        timeoutMs: 5000
+        timeoutMs: 5000,
       });
       React.useTransition({
-        timeoutMs: 3000
+        timeoutMs: 3000,
       });
-      return <div />
+      return <div />;
     }
-    const renderer = ReactTestRenderer.create(null, {unstable_isConcurrent: false});
+    const renderer = ReactTestRenderer.create(null, {
+      unstable_isConcurrent: false,
+    });
     expect(() => {
       act(() => {
-        renderer.update(<Parent />)
-      })
+        renderer.update(<Parent />);
+      });
     }).toErrorDev([
       'useDeferredValue can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
       'useTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
       'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
-    ])
+    ]);
 
     function Parent2() {
       /* eslint-disable no-unused-vars */
-      const [_, setState] = React.useState(5)
-      return (<div onClick={() => {
- React.startTransition(() => {
-        setState(6);
-      }); 
-}} />)
+      const [_, setState] = React.useState(5);
+      return (
+        <div
+          onClick={() => {
+            React.startTransition(() => {
+              setState(6);
+            });
+          }}
+        />
+      );
     }
     expect(() => {
       act(() => {
-        renderer.update(<Parent2 />)
-        renderer.root.findByType('div').props.onClick()
-      })
-    }).toErrorDev([
-      'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
-    ], {withoutStack: true})
+        renderer.update(<Parent2 />);
+        renderer.root.findByType('div').props.onClick();
+      });
+    }).toErrorDev(
+      [
+        'startTransition can only be used inside concurrent mode. Use React.createRoot instead of ReactDOM.render',
+      ],
+      {withoutStack: true},
+    );
 
     act(() => {
       ReactTestRenderer.create(<Parent />, {unstable_isConcurrent: true});
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
## Summary

React has a new API for creating roots, ReactDOM.createRoot. The old API is ReactDOM.render. We refer to these as "legacy" roots.

The new roots support additional features that aren't supported in legacy mode, like concurrent rendering.

We should warn in development if someone uses one of these concurrent-only APIs in a legacy root:

React.startTransition
React.useTransition
React.useDeferredValue


## Test Plan
Test cases added to ReactHooks-test.internal.js
Existing affected test cases were updated.
`yarn test` ran successfully.
