### PR TITLE
Add warning and test for useSyncExternalStore when getSnapshot isn't cached

### DIFF
--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -627,7 +627,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       return <Text text={JSON.stringify(text)} />;
     }
 
-    spyOnDevAndProd(console, 'error')
+    spyOnDev(console, 'error')
 
     expect(() => {
       act(() => {
@@ -639,6 +639,8 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       'calls setState inside componentWillUpdate or componentDidUpdate. React limits ' + 
       'the number of nested updates to prevent infinite loops.'
     )
-    expect(console.error.calls.argsFor(0)[0]).toMatch('The result of getSnapshot should be cached to avoid an infinite loop')
+    if (__DEV__) {
+      expect(console.error.calls.argsFor(0)[0]).toMatch('The result of getSnapshot should be cached to avoid an infinite loop')
+    }
   });
 });

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -627,20 +627,21 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       return <Text text={JSON.stringify(text)} />;
     }
 
-    spyOnDev(console, 'error')
+    spyOnDev(console, 'error');
 
     expect(() => {
       act(() => {
         createRoot(<App />);
-      })
-    })
-    .toThrow(
+      });
+    }).toThrow(
       'Maximum update depth exceeded. This can happen when a component repeatedly ' +
-      'calls setState inside componentWillUpdate or componentDidUpdate. React limits ' + 
-      'the number of nested updates to prevent infinite loops.'
-    )
+        'calls setState inside componentWillUpdate or componentDidUpdate. React limits ' +
+        'the number of nested updates to prevent infinite loops.',
+    );
     if (__DEV__) {
-      expect(console.error.calls.argsFor(0)[0]).toMatch('The result of getSnapshot should be cached to avoid an infinite loop')
+      expect(console.error.calls.argsFor(0)[0]).toMatch(
+        'The result of getSnapshot should be cached to avoid an infinite loop',
+      );
     }
   });
 });

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -618,4 +618,27 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       expect(root).toMatchRenderedOutput('A1B1');
     });
   });
+
+  test('Infinite loop if getSnapshot keeps returning new reference', () => {
+    const store = createExternalStore({});
+
+    function App() {
+      const text = useSyncExternalStore(store.subscribe, () => ({}));
+      return <Text text={JSON.stringify(text)} />;
+    }
+
+    spyOnDevAndProd(console, 'error')
+
+    expect(() => {
+      act(() => {
+        createRoot(<App />);
+      })
+    })
+    .toThrow(
+      'Maximum update depth exceeded. This can happen when a component repeatedly ' +
+      'calls setState inside componentWillUpdate or componentDidUpdate. React limits ' + 
+      'the number of nested updates to prevent infinite loops.'
+    )
+    expect(console.error.calls.argsFor(0)[0]).toMatch('The result of getSnapshot should be cached to avoid an infinite loop')
+  });
 });

--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -29,7 +29,7 @@ export const useSyncExternalStore =
   builtInAPI !== undefined ? builtInAPI : useSyncExternalStore_shim;
 
 let didWarnOld18Alpha = false;
-let didWarnUncachedGetSnapshot = false
+let didWarnUncachedGetSnapshot = false;
 
 // Disclaimer: This shim breaks many of the rules of React, and only works
 // because of a very particular set of implementation details and assumptions
@@ -67,8 +67,10 @@ function useSyncExternalStore_shim<T>(
   if (__DEV__) {
     if (!didWarnUncachedGetSnapshot) {
       if (value !== getSnapshot()) {
-        console.error('The result of getSnapshot should be cached to avoid an infinite loop')
-        didWarnUncachedGetSnapshot = true
+        console.error(
+          'The result of getSnapshot should be cached to avoid an infinite loop',
+        );
+        didWarnUncachedGetSnapshot = true;
       }
     }
   }

--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -29,6 +29,7 @@ export const useSyncExternalStore =
   builtInAPI !== undefined ? builtInAPI : useSyncExternalStore_shim;
 
 let didWarnOld18Alpha = false;
+let didWarnUncachedGetSnapshot = false
 
 // Disclaimer: This shim breaks many of the rules of React, and only works
 // because of a very particular set of implementation details and assumptions
@@ -63,6 +64,14 @@ function useSyncExternalStore_shim<T>(
   // implementation details, most importantly that updates are
   // always synchronous.
   const value = getSnapshot();
+  if (__DEV__) {
+    if (!didWarnUncachedGetSnapshot) {
+      if (value !== getSnapshot()) {
+        console.error('The result of getSnapshot should be cached to avoid an infinite loop')
+        didWarnUncachedGetSnapshot = true
+      }
+    }
+  }
 
   // Because updates are synchronous, we don't queue them. Instead we force a
   // re-render whenever the subscribed state changes by updating an some


### PR DESCRIPTION
- Add a test to the React repo (useSyncExternalStore-test.js) that renders a component that uses `useSyncExternalStore`.
- Pass a `getSnapshot` function to `useSyncExternalStore` that returns a new object each time it's called
- The test will throw because of an infinite update loop. It should also log a warning in development that the result of `getSnapshot` must be cached (can bikeshed the exact text of the warning during code review)

Test Plan:
yarn test 
