### PR TITLE
[DevTools] Add initial APIs for logging instrumentation events under feature flag

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -88,7 +88,7 @@ function createPanelIfReactLoaded() {
 
       const tabId = chrome.devtools.inspectedWindow.tabId;
 
-      registerEventLogger((_event: LogEvent) => {
+      registerEventLogger((event: LogEvent) => {
         // TODO: hook up event logging
       });
 

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -18,6 +18,7 @@ import {
   localStorageRemoveItem,
   localStorageSetItem,
 } from 'react-devtools-shared/src/storage';
+import {registerEventLogger} from 'react-devtools-shared/src/Logger';
 import DevTools from 'react-devtools-shared/src/devtools/views/DevTools';
 import {__DEBUG__} from 'react-devtools-shared/src/constants';
 
@@ -86,6 +87,10 @@ function createPanelIfReactLoaded() {
       let root = null;
 
       const tabId = chrome.devtools.inspectedWindow.tabId;
+
+      registerEventLogger((_event: LogEvent) => {
+        // TODO: hook up event logging
+      });
 
       function initBridgeAndStore() {
         const port = chrome.runtime.connect({

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -14,7 +14,7 @@ type LoadHookNamesEvent = {|
   +displayName: string | null,
   +numberOfHooks: number | null,
   +durationMs: number,
-  +resolution: 'success' | 'error' | 'timeout',
+  +resolution: 'success' | 'error' | 'timeout' | 'unknown',
 |};
 
 // prettier-ignore

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -10,7 +10,7 @@
 import {enableLogger} from 'react-devtools-feature-flags';
 
 export type LogEvent = {|
-  +name: 'parseHookNames',
+  +name: 'loadHookNames',
   +displayName: string | null,
   +numberOfHooks: number | null,
   +durationMs: number,

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -9,13 +9,17 @@
 
 import {enableLogger} from 'react-devtools-feature-flags';
 
-export type LogEvent = {|
+type LoadHookNamesEvent = {|
   +name: 'loadHookNames',
   +displayName: string | null,
   +numberOfHooks: number | null,
   +durationMs: number,
   +resolution: 'success' | 'error' | 'timeout',
 |};
+
+// prettier-ignore
+export type LogEvent =
+  | LoadHookNamesEvent;
 
 export type LogFunction = LogEvent => void;
 

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -23,7 +23,7 @@ export type LogEvent =
 
 export type LogFunction = LogEvent => void;
 
-let loggers = [];
+let loggers: Array<LogFunction> = [];
 export const logEvent: LogFunction =
   enableLogger === true
     ? function logEvent(event: LogEvent): void {

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import {enableLogger} from 'react-devtools-feature-flags';
+
+export type LogEvent = {|
+  +name: 'parseHookNames',
+  +displayName: string | null,
+  +numberOfHooks: number | null,
+  +durationMs: number,
+  +resolution: 'success' | 'error' | 'timeout',
+|};
+
+export type LogFunction = LogEvent => void;
+
+let loggers = [];
+export const logEvent: LogFunction =
+  enableLogger === true
+    ? function logEvent(event: LogEvent): void {
+        loggers.forEach(log => {
+          log(event);
+        });
+      }
+    : function logEvent() {};
+
+export const registerEventLogger =
+  enableLogger === true
+    ? function registerEventLogger(eventLogger: LogFunction): () => void {
+        if (enableLogger) {
+          loggers.push(eventLogger);
+          return function unregisterEventLogger() {
+            loggers = loggers.filter(logger => logger !== eventLogger);
+          };
+        }
+        return () => {};
+      }
+    : function registerEventLogger() {};

--- a/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
+++ b/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
@@ -83,24 +83,24 @@ export function withSyncPerfMeasurements<TReturn>(
   return result;
 }
 
-export function withCallbackPerfMeasurements<TReturn, TArgs>(
+export function withCallbackPerfMeasurements<TReturn>(
   markName: string,
-  callback: (done: (args: TArgs) => void) => TReturn,
-  onComplete?: (number, args: TArgs) => void,
+  callback: (done: () => void) => TReturn,
+  onComplete?: number => void,
 ): TReturn {
   const start = now();
   if (__PERFORMANCE_PROFILE__) {
     mark(markName);
   }
 
-  const done = args => {
+  const done = () => {
     if (__PERFORMANCE_PROFILE__) {
       measure(markName);
     }
 
     if (onComplete != null) {
       const duration = now() - start;
-      onComplete(duration, args);
+      onComplete(duration);
     }
   };
   return callback(done);

--- a/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
+++ b/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
@@ -85,22 +85,22 @@ export function withSyncPerfMeasurements<TReturn>(
 
 export function withCallbackPerfMeasurements<TReturn, TArgs>(
   markName: string,
-  callback: (done: (...args: TArgs[]) => void) => TReturn,
-  onComplete?: (number, ...args: TArgs[]) => void,
+  callback: (done: (args: TArgs) => void) => TReturn,
+  onComplete?: (number, args: TArgs) => void,
 ): TReturn {
   const start = now();
   if (__PERFORMANCE_PROFILE__) {
     mark(markName);
   }
 
-  const done = (...args) => {
+  const done = args => {
     if (__PERFORMANCE_PROFILE__) {
       measure(markName);
     }
 
     if (onComplete != null) {
       const duration = now() - start;
-      onComplete(duration, ...args);
+      onComplete(duration, args);
     }
   };
   return callback(done);

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
@@ -17,7 +17,6 @@ export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 export const enableNamedHooksFeature = false;
 export const enableLogger = false;
-
 export const consoleManagedByDevToolsDuringStrictMode = false;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-fb.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 export const enableNamedHooksFeature = false;
+export const enableLogger = false;
+
 export const consoleManagedByDevToolsDuringStrictMode = false;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
@@ -17,7 +17,6 @@ export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = false;
 export const enableLogger = false;
-
 export const consoleManagedByDevToolsDuringStrictMode = false;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = false;
+export const enableLogger = false;
+
 export const consoleManagedByDevToolsDuringStrictMode = false;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
@@ -17,5 +17,4 @@ export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = true;
 export const enableLogger = false;
-
 export const consoleManagedByDevToolsDuringStrictMode = true;

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
@@ -16,4 +16,6 @@
 export const enableProfilerChangedHookIndices = false;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = true;
+export const enableLogger = false;
+
 export const consoleManagedByDevToolsDuringStrictMode = true;

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 export const enableNamedHooksFeature = true;
+export const enableLogger = false;
+
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
@@ -17,7 +17,6 @@ export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 export const enableNamedHooksFeature = true;
 export const enableLogger = false;
-
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
@@ -16,6 +16,8 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = true;
+export const enableLogger = false;
+
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
@@ -17,7 +17,6 @@ export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = false;
 export const enableNamedHooksFeature = true;
 export const enableLogger = false;
-
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 /************************************************************************

--- a/packages/react-devtools-shared/src/hooks/astUtils.js
+++ b/packages/react-devtools-shared/src/hooks/astUtils.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {withSyncPerformanceMark} from 'react-devtools-shared/src/PerformanceMarks';
+import {withSyncPerformanceMark} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 import traverse, {NodePath, Node} from '@babel/traverse';
 import {File} from '@babel/types';
 

--- a/packages/react-devtools-shared/src/hooks/astUtils.js
+++ b/packages/react-devtools-shared/src/hooks/astUtils.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {withSyncPerformanceMark} from 'react-devtools-shared/src/PerformanceLoggingUtils';
+import {withSyncPerfMeasurements} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 import traverse, {NodePath, Node} from '@babel/traverse';
 import {File} from '@babel/types';
 
@@ -132,7 +132,7 @@ export function getHookName(
   originalSourceLineNumber: number,
   originalSourceColumnNumber: number,
 ): string | null {
-  const hooksFromAST = withSyncPerformanceMark(
+  const hooksFromAST = withSyncPerfMeasurements(
     'getPotentialHookDeclarationsFromAST(originalSourceAST)',
     () => getPotentialHookDeclarationsFromAST(originalSourceAST),
   );
@@ -176,7 +176,7 @@ export function getHookName(
   // nodesAssociatedWithReactHookASTNode could directly be used to obtain the hook variable name
   // depending on the type of potentialReactHookASTNode
   try {
-    const nodesAssociatedWithReactHookASTNode = withSyncPerformanceMark(
+    const nodesAssociatedWithReactHookASTNode = withSyncPerfMeasurements(
       'getFilteredHookASTNodes()',
       () =>
         getFilteredHookASTNodes(
@@ -186,7 +186,7 @@ export function getHookName(
         ),
     );
 
-    const name = withSyncPerformanceMark('getHookNameFromNode()', () =>
+    const name = withSyncPerfMeasurements('getHookNameFromNode()', () =>
       getHookNameFromNode(
         hook,
         nodesAssociatedWithReactHookASTNode,
@@ -297,7 +297,7 @@ function getHookVariableName(
 
 function getPotentialHookDeclarationsFromAST(sourceAST: File): NodePath[] {
   const potentialHooksFound: NodePath[] = [];
-  withSyncPerformanceMark('traverse(sourceAST)', () =>
+  withSyncPerfMeasurements('traverse(sourceAST)', () =>
     traverse(sourceAST, {
       enter(path) {
         if (path.isVariableDeclarator() && isPotentialHookDeclaration(path)) {

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/index.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/index.js
@@ -12,7 +12,7 @@ import type {HooksNode, HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
 import type {HookNames} from 'react-devtools-shared/src/types';
 import type {FetchFileWithCaching} from 'react-devtools-shared/src/devtools/views/Components/FetchFileWithCachingContext';
 
-import {withAsyncPerformanceMark} from 'react-devtools-shared/src/PerformanceMarks';
+import {withAsyncPerformanceMark} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 import WorkerizedParseSourceAndMetadata from './parseSourceAndMetadata.worker';
 import typeof * as ParseSourceAndMetadataModule from './parseSourceAndMetadata';
 import {flattenHooksList, loadSourceAndMetadata} from './loadSourceAndMetadata';

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/index.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/index.js
@@ -12,7 +12,7 @@ import type {HooksNode, HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
 import type {HookNames} from 'react-devtools-shared/src/types';
 import type {FetchFileWithCaching} from 'react-devtools-shared/src/devtools/views/Components/FetchFileWithCachingContext';
 
-import {withAsyncPerformanceMark} from 'react-devtools-shared/src/PerformanceLoggingUtils';
+import {withAsyncPerfMeasurements} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 import WorkerizedParseSourceAndMetadata from './parseSourceAndMetadata.worker';
 import typeof * as ParseSourceAndMetadataModule from './parseSourceAndMetadata';
 import {flattenHooksList, loadSourceAndMetadata} from './loadSourceAndMetadata';
@@ -37,7 +37,7 @@ export async function parseHookNames(
   hooksTree: HooksTree,
   fetchFileWithCaching: FetchFileWithCaching | null,
 ): Promise<HookNames | null> {
-  return withAsyncPerformanceMark('parseHookNames', async () => {
+  return withAsyncPerfMeasurements('parseHookNames', async () => {
     const hooksList = flattenHooksList(hooksTree);
     if (hooksList.length === 0) {
       // This component tree contains no named hooks.

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/loadSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/loadSourceAndMetadata.js
@@ -49,9 +49,9 @@ import {__DEBUG__} from 'react-devtools-shared/src/constants';
 import {getHookSourceLocationKey} from 'react-devtools-shared/src/hookNamesCache';
 import {sourceMapIncludesSource} from '../SourceMapUtils';
 import {
-  withAsyncPerformanceMark,
-  withCallbackPerformanceMark,
-  withSyncPerformanceMark,
+  withAsyncPerfMeasurements,
+  withCallbackPerfMeasurements,
+  withSyncPerfMeasurements,
 } from 'react-devtools-shared/src/PerformanceLoggingUtils';
 
 import type {
@@ -98,17 +98,17 @@ export async function loadSourceAndMetadata(
   hooksList: HooksList,
   fetchFileWithCaching: FetchFileWithCaching | null,
 ): Promise<LocationKeyToHookSourceAndMetadata> {
-  return withAsyncPerformanceMark('loadSourceAndMetadata()', async () => {
-    const locationKeyToHookSourceAndMetadata = withSyncPerformanceMark(
+  return withAsyncPerfMeasurements('loadSourceAndMetadata()', async () => {
+    const locationKeyToHookSourceAndMetadata = withSyncPerfMeasurements(
       'initializeHookSourceAndMetadata',
       () => initializeHookSourceAndMetadata(hooksList),
     );
 
-    await withAsyncPerformanceMark('loadSourceFiles()', () =>
+    await withAsyncPerfMeasurements('loadSourceFiles()', () =>
       loadSourceFiles(locationKeyToHookSourceAndMetadata, fetchFileWithCaching),
     );
 
-    await withAsyncPerformanceMark('extractAndLoadSourceMapJSON()', () =>
+    await withAsyncPerfMeasurements('extractAndLoadSourceMapJSON()', () =>
       extractAndLoadSourceMapJSON(locationKeyToHookSourceAndMetadata),
     );
 
@@ -157,7 +157,7 @@ function extractAndLoadSourceMapJSON(
     // TODO (named hooks) If this RegExp search is slow, we could try breaking it up
     // first using an indexOf(' sourceMappingURL=') to find the start of the comment
     // (probably at the end of the file) and then running the RegExp on the remaining substring.
-    let sourceMappingURLMatch = withSyncPerformanceMark(
+    let sourceMappingURLMatch = withSyncPerfMeasurements(
       'sourceMapRegex.exec(runtimeSourceCode)',
       () => sourceMapRegex.exec(runtimeSourceCode),
     );
@@ -185,12 +185,12 @@ function extractAndLoadSourceMapJSON(
             const trimmed = ((sourceMappingURL.match(
               /base64,([a-zA-Z0-9+\/=]+)/,
             ): any): Array<string>)[1];
-            const decoded = withSyncPerformanceMark(
+            const decoded = withSyncPerfMeasurements(
               'decodeBase64String()',
               () => decodeBase64String(trimmed),
             );
 
-            const sourceMapJSON = withSyncPerformanceMark(
+            const sourceMapJSON = withSyncPerfMeasurements(
               'JSON.parse(decoded)',
               () => JSON.parse(decoded),
             );
@@ -227,7 +227,7 @@ function extractAndLoadSourceMapJSON(
         }
 
         // If the first source map we found wasn't a match, check for more.
-        sourceMappingURLMatch = withSyncPerformanceMark(
+        sourceMappingURLMatch = withSyncPerfMeasurements(
           'sourceMapRegex.exec(runtimeSourceCode)',
           () => sourceMapRegex.exec(runtimeSourceCode),
         );
@@ -266,7 +266,7 @@ function extractAndLoadSourceMapJSON(
             dedupedFetchPromises.get(url) ||
             fetchFile(url).then(
               sourceMapContents => {
-                const sourceMapJSON = withSyncPerformanceMark(
+                const sourceMapJSON = withSyncPerfMeasurements(
                   'JSON.parse(sourceMapContents)',
                   () => JSON.parse(sourceMapContents),
                 );
@@ -316,7 +316,7 @@ function fetchFile(
   url: string,
   markName?: string = 'fetchFile',
 ): Promise<string> {
-  return withCallbackPerformanceMark(`${markName}("${url}")`, done => {
+  return withCallbackPerfMeasurements(`${markName}("${url}")`, done => {
     return new Promise((resolve, reject) => {
       fetch(url, FETCH_OPTIONS).then(
         response => {
@@ -376,7 +376,7 @@ export function hasNamedHooks(hooksTree: HooksTree): boolean {
 
 export function flattenHooksList(hooksTree: HooksTree): HooksList {
   const hooksList: HooksList = [];
-  withSyncPerformanceMark('flattenHooksList()', () => {
+  withSyncPerfMeasurements('flattenHooksList()', () => {
     flattenHooksListImpl(hooksTree, hooksList);
   });
 
@@ -472,7 +472,7 @@ function loadSourceFiles(
       // If a helper function has been injected to fetch with caching,
       // use it to fetch the (already loaded) source file.
       fetchFileFunction = url => {
-        return withAsyncPerformanceMark(
+        return withAsyncPerfMeasurements(
           `fetchFileWithCaching("${url}")`,
           () => {
             return ((fetchFileWithCaching: any): FetchFileWithCaching)(url);

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/loadSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/loadSourceAndMetadata.js
@@ -52,7 +52,7 @@ import {
   withAsyncPerformanceMark,
   withCallbackPerformanceMark,
   withSyncPerformanceMark,
-} from 'react-devtools-shared/src/PerformanceMarks';
+} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 
 import type {
   HooksNode,

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
@@ -19,8 +19,8 @@ import {__DEBUG__} from 'react-devtools-shared/src/constants';
 import {getHookSourceLocationKey} from 'react-devtools-shared/src/hookNamesCache';
 import {SourceMapMetadataConsumer} from '../SourceMapMetadataConsumer';
 import {
-  withAsyncPerformanceMark,
-  withSyncPerformanceMark,
+  withAsyncPerfMeasurements,
+  withSyncPerfMeasurements,
 } from 'react-devtools-shared/src/PerformanceLoggingUtils';
 
 import type {
@@ -106,27 +106,27 @@ export async function parseSourceAndMetadata(
   hooksList: HooksList,
   locationKeyToHookSourceAndMetadata: LocationKeyToHookSourceAndMetadata,
 ): Promise<HookNames | null> {
-  return withAsyncPerformanceMark('parseSourceAndMetadata()', async () => {
-    const locationKeyToHookParsedMetadata = withSyncPerformanceMark(
+  return withAsyncPerfMeasurements('parseSourceAndMetadata()', async () => {
+    const locationKeyToHookParsedMetadata = withSyncPerfMeasurements(
       'initializeHookParsedMetadata',
       () => initializeHookParsedMetadata(locationKeyToHookSourceAndMetadata),
     );
 
-    withSyncPerformanceMark('parseSourceMaps', () =>
+    withSyncPerfMeasurements('parseSourceMaps', () =>
       parseSourceMaps(
         locationKeyToHookSourceAndMetadata,
         locationKeyToHookParsedMetadata,
       ),
     );
 
-    withSyncPerformanceMark('parseSourceAST()', () =>
+    withSyncPerfMeasurements('parseSourceAST()', () =>
       parseSourceAST(
         locationKeyToHookSourceAndMetadata,
         locationKeyToHookParsedMetadata,
       ),
     );
 
-    return withSyncPerformanceMark('findHookNames()', () =>
+    return withSyncPerfMeasurements('findHookNames()', () =>
       findHookNames(hooksList, locationKeyToHookParsedMetadata),
     );
   });
@@ -174,7 +174,7 @@ function findHookNames(
     let name;
     const {metadataConsumer} = hookParsedMetadata;
     if (metadataConsumer != null) {
-      name = withSyncPerformanceMark('metadataConsumer.hookNameFor()', () =>
+      name = withSyncPerfMeasurements('metadataConsumer.hookNameFor()', () =>
         metadataConsumer.hookNameFor({
           line: originalSourceLineNumber,
           column: originalSourceColumnNumber,
@@ -184,7 +184,7 @@ function findHookNames(
     }
 
     if (name == null) {
-      name = withSyncPerformanceMark('getHookName()', () =>
+      name = withSyncPerfMeasurements('getHookName()', () =>
         getHookName(
           hook,
           hookParsedMetadata.originalSourceAST,
@@ -303,7 +303,7 @@ function parseSourceAST(
         // Now that the source map has been loaded,
         // extract the original source for later.
         // TODO (named hooks) Refactor this read, github.com/facebook/react/pull/22181
-        const {column, line, source} = withSyncPerformanceMark(
+        const {column, line, source} = withSyncPerfMeasurements(
           'sourceConsumer.originalPositionFor()',
           () =>
             sourceConsumer.originalPositionFor({
@@ -329,7 +329,7 @@ function parseSourceAST(
         // It can be relative if the source map specifies it that way,
         // but we use it as a cache key across different source maps and there can be collisions.
         originalSourceURL = (source: string);
-        originalSourceCode = withSyncPerformanceMark(
+        originalSourceCode = withSyncPerfMeasurements(
           'sourceConsumer.sourceContentFor()',
           () => (sourceConsumer.sourceContentFor(source, true): string),
         );
@@ -401,7 +401,7 @@ function parseSourceAST(
 
         // TODO (named hooks) This is probably where we should check max source length,
         // rather than in loadSourceAndMetatada -> loadSourceFiles().
-        const originalSourceAST = withSyncPerformanceMark(
+        const originalSourceAST = withSyncPerfMeasurements(
           '[@babel/parser] parse(originalSourceCode)',
           () =>
             parse(originalSourceCode, {
@@ -441,11 +441,11 @@ function parseSourceMaps(
 
       const sourceMapJSON = hookSourceAndMetadata.sourceMapJSON;
       if (sourceMapJSON != null) {
-        hookParsedMetadata.metadataConsumer = withSyncPerformanceMark(
+        hookParsedMetadata.metadataConsumer = withSyncPerfMeasurements(
           'new SourceMapMetadataConsumer(sourceMapJSON)',
           () => new SourceMapMetadataConsumer(sourceMapJSON),
         );
-        hookParsedMetadata.sourceConsumer = withSyncPerformanceMark(
+        hookParsedMetadata.sourceConsumer = withSyncPerfMeasurements(
           'new SourceMapConsumer(sourceMapJSON)',
           () => new SourceMapConsumer(sourceMapJSON),
         );

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
@@ -21,7 +21,7 @@ import {SourceMapMetadataConsumer} from '../SourceMapMetadataConsumer';
 import {
   withAsyncPerformanceMark,
   withSyncPerformanceMark,
-} from 'react-devtools-shared/src/PerformanceMarks';
+} from 'react-devtools-shared/src/PerformanceLoggingUtils';
 
 import type {
   HooksList,


### PR DESCRIPTION
## Summary

This commit is being used as proposal for adding a logger (`Logger`) that allows us to records events happening in the DevTools runtime. In particular, a version of this code was used for collecting profiling data to measure runtime the performance of `parseHookNames`.

**API**

The `Logger` module exposes 2 main functions:

- `registerEventLogger`: This function allows the caller to register a callback that listens to any log events being emitted from the DevTools runtime.
- `logEvent`: This function allows the DevTools runtime to log any relevant events. The events that can be logged are statically enforced via Flow, and they can be extended to log different types of events (e.g. other performance or usage metrics).

Both of these functions only work under the new DevTools feature flag: `enableLogger`, and are no-ops if the flag is not enabled.

As of this commit, the feature flag is completely disabled in every build, and the code being committed is only illustrating how the logger can be used: we are logging an event for measuring the duration for `parseHookNames`, and we are registering a logger when initializing the DevTools extension. The registered logger is currently a no-op, and in a follow up PR we will add an implementation that actually records those events **for internal builds of DevTools only** (not open source builds).

## Test Plan

- yarn flow
- yarn test
- yarn test-build-devtools
- used this code to collect performance data for parseNamedHooks.
- temporarily enable feature flag and verify events that would be logged:

![image](https://user-images.githubusercontent.com/1271509/132600245-130d42cd-a9cd-45fe-a632-2ef5966c743c.png)

![image](https://user-images.githubusercontent.com/1271509/132600323-34929624-91d8-4c9b-ac8a-afe9e97d9d1b.png)


