### PR TITLE
[DevTools] Fix `react-devtools-extension` build error and `react-devtools-inline`'s `package.json`

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -289,7 +289,7 @@ function createPanelIfReactLoaded() {
 
         // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.
         const hookNamesModuleLoaderFunction = () =>
-          import('react-devtools-inline/hookNames');
+          import('react-devtools-shared/src/hooks/parseHookNames');
 
         root = createRoot(document.createElement('div'));
 

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -13,7 +13,8 @@
     "dist",
     "backend.js",
     "build-info.json",
-    "frontend.js"
+    "frontend.js",
+    "hookNames.js"
   ],
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --config webpack.config.js",


### PR DESCRIPTION
This PR includes two bug fixes:
1. `react-devtools-extension` cannot import from `react-devtools-inline`. It should only be importing shared code from `react-devtools-shared`. Fix this by importing the `react-devtools-shared` version of `hookNames`.
2. Add `hookNames.js` as an file to be included when `react-devtools-inline` is installed as a dependency.

Tested these bug fixes by building the extension and the test shell and verifying named hooks works as expected.