### PR TITLE
[DevTools] Add React Devtools Extension Startup and File Structure to OVERVIEW.md

### DIFF
--- a/packages/react-devtools/OVERVIEW.md
+++ b/packages/react-devtools/OVERVIEW.md
@@ -297,3 +297,11 @@ Once profiling is finished, the frontend requests profiling data from the backen
 ### Importing/exporting data
 
 Because all of the data is merged in the frontend after a profiling session is completed, it can be exported and imported (as a single JSON object), enabling profiling sessions to be shared between users.
+
+## Package Specific Details
+
+### Devtools Extension
+
+### React Devtools Extension Startup and File Structure
+![React Devtools Extension](https://user-images.githubusercontent.com/2735514/132768489-6ab85156-b816-442f-9c3f-7af738ee9e49.png)
+

--- a/packages/react-devtools/OVERVIEW.md
+++ b/packages/react-devtools/OVERVIEW.md
@@ -300,7 +300,7 @@ Because all of the data is merged in the frontend after a profiling session is c
 
 ## Package Specific Details
 
-### Devtools Extension
+### Devtools Extension Overview Diagram
 
 ![React Devtools Extension](https://user-images.githubusercontent.com/2735514/132768489-6ab85156-b816-442f-9c3f-7af738ee9e49.png)
 

--- a/packages/react-devtools/OVERVIEW.md
+++ b/packages/react-devtools/OVERVIEW.md
@@ -302,6 +302,5 @@ Because all of the data is merged in the frontend after a profiling session is c
 
 ### Devtools Extension
 
-### React Devtools Extension Startup and File Structure
 ![React Devtools Extension](https://user-images.githubusercontent.com/2735514/132768489-6ab85156-b816-442f-9c3f-7af738ee9e49.png)
 


### PR DESCRIPTION
I made an excalidraw to map out how the React Devtools Extension files are laid out and how initialization works.

Future TODO: Expand this section, add how standalone/inline files are laid out, and make this not an image and/or add accessibility text