### PR TITLE
feat(eslint-plugin-react-hooks): support componentWrapperFunctions option

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -74,7 +74,7 @@ To achieve that one can make use of `componentWrapperFunctions` option, which, s
       "rules": {
         // ...
         "react-hooks/rules-of-hooks": ["warn", {
-          "additionalHooks": '^(observer|styled)$'
+          "componentWrapperFunctions": '^(observer|styled)$'
         }]
       }
     }

--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -50,22 +50,38 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 ## Advanced Configuration
 
-`exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
+- `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
+    
+    ```js
+    {
+      "rules": {
+        // ...
+        "react-hooks/exhaustive-deps": ["warn", {
+          "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+        }]
+      }
+    }
+    ```
+    
+    We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
 
-```js
-{
-  "rules": {
-    // ...
-    "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
-    }]
-  }
-}
-```
+- `rules-of-hooks` can be configured to treat certain functions that do not start with a non-lowercase letter as a React component. 
+To achieve that one can make use of `componentWrapperFunctions` option, which, similarly to `additionalHooks` for `exhaustive-deps`, is a regex to match the names of aforementioned functions.
 
-We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
-
+  ```js
+    {
+      "rules": {
+        // ...
+        "react-hooks/rules-of-hooks": ["warn", {
+          "additionalHooks": '^(observer|styled)$'
+        }]
+      }
+    }
+  ```
+  
+  Same as with `additionalHooks`, it's not recommended to use this option. Overall, it's better to use a valid name for a function, such as `MyComponent`, `Button`, etc.
+ 
 ## Valid and Invalid Examples
 
 Please refer to the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html) documentation and the [Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#what-exactly-do-the-lint-rules-enforce) to learn more about this rule.

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -337,6 +337,18 @@ const tests = {
         const [myState, setMyState] = useState(null);
       }
     `,
+    {
+      code: `
+        // valid because componentWrapperFunctions is not matched
+        const ObservedButton = pureRouteMemo(withWorkspace(props => {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button {...props} />
+        }));
+      `,
+      options: [{componentWrapperFunctions: '^(observer|styled)$'}],
+    },
   ],
   invalid: [
     {
@@ -886,6 +898,30 @@ const tests = {
         (class {i() { useState(); }});
       `,
       errors: [classError('useState')],
+    },
+    {
+      code: `
+        const ObservedButton = observer(props => {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button {...props} />
+        });
+      `,
+      options: [{componentWrapperFunctions: '^observer$'}],
+      errors: [conditionalError('useCustomHook')],
+    },
+    {
+      code: `
+        const ObservedButton = observer(styled(props => {
+          if (props.fancy) {
+            useCustomHook();
+          }
+          return <button {...props} />
+        }));
+      `,
+      options: [{componentWrapperFunctions: '^observer$'}],
+      errors: [conditionalError('useCustomHook')],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -88,7 +88,24 @@ function isMemoCallback(node) {
   );
 }
 
-function isInsideComponentOrHook(node) {
+function isKnownWrapperFunction(node, componentWrapperFunctions) {
+  if (!componentWrapperFunctions) {
+    return false;
+  }
+
+  let parent = node.parent;
+  while (parent && parent.callee) {
+    if (componentWrapperFunctions.test(parent.callee.name)) {
+      return true;
+    }
+
+    parent = parent.parent;
+  }
+
+  return false;
+}
+
+function isInsideComponentOrHook(node, componentWrapperFunctions) {
   while (node) {
     const functionName = getFunctionName(node);
     if (functionName) {
@@ -96,7 +113,11 @@ function isInsideComponentOrHook(node) {
         return true;
       }
     }
-    if (isForwardRefCallback(node) || isMemoCallback(node)) {
+    if (
+      isForwardRefCallback(node) ||
+      isMemoCallback(node) ||
+      isKnownWrapperFunction(node, componentWrapperFunctions)
+    ) {
       return true;
     }
     node = node.parent;
@@ -114,6 +135,13 @@ export default {
     },
   },
   create(context) {
+    const componentWrapperFunctions =
+      context.options &&
+      context.options[0] &&
+      context.options[0].componentWrapperFunctions
+        ? new RegExp(context.options[0].componentWrapperFunctions)
+        : undefined;
+
     const codePathReactHooksMapStack = [];
     const codePathSegmentStack = [];
     return {
@@ -347,11 +375,14 @@ export default {
         // function component or we are in a hook function.
         const isSomewhereInsideComponentOrHook = isInsideComponentOrHook(
           codePathNode,
+          componentWrapperFunctions,
         );
         const isDirectlyInsideComponentOrHook = codePathFunctionName
           ? isComponentName(codePathFunctionName) ||
             isHook(codePathFunctionName)
-          : isForwardRefCallback(codePathNode) || isMemoCallback(codePathNode);
+          : isForwardRefCallback(codePathNode) ||
+            isMemoCallback(codePathNode) ||
+            isKnownWrapperFunction(codePathNode, componentWrapperFunctions); // Compute the earliest finalizer level using information from the
 
         // Compute the earliest finalizer level using information from the
         // cache. We expect all reachable final segments to have a cache entry


### PR DESCRIPTION
Related to https://github.com/facebook/react/issues/21422
## Summary

Currently, if you provide a function not starting with an upper-case letter, `rules-of-hooks` is pretty much a no-op.
While it's a rather alright behavior for most of the time, there are cases where people tend to use an arrow function instead, mostly when using some HOCs.
Although one can fix the code quite easily (arrow fn -> fn with a proper name), it's still relatively tedious if you lots of components not following the guidelines, and you're unable to perform a more automated refactoring.
Having an escape hatch might be fairly useful until you refactor the code. 

No hard feelings if this doesn't get through - I do realize the option may make it temptive for some to not obey the guidelines.

## How did you test this change?

- applied a git patch to the existing instance of eslint-plugin-react-hooks and used it in my own project
- tests
