### PR TITLE
[Draft] don't patch console during first render

### DIFF
--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -16,7 +16,7 @@ import {getInternalReactConstants} from './renderer';
 import {getStackByFiberInDevAndProd} from './DevToolsFiberComponentStack';
 import {consoleManagedByDevToolsDuringStrictMode} from 'react-devtools-feature-flags';
 
-const OVERRIDE_CONSOLE_METHODS = ['error', 'trace', 'warn', 'log'];
+const OVERRIDE_CONSOLE_METHODS = ['error', 'trace', 'warn'];
 const DIMMED_NODE_CONSOLE_COLOR = '\x1b[2m%s\x1b[0m';
 
 // React's custom built component stack strings match "\s{4}in"
@@ -30,6 +30,37 @@ export function isStringComponentStack(text: string): boolean {
   return PREFIX_REGEX.test(text) || ROW_COLUMN_NUMBER_REGEX.test(text);
 }
 
+const STYLE_DIRECTIVE_REGEX = /^%c/;
+
+// This function tells whether or not the arguments for a console
+// method has been overridden by the patchForStrictMode function.
+// If it has we'll need to do some special formatting of the arguments
+// so the console color stays consistent
+function isStrictModeOverride(args: Array<string>, method: string): boolean {
+  return (
+    args.length === 2 &&
+    STYLE_DIRECTIVE_REGEX.test(args[0]) &&
+    args[1] === `color: ${getConsoleColor(method) || ''}`
+  );
+}
+
+function getConsoleColor(method: string): ?string {
+  switch (method) {
+    case 'warn':
+      return consoleSettingsRef.browserTheme === 'light'
+        ? process.env.LIGHT_MODE_DIMMED_WARNING_COLOR
+        : process.env.DARK_MODE_DIMMED_WARNING_COLOR;
+    case 'error':
+      return consoleSettingsRef.browserTheme === 'light'
+        ? process.env.LIGHT_MODE_DIMMED_ERROR_COLOR
+        : process.env.DARK_MODE_DIMMED_ERROR_COLOR;
+    case 'log':
+    default:
+      return consoleSettingsRef.browserTheme === 'light'
+        ? process.env.LIGHT_MODE_DIMMED_LOG_COLOR
+        : process.env.DARK_MODE_DIMMED_LOG_COLOR;
+  }
+}
 type OnErrorOrWarning = (
   fiber: Fiber,
   type: 'error' | 'warn',
@@ -43,7 +74,6 @@ const injectedRenderers: Map<
     getCurrentFiber: () => Fiber | null,
     onErrorOrWarning: ?OnErrorOrWarning,
     workTagMap: WorkTagMap,
-    getIsStrictMode: ?() => boolean,
   |},
 > = new Map();
 
@@ -82,7 +112,6 @@ export function registerRenderer(
   const {
     currentDispatcherRef,
     getCurrentFiber,
-    getIsStrictMode,
     findFiberByHostInstance,
     version,
   } = renderer;
@@ -100,7 +129,6 @@ export function registerRenderer(
     injectedRenderers.set(renderer, {
       currentDispatcherRef,
       getCurrentFiber,
-      getIsStrictMode,
       workTagMap: ReactTypeOfWork,
       onErrorOrWarning,
     });
@@ -112,11 +140,11 @@ const consoleSettingsRef = {
   breakOnConsoleErrors: false,
   showInlineWarningsAndErrors: false,
   hideConsoleLogsInStrictMode: false,
+  browserTheme: 'dark',
 };
 
 // Patches console methods to append component stack for the current fiber.
 // Call unpatch() to remove the injected behavior.
-// NOTE: KEEP IN SYNC with src/hook.js:patchConsoleForInitialRenderInExtension
 export function patch({
   appendComponentStack,
   breakOnConsoleErrors,
@@ -136,160 +164,127 @@ export function patch({
   consoleSettingsRef.breakOnConsoleErrors = breakOnConsoleErrors;
   consoleSettingsRef.showInlineWarningsAndErrors = showInlineWarningsAndErrors;
   consoleSettingsRef.hideConsoleLogsInStrictMode = hideConsoleLogsInStrictMode;
+  consoleSettingsRef.browserTheme = browserTheme;
 
-  if (unpatchFn !== null) {
-    // Don't patch twice.
-    return;
-  }
-
-  const originalConsoleMethods = {};
-
-  unpatchFn = () => {
-    for (const method in originalConsoleMethods) {
-      try {
-        // $FlowFixMe property error|warn is not writable.
-        targetConsole[method] = originalConsoleMethods[method];
-      } catch (error) {}
+  if (
+    appendComponentStack ||
+    breakOnConsoleErrors ||
+    showInlineWarningsAndErrors
+  ) {
+    if (unpatchFn !== null) {
+      // Don't patch twice.
+      return;
     }
-  };
 
-  OVERRIDE_CONSOLE_METHODS.forEach(method => {
-    try {
-      const originalMethod = (originalConsoleMethods[method] = targetConsole[
-        method
-      ].__REACT_DEVTOOLS_ORIGINAL_METHOD__
-        ? targetConsole[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__
-        : targetConsole[method]);
+    const originalConsoleMethods = {};
 
-      const overrideMethod = (...args) => {
-        let shouldAppendWarningStack = false;
-        if (method !== 'log') {
-          if (consoleSettingsRef.appendComponentStack) {
-            const lastArg = args.length > 0 ? args[args.length - 1] : null;
-            const alreadyHasComponentStack =
-              typeof lastArg === 'string' && isStringComponentStack(lastArg);
+    unpatchFn = () => {
+      for (const method in originalConsoleMethods) {
+        try {
+          // $FlowFixMe property error|warn is not writable.
+          targetConsole[method] = originalConsoleMethods[method];
+        } catch (error) {}
+      }
+    };
 
-            // If we are ever called with a string that already has a component stack,
-            // e.g. a React error/warning, don't append a second stack.
-            shouldAppendWarningStack = !alreadyHasComponentStack;
+    OVERRIDE_CONSOLE_METHODS.forEach(method => {
+      try {
+        const originalMethod = (originalConsoleMethods[method] = targetConsole[
+          method
+        ].__REACT_DEVTOOLS_ORIGINAL_METHOD__
+          ? targetConsole[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__
+          : targetConsole[method]);
+
+        const overrideMethod = (...args) => {
+          let shouldAppendWarningStack = false;
+          if (method !== 'log') {
+            if (consoleSettingsRef.appendComponentStack) {
+              const lastArg = args.length > 0 ? args[args.length - 1] : null;
+              const alreadyHasComponentStack =
+                typeof lastArg === 'string' && isStringComponentStack(lastArg);
+
+              // If we are ever called with a string that already has a component stack,
+              // e.g. a React error/warning, don't append a second stack.
+              shouldAppendWarningStack = !alreadyHasComponentStack;
+            }
           }
-        }
 
-        const shouldShowInlineWarningsAndErrors =
-          consoleSettingsRef.showInlineWarningsAndErrors &&
-          (method === 'error' || method === 'warn');
+          const shouldShowInlineWarningsAndErrors =
+            consoleSettingsRef.showInlineWarningsAndErrors &&
+            (method === 'error' || method === 'warn');
 
-        let isInStrictMode = false;
+          // Search for the first renderer that has a current Fiber.
+          // We don't handle the edge case of stacks for more than one (e.g. interleaved renderers?)
+          // eslint-disable-next-line no-for-of-loops/no-for-of-loops
+          for (const {
+            currentDispatcherRef,
+            getCurrentFiber,
+            onErrorOrWarning,
+            workTagMap,
+          } of injectedRenderers.values()) {
+            const current: ?Fiber = getCurrentFiber();
+            if (current != null) {
+              try {
+                if (shouldShowInlineWarningsAndErrors) {
+                  // patch() is called by two places: (1) the hook and (2) the renderer backend.
+                  // The backend is what implements a message queue, so it's the only one that injects onErrorOrWarning.
+                  if (typeof onErrorOrWarning === 'function') {
+                    onErrorOrWarning(
+                      current,
+                      ((method: any): 'error' | 'warn'),
+                      // Copy args before we mutate them (e.g. adding the component stack)
+                      args.slice(),
+                    );
+                  }
+                }
 
-        // Search for the first renderer that has a current Fiber.
-        // We don't handle the edge case of stacks for more than one (e.g. interleaved renderers?)
-        // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-        for (const {
-          currentDispatcherRef,
-          getCurrentFiber,
-          onErrorOrWarning,
-          workTagMap,
-          getIsStrictMode,
-        } of injectedRenderers.values()) {
-          const current: ?Fiber = getCurrentFiber();
-          if (current != null) {
-            try {
-              if (typeof getIsStrictMode === 'function' && getIsStrictMode()) {
-                isInStrictMode = true;
-              }
-
-              if (shouldShowInlineWarningsAndErrors) {
-                // patch() is called by two places: (1) the hook and (2) the renderer backend.
-                // The backend is what implements a message queue, so it's the only one that injects onErrorOrWarning.
-                if (typeof onErrorOrWarning === 'function') {
-                  onErrorOrWarning(
+                if (shouldAppendWarningStack) {
+                  const componentStack = getStackByFiberInDevAndProd(
+                    workTagMap,
                     current,
-                    ((method: any): 'error' | 'warn'),
-                    // Copy args before we mutate them (e.g. adding the component stack)
-                    args.slice(),
+                    currentDispatcherRef,
                   );
+                  if (componentStack !== '') {
+                    if (isStrictModeOverride(args, method)) {
+                      args[0] = format(args[0], componentStack);
+                    } else {
+                      args.push(componentStack);
+                    }
+                  }
                 }
-              }
-
-              if (shouldAppendWarningStack) {
-                const componentStack = getStackByFiberInDevAndProd(
-                  workTagMap,
-                  current,
-                  currentDispatcherRef,
-                );
-                if (componentStack !== '') {
-                  args.push(componentStack);
-                }
-              }
-            } catch (error) {
-              // Don't let a DevTools or React internal error interfere with logging.
-              setTimeout(() => {
-                throw error;
-              }, 0);
-            } finally {
-              break;
-            }
-          }
-        }
-
-        if (consoleSettingsRef.breakOnConsoleErrors) {
-          // --- Welcome to debugging with React DevTools ---
-          // This debugger statement means that you've enabled the "break on warnings" feature.
-          // Use the browser's Call Stack panel to step out of this override function-
-          // to where the original warning or error was logged.
-          // eslint-disable-next-line no-debugger
-          debugger;
-        }
-
-        if (consoleManagedByDevToolsDuringStrictMode && isInStrictMode) {
-          if (!consoleSettingsRef.hideConsoleLogsInStrictMode) {
-            // Dim the text color of the double logs if we're not
-            // hiding them.
-            if (isNode) {
-              originalMethod(DIMMED_NODE_CONSOLE_COLOR, format(...args));
-            } else {
-              let color;
-              switch (method) {
-                case 'warn':
-                  color =
-                    browserTheme === 'light'
-                      ? process.env.LIGHT_MODE_DIMMED_WARNING_COLOR
-                      : process.env.DARK_MODE_DIMMED_WARNING_COLOR;
-                  break;
-                case 'error':
-                  color =
-                    browserTheme === 'light'
-                      ? process.env.LIGHT_MODE_DIMMED_ERROR_COLOR
-                      : process.env.DARK_MODE_DIMMED_ERROR_COLOR;
-                  break;
-                case 'log':
-                default:
-                  color =
-                    browserTheme === 'light'
-                      ? process.env.LIGHT_MODE_DIMMED_LOG_COLOR
-                      : process.env.DARK_MODE_DIMMED_LOG_COLOR;
-                  break;
-              }
-
-              if (color) {
-                originalMethod(`%c${format(...args)}`, `color: ${color}`);
-              } else {
-                throw Error('Console color is not defined');
+              } catch (error) {
+                // Don't let a DevTools or React internal error interfere with logging.
+                setTimeout(() => {
+                  throw error;
+                }, 0);
+              } finally {
+                break;
               }
             }
           }
-        } else {
+
+          if (consoleSettingsRef.breakOnConsoleErrors) {
+            // --- Welcome to debugging with React DevTools ---
+            // This debugger statement means that you've enabled the "break on warnings" feature.
+            // Use the browser's Call Stack panel to step out of this override function-
+            // to where the original warning or error was logged.
+            // eslint-disable-next-line no-debugger
+            debugger;
+          }
+
           originalMethod(...args);
-        }
-      };
+        };
 
-      overrideMethod.__REACT_DEVTOOLS_ORIGINAL_METHOD__ = originalMethod;
-      originalMethod.__REACT_DEVTOOLS_OVERRIDE_METHOD__ = overrideMethod;
+        overrideMethod.__REACT_DEVTOOLS_ORIGINAL_METHOD__ = originalMethod;
+        originalMethod.__REACT_DEVTOOLS_OVERRIDE_METHOD__ = overrideMethod;
 
-      // $FlowFixMe property error|warn is not writable.
-      targetConsole[method] = overrideMethod;
-    } catch (error) {}
-  });
+        // $FlowFixMe property error|warn is not writable.
+        targetConsole[method] = overrideMethod;
+      } catch (error) {}
+    });
+  } else {
+    unpatch();
+  }
 }
 
 // Removed component stack patch from console methods.
@@ -297,5 +292,73 @@ export function unpatch(): void {
   if (unpatchFn !== null) {
     unpatchFn();
     unpatchFn = null;
+  }
+}
+
+let unpatchForStrictModeFn: null | (() => void) = null;
+
+// NOTE: KEEP IN SYNC with src/hook.js:patchConsoleForInitialRenderInStrictMode
+export function patchForStrictMode() {
+  if (consoleManagedByDevToolsDuringStrictMode) {
+    const overrideConsoleMethods = ['error', 'trace', 'warn', 'log'];
+
+    if (unpatchForStrictModeFn !== null) {
+      // Don't patch twice.
+      return;
+    }
+
+    const originalConsoleMethods = {};
+
+    unpatchForStrictModeFn = () => {
+      for (const method in originalConsoleMethods) {
+        try {
+          // $FlowFixMe property error|warn is not writable.
+          targetConsole[method] = originalConsoleMethods[method];
+        } catch (error) {}
+      }
+    };
+
+    overrideConsoleMethods.forEach(method => {
+      try {
+        const originalMethod = (originalConsoleMethods[method] = targetConsole[
+          method
+        ].__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__
+          ? targetConsole[method].__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__
+          : targetConsole[method]);
+
+        const overrideMethod = (...args) => {
+          if (!consoleSettingsRef.hideConsoleLogsInStrictMode) {
+            // Dim the text color of the double logs if we're not
+            // hiding them.
+            if (isNode) {
+              originalMethod(DIMMED_NODE_CONSOLE_COLOR, format(...args));
+            } else {
+              const color = getConsoleColor(method);
+              if (color) {
+                originalMethod(`%c${format(...args)}`, `color: ${color}`);
+              } else {
+                throw Error('Console color is not defined');
+              }
+            }
+          }
+        };
+
+        overrideMethod.__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__ = originalMethod;
+        originalMethod.__REACT_DEVTOOLS_STRICT_MODE_OVERRIDE_METHOD__ = overrideMethod;
+
+        // $FlowFixMe property error|warn is not writable.
+        targetConsole[method] = overrideMethod;
+      } catch (error) {}
+    });
+  }
+}
+
+// NOTE: KEEP IN SYNC with src/hook.js:unpatchConsoleForInitialRenderInStrictMode
+export function unpatchForStrictMode(): void {
+  if (consoleManagedByDevToolsDuringStrictMode) {
+    if (unpatchForStrictModeFn !== null) {
+      unpatchForStrictModeFn();
+      unpatchForStrictModeFn = null;
+    }
   }
 }

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -1073,6 +1073,10 @@ export function attach(
     // Not implemented
   }
 
+  function patchConsoleForStrictMode() {}
+
+  function unpatchConsoleForStrictMode() {}
+
   return {
     clearErrorsAndWarnings,
     clearErrorsForFiberID,
@@ -1101,6 +1105,7 @@ export function attach(
     overrideSuspense,
     overrideValueAtPath,
     renamePath,
+    patchConsoleForStrictMode,
     prepareViewAttributeSource,
     prepareViewElementSource,
     renderer,
@@ -1109,6 +1114,7 @@ export function attach(
     startProfiling,
     stopProfiling,
     storeAsGlobal,
+    unpatchConsoleForStrictMode,
     updateComponentFilters,
   };
 }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -59,6 +59,8 @@ import {inspectHooksOfFiber} from 'react-debug-tools';
 import {
   patch as patchConsole,
   registerRenderer as registerRendererWithConsole,
+  patchForStrictMode as patchConsoleForStrictMode,
+  unpatchForStrictMode as unpatchConsoleForStrictMode,
 } from './console';
 import {
   CONCURRENT_MODE_NUMBER,
@@ -4249,6 +4251,7 @@ export function attach(
     handlePostCommitFiberRoot,
     inspectElement,
     logElementToConsole,
+    patchConsoleForStrictMode,
     prepareViewAttributeSource,
     prepareViewElementSource,
     overrideError,
@@ -4261,6 +4264,7 @@ export function attach(
     startProfiling,
     stopProfiling,
     storeAsGlobal,
+    unpatchConsoleForStrictMode,
     updateComponentFilters,
   };
 }

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -136,8 +136,6 @@ export type ReactRenderer = {
   // Only injected by React v16.9+ in DEV mode.
   // Enables DevTools to append owners-only component stack to error messages.
   getCurrentFiber?: () => Fiber | null,
-
-  getIsStrictMode?: () => boolean,
   // 17.0.2+
   reconcilerVersion?: string,
   // Uniquely identifies React DOM v15.
@@ -352,6 +350,7 @@ export type RendererInterface = {
     path: Array<string | number>,
     value: any,
   ) => void,
+  patchConsoleForStrictMode: () => void,
   prepareViewAttributeSource: (
     id: number,
     path: Array<string | number>,
@@ -374,6 +373,7 @@ export type RendererInterface = {
     path: Array<string | number>,
     count: number,
   ) => void,
+  unpatchConsoleForStrictMode: () => void,
   updateComponentFilters: (componentFilters: Array<ComponentFilter>) => void,
   ...
 };
@@ -408,5 +408,8 @@ export type DevToolsHook = {
     // Added in v16.9 to support Fast Refresh
     didError?: boolean,
   ) => void,
+
+  // Testing
+  dangerous_setTargetConsoleForTesting?: (fakeConsole: Object) => void,
   ...
 };

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -8,15 +8,12 @@
  * @flow
  */
 
-import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
-import type {ReactRenderer} from './backend/types';
 import type {BrowserTheme} from 'react-devtools-shared/src/devtools/views/DevTools';
 
 import {
   patch as patchConsole,
   registerRenderer as registerRendererWithConsole,
 } from './backend/console';
-import {consoleManagedByDevToolsDuringStrictMode} from 'react-devtools-feature-flags';
 
 import type {DevToolsHook} from 'react-devtools-shared/src/backend/types';
 
@@ -25,6 +22,23 @@ declare var window: any;
 export function installHook(target: any): DevToolsHook | null {
   if (target.hasOwnProperty('__REACT_DEVTOOLS_GLOBAL_HOOK__')) {
     return null;
+  }
+
+  let targetConsole: Object = console;
+  let targetConsoleMethods = {};
+  for (const method in console) {
+    targetConsoleMethods[method] = console[method];
+  }
+
+  function dangerous_setTargetConsoleForTesting(
+    targetConsoleForTesting: Object,
+  ): void {
+    targetConsole = targetConsoleForTesting;
+
+    targetConsoleMethods = {};
+    for (const method in targetConsole) {
+      targetConsoleMethods[method] = console[method];
+    }
   }
 
   function detectReactBuildType(renderer) {
@@ -163,156 +177,148 @@ export function installHook(target: any): DevToolsHook | null {
     maybeMessage: any,
     ...inputArgs: $ReadOnlyArray<any>
   ): string {
-    if (consoleManagedByDevToolsDuringStrictMode) {
-      const args = inputArgs.slice();
+    const args = inputArgs.slice();
 
-      // Symbols cannot be concatenated with Strings.
-      let formatted: string =
-        typeof maybeMessage === 'symbol'
-          ? maybeMessage.toString()
-          : '' + maybeMessage;
+    // Symbols cannot be concatenated with Strings.
+    let formatted: string =
+      typeof maybeMessage === 'symbol'
+        ? maybeMessage.toString()
+        : '' + maybeMessage;
 
-      // If the first argument is a string, check for substitutions.
-      if (typeof maybeMessage === 'string') {
-        if (args.length) {
-          const REGEXP = /(%?)(%([jds]))/g;
-
-          formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
-            let arg = args.shift();
-            switch (flag) {
-              case 's':
-                arg += '';
-                break;
-              case 'd':
-              case 'i':
-                arg = parseInt(arg, 10).toString();
-                break;
-              case 'f':
-                arg = parseFloat(arg).toString();
-                break;
-            }
-            if (!escaped) {
-              return arg;
-            }
-            args.unshift(arg);
-            return match;
-          });
-        }
-      }
-
-      // Arguments that remain after formatting.
+    // If the first argument is a string, check for substitutions.
+    if (typeof maybeMessage === 'string') {
       if (args.length) {
-        for (let i = 0; i < args.length; i++) {
-          const arg = args[i];
+        const REGEXP = /(%?)(%([jds]))/g;
 
-          // Symbols cannot be concatenated with Strings.
-          formatted += ' ' + (typeof arg === 'symbol' ? arg.toString() : arg);
-        }
-      }
-
-      // Update escaped %% values.
-      formatted = formatted.replace(/%{2,2}/g, '%');
-
-      return '' + formatted;
-    }
-
-    return '';
-  }
-
-  // NOTE: KEEP IN SYNC with src/backend/console.js:patch
-  function patchConsoleForInitialRenderInExtension(
-    renderer: ReactRenderer,
-    {
-      hideConsoleLogsInStrictMode,
-      browserTheme,
-    }: {hideConsoleLogsInStrictMode: boolean, browserTheme: BrowserTheme},
-  ): void {
-    if (consoleManagedByDevToolsDuringStrictMode) {
-      const overrideConsoleMethods = ['error', 'trace', 'warn', 'log'];
-
-      if (__EXTENSION__) {
-        const targetConsole = console;
-
-        const originalConsoleMethods = {};
-
-        overrideConsoleMethods.forEach(method => {
-          try {
-            const originalMethod = (originalConsoleMethods[
-              method
-            ] = targetConsole[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__
-              ? targetConsole[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__
-              : targetConsole[method]);
-
-            const overrideMethod = (...args) => {
-              let isInStrictMode = false;
-
-              // Search for the first renderer that has a current Fiber.
-              // We don't handle the edge case of stacks for more than one (e.g. interleaved renderers?)
-              const {getCurrentFiber, getIsStrictMode} = renderer;
-              if (typeof getCurrentFiber !== 'function') {
-                return;
-              }
-
-              const current: ?Fiber = getCurrentFiber();
-              if (current != null) {
-                try {
-                  if (
-                    typeof getIsStrictMode === 'function' &&
-                    getIsStrictMode()
-                  ) {
-                    isInStrictMode = true;
-                  }
-                } catch (error) {
-                  // Don't let a DevTools or React internal error interfere with logging.
-                }
-              }
-
-              if (isInStrictMode) {
-                if (!hideConsoleLogsInStrictMode) {
-                  // Dim the text color of the double logs if we're not
-                  // hiding them.
-                  let color;
-                  switch (method) {
-                    case 'warn':
-                      color =
-                        browserTheme === 'light'
-                          ? process.env.LIGHT_MODE_DIMMED_WARNING_COLOR
-                          : process.env.DARK_MODE_DIMMED_WARNING_COLOR;
-                      break;
-                    case 'error':
-                      color =
-                        browserTheme === 'light'
-                          ? process.env.LIGHT_MODE_DIMMED_ERROR_COLOR
-                          : process.env.DARK_MODE_DIMMED_ERROR_COLOR;
-                      break;
-                    case 'log':
-                    default:
-                      color =
-                        browserTheme === 'light'
-                          ? process.env.LIGHT_MODE_DIMMED_LOG_COLOR
-                          : process.env.DARK_MODE_DIMMED_LOG_COLOR;
-                      break;
-                  }
-
-                  if (color) {
-                    originalMethod(`%c${format(...args)}`, `color: ${color}`);
-                  } else {
-                    throw Error('Console color is not defined');
-                  }
-                }
-              } else {
-                originalMethod(...args);
-              }
-            };
-
-            overrideMethod.__REACT_DEVTOOLS_ORIGINAL_METHOD__ = originalMethod;
-            originalMethod.__REACT_DEVTOOLS_OVERRIDE_METHOD__ = overrideMethod;
-
-            // $FlowFixMe property error|warn is not writable.
-            targetConsole[method] = overrideMethod;
-          } catch (error) {}
+        formatted = formatted.replace(REGEXP, (match, escaped, ptn, flag) => {
+          let arg = args.shift();
+          switch (flag) {
+            case 's':
+              arg += '';
+              break;
+            case 'd':
+            case 'i':
+              arg = parseInt(arg, 10).toString();
+              break;
+            case 'f':
+              arg = parseFloat(arg).toString();
+              break;
+          }
+          if (!escaped) {
+            return arg;
+          }
+          args.unshift(arg);
+          return match;
         });
       }
+    }
+
+    // Arguments that remain after formatting.
+    if (args.length) {
+      for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        // Symbols cannot be concatenated with Strings.
+        formatted += ' ' + (typeof arg === 'symbol' ? arg.toString() : arg);
+      }
+    }
+
+    // Update escaped %% values.
+    formatted = formatted.replace(/%{2,2}/g, '%');
+
+    return '' + formatted;
+  }
+
+  let unpatchFn = null;
+
+  // NOTE: KEEP IN SYNC with src/backend/console.js:patchForStrictMode
+  // This function hides or dims console logs during the initial double renderer
+  // in Strict Mode. We need this function because during initial render,
+  // React and DevTools are connecting and the renderer interface isn't avaiable
+  // and we want to be able to have consistent logging behavior for double logs
+  // during the initial renderer.
+  function patchConsoleForInitialRenderInStrictMode({
+    hideConsoleLogsInStrictMode,
+    browserTheme,
+  }: {
+    hideConsoleLogsInStrictMode: boolean,
+    browserTheme: BrowserTheme,
+  }) {
+    const overrideConsoleMethods = ['error', 'trace', 'warn', 'log'];
+
+    if (unpatchFn !== null) {
+      // Don't patch twice.
+      return;
+    }
+
+    const originalConsoleMethods = {};
+
+    unpatchFn = () => {
+      for (const method in originalConsoleMethods) {
+        try {
+          // $FlowFixMe property error|warn is not writable.
+          targetConsole[method] = originalConsoleMethods[method];
+        } catch (error) {}
+      }
+    };
+
+    overrideConsoleMethods.forEach(method => {
+      try {
+        const originalMethod = (originalConsoleMethods[method] = targetConsole[
+          method
+        ].__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__
+          ? targetConsole[method].__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__
+          : targetConsole[method]);
+
+        const overrideMethod = (...args) => {
+          if (!hideConsoleLogsInStrictMode) {
+            // Dim the text color of the double logs if we're not
+            // hiding them.
+            let color;
+            switch (method) {
+              case 'warn':
+                color =
+                  browserTheme === 'light'
+                    ? process.env.LIGHT_MODE_DIMMED_WARNING_COLOR
+                    : process.env.DARK_MODE_DIMMED_WARNING_COLOR;
+                break;
+              case 'error':
+                color =
+                  browserTheme === 'light'
+                    ? process.env.LIGHT_MODE_DIMMED_ERROR_COLOR
+                    : process.env.DARK_MODE_DIMMED_ERROR_COLOR;
+                break;
+              case 'log':
+              default:
+                color =
+                  browserTheme === 'light'
+                    ? process.env.LIGHT_MODE_DIMMED_LOG_COLOR
+                    : process.env.DARK_MODE_DIMMED_LOG_COLOR;
+                break;
+            }
+
+            if (color) {
+              originalMethod(`%c${format(...args)}`, `color: ${color}`);
+            } else {
+              throw Error('Console color is not defined');
+            }
+          }
+        };
+
+        overrideMethod.__REACT_DEVTOOLS_STRICT_MODE_ORIGINAL_METHOD__ = originalMethod;
+        originalMethod.__REACT_DEVTOOLS_STRICT_MODE_OVERRIDE_METHOD__ = overrideMethod;
+
+        // $FlowFixMe property error|warn is not writable.
+        targetConsole[method] = overrideMethod;
+      } catch (error) {}
+    });
+  }
+
+  // NOTE: KEEP IN SYNC with src/backend/console.js:unpatchForStrictMode
+  function unpatchConsoleForInitialRenderInStrictMode() {
+    if (unpatchFn !== null) {
+      unpatchFn();
+      unpatchFn = null;
     }
   }
 
@@ -343,7 +349,7 @@ export function installHook(target: any): DevToolsHook | null {
     // Note that because this function is inlined, this conditional check must only use static booleans.
     // Otherwise the extension will throw with an undefined error.
     // (See comments in the try/catch below for more context on inlining.)
-    if (!__TEST__) {
+    if (!__TEST__ && !__EXTENSION__) {
       try {
         const appendComponentStack =
           window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ !== false;
@@ -362,23 +368,14 @@ export function installHook(target: any): DevToolsHook | null {
         // but Webpack wraps imports with an object (e.g. _backend_console__WEBPACK_IMPORTED_MODULE_0__)
         // and the object itself will be undefined as well for the reasons mentioned above,
         // so we use try/catch instead.
-        if (!__EXTENSION__) {
-          registerRendererWithConsole(renderer);
-          patchConsole({
-            appendComponentStack,
-            breakOnConsoleErrors,
-            showInlineWarningsAndErrors,
-            hideConsoleLogsInStrictMode,
-            browserTheme,
-          });
-        } else {
-          if (consoleManagedByDevToolsDuringStrictMode) {
-            patchConsoleForInitialRenderInExtension(renderer, {
-              hideConsoleLogsInStrictMode,
-              browserTheme,
-            });
-          }
-        }
+        registerRendererWithConsole(renderer);
+        patchConsole({
+          appendComponentStack,
+          breakOnConsoleErrors,
+          showInlineWarningsAndErrors,
+          hideConsoleLogsInStrictMode,
+          browserTheme,
+        });
       } catch (error) {}
     }
 
@@ -473,6 +470,32 @@ export function installHook(target: any): DevToolsHook | null {
     }
   }
 
+  function setStrictMode(rendererID, isStrictMode) {
+    const rendererInterface = rendererInterfaces.get(rendererID);
+    if (rendererInterface != null) {
+      if (isStrictMode) {
+        rendererInterface.patchConsoleForStrictMode();
+      } else {
+        rendererInterface.unpatchConsoleForStrictMode();
+      }
+    } else {
+      // This should only happen during initial render in the extension before DevTools
+      // finishes its handshake with React DOM
+      if (isStrictMode) {
+        const hideConsoleLogsInStrictMode =
+          window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ === true;
+        const browserTheme = window.__REACT_DEVTOOLS_BROWSER_THEME__;
+
+        patchConsoleForInitialRenderInStrictMode({
+          hideConsoleLogsInStrictMode,
+          browserTheme,
+        });
+      } else {
+        unpatchConsoleForInitialRenderInStrictMode();
+      }
+    }
+  }
+
   // TODO: More meaningful names for "rendererInterfaces" and "renderers".
   const fiberRoots = {};
   const rendererInterfaces = new Map();
@@ -502,7 +525,12 @@ export function installHook(target: any): DevToolsHook | null {
     onCommitFiberUnmount,
     onCommitFiberRoot,
     onPostCommitFiberRoot,
+    setStrictMode,
   };
+
+  if (__TEST__) {
+    hook.dangerous_setTargetConsoleForTesting = dangerous_setTargetConsoleForTesting;
+  }
 
   Object.defineProperty(
     target,

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -480,7 +480,7 @@ export function installHook(target: any): DevToolsHook | null {
       }
     } else {
       // This should only happen during initial render in the extension before DevTools
-      // finishes its handshake with React DOM
+      // finishes its handshake with the injected renderer
       if (isStrictMode) {
         const hideConsoleLogsInStrictMode =
           window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ === true;

--- a/packages/react-devtools-shell/src/app/console.js
+++ b/packages/react-devtools-shell/src/app/console.js
@@ -11,12 +11,6 @@ function ignoreStrings(
   methodName: string,
   stringsToIgnore: Array<string>,
 ): void {
-  // HACKY In the test harness, DevTools overrides the parent window's console.
-  // Our test app code uses the iframe's console though.
-  // To simulate a more accurate end-to-end environment,
-  // the shell's console patching should pass through to the parent override methods.
-  const originalMethod = window.parent.console[methodName];
-
   console[methodName] = (...args) => {
     const maybeString = args[0];
     if (typeof maybeString === 'string') {
@@ -26,7 +20,12 @@ function ignoreStrings(
         }
       }
     }
-    originalMethod(...args);
+
+    // HACKY In the test harness, DevTools overrides the parent window's console.
+    // Our test app code uses the iframe's console though.
+    // To simulate a more accurate end-to-end environment,
+    // the shell's console patching should pass through to the parent override methods.
+    window.parent.console[methodName](...args);
   };
 }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -149,11 +149,7 @@ import {
   getOffscreenContainerProps,
 } from './ReactFiberHostConfig';
 import type {SuspenseInstance} from './ReactFiberHostConfig';
-import {
-  shouldError,
-  shouldSuspend,
-  setIsStrictModeForDevtools,
-} from './ReactFiberReconciler';
+import {shouldError, shouldSuspend} from './ReactFiberReconciler';
 import {pushHostContext, pushHostContainer} from './ReactFiberHostContext.new';
 import {
   suspenseStackCursor,
@@ -235,6 +231,7 @@ import {createCapturedValue} from './ReactCapturedValue';
 import {createClassErrorUpdate} from './ReactFiberThrow.new';
 import {completeSuspendedOffscreenHostContainer} from './ReactFiberCompleteWork.new';
 import is from 'shared/objectIs';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.new';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -149,11 +149,7 @@ import {
   getOffscreenContainerProps,
 } from './ReactFiberHostConfig';
 import type {SuspenseInstance} from './ReactFiberHostConfig';
-import {
-  shouldError,
-  shouldSuspend,
-  setIsStrictModeForDevtools,
-} from './ReactFiberReconciler';
+import {shouldError, shouldSuspend} from './ReactFiberReconciler';
 import {pushHostContext, pushHostContainer} from './ReactFiberHostContext.old';
 import {
   suspenseStackCursor,
@@ -235,6 +231,7 @@ import {createCapturedValue} from './ReactCapturedValue';
 import {createClassErrorUpdate} from './ReactFiberThrow.old';
 import {completeSuspendedOffscreenHostContainer} from './ReactFiberCompleteWork.old';
 import is from 'shared/objectIs';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.old';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -38,7 +38,7 @@ import getComponentNameFromType from 'shared/getComponentNameFromType';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
 import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
-import {setIsStrictModeForDevtools} from './ReactFiberReconciler';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.new';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.new';
 import {

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -38,7 +38,7 @@ import getComponentNameFromType from 'shared/getComponentNameFromType';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
 import {REACT_CONTEXT_TYPE, REACT_PROVIDER_TYPE} from 'shared/ReactSymbols';
-import {setIsStrictModeForDevtools} from './ReactFiberReconciler';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.old';
 
 import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
 import {

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -48,8 +48,6 @@ import {
   observeVisibleRects as observeVisibleRects_old,
   runWithPriority as runWithPriority_old,
   getCurrentUpdatePriority as getCurrentUpdatePriority_old,
-  getIsStrictModeForDevtools as getIsStrictModeForDevtools_old,
-  setIsStrictModeForDevtools as setIsStrictModeForDevtools_old,
 } from './ReactFiberReconciler.old';
 
 import {
@@ -86,8 +84,6 @@ import {
   observeVisibleRects as observeVisibleRects_new,
   runWithPriority as runWithPriority_new,
   getCurrentUpdatePriority as getCurrentUpdatePriority_new,
-  getIsStrictModeForDevtools as getIsStrictModeForDevtools_new,
-  setIsStrictModeForDevtools as setIsStrictModeForDevtools_new,
 } from './ReactFiberReconciler.new';
 
 export const createContainer = enableNewReconciler
@@ -189,10 +185,3 @@ export const observeVisibleRects = enableNewReconciler
 export const runWithPriority = enableNewReconciler
   ? runWithPriority_new
   : runWithPriority_old;
-
-export const getIsStrictModeForDevtools = enableNewReconciler
-  ? getIsStrictModeForDevtools_new
-  : getIsStrictModeForDevtools_old;
-export const setIsStrictModeForDevtools = enableNewReconciler
-  ? setIsStrictModeForDevtools_new
-  : setIsStrictModeForDevtools_old;

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -35,10 +35,7 @@ import {
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
-import {
-  enableSchedulingProfiler,
-  consoleManagedByDevToolsDuringStrictMode,
-} from 'shared/ReactFeatureFlags';
+import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -106,10 +103,6 @@ export {
   focusWithin,
   observeVisibleRects,
 } from './ReactTestSelectors';
-
-import * as Scheduler from './Scheduler';
-import {setSuppressWarning} from 'shared/consoleWithStackDev';
-import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
 type OpaqueRoot = FiberRoot;
 
@@ -464,8 +457,6 @@ export function shouldSuspend(fiber: Fiber): boolean {
   return shouldSuspendImpl(fiber);
 }
 
-let isStrictMode = false;
-
 let overrideHookState = null;
 let overrideHookStateDeletePath = null;
 let overrideHookStateRenamePath = null;
@@ -715,30 +706,6 @@ function getCurrentFiberForDevTools() {
   return ReactCurrentFiberCurrent;
 }
 
-export function getIsStrictModeForDevtools() {
-  return isStrictMode;
-}
-
-export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
-  isStrictMode = newIsStrictMode;
-
-  if (consoleManagedByDevToolsDuringStrictMode) {
-    // We're in a test because Scheduler.unstable_yieldValue only exists
-    // in SchedulerMock. To reduce the noise in strict mode tests,
-    // suppress warnings and disable scheduler yielding during the double render
-    if (typeof Scheduler.unstable_yieldValue === 'function') {
-      Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
-      setSuppressWarning(newIsStrictMode);
-    }
-  } else {
-    if (newIsStrictMode) {
-      disableLogs();
-    } else {
-      reenableLogs();
-    }
-  }
-}
-
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {findFiberByHostInstance} = devToolsConfig;
   const {ReactCurrentDispatcher} = ReactSharedInternals;
@@ -768,7 +735,6 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
     // Enables DevTools to append owner stacks to error messages in DEV mode.
     getCurrentFiber: __DEV__ ? getCurrentFiberForDevTools : null,
-    getIsStrictMode: __DEV__ ? getIsStrictModeForDevtools : null,
     // Enables DevTools to detect reconciler version rather than renderer version
     // which may not match for third party renderers.
     reconcilerVersion: ReactVersion,

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -35,10 +35,7 @@ import {
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import invariant from 'shared/invariant';
 import isArray from 'shared/isArray';
-import {
-  enableSchedulingProfiler,
-  consoleManagedByDevToolsDuringStrictMode,
-} from 'shared/ReactFeatureFlags';
+import {enableSchedulingProfiler} from 'shared/ReactFeatureFlags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {getPublicInstance} from './ReactFiberHostConfig';
 import {
@@ -106,10 +103,6 @@ export {
   focusWithin,
   observeVisibleRects,
 } from './ReactTestSelectors';
-
-import * as Scheduler from './Scheduler';
-import {setSuppressWarning} from 'shared/consoleWithStackDev';
-import {disableLogs, reenableLogs} from 'shared/ConsolePatchingDev';
 
 type OpaqueRoot = FiberRoot;
 
@@ -464,8 +457,6 @@ export function shouldSuspend(fiber: Fiber): boolean {
   return shouldSuspendImpl(fiber);
 }
 
-let isStrictMode = false;
-
 let overrideHookState = null;
 let overrideHookStateDeletePath = null;
 let overrideHookStateRenamePath = null;
@@ -715,30 +706,6 @@ function getCurrentFiberForDevTools() {
   return ReactCurrentFiberCurrent;
 }
 
-export function getIsStrictModeForDevtools() {
-  return isStrictMode;
-}
-
-export function setIsStrictModeForDevtools(newIsStrictMode: boolean) {
-  isStrictMode = newIsStrictMode;
-
-  if (consoleManagedByDevToolsDuringStrictMode) {
-    // We're in a test because Scheduler.unstable_yieldValue only exists
-    // in SchedulerMock. To reduce the noise in strict mode tests,
-    // suppress warnings and disable scheduler yielding during the double render
-    if (typeof Scheduler.unstable_yieldValue === 'function') {
-      Scheduler.unstable_setDisableYieldValue(newIsStrictMode);
-      setSuppressWarning(newIsStrictMode);
-    }
-  } else {
-    if (newIsStrictMode) {
-      disableLogs();
-    } else {
-      reenableLogs();
-    }
-  }
-}
-
 export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
   const {findFiberByHostInstance} = devToolsConfig;
   const {ReactCurrentDispatcher} = ReactSharedInternals;
@@ -768,7 +735,6 @@ export function injectIntoDevTools(devToolsConfig: DevToolsConfig): boolean {
     setRefreshHandler: __DEV__ ? setRefreshHandler : null,
     // Enables DevTools to append owner stacks to error messages in DEV mode.
     getCurrentFiber: __DEV__ ? getCurrentFiberForDevTools : null,
-    getIsStrictMode: __DEV__ ? getIsStrictModeForDevtools : null,
     // Enables DevTools to detect reconciler version rather than renderer version
     // which may not match for third party renderers.
     reconcilerVersion: ReactVersion,

--- a/packages/react-reconciler/src/ReactUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.new.js
@@ -110,7 +110,7 @@ import {
   isInterleavedUpdate,
 } from './ReactFiberWorkLoop.new';
 import {pushInterleavedQueue} from './ReactFiberInterleavedUpdates.new';
-import {setIsStrictModeForDevtools} from './ReactFiberReconciler';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.new';
 
 import invariant from 'shared/invariant';
 

--- a/packages/react-reconciler/src/ReactUpdateQueue.old.js
+++ b/packages/react-reconciler/src/ReactUpdateQueue.old.js
@@ -110,7 +110,7 @@ import {
   isInterleavedUpdate,
 } from './ReactFiberWorkLoop.old';
 import {pushInterleavedQueue} from './ReactFiberInterleavedUpdates.old';
-import {setIsStrictModeForDevtools} from './ReactFiberReconciler';
+import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook.old';
 
 import invariant from 'shared/invariant';
 


### PR DESCRIPTION
## Summary

Previously, DevTools always overrode the native console to dim or supress `StrictMode` double logging. It also overrode `console.log` (in addition to `console.error` and `console.warn`). However, this changes the location shown by the browser console, which causes a [bad developer experience](https://github.com/facebook/react/issues/22257). There is currently a [TC39 proposal](https://github.com/tc39/proposal-function-implementation-hiding) that would allow us to extend console without breaking developer experience, but in the meantime this PR changes the `StrictMode` console override behavior so that we only patch the console during the `StrictMode` double render so that, during the first render, the location points to developer code rather than our DevTools console code.

## How did you test this change?
Added jest tests
Tested in `react-devtools-inline` and `react-devtools-extensions` to make sure behavior is as expected