### PR TITLE
[useSES shim] Import prefixed native API

### DIFF
--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -46,6 +46,8 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
           startTransition: _,
           // eslint-disable-next-line no-unused-vars
           useSyncExternalStore: __,
+          // eslint-disable-next-line no-unused-vars
+          unstable_useSyncExternalStore: ___,
           ...otherExports
         } = jest.requireActual('react');
         return otherExports;

--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -17,7 +17,8 @@ const {
   useEffect,
   useLayoutEffect,
   useDebugValue,
-  useSyncExternalStore: builtInAPI,
+  // The built-in API is still prefixed.
+  unstable_useSyncExternalStore: builtInAPI,
 } = React;
 
 // Prefer the built-in API, if it exists. If it doesn't exist, then we assume


### PR DESCRIPTION
Until useSyncExternalStore is finalized, the shim should import the prefixed version (unstable_useSyncExternalStore), which is available in the experimental builds. That way our early testers can start using it.