### PR TITLE
Fixed issue for better bundles,chunks and workers name in devtools-extensions.

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -331,7 +331,9 @@ function createPanelIfReactLoaded() {
 
         // TODO (Webpack 5) Hopefully we can remove this prop after the Webpack 5 migration.
         const hookNamesModuleLoaderFunction = () =>
-          import('react-devtools-shared/src/hooks/parseHookNames');
+          import(
+            /* webpackChunkName: 'parseHookNames' */ 'react-devtools-shared/src/hooks/parseHookNames'
+          );
 
         root = createRoot(document.createElement('div'));
 

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -114,6 +114,7 @@ module.exports = {
             loader: 'workerize-loader',
             options: {
               inline: true,
+              name: '[name]',
             },
           },
           {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This Pull request fixes #22115 

## How did you test this change?
 ran `yarn test:chrome `
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
## Demonstration of the proposed changes
Using magic comments on dynamic imports fixes the chunk names properly. 
For workers I added a name property to the workerize-loader in webpack.config.js

## Result
Now the files after building devtools-extensions are as follows.
![image](https://user-images.githubusercontent.com/51379307/133440506-e255da71-cc50-48da-9a98-3b02361b6441.png)
