### PR TITLE
[DevTools] Fix runtime error when inspecting an element times out

### DIFF
--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -158,7 +158,9 @@ function getPromiseForRequestID<T>(
 
     const onTimeout = () => {
       cleanup();
-      reject(new Error(`Timed out waiting for event ${eventType} from bridge`));
+      reject(
+        new Error(`Timed out waiting for event '${eventType}' from bridge`),
+      );
     };
 
     bridge.addListener(eventType, onInspectedElement);

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -158,7 +158,7 @@ function getPromiseForRequestID<T>(
 
     const onTimeout = () => {
       cleanup();
-      reject();
+      reject(new Error(`Timed out waiting for event ${eventType} from bridge`));
     };
 
     bridge.addListener(eventType, onInspectedElement);


### PR DESCRIPTION
## Summary

Back in #22280, we added error handlers when calling `inspectElementMutableSource` in order to at least log the errors to the console or handle them.

However, while testing the standalone app, I noticed that the error handler inside `inspectedElementCache.js` was actually being called with an `undefined` error, which then produced a new runtime error when trying to access `error.message`: https://github.com/facebook/react/blob/e8feb11b62e869804970258fa629922edbfc836b/packages/react-devtools-shared/src/inspectedElementCache.js#L133-L141

I traced this back to this promise in `backendAPI.js` which was rejecting without any error, making the error `undefined`: https://github.com/facebook/react/blob/e8feb11b62e869804970258fa629922edbfc836b/packages/react-devtools-shared/src/backendAPI.js#L159-L162

The fix in this commit is to pass an error when rejecting the promise 

## Test Plan

- yarn flow
- yarn test
- yarn test-build-devtools
- inspecting elements no longer fail with undefined errors or produce other runtime errors

**Before**

![image](https://user-images.githubusercontent.com/1271509/133510663-e09d5af0-dca5-433f-b531-7b2e219a4e99.png)


**After**
![image](https://user-images.githubusercontent.com/1271509/133510032-8a7850e8-3f09-427a-b255-00706249ef6a.png)
