### PR TITLE
Updated the utfDecodeString() method to avoid call stack exceeded error

### DIFF
--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -126,7 +126,16 @@ export function getUID(): number {
 }
 
 export function utfDecodeString(array: Array<number>): string {
-  return String.fromCodePoint(...array);
+  // Avoid spreading the array (e.g. String.fromCodePoint(...array))
+  // Functions arguments are first placed on the stack before the function is called
+  // which throws a RangeError for large arrays.
+  // See github.com/facebook/react/issues/22293
+  let string = '';
+  for (let i = 0; i < array.length; i++) {
+    const char = array[i];
+    string += String.fromCodePoint(char);
+  }
+  return string;
 }
 
 export function utfEncodeString(string: string): Array<number> {


### PR DESCRIPTION
Resolves #22293

I'd like to add a test for this, but I'm not sure how. (Even if I disable the infinite loop detection, trying to provoke this scenario crashes Jest.)

I think this is an exception where it's okay to fix without a test.