### PR TITLE
Clear performance marks after measuring

### DIFF
--- a/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
+++ b/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
@@ -27,6 +27,8 @@ function measure(markName: string): void {
   if (supportsUserTiming) {
     performance.mark(markName + '-end');
     performance.measure(markName, markName + '-start', markName + '-end');
+    performance.clearMarks(markName + '-start');
+    performance.clearMarks(markName + '-end');
   }
 }
 


### PR DESCRIPTION
Once we've measured an event duration, we no longer need the marks. This PR adds calls to [`clearMarks`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/clearMarks) to remove them from the browser's performance entry buffer. (They'll still be in the exported profiling JSON which is what the scheduling profiler needs.)