### PR TITLE
DevTools: Fix memory leak via alternate Fiber pointer

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1140,6 +1140,13 @@ export function attach(
 
     untrackFibersSet.add(fiber);
 
+    // React may detach alternate pointers during unmount;
+    // Since our untracking code is async, we should explicily track the pending alternate here as well.
+    const alternate = fiber.alternate;
+    if (alternate !== null) {
+      untrackFibersSet.add(alternate);
+    }
+
     if (untrackFibersTimeoutID === null) {
       untrackFibersTimeoutID = setTimeout(untrackFibers, 1000);
     }


### PR DESCRIPTION
DevTools delays untracking Fibers to support a Fast Refresh edge case. React may detach alternate pointers during unmount though (related to deletedTreeCleanUpLevel). Because DevTools untracking is async, it needs to explicily store the pending alternate Fiber as well. Otherwise by the time the untracking code runs, the alternate pointer may be nulled out, leading to a leak.

Resolves #17624