### PR TITLE
[Draft] Add Next.js runtime support

### DIFF
--- a/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-next.js
+++ b/packages/react-client/src/forks/ReactFlightClientHostConfig.dom-next.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ export * from 'react-client/src/ReactFlightClientHostConfigBrowser';
+ export * from 'react-client/src/ReactFlightClientHostConfigStream';
+ export * from 'react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig';
+ 

--- a/packages/react-dom/src/server/ReactDOMFizzServerNext.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNext.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ import type {ReactNodeList} from 'shared/ReactTypes';
+ import type {Destination, NextExecutor} from 'react-server/src/ReactServerStreamConfigNext'
+ 
+ import ReactVersion from 'shared/ReactVersion';
+ 
+ import {
+   createRequest,
+   startWork,
+   startFlowing,
+   stopFlowing,
+   abort,
+ } from 'react-server/src/ReactFizzServer';
+ 
+ import {
+   createResponseState,
+   createRootFormatContext,
+ } from './ReactDOMServerFormatConfig';
+ 
+ type Options = {|
+   identifierPrefix?: string,
+   namespaceURI?: string,
+   progressiveChunkSize?: number,
+   onReadyToStream?: () => void,
+   onCompleteAll?: () => void,
+   onError?: (error: mixed) => void,
+ |};
+ 
+ type Controls = {|
+   // Cancel any pending I/O and put anything remaining into
+   // client rendered mode.
+   abort(): void,
+ |};
+ 
+ function createRequestImpl(
+   children: ReactNodeList,
+   destination: Destination,
+   options: void | Options,
+ ) {
+   return createRequest(
+     children,
+     destination,
+     createResponseState(options ? options.identifierPrefix : undefined),
+     createRootFormatContext(options ? options.namespaceURI : undefined),
+     options ? options.progressiveChunkSize : undefined,
+     options ? options.onError : undefined,
+     options ? options.onCompleteAll : undefined,
+     options ? options.onReadyToStream : undefined,
+   );
+ }
+ 
+ function pipeToNextExecutor(
+   children: ReactNodeList,
+   executor: NextExecutor,
+   options?: Options,
+ ): Controls {
+   const destination = {
+     exec: executor,
+     state: {
+       full: false,
+       update: () => {},
+     }
+   }
+   const request = createRequestImpl(children, destination, options);
+   destination.state.update = () => {
+     if (destination.state.full) {
+       stopFlowing(request);
+     } else {
+       startFlowing(request)
+     }
+   }
+   executor(0, destination.state)
+   startWork(request);
+   return {
+     abort() {
+       abort(request);
+     },
+   };
+ }
+ 
+ export {pipeToNextExecutor, ReactVersion as version};
+ 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -16,7 +16,7 @@ export type Destination = {
 export type PrecomputedChunk = string;
 export type Chunk = string;
 
-export function scheduleWork(callback: () => void) {
+export function scheduleWork(destination: Destination, callback: () => void) {
   callback();
 }
 

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -56,7 +56,7 @@ const POP = Buffer.from('/', 'utf8');
 let opaqueID = 0;
 
 const ReactNoopServer = ReactFizzServer({
-  scheduleWork(callback: () => void) {
+  scheduleWork(destination: Destination, callback: () => void) {
     callback();
   },
   beginWriting(destination: Destination): void {},

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.dom-next.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.dom-next.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ export * from 'react-dom/src/client/ReactDOMHostConfig';

--- a/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
+++ b/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
@@ -17,7 +17,7 @@ export type Destination = {
 export type PrecomputedChunk = string;
 export type Chunk = string;
 
-export function scheduleWork(callback: () => void) {
+export function scheduleWork(destination: Destination, callback: () => void) {
   // We don't schedule work in this model, and instead expect performWork to always be called repeatedly.
 }
 

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -272,7 +272,7 @@ function pingTask(request: Request, task: Task): void {
   const pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   if (pingedTasks.length === 1) {
-    scheduleWork(() => performWork(request));
+    scheduleWork(request.destination, () => performWork(request));
   }
 }
 
@@ -1899,7 +1899,7 @@ function flushCompletedQueues(request: Request): void {
 }
 
 export function startWork(request: Request): void {
-  scheduleWork(() => performWork(request));
+  scheduleWork(request.destination, () => performWork(request));
 }
 
 export function startFlowing(request: Request): void {
@@ -1913,6 +1913,13 @@ export function startFlowing(request: Request): void {
     reportError(request, error);
     fatalError(request, error);
   }
+}
+
+export function stopFlowing(request: Request): void {
+  if (request.status === CLOSED) {
+    return;
+  }
+  request.status = BUFFERING;
 }
 
 // This is called to early terminate a request. It puts all pending boundaries in client rendered state.

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -12,7 +12,7 @@ export type Destination = ReadableStreamController;
 export type PrecomputedChunk = Uint8Array;
 export type Chunk = Uint8Array;
 
-export function scheduleWork(callback: () => void) {
+export function scheduleWork(destination: Destination, callback: () => void) {
   callback();
 }
 

--- a/packages/react-server/src/ReactServerStreamConfigNext.js
+++ b/packages/react-server/src/ReactServerStreamConfigNext.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ const INIT: 0 = 0
+ const WRITE: 1 = 1
+ const BUFFER: 2 = 2
+ const FLUSH: 3 = 3
+ const CLOSE: 4 = 4
+ const SCHEDULE: 5 = 5
+ 
+ type NextExecutorCommand =
+   | [typeof INIT, { full: boolean, update: () => void }]
+   | [typeof WRITE, Uint8Array]
+   | [typeof BUFFER, boolean]
+   | [typeof FLUSH]
+   | [typeof CLOSE]
+   | [typeof CLOSE, mixed]
+   | [typeof SCHEDULE, () => void]
+ 
+ export type NextExecutor = (...args: NextExecutorCommand) => void
+
+ export type Destination = {
+  exec: NextExecutor,
+  state: {
+    full: boolean,
+    update: () => void
+  }
+ };
+
+ export type PrecomputedChunk = Uint8Array;
+ export type Chunk = Uint8Array;
+ 
+ export function scheduleWork(destination: Destination, callback: () => void) {
+   destination.exec(SCHEDULE, callback);
+ }
+ 
+ export function flushBuffered(destination: Destination) {
+   destination.exec(FLUSH);
+ }
+ 
+ export function beginWriting(destination: Destination) {
+   destination.exec(BUFFER, true);
+ }
+ 
+ export function writeChunk(
+   destination: Destination,
+   chunk: PrecomputedChunk | Chunk,
+ ): boolean {
+   destination.exec(WRITE, chunk);
+   return destination.state.full;
+ }
+ 
+ export function completeWriting(destination: Destination) {
+   destination.exec(BUFFER, false);
+ }
+ 
+ export function close(destination: Destination) {
+   destination.exec(CLOSE);
+ }
+ 
+ const textEncoder = new TextEncoder();
+ 
+ export function stringToChunk(content: string): Chunk {
+   return textEncoder.encode(content);
+ }
+ 
+ export function stringToPrecomputedChunk(content: string): PrecomputedChunk {
+   return textEncoder.encode(content);
+ }
+ 
+ export function closeWithError(destination: Destination, error: mixed): void {
+   destination.exec(CLOSE, error)
+ }
+ 

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -19,7 +19,7 @@ export type Destination = Writable & MightBeFlushable;
 export type PrecomputedChunk = Uint8Array;
 export type Chunk = string;
 
-export function scheduleWork(callback: () => void) {
+export function scheduleWork(destination: Destination, callback: () => void) {
   setImmediate(callback);
 }
 

--- a/packages/react-server/src/forks/ReactFlightServerConfig.dom-next.js
+++ b/packages/react-server/src/forks/ReactFlightServerConfig.dom-next.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ export * from '../ReactFlightServerConfigStream';
+ export * from 'react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig';
+ 

--- a/packages/react-server/src/forks/ReactServerFormatConfig.dom-next.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.dom-next.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ export * from 'react-dom/src/server/ReactDOMServerFormatConfig';

--- a/packages/react-server/src/forks/ReactServerStreamConfig.dom-next.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.dom-next.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+ export * from '../ReactServerStreamConfigNext';

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -277,6 +277,14 @@ const bundles = [
     externals: ['react'],
   },
   {
+    bundleTypes: [NODE_DEV, NODE_PROD],
+    moduleType: RENDERER,
+    entry: 'react-dom/src/server/ReactDOMFizzServerNext',
+    name: 'react-dom-server.next',
+    global: 'ReactDOMServer',
+    externals: ['react'],
+  },
+  {
     bundleTypes: __EXPERIMENTAL__ ? [FB_WWW_DEV, FB_WWW_PROD] : [],
     moduleType: RENDERER,
     entry: 'react-server-dom-relay/src/ReactDOMServerFB',

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -67,6 +67,17 @@ module.exports = [
     isServerSupported: true,
   },
   {
+    shortName: 'dom-next',
+    entryPoints: [
+      'react-dom/src/server/ReactDOMFizzServerNext', // react-dom/server
+    ],
+    paths: [
+      'react-dom/src/server/ReactDOMFizzServerNext.js', // react-dom/server.browser
+    ],
+    isFlowTyped: true,
+    isServerSupported: true,
+  },
+  {
     shortName: 'art',
     entryPoints: ['react-art'],
     paths: ['react-art'],


### PR DESCRIPTION
## Summary
Support for a Next.js runtime in `ReactFizzServer` that doesn't rely on Node or Browser APIs.

I also added `stopFlowing` so that React can handle backpressure _before_ it tries to write data. Consider if Next.js e.g. writes some stylesheets that cause the buffer to overflow. If React then goes to write data, it will be buffered. With `stopFlowing`, React can be informed ahead of time that the buffer is full and it can spend more time processing. 

## How did you test this change?
Implemented in Next.js (https://github.com/azukaru/next.js/pull/695/files) and ran against CI.
