### PR TITLE
Build use-sync-external-store in codesandbox-ci

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,11 +1,12 @@
 {
-  "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/src/server,react-dom/test-utils,scheduler/index,react/jsx-runtime,react/jsx-dev-runtime",
+  "packages": ["packages/react", "packages/react-dom", "packages/scheduler", "packages/use-sync-external-store"],
+  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/src/server,react-dom/test-utils,scheduler/index,react/jsx-runtime,react/jsx-dev-runtime,use-sync-external-store,use-sync-external-store/extra",
   "node": "12",
   "publishDirectory": {
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom",
-    "scheduler": "build/node_modules/scheduler"
+    "scheduler": "build/node_modules/scheduler",
+    "use-sync-external-store": "build/node_modules/use-sync-external-store"
   },
   "sandboxes": ["new"],
   "silent": true


### PR DESCRIPTION
## Summary

Wanted to play around with https://github.com/facebook/react/pull/22347 but `use-sync-external-store` isn't built in codesandbox-ci. For React 18 repros it isn't that big of deal since I can just use the variant exported from `react`. Bur for older React versions I need the shim form the package.

## How did you test this change?

- [x] Can use a build of `use-sync-external-store` from this PR in https://codesandbox.io/s/pedantic-archimedes-9q0nb?file=/src/App.js: https://codesandbox.io/s/sleepy-moon-d561m
