### PR TITLE
Generate aria attribute data using an array

### DIFF
--- a/packages/react-dom/src/shared/validAriaProperties.js
+++ b/packages/react-dom/src/shared/validAriaProperties.js
@@ -4,61 +4,66 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-const ariaProperties = {
-  'aria-current': 0, // state
-  'aria-description': 0,
-  'aria-details': 0,
-  'aria-disabled': 0, // state
-  'aria-hidden': 0, // state
-  'aria-invalid': 0, // state
-  'aria-keyshortcuts': 0,
-  'aria-label': 0,
-  'aria-roledescription': 0,
+const properties = [
+  'current', // state
+  'description',
+  'details',
+  'disabled', // state
+  'hidden', // state
+  'invalid', // state
+  'keyshortcuts',
+  'label',
+  'roledescription',
   // Widget Attributes
-  'aria-autocomplete': 0,
-  'aria-checked': 0,
-  'aria-expanded': 0,
-  'aria-haspopup': 0,
-  'aria-level': 0,
-  'aria-modal': 0,
-  'aria-multiline': 0,
-  'aria-multiselectable': 0,
-  'aria-orientation': 0,
-  'aria-placeholder': 0,
-  'aria-pressed': 0,
-  'aria-readonly': 0,
-  'aria-required': 0,
-  'aria-selected': 0,
-  'aria-sort': 0,
-  'aria-valuemax': 0,
-  'aria-valuemin': 0,
-  'aria-valuenow': 0,
-  'aria-valuetext': 0,
+  'autocomplete',
+  'checked',
+  'expanded',
+  'haspopup',
+  'level',
+  'modal',
+  'multiline',
+  'multiselectable',
+  'orientation',
+  'placeholder',
+  'pressed',
+  'readonly',
+  'required',
+  'selected',
+  'sort',
+  'valuemax',
+  'valuemin',
+  'valuenow',
+  'valuetext',
   // Live Region Attributes
-  'aria-atomic': 0,
-  'aria-busy': 0,
-  'aria-live': 0,
-  'aria-relevant': 0,
+  'atomic',
+  'busy',
+  'live',
+  'relevant',
   // Drag-and-Drop Attributes
-  'aria-dropeffect': 0,
-  'aria-grabbed': 0,
+  'dropeffect',
+  'grabbed',
   // Relationship Attributes
-  'aria-activedescendant': 0,
-  'aria-colcount': 0,
-  'aria-colindex': 0,
-  'aria-colspan': 0,
-  'aria-controls': 0,
-  'aria-describedby': 0,
-  'aria-errormessage': 0,
-  'aria-flowto': 0,
-  'aria-labelledby': 0,
-  'aria-owns': 0,
-  'aria-posinset': 0,
-  'aria-rowcount': 0,
-  'aria-rowindex': 0,
-  'aria-rowspan': 0,
-  'aria-setsize': 0,
-};
+  'activedescendant',
+  'colcount',
+  'colindex',
+  'colspan',
+  'controls',
+  'describedby',
+  'errormessage',
+  'flowto',
+  'labelledby',
+  'owns',
+  'posinset',
+  'rowcount',
+  'rowindex',
+  'rowspan',
+  'setsize',
+];
+
+const ariaProperties = {};
+
+properties.forEach(property => {
+  ariaProperties['aria-' + property] = 0;
+});
 
 export default ariaProperties;


### PR DESCRIPTION
Save more than two hundred characters of space.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The aria attribute defined in the file has a large number of duplicate strings, and this PR saves a lot of space.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

This is the result of commit.
![image](https://user-images.githubusercontent.com/1947344/133935177-77b610f6-1b46-4dab-8885-24645eb5bab0.png)

