### PR TITLE
Remove root Fiber fields that were used for hydrating `useMutableSource`

### DIFF
--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -10,7 +10,7 @@
 import type {FiberRoot, SuspenseHydrationCallbacks} from './ReactInternalTypes';
 import type {RootTag} from './ReactRootTags';
 
-import {noTimeout, supportsHydration} from './ReactFiberHostConfig';
+import {noTimeout} from './ReactFiberHostConfig';
 import {createHostRootFiber} from './ReactFiber.new';
 import {
   NoLane,
@@ -57,10 +57,6 @@ function FiberRootNode(containerInfo, tag, hydrate) {
   if (enableCache) {
     this.pooledCache = null;
     this.pooledCacheLanes = NoLanes;
-  }
-
-  if (supportsHydration) {
-    this.mutableSourceEagerHydrationData = null;
   }
 
   if (enableSuspenseCallback) {

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -10,7 +10,7 @@
 import type {FiberRoot, SuspenseHydrationCallbacks} from './ReactInternalTypes';
 import type {RootTag} from './ReactRootTags';
 
-import {noTimeout, supportsHydration} from './ReactFiberHostConfig';
+import {noTimeout} from './ReactFiberHostConfig';
 import {createHostRootFiber} from './ReactFiber.old';
 import {
   NoLane,
@@ -57,10 +57,6 @@ function FiberRootNode(containerInfo, tag, hydrate) {
   if (enableCache) {
     this.pooledCache = null;
     this.pooledCacheLanes = NoLanes;
-  }
-
-  if (supportsHydration) {
-    this.mutableSourceEagerHydrationData = null;
   }
 
   if (enableSuspenseCallback) {


### PR DESCRIPTION


## Summary

Removes `mutableSourceEagerHydrationData` which was added in https://github.com/facebook/react/pull/18771 but is no longer read nor written to after initialization with https://github.com/facebook/react/pull/22292

## How did you test this change?

- [x] CI green
