### PR TITLE
build2 -> build

### DIFF
--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "prestart": "cp ../../build2/oss-stable/scheduler/umd/scheduler-unstable_mock.development.js ../../build2/oss-stable/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build2/oss-stable/react/umd/react.development.js ../../build2/oss-stable/react-dom/umd/react-dom.development.js ../../build2/oss-stable/react/umd/react.production.min.js ../../build2/oss-stable/react-dom/umd/react-dom.production.min.js ../../build2/oss-stable/react-dom/umd/react-dom-server.browser.development.js ../../build2/oss-stable/react-dom/umd/react-dom-server.browser.production.min.js ../../build2/oss-stable/react-dom/umd/react-dom-test-utils.development.js ../../build2/oss-stable/react-dom/umd/react-dom-test-utils.production.min.js public/ && cp -a ../../build2/oss-stable/. node_modules",
+    "prestart": "cp ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.development.js ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build/oss-stable/react/umd/react.development.js ../../build/oss-stable/react-dom/umd/react-dom.development.js ../../build/oss-stable/react/umd/react.production.min.js ../../build/oss-stable/react-dom/umd/react-dom.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.development.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.development.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.production.min.js public/ && cp -a ../../build/oss-stable/. node_modules",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "scripts": {
     "build": "node ./scripts/rollup/build.js",
     "build-combined": "node ./scripts/rollup/build-all-release-channels.js",
-    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react-dom,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh --type=NODE && rm -rf build2 && mkdir build2 && cp -r ./build/node_modules build2/oss-experimental/",
+    "build-for-devtools": "cross-env RELEASE_CHANNEL=experimental yarn build react/index,react/jsx,react-dom,react-is,react-debug-tools,scheduler,react-test-renderer,react-refresh --type=NODE && rm -rf build && mkdir build && cp -r ./build/node_modules build/oss-experimental/",
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
     "linc": "node ./scripts/tasks/linc.js",

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -22,7 +22,7 @@ const builtModulesDir = resolve(
   __dirname,
   '..',
   '..',
-  'build2',
+  'build',
   'oss-experimental',
 );
 

--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -22,7 +22,7 @@ const builtModulesDir = resolve(
   __dirname,
   '..',
   '..',
-  'build2',
+  'build',
   'oss-experimental',
 );
 

--- a/packages/react-devtools-extensions/build.js
+++ b/packages/react-devtools-extensions/build.js
@@ -27,7 +27,7 @@ const ensureLocalBuild = async () => {
     __dirname,
     '..',
     '..',
-    'build2',
+    'build',
     'oss-experimental',
   );
 

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -24,7 +24,7 @@ const builtModulesDir = resolve(
   __dirname,
   '..',
   '..',
-  'build2',
+  'build',
   'oss-experimental',
 );
 

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -24,7 +24,7 @@ const builtModulesDir = resolve(
   __dirname,
   '..',
   '..',
-  'build2',
+  'build',
   'oss-experimental',
 );
 

--- a/packages/react-devtools-shell/webpack.config.js
+++ b/packages/react-devtools-shell/webpack.config.js
@@ -28,7 +28,7 @@ const builtModulesDir = resolve(
   __dirname,
   '..',
   '..',
-  'build2',
+  'build',
   'oss-experimental',
 );
 

--- a/scripts/circleci/check_minified_errors.sh
+++ b/scripts/circleci/check_minified_errors.sh
@@ -2,7 +2,7 @@
 
 # Ensure errors are minified in production
 
-OUT=$(git --no-pager grep -n --untracked --no-exclude-standard 'FIXME (minify-errors-in-prod)' -- './build2/*')
+OUT=$(git --no-pager grep -n --untracked --no-exclude-standard 'FIXME (minify-errors-in-prod)' -- './build/*')
 
 if [ "$OUT" != "" ]; then
   echo "$OUT";

--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -35,13 +35,11 @@ moduleNameMapper['react-devtools-feature-flags'] =
 // Map packages to bundles
 packages.forEach(name => {
   // Root entry point
-  moduleNameMapper[
-    `^${name}$`
-  ] = `<rootDir>/build2/${NODE_MODULES_DIR}/${name}`;
+  moduleNameMapper[`^${name}$`] = `<rootDir>/build/${NODE_MODULES_DIR}/${name}`;
   // Named entry points
   moduleNameMapper[
     `^${name}\/([^\/]+)$`
-  ] = `<rootDir>/build2/${NODE_MODULES_DIR}/${name}/$1`;
+  ] = `<rootDir>/build/${NODE_MODULES_DIR}/${name}/$1`;
 });
 
 // Allow tests to import shared code (e.g. feature flags, getStackByFiberInDevAndProd)
@@ -57,7 +55,7 @@ module.exports = Object.assign({}, baseConfig, {
   // Exclude the build output from transforms
   transformIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/build2/',
+    '<rootDir>/build/',
     '/__compiled__/',
     '/__untransformed__/',
   ],

--- a/scripts/jest/config.build.js
+++ b/scripts/jest/config.build.js
@@ -38,13 +38,11 @@ moduleNameMapper[
 // Map packages to bundles
 packages.forEach(name => {
   // Root entry point
-  moduleNameMapper[
-    `^${name}$`
-  ] = `<rootDir>/build2/${NODE_MODULES_DIR}/${name}`;
+  moduleNameMapper[`^${name}$`] = `<rootDir>/build/${NODE_MODULES_DIR}/${name}`;
   // Named entry points
   moduleNameMapper[
     `^${name}\/([^\/]+)$`
-  ] = `<rootDir>/build2/${NODE_MODULES_DIR}/${name}/$1`;
+  ] = `<rootDir>/build/${NODE_MODULES_DIR}/${name}/$1`;
 });
 
 module.exports = Object.assign({}, baseConfig, {
@@ -58,7 +56,7 @@ module.exports = Object.assign({}, baseConfig, {
   // Don't run bundle tests on -test.internal.* files
   testPathIgnorePatterns: ['/node_modules/', '-test.internal.js$'],
   // Exclude the build output from transforms
-  transformIgnorePatterns: ['/node_modules/', '<rootDir>/build2/'],
+  transformIgnorePatterns: ['/node_modules/', '<rootDir>/build/'],
   setupFiles: [
     ...baseConfig.setupFiles,
     require.resolve('./setupTests.build.js'),

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -219,7 +219,7 @@ function validateOptions() {
 
   if (argv.build) {
     // TODO: We could build this if it hasn't been built yet.
-    const buildDir = path.resolve('./build2');
+    const buildDir = path.resolve('./build');
     if (!fs.existsSync(buildDir)) {
       logError(
         'Build directory does not exist, please run `yarn build-combined` or remove the --build option.'

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -125,7 +125,7 @@ const getCommitFromCurrentBuild = async () => {
   // This is important to make the build reproducible (e.g. by Mozilla reviewers).
   const buildInfoJSON = join(
     cwd,
-    'build2',
+    'build',
     'oss-experimental',
     'react',
     'build-info.json'
@@ -136,7 +136,7 @@ const getCommitFromCurrentBuild = async () => {
   } else {
     const packageJSON = join(
       cwd,
-      'build2',
+      'build',
       'oss-experimental',
       'react',
       'package.json'

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -79,7 +79,7 @@ async function lint(eslint, filepaths) {
 async function lintEverything() {
   console.log(`Linting build artifacts...`);
 
-  const allFilepaths = await glob('build2/**/*.js');
+  const allFilepaths = await glob('build/**/*.js');
 
   const pathsByFormat = new Map();
   for (const filepath of allFilepaths) {


### PR DESCRIPTION
Now that all the CI jobs have been migrated to the new build script, we can start renaming the `build2` directory to `build`.

Since there are lots of scripts that reference `build2`, including downstream scripts that live outside this repo, I'm going to keep the `build2` directory around as a copy of `build`.

Then once all the references are updated, I will delete the copy.