### PR TITLE
Delete all but one `build2` reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,7 @@ jobs:
       - run: yarn build-combined
       - persist_to_workspace:
           root: .
-          # TODO: Migrate scripts to use `build` directory instead of `build2`
           paths:
-            - build2
             - build
 
   get_base_build:
@@ -121,7 +119,7 @@ jobs:
               git fetch origin main
               cd ./scripts/release && yarn && cd ../../
               scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/main)
-              mv ./build2 ./base-build
+              mv ./build ./base-build
       - persist_to_workspace:
           root: .
           paths:
@@ -136,12 +134,11 @@ jobs:
           at: .
       - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
-      - run: echo "<< pipeline.git.revision	>>" >> build2/COMMIT_SHA
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
         # Compress build directory into a single tarball for easy download
-      - run: tar -zcvf ./build2.tgz ./build2
-        # TODO: Migrate scripts to use `build` directory instead of `build2`
       - run: tar -zcvf ./build.tgz ./build
+        # TODO: Migrate scripts to use `build` directory instead of `build2`
+      - run: cp ./build.tgz ./build2.tgz
       - store_artifacts:
           path: ./build2.tgz
       - store_artifacts:
@@ -154,7 +151,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: echo "<< pipeline.git.revision	>>" >> build2/COMMIT_SHA
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
       - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,9 +6,6 @@ packages/react-art/npm/lib
 
 # Build products
 build/
-# TODO: Currently storing artifacts as `./build2` so that it doesn't conflict
-# with old build job. Remove once we migrate rest of build/test pipeline.
-build2/
 coverage/
 fixtures/
 scripts/bench/benchmarks/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ scripts/flow/*/.flowconfig
 _SpecRunner.html
 __benchmarks__
 build/
-build2/
 remote-repo/
 coverage/
 .module-cache

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -1,7 +1,6 @@
 [ignore]
 .*/scripts/bench/.*
 .*/build/.*
-.*/build2/.*
 .*/fixtures/.*
 .*/.tempUserDataDir/.*
 

--- a/scripts/release/shared-commands/download-build-artifacts.js
+++ b/scripts/release/shared-commands/download-build-artifacts.js
@@ -4,7 +4,6 @@
 
 const {exec} = require('child-process-promise');
 const {existsSync} = require('fs');
-const fse = require('fs-extra');
 const {join} = require('path');
 const {getArtifactsList, logPromise} = require('../utils');
 const theme = require('../theme');
@@ -30,11 +29,6 @@ const run = async ({build, cwd, releaseChannel}) => {
       cwd,
     }
   );
-
-  // TODO: Currently storing a copy of the artifacts as `./build2`, because
-  // some scripts reference that directory. Remove once we migrate everything to
-  // reference `./build` instead.
-  fse.copySync('./build', './build2');
 
   // Copy to staging directory
   // TODO: Consider staging the release in a different directory from the CI

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -56,11 +56,6 @@ if (process.env.CIRCLE_NODE_TOTAL) {
     buildForChannel('experimental', nodeTotal, nodeIndex);
     processExperimental('./build');
   }
-
-  // TODO: Currently storing a copy of the artifacts as `./build2`, because
-  // some scripts reference that directory. Remove once we migrate everything to
-  // reference `./build` instead.
-  fse.copySync('./build', './build2');
 } else {
   // Running locally, no concurrency. Move each channel's build artifacts into
   // a temporary directory so that they don't conflict.
@@ -87,10 +82,6 @@ if (process.env.CIRCLE_NODE_TOTAL) {
 
   // Now restore the combined directory back to its original name
   crossDeviceRenameSync(stableDir, './build');
-  // TODO: Currently storing a copy of the artifacts as `./build2`, because
-  // some scripts reference that directory. Remove once we migrate everything to
-  // reference `./build` instead.
-  fse.copySync('./build', './build2');
 }
 
 function buildForChannel(channel, nodeTotal, nodeIndex) {


### PR DESCRIPTION
This removes all the remaining references to the `build2` directory except for the CI job that stores the artifacts. We'll keep the `build2` artifact until downstream scripts are migrated to `build`.