### PR TITLE
[Old server renderer] Retry error on client

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -2671,4 +2671,32 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(span);
     expect(ref.current.innerHTML).toBe('Hidden child');
   });
+
+  it('should retry on client if something throws', async () => {
+    let isServer = true;
+    function ThrowsOnServerOnly() {
+      if (isServer) {
+        throw new Error('Oops!');
+      }
+      return 'Yay!';
+    }
+
+    function App() {
+      return (
+        <React.Suspense fallback="Loading...">
+          <ThrowsOnServerOnly />
+        </React.Suspense>
+      );
+    }
+
+    const element = document.createElement('div');
+    element.innerHTML = ReactDOMServer.renderToString(<App />);
+    expect(element.textContent).toBe('Loading...');
+
+    isServer = false;
+    await act(async () => {
+      ReactDOM.hydrateRoot(element, <App />);
+    });
+    expect(element.textContent).toBe('Yay!');
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSuspense-test.internal.js
@@ -115,6 +115,20 @@ describe('ReactDOMServerSuspense', () => {
     expect(getVisibleChildren(c)).toEqual(<div>Fallback</div>);
   });
 
+  it('should render the fallback when an error is thrown', async () => {
+    function Throws() {
+      throw new Error('Oops!');
+    }
+    const c = await serverRender(
+      <div>
+        <React.Suspense fallback={<Text text="Fallback" />}>
+          <Throws />
+        </React.Suspense>
+      </div>,
+    );
+    expect(getVisibleChildren(c)).toEqual(<div>Fallback</div>);
+  });
+
   it('should work with nested suspense components', async () => {
     const c = await serverRender(
       <div>


### PR DESCRIPTION
We're still in the process of migrating to the Fizz server renderer. In the meantime, this makes the error semantics on the old server renderer match the behavior of the new one: if an error is thrown, it triggers a Suspense fallback, just as if it suspended (this part was already implemented). Then the errored tree is retried on the client, where it may recover and finish successfully.