### PR TITLE
Update CodeSandbox to pull build artifacts from CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,11 +1,11 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
-  "buildCommand": "build --type=NODE react/index,react-dom/index,react-dom/src/server,react-dom/test-utils,scheduler/index,react/jsx-runtime,react/jsx-dev-runtime",
+  "buildCommand": "download-build-in-codesandbox-ci",
   "node": "12",
   "publishDirectory": {
-    "react": "build/node_modules/react",
-    "react-dom": "build/node_modules/react-dom",
-    "scheduler": "build/node_modules/scheduler"
+    "react": "build/oss-experimental/react",
+    "react-dom": "build/oss-experimental/react-dom",
+    "scheduler": "build/oss-experimental/scheduler"
   },
   "sandboxes": ["new"],
   "silent": true

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     "version-check": "node ./scripts/tasks/version-check.js",
     "merge-fork": "node ./scripts/merge-fork/merge-fork.js",
     "replace-fork": "node ./scripts/merge-fork/replace-fork.js",
-    "publish-prereleases": "node ./scripts/release/publish-using-ci-workflow.js"
+    "publish-prereleases": "node ./scripts/release/publish-using-ci-workflow.js",
+    "download-build": "node ./scripts/release/download-experimental-build.js",
+    "download-build-for-head": "node ./scripts/release/download-experimental-build.js --commit=$(git rev-parse HEAD)",
+    "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head"
   }
 }


### PR DESCRIPTION
Instead of building them from source.

The `download-experimental-build` script polls CI until the build has finished.