### PR TITLE
Fix missing else in ReactDOMServerFormatConfig.js

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -919,12 +919,7 @@ function pushStartTextArea(
         children.length <= 1,
         '<textarea> can only have at most one child.',
       );
-      // TODO: remove the coercion and the DEV check below because it will
-      // always be overwritten by the coercion several lines below it. #22309
-      if (__DEV__) {
-        checkHtmlStringCoercion(children[0]);
-      }
-      value = '' + children[0];
+      // Fall through, as `'' + children === '' + children[0]` for 1-element arrays.
     }
     if (__DEV__) {
       checkHtmlStringCoercion(children);


### PR DESCRIPTION
 Removed else statement from ReactDOMServerFormatConfig.js
 Else statement was redundant since value is set anyways.
 Solves bug 22309.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This PR removes redundant code from the ReactDOMServerFormatConfig.js file.
As discussed here [22309](https://github.com/facebook/react/issues/22309)

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Tested it using 
yarn prettier
yarn linc
yarn build and test

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
