### PR TITLE
Selectively hydrate during capture phase

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerSelectiveHydration-test.internal.js
@@ -459,7 +459,15 @@ describe('ReactDOMServerSelectiveHydration', () => {
         });
       }
 
-      return <span ref={ref}>{text}</span>;
+      return (
+        <span
+          ref={ref}
+          onClickCapture={() => {
+            Scheduler.unstable_yieldValue('Capture Clicked ' + text);
+          }}>
+          {text}
+        </span>
+      );
     }
 
     function App() {
@@ -519,7 +527,12 @@ describe('ReactDOMServerSelectiveHydration', () => {
       resolve();
       await promise;
     });
-    expect(Scheduler).toHaveYielded(['D', 'Clicked D', 'A']);
+    expect(Scheduler).toHaveYielded([
+      'D',
+      'Capture Clicked D',
+      'Clicked D',
+      'A',
+    ]);
 
     document.body.removeChild(container);
   });

--- a/packages/react-dom/src/events/EventSystemFlags.js
+++ b/packages/react-dom/src/events/EventSystemFlags.js
@@ -25,4 +25,4 @@ export const SHOULD_NOT_DEFER_CLICK_FOR_FB_SUPPORT_MODE =
 // will result in endless cycles like an infinite loop.
 // We also don't want to defer during event replaying.
 export const SHOULD_NOT_PROCESS_POLYFILL_EVENT_PLUGINS =
-  IS_EVENT_HANDLE_NON_MANAGED_NODE | IS_NON_DELEGATED | IS_CAPTURE_PHASE;
+  IS_EVENT_HANDLE_NON_MANAGED_NODE | IS_NON_DELEGATED;

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -25,7 +25,7 @@ import {
   getSuspenseInstanceFromFiber,
 } from 'react-reconciler/src/ReactFiberTreeReflection';
 import {HostRoot, SuspenseComponent} from 'react-reconciler/src/ReactWorkTags';
-import {type EventSystemFlags, IS_CAPTURE_PHASE} from './EventSystemFlags';
+import {type EventSystemFlags} from './EventSystemFlags';
 
 import getEventTarget from './getEventTarget';
 import {getClosestInstanceFromNode} from '../client/ReactDOMComponentTree';

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -174,9 +174,7 @@ export function dispatchEvent(
 
   if (blockedOn === null) {
     // We successfully dispatched this event.
-    if (allowReplay) {
-      clearIfContinuousEvent(domEventName, nativeEvent);
-    }
+    clearIfContinuousEvent(domEventName, nativeEvent);
     return;
   }
 


### PR DESCRIPTION
## Summary

This PR adds selective hydration in the capture phase of an event. This makes it so that we run react `on*Capture` listeners after hydrating.

## How did you test this change?
Jest