### PR TITLE
prevent unused exec getCurrentValue after re-render

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -264,11 +264,11 @@ export function useSubscription<Value>({
   getCurrentValue: () => Value,
   subscribe: (callback: Function) => () => void,
 |}): Value {
-  const [state, setState] = useState({
+  const [state, setState] = useState(() => ({
     getCurrentValue,
     subscribe,
     value: getCurrentValue(),
-  });
+  }));
 
   if (
     state.getCurrentValue !== getCurrentValue ||


### PR DESCRIPTION
`getCurrentValue` at line `270` always run after a re-render but `useState` skipped after first render, so we can add it to the initial function to prevent that

@bvaughn
