### PR TITLE
[Fizz] Rename onReadyToStream to onCompleteShell

### DIFF
--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -24,7 +24,7 @@ export default function render(url, res) {
     <App assets={assets} />,
     res,
     {
-      onReadyToStream() {
+      onCompleteShell() {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;
         res.setHeader('Content-type', 'text/html');

--- a/fixtures/ssr2/server/render.js
+++ b/fixtures/ssr2/server/render.js
@@ -43,7 +43,7 @@ module.exports = function render(url, res) {
     </DataProvider>,
     res,
     {
-      onReadyToStream() {
+      onCompleteShell() {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;
         res.setHeader('Content-type', 'text/html');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -768,7 +768,7 @@ describe('ReactDOMFizzServer', () => {
         writableA,
         {
           identifierPrefix: 'A_',
-          onReadyToStream() {
+          onCompleteShell() {
             writableA.write('<div id="container-A">');
             startWriting();
             writableA.write('</div>');
@@ -788,7 +788,7 @@ describe('ReactDOMFizzServer', () => {
         writableB,
         {
           identifierPrefix: 'B_',
-          onReadyToStream() {
+          onCompleteShell() {
             writableB.write('<div id="container-B">');
             startWriting();
             writableB.write('</div>');
@@ -1029,7 +1029,7 @@ describe('ReactDOMFizzServer', () => {
         writable,
         {
           namespaceURI: 'http://www.w3.org/2000/svg',
-          onReadyToStream() {
+          onCompleteShell() {
             writable.write('<svg>');
             startWriting();
             writable.write('</svg>');

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -28,7 +28,7 @@ type Options = {|
   namespaceURI?: string,
   progressiveChunkSize?: number,
   signal?: AbortSignal,
-  onReadyToStream?: () => void,
+  onCompleteShell?: () => void,
   onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 |};
@@ -56,7 +56,7 @@ function renderToReadableStream(
         options ? options.progressiveChunkSize : undefined,
         options ? options.onError : undefined,
         options ? options.onCompleteAll : undefined,
-        options ? options.onReadyToStream : undefined,
+        options ? options.onCompleteShell : undefined,
       );
       startWork(request);
     },

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -32,7 +32,7 @@ type Options = {|
   identifierPrefix?: string,
   namespaceURI?: string,
   progressiveChunkSize?: number,
-  onReadyToStream?: () => void,
+  onCompleteShell?: () => void,
   onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 |};
@@ -57,7 +57,7 @@ function createRequestImpl(
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
     options ? options.onCompleteAll : undefined,
-    options ? options.onReadyToStream : undefined,
+    options ? options.onCompleteShell : undefined,
   );
 }
 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -54,7 +54,7 @@ function renderToStringImpl(
   };
 
   let readyToStream = false;
-  function onReadyToStream() {
+  function onCompleteShell() {
     readyToStream = true;
   }
   const request = createRequest(
@@ -68,7 +68,7 @@ function renderToStringImpl(
     Infinity,
     onError,
     undefined,
-    onReadyToStream,
+    onCompleteShell,
   );
   startWork(request);
   // If anything suspended and is still pending, we'll abort it before writing.

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -242,7 +242,7 @@ const ReactNoopServer = ReactFizzServer({
 
 type Options = {
   progressiveChunkSize?: number,
-  onReadyToStream?: () => void,
+  onCompleteShell?: () => void,
   onCompleteAll?: () => void,
   onError?: (error: mixed) => void,
 };
@@ -265,7 +265,7 @@ function render(children: React$Element<any>, options?: Options): Destination {
     options ? options.progressiveChunkSize : undefined,
     options ? options.onError : undefined,
     options ? options.onCompleteAll : undefined,
-    options ? options.onReadyToStream : undefined,
+    options ? options.onCompleteShell : undefined,
   );
   ReactNoopServer.startWork(request);
   ReactNoopServer.startFlowing(request);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -190,10 +190,10 @@ export opaque type Request = {
   // onCompleteAll is called when all pending task is done but it may not have flushed yet.
   // This is a good time to start writing if you want only HTML and no intermediate steps.
   onCompleteAll: () => void,
-  // onReadyToStream is called when there is at least a root fallback ready to show.
+  // onCompleteShell is called when there is at least a root fallback ready to show.
   // Typically you don't need this callback because it's best practice to always have a
   // root fallback ready so there's no need to wait.
-  onReadyToStream: () => void,
+  onCompleteShell: () => void,
 };
 
 // This is a default heuristic for how to split up the HTML content into progressive
@@ -227,7 +227,7 @@ export function createRequest(
   progressiveChunkSize: void | number,
   onError: void | ((error: mixed) => void),
   onCompleteAll: void | (() => void),
-  onReadyToStream: void | (() => void),
+  onCompleteShell: void | (() => void),
 ): Request {
   const pingedTasks = [];
   const abortSet: Set<Task> = new Set();
@@ -250,7 +250,7 @@ export function createRequest(
     partialBoundaries: [],
     onError: onError === undefined ? defaultErrorHandler : onError,
     onCompleteAll: onCompleteAll === undefined ? noop : onCompleteAll,
-    onReadyToStream: onReadyToStream === undefined ? noop : onReadyToStream,
+    onCompleteShell: onCompleteShell === undefined ? noop : onCompleteShell,
   };
   // This segment represents the root fallback.
   const rootSegment = createPendingSegment(request, 0, null, rootFormatContext);
@@ -1370,8 +1370,8 @@ function finishedTask(
     }
     request.pendingRootTasks--;
     if (request.pendingRootTasks === 0) {
-      const onReadyToStream = request.onReadyToStream;
-      onReadyToStream();
+      const onCompleteShell = request.onCompleteShell;
+      onCompleteShell();
     }
   } else {
     boundary.pendingTasks--;


### PR DESCRIPTION
The onReadyToStream callback gets called when the first root level up until the first Suspense boundary is ready to flush. Meaning you can meaningfully show some content.

Currently that happens to be the first time there's any reason to flush anything to the stream. However, I think we'll want to start emitting some content earlier than this - specifically preload tags (assuming startWriting has been called).

This means that there's a reason to start writing before this callback is called.

cc @devknoll