### PR TITLE
[Fizz/Flight] pipeToNodeWritable(..., writable).startWriting() -> renderToPipeableStream(...).pipe(writable)

### DIFF
--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -22,10 +22,9 @@ module.exports = function(req, res) {
         const moduleMap = JSON.parse(data);
         const {startWriting} = renderToNodePipe(
           React.createElement(App),
-          res,
           moduleMap
         );
-        startWriting();
+        startWriting(res);
       }
     );
   });

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -20,7 +20,12 @@ module.exports = function(req, res) {
         const App = m.default.default || m.default;
         res.setHeader('Access-Control-Allow-Origin', '*');
         const moduleMap = JSON.parse(data);
-        renderToNodePipe(React.createElement(App), res, moduleMap);
+        const {startWriting} = renderToNodePipe(
+          React.createElement(App),
+          res,
+          moduleMap
+        );
+        startWriting();
       }
     );
   });

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -20,11 +20,8 @@ module.exports = function(req, res) {
         const App = m.default.default || m.default;
         res.setHeader('Access-Control-Allow-Origin', '*');
         const moduleMap = JSON.parse(data);
-        const {startWriting} = renderToNodePipe(
-          React.createElement(App),
-          moduleMap
-        );
-        startWriting(res);
+        const {pipe} = renderToNodePipe(React.createElement(App), moduleMap);
+        pipe(res);
       }
     );
   });

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {pipeToNodeWritable} = require('react-server-dom-webpack/writer');
+const {renderToNodePipe} = require('react-server-dom-webpack/writer');
 const {readFile} = require('fs');
 const {resolve} = require('path');
 const React = require('react');
@@ -20,7 +20,7 @@ module.exports = function(req, res) {
         const App = m.default.default || m.default;
         res.setHeader('Access-Control-Allow-Origin', '*');
         const moduleMap = JSON.parse(data);
-        pipeToNodeWritable(React.createElement(App), res, moduleMap);
+        renderToNodePipe(React.createElement(App), res, moduleMap);
       }
     );
   });

--- a/fixtures/flight/server/handler.server.js
+++ b/fixtures/flight/server/handler.server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {renderToNodePipe} = require('react-server-dom-webpack/writer');
+const {renderToPipeableStream} = require('react-server-dom-webpack/writer');
 const {readFile} = require('fs');
 const {resolve} = require('path');
 const React = require('react');
@@ -20,7 +20,10 @@ module.exports = function(req, res) {
         const App = m.default.default || m.default;
         res.setHeader('Access-Control-Allow-Origin', '*');
         const moduleMap = JSON.parse(data);
-        const {pipe} = renderToNodePipe(React.createElement(App), moduleMap);
+        const {pipe} = renderToPipeableStream(
+          React.createElement(App),
+          moduleMap
+        );
         pipe(res);
       }
     );

--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {renderToNodePipe} from 'react-dom/server';
+import {renderToPipeableStream} from 'react-dom/server';
 
 import App from '../src/components/App';
 
@@ -20,7 +20,7 @@ export default function render(url, res) {
     console.error('Fatal', error);
   });
   let didError = false;
-  const {pipe, abort} = renderToNodePipe(<App assets={assets} />, {
+  const {pipe, abort} = renderToPipeableStream(<App assets={assets} />, {
     onCompleteShell() {
       // If something errored before we started streaming, we set the error code appropriately.
       res.statusCode = didError ? 500 : 200;

--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {pipeToNodeWritable} from 'react-dom/server';
+import {renderToNodePipe} from 'react-dom/server';
 
 import App from '../src/components/App';
 
@@ -20,22 +20,18 @@ export default function render(url, res) {
     console.error('Fatal', error);
   });
   let didError = false;
-  const {startWriting, abort} = pipeToNodeWritable(
-    <App assets={assets} />,
-    res,
-    {
-      onCompleteShell() {
-        // If something errored before we started streaming, we set the error code appropriately.
-        res.statusCode = didError ? 500 : 200;
-        res.setHeader('Content-type', 'text/html');
-        startWriting();
-      },
-      onError(x) {
-        didError = true;
-        console.error(x);
-      },
-    }
-  );
+  const {startWriting, abort} = renderToNodePipe(<App assets={assets} />, res, {
+    onCompleteShell() {
+      // If something errored before we started streaming, we set the error code appropriately.
+      res.statusCode = didError ? 500 : 200;
+      res.setHeader('Content-type', 'text/html');
+      startWriting();
+    },
+    onError(x) {
+      didError = true;
+      console.error(x);
+    },
+  });
   // Abandon and switch to client rendering after 5 seconds.
   // Try lowering this to see the client recover.
   setTimeout(abort, 5000);

--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -20,12 +20,12 @@ export default function render(url, res) {
     console.error('Fatal', error);
   });
   let didError = false;
-  const {startWriting, abort} = renderToNodePipe(<App assets={assets} />, {
+  const {pipe, abort} = renderToNodePipe(<App assets={assets} />, {
     onCompleteShell() {
       // If something errored before we started streaming, we set the error code appropriately.
       res.statusCode = didError ? 500 : 200;
       res.setHeader('Content-type', 'text/html');
-      startWriting(res);
+      pipe(res);
     },
     onError(x) {
       didError = true;

--- a/fixtures/ssr/server/render.js
+++ b/fixtures/ssr/server/render.js
@@ -20,12 +20,12 @@ export default function render(url, res) {
     console.error('Fatal', error);
   });
   let didError = false;
-  const {startWriting, abort} = renderToNodePipe(<App assets={assets} />, res, {
+  const {startWriting, abort} = renderToNodePipe(<App assets={assets} />, {
     onCompleteShell() {
       // If something errored before we started streaming, we set the error code appropriately.
       res.statusCode = didError ? 500 : 200;
       res.setHeader('Content-type', 'text/html');
-      startWriting();
+      startWriting(res);
     },
     onError(x) {
       didError = true;

--- a/fixtures/ssr2/server/render.js
+++ b/fixtures/ssr2/server/render.js
@@ -41,13 +41,12 @@ module.exports = function render(url, res) {
     <DataProvider data={data}>
       <App assets={assets} />
     </DataProvider>,
-    res,
     {
       onCompleteShell() {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;
         res.setHeader('Content-type', 'text/html');
-        startWriting();
+        startWriting(res);
       },
       onError(x) {
         didError = true;

--- a/fixtures/ssr2/server/render.js
+++ b/fixtures/ssr2/server/render.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 // import {renderToString} from 'react-dom/server';
-import {renderToNodePipe} from 'react-dom/server';
+import {renderToPipeableStream} from 'react-dom/server';
 import App from '../src/App';
 import {DataProvider} from '../src/data';
 import {API_DELAY, ABORT_DELAY} from './delays';
@@ -37,7 +37,7 @@ module.exports = function render(url, res) {
   });
   let didError = false;
   const data = createServerData();
-  const {pipe, abort} = renderToNodePipe(
+  const {pipe, abort} = renderToPipeableStream(
     <DataProvider data={data}>
       <App assets={assets} />
     </DataProvider>,

--- a/fixtures/ssr2/server/render.js
+++ b/fixtures/ssr2/server/render.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 // import {renderToString} from 'react-dom/server';
-import {pipeToNodeWritable} from 'react-dom/server';
+import {renderToNodePipe} from 'react-dom/server';
 import App from '../src/App';
 import {DataProvider} from '../src/data';
 import {API_DELAY, ABORT_DELAY} from './delays';
@@ -37,7 +37,7 @@ module.exports = function render(url, res) {
   });
   let didError = false;
   const data = createServerData();
-  const {startWriting, abort} = pipeToNodeWritable(
+  const {startWriting, abort} = renderToNodePipe(
     <DataProvider data={data}>
       <App assets={assets} />
     </DataProvider>,

--- a/fixtures/ssr2/server/render.js
+++ b/fixtures/ssr2/server/render.js
@@ -37,7 +37,7 @@ module.exports = function render(url, res) {
   });
   let didError = false;
   const data = createServerData();
-  const {startWriting, abort} = renderToNodePipe(
+  const {pipe, abort} = renderToNodePipe(
     <DataProvider data={data}>
       <App assets={assets} />
     </DataProvider>,
@@ -46,7 +46,7 @@ module.exports = function render(url, res) {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;
         res.setHeader('Content-type', 'text/html');
-        startWriting(res);
+        pipe(res);
       },
       onError(x) {
         didError = true;

--- a/packages/react-dom/npm/server.node.js
+++ b/packages/react-dom/npm/server.node.js
@@ -14,4 +14,4 @@ exports.renderToString = l.renderToString;
 exports.renderToStaticMarkup = l.renderToStaticMarkup;
 exports.renderToNodeStream = l.renderToNodeStream;
 exports.renderToStaticNodeStream = l.renderToStaticNodeStream;
-exports.pipeToNodeWritable = s.pipeToNodeWritable;
+exports.renderToNodePipe = s.renderToNodePipe;

--- a/packages/react-dom/npm/server.node.js
+++ b/packages/react-dom/npm/server.node.js
@@ -14,4 +14,4 @@ exports.renderToString = l.renderToString;
 exports.renderToStaticMarkup = l.renderToStaticMarkup;
 exports.renderToNodeStream = l.renderToNodeStream;
 exports.renderToStaticNodeStream = l.renderToStaticNodeStream;
-exports.renderToNodePipe = s.renderToNodePipe;
+exports.renderToPipeableStream = s.renderToPipeableStream;

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -36,8 +36,8 @@ export function renderToStaticNodeStream() {
   );
 }
 
-export function pipeToNodeWritable() {
-  return require('./src/server/ReactDOMFizzServerNode').pipeToNodeWritable.apply(
+export function renderToNodePipe() {
+  return require('./src/server/ReactDOMFizzServerNode').renderToNodePipe.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/server.node.js
+++ b/packages/react-dom/server.node.js
@@ -36,8 +36,8 @@ export function renderToStaticNodeStream() {
   );
 }
 
-export function renderToNodePipe() {
-  return require('./src/server/ReactDOMFizzServerNode').renderToNodePipe.apply(
+export function renderToPipeableStream() {
+  return require('./src/server/ReactDOMFizzServerNode').renderToPipeableStream.apply(
     this,
     arguments,
   );

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -239,7 +239,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <div>
             <Suspense fallback={<Text text="Loading..." />}>
@@ -253,7 +253,7 @@ describe('ReactDOMFizzServer', () => {
           </div>
         </div>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -303,7 +303,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
 
         {
@@ -312,7 +312,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(loggedErrors).toEqual([]);
 
@@ -355,14 +355,14 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             {lazyElement}
           </Suspense>
         </div>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
     await act(async () => {
@@ -394,7 +394,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
 
         {
@@ -403,7 +403,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(loggedErrors).toEqual([]);
 
@@ -439,14 +439,14 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should asynchronously load the suspense boundary', async () => {
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             <AsyncText text="Hello World" />
           </Suspense>
         </div>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
     await act(async () => {
@@ -472,8 +472,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-      startWriting(writable);
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      pipe(writable);
     });
 
     // We're still showing a fallback.
@@ -544,7 +544,7 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
 
         {
@@ -553,7 +553,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
 
     // We're still showing a fallback.
@@ -627,10 +627,10 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App showMore={false} />,
       );
-      startWriting(writable);
+      pipe(writable);
     });
 
     const root = ReactDOM.createRoot(container, {hydrate: true});
@@ -695,7 +695,7 @@ describe('ReactDOMFizzServer', () => {
     let controls;
     await act(async () => {
       controls = ReactDOMFizzServer.renderToNodePipe(<App />);
-      controls.startWriting(writable);
+      controls.pipe(writable);
     });
 
     // We're still showing a fallback.
@@ -746,7 +746,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         // We use two nested boundaries to flush out coverage of an old reentrancy bug.
         <Suspense fallback="Loading...">
           <Suspense fallback={<Text text="Loading A..." />}>
@@ -762,7 +762,7 @@ describe('ReactDOMFizzServer', () => {
           identifierPrefix: 'A_',
           onCompleteShell() {
             writableA.write('<div id="container-A">');
-            startWriting(writableA);
+            pipe(writableA);
             writableA.write('</div>');
           },
         },
@@ -770,7 +770,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback={<Text text="Loading B..." />}>
           <Text text="This will show B: " />
           <div>
@@ -781,7 +781,7 @@ describe('ReactDOMFizzServer', () => {
           identifierPrefix: 'B_',
           onCompleteShell() {
             writableB.write('<div id="container-B">');
-            startWriting(writableB);
+            pipe(writableB);
             writableB.write('</div>');
           },
         },
@@ -867,8 +867,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-      startWriting(writable);
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      pipe(writable);
     });
 
     expect(getVisibleChildren(container)).toEqual(
@@ -955,8 +955,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-      startWriting(writable);
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      pipe(writable);
     });
 
     expect(getVisibleChildren(container)).toEqual(
@@ -1009,14 +1009,14 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
 
         {
           namespaceURI: 'http://www.w3.org/2000/svg',
           onCompleteShell() {
             writable.write('<svg>');
-            startWriting(writable);
+            pipe(writable);
             writable.write('</svg>');
           },
         },
@@ -1096,8 +1096,8 @@ describe('ReactDOMFizzServer', () => {
 
     try {
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<A />);
-        startWriting(writable);
+        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<A />);
+        pipe(writable);
       });
 
       expect(getVisibleChildren(container)).toEqual(
@@ -1195,7 +1195,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <TestProvider ctx="A">
           <div>
             <Suspense fallback={[<Text text="Loading: " />, <TestConsumer />]}>
@@ -1207,7 +1207,7 @@ describe('ReactDOMFizzServer', () => {
           </div>
         </TestProvider>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -1253,7 +1253,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <PrintA />
           <div>
@@ -1269,7 +1269,7 @@ describe('ReactDOMFizzServer', () => {
           <PrintA />
         </div>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -1315,7 +1315,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <PrintA />
           <div>
@@ -1342,7 +1342,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(loggedErrors.length).toBe(1);
     expect(loggedErrors[0].message).toEqual('A0.1.1');
@@ -1385,7 +1385,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      controls.startWriting(writable);
+      controls.pipe(writable);
     });
 
     // We're still showing a fallback.
@@ -1436,7 +1436,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should be able to abort the fallback if the main content finishes first', async () => {
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback={<Text text="Loading Outer" />}>
           <div>
             <Suspense
@@ -1451,7 +1451,7 @@ describe('ReactDOMFizzServer', () => {
           </div>
         </Suspense>,
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual('Loading Outer');
     // We should have received a partial segment containing the a partial of the fallback.
@@ -1533,10 +1533,10 @@ describe('ReactDOMFizzServer', () => {
     await jest.runAllTimers();
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
       );
-      startWriting(writable);
+      pipe(writable);
     });
 
     // Nothing is output since root has a suspense with avoidedThisFallback that hasn't resolved
@@ -1647,7 +1647,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1658,7 +1658,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(Scheduler).toHaveYielded(['server']);
 
@@ -1730,7 +1730,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1741,7 +1741,7 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-      startWriting(writable);
+      pipe(writable);
     });
     expect(Scheduler).toHaveYielded(['server']);
 
@@ -1816,8 +1816,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-        startWriting(writable);
+        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 
@@ -1897,8 +1897,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-        startWriting(writable);
+        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 
@@ -1969,8 +1969,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
-        startWriting(writable);
+        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -239,7 +239,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <div>
             <Suspense fallback={<Text text="Loading..." />}>
@@ -304,7 +304,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
         writable,
         {
@@ -356,7 +356,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             {lazyElement}
@@ -396,7 +396,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
         writable,
         {
@@ -441,7 +441,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should asynchronously load the suspense boundary', async () => {
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             <AsyncText text="Hello World" />
@@ -475,7 +475,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
         writable,
       );
@@ -550,7 +550,7 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
         writable,
         {
@@ -633,7 +633,7 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App showMore={false} />,
         writable,
       );
@@ -701,7 +701,7 @@ describe('ReactDOMFizzServer', () => {
 
     let controls;
     await act(async () => {
-      controls = ReactDOMFizzServer.pipeToNodeWritable(<App />, writable);
+      controls = ReactDOMFizzServer.renderToNodePipe(<App />, writable);
       controls.startWriting();
     });
 
@@ -753,7 +753,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         // We use two nested boundaries to flush out coverage of an old reentrancy bug.
         <Suspense fallback="Loading...">
           <Suspense fallback={<Text text="Loading A..." />}>
@@ -778,7 +778,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback={<Text text="Loading B..." />}>
           <Text text="This will show B: " />
           <div>
@@ -876,7 +876,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
         writable,
       );
@@ -967,7 +967,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
         writable,
       );
@@ -1024,7 +1024,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
         writable,
         {
@@ -1111,7 +1111,7 @@ describe('ReactDOMFizzServer', () => {
 
     try {
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
           <A />,
           writable,
         );
@@ -1213,7 +1213,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <TestProvider ctx="A">
           <div>
             <Suspense fallback={[<Text text="Loading: " />, <TestConsumer />]}>
@@ -1272,7 +1272,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <PrintA />
           <div>
@@ -1335,7 +1335,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <div>
           <PrintA />
           <div>
@@ -1396,7 +1396,7 @@ describe('ReactDOMFizzServer', () => {
     const loggedErrors = [];
     let controls;
     await act(async () => {
-      controls = ReactDOMFizzServer.pipeToNodeWritable(
+      controls = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
         writable,
         {
@@ -1456,7 +1456,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should be able to abort the fallback if the main content finishes first', async () => {
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback={<Text text="Loading Outer" />}>
           <div>
             <Suspense
@@ -1554,7 +1554,7 @@ describe('ReactDOMFizzServer', () => {
     await jest.runAllTimers();
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
         writable,
       );
@@ -1669,7 +1669,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1752,7 +1752,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1838,7 +1838,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
           <App />,
           writable,
         );
@@ -1922,7 +1922,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
           <App />,
           writable,
         );
@@ -1997,7 +1997,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
           <App />,
           writable,
         );

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -252,9 +252,8 @@ describe('ReactDOMFizzServer', () => {
             </Suspense>
           </div>
         </div>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -306,14 +305,14 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(loggedErrors).toEqual([]);
 
@@ -362,9 +361,8 @@ describe('ReactDOMFizzServer', () => {
             {lazyElement}
           </Suspense>
         </div>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
     await act(async () => {
@@ -398,14 +396,14 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(loggedErrors).toEqual([]);
 
@@ -447,9 +445,8 @@ describe('ReactDOMFizzServer', () => {
             <AsyncText text="Hello World" />
           </Suspense>
         </div>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
     await act(async () => {
@@ -475,11 +472,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-        <App />,
-        writable,
-      );
-      startWriting();
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      startWriting(writable);
     });
 
     // We're still showing a fallback.
@@ -552,14 +546,14 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
 
     // We're still showing a fallback.
@@ -635,9 +629,8 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App showMore={false} />,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
 
     const root = ReactDOM.createRoot(container, {hydrate: true});
@@ -701,8 +694,8 @@ describe('ReactDOMFizzServer', () => {
 
     let controls;
     await act(async () => {
-      controls = ReactDOMFizzServer.renderToNodePipe(<App />, writable);
-      controls.startWriting();
+      controls = ReactDOMFizzServer.renderToNodePipe(<App />);
+      controls.startWriting(writable);
     });
 
     // We're still showing a fallback.
@@ -765,12 +758,11 @@ describe('ReactDOMFizzServer', () => {
             </>
           </Suspense>
         </Suspense>,
-        writableA,
         {
           identifierPrefix: 'A_',
           onCompleteShell() {
             writableA.write('<div id="container-A">');
-            startWriting();
+            startWriting(writableA);
             writableA.write('</div>');
           },
         },
@@ -785,12 +777,11 @@ describe('ReactDOMFizzServer', () => {
             <AsyncText text="B" />
           </div>
         </Suspense>,
-        writableB,
         {
           identifierPrefix: 'B_',
           onCompleteShell() {
             writableB.write('<div id="container-B">');
-            startWriting();
+            startWriting(writableB);
             writableB.write('</div>');
           },
         },
@@ -876,11 +867,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-        <App />,
-        writable,
-      );
-      startWriting();
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      startWriting(writable);
     });
 
     expect(getVisibleChildren(container)).toEqual(
@@ -967,11 +955,8 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-        <App />,
-        writable,
-      );
-      startWriting();
+      const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      startWriting(writable);
     });
 
     expect(getVisibleChildren(container)).toEqual(
@@ -1026,12 +1011,12 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App />,
-        writable,
+
         {
           namespaceURI: 'http://www.w3.org/2000/svg',
           onCompleteShell() {
             writable.write('<svg>');
-            startWriting();
+            startWriting(writable);
             writable.write('</svg>');
           },
         },
@@ -1111,11 +1096,8 @@ describe('ReactDOMFizzServer', () => {
 
     try {
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-          <A />,
-          writable,
-        );
-        startWriting();
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<A />);
+        startWriting(writable);
       });
 
       expect(getVisibleChildren(container)).toEqual(
@@ -1224,9 +1206,8 @@ describe('ReactDOMFizzServer', () => {
             </Suspense>
           </div>
         </TestProvider>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -1287,9 +1268,8 @@ describe('ReactDOMFizzServer', () => {
           </div>
           <PrintA />
         </div>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -1355,14 +1335,14 @@ describe('ReactDOMFizzServer', () => {
           </div>
           <PrintA />
         </div>,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(loggedErrors.length).toBe(1);
     expect(loggedErrors[0].message).toEqual('A0.1.1');
@@ -1398,14 +1378,14 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       controls = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      controls.startWriting();
+      controls.startWriting(writable);
     });
 
     // We're still showing a fallback.
@@ -1470,9 +1450,8 @@ describe('ReactDOMFizzServer', () => {
             </Suspense>
           </div>
         </Suspense>,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(getVisibleChildren(container)).toEqual('Loading Outer');
     // We should have received a partial segment containing the a partial of the fallback.
@@ -1556,9 +1535,8 @@ describe('ReactDOMFizzServer', () => {
     await act(async () => {
       const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
         <App isClient={false} />,
-        writable,
       );
-      startWriting();
+      startWriting(writable);
     });
 
     // Nothing is output since root has a suspense with avoidedThisFallback that hasn't resolved
@@ -1673,14 +1651,14 @@ describe('ReactDOMFizzServer', () => {
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(Scheduler).toHaveYielded(['server']);
 
@@ -1756,14 +1734,14 @@ describe('ReactDOMFizzServer', () => {
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
-        writable,
+
         {
           onError(x) {
             loggedErrors.push(x);
           },
         },
       );
-      startWriting();
+      startWriting(writable);
     });
     expect(Scheduler).toHaveYielded(['server']);
 
@@ -1838,11 +1816,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-          <App />,
-          writable,
-        );
-        startWriting();
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        startWriting(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 
@@ -1922,11 +1897,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-          <App />,
-          writable,
-        );
-        startWriting();
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        startWriting(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 
@@ -1997,11 +1969,8 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
-          <App />,
-          writable,
-        );
-        startWriting();
+        const {startWriting} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        startWriting(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -239,7 +239,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <div>
           <div>
             <Suspense fallback={<Text text="Loading..." />}>
@@ -303,7 +303,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
 
         {
@@ -355,7 +355,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             {lazyElement}
@@ -394,7 +394,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
 
         {
@@ -439,7 +439,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should asynchronously load the suspense boundary', async () => {
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <div>
           <Suspense fallback={<Text text="Loading..." />}>
             <AsyncText text="Hello World" />
@@ -472,7 +472,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
       pipe(writable);
     });
 
@@ -544,7 +544,7 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App />,
 
         {
@@ -627,7 +627,7 @@ describe('ReactDOMFizzServer', () => {
 
     // We originally suspend the boundary and start streaming the loading state.
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App showMore={false} />,
       );
       pipe(writable);
@@ -694,7 +694,7 @@ describe('ReactDOMFizzServer', () => {
 
     let controls;
     await act(async () => {
-      controls = ReactDOMFizzServer.renderToNodePipe(<App />);
+      controls = ReactDOMFizzServer.renderToPipeableStream(<App />);
       controls.pipe(writable);
     });
 
@@ -746,7 +746,7 @@ describe('ReactDOMFizzServer', () => {
     };
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         // We use two nested boundaries to flush out coverage of an old reentrancy bug.
         <Suspense fallback="Loading...">
           <Suspense fallback={<Text text="Loading A..." />}>
@@ -770,7 +770,7 @@ describe('ReactDOMFizzServer', () => {
     });
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <Suspense fallback={<Text text="Loading B..." />}>
           <Text text="This will show B: " />
           <div>
@@ -867,7 +867,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
       pipe(writable);
     });
 
@@ -955,7 +955,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
       pipe(writable);
     });
 
@@ -1009,7 +1009,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App />,
 
         {
@@ -1096,7 +1096,7 @@ describe('ReactDOMFizzServer', () => {
 
     try {
       await act(async () => {
-        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<A />);
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<A />);
         pipe(writable);
       });
 
@@ -1195,7 +1195,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <TestProvider ctx="A">
           <div>
             <Suspense fallback={[<Text text="Loading: " />, <TestConsumer />]}>
@@ -1253,7 +1253,7 @@ describe('ReactDOMFizzServer', () => {
     }
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <div>
           <PrintA />
           <div>
@@ -1315,7 +1315,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <div>
           <PrintA />
           <div>
@@ -1376,7 +1376,7 @@ describe('ReactDOMFizzServer', () => {
     const loggedErrors = [];
     let controls;
     await act(async () => {
-      controls = ReactDOMFizzServer.renderToNodePipe(
+      controls = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
 
         {
@@ -1436,7 +1436,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should be able to abort the fallback if the main content finishes first', async () => {
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <Suspense fallback={<Text text="Loading Outer" />}>
           <div>
             <Suspense
@@ -1533,7 +1533,7 @@ describe('ReactDOMFizzServer', () => {
     await jest.runAllTimers();
 
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <App isClient={false} />,
       );
       pipe(writable);
@@ -1647,7 +1647,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1730,7 +1730,7 @@ describe('ReactDOMFizzServer', () => {
 
     const loggedErrors = [];
     await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
         <Suspense fallback="Loading...">
           <App />
         </Suspense>,
@@ -1816,7 +1816,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
         pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
@@ -1897,7 +1897,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
         pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);
@@ -1969,7 +1969,7 @@ describe('ReactDOMFizzServer', () => {
       }
 
       await act(async () => {
-        const {pipe} = ReactDOMFizzServer.renderToNodePipe(<App />);
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(<App />);
         pipe(writable);
       });
       expect(Scheduler).toHaveYielded(['Yay!']);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -61,9 +61,8 @@ describe('ReactDOMFizzServer', () => {
     const {writable, output} = getTestWritable();
     const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>hello world</div>,
-      writable,
     );
-    startWriting();
+    startWriting(writable);
     jest.runAllTimers();
     expect(output.result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
   });
@@ -75,9 +74,8 @@ describe('ReactDOMFizzServer', () => {
       <html>
         <body>hello world</body>
       </html>,
-      writable,
     );
-    startWriting();
+    startWriting(writable);
     jest.runAllTimers();
     expect(output.result).toMatchInlineSnapshot(
       `"<!DOCTYPE html><html><body>hello world</body></html>"`,
@@ -89,14 +87,13 @@ describe('ReactDOMFizzServer', () => {
     const {writable, output} = getTestWritable();
     const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>hello world</div>,
-      writable,
     );
     jest.runAllTimers();
     // First we write our header.
     output.result +=
       '<!doctype html><html><head><title>test</title><head><body>';
     // Then React starts writing.
-    startWriting();
+    startWriting(writable);
     expect(output.result).toMatchInlineSnapshot(
       `"<!doctype html><html><head><title>test</title><head><body><div>hello world</div>"`,
     );
@@ -121,7 +118,7 @@ describe('ReactDOMFizzServer', () => {
           <Wait />
         </Suspense>
       </div>,
-      writable,
+
       {
         onCompleteAll() {
           isCompleteCalls++;
@@ -144,7 +141,7 @@ describe('ReactDOMFizzServer', () => {
     output.result +=
       '<!doctype html><html><head><title>test</title><head><body>';
     // Then React starts writing.
-    startWriting();
+    startWriting(writable);
     expect(output.result).toMatchInlineSnapshot(
       `"<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!-- --><!--/$--></div>"`,
     );
@@ -158,7 +155,7 @@ describe('ReactDOMFizzServer', () => {
       <div>
         <Throw />
       </div>,
-      writable,
+
       {
         onError(x) {
           reportedErrors.push(x);
@@ -167,7 +164,7 @@ describe('ReactDOMFizzServer', () => {
     );
 
     // The stream is errored once we start writing.
-    startWriting();
+    startWriting(writable);
 
     await completed;
 
@@ -187,14 +184,14 @@ describe('ReactDOMFizzServer', () => {
           <InfiniteSuspend />
         </Suspense>
       </div>,
-      writable,
+
       {
         onError(x) {
           reportedErrors.push(x);
         },
       },
     );
-    startWriting();
+    startWriting(writable);
 
     await completed;
 
@@ -213,14 +210,14 @@ describe('ReactDOMFizzServer', () => {
           <Throw />
         </Suspense>
       </div>,
-      writable,
+
       {
         onError(x) {
           reportedErrors.push(x);
         },
       },
     );
-    startWriting();
+    startWriting(writable);
 
     await completed;
 
@@ -246,9 +243,8 @@ describe('ReactDOMFizzServer', () => {
       <Suspense fallback={<Fallback />}>
         <Content />
       </Suspense>,
-      writable,
     );
-    startWriting();
+    startWriting(writable);
 
     await completed;
 
@@ -267,14 +263,14 @@ describe('ReactDOMFizzServer', () => {
           <InfiniteSuspend />
         </Suspense>
       </div>,
-      writable,
+
       {
         onCompleteAll() {
           isCompleteCalls++;
         },
       },
     );
-    startWriting();
+    startWriting(writable);
 
     jest.runAllTimers();
 
@@ -302,14 +298,14 @@ describe('ReactDOMFizzServer', () => {
           </Suspense>
         </Suspense>
       </div>,
-      writable,
+
       {
         onCompleteAll() {
           isCompleteCalls++;
         },
       },
     );
-    startWriting();
+    startWriting(writable);
 
     jest.runAllTimers();
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -57,9 +57,11 @@ describe('ReactDOMFizzServer', () => {
   }
 
   // @gate experimental
-  it('should call renderToNodePipe', () => {
+  it('should call renderToPipeableStream', () => {
     const {writable, output} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(<div>hello world</div>);
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+      <div>hello world</div>,
+    );
     pipe(writable);
     jest.runAllTimers();
     expect(output.result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
@@ -68,7 +70,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should emit DOCTYPE at the root of the document', () => {
     const {writable, output} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <html>
         <body>hello world</body>
       </html>,
@@ -83,7 +85,9 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should start writing after pipe', () => {
     const {writable, output} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(<div>hello world</div>);
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+      <div>hello world</div>,
+    );
     jest.runAllTimers();
     // First we write our header.
     output.result +=
@@ -108,7 +112,7 @@ describe('ReactDOMFizzServer', () => {
     }
     let isCompleteCalls = 0;
     const {writable, output} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Suspense fallback="Loading">
           <Wait />
@@ -147,7 +151,7 @@ describe('ReactDOMFizzServer', () => {
   it('should error the stream when an error is thrown at the root', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Throw />
       </div>,
@@ -174,7 +178,7 @@ describe('ReactDOMFizzServer', () => {
   it('should error the stream when an error is thrown inside a fallback', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Suspense fallback={<Throw />}>
           <InfiniteSuspend />
@@ -200,7 +204,7 @@ describe('ReactDOMFizzServer', () => {
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <Throw />
@@ -235,7 +239,7 @@ describe('ReactDOMFizzServer', () => {
     function Content() {
       return 'Hi';
     }
-    const {pipe} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
       <Suspense fallback={<Fallback />}>
         <Content />
       </Suspense>,
@@ -253,7 +257,7 @@ describe('ReactDOMFizzServer', () => {
   it('should be able to complete by aborting even if the promise never resolves', async () => {
     let isCompleteCalls = 0;
     const {writable, output, completed} = getTestWritable();
-    const {pipe, abort} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe, abort} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <InfiniteSuspend />
@@ -286,7 +290,7 @@ describe('ReactDOMFizzServer', () => {
   it('should be able to complete by abort when the fallback is also suspended', async () => {
     let isCompleteCalls = 0;
     const {writable, output, completed} = getTestWritable();
-    const {pipe, abort} = ReactDOMFizzServer.renderToNodePipe(
+    const {pipe, abort} = ReactDOMFizzServer.renderToPipeableStream(
       <div>
         <Suspense fallback="Loading">
           <Suspense fallback={<InfiniteSuspend />}>

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -57,9 +57,9 @@ describe('ReactDOMFizzServer', () => {
   }
 
   // @gate experimental
-  it('should call pipeToNodeWritable', () => {
+  it('should call renderToNodePipe', () => {
     const {writable, output} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>hello world</div>,
       writable,
     );
@@ -71,7 +71,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should emit DOCTYPE at the root of the document', () => {
     const {writable, output} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <html>
         <body>hello world</body>
       </html>,
@@ -87,7 +87,7 @@ describe('ReactDOMFizzServer', () => {
   // @gate experimental
   it('should start writing after startWriting', () => {
     const {writable, output} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>hello world</div>,
       writable,
     );
@@ -115,7 +115,7 @@ describe('ReactDOMFizzServer', () => {
     }
     let isCompleteCalls = 0;
     const {writable, output} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Suspense fallback="Loading">
           <Wait />
@@ -154,7 +154,7 @@ describe('ReactDOMFizzServer', () => {
   it('should error the stream when an error is thrown at the root', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Throw />
       </div>,
@@ -181,7 +181,7 @@ describe('ReactDOMFizzServer', () => {
   it('should error the stream when an error is thrown inside a fallback', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Suspense fallback={<Throw />}>
           <InfiniteSuspend />
@@ -207,7 +207,7 @@ describe('ReactDOMFizzServer', () => {
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
     const {writable, output, completed} = getTestWritable();
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <Throw />
@@ -242,7 +242,7 @@ describe('ReactDOMFizzServer', () => {
     function Content() {
       return 'Hi';
     }
-    const {startWriting} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting} = ReactDOMFizzServer.renderToNodePipe(
       <Suspense fallback={<Fallback />}>
         <Content />
       </Suspense>,
@@ -261,7 +261,7 @@ describe('ReactDOMFizzServer', () => {
   it('should be able to complete by aborting even if the promise never resolves', async () => {
     let isCompleteCalls = 0;
     const {writable, output, completed} = getTestWritable();
-    const {startWriting, abort} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting, abort} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Suspense fallback={<div>Loading</div>}>
           <InfiniteSuspend />
@@ -294,7 +294,7 @@ describe('ReactDOMFizzServer', () => {
   it('should be able to complete by abort when the fallback is also suspended', async () => {
     let isCompleteCalls = 0;
     const {writable, output, completed} = getTestWritable();
-    const {startWriting, abort} = ReactDOMFizzServer.pipeToNodeWritable(
+    const {startWriting, abort} = ReactDOMFizzServer.renderToNodePipe(
       <div>
         <Suspense fallback="Loading">
           <Suspense fallback={<InfiniteSuspend />}>

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -56,7 +56,7 @@ function createRequestImpl(children: ReactNodeList, options: void | Options) {
   );
 }
 
-function pipeToNodeWritable(
+function renderToNodePipe(
   children: ReactNodeList,
   destination: Writable,
   options?: Options,
@@ -79,4 +79,4 @@ function pipeToNodeWritable(
   };
 }
 
-export {pipeToNodeWritable, ReactVersion as version};
+export {renderToNodePipe, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -41,7 +41,7 @@ type Controls = {|
   // Cancel any pending I/O and put anything remaining into
   // client rendered mode.
   abort(): void,
-  startWriting(): void,
+  startWriting(destination: Writable): void,
 |};
 
 function createRequestImpl(children: ReactNodeList, options: void | Options) {
@@ -58,14 +58,13 @@ function createRequestImpl(children: ReactNodeList, options: void | Options) {
 
 function renderToNodePipe(
   children: ReactNodeList,
-  destination: Writable,
   options?: Options,
 ): Controls {
   const request = createRequestImpl(children, options);
   let hasStartedFlowing = false;
   startWork(request);
   return {
-    startWriting() {
+    startWriting(destination) {
       if (hasStartedFlowing) {
         return;
       }

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -56,7 +56,7 @@ function createRequestImpl(children: ReactNodeList, options: void | Options) {
   );
 }
 
-function renderToNodePipe(
+function renderToPipeableStream(
   children: ReactNodeList,
   options?: Options,
 ): Controls {
@@ -81,4 +81,4 @@ function renderToNodePipe(
   };
 }
 
-export {renderToNodePipe, ReactVersion as version};
+export {renderToPipeableStream, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -41,7 +41,7 @@ type Controls = {|
   // Cancel any pending I/O and put anything remaining into
   // client rendered mode.
   abort(): void,
-  startWriting(destination: Writable): void,
+  pipe<T: Writable>(destination: T): T,
 |};
 
 function createRequestImpl(children: ReactNodeList, options: void | Options) {
@@ -64,13 +64,16 @@ function renderToNodePipe(
   let hasStartedFlowing = false;
   startWork(request);
   return {
-    startWriting(destination) {
+    pipe<T: Writable>(destination: T): T {
       if (hasStartedFlowing) {
-        return;
+        throw new Error(
+          'React currently only supports piping to one writable stream.',
+        );
       }
       hasStartedFlowing = true;
       startFlowing(request, destination);
       destination.on('drain', createDrainHandler(destination, request));
+      return destination;
     },
     abort() {
       abort(request);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -26,12 +26,11 @@ type Options = {
 };
 
 type Controls = {|
-  startWriting(): void,
+  startWriting(destination: Writable): void,
 |};
 
 function renderToNodePipe(
   model: ReactModel,
-  destination: Writable,
   webpackMap: BundlerConfig,
   options?: Options,
 ): Controls {
@@ -40,11 +39,16 @@ function renderToNodePipe(
     webpackMap,
     options ? options.onError : undefined,
   );
+  let hasStartedFlowing = false;
   startWork(request);
-  destination.on('drain', createDrainHandler(destination, request));
   return {
-    startWriting() {
+    startWriting(destination) {
+      if (hasStartedFlowing) {
+        return;
+      }
+      hasStartedFlowing = true;
       startFlowing(request, destination);
+      destination.on('drain', createDrainHandler(destination, request));
     },
   };
 }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -29,7 +29,7 @@ type Controls = {|
   pipe<T: Writable>(destination: T): T,
 |};
 
-function renderToNodePipe(
+function renderToPipeableStream(
   model: ReactModel,
   webpackMap: BundlerConfig,
   options?: Options,
@@ -56,4 +56,4 @@ function renderToNodePipe(
   };
 }
 
-export {renderToNodePipe};
+export {renderToPipeableStream};

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -25,7 +25,7 @@ type Options = {
   onError?: (error: mixed) => void,
 };
 
-function pipeToNodeWritable(
+function renderToNodePipe(
   model: ReactModel,
   destination: Writable,
   webpackMap: BundlerConfig,
@@ -41,4 +41,4 @@ function pipeToNodeWritable(
   destination.on('drain', createDrainHandler(destination, request));
 }
 
-export {pipeToNodeWritable};
+export {renderToNodePipe};

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -25,20 +25,28 @@ type Options = {
   onError?: (error: mixed) => void,
 };
 
+type Controls = {|
+  startWriting(): void,
+|};
+
 function renderToNodePipe(
   model: ReactModel,
   destination: Writable,
   webpackMap: BundlerConfig,
   options?: Options,
-): void {
+): Controls {
   const request = createRequest(
     model,
     webpackMap,
     options ? options.onError : undefined,
   );
   startWork(request);
-  startFlowing(request, destination);
   destination.on('drain', createDrainHandler(destination, request));
+  return {
+    startWriting() {
+      startFlowing(request, destination);
+    },
+  };
 }
 
 export {renderToNodePipe};

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -26,7 +26,7 @@ type Options = {
 };
 
 type Controls = {|
-  startWriting(destination: Writable): void,
+  pipe<T: Writable>(destination: T): T,
 |};
 
 function renderToNodePipe(
@@ -42,13 +42,16 @@ function renderToNodePipe(
   let hasStartedFlowing = false;
   startWork(request);
   return {
-    startWriting(destination) {
+    pipe<T: Writable>(destination: T): T {
       if (hasStartedFlowing) {
-        return;
+        throw new Error(
+          'React currently only supports piping to one writable stream.',
+        );
       }
       hasStartedFlowing = true;
       startFlowing(request, destination);
       destination.on('drain', createDrainHandler(destination, request));
+      return destination;
     },
   };
 }

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -113,7 +113,10 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(<App />, webpackMap);
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
+      <App />,
+      webpackMap,
+    );
     pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
     await waitForSuspense(() => {
@@ -163,7 +166,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
       <RootModel />,
       webpackMap,
     );
@@ -201,7 +204,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
       <RootModel />,
       webpackMap,
     );
@@ -237,7 +240,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
       <RootModel />,
       webpackMap,
     );
@@ -372,11 +375,15 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(model, webpackMap, {
-      onError(x) {
-        reportedErrors.push(x);
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
+      model,
+      webpackMap,
+      {
+        onError(x) {
+          reportedErrors.push(x);
+        },
       },
-    });
+    );
     pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
@@ -483,7 +490,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOM.createRoot(container);
 
     const stream1 = getTestStream();
-    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToPipeableStream(
       <App color="red" />,
       webpackMap,
     );
@@ -511,7 +518,7 @@ describe('ReactFlightDOM', () => {
     inputB.value = 'goodbye';
 
     const stream2 = getTestStream();
-    const {pipe: pipe2} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe: pipe2} = ReactServerDOMWriter.renderToPipeableStream(
       <App color="blue" />,
       webpackMap,
     );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -113,7 +113,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(<App />, writable, webpackMap);
+    ReactServerDOMWriter.renderToNodePipe(<App />, writable, webpackMap);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
     await waitForSuspense(() => {
       const model = response.readRoot();
@@ -162,11 +162,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(
-      <RootModel />,
-      writable,
-      webpackMap,
-    );
+    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -200,11 +196,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(
-      <RootModel />,
-      writable,
-      webpackMap,
-    );
+    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -236,11 +228,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(
-      <RootModel />,
-      writable,
-      webpackMap,
-    );
+    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -371,7 +359,7 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(model, writable, webpackMap, {
+    ReactServerDOMWriter.renderToNodePipe(model, writable, webpackMap, {
       onError(x) {
         reportedErrors.push(x);
       },
@@ -481,7 +469,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOM.createRoot(container);
 
     const stream1 = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(
+    ReactServerDOMWriter.renderToNodePipe(
       <App color="red" />,
       stream1.writable,
       webpackMap,
@@ -509,7 +497,7 @@ describe('ReactFlightDOM', () => {
     inputB.value = 'goodbye';
 
     const stream2 = getTestStream();
-    ReactServerDOMWriter.pipeToNodeWritable(
+    ReactServerDOMWriter.renderToNodePipe(
       <App color="blue" />,
       stream2.writable,
       webpackMap,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -57,8 +57,8 @@ describe('ReactFlightDOM', () => {
       },
     });
     return {
-      writable,
       readable,
+      writable,
     };
   }
 
@@ -115,10 +115,9 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <App />,
-      writable,
       webpackMap,
     );
-    startWriting();
+    startWriting(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
     await waitForSuspense(() => {
       const model = response.readRoot();
@@ -169,10 +168,9 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
-      writable,
       webpackMap,
     );
-    startWriting();
+    startWriting(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -208,10 +206,9 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
-      writable,
       webpackMap,
     );
-    startWriting();
+    startWriting(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -245,10 +242,9 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
-      writable,
       webpackMap,
     );
-    startWriting();
+    startWriting(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -381,7 +377,6 @@ describe('ReactFlightDOM', () => {
     const {writable, readable} = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       model,
-      writable,
       webpackMap,
       {
         onError(x) {
@@ -389,7 +384,7 @@ describe('ReactFlightDOM', () => {
         },
       },
     );
-    startWriting();
+    startWriting(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -497,10 +492,9 @@ describe('ReactFlightDOM', () => {
     const stream1 = getTestStream();
     const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <App color="red" />,
-      stream1.writable,
       webpackMap,
     );
-    startWriting();
+    startWriting(stream1.writable);
     const response1 = ReactServerDOMReader.createFromReadableStream(
       stream1.readable,
     );
@@ -526,10 +520,9 @@ describe('ReactFlightDOM', () => {
     const stream2 = getTestStream();
     const {startWriting: startWriting2} = ReactServerDOMWriter.renderToNodePipe(
       <App color="blue" />,
-      stream2.writable,
       webpackMap,
     );
-    startWriting2();
+    startWriting2(stream2.writable);
     const response2 = ReactServerDOMReader.createFromReadableStream(
       stream2.readable,
     );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -113,11 +113,8 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
-      <App />,
-      webpackMap,
-    );
-    startWriting(writable);
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(<App />, webpackMap);
+    pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
     await waitForSuspense(() => {
       const model = response.readRoot();
@@ -166,11 +163,11 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
       webpackMap,
     );
-    startWriting(writable);
+    pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -204,11 +201,11 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
       webpackMap,
     );
-    startWriting(writable);
+    pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -240,11 +237,11 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
       <RootModel />,
       webpackMap,
     );
-    startWriting(writable);
+    pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -375,16 +372,12 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
-      model,
-      webpackMap,
-      {
-        onError(x) {
-          reportedErrors.push(x);
-        },
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(model, webpackMap, {
+      onError(x) {
+        reportedErrors.push(x);
       },
-    );
-    startWriting(writable);
+    });
+    pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -490,11 +483,11 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOM.createRoot(container);
 
     const stream1 = getTestStream();
-    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe} = ReactServerDOMWriter.renderToNodePipe(
       <App color="red" />,
       webpackMap,
     );
-    startWriting(stream1.writable);
+    pipe(stream1.writable);
     const response1 = ReactServerDOMReader.createFromReadableStream(
       stream1.readable,
     );
@@ -518,11 +511,11 @@ describe('ReactFlightDOM', () => {
     inputB.value = 'goodbye';
 
     const stream2 = getTestStream();
-    const {startWriting: startWriting2} = ReactServerDOMWriter.renderToNodePipe(
+    const {pipe: pipe2} = ReactServerDOMWriter.renderToNodePipe(
       <App color="blue" />,
       webpackMap,
     );
-    startWriting2(stream2.writable);
+    pipe2(stream2.writable);
     const response2 = ReactServerDOMReader.createFromReadableStream(
       stream2.readable,
     );

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -113,7 +113,12 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(<App />, writable, webpackMap);
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+      <App />,
+      writable,
+      webpackMap,
+    );
+    startWriting();
     const response = ReactServerDOMReader.createFromReadableStream(readable);
     await waitForSuspense(() => {
       const model = response.readRoot();
@@ -162,7 +167,12 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+      <RootModel />,
+      writable,
+      webpackMap,
+    );
+    startWriting();
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -196,7 +206,12 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+      <RootModel />,
+      writable,
+      webpackMap,
+    );
+    startWriting();
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -228,7 +243,12 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(<RootModel />, writable, webpackMap);
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+      <RootModel />,
+      writable,
+      webpackMap,
+    );
+    startWriting();
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -359,11 +379,17 @@ describe('ReactFlightDOM', () => {
     }
 
     const {writable, readable} = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(model, writable, webpackMap, {
-      onError(x) {
-        reportedErrors.push(x);
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
+      model,
+      writable,
+      webpackMap,
+      {
+        onError(x) {
+          reportedErrors.push(x);
+        },
       },
-    });
+    );
+    startWriting();
     const response = ReactServerDOMReader.createFromReadableStream(readable);
 
     const container = document.createElement('div');
@@ -469,11 +495,12 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOM.createRoot(container);
 
     const stream1 = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(
+    const {startWriting} = ReactServerDOMWriter.renderToNodePipe(
       <App color="red" />,
       stream1.writable,
       webpackMap,
     );
+    startWriting();
     const response1 = ReactServerDOMReader.createFromReadableStream(
       stream1.readable,
     );
@@ -497,11 +524,12 @@ describe('ReactFlightDOM', () => {
     inputB.value = 'goodbye';
 
     const stream2 = getTestStream();
-    ReactServerDOMWriter.renderToNodePipe(
+    const {startWriting: startWriting2} = ReactServerDOMWriter.renderToNodePipe(
       <App color="blue" />,
       stream2.writable,
       webpackMap,
     );
+    startWriting2();
     const response2 = ReactServerDOMReader.createFromReadableStream(
       stream2.readable,
     );

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -401,5 +401,6 @@
   "413": "Expected finished root and lanes to be set. This is a bug in React.",
   "414": "Did not expect this call in production. This is a bug in React. Please file an issue.",
   "415": "Error parsing the data. It's probably an error code or network corruption.",
-  "416": "This environment don't support binary chunks."
+  "416": "This environment don't support binary chunks.",
+  "417": "React currently only supports piping to one writable stream."
 }


### PR DESCRIPTION
This changes the API from:

```js
pipeToNodeWritable(..., writable).startWriting();
```

to:

```js
renderToNodePipe(...).pipe(writable);
```

The idea is that this more closely mirrors what you'd typically do with a Node stream. It still allows you to delay writing until a time for your choice (such as after onCompleteAll).

However, now that I think about it there are not really that many best practices remaining.

The idea was that you could wait until you've accumulated enough info to populate the header with meta data - such as the HTTP status code and `<head>`.

However, it's not really great to wait before writing because you can't emit the preload tags as early as possible in the stream. You don't have to wait for that to deal with `<head>` but you do for status codes.

There's really only two valid options emerging:

1) Wait for onCompleteAll if the UA is a bot that cares about head tags and status codes.
2) Otherwise stream as early as possible but let React buffer/throttle things to avoid sending too small chunks.

It might be better to just let the API reflect that and have two root APIs that do just that and then you don't have to bother with when to call startWriting/pipe. So I might abandon this.

cc @devknoll 