### PR TITLE
Call get snapshot in useSyncExternalStore server shim

### DIFF
--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShimServer-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShimServer-test.js
@@ -92,7 +92,9 @@ describe('useSyncExternalStore (userspace shim, server rendering)', () => {
     }
 
     const html = ReactDOMServer.renderToString(<App />);
-    expect(Scheduler).toHaveYielded(['server']);
-    expect(html).toEqual('server');
+
+    // We don't call getServerSnapshot in the shim
+    expect(Scheduler).toHaveYielded(['client']);
+    expect(html).toEqual('client');
   });
 });

--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -10,5 +10,13 @@
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import {useSyncExternalStore as client} from './useSyncExternalStoreClient';
 import {useSyncExternalStore as server} from './useSyncExternalStoreServer';
+import * as React from 'react';
 
-export const useSyncExternalStore = canUseDOM ? client : server;
+const {unstable_useSyncExternalStore: builtInAPI} = React;
+
+export const useSyncExternalStore =
+  builtInAPI !== undefined
+    ? ((builtInAPI: any): typeof client)
+    : canUseDOM
+    ? client
+    : server;

--- a/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
@@ -12,22 +12,7 @@ import is from 'shared/objectIs';
 
 // Intentionally not using named imports because Rollup uses dynamic
 // dispatch for CommonJS interop named imports.
-const {
-  useState,
-  useEffect,
-  useLayoutEffect,
-  useDebugValue,
-  // The built-in API is still prefixed.
-  unstable_useSyncExternalStore: builtInAPI,
-} = React;
-
-// Prefer the built-in API, if it exists. If it doesn't exist, then we assume
-// we're in version 16 or 17, so rendering is always synchronous. The shim
-// does not support concurrent rendering, only the built-in API.
-export const useSyncExternalStore =
-  builtInAPI !== undefined
-    ? ((builtInAPI: any): typeof useSyncExternalStore_client)
-    : useSyncExternalStore_client;
+const {useState, useEffect, useLayoutEffect, useDebugValue} = React;
 
 let didWarnOld18Alpha = false;
 let didWarnUncachedGetSnapshot = false;
@@ -42,7 +27,7 @@ let didWarnUncachedGetSnapshot = false;
 //
 // Do not assume that the clever hacks used by this hook also work in general.
 // The point of this shim is to replace the need for hacks by other libraries.
-function useSyncExternalStore_client<T>(
+export function useSyncExternalStore<T>(
   subscribe: (() => void) => () => void,
   getSnapshot: () => T,
   // Note: The client shim does not use getServerSnapshot, because pre-18

--- a/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
@@ -29,6 +29,8 @@ export const useSyncExternalStore =
     ? ((builtInAPI: any): typeof useSyncExternalStore_client)
     : useSyncExternalStore_client;
 
+export const isShim = builtInAPI === undefined;
+
 let didWarnOld18Alpha = false;
 let didWarnUncachedGetSnapshot = false;
 

--- a/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreClient.js
@@ -29,8 +29,6 @@ export const useSyncExternalStore =
     ? ((builtInAPI: any): typeof useSyncExternalStore_client)
     : useSyncExternalStore_client;
 
-export const isShim = builtInAPI === undefined;
-
 let didWarnOld18Alpha = false;
 let didWarnUncachedGetSnapshot = false;
 

--- a/packages/use-sync-external-store/src/useSyncExternalStoreServer.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreServer.js
@@ -8,12 +8,16 @@
  */
 
 import invariant from 'shared/invariant';
+import {isShim} from './useSyncExternalStoreClient';
 
 export function useSyncExternalStore<T>(
   subscribe: (() => void) => () => void,
   getSnapshot: () => T,
   getServerSnapshot?: () => T,
 ): T {
+  if (isShim) {
+    return getSnapshot();
+  }
   if (getServerSnapshot === undefined) {
     invariant(
       false,

--- a/packages/use-sync-external-store/src/useSyncExternalStoreServer.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreServer.js
@@ -7,23 +7,10 @@
  * @flow
  */
 
-import invariant from 'shared/invariant';
-import {isShim} from './useSyncExternalStoreClient';
-
 export function useSyncExternalStore<T>(
   subscribe: (() => void) => () => void,
   getSnapshot: () => T,
   getServerSnapshot?: () => T,
 ): T {
-  if (isShim) {
-    return getSnapshot();
-  }
-  if (getServerSnapshot === undefined) {
-    invariant(
-      false,
-      'Missing getServerSnapshot, which is required for server-' +
-        'rendered content.',
-    );
-  }
-  return getServerSnapshot();
+  return getSnapshot();
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

@acdlite 
> There's no way to implement getServerSnapshot correctly during hydration in older versions of React, so they already have to account for this by putting server logic into the regular getSnapshot.


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Updated jest test
