### PR TITLE
Release pooled cache reference in complete/unwind

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
@@ -99,14 +99,16 @@ export function popRootCachePool(root: FiberRoot, renderLanes: Lanes) {
     return;
   }
   // The `pooledCache` variable points to the cache that was used for new
-  // cache boundaries during this render, if any. Stash it on the root so that
-  // parallel transitions may share the same cache. We will clear this field
-  // once all the transitions that depend on it (which we track with
-  // `pooledCacheLanes`) have committed.
+  // cache boundaries during this render, if any. Move ownership of the
+  // cache to the root so that parallel transitions may share the same
+  // cache. We will clear this field once all the transitions that depend
+  // on it (which we track with `pooledCacheLanes`) have committed.
   root.pooledCache = pooledCache;
   if (pooledCache !== null) {
     root.pooledCacheLanes |= renderLanes;
   }
+  // set to null, conceptually we are moving ownership to the root
+  pooledCache = null;
 }
 
 export function restoreSpawnedCachePool(

--- a/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
@@ -99,14 +99,16 @@ export function popRootCachePool(root: FiberRoot, renderLanes: Lanes) {
     return;
   }
   // The `pooledCache` variable points to the cache that was used for new
-  // cache boundaries during this render, if any. Stash it on the root so that
-  // parallel transitions may share the same cache. We will clear this field
-  // once all the transitions that depend on it (which we track with
-  // `pooledCacheLanes`) have committed.
+  // cache boundaries during this render, if any. Move ownership of the
+  // cache to the root so that parallel transitions may share the same
+  // cache. We will clear this field once all the transitions that depend
+  // on it (which we track with `pooledCacheLanes`) have committed.
   root.pooledCache = pooledCache;
   if (pooledCache !== null) {
     root.pooledCacheLanes |= renderLanes;
   }
+  // set to null, conceptually we are moving ownership to the root
+  pooledCache = null;
 }
 
 export function restoreSpawnedCachePool(


### PR DESCRIPTION
## Summary

The pooled Cache instance is conceptually _moved_ to the root on complete or unwind. However currently we don't reset the reference back to null, instead relying on pushRootCachePool to update it when the next render begins/resumes. This PR explicitly sets the cache back to null and updates the comments to clarify that conceptually `popCacheRootPool()` is moving ownership. This doesn't change much but maybe gives GC a chance to free the data a tad earlier.

## How did you test this change?

`yarn test` and `yarn test --prod`