### PR TITLE
CodeSandbox CI: Fall back to local build

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,6 @@
     "publish-prereleases": "node ./scripts/release/publish-using-ci-workflow.js",
     "download-build": "node ./scripts/release/download-experimental-build.js",
     "download-build-for-head": "node ./scripts/release/download-experimental-build.js --commit=$(git rev-parse HEAD)",
-    "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head"
+    "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head || yarn build-combined --type=node react/index react-dom scheduler"
   }
 }


### PR DESCRIPTION
The `download-experimental-build` script has been flaky on CodeSandbox CI, I think because of GitHub rate limiting.

Until we figure out how to fix that, I've updated it to fall back to a local build.