### PR TITLE
[DevTools] Enable logger for internal build of DevTools extensions

### DIFF
--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-fb.js
@@ -16,7 +16,7 @@
 export const enableProfilerChangedHookIndices = true;
 export const isInternalFacebookBuild = true;
 export const enableNamedHooksFeature = true;
-export const enableLogger = false;
+export const enableLogger = true;
 export const consoleManagedByDevToolsDuringStrictMode = true;
 
 /************************************************************************


### PR DESCRIPTION
## Summary

Enables logging (`enableLogger` feature flag) for internal (fb-only) builds of DevTools extensions

## How did you test this change?

- yarn flow
- yarn test
- yarn test-build-devtools
- ran internal build manually `yarn build:chrome:fb` and verified that events were correctly communicated to iframe that loads an internal endpoint.
