### PR TITLE
Reactdevtools  -----> Modal deleting filter fix

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -239,7 +239,7 @@ export function useModalDismissSignal(
       ownerDocument = ((modalRef.current: any): HTMLDivElement).ownerDocument;
       ownerDocument.addEventListener('keydown', handleDocumentKeyDown);
       if (dismissOnClickOutside) {
-        ownerDocument.addEventListener('click', handleDocumentClick);
+        ownerDocument.addEventListener('click', handleDocumentClick,true);
         ownerDocument.removeEventListener('click', handleDocumentClick,true);
 
       }

--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -239,7 +239,7 @@ export function useModalDismissSignal(
       ownerDocument = ((modalRef.current: any): HTMLDivElement).ownerDocument;
       ownerDocument.addEventListener('keydown', handleDocumentKeyDown);
       if (dismissOnClickOutside) {
-        ownerDocument.addEventListener('click', handleDocumentClick);
+        ownerDocument.addEventListener('click', handleDocumentClick, true);
       }
     }, 0);
 

--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -239,7 +239,9 @@ export function useModalDismissSignal(
       ownerDocument = ((modalRef.current: any): HTMLDivElement).ownerDocument;
       ownerDocument.addEventListener('keydown', handleDocumentKeyDown);
       if (dismissOnClickOutside) {
-        ownerDocument.addEventListener('click', handleDocumentClick, true);
+        ownerDocument.addEventListener('click', handleDocumentClick);
+        ownerDocument.removeEventListener('click', handleDocumentClick,true);
+
       }
     }, 0);
 


### PR DESCRIPTION
whats the problem?

As you can see in below when we try to delete the last filter index , it closes the whole modal but rather it should just delete the last filter this PR fixes this issue
![127568480-5210f281-2f37-4388-baf3-ac81008cd8eb](https://user-images.githubusercontent.com/72331432/135650644-75132201-57aa-41a7-8ff2-4f613c47a498.gif)

Fixed-
![127568697-12c28e3e-bf43-47dd-ac69-8b88457b01b3](https://user-images.githubusercontent.com/72331432/135650875-03a0b267-b859-4693-bcaf-6fd96156352e.gif)

