### PR TITLE
Show different error boundary UI for timeouts than normal errors

### DIFF
--- a/packages/react-devtools-shared/src/TimeoutError.js
+++ b/packages/react-devtools-shared/src/TimeoutError.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TimeoutError);
+    }
+
+    this.name = 'TimeoutError';
+  }
+}

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -10,6 +10,7 @@
 import {hydrate, fillInPath} from 'react-devtools-shared/src/hydration';
 import {separateDisplayNameAndHOCs} from 'react-devtools-shared/src/utils';
 import Store from 'react-devtools-shared/src/devtools/store';
+import TimeoutError from 'react-devtools-shared/src/TimeoutError';
 
 import type {
   InspectedElement as InspectedElementBackend,
@@ -162,7 +163,9 @@ function getPromiseForRequestID<T>(
     const onTimeout = () => {
       cleanup();
       reject(
-        new Error(`Timed out waiting for event '${eventType}' from bridge`),
+        new TimeoutError(
+          `Timed out waiting for event '${eventType}' from bridge`,
+        ),
       );
     };
 

--- a/packages/react-devtools-shared/src/backendAPI.js
+++ b/packages/react-devtools-shared/src/backendAPI.js
@@ -103,6 +103,7 @@ export function inspectElement({
     requestID,
     'inspectedElement',
     bridge,
+    `Timed out while inspecting element ${id}.`,
   );
 
   bridge.send('inspectElement', {
@@ -145,6 +146,7 @@ function getPromiseForRequestID<T>(
   requestID: number,
   eventType: $Keys<BackendEvents>,
   bridge: FrontendBridge,
+  timeoutMessage: string,
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     const cleanup = () => {
@@ -162,11 +164,7 @@ function getPromiseForRequestID<T>(
 
     const onTimeout = () => {
       cleanup();
-      reject(
-        new TimeoutError(
-          `Timed out waiting for event '${eventType}' from bridge`,
-        ),
-      );
+      reject(new TimeoutError(timeoutMessage));
     };
 
     bridge.addListener(eventType, onInspectedElement);

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/TimeoutView.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/TimeoutView.js
@@ -16,11 +16,11 @@ type Props = {|
   callStack: string | null,
   children: React$Node,
   componentStack: string | null,
-  dismissError: Function | null,
+  dismissError: Function,
   errorMessage: string | null,
 |};
 
-export default function ErrorView({
+export default function TimeoutView({
   callStack,
   children,
   componentStack,
@@ -32,24 +32,17 @@ export default function ErrorView({
       {children}
       <div className={styles.ErrorInfo}>
         <div className={styles.HeaderRow}>
-          <div className={styles.ErrorHeader}>
-            Uncaught Error: {errorMessage || ''}
+          <div className={styles.TimeoutHeader}>
+            {errorMessage || 'Timed out waiting'}
           </div>
-          {dismissError !== null && (
-            <Button className={styles.CloseButton} onClick={dismissError}>
-              Dismiss
-              <ButtonIcon className={styles.CloseButtonIcon} type="close" />
-            </Button>
-          )}
+          <Button className={styles.CloseButton} onClick={dismissError}>
+            Retry
+            <ButtonIcon className={styles.CloseButtonIcon} type="close" />
+          </Button>
         </div>
-        {!!callStack && (
-          <div className={styles.ErrorStack}>
-            The error was thrown {callStack.trim()}
-          </div>
-        )}
         {!!componentStack && (
-          <div className={styles.ErrorStack}>
-            The error occurred {componentStack.trim()}
+          <div className={styles.TimeoutStack}>
+            The timeout occurred {componentStack.trim()}
           </div>
         )}
       </div>

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/shared.css
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/shared.css
@@ -30,6 +30,7 @@
   background-color: var(--color-background);
   display: flex;
   flex-direction: column;
+  border: 1px solid var(--color-border);
 }
 
 .ErrorInfo {
@@ -42,10 +43,10 @@
   flex-direction: row;
   font-size: var(--font-size-sans-large);
   font-weight: bold;
-  color: var(--color-error-text);
 }
 
-.Header {
+.ErrorHeader,
+.TimeoutHeader {
   flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -53,17 +54,35 @@
   min-width: 0;
 }
 
-.Stack {
+.ErrorHeader {
+  color: var(--color-error-text);
+}
+.TimeoutHeader {
+  color: var(--color-text);
+}
+
+.ErrorStack,
+.TimeoutStack {
   margin-top: 0.5rem;
   white-space: pre-wrap;
   font-family: var(--font-family-monospace);
   font-size: var(--font-size-monospace-normal);
   -webkit-font-smoothing: initial;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  overflow: auto;
+}
+
+.ErrorStack {
   background-color: var(--color-error-background);
   border: 1px solid var(--color-error-border);
   color: var(--color-error-text);
-  border-radius: 0.25rem;
-  padding: 0.5rem;
+}
+
+.TimeoutStack {
+  background-color: var(--color-console-warning-background);
+  color: var(--color-console-warning-text);
+  border: var(--color-console-warning-border)
 }
 
 .LoadingIcon {

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -38,7 +38,7 @@ type ResolvedRecord<T> = {|
 
 type RejectedRecord = {|
   status: 2,
-  value: string,
+  value: Error | string,
 |};
 
 type Record<T> = PendingRecord | ResolvedRecord<T> | RejectedRecord;
@@ -113,7 +113,9 @@ export function inspectElement(
     if (rendererID == null) {
       const rejectedRecord = ((newRecord: any): RejectedRecord);
       rejectedRecord.status = Rejected;
-      rejectedRecord.value = `Could not inspect element with id "${element.id}". No renderer found.`;
+      rejectedRecord.value = new Error(
+        `Could not inspect element with id "${element.id}". No renderer found.`,
+      );
 
       map.set(element, record);
 
@@ -139,7 +141,7 @@ export function inspectElement(
 
         const rejectedRecord = ((newRecord: any): RejectedRecord);
         rejectedRecord.status = Rejected;
-        rejectedRecord.value = `Could not inspect element with id "${element.id}". Error thrown:\n${error.message}`;
+        rejectedRecord.value = error;
 
         wake();
       },


### PR DESCRIPTION
Added new `TimeoutError` type that gets treated different by our Error Boundary. (It shows a less scary overlay, does not suggest filing a GitHub issue, and shows a "Retry" rather than "Dismiss" button.)

## Errors

<img width="735" alt="Screen Shot 2021-10-01 at 2 27 12 PM" src="https://user-images.githubusercontent.com/29597/135669932-747160bd-4aec-46d7-88f5-0722e800f693.png">

<img width="734" alt="Screen Shot 2021-10-01 at 2 27 21 PM" src="https://user-images.githubusercontent.com/29597/135669934-ca1c3de8-ed42-4ea8-86e7-7989ef1158e1.png">

## Timeouts

<img width="736" alt="Screen Shot 2021-10-01 at 2 26 10 PM" src="https://user-images.githubusercontent.com/29597/135669931-6e47b111-d650-4252-b3a3-fa72dc873f44.png">

<img width="733" alt="Screen Shot 2021-10-01 at 2 25 49 PM" src="https://user-images.githubusercontent.com/29597/135669929-97e35cc0-9993-4f70-8359-a72ce1f91739.png">