### PR TITLE
Add new Jest --compact-console flag for DevTools tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -7,10 +7,30 @@
  * @flow
  */
 
+import {CustomConsole} from '@jest/console';
+
 import type {
   BackendBridge,
   FrontendBridge,
 } from 'react-devtools-shared/src/bridge';
+
+// Argument is serialized when passed from jest-cli script through to setupTests.
+const compactConsole = process.env.compactConsole === 'true';
+if (compactConsole) {
+  const formatter = (type, message) => {
+    switch (type) {
+      case 'error':
+        return '\x1b[31m' + message + '\x1b[0m';
+      case 'warn':
+        return '\x1b[33m' + message + '\x1b[0m';
+      case 'log':
+      default:
+        return message;
+    }
+  };
+
+  global.console = new CustomConsole(process.stdout, process.stderr, formatter);
+}
 
 const env = jasmine.getEnv();
 env.beforeEach(() => {


### PR DESCRIPTION
This flag uses the @jest/console CustomConsole to override default formatting and remove the logging source location (makin

# Default logging behavior
<img width="747" alt="Screen Shot 2021-10-03 at 12 57 22 PM" src="https://user-images.githubusercontent.com/29597/135764075-9011cb38-f5ba-437a-993d-72d35209c1de.png">
g console logging more compact).

# Example with `-c` or `--compact-console` flag
<img width="584" alt="Screen Shot 2021-10-03 at 12 53 28 PM" src="https://user-images.githubusercontent.com/29597/135764074-f00d2486-1159-4013-af41-4c2986ec950d.png">
