### PR TITLE
fix: fix contributing guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Want to contribute to React? There are a few things you need to know.  
 
-We wrote a **[contribution guide](https://reactjs.org/contributing/how-to-contribute.html)** to help you get started.
+We wrote a **[contribution guide](https://reactjs.org/docs/how-to-contribute.html)** to help you get started.

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ The main purpose of this repository is to continue evolving React core, making i
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
-### [Contributing Guide](https://reactjs.org/contributing/how-to-contribute.html)
+### [Contributing Guide](https://reactjs.org/docs/how-to-contribute.html)
 
-Read our [contributing guide](https://reactjs.org/contributing/how-to-contribute.html) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
+Read our [contributing guide](https://reactjs.org/docs/how-to-contribute.html) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
 
 ### Good First Issues
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The contributing guide link (https://reactjs.org/contributing/how-to-contribute.html) in `CONTRIBUTING.md`  and `README.md` points to a 404 page. It then redirects to https://reactjs.org/docs/how-to-contribute.html

## How did you test this change?

Check https://reactjs.org/docs/how-to-contribute.html is working
