### PR TITLE
feat: add no import expression eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,6 +124,7 @@ module.exports = {
         new: [],
       },
     ],
+    'react-internal/no-dynamic-import-in-literal': ERROR,
   },
 
   overrides: [
@@ -198,6 +199,7 @@ module.exports = {
         'jest/no-focused-tests': ERROR,
         'jest/valid-expect': ERROR,
         'jest/valid-expect-in-promise': ERROR,
+        'react-internal/no-dynamic-import-in-literal': OFF,
       },
     },
     {

--- a/scripts/eslint-rules/__tests__/no-dynamic-import-in-literal-test.internal.js
+++ b/scripts/eslint-rules/__tests__/no-dynamic-import-in-literal-test.internal.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const rule = require('../no-dynamic-import-in-literal');
+const {RuleTester} = require('eslint');
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('eslint-rules/no-dynamic-import-in-literal', rule, {
+  valid: [
+    `console.log(
+      'import react from "react"'
+    )`,
+    `console.log(
+      'should work for non-import expression'
+    )`,
+  ],
+  invalid: [
+    {
+      code: `console.log(
+          'import("react")'
+        )`,
+      errors: [
+        {
+          message: 'Possible dynamic import expression in literal',
+        },
+      ],
+    },
+    {
+      code: `console.log(
+          'const MyComponent = lazy(() => import("./MyComponent"))'
+        )`,
+      errors: [
+        {
+          message: 'Possible dynamic import expression in literal',
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/eslint-rules/index.js
+++ b/scripts/eslint-rules/index.js
@@ -11,5 +11,6 @@ module.exports = {
     'no-cross-fork-imports': require('./no-cross-fork-imports'),
     'no-cross-fork-types': require('./no-cross-fork-types'),
     'safe-string-coercion': require('./safe-string-coercion'),
+    'no-dynamic-import-in-literal': require('./no-dynamic-import-in-literal'),
   },
 };

--- a/scripts/eslint-rules/no-dynamic-import-in-literal.js
+++ b/scripts/eslint-rules/no-dynamic-import-in-literal.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+const IMPORT_PATTERN = /import\(([`'"]([^`'"]+)[`'"])*\)/;
+
+module.exports = {
+  meta: {
+    schema: [],
+  },
+  create(context) {
+    function checkIsImportExpression(node) {
+      const {type: nodeType} = node;
+      const content =
+        (nodeType === 'Literal' && node.value) ||
+        (nodeType === 'TemplateLiteral' && node.quasis[0].value.raw);
+      const isPossibleImportExpression = IMPORT_PATTERN.test(content);
+      if (isPossibleImportExpression) {
+        context.report(node, 'Possible dynamic import expression in literal');
+      }
+    }
+    return {
+      Literal: checkIsImportExpression,
+      TemplateLiteral: checkIsImportExpression,
+    };
+  },
+};


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This is a follow-up of PR #21918 and issue #21910 . It introduces a custom internal eslint rule to prevent dynamic import expression in literal. 

## How did you test this change?

1. new tests are added.
2. `yarn test` passes.
3. `yarn run eslint` passes.
4. When dynamic import expression is used in literal, E.g.

```
console.log(
     'lazy: Expected the result of a dynamic import() call. ' +
     "const MyComponent = lazy(() => import('./MyComponent'))"
);
```
it does report a lint error