### PR TITLE
Remove duplicate error code

### DIFF
--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -396,7 +396,6 @@
   "407": "Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.",
   "408": "Missing getServerSnapshot, which is required for server-rendered content.",
   "409": "Cannot update an unmounted root.",
-  "410": "%s suspended while rendering, but no fallback UI was specified.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.",
   "411": "%s suspended while rendering, but no fallback UI was specified.\n\nAdd a <Suspense fallback=...> component higher in the tree to provide a loading indicator or placeholder to display.",
   "412": "Connection closed.",
   "413": "Expected finished root and lanes to be set. This is a bug in React.",


### PR DESCRIPTION
The codemod seem to have found this error message twice.

There's kind of a flaw in the extract-errors script in that it uses map from message to ID which doesn't allow multiple IDs with the same name. That could happen if we end up changing names of something in the future.

Currently this means that running `extract-errors` will delete a row.

We should never delete a code that has been used. Even an unreleased one can show up in FB error logs even in the future.

However, since this is so recent, this shouldn't have leaked much yet so maybe it's fine to just delete this duplicate.