### PR TITLE
Enabled scheduling profiler marks for React Native FB target

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -20,7 +20,7 @@ export const {enablePersistentOffscreenHostContainer} = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;
-export const enableSchedulingProfiler = false;
+export const enableSchedulingProfiler = true;
 export const enableProfilerTimer = __PROFILE__;
 export const enableProfilerCommitHooks = __PROFILE__;
 export const enableProfilerNestedUpdatePhase = __PROFILE__;


### PR DESCRIPTION
This will let @feedthejim and I look at Systrace data with the Scheduling Profiler marks in order to figure out how to parse this data. Note that this change *only impacts DEV and PRODUCTION build targets* and so will have *no impact* on public React Native apps.