### PR TITLE
Improved Workers filenames in devtools-core

### DIFF
--- a/packages/react-devtools-core/webpack.standalone.js
+++ b/packages/react-devtools-core/webpack.standalone.js
@@ -103,6 +103,7 @@ module.exports = {
             loader: 'workerize-loader',
             options: {
               inline: true,
+              name: '[name]',
             },
           },
           {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Currently, when building `react-devtools-core`  by using `yarn build` , Webpack bundles and add the files to `dist` directory.
In `dist` there are weird naming of worker files with names like `jafje9390303kdjlfa29e02.worker.js`
This PR improves this and added worker names to files.
This is very similar to one of my previous PR #22322 
 
## How did you test this change?
Using `yarn build`

These are the file names after building. 

![image](https://user-images.githubusercontent.com/51379307/137337840-d05823ed-f15e-4df1-8d55-d89252afde82.png)

