### PR TITLE
[Hydration] Bail out from hydrating suspense boundary if component suspends

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -2775,7 +2775,7 @@ describe('ReactDOMServerPartialHydration', () => {
     // On the client we don't have all data yet but we want to start
     // hydrating anyway.
     suspend = true;
-    const root = ReactDOM.hydrateRoot(container, <App />);
+    ReactDOM.hydrateRoot(container, <App />);
     Scheduler.unstable_flushAll();
     jest.runAllTimers();
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1312,7 +1312,6 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes) {
 }
 
 function handleError(root, thrownValue): void {
-  debugger;
   do {
     let erroredWork = workInProgress;
     try {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -14,6 +14,7 @@ import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 import type {StackCursor} from './ReactFiberStack.old';
 import type {Flags} from './ReactFiberFlags';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.old';
+import {getIsHydrating} from './ReactFiberHydrationContext.old';
 
 import {
   warnAboutDeprecatedLifecycles,
@@ -1746,7 +1747,11 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
     }
 
     const siblingFiber = completedWork.sibling;
-    if (siblingFiber !== null) {
+    const isHydrating = getIsHydrating();
+    if (
+      siblingFiber !== null &&
+      (!isHydrating || (completedWork.flags & Incomplete) === NoFlags)
+    ) {
       // If there is more work to do in this returnFiber, do that next.
       workInProgress = siblingFiber;
       return;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This fixes the issue pointed out by @gaearon in this PR: https://github.com/facebook/react/pull/21630/files.

The issue is that when a component in a boundary suspends while hydrating we attempt to hydrate its sibling. However we don't know how many nodes the suspended component would have rendered (because we don't add comment nodes to signal this since it would bloat the HTML) so we can't tell where the sibling should hydrate. Rather than attempt to hydrate it the solution in this PR bails on hydrating the boundary from within the current parent fiber. It will continue with the sibling to the parent fiber which is fine since the hydration pointer will be correct in this case.

This means we won't call render on any siblings or children but I think it should be fine since we don't reuse the work anyways. Since we don't call render we also don't "warm up"  the codepath but that might be okay if there's other CPU work to do anyways we might actually see an improvement from allowing other higher priority work to happen.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Jest

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
