### PR TITLE
DevTools prepare release script resets patch version when bumping minor

### DIFF
--- a/scripts/devtools/prepare-release.js
+++ b/scripts/devtools/prepare-release.js
@@ -38,7 +38,7 @@ async function main() {
   const {major, minor, patch} = semver(previousVersion);
   const nextVersion =
     releaseType === 'minor'
-      ? `${major}.${minor + 1}.${patch}`
+      ? `${major}.${minor + 1}.0`
       : `${major}.${minor}.${patch + 1}`;
 
   updatePackageVersions(previousVersion, nextVersion);


### PR DESCRIPTION
## Summary

When bumping a minor version, the patch version should be reset to 0.

e.g. the next minor version after 4.19.2 should be 4.20.0, not 4.20.2


## How did you test this change?

`scripts/devtools/prepare-release` bumps minor version correctly
