### PR TITLE
Only show DevTools warning about unrecognized build in Chrome

### DIFF
--- a/packages/react-devtools-extensions/src/checkForDuplicateInstallations.js
+++ b/packages/react-devtools-extensions/src/checkForDuplicateInstallations.js
@@ -10,12 +10,15 @@
 declare var chrome: any;
 
 import {__DEBUG__} from 'react-devtools-shared/src/constants';
+import {getBrowserName} from './utils';
 import {
   EXTENSION_INSTALL_CHECK,
   EXTENSION_INSTALLATION_TYPE,
   INTERNAL_EXTENSION_ID,
   LOCAL_EXTENSION_ID,
 } from './constants';
+
+const IS_CHROME = getBrowserName() === 'Chrome';
 
 const UNRECOGNIZED_EXTENSION_ERROR =
   'React Developer Tools: You are running an unrecognized installation of the React Developer Tools extension, which might conflict with other versions of the extension installed in your browser. ' +
@@ -76,14 +79,17 @@ export function checkForDuplicateInstallations(callback: boolean => void) {
       break;
     }
     case 'unknown': {
-      // If we don't know how this extension was built, we can't reliably detect if there
-      // are other installations of DevTools present.
-      // In this case, assume there are no duplicate exensions and show a warning about
-      // potential conflicts.
-      console.error(UNRECOGNIZED_EXTENSION_ERROR);
-      chrome.devtools.inspectedWindow.eval(
-        `console.error("${UNRECOGNIZED_EXTENSION_ERROR}")`,
-      );
+      // TODO: Support duplicate extension detection in other browsers
+      if (IS_CHROME) {
+        // If we don't know how this extension was built, we can't reliably detect if there
+        // are other installations of DevTools present.
+        // In this case, assume there are no duplicate exensions and show a warning about
+        // potential conflicts.
+        console.error(UNRECOGNIZED_EXTENSION_ERROR);
+        chrome.devtools.inspectedWindow.eval(
+          `console.error("${UNRECOGNIZED_EXTENSION_ERROR}")`,
+        );
+      }
       callback(false);
       break;
     }


### PR DESCRIPTION
## Summary

#22517 added logic to detect when duplicate installations of DevTools extension are present (which relies on extension IDs), and when we can't detect what kind of build is present, we show an error in the console.

This detection currently only works for Chrome (which is the case where we would realistically observe duplicate extensions), however, in other browsers, we are still unnecessarily showing the warning about an unrecognized build, without anything actionable for the user to do.

This commit makes it so we only show the warning in Chrome.

Resolves #22572

## How did you test this change?

- verified that warning is no longer shown in firefox
