### PR TITLE
DevTools: Include Edge in browser name detection

### DIFF
--- a/packages/react-devtools-extensions/src/utils.js
+++ b/packages/react-devtools-extensions/src/utils.js
@@ -2,12 +2,25 @@
 
 import type {BrowserTheme} from 'react-devtools-shared/src/devtools/views/DevTools';
 
-const IS_CHROME = navigator.userAgent.indexOf('Firefox') < 0;
+const IS_EDGE = navigator.userAgent.indexOf('Edg') >= 0;
+const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0;
+const IS_CHROME = IS_EDGE === false && IS_FIREFOX === false;
 
-export type BrowserName = 'Chrome' | 'Firefox';
+export type BrowserName = 'Chrome' | 'Firefox' | 'Edge';
 
 export function getBrowserName(): BrowserName {
-  return IS_CHROME ? 'Chrome' : 'Firefox';
+  if (IS_EDGE) {
+    return 'Edge';
+  }
+  if (IS_FIREFOX) {
+    return 'Firefox';
+  }
+  if (IS_CHROME) {
+    return 'Chrome';
+  }
+  throw new Error(
+    'Expected browser name to be one of Chrome, Edge or Firefox.',
+  );
 }
 
 export function getBrowserTheme(): BrowserTheme {


### PR DESCRIPTION
## Summary

When testing #22571 on Edge, I noticed that the warning was still being shown. This is because we don't differentiate between Edge and Chrome. This commit makes it so we correctly detect Edge.

## How did you test this change?

- yarn flow, test, test-build-devtools
- verified that warning is no longer shown in Edge
