### PR TITLE
DevTools: Fix passing extensionId in evaled postMessage calls

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -216,7 +216,7 @@ function createPanelIfReactLoaded() {
           chrome.devtools.inspectedWindow.eval(
             `window.postMessage({
                source: 'react-devtools-inject-backend',
-               extensionId: "${CURRENT_EXTENSION_ID}"
+               extensionId: "${CURRENT_EXTENSION_ID}",
              }, '*');`,
             function(response, evalError) {
               if (evalError) {
@@ -361,15 +361,15 @@ function createPanelIfReactLoaded() {
               chrome.runtime.onMessage.addListener(onPortMessage);
 
               chrome.devtools.inspectedWindow.eval(`
-              window.postMessage({
-                source: 'react-devtools-extension',
-                extensionId: "${CURRENT_EXTENSION_ID}"
-                payload: {
-                  type: 'fetch-file-with-cache',
-                  url: "${url}",
-                },
-              });
-            `);
+                window.postMessage({
+                  source: 'react-devtools-extension',
+                  extensionId: "${CURRENT_EXTENSION_ID}",
+                  payload: {
+                    type: 'fetch-file-with-cache',
+                    url: "${url}",
+                  },
+                }, '*');
+              `);
             };
 
             // Fetching files from the extension won't make use of the network cache


### PR DESCRIPTION
## Summary

When adding `extensionId` to postMessage calls accidentally missed a comma. Unfortunately that code wasn't syntax checked so it was missed.

This made it so fetching files with network caching from the content window failed, causing named hooks to not work.

Fixes #22591



## How did you test this change?

- yarn flow dom
- yarn test-build-devtools
- named hooks now correctly work again on fb:

**Before**
![image](https://user-images.githubusercontent.com/1271509/137995297-fe3d4efa-0995-49b5-a1ce-9363bcf03840.png)


**After**
![image](https://user-images.githubusercontent.com/1271509/137995608-0554119c-9930-4246-89b7-be9fae0a56d2.png)
