### PR TITLE
Enable 'Reload and Start Profiling' for Microsoft Edge

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -33,6 +33,7 @@ const LOCAL_STORAGE_SUPPORTS_PROFILING_KEY =
   'React::DevTools::supportsProfiling';
 
 const isChrome = getBrowserName() === 'Chrome';
+const isEdge = getBrowserName() === 'Edge';
 
 let panelCreated = false;
 
@@ -203,7 +204,7 @@ function createPanelIfReactLoaded() {
 
           store = new Store(bridge, {
             isProfiling,
-            supportsReloadAndProfile: isChrome,
+            supportsReloadAndProfile: isChrome || isEdge,
             supportsProfiling,
             // At this time, the scheduling profiler can only parse Chrome performance profiles.
             supportsSchedulingProfiler: isChrome,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The 'Reload and Start Profiling' button was disabled for Microsoft Edge, as noted in issue #22630. This change enables it instead.

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Functionality was tested by using the already established function in Chrome and comparing the results with the newly enabled Edge version, which seems to indicate that the Edge version works just the same way. In addition all test were run and passed.

