### PR TITLE
mark webpack as optional for react-server-dom-webpack

### DIFF
--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -52,6 +52,11 @@
     "react-dom": "^17.0.0",
     "webpack": "^4.43.0"
   },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "acorn": "^6.2.1",
     "neo-async": "^2.6.1",


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Mark webpack as optional peer depdenency for case that when flight plugin is not been used.

