### PR TITLE
DevTools supports ENV-injected version for better internal bug reports

### DIFF
--- a/packages/react-devtools-extensions/utils.js
+++ b/packages/react-devtools-extensions/utils.js
@@ -30,12 +30,14 @@ function getGitCommit() {
   }
 }
 
-function getVersionString() {
-  const packageVersion = JSON.parse(
-    readFileSync(
-      resolve(__dirname, '..', 'react-devtools-core', './package.json'),
-    ),
-  ).version;
+function getVersionString(packageVersion = null) {
+  if (packageVersion == null) {
+    packageVersion = JSON.parse(
+      readFileSync(
+        resolve(__dirname, '..', 'react-devtools-core', './package.json'),
+      ),
+    ).version;
+  }
 
   const commit = getGitCommit();
 

--- a/packages/react-devtools-extensions/webpack.backend.js
+++ b/packages/react-devtools-extensions/webpack.backend.js
@@ -30,7 +30,7 @@ const builtModulesDir = resolve(
 
 const __DEV__ = NODE_ENV === 'development';
 
-const DEVTOOLS_VERSION = getVersionString();
+const DEVTOOLS_VERSION = getVersionString(process.env.DEVTOOLS_VERSION);
 
 const featureFlagTarget = process.env.FEATURE_FLAG_TARGET || 'extension-oss';
 

--- a/packages/react-devtools-extensions/webpack.config.js
+++ b/packages/react-devtools-extensions/webpack.config.js
@@ -30,7 +30,7 @@ const builtModulesDir = resolve(
 
 const __DEV__ = NODE_ENV === 'development';
 
-const DEVTOOLS_VERSION = getVersionString();
+const DEVTOOLS_VERSION = getVersionString(process.env.DEVTOOLS_VERSION);
 
 const LOGGING_URL = process.env.LOGGING_URL || null;
 


### PR DESCRIPTION
Internal version numbers use a 4-digit format (e.g. 4.20.2.0) but the version shown in the settings dialog is the 3-digit format, plus a Git commit hash (e.g. 4.20.2-c213030b4). This means we have to map between the two when internal users report DevTools bugs, which can be a little confusing.

Internally, the 4-digit version is generated based on the current (in Git) 3-digit version that's specified in the package.json. If we do more than one internal release between external releases, we increment (e.g. 4.20.2 becomes 4.20.2.0 then 4.20.2.1 etc).

This diff adds support for DevTools to display the 4-digit version number in the Settings dialog so that internal bug reports were more straight forward.

---

For example, this is a build showing the new param:
```sh
DEVTOOLS_VERSION=4.20.2.2 yarn build:chrome:local && yarn test:chrome
```
<img width="744" alt="Screen Shot 2021-10-27 at 12 01 36 PM" src="https://user-images.githubusercontent.com/29597/139104438-1824a697-a746-4307-9fb2-4f1937613d45.png">

And here is a test showing the previous behavior remains unchanged:
```sh
yarn build:chrome:local && yarn test:chrome
```
<img width="742" alt="Screen Shot 2021-10-27 at 12 02 29 PM" src="https://user-images.githubusercontent.com/29597/139104541-fb3db1a0-1165-42a8-b8ee-3f2cebbf3dcb.png">
