### PR TITLE
More robust act async detection

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -499,30 +499,9 @@ function runActTests(label, render, unmount, rerender) {
       });
 
       // @gate __DEV__
-      test('warns if you do not await an act call with thenable without finally support', async () => {
-        spyOnDevAndProd(console, 'error');
-        act(() => ({then: cb => cb()}));
-        await sleep(0);
-        if (__DEV__) {
-          expect(console.error.calls.count()).toEqual(1);
-          expect(console.error.calls.argsFor(0)[0]).toMatch(
-            'You called act(async () => ...) without await.',
-          );
-        }
-      });
-
-      // @gate __DEV__
       test('does not warn if you await an act call with Promise', async () => {
         spyOnDevAndProd(console, 'error');
         await act(async () => {});
-        await sleep(0);
-        expect(console.error.calls.count()).toEqual(0);
-      });
-
-      // @gate __DEV__
-      test('does not warn if you await an act call with thenable without finally support', async () => {
-        spyOnDevAndProd(console, 'error');
-        await act(() => ({then: cb => cb()}));
         await sleep(0);
         expect(console.error.calls.count()).toEqual(0);
       });

--- a/packages/react/src/ReactAct.js
+++ b/packages/react/src/ReactAct.js
@@ -91,30 +91,23 @@ export function act<T>(callback: () => T | Thenable<T>): Thenable<T> {
 
       if (__DEV__) {
         if (!didWarnNoAwaitAct && typeof Promise !== 'undefined') {
-          const awaitDetector = () => {
-            if (!wasAwaited) {
-              didWarnNoAwaitAct = true;
-              console.error(
-                'You called act(async () => ...) without await. ' +
-                  'This could lead to unexpected testing behaviour, ' +
-                  'interleaving multiple act calls and mixing their ' +
-                  'scopes. ' +
-                  'You should - await act(async () => ...);',
-              );
-            }
-          };
-          if (result instanceof Promise && 'finally' in result) {
-            // Using finally here is more compatible with native promises
-            // and promise libraries like core.js
-            result
-              .finally(() => {})
-              .catch(() => {})
-              .then(awaitDetector);
-          } else {
-            Promise.resolve()
-              .then(() => {})
-              .then(awaitDetector);
-          }
+          Promise.resolve(result)
+            .then(
+              () => {},
+              () => {},
+            )
+            .then(() => {
+              if (!wasAwaited) {
+                didWarnNoAwaitAct = true;
+                console.error(
+                  'You called act(async () => ...) without await. ' +
+                    'This could lead to unexpected testing behaviour, ' +
+                    'interleaving multiple act calls and mixing their ' +
+                    'scopes. ' +
+                    'You should - await act(async () => ...);',
+                );
+              }
+            });
         }
       }
       return thenable;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
Fixes #22634

In some setups (i.e. React Native + `@testing-library/react`), the `act()` await detection reports false-positive error messages on the console.

```
You called act(async () => ...) without await..
```

The current method depends on simple promise chains that are expected to "beat" the test's `then` execution on the callback.

This change uses `Promise#finally` when it is available instead of promise chains. This maintains the error warnings while also being compatible with React Native's core.js promise implementation.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I have verified this change functions correctly in the positive and negative use-cases for:
* Existing React Native + `@testing-library/react-native` (which suffers from this specific issue) and it does indeed solve the problem while still maintaining the error message in the correct scenarios.
* ✅ Reproduction steps in the #22634 
* ✅ React web app (create-react-app) with a similar setup to above
* ✅ React web app (create-react-app) with @testing-library/react

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Edits:
* Rewrote a test to use `async` instead of `done` and removed mention in this comment.