### PR TITLE
Repair support for eslint 8

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -12,6 +12,7 @@
 export default {
   meta: {
     type: 'suggestion',
+    hasSuggestions: true,
     docs: {
       description:
         'verifies the list of dependencies for Hooks like useEffect and similar',


### PR DESCRIPTION

## Summary

When currently running eslint with eslint-plugin-react-hooks enabled, the build fails with "Rules with suggestions must set the `meta.hasSuggestions` property to `true`.".
When actually setting this property, the error goes away.

## How did you test this change?

I tried out the change in an actual project. This is also where I found the error message. With the change the error goes away.
Not sure whether you want to have a unit test for this. The actual test would be probably to pull the whole react repository to eslint 8 (which I don't want to do in this PR :-))
