### PR TITLE
Removed console.error

### DIFF
--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -396,13 +396,6 @@ function useInsertionEffect(
 ) {
   if (__DEV__) {
     currentHookNameInDev = 'useInsertionEffect';
-    console.error(
-      'useInsertionEffect does nothing on the server, because its effect cannot ' +
-        "be encoded into the server renderer's output format. This will lead " +
-        'to a mismatch between the initial, non-hydrated UI and the intended ' +
-        'UI. To avoid this, useInsertionEffect should only be used in ' +
-        'components that render exclusively on the client.',
-    );
   }
 }
 
@@ -412,14 +405,6 @@ export function useLayoutEffect(
 ) {
   if (__DEV__) {
     currentHookNameInDev = 'useLayoutEffect';
-    console.error(
-      'useLayoutEffect does nothing on the server, because its effect cannot ' +
-        "be encoded into the server renderer's output format. This will lead " +
-        'to a mismatch between the initial, non-hydrated UI and the intended ' +
-        'UI. To avoid this, useLayoutEffect should only be used in ' +
-        'components that render exclusively on the client. ' +
-        'See https://reactjs.org/link/uselayouteffect-ssr for common fixes.',
-    );
   }
 }
 


### PR DESCRIPTION
Hi! Removed console error of this:

**Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.**

This text is not true since there are cases that do not lead to mismatch, e.g., useLayoutEffect on some property change that is not supposed to run on initial render. Therefore we can useLayoutEffect on server and error should not be displayed in console.

Error is quite annoying to see in build logs, it is not helpful in described case, it makes difficult to see helpful information in logs: for me there are hundreds of lines of this useless information.