### PR TITLE
Pin CI to Node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 aliases:
   - &docker
-    - image: circleci/openjdk:8-jdk-node-browsers
+    - image: cimg/openjdk:17.0.0-node
 
   - &environment
     TZ: /usr/share/zoneinfo/America/Los_Angeles


### PR DESCRIPTION
CI starting running Node 16, which breaks some of our tests because the error message text for undefined property access has changed.

We should pin to Node 14 until we are able to update the messages.