### PR TITLE
Fix DevTools advanced tooltip display conditional check

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
@@ -217,7 +217,11 @@ function List({
 
     // Only some React versions include commit durations.
     // Show a richer tooltip only for builds that have that info.
-    if (effectDuration !== null || passiveEffectDuration !== null) {
+    if (
+      effectDuration !== null ||
+      passiveEffectDuration !== null ||
+      priorityLevel !== null
+    ) {
       tooltipLabel = (
         <ul className={styles.TooltipList}>
           {priorityLevel !== null && (


### PR DESCRIPTION
Previously we would not show the advanced tooltip format unless we had effect durations. This meant that commits with no effects would not properly show their priority level.

Noticed this while creating example content for conf keynote.