### PR TITLE
Remove @flow pragma comment from module registration start/stop templates

### DIFF
--- a/packages/shared/registerInternalModuleStart.js
+++ b/packages/shared/registerInternalModuleStart.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */

--- a/packages/shared/registerInternalModuleStop.js
+++ b/packages/shared/registerInternalModuleStop.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */


### PR DESCRIPTION
This results in a duplicate `@flow` pragma in built bundles, which breaks xplat CI.