### PR TITLE
Fix module-boundary wrappers

### DIFF
--- a/scripts/rollup/wrappers.js
+++ b/scripts/rollup/wrappers.js
@@ -27,24 +27,23 @@ const {
 
 const {RECONCILER} = moduleTypes;
 
+const USE_STRICT_HEADER_REGEX = /'use strict';\n+/;
+
 function registerInternalModuleStart(globalName) {
-  const path = resolve(
-    __dirname,
-    '..',
-    '..',
-    'packages/shared/registerInternalModuleStart.js'
-  );
-  return String(readFileSync(path)).trim();
+  const path = resolve(__dirname, 'wrappers', 'registerInternalModuleBegin.js');
+  const file = readFileSync(path);
+  return String(file).trim();
 }
 
 function registerInternalModuleStop(globalName) {
-  const path = resolve(
-    __dirname,
-    '..',
-    '..',
-    'packages/shared/registerInternalModuleStop.js'
-  );
-  return String(readFileSync(path)).trim();
+  const path = resolve(__dirname, 'wrappers', 'registerInternalModuleEnd.js');
+  const file = readFileSync(path);
+
+  // Remove the 'use strict' directive from the footer.
+  // This directive is only meaningful when it is the first statement in a file or function.
+  return String(file)
+    .replace(USE_STRICT_HEADER_REGEX, '')
+    .trim();
 }
 
 const license = ` * Copyright (c) Facebook, Inc. and its affiliates.
@@ -359,6 +358,11 @@ function wrapBundle(
       case RN_OSS_PROFILING:
       case RN_FB_DEV:
       case RN_FB_PROFILING:
+        // Remove the 'use strict' directive from source.
+        // The module start wrapper will add its own.
+        // This directive is only meaningful when it is the first statement in a file or function.
+        source = source.replace(USE_STRICT_HEADER_REGEX, '');
+
         // Certain DEV and Profiling bundles should self-register their own module boundaries with DevTools.
         // This allows the Scheduling Profiler to de-emphasize (dim) internal stack frames.
         source = `

--- a/scripts/rollup/wrappers/registerInternalModuleBegin.js
+++ b/scripts/rollup/wrappers/registerInternalModuleBegin.js
@@ -1,14 +1,6 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+'use strict';
 
 /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
-
-// Don't require this file directly; it's embedded by Rollup during build.
-
 if (
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart ===

--- a/scripts/rollup/wrappers/registerInternalModuleEnd.js
+++ b/scripts/rollup/wrappers/registerInternalModuleEnd.js
@@ -1,14 +1,6 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+'use strict';
 
 /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
-
-// Don't require this file directly; it's embedded by Rollup during build.
-
 if (
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
   typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop ===


### PR DESCRIPTION
Resolves #22673

Also fixes the scope of `'use strict';` (which the previous change had bumped slightly down in the function, breaking it).

---
Before I added the module boundary wrappers:
```js
/** @license React vundefined
 * react.development.js
 *
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

'use strict';

if (process.env.NODE_ENV !== "production") {
  (function() {
'use strict';

var _assign = require('object-assign');

// Other code ...

exports.version = ReactVersion;
  })();
}
```

---
Before the changes in this PR (with module wrappers):
```js
/** @license React vundefined
 * react.development.js
 *
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

'use strict';

if (process.env.NODE_ENV !== "production") {
  (function() {

          /**
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

/* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */

// Don't require this file directly; it's embedded by Rollup during build.

if (
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart ===
    'function'
) {
  __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart(new Error());
}
          'use strict';

var _assign = require('object-assign');

// ...

exports.version = ReactVersion;
          /**
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

/* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */

// Don't require this file directly; it's embedded by Rollup during build.

if (
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop ===
    'function'
) {
  __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
}
        
  })();
}

```

---
After the changes in this PR:
```js
/** @license React vundefined
 * react.development.js
 *
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 */

'use strict';

if (process.env.NODE_ENV !== "production") {
  (function() {

          'use strict';

/* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
if (
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart ===
    'function'
) {
  __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStart(new Error());
}
          var _assign = require('object-assign');

// ...

// Other code ...

exports.version = ReactVersion;
          /* global __REACT_DEVTOOLS_GLOBAL_HOOK__ */
if (
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== 'undefined' &&
  typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop ===
    'function'
) {
  __REACT_DEVTOOLS_GLOBAL_HOOK__.registerInternalModuleStop(new Error());
}
        
  })();
}
```
