### PR TITLE
fix: document can be `null`, not just `undefined`

### DIFF
--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -81,7 +81,7 @@ if (__DEV__) {
       // when we call document.createEvent(). However this can cause confusing
       // errors: https://github.com/facebook/create-react-app/issues/3482
       // So we preemptively throw with a better message instead.
-      if (typeof document === 'undefined') {
+      if (typeof document === 'undefined' || document === null) {
         throw new Error(
           'The `document` global was defined when React was initialized, but is not ' +
             'defined anymore. This can happen in a test environment if a component ' +


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Jest sets `document` to `null`, not `undefined` (or `delete` which the test from #11677 does) when tearing down the env. https://github.com/facebook/jest/blob/95f49691d3472d8187640f1b703209b93c2bcecc/packages/jest-environment-jsdom/src/index.ts#L135-L136

## How did you test this change?

At work we get

```
/workspace/node_modules/react-dom/cjs/react-dom.development.js:3905
      var evt = document.createEvent('Event');
                         ^
TypeError: Cannot read properties of null (reading 'createEvent')
    at Object.invokeGuardedCallbackDev (/workspace/node_modules/react-dom/cjs/react-dom.development.js:3905:26)
    at invokeGuardedCallback (/workspace/node_modules/react-dom/cjs/react-dom.development.js:4056:31)
    at flushPassiveEffectsImpl (/workspace/node_modules/react-dom/cjs/react-dom.development.js:23543:11)
    at unstable_runWithPriority (/workspace/node_modules/scheduler/cjs/scheduler.development.js:468:12)
    at runWithPriority$1 (/workspace/node_modules/react-dom/cjs/react-dom.development.js:11276:10)
    at flushPassiveEffects (/workspace/node_modules/react-dom/cjs/react-dom.development.js:23447:14)
    at Object.<anonymous>.flushWork (/workspace/node_modules/react-dom/cjs/react-dom-test-utils.development.js:992:10)
    at Immediate.<anonymous> (/workspace/node_modules/react-dom/cjs/react-dom-test-utils.development.js:1003:11)
    at processImmediate (node:internal/timers:464:21)
    at process.topLevelDomainCallback (node:domain:152:15)
    at process.callbackTrampoline (node:internal/async_hooks:128:24)
```

_sometimes_. I've been unable to track down where in our code we're missing a teardown (unfortunately the stack only points to react internals, no trace back to user code), but the error can be cleaner 🙂 