### PR TITLE
Fix small typos

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -69,7 +69,7 @@ describe('console', () => {
     );
   }
 
-  it('should not patch console methods that are not explicitly overriden', () => {
+  it('should not patch console methods that are not explicitly overridden', () => {
     expect(fakeConsole.error).not.toBe(mockError);
     expect(fakeConsole.info).toBe(mockInfo);
     expect(fakeConsole.log).toBe(mockLog);

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -50,7 +50,7 @@ export function getBoundingClientRectWithBorderOffset(node: HTMLElement) {
       right: dimensions.borderRight,
       // This width and height won't get used by mergeRectOffsets (since this
       // is not the first rect in the array), but we set them so that this
-      // object typechecks as a ClientRect.
+      // object type checks as a ClientRect.
       width: 0,
       height: 0,
     },

--- a/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
+++ b/scripts/release/prepare-release-from-npm-commands/update-stable-version-numbers.js
@@ -132,7 +132,7 @@ const run = async ({cwd, packages, version}, versionsMap) => {
   let diff = '';
   let numFilesModified = 0;
 
-  // Find-and-replace hard coded version (in built JS) for renderers.
+  // Find-and-replace hardcoded version (in built JS) for renderers.
   for (let i = 0; i < packages.length; i++) {
     const packageName = packages[i];
     const packagePath = join(nodeModulesPath, packageName);


### PR DESCRIPTION
Hello,
I've found some minor typos in the documentation, solved with this PR.

Fix typo: 
overriden -> overridden
typechecks  -> type checks
hard coded -> hardcoded