### PR TITLE
Fix a few minor typos

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -812,7 +812,7 @@ describe('ReactDOMFizzServer', () => {
 
     await act(async () => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-        // We use two nested boundaries to flush out coverage of an old reentrancy bug.
+        // We use two nested boundaries to flush out coverage of an old re-entrance bug.
         <Suspense fallback="Loading...">
           <Suspense fallback={<Text text="Loading A..." />}>
             <>

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -455,7 +455,7 @@ describe('ReactDOMServer', () => {
       expect(results).toEqual([2, 1, 3, 1]);
     });
 
-    it('renders context API, reentrancy', () => {
+    it('renders context API, re-entrance', () => {
       const Context = React.createContext(0);
 
       function Consumer(props) {

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -61,7 +61,7 @@ function escapeUserProvidedKey(text: string): string {
  * @return {string}
  */
 function getElementKey(element: any, index: number): string {
-  // Do some typechecking here since we call this blindly. We want to ensure
+  // Do some type checking here since we call this blindly. We want to ensure
   // that we don't block potential future ES APIs.
   if (typeof element === 'object' && element !== null && element.key != null) {
     // Explicit key

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -23,7 +23,7 @@ function getFormat(filepath) {
     if (filepath.includes('shims')) {
       // We don't currently lint these shims. We rely on the downstream Facebook
       // repo to transform them.
-      // TODO: Should we we lint them?
+      // TODO: Should we lint them?
       return null;
     }
     return 'rn';

--- a/scripts/tasks/flow.js
+++ b/scripts/tasks/flow.js
@@ -36,7 +36,7 @@ if (!primaryRenderer) {
   console.log();
   console.log('If you are not sure, run ' + chalk.green('yarn flow dom') + '.');
   console.log(
-    'This will still typecheck non-DOM packages, although less precisely.'
+    'This will still type check non-DOM packages, although less precisely.'
   );
   console.log();
   console.log('Note that checks for all renderers will run on CI.');


### PR DESCRIPTION
Hello,
I've found some minor typos in the documentation, solved with this PR.

Fix typo:
we we -> we
typechecking -> type checking 
typecheck  -> type check
reentrancy  -> re-entrance