### PR TITLE
Add Scheduling Profiler GK link to Timeline UI for FB build

### DIFF
--- a/packages/react-devtools-timeline/src/Timeline.js
+++ b/packages/react-devtools-timeline/src/Timeline.js
@@ -10,6 +10,7 @@
 import type {DataResource} from './createDataResourceFromImportedFile';
 import type {ViewState} from './types';
 
+import {isInternalFacebookBuild} from 'react-devtools-feature-flags';
 import * as React from 'react';
 import {
   Suspense,
@@ -79,6 +80,19 @@ export function Timeline(_: {||}) {
 
 const Welcome = ({onFileSelect}: {|onFileSelect: (file: File) => void|}) => (
   <ol className={styles.WelcomeInstructionsList}>
+    {isInternalFacebookBuild && (
+      <li className={styles.WelcomeInstructionsListItem}>
+        Enable the
+        <a
+          className={styles.WelcomeInstructionsListItemLink}
+          href="https://fburl.com/react-devtools-scheduling-profiler-gk"
+          rel="noopener noreferrer"
+          target="_blank">
+          <code>react_enable_scheduling_profiler</code> GK
+        </a>
+        .
+      </li>
+    )}
     <li className={styles.WelcomeInstructionsListItem}>
       Open a website that's built with the
       <a


### PR DESCRIPTION
This is a constant source of confusion for FB engineers trying to figure out why Chrome profiling data does not have any React marks.

Internal Facebook build will now show the following additional line:
<img width="524" alt="Screen Shot 2021-11-09 at 3 23 21 PM" src="https://user-images.githubusercontent.com/29597/140998934-7fb9087c-3716-4a59-bd85-004d4965c0d7.png">