### PR TITLE
Track late-mounted roots in Fast Refresh

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -554,7 +554,9 @@ export function injectIntoGlobalHook(globalObject: any): void {
         if (alternate !== null) {
           const wasMounted =
             alternate.memoizedState != null &&
-            alternate.memoizedState.element != null;
+            alternate.memoizedState.element != null &&
+            mountedRoots.has(root);
+
           const isMounted =
             current.memoizedState != null &&
             current.memoizedState.element != null;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

In doing the micro front-end sub-application encountered the problem of sub-application hot update does not work, I debugged it like this
1. use the online (test environment) main application address
2. proxy the sub-application to be debugged to localhost (localhost domain)

In order to keep the `Shared React Context`, our sub-application is loaded by the main application as a `React component`, because `react-refresh` is loaded only when the sub-application is executed, so the current root is not properly collected in the `mountedRoots`, and eventually the hot update of the application does not work.

## How did you test this change?

When determining `wasMounted`, adjust to
```js
const wasMounted =
            alternate.memoizedState != null &&
            alternate.memoizedState.element != null &&
            mountedRoots.has(root);
```

Logically, there is no breaking change here, and it solves my problem perfectly
![demo](https://sf16-va.tiktokcdn.com/obj/eden-va2/eueh7vhojuh/demo.gif)
