### PR TITLE
Re-enable useMutableSource in internal RN

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -74,7 +74,7 @@ export const enableSyncDefaultUpdates = true;
 export const allowConcurrentByDefault = true;
 
 export const consoleManagedByDevToolsDuringStrictMode = false;
-export const enableUseMutableSource = false;
+export const enableUseMutableSource = true;
 
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## Overview

Similar to https://github.com/facebook/react/pull/22664, some internal callers of useMutableSource that we haven't migrated yet.