### PR TITLE
devtools: dont restore profiling data if we're profling

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -156,7 +156,9 @@ function createPanelIfReactLoaded() {
           supportsTimeline: isChrome,
           supportsTraceUpdates: true,
         });
-        store.profilerStore.profilingData = profilingData;
+        if (!isProfiling) {
+          store.profilerStore.profilingData = profilingData;
+        }
 
         // Initialize the backend only once the Store has been initialized.
         // Otherwise the Store may miss important initial tree op codes.


### PR DESCRIPTION
## Summary

Skip no-op to prevent console warning "Profiling data cannot be updated while profiling is in progress." triggered by https://github.com/facebook/react/blob/c0c71a868560b3042847722659579418bfe2d7e1/packages/react-devtools-shared/src/devtools/ProfilerStore.js#L154-L159

Warning is currently issued on "Reload and start profiling"

## How did you test this change?

Didn't test. The warning is noisy considering we do know at this poin that setting the data has no effect. 
Though maybe the warning should just not exist?
