### PR TITLE
Modified eslint error message

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -932,7 +932,7 @@ function genericError(hook) {
 function topLevelError(hook) {
   return {
     message:
-      `React Hook "${hook}" cannot be called at the top level. React Hooks ` +
+      `React Hook "${hook}" cannot be called outside of a React Function. React Hooks ` +
       'must be called in a React function component or a custom React ' +
       'Hook function.',
   };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -488,7 +488,7 @@ export default {
               // These are dangerous if you have inline requires enabled.
               const message =
                 `React Hook "${context.getSource(hook)}" cannot be called ` +
-                'at the top level. React Hooks must be called in a ' +
+                'outside of a React Function. React Hooks must be called in a ' +
                 'React function component or a custom React Hook function.';
               context.report({node: hook, message});
             } else {


### PR DESCRIPTION
Here top level errors looks a bit confusing for the developers.further they are directed to rules of hooks page and it mentions that "Hooks are called only at the top level" whereas the message reads "React hooks cannot be called at the top level".

I feel this commit clarifies the error message and also keeps it in check with the documentation

