### PR TITLE
Fix typo in rollup/validate/index.js

### DIFF
--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -23,7 +23,7 @@ function getFormat(filepath) {
     if (filepath.includes('shims')) {
       // We don't currently lint these shims. We rely on the downstream Facebook
       // repo to transform them.
-      // TODO: Should we we lint them?
+      // TODO: Should we lint them?
       return null;
     }
     return 'rn';


### PR DESCRIPTION
Hello,
I removed the redundant word in the documentation.

Fix typo:
we we -> we