### PR TITLE
Use globalThis if possible to access fetch in react-fetch browser build

### DIFF
--- a/packages/react-fetch/src/ReactFetchBrowser.js
+++ b/packages/react-fetch/src/ReactFetchBrowser.js
@@ -32,8 +32,11 @@ type RejectedRecord = {|
 
 type Record = PendingRecord | ResolvedRecord | RejectedRecord;
 
+declare var globalThis: any;
+
 // TODO: this is a browser-only version. Add a separate Node entry point.
-const nativeFetch = window.fetch;
+const nativeFetch = (typeof globalThis !== 'undefined' ? globalThis : window)
+  .fetch;
 
 function getRecordMap(): Map<string, Record> {
   return unstable_getCacheForType(createRecordMap);

--- a/scripts/rollup/validate/eslintrc.cjs.js
+++ b/scripts/rollup/validate/eslintrc.cjs.js
@@ -15,6 +15,7 @@ module.exports = {
     WeakSet: true,
     Uint16Array: true,
     Reflect: true,
+    globalThis: true,
     // Vendor specific
     MSApp: true,
     __REACT_DEVTOOLS_GLOBAL_HOOK__: true,


### PR DESCRIPTION
## Summary

Make the browser build of react-fetch is more flexible to be adopted in web runtime like next.js custom web runtime for streaming.

## How did you test this change?

Test with next-rsc-demo by using react-fetch and chaing the dist code of `react-fetch@experimental` with following changes locally.