### PR TITLE
Add warning on hydration mismatch that makes it easy to identify it

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -307,8 +307,7 @@ describe('ReactDOMServerPartialHydration', () => {
           'Component',
           'Component',
         ]);
-        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
-      }).toWarnDev(
+      }).toErrorDev(
         'Warning: An error occurred during hydration. expected article got DIV. At:  [object HTMLDivElement] Inside:  [object HTMLDivElement]',
         {withoutStack: true},
       );

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -244,11 +244,13 @@ describe('ReactDOMServerPartialHydration', () => {
     function App() {
       return (
         <Suspense fallback="Loading...">
-          <Child />
-          <Component />
-          <Component />
-          <Component />
-          <Component shouldMismatch={true} />
+          <div>
+            <Child />
+            <Component />
+            <Component />
+            <Component />
+            <Component shouldMismatch={true} />
+          </div>
         </Suspense>
       );
     }
@@ -264,7 +266,7 @@ describe('ReactDOMServerPartialHydration', () => {
     ]);
 
     expect(container.innerHTML).toBe(
-      '<!--$-->Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div><!--/$-->',
+      '<!--$--><div>Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div></div><!--/$-->',
     );
 
     suspend = true;
@@ -282,31 +284,39 @@ describe('ReactDOMServerPartialHydration', () => {
 
     // Unchanged
     expect(container.innerHTML).toBe(
-      '<!--$-->Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div><!--/$-->',
+      '<!--$--><div>Hello<div>Component</div><div>Component</div><div>Component</div><div>Component</div></div><!--/$-->',
     );
 
     suspend = false;
     resolve();
     await promise;
 
-    expect(Scheduler).toFlushAndYield([
-      // first pass, mismatches at end
-      'Hello',
-      'Component',
-      'Component',
-      'Component',
-      'Component',
-      // second pass as client render
-      'Hello',
-      'Component',
-      'Component',
-      'Component',
-      'Component',
-    ]);
+    expect(() => {
+      expect(() => {
+        expect(Scheduler).toFlushAndYield([
+          // first pass, mismatches at end
+          'Hello',
+          'Component',
+          'Component',
+          'Component',
+          'Component',
+          // second pass as client render
+          'Hello',
+          'Component',
+          'Component',
+          'Component',
+          'Component',
+        ]);
+        // eslint-disable-next-line react-internal/no-to-warn-dev-within-to-throw
+      }).toWarnDev(
+        'Warning: An error occurred during hydration. expected article got DIV. At:  [object HTMLDivElement] Inside:  [object HTMLDivElement]',
+        {withoutStack: true},
+      );
+    }).toThrow('Received 5 arguments for a message with 2 placeholders');
 
     // Client rendered - suspense comment nodes removed
     expect(container.innerHTML).toBe(
-      'Hello<div>Component</div><div>Component</div><div>Component</div><article>Mismatch</article>',
+      '<div>Hello<div>Component</div><div>Component</div><div>Component</div><article>Mismatch</article></div>',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -291,7 +291,7 @@ describe('ReactDOMServerPartialHydration', () => {
     resolve();
     await promise;
 
-    expect(() => {
+    function whatWeExpect() {
       expect(() => {
         expect(Scheduler).toFlushAndYield([
           // first pass, mismatches at end
@@ -312,7 +312,15 @@ describe('ReactDOMServerPartialHydration', () => {
         'Warning: An error occurred during hydration. expected article got DIV. At:  [object HTMLDivElement] Inside:  [object HTMLDivElement]',
         {withoutStack: true},
       );
-    }).toThrow('Received 5 arguments for a message with 2 placeholders');
+    }
+
+    if (__DEV__) {
+      expect(whatWeExpect).toThrow(
+        'Received 5 arguments for a message with 2 placeholders',
+      );
+    } else {
+      whatWeExpect();
+    }
 
     // Client rendered - suspense comment nodes removed
     expect(container.innerHTML).toBe(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -1088,7 +1088,7 @@ export function warnOnHydrationMismatch(
 ) {
   if (__DEV__) {
     // eslint-disable-next-line react-internal/warning-args
-    console.warn(
+    console.error(
       'An error occurred during hydration. expected %s got %s. At: ',
       fiber.type,
       hydratableInstance ? hydratableInstance.nodeName : '<null>',

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -66,7 +66,11 @@ import {
   enableCreateEventHandleAPI,
   enableScopeAPI,
 } from 'shared/ReactFeatureFlags';
-import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
+import {
+  HostComponent,
+  HostText,
+  SuspenseComponent,
+} from 'react-reconciler/src/ReactWorkTags';
 import {listenToAllSupportedEvents} from '../events/DOMPluginEventSystem';
 
 import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
@@ -1073,6 +1077,28 @@ export function errorHydratingContainer(parentContainer: Container): void {
     console.error(
       'An error occurred during hydration. The server HTML was replaced with client content in <%s>.',
       parentContainer.nodeName.toLowerCase(),
+    );
+  }
+}
+
+export function warnOnHydrationMismatch(
+  fiber: Fiber,
+  parentFiber: Fiber | null,
+  hydratableInstance: HydratableInstance | null,
+) {
+  if (__DEV__) {
+    // eslint-disable-next-line react-internal/warning-args
+    console.warn(
+      'An error occurred during hydration. expected %s got %s. At: ',
+      fiber.type,
+      hydratableInstance ? hydratableInstance.nodeName : '<null>',
+      hydratableInstance,
+      'Inside: ',
+      parentFiber
+        ? parentFiber.tag === SuspenseComponent
+          ? '<Suspense>'
+          : parentFiber.stateNode
+        : null,
     );
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
@@ -55,3 +55,4 @@ export const didNotFindHydratableInstance = shim;
 export const didNotFindHydratableTextInstance = shim;
 export const didNotFindHydratableSuspenseInstance = shim;
 export const errorHydratingContainer = shim;
+export const warnOnHydrationMismatch = shim;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -61,6 +61,7 @@ import {
   didNotFindHydratableInstance,
   didNotFindHydratableTextInstance,
   didNotFindHydratableSuspenseInstance,
+  warnOnHydrationMismatch as hostWarnOnHydrationMismatch,
 } from './ReactFiberHostConfig';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
 import {OffscreenLane} from './ReactFiberLane.new';
@@ -324,7 +325,15 @@ function tryHydrate(fiber, nextInstance) {
   }
 }
 
-function throwOnHydrationMismatchIfConcurrentMode(fiber) {
+export function warnOnHydrationMismatch(fiber: Fiber) {
+  hostWarnOnHydrationMismatch(
+    fiber,
+    hydrationParentFiber,
+    nextHydratableInstance,
+  );
+}
+
+function throwOnHydrationMismatchIfConcurrentMode(fiber: Fiber) {
   if ((fiber.mode & ConcurrentMode) !== NoMode) {
     throw new Error(
       'An error occurred during hydration. The server HTML was replaced with client content',

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -61,6 +61,7 @@ import {
   didNotFindHydratableInstance,
   didNotFindHydratableTextInstance,
   didNotFindHydratableSuspenseInstance,
+  warnOnHydrationMismatch as hostWarnOnHydrationMismatch,
 } from './ReactFiberHostConfig';
 import {enableSuspenseServerRenderer} from 'shared/ReactFeatureFlags';
 import {OffscreenLane} from './ReactFiberLane.old';
@@ -324,7 +325,15 @@ function tryHydrate(fiber, nextInstance) {
   }
 }
 
-function throwOnHydrationMismatchIfConcurrentMode(fiber) {
+export function warnOnHydrationMismatch(fiber: Fiber) {
+  hostWarnOnHydrationMismatch(
+    fiber,
+    hydrationParentFiber,
+    nextHydratableInstance,
+  );
+}
+
+function throwOnHydrationMismatchIfConcurrentMode(fiber: Fiber) {
   if ((fiber.mode & ConcurrentMode) !== NoMode) {
     throw new Error(
       'An error occurred during hydration. The server HTML was replaced with client content',

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -79,7 +79,10 @@ import {
   mergeLanes,
   pickArbitraryLane,
 } from './ReactFiberLane.new';
-import {getIsHydrating} from './ReactFiberHydrationContext.new';
+import {
+  warnOnHydrationMismatch,
+  getIsHydrating,
+} from './ReactFiberHydrationContext.new';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
@@ -499,6 +502,18 @@ function throwException(
           // Set a flag to indicate that we should try rendering the normal
           // children again, not the fallback.
           suspenseBoundary.flags |= ForceClientRender;
+          if (__DEV__) {
+            if (
+              value &&
+              value.message &&
+              value.message.startsWith instanceof Function &&
+              (value.message.startsWith: any)(
+                'An error occurred during hydration',
+              )
+            ) {
+              warnOnHydrationMismatch(sourceFiber);
+            }
+          }
         }
         markSuspenseBoundaryShouldCapture(
           suspenseBoundary,

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -79,7 +79,10 @@ import {
   mergeLanes,
   pickArbitraryLane,
 } from './ReactFiberLane.old';
-import {getIsHydrating} from './ReactFiberHydrationContext.old';
+import {
+  warnOnHydrationMismatch,
+  getIsHydrating,
+} from './ReactFiberHydrationContext.old';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
@@ -499,6 +502,18 @@ function throwException(
           // Set a flag to indicate that we should try rendering the normal
           // children again, not the fallback.
           suspenseBoundary.flags |= ForceClientRender;
+          if (__DEV__) {
+            if (
+              value &&
+              value.message &&
+              value.message.startsWith instanceof Function &&
+              (value.message.startsWith: any)(
+                'An error occurred during hydration',
+              )
+            ) {
+              warnOnHydrationMismatch(sourceFiber);
+            }
+          }
         }
         markSuspenseBoundaryShouldCapture(
           suspenseBoundary,

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -189,3 +189,4 @@ export const didNotFindHydratableTextInstance =
 export const didNotFindHydratableSuspenseInstance =
   $$$hostConfig.didNotFindHydratableSuspenseInstance;
 export const errorHydratingContainer = $$$hostConfig.errorHydratingContainer;
+export const warnOnHydrationMismatch = $$$hostConfig.warnOnHydrationMismatch;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This warning makes it a lot easier to identify where exactly a hydration mismatch occurs. It looks like this:

```
An error occurred during hydration. expected article got DIV. At: [object HTMLDivElement] Inside: [object HTMLDivElement]
```

I opted to log the HTML element object itself rather than stringifying it to make it much easier for developers to identify where exactly the mismatch is. Otherwise it could still be difficult to identify where it is. Open to any other approaches/suggestions.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

jest

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
