### PR TITLE
Don't warn about concurrently rendering contexts if we finished rendering

### DIFF
--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -141,6 +141,7 @@ export function popProvider(
     } else {
       context._currentValue = currentValue;
     }
+    context._currentRenderer = null;
   } else {
     if (
       enableServerContext &&
@@ -150,6 +151,7 @@ export function popProvider(
     } else {
       context._currentValue2 = currentValue;
     }
+    context._currentRenderer2 = null;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -141,7 +141,9 @@ export function popProvider(
     } else {
       context._currentValue = currentValue;
     }
-    context._currentRenderer = null;
+    if (__DEV__) {
+      context._currentRenderer = null;
+    }
   } else {
     if (
       enableServerContext &&
@@ -151,7 +153,9 @@ export function popProvider(
     } else {
       context._currentValue2 = currentValue;
     }
-    context._currentRenderer2 = null;
+    if (__DEV__) {
+      context._currentRenderer2 = null;
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -49,6 +49,15 @@ import {REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED} from 'shared/ReactSymbols
 
 const valueCursor: StackCursor<mixed> = createCursor(null);
 
+let rendererCursorDEV: StackCursor<Object | null>;
+if (__DEV__) {
+  rendererCursorDEV = createCursor(null);
+}
+let renderer2CursorDEV: StackCursor<Object | null>;
+if (__DEV__) {
+  renderer2CursorDEV = createCursor(null);
+}
+
 let rendererSigil;
 if (__DEV__) {
   // Use this to detect multiple renderers using the same context
@@ -94,6 +103,8 @@ export function pushProvider<T>(
 
     context._currentValue = nextValue;
     if (__DEV__) {
+      push(rendererCursorDEV, context._currentRenderer, providerFiber);
+
       if (
         context._currentRenderer !== undefined &&
         context._currentRenderer !== null &&
@@ -111,6 +122,8 @@ export function pushProvider<T>(
 
     context._currentValue2 = nextValue;
     if (__DEV__) {
+      push(renderer2CursorDEV, context._currentRenderer2, providerFiber);
+
       if (
         context._currentRenderer2 !== undefined &&
         context._currentRenderer2 !== null &&
@@ -131,7 +144,7 @@ export function popProvider(
   providerFiber: Fiber,
 ): void {
   const currentValue = valueCursor.current;
-  pop(valueCursor, providerFiber);
+
   if (isPrimaryRenderer) {
     if (
       enableServerContext &&
@@ -142,7 +155,9 @@ export function popProvider(
       context._currentValue = currentValue;
     }
     if (__DEV__) {
-      context._currentRenderer = null;
+      const currentRenderer = rendererCursorDEV.current;
+      pop(rendererCursorDEV, providerFiber);
+      context._currentRenderer = currentRenderer;
     }
   } else {
     if (
@@ -154,9 +169,13 @@ export function popProvider(
       context._currentValue2 = currentValue;
     }
     if (__DEV__) {
-      context._currentRenderer2 = null;
+      const currentRenderer2 = renderer2CursorDEV.current;
+      pop(renderer2CursorDEV, providerFiber);
+      context._currentRenderer2 = currentRenderer2;
     }
   }
+
+  pop(valueCursor, providerFiber);
 }
 
 export function scheduleContextWorkOnParentPath(

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -874,7 +874,7 @@ describe('ReactNewContext', () => {
       }
     });
 
-    it('warns not if multiple renderers finished rendering the same context', () => {
+    it('does not warn if multiple renderers use the same context sequentially', () => {
       spyOnDev(console, 'error');
       const Context = React.createContext(0);
 

--- a/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNewContext-test.js
@@ -874,6 +874,48 @@ describe('ReactNewContext', () => {
       }
     });
 
+    it('warns not if multiple renderers finished rendering the same context', () => {
+      spyOnDev(console, 'error');
+      const Context = React.createContext(0);
+
+      function Foo(props) {
+        Scheduler.unstable_yieldValue('Foo');
+        return null;
+      }
+
+      function App(props) {
+        return (
+          <Context.Provider value={props.value}>
+            <Foo />
+            <Foo />
+          </Context.Provider>
+        );
+      }
+
+      if (gate(flags => flags.enableSyncDefaultUpdates)) {
+        React.startTransition(() => {
+          ReactNoop.render(<App value={1} />);
+        });
+      } else {
+        ReactNoop.render(<App value={1} />);
+      }
+      expect(Scheduler).toFlushAndYield(['Foo', 'Foo']);
+
+      // Get a new copy of ReactNoop
+      jest.resetModules();
+      React = require('react');
+      ReactNoop = require('react-noop-renderer');
+      Scheduler = require('scheduler');
+
+      // Render the provider again using a different renderer
+      ReactNoop.render(<App value={1} />);
+      expect(Scheduler).toFlushAndYield(['Foo', 'Foo']);
+
+      if (__DEV__) {
+        expect(console.error).not.toHaveBeenCalled();
+      }
+    });
+
     it('provider bails out if children and value are unchanged (like sCU)', () => {
       const Context = React.createContext(0);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/22796

## How did you test this change?

- yarn test ReactFiberNewContext
- [x] CI
- ~[ ] codesandbox of linked issue~ Can't test codesandbox since `react-test-renderer` isn't built by Codesandbox CI. Though I tested it locally by adding `context._currentRenderer2 = null;` to `popProvider` in `react-test-renderer.development.js`.
