### PR TITLE
[rfc] Insert empty text node during hydration

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -2958,4 +2958,44 @@ describe('ReactDOMServerPartialHydration', () => {
     expect(ref.current).toBe(span);
     expect(ref.current.innerHTML).toBe('Hidden child');
   });
+
+  function itHydratesWithoutMismatch(msg, App) {
+    it(msg + ' without mismatch', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const finalHTML = ReactDOMServer.renderToString(<App />);
+      container.innerHTML = finalHTML;
+
+      ReactDOM.hydrateRoot(container, <App />);
+      Scheduler.unstable_flushAll();
+    });
+  }
+
+  itHydratesWithoutMismatch('can hydrate empty string ', function App() {
+    return (
+      <div>
+        <div id="test">Test</div>
+        {'' && <div>Test</div>}
+        <div>Test</div>
+      </div>
+    );
+  });
+
+  itHydratesWithoutMismatch('can hydrate empty string simple', function App() {
+    return '';
+  });
+  itHydratesWithoutMismatch('can hydrate empty string simple', function App() {
+    return (
+      <>
+        {''}
+        {'sup'}
+      </>
+    );
+  });
+  itHydratesWithoutMismatch(
+    'can hydrate empty string without mismatch simple 2',
+    function App() {
+      return <Suspense>{'' && false}</Suspense>;
+    },
+  );
 });

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -692,12 +692,31 @@ export function canHydrateTextInstance(
   instance: HydratableInstance,
   text: string,
 ): null | TextInstance {
-  if (text === '' || instance.nodeType !== TEXT_NODE) {
-    // Empty strings are not parsed by HTML so there won't be a correct match here.
+  if (
+    (instance.textContent !== '' && text === '') ||
+    instance.nodeType !== TEXT_NODE
+  ) {
     return null;
   }
   // This has now been refined to a text node.
   return ((instance: any): TextInstance);
+}
+
+export function insertMissingEmptyTextNode(
+  instance: null | HydratableInstance,
+  parent: null | HydratableInstance,
+): null | HydratableInstance {
+  const parentNode = instance ? instance.parentNode : parent;
+  if (parentNode) {
+    const textNode = document.createTextNode('');
+    if (instance) {
+      parentNode.insertBefore(textNode, instance);
+    } else {
+      parentNode.appendChild(textNode);
+    }
+    return (textNode: TextInstance);
+  }
+  return null;
 }
 
 export function canHydrateSuspenseInstance(

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
@@ -23,6 +23,7 @@ export type SuspenseInstance = mixed;
 export const supportsHydration = false;
 export const canHydrateInstance = shim;
 export const canHydrateTextInstance = shim;
+export const insertMissingEmptyTextNode = shim;
 export const canHydrateSuspenseInstance = shim;
 export const isSuspenseInstancePending = shim;
 export const isSuspenseInstanceFallback = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -134,6 +134,8 @@ export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
 // -------------------
 export const canHydrateInstance = $$$hostConfig.canHydrateInstance;
 export const canHydrateTextInstance = $$$hostConfig.canHydrateTextInstance;
+export const insertMissingEmptyTextNode =
+  $$$hostConfig.insertMissingEmptyTextNode;
 export const canHydrateSuspenseInstance =
   $$$hostConfig.canHydrateSuspenseInstance;
 export const isSuspenseInstancePending =


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

When we server render an empty string from the server the browser does not create a text node for the empty string. This leads to a hydration mismatch. Since #22629 we now throw on mismatches and fallback to client render. This causes empty strings to always lead to client rendering #22784. This diff adds logic in hydration to insert an empty text node if there isn't one already when processing a fiber for an empty string text node. If we do another pass and see the empty text node again then it should be there already so we use the previously created one.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

jest

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
