### PR TITLE
Warn on setState inside insertionEffect

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -157,6 +157,7 @@ import {
   markComponentLayoutEffectUnmountStopped,
 } from './SchedulingProfiler';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.new';
+import {setInsideInsertionEffectDEV} from './ReactFiberHooks.new';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -567,6 +568,12 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
           }
         }
 
+        if (__DEV__) {
+          if ((effect.tag & HookInsertion) !== NoHookEffect) {
+            setInsideInsertionEffectDEV(true);
+          }
+        }
+
         // Mount
         const create = effect.create;
         effect.destroy = create();
@@ -580,6 +587,9 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
         }
 
         if (__DEV__) {
+          if ((effect.tag & HookInsertion) !== NoHookEffect) {
+            setInsideInsertionEffectDEV(false);
+          }
           const destroy = effect.destroy;
           if (destroy !== undefined && typeof destroy !== 'function') {
             let hookName;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -568,12 +568,6 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
           }
         }
 
-        if (__DEV__) {
-          if ((effect.tag & HookInsertion) !== NoHookEffect) {
-            setInsideInsertionEffectDEV(true);
-          }
-        }
-
         // Mount
         const create = effect.create;
         effect.destroy = create();
@@ -587,9 +581,6 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
         }
 
         if (__DEV__) {
-          if ((effect.tag & HookInsertion) !== NoHookEffect) {
-            setInsideInsertionEffectDEV(false);
-          }
           const destroy = effect.destroy;
           if (destroy !== undefined && typeof destroy !== 'function') {
             let hookName;
@@ -1838,7 +1829,13 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           finishedWork,
           finishedWork.return,
         );
+        if (__DEV__) {
+          setInsideInsertionEffectDEV(true);
+        }
         commitHookEffectListMount(HookInsertion | HookHasEffect, finishedWork);
+        if (__DEV__) {
+          setInsideInsertionEffectDEV(false);
+        }
 
         // Layout effects are destroyed during the mutation phase so that all
         // destroy functions for all fibers are called before any create functions.
@@ -1917,7 +1914,13 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         finishedWork,
         finishedWork.return,
       );
+      if (__DEV__) {
+        setInsideInsertionEffectDEV(true);
+      }
       commitHookEffectListMount(HookInsertion | HookHasEffect, finishedWork);
+      if (__DEV__) {
+        setInsideInsertionEffectDEV(false);
+      }
       // Layout effects are destroyed during the mutation phase so that all
       // destroy functions for all fibers are called before any create functions.
       // This prevents sibling component effects from interfering with each other,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -157,6 +157,7 @@ import {
   markComponentLayoutEffectUnmountStopped,
 } from './SchedulingProfiler';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.old';
+import {setInsideInsertionEffectDEV} from './ReactFiberHooks.old';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -567,6 +568,12 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
           }
         }
 
+        if (__DEV__) {
+          if ((effect.tag & HookInsertion) !== NoHookEffect) {
+            setInsideInsertionEffectDEV(true);
+          }
+        }
+
         // Mount
         const create = effect.create;
         effect.destroy = create();
@@ -580,6 +587,9 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
         }
 
         if (__DEV__) {
+          if ((effect.tag & HookInsertion) !== NoHookEffect) {
+            setInsideInsertionEffectDEV(false);
+          }
           const destroy = effect.destroy;
           if (destroy !== undefined && typeof destroy !== 'function') {
             let hookName;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -568,12 +568,6 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
           }
         }
 
-        if (__DEV__) {
-          if ((effect.tag & HookInsertion) !== NoHookEffect) {
-            setInsideInsertionEffectDEV(true);
-          }
-        }
-
         // Mount
         const create = effect.create;
         effect.destroy = create();
@@ -587,9 +581,6 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
         }
 
         if (__DEV__) {
-          if ((effect.tag & HookInsertion) !== NoHookEffect) {
-            setInsideInsertionEffectDEV(false);
-          }
           const destroy = effect.destroy;
           if (destroy !== undefined && typeof destroy !== 'function') {
             let hookName;
@@ -1838,7 +1829,13 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
           finishedWork,
           finishedWork.return,
         );
+        if (__DEV__) {
+          setInsideInsertionEffectDEV(true);
+        }
         commitHookEffectListMount(HookInsertion | HookHasEffect, finishedWork);
+        if (__DEV__) {
+          setInsideInsertionEffectDEV(false);
+        }
 
         // Layout effects are destroyed during the mutation phase so that all
         // destroy functions for all fibers are called before any create functions.
@@ -1917,7 +1914,13 @@ function commitWork(current: Fiber | null, finishedWork: Fiber): void {
         finishedWork,
         finishedWork.return,
       );
+      if (__DEV__) {
+        setInsideInsertionEffectDEV(true);
+      }
       commitHookEffectListMount(HookInsertion | HookHasEffect, finishedWork);
+      if (__DEV__) {
+        setInsideInsertionEffectDEV(false);
+      }
       // Layout effects are destroyed during the mutation phase so that all
       // destroy functions for all fibers are called before any create functions.
       // This prevents sibling component effects from interfering with each other,

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -2191,7 +2191,7 @@ function dispatchSetState<S, A>(
       !didWarnSetStateInsideInsertionEffect.has(componentName)
     ) {
       didWarnSetStateInsideInsertionEffect.add(componentName);
-      console.warn(
+      console.error(
         'Unsafe setState inside useInsertionEffect in %s',
         componentName,
       );

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -2162,6 +2162,16 @@ function dispatchReducerAction<S, A>(
   markUpdateInDevTools(fiber, lane, action);
 }
 
+let didWarnSetStateInsideInsertionEffect;
+let devInsideInsertionEffect;
+if (__DEV__) {
+  didWarnSetStateInsideInsertionEffect = new Set();
+}
+export function setInsideInsertionEffectDEV(isInside: boolean) {
+  if (__DEV__) {
+    devInsideInsertionEffect = isInside;
+  }
+}
 function dispatchSetState<S, A>(
   fiber: Fiber,
   queue: UpdateQueue<S, A>,
@@ -2173,6 +2183,17 @@ function dispatchSetState<S, A>(
         "State updates from the useState() and useReducer() Hooks don't support the " +
           'second callback argument. To execute a side effect after ' +
           'rendering, declare it in the component body with useEffect().',
+      );
+    }
+    const componentName = getComponentNameFromFiber(fiber);
+    if (
+      devInsideInsertionEffect &&
+      !didWarnSetStateInsideInsertionEffect.has(componentName)
+    ) {
+      didWarnSetStateInsideInsertionEffect.add(componentName);
+      console.warn(
+        'Unsafe setState inside useInsertionEffect in %s',
+        componentName,
       );
     }
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -2191,7 +2191,7 @@ function dispatchSetState<S, A>(
       !didWarnSetStateInsideInsertionEffect.has(componentName)
     ) {
       didWarnSetStateInsideInsertionEffect.add(componentName);
-      console.warn(
+      console.error(
         'Unsafe setState inside useInsertionEffect in %s',
         componentName,
       );

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -2162,6 +2162,16 @@ function dispatchReducerAction<S, A>(
   markUpdateInDevTools(fiber, lane, action);
 }
 
+let didWarnSetStateInsideInsertionEffect;
+let devInsideInsertionEffect;
+if (__DEV__) {
+  didWarnSetStateInsideInsertionEffect = new Set();
+}
+export function setInsideInsertionEffectDEV(isInside: boolean) {
+  if (__DEV__) {
+    devInsideInsertionEffect = isInside;
+  }
+}
 function dispatchSetState<S, A>(
   fiber: Fiber,
   queue: UpdateQueue<S, A>,
@@ -2173,6 +2183,17 @@ function dispatchSetState<S, A>(
         "State updates from the useState() and useReducer() Hooks don't support the " +
           'second callback argument. To execute a side effect after ' +
           'rendering, declare it in the component body with useEffect().',
+      );
+    }
+    const componentName = getComponentNameFromFiber(fiber);
+    if (
+      devInsideInsertionEffect &&
+      !didWarnSetStateInsideInsertionEffect.has(componentName)
+    ) {
+      didWarnSetStateInsideInsertionEffect.add(componentName);
+      console.warn(
+        'Unsafe setState inside useInsertionEffect in %s',
+        componentName,
       );
     }
   }

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -4396,7 +4396,6 @@ describe('ReactHooksWithNoopRenderer', () => {
     function App() {
       const [_, setState] = useState();
       useInsertionEffect(() => {
-        debugger;
         setState('test');
       }, []);
       return <div />;

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -4397,15 +4397,17 @@ describe('ReactHooksWithNoopRenderer', () => {
       const [_, setState] = useState();
       useInsertionEffect(() => {
         setState('test');
+        Scheduler.unstable_yieldValue('useInsertionEffect');
       }, []);
       return <div />;
     }
 
-    const root = ReactNoop.createRoot();
-    expect(async () => {
-      await act(async () => {
-        root.render(<App />);
+    expect(() => {
+      act(() => {
+        ReactNoop.render(<App />);
       });
     }).toWarnDev('Unsafe setState inside useInsertionEffect in App');
+
+    expect(Scheduler).toHaveYielded(['useInsertionEffect']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -4406,7 +4406,7 @@ describe('ReactHooksWithNoopRenderer', () => {
       act(() => {
         ReactNoop.render(<App />);
       });
-    }).toWarnDev('Unsafe setState inside useInsertionEffect in App');
+    }).toErrorDev('Unsafe setState inside useInsertionEffect in App');
 
     expect(Scheduler).toHaveYielded(['useInsertionEffect']);
   });

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -4394,7 +4394,7 @@ describe('ReactHooksWithNoopRenderer', () => {
 
   it('warn on setState inside useInsertionEffect', async () => {
     function App() {
-      const [_, setState] = useState();
+      const setState = useState()[1];
       useInsertionEffect(() => {
         setState('test');
         Scheduler.unstable_yieldValue('useInsertionEffect');

--- a/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooksWithNoopRenderer-test.js
@@ -4391,4 +4391,22 @@ describe('ReactHooksWithNoopRenderer', () => {
 
     expect(Scheduler).toHaveYielded(['Render: 0']);
   });
+
+  it('warn on setState inside useInsertionEffect', async () => {
+    function App() {
+      const [_, setState] = useState();
+      useInsertionEffect(() => {
+        debugger;
+        setState('test');
+      }, []);
+      return <div />;
+    }
+
+    const root = ReactNoop.createRoot();
+    expect(async () => {
+      await act(async () => {
+        root.render(<App />);
+      });
+    }).toWarnDev('Unsafe setState inside useInsertionEffect in App');
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

We want to warn when setState is called from inside useInsertionEffect. Instead useEffect should be used.

## How did you test this change?

Added a jest test

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
