### PR TITLE
Ensure react-is version used for resolution for playwright is installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,6 @@
     "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head || yarn build-combined --type=node react/index react-dom scheduler"
   },
   "resolutions": {
-    "**/@playwright/test/**/react-is": "^16.0.0"
+    "react-is": "npm:react-is"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13629,10 +13629,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     prop-types "^15.6.2"
     scheduler "^0.13.0"
 
-react-is@^16.0.0, react-is@^16.8.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+react-is@^16.8.1, "react-is@npm:react-is":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

In #22790, we added a custom yarn resolution for the `react-is` package so that when we ran React Devtools E2E tests using playwright, we wouldn't incorrectly use the top level version of `react-is` in this repo (which would fail because src code hasn't undergone transpilation), and instead use the actual packaged version from npm.

However, we noticed that when trying to run an internal build of devtools we were running into the following error:

![image](https://user-images.githubusercontent.com/1271509/143052360-349004c2-9129-4955-ad6d-6391510e8b7c.png)

The reason was that the package specified in the `resolutions` wasn't installed at all in the repo for some reason, so yarn couldn't find it.

To fix this, this commit makes it so we always install `react-is` from npm via our `resolutions`, instead of a specific version.

## How did you test this change?

- Locally in `react-devtools-inline`: `yarn test:e2e` works now (tests are running, but they are failing on main currently)
- Internally sync script can correctly build devtools now