### PR TITLE
DevTools: Log version in internal logger

### DIFF
--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -25,6 +25,7 @@ export function registerDevToolsEventLogger(surface: string) {
             event: event,
             context: {
               surface,
+              version: process.env.DEVTOOLS_VERSION,
             },
           },
           '*',


### PR DESCRIPTION
## Summary

Log the version in our internal logger.

## How did you test this change?

- yarn flow
- yarn test-build-devtools
- version is logged correctly

![image](https://user-images.githubusercontent.com/1271509/143333631-09672c33-c290-4548-ae7c-31796fb1a801.png)

