### PR TITLE
Show warning on invalid value for option

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -724,8 +724,13 @@ function pushStartOption(
       }
     }
   }
-  
-  const isAttributeValueRemovable = shouldRemoveAttributeWithWarning('option', value, getPropertyInfo('option'), false);
+
+  const isAttributeValueRemovable = shouldRemoveAttributeWithWarning(
+    'option',
+    value,
+    getPropertyInfo('option'),
+    false,
+  );
   let stringValue;
   if (value !== null && !isAttributeValueRemovable) {
     if (__DEV__) {
@@ -744,9 +749,9 @@ function pushStartOption(
         }
       }
     }
-    stringValue = flattenOptionChildren(children); 
+    stringValue = flattenOptionChildren(children);
   }
-  
+
   if (selectedValue != null && stringValue !== undefined) {
     if (isArray(selectedValue)) {
       // multiple

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -38,6 +38,7 @@ import {
   OVERLOADED_BOOLEAN,
   NUMERIC,
   POSITIVE_NUMERIC,
+  shouldRemoveAttributeWithWarning,
 } from '../shared/DOMProperty';
 import {isUnitlessNumber} from '../shared/CSSProperty';
 
@@ -723,28 +724,30 @@ function pushStartOption(
       }
     }
   }
-
-  if (selectedValue !== null) {
-    let stringValue;
-    if (value !== null) {
-      if (__DEV__) {
-        checkAttributeStringCoercion(value, 'value');
-      }
-      stringValue = '' + value;
-    } else {
-      if (__DEV__) {
-        if (innerHTML !== null) {
-          if (!didWarnInvalidOptionInnerHTML) {
-            didWarnInvalidOptionInnerHTML = true;
-            console.error(
-              'Pass a `value` prop if you set dangerouslyInnerHTML so React knows ' +
-                'which value should be selected.',
-            );
-          }
+  
+  const isAttributeValueRemovable = shouldRemoveAttributeWithWarning('option', value, getPropertyInfo('option'), false);
+  let stringValue;
+  if (value !== null && !isAttributeValueRemovable) {
+    if (__DEV__) {
+      checkAttributeStringCoercion(value, 'value');
+    }
+    stringValue = '' + value;
+  } else {
+    if (__DEV__) {
+      if (innerHTML !== null) {
+        if (!didWarnInvalidOptionInnerHTML) {
+          didWarnInvalidOptionInnerHTML = true;
+          console.error(
+            'Pass a `value` prop if you set dangerouslyInnerHTML so React knows ' +
+              'which value should be selected.',
+          );
         }
       }
-      stringValue = flattenOptionChildren(children);
     }
+    stringValue = flattenOptionChildren(children); 
+  }
+  
+  if (selectedValue != null && stringValue !== undefined) {
     if (isArray(selectedValue)) {
       // multiple
       for (let i = 0; i < selectedValue.length; i++) {


### PR DESCRIPTION
## Summary
Reference: #11734  
if `value= {Symbol | Function}` for an option, we ensure that it is ignored (with a warning displayed in dev) rather than have an error thrown onto the browser. Note that this is specific to SSR.  

The reason why this occurred is because there was an attempt in converting `value` to a string at line 733, which would then throw if the type of `value` was a `symbol` or `function`. So to prevent this from happening, I re-used the function `shouldRemoveAttributeWithWarning` to firstly determine if the value was a `symbol` or `function` (or any other invalid type) before casting this into a string.

## How did you test this change?
I tested this by setting up a simple react component as shown below, and utilised `ReactDOMServer.renderToString` to render the component and sent this to the client (effectively replicating SSR behaviour). 
```
  export default () => {
    return (
      <>
        <label htmlFor="letters">Choose a letter:</label>

        <select>
          <option value={Symbol('test')}>A</option>
          <option value="B">B</option>
          <option value="C">C</option>
          <option value="D">D</option>
        </select>
      </>
    );
  };
```

Behaviour if using Main branch (further debug information that is provided as part of the error message has been omitted):
![image](https://user-images.githubusercontent.com/47930216/143719364-b5e5341c-9c55-494b-9b94-3257d8809f78.png)

Behaviour with my changes:
![image](https://user-images.githubusercontent.com/47930216/143718624-1e828a35-389e-40bd-8973-9f2ea5a11f8c.png)

Note that I did attempt to write a test (via the file `ReactDOMServerIntegrationSelect-test`) to confirm that the html option object's `value` property is empty if the developer specifies a `symbol` or `function` type. However, although this test would pass for client-side rendered html elements, this does not pass if rendered server side (even though no `value` attribute is explicitly attached to the option element). If rendered server-side and if the option's `value` attribute is queried, it looks like the option element will implicitly return its child text element if its `value` attribute is empty. So going with the markup above as an example, querying the value for the first option element will return "A" if rendered server side. This does bring to light some very subtle differences in behaviour both server and client-side that I'm not too sure is worth addressing in this PR.

Here's the test that I wrote below just as an FYI:

```
 itRenders(
    'a select option with no value if the initial value was a symbol type',
    async render => {
      const e = await render(
        <select readOnly={true}>
          <option value={Symbol('test')}>A</option>
        </select>,
        1
      );
      const option = e.options[0];
      expect(option.value).toBe('');
    }
```

