### PR TITLE
Decouple dispatching from attemptToDispatchEvent

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -186,7 +186,7 @@ export function dispatchEvent(
     targetContainer,
     nativeEvent,
   );
-  if (return_shouldDispatch) {
+  if (blockedOn === null) {
     dispatchEventForPluginEventSystem(
       domEventName,
       eventSystemFlags,
@@ -194,9 +194,6 @@ export function dispatchEvent(
       return_targetInst,
       targetContainer,
     );
-  }
-  if (blockedOn === null) {
-    // We successfully dispatched this event.
     if (allowReplay) {
       clearIfContinuousEvent(domEventName, nativeEvent);
     }
@@ -250,7 +247,7 @@ export function dispatchEvent(
         targetContainer,
         nativeEvent,
       );
-      if (return_shouldDispatch) {
+      if (nextBlockedOn === null) {
         dispatchEventForPluginEventSystem(
           domEventName,
           eventSystemFlags,
@@ -281,21 +278,19 @@ export function dispatchEvent(
   );
 }
 
-export let return_shouldDispatch = false;
 export let return_targetInst = null;
 
 // Returns a SuspenseInstance or Container if it's blocked.
-// The two fields above are conceptually part of the return value.
+// The return_targetInst field above is conceptually part of the return value.
 export function findInstanceBlockingEvent(
   domEventName: DOMEventName,
   eventSystemFlags: EventSystemFlags,
   targetContainer: EventTarget,
   nativeEvent: AnyNativeEvent,
 ): null | Container | SuspenseInstance {
-  return_shouldDispatch = false;
-  return_targetInst = null;
-
   // TODO: Warn if _enabled is false.
+
+  return_targetInst = null;
 
   const nativeEventTarget = getEventTarget(nativeEvent);
   let targetInst = getClosestInstanceFromNode(nativeEventTarget);
@@ -338,7 +333,6 @@ export function findInstanceBlockingEvent(
     }
   }
   return_targetInst = targetInst;
-  return_shouldDispatch = true;
   // We're not blocked on anything.
   return null;
 }

--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -30,7 +30,6 @@ import {
 import {
   findInstanceBlockingEvent,
   return_targetInst,
-  return_shouldDispatch,
 } from './ReactDOMEventListener';
 import {dispatchEventForPluginEventSystem} from './DOMPluginEventSystem';
 import {
@@ -473,7 +472,7 @@ function attemptReplayContinuousQueuedEvent(
       targetContainer,
       queuedEvent.nativeEvent,
     );
-    if (return_shouldDispatch) {
+    if (nextBlockedOn === null) {
       dispatchEventForPluginEventSystem(
         queuedEvent.domEventName,
         queuedEvent.eventSystemFlags,
@@ -481,8 +480,7 @@ function attemptReplayContinuousQueuedEvent(
         return_targetInst,
         targetContainer,
       );
-    }
-    if (nextBlockedOn !== null) {
+    } else {
       // We're still blocked. Try again later.
       const fiber = getInstanceFromNode(nextBlockedOn);
       if (fiber !== null) {
@@ -532,7 +530,7 @@ function replayUnblockedEvents() {
           targetContainer,
           nextDiscreteEvent.nativeEvent,
         );
-        if (return_shouldDispatch) {
+        if (nextBlockedOn === null) {
           dispatchEventForPluginEventSystem(
             nextDiscreteEvent.domEventName,
             nextDiscreteEvent.eventSystemFlags,
@@ -540,8 +538,7 @@ function replayUnblockedEvents() {
             return_targetInst,
             targetContainer,
           );
-        }
-        if (nextBlockedOn !== null) {
+        } else {
           // We're still blocked. Try again later.
           nextDiscreteEvent.blockedOn = nextBlockedOn;
           break;


### PR DESCRIPTION
**Purely refactoring, no functional changes.**

We need to split up dispatching from finding the blocked instance, so that we can apply different logic in each case (e.g. replay instead of dispatching through the event system). In #22680 we tried to do this via a special return type, but it's really noisy and I find it difficult to verify the existing behavior is intact. This is an alternative proposal, where we just use a few fields as makeshift "return values" to avoid allocating. I think I've seen this somewhere in the code. (I mean, we could also just use a tuple but idk if this is controversial for some reason.)

If we land this I think we can make #22680 simpler and more self-contained.