### PR TITLE
Added E2E test for ParseHookNames

### DIFF
--- a/packages/react-devtools-inline/__tests__/__e2e__/inspecting-props.test.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/inspecting-props.test.js
@@ -4,15 +4,22 @@ const {test, expect} = require('@playwright/test');
 const config = require('../../playwright.config');
 test.use(config);
 
-test.describe('Testing Todo-List App', () => {
+test.describe.serial('Testing Todo-List App', () => {
   let page, frameElementHandle, frame;
+  const inspectButtonSelector = '[class^=ToggleContent]';
   test.beforeAll(async ({browser}) => {
-    page = await browser.newPage();
+    const context = await browser.newContext();
+    page = await context.newPage();
+    // page = await browser.newPage();
     await page.goto('http://localhost:8080/', {waitUntil: 'domcontentloaded'});
     await page.waitForSelector('iframe#target');
     frameElementHandle = await page.$('#target');
     frame = await frameElementHandle.contentFrame();
   });
+
+  // test.afterAll(async ({ browser }) => {
+  //   await browser.close();
+  // });
 
   test('The Todo List should contain 3 items by default', async () => {
     const list = frame.locator('.listitem');
@@ -40,9 +47,9 @@ test.describe('Testing Todo-List App', () => {
     // click on the list item to quickly navigate to the list item component in devtools
     // comparing displayed props with the array of props.
     for (let i = 1; i <= countOfItems; ++i) {
-      await page.click('[class^=ToggleContent]', {delay: 100});
+      await page.click(inspectButtonSelector, {delay: 100});
       await frame.click(`.listitem:nth-child(${i})`, {delay: 50});
-      await page.waitForSelector('span.Value___tNzum');
+      await page.waitForSelector('span[class^=Value]');
       const text = await page.innerText('span[class^=Value]');
       await expect(text).toEqual(listItemsProps[i]);
     }

--- a/packages/react-devtools-inline/__tests__/__e2e__/inspecting-props.test.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/inspecting-props.test.js
@@ -4,22 +4,21 @@ const {test, expect} = require('@playwright/test');
 const config = require('../../playwright.config');
 test.use(config);
 
-test.describe.serial('Testing Todo-List App', () => {
-  let page, frameElementHandle, frame;
+test.describe('Testing Todo-List App', () => {
+  let page, frameElementHandle, frame, context;
   const inspectButtonSelector = '[class^=ToggleContent]';
   test.beforeAll(async ({browser}) => {
-    const context = await browser.newContext();
+    context = await browser.newContext();
     page = await context.newPage();
-    // page = await browser.newPage();
     await page.goto('http://localhost:8080/', {waitUntil: 'domcontentloaded'});
     await page.waitForSelector('iframe#target');
     frameElementHandle = await page.$('#target');
     frame = await frameElementHandle.contentFrame();
   });
 
-  // test.afterAll(async ({ browser }) => {
-  //   await browser.close();
-  // });
+  test.afterAll(async () => {
+    context.close();
+  });
 
   test('The Todo List should contain 3 items by default', async () => {
     const list = frame.locator('.listitem');

--- a/packages/react-devtools-inline/__tests__/__e2e__/parse-hooks.test.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/parse-hooks.test.js
@@ -4,15 +4,34 @@ const {test, expect} = require('@playwright/test');
 const config = require('../../playwright.config');
 test.use(config);
 
-test.describe('Parsing Hook Names from React Components', () => {
+test.describe.serial('Parsing Hook Names from React Components', () => {
   let page, frameElementHandle, frame;
+  const inspectButtonSelector = '[class^=ToggleContent]';
+  const parseHookNamesSelector = 'button[class^=ToggleOff].null';
   test.beforeAll(async ({browser}) => {
-    page = await browser.newPage();
+    const context = await browser.newContext();
+    page = await context.newPage();
+    // page = await browser.newPage();
     await page.goto('http://localhost:8080/', {waitUntil: 'domcontentloaded'});
     await page.waitForSelector('iframe#target');
     frameElementHandle = await page.$('#target');
     frame = await frameElementHandle.contentFrame();
   });
+
+  // test.afterAll(async ({ browser }) => {
+  //   await browser.close();
+  // });
+
+  const extractHookNames = async selector => {
+    await page.click(inspectButtonSelector, {delay: 100});
+    await frame.click(selector);
+    await page.click(parseHookNamesSelector);
+    await page.waitForSelector('span[class^=HookName]');
+    const extractedHooks = await page.$$eval('span[class^=HookName]', Hooks =>
+      Hooks.map(Hook => Hook.textContent)
+    );
+    return extractedHooks;
+  };
   test('Parse Hooks in ToDo List', async () => {
     const ToDoListHooks = [
       '(newItemText)',
@@ -22,13 +41,43 @@ test.describe('Parsing Hook Names from React Components', () => {
       '(handleKeyPress)',
       '(handleChange)',
       '(removeItem)',
-      '(toggleItem)'
+      '(toggleItem)',
     ];
-    await page.click('[class^=ToggleContent]', {delay: 100});
-    await frame.click('h1:has-text("List")');
-    await page.click('button[class^=ToggleOff].null');
-    await page.waitForSelector('span[class^=HookName]');
-    const devToolsHooks = await page.$$eval('span[class^=HookName]',Hooks => Hooks.map(Hook => Hook.textContent))
-    expect(devToolsHooks).toEqual(ToDoListHooks);
+    const devtoolsHooks = await extractHookNames('h1:has-text("List")');
+    expect(devtoolsHooks).toEqual(ToDoListHooks);
   });
-})
+
+  test.describe('Parse Hook Names in CustomHooks Component', () => {
+    const customHooks = [
+      '(count)',
+      '(contextValueA)',
+      '(_)',
+      '(debouncedCount)',
+      '(debouncedValue)',
+      '(onClick)',
+      '(contextValueB)',
+    ];
+
+    test('Parse Hooks in CustomHooks', async () => {
+      const devToolsHooks = await extractHookNames('#customHooksButton');
+      expect(devToolsHooks).toEqual(customHooks);
+    });
+
+    test('Parse Hooks in CustomHooks with Memo', async () => {
+      const devToolsHooks = await extractHookNames('#customHooksButtonMemo');
+      expect(devToolsHooks).toEqual(customHooks);
+    });
+
+    test('Parse Hooks in CustomHooks with ForwardRefs', async () => {
+      const devToolsHooks = await extractHookNames(
+        '#customHooksButtonForwardRef'
+      );
+      expect(devToolsHooks).toEqual(customHooks);
+    });
+
+    test('Parse Hooks in CustomHooks with Hoc', async () => {
+      const devToolsHooks = await extractHookNames('#customHooksButtonwithHoc');
+      expect(devToolsHooks).toEqual(customHooks);
+    });
+  });
+});

--- a/packages/react-devtools-inline/__tests__/__e2e__/parse-hooks.test.js
+++ b/packages/react-devtools-inline/__tests__/__e2e__/parse-hooks.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const {test, expect} = require('@playwright/test');
+const config = require('../../playwright.config');
+test.use(config);
+
+test.describe('Parsing Hook Names from React Components', () => {
+  let page, frameElementHandle, frame;
+  test.beforeAll(async ({browser}) => {
+    page = await browser.newPage();
+    await page.goto('http://localhost:8080/', {waitUntil: 'domcontentloaded'});
+    await page.waitForSelector('iframe#target');
+    frameElementHandle = await page.$('#target');
+    frame = await frameElementHandle.contentFrame();
+  });
+  test('Parse Hooks in ToDo List', async () => {
+    const ToDoListHooks = [
+      '(newItemText)',
+      '(items)',
+      '(uid)',
+      '(handleClick)',
+      '(handleKeyPress)',
+      '(handleChange)',
+      '(removeItem)',
+      '(toggleItem)'
+    ];
+    await page.click('[class^=ToggleContent]', {delay: 100});
+    await frame.click('h1:has-text("List")');
+    await page.click('button[class^=ToggleOff].null');
+    await page.waitForSelector('span[class^=HookName]');
+    const devToolsHooks = await page.$$eval('span[class^=HookName]',Hooks => Hooks.map(Hook => Hook.textContent))
+    expect(devToolsHooks).toEqual(ToDoListHooks);
+  });
+})

--- a/packages/react-devtools-inline/playwright.config.js
+++ b/packages/react-devtools-inline/playwright.config.js
@@ -6,6 +6,7 @@ const config = {
       slowMo: 100,
     },
   },
+  workers: 1,
 };
 
 module.exports = config;

--- a/packages/react-devtools-inline/playwright.config.js
+++ b/packages/react-devtools-inline/playwright.config.js
@@ -5,6 +5,7 @@ const config = {
     launchOptions: {
       slowMo: 100,
     },
+    viewport: {width: 1000, height: 600},
   },
   workers: 1,
 };

--- a/packages/react-devtools-shell/src/app/EditableProps/index.js
+++ b/packages/react-devtools-shell/src/app/EditableProps/index.js
@@ -48,7 +48,7 @@ function StatefulFunction({name}: StatefulFunctionProps) {
   );
 
   return (
-    <ul>
+    <ul id={'StatefulFunction'}>
       <li>Name: {name}</li>
       <li>
         <button onClick={handleUpdateCountClick}>

--- a/packages/react-devtools-shell/src/app/Hydration/index.js
+++ b/packages/react-devtools-shell/src/app/Hydration/index.js
@@ -140,7 +140,7 @@ function DeepHooks(props: any) {
   const bar = useOuterBar();
   const baz = useOuterBaz();
   return (
-    <ul>
+    <ul id={'DeepHooks'}>
       <li>foo: {foo}</li>
       <li>bar: {bar}</li>
       <li>baz: {baz}</li>

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -70,6 +70,8 @@ const ContextA = createContext('A');
 const ContextB = createContext('B');
 
 function FunctionWithHooks(props: any, ref: React$Ref<any>) {
+  const {id} = props;
+  const componentId = `customHooksButton${id ?? ''}`;
   const [count, updateCount] = useState(0);
   // eslint-disable-next-line no-unused-vars
   const contextValueA = useContext(ContextA);
@@ -98,14 +100,18 @@ function FunctionWithHooks(props: any, ref: React$Ref<any>) {
   // Verify deep nesting doesn't break
   useDeepHookA();
 
-  return <button onClick={onClick}>Count: {debouncedCount}</button>;
+  return (
+    <button id={componentId} onClick={onClick}>
+      Count: {debouncedCount}
+    </button>
+  );
 }
 const MemoWithHooks = memo(FunctionWithHooks);
 const ForwardRefWithHooks = forwardRef(FunctionWithHooks);
 
 function wrapWithHoc(Component) {
   function Hoc() {
-    return <Component />;
+    return <Component id="withHoc" />;
   }
   // $FlowFixMe
   const displayName = Component.displayName || Component.name;
@@ -118,8 +124,8 @@ export default function CustomHooks() {
   return (
     <Fragment>
       <FunctionWithHooks />
-      <MemoWithHooks />
-      <ForwardRefWithHooks />
+      <MemoWithHooks id="Memo" />
+      <ForwardRefWithHooks id="ForwardRef" />
       <HocWithHooks />
     </Fragment>
   );


### PR DESCRIPTION
## Summary
Adding an E2E test for the parseHooksNames feature.
Linked Issue #22646 

## What the test is trying to do? 
Added tests for every component which have hooks.
How it works:
 - Goes to the components through inspecting in dev tools.
 - Clicks on parse hooks names toggle and wait for parsing to complete.
 - Validates the hook names with predefined hooks array.

## How did you test this change?
Ran `yarn test:e2e` and all tests are passing.

## What changes have you done till now?
- Fixed problem of previous test breaking randomly on hashed selectors.
- Refactored the code for previous tests.
- Improved Code quality
- Added test for every Hook component
- Assigned IDs to various components accordingly to make it easier for writing tests.
- Solved problem of tests running simultaneously now they are running sequentially.

## Quick Demo

https://user-images.githubusercontent.com/51379307/145072517-e4da36f6-be9f-4ae9-a878-fbe8111d819b.mp4


