### PR TITLE
Don't override use-sync-external-store peerDeps

### DIFF
--- a/packages/use-sync-external-store/package.json
+++ b/packages/use-sync-external-store/package.json
@@ -20,6 +20,6 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0-rc"
   }
 }

--- a/scripts/release/publish-commands/parse-params.js
+++ b/scripts/release/publish-commands/parse-params.js
@@ -45,6 +45,7 @@ module.exports = () => {
       case 'experimental':
       case 'alpha':
       case 'beta':
+      case 'rc':
       case 'untagged':
         break;
       default:

--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -243,6 +243,13 @@ function updatePackageVersions(
         }
       }
       if (packageInfo.peerDependencies) {
+        if (!pinToExactVersion && moduleName === 'use-sync-external-store') {
+          // use-sync-external-store supports older versions of React, too, so
+          // we don't override to the latest version. We should figure out some
+          // better way to handle this.
+          // TODO: Remove this special case.
+          continue;
+        }
         for (const dep of Object.keys(packageInfo.peerDependencies)) {
           const depVersion = versionsMap.get(dep);
           if (depVersion !== undefined) {


### PR DESCRIPTION
Usually the build script updates transitive React dependencies so that they refer to the corresponding release version.

For use-sync-external-store, though, we also want to support older versions of React, too. So the normal behavior of the build script isn't sufficient.

For now, to unblock, I hardcoded a special case, but we should consider a better way to handle this in the future.