### PR TITLE
Fix misleading comment in ReactFlushSync test file

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -92,7 +92,7 @@ describe('ReactFlushSync', () => {
           // startTransition is closer.
           setState(1);
           ReactNoop.flushSync(() => {
-            // This should be async even though startTransition is on the stack,
+            // This should be sync even though startTransition is on the stack,
             // because flushSync is closer.
             setSyncState(1);
           });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

I am studying React v18 by [comparing the tests](https://github.com/dtinth/react-tests/blob/main/reports/v17.0.2_VS_v18.0.0-rc.0.md) (because I haven’t followed all the discussion) and I spotted some comments in the test files that I believe are misleading.

## How did you test this change?

N/A, comment change only.