### PR TITLE
[DevTools] Log errors occurring or reported to the frontend

### DIFF
--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -14,6 +14,12 @@ export type LogEvent =
       +event_name: 'loaded-dev-tools',
     |}
   | {|
+      +event_name: 'error',
+      +error_message: string | null,
+      +error_stack: string | null,
+      +error_component_stack: string | null,
+    |}
+  | {|
       +event_name: 'selected-components-tab',
     |}
   | {|

--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -15,6 +15,7 @@ import SearchingGitHubIssues from './SearchingGitHubIssues';
 import SuspendingErrorView from './SuspendingErrorView';
 import TimeoutView from './TimeoutView';
 import TimeoutError from 'react-devtools-shared/src/TimeoutError';
+import {logEvent} from 'react-devtools-shared/src/Logger';
 
 type Props = {|
   children: React$Node,
@@ -73,6 +74,12 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: any, {componentStack}: any) {
+    logEvent({
+      event_name: 'error',
+      error_message: error.message ?? null,
+      error_stack: error.stack ?? null,
+      error_component_stack: componentStack ?? null,
+    });
     this.setState({
       componentStack,
     });


### PR DESCRIPTION
## Summary

Only for internal builds, logs errors that occur in the frontend, or that are reported to the frotnend and that are captured by our ErrorBoundary

## How did you test this change?

- yarn flow dom
- yarn test-build-devtools
- verified that errors are logged
