### PR TITLE
DevTools: Correctly log errors reported from the store

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
+++ b/packages/react-devtools-shared/src/devtools/views/ErrorBoundary/ErrorBoundary.js
@@ -74,12 +74,7 @@ export default class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: any, {componentStack}: any) {
-    logEvent({
-      event_name: 'error',
-      error_message: error.message ?? null,
-      error_stack: error.stack ?? null,
-      error_component_stack: componentStack ?? null,
-    });
+    this._logError(error, componentStack);
     this.setState({
       componentStack,
     });
@@ -146,6 +141,15 @@ export default class ErrorBoundary extends Component<Props, State> {
     return children;
   }
 
+  _logError = (error: any, componentStack: string | null) => {
+    logEvent({
+      event_name: 'error',
+      error_message: error.message ?? null,
+      error_stack: error.stack ?? null,
+      error_component_stack: componentStack ?? null,
+    });
+  };
+
   _dismissError = () => {
     const onBeforeDismissCallback = this.props.onBeforeDismissCallback;
     if (typeof onBeforeDismissCallback === 'function') {
@@ -157,6 +161,7 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   _onStoreError = (error: Error) => {
     if (!this.state.hasError) {
+      this._logError(error, null);
       this.setState({
         ...ErrorBoundary.getDerivedStateFromError(error),
         canDismiss: true,


### PR DESCRIPTION
## Summary

#22948 added (internal-only) logging to errors caught via `componentDidCatch`, however, this wouldn't account for the case when we handle an error reported from the store, since in that case we are manually setting the error state and that doesn't trigger `componentDidCatch`

In order to fix that, we also log when an error is reported by the store.

## How did you test this change?

Manually throw an error from the store, verify it goes through our logging