### PR TITLE
Remove usage of Array push

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -554,9 +554,9 @@ export function higherPriorityLane(a: Lane, b: Lane) {
 export function createLaneMap<T>(initial: T): LaneMap<T> {
   // Intentionally pushing one by one.
   // https://v8.dev/blog/elements-kinds#avoid-creating-holes
-  const laneMap = [];
+  const laneMap = new Array(TotalLanes);
   for (let i = 0; i < TotalLanes; i++) {
-    laneMap.push(initial);
+    laneMap[i] = initial;
   }
   return laneMap;
 }

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -554,9 +554,9 @@ export function higherPriorityLane(a: Lane, b: Lane) {
 export function createLaneMap<T>(initial: T): LaneMap<T> {
   // Intentionally pushing one by one.
   // https://v8.dev/blog/elements-kinds#avoid-creating-holes
-  const laneMap = [];
+  const laneMap = new Array(TotalLanes);
   for (let i = 0; i < TotalLanes; i++) {
-    laneMap.push(initial);
+    laneMap[i] = initial;
   }
   return laneMap;
 }


### PR DESCRIPTION
## Summary
`new Array()` is faster because Array length is settled.

![WX20211216-133152](https://user-images.githubusercontent.com/49217418/146313902-e05d4e24-07ed-4c0d-865c-27a64f323137.png)
## How did you test this change?
`The changes made have no impact on the functioning of the library.`