### PR TITLE
Remove unnecessary clearContainer call

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -86,7 +86,6 @@ import {
   cancelTimeout,
   noTimeout,
   afterActiveInstanceBlur,
-  clearContainer,
   getCurrentEventPriority,
   supportsMicrotasks,
   errorHydratingContainer,
@@ -885,7 +884,6 @@ function recoverFromConcurrentError(root, errorRetryLanes) {
     if (__DEV__) {
       errorHydratingContainer(root.containerInfo);
     }
-    clearContainer(root.containerInfo);
   }
 
   let exitStatus;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -86,7 +86,6 @@ import {
   cancelTimeout,
   noTimeout,
   afterActiveInstanceBlur,
-  clearContainer,
   getCurrentEventPriority,
   supportsMicrotasks,
   errorHydratingContainer,
@@ -885,7 +884,6 @@ function recoverFromConcurrentError(root, errorRetryLanes) {
     if (__DEV__) {
       errorHydratingContainer(root.containerInfo);
     }
-    clearContainer(root.containerInfo);
   }
 
   let exitStatus;


### PR DESCRIPTION
This was added when we added error recovery for hydration errors. However, when the fix up pass happens later on, it'll still call clearContainer in the commit phase - like any other client root render. So this call is unnecessary.