### PR TITLE
Removed snapshot from `useMutableSource` from function types

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -257,7 +257,7 @@ function useMemo<T>(
 function useMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   // useMutableSource() composes multiple hooks internally.
   // Advance the current hook index the same number of times

--- a/packages/react-dom/src/server/ReactPartialRendererHooks.js
+++ b/packages/react-dom/src/server/ReactPartialRendererHooks.js
@@ -476,7 +476,7 @@ export function useCallback<T>(
 function useMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   resolveCurrentlyRenderingComponent();
   return getSnapshot(source._source);

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -968,7 +968,7 @@ type MutableSourceMemoizedState<Source, Snapshot> = {|
     setSnapshot: Snapshot => void,
   },
   source: MutableSource<any>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 |};
 
 function readFromUnsubscribedMutableSource<Source, Snapshot>(
@@ -1062,7 +1062,7 @@ function useMutableSource<Source, Snapshot>(
   hook: Hook,
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -1227,7 +1227,7 @@ function useMutableSource<Source, Snapshot>(
 function mountMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -1248,7 +1248,7 @@ function mountMutableSource<Source, Snapshot>(
 function updateMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -2624,7 +2624,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       mountHookTypesDev();
@@ -2766,7 +2766,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       updateHookTypesDev();
@@ -2908,7 +2908,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       updateHookTypesDev();
@@ -3050,8 +3050,8 @@ if (__DEV__) {
     },
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
-      getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      getSnapshot: MutableSourceGetSnapshotFn<Source>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       updateHookTypesDev();
@@ -3207,7 +3207,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       warnInvalidHookAccess();
@@ -3365,8 +3365,8 @@ if (__DEV__) {
     },
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
-      getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      getSnapshot: MutableSourceGetSnapshotFn<Source>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       warnInvalidHookAccess();
@@ -3526,7 +3526,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       warnInvalidHookAccess();

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -968,7 +968,7 @@ type MutableSourceMemoizedState<Source, Snapshot> = {|
     setSnapshot: Snapshot => void,
   },
   source: MutableSource<any>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 |};
 
 function readFromUnsubscribedMutableSource<Source, Snapshot>(
@@ -1062,7 +1062,7 @@ function useMutableSource<Source, Snapshot>(
   hook: Hook,
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -1227,7 +1227,7 @@ function useMutableSource<Source, Snapshot>(
 function mountMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -1248,7 +1248,7 @@ function mountMutableSource<Source, Snapshot>(
 function updateMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   if (!enableUseMutableSource) {
     return (undefined: any);
@@ -2624,7 +2624,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       mountHookTypesDev();
@@ -2908,7 +2908,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       updateHookTypesDev();
@@ -3051,7 +3051,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       updateHookTypesDev();
@@ -3207,7 +3207,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       warnInvalidHookAccess();
@@ -3366,7 +3366,7 @@ if (__DEV__) {
     useMutableSource<Source, Snapshot>(
       source: MutableSource<Source>,
       getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-      subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+      subscribe: MutableSourceSubscribeFn<Source>,
     ): Snapshot {
       currentHookNameInDev = 'useMutableSource';
       warnInvalidHookAccess();

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -176,7 +176,7 @@ export function useId(): string {
 export function useMutableSource<Source, Snapshot>(
   source: MutableSource<Source>,
   getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
-  subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
+  subscribe: MutableSourceSubscribeFn<Source>,
 ): Snapshot {
   const dispatcher = resolveDispatcher();
   return dispatcher.useMutableSource(source, getSnapshot, subscribe);

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -110,9 +110,9 @@ export type MutableSourceGetSnapshotFn<
   Snapshot,
 > = (source: Source) => Snapshot;
 
-export type MutableSourceSubscribeFn<Source: $NonMaybeType<mixed>, Snapshot> = (
+export type MutableSourceSubscribeFn<Source: $NonMaybeType<mixed>> = (
   source: Source,
-  callback: (snapshot: Snapshot) => void,
+  callback: () => void,
 ) => () => void;
 
 export type MutableSourceGetVersionFn = (


### PR DESCRIPTION
Currently, the types for the subscribe function passed to useMutableSource indicate that the subscribe callback should receive a Snapshot. However, this snapshot is never actually used.

This PR removes the Snapshot type from the callback, which makes it clearer that it's possible to useMutableSource without passing a snapshot to subscribe callbacks. This is important for library developers, as the requirement for subscribe callbacks to receive a snapshot could significantly change the design of library code.


