### PR TITLE
Fix:Removed unneccesary assignment to Null

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -1391,7 +1391,6 @@ export function cloneChildFibers(
     );
     newChild.return = workInProgress;
   }
-  newChild.sibling = null;
 }
 
 // Reset a workInProgress child set to prepare it for a second pass.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -1391,7 +1391,6 @@ export function cloneChildFibers(
     );
     newChild.return = workInProgress;
   }
-  newChild.sibling = null;
 }
 
 // Reset a workInProgress child set to prepare it for a second pass.


### PR DESCRIPTION
During the first time, the sibling of the fibre must be `null` , so we don't need to assign it further again