### PR TITLE
Update babel-standalone to use createRoot api

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,8 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+      const root = ReactDOM.createRoot(document.getElementById('container'));
+      root.render(<h1>Hello World!</h1>);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
According to the contributing guide 

The easiest way to try your changes is to run yarn build react/index,react-dom/index --type=UMD, and then open fixtures/packaging/babel-standalone/dev.html. This file already uses react.development.js from the build folder so that it will pick up your changes.

But when you open the fixtures/packaging/babel-standalone/dev.html, there will be a **warning**.

<img width="1438" alt="Screenshot 2021-12-20 at 17 57 00" src="https://user-images.githubusercontent.com/45145592/146795899-c03c9df7-7e71-4617-bac3-793e0428da9d.png">


