### PR TITLE
DevTools: Only show StrictMode badge on root elements

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -118,14 +118,9 @@ export default function Element({data, index, style}: Props) {
     type,
   } = ((element: any): ElementType);
 
-  let showStrictModeBadge = isStrictModeNonCompliant;
-  if (depth > 0) {
-    const parent =
-      element.parentID !== null ? store.getElementByID(element.parentID) : null;
-    if (parent !== null && parent.isStrictModeNonCompliant) {
-      showStrictModeBadge = false;
-    }
-  }
+  // Only show strict mode non-compliance badges for top level elements.
+  // Showing an inline badge for every element in the tree would be noisy.
+  const showStrictModeBadge = isStrictModeNonCompliant && depth === 0;
 
   let className = styles.Element;
   if (isSelected) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/Element.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Element.js
@@ -118,6 +118,15 @@ export default function Element({data, index, style}: Props) {
     type,
   } = ((element: any): ElementType);
 
+  let showStrictModeBadge = isStrictModeNonCompliant;
+  if (depth > 0) {
+    const parent =
+      element.parentID !== null ? store.getElementByID(element.parentID) : null;
+    if (parent !== null && parent.isStrictModeNonCompliant) {
+      showStrictModeBadge = false;
+    }
+  }
+
   let className = styles.Element;
   if (isSelected) {
     className = treeFocused
@@ -194,7 +203,7 @@ export default function Element({data, index, style}: Props) {
             }
           />
         )}
-        {isStrictModeNonCompliant && (
+        {showStrictModeBadge && (
           <Icon
             className={
               isSelected && treeFocused


### PR DESCRIPTION
Showing an inline non-compliance badge for every element in the tree is noisy. This commit changes it so that we only show inline icons for root elements (although we continue to show an icon for inspected elements regardless).

### Before
<img width="1035" alt="Screen Shot 2021-12-21 at 12 46 26 PM" src="https://user-images.githubusercontent.com/29597/146975284-b3e2c179-99dd-46a7-ae2e-4e727567fcef.png">

### After
<img width="1035" alt="Screen Shot 2021-12-21 at 12 42 50 PM" src="https://user-images.githubusercontent.com/29597/146975337-7335525e-ae83-4d7d-80cf-ab4cc3da626f.png">