### PR TITLE
Fix:Added missing import

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -11,6 +11,7 @@ import Mode from 'art/modes/current';
 import {TYPES, EVENT_TYPES, childrenAsString} from './ReactARTInternals';
 
 import {DefaultEventPriority} from 'react-reconciler/src/ReactEventPriorities';
+import {Instance} from 'chalk';
 
 const pooledTransform = new Transform();
 


### PR DESCRIPTION
`
export function detachDeletedInstance(node: Instance): void {
  // noop
}`

`instance` was being used without importing