### PR TITLE
Fix: Fixed taking of wrong parameters

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationLegacyContextDisabled-test.internal.js
@@ -108,7 +108,7 @@ describe('ReactDOMServerIntegrationLegacyContextDisabled', () => {
       </LegacyProvider>,
       3,
     );
-    expect(e.textContent).toBe('{}undefinedundefined');
+    expect(e.textContent).toBe('{}undefined');
     expect(lifecycleContextLog).toEqual([]);
   });
 


### PR DESCRIPTION
i think it should be `expect(e.textContent).toBe('{}undefined')` rather than `expect(e.textContent).toBe('{}undefinedundefined');`