### PR TITLE
Fix:Fixed variable names and removed overwritten css property

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.css
@@ -116,7 +116,7 @@
   color: var(--color-button);
 }
 
-.TimlineSearchInputContainer {
+.TimelineSearchInputContainer {
   flex: 1 1;
   display: flex;
   align-items: center;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -125,7 +125,7 @@ function Profiler(_: {||}) {
             {!isLegacyProfilerSelected && (
               <div
                 ref={searchInputContainerRef}
-                className={styles.TimlineSearchInputContainer}
+                className={styles.TimelineSearchInputContainer}
               />
             )}
             <SettingsModalContextToggle />

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarCommitInfo.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarCommitInfo.css
@@ -45,7 +45,6 @@
 .DurationsList {
   list-style: none;
   margin: 0.25rem 0 0 0;
-  padding: 0;
   background: var(--color-background-inactive);
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;

--- a/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/UnsupportedVersionDialog.js
@@ -16,12 +16,12 @@ import {UNSUPPORTED_VERSION_URL} from 'react-devtools-shared/src/constants';
 
 import styles from './UnsupportedVersionDialog.css';
 
-type DAILOG_STATE = 'dialog-not-shown' | 'show-dialog' | 'dialog-shown';
+type DIALOG_STATE = 'dialog-not-shown' | 'show-dialog' | 'dialog-shown';
 
 export default function UnsupportedVersionDialog(_: {||}) {
   const {dispatch} = useContext(ModalDialogContext);
   const store = useContext(StoreContext);
-  const [state, setState] = useState<DAILOG_STATE>('dialog-not-shown');
+  const [state, setState] = useState<DIALOG_STATE>('dialog-not-shown');
 
   useEffect(() => {
     if (state === 'dialog-not-shown') {


### PR DESCRIPTION
there were few files with few typos on variable and types;
`TimlineSearchInputContainer`  ------>  `.TimelineSearchInputContainer `
`DAILOG_STATE`  -----> `DIALOG_STATE`

here in this file-`packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js`
we have already applied padding of .25rem and .5rem for top-bottom, right-left respectively