### PR TITLE
Remove duplicated imports

### DIFF
--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -13,6 +13,9 @@ import {
   SHOULD_NOT_DEFER_CLICK_FOR_FB_SUPPORT_MODE,
   IS_LEGACY_FB_SUPPORT_MODE,
   SHOULD_NOT_PROCESS_POLYFILL_EVENT_PLUGINS,
+  IS_CAPTURE_PHASE,
+  IS_EVENT_HANDLE_NON_MANAGED_NODE,
+  IS_NON_DELEGATED,
 } from './EventSystemFlags';
 import type {AnyNativeEvent} from './PluginModuleType';
 import type {
@@ -22,11 +25,6 @@ import type {
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {allNativeEvents} from './EventRegistry';
-import {
-  IS_CAPTURE_PHASE,
-  IS_EVENT_HANDLE_NON_MANAGED_NODE,
-  IS_NON_DELEGATED,
-} from './EventSystemFlags';
 
 import {
   HostRoot,
@@ -42,7 +40,7 @@ import {
   getEventListenerSet,
   getEventHandlerListeners,
 } from '../client/ReactDOMComponentTree';
-import {COMMENT_NODE} from '../shared/HTMLNodeType';
+import {COMMENT_NODE, DOCUMENT_NODE} from '../shared/HTMLNodeType';
 import {batchedEventUpdates} from './ReactDOMUpdateBatching';
 import getListener from './getListener';
 import {passiveBrowserEventsSupported} from './checkPassiveEvents';
@@ -56,7 +54,6 @@ import {
   invokeGuardedCallbackAndCatchFirstError,
   rethrowCaughtError,
 } from 'shared/ReactErrorUtils';
-import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
 import {createEventListenerWrapperWithPriority} from './ReactDOMEventListener';
 import {
   removeEventListener,


### PR DESCRIPTION
Hey guys! This is my first PR, completed my CLA.
I've noticed duplicated imports in `packages/react-dom/src/events/DOMPluginEventSystem.js`,
so I decided to clear it up a bit as using single import statement per module will make the code clearer because you can see everything being imported from that module on one line.

Made sure this does not introduce any regressions by running `yarn test`, also as you can see, I did not forget to run prettier. 