### PR TITLE
Allow webComponent to receive reference type data , Pass children to …

### DIFF
--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -23,6 +23,7 @@ describe('DOMPropertyOperations', () => {
   });
 
   describe('setValueForProperty', () => {
+
     it('should set values as properties by default', () => {
       const container = document.createElement('div');
       ReactDOM.render(<div title="Tip!" />, container);
@@ -504,6 +505,34 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.foo).toBe('two');
       expect(customElement.getAttribute('foo')).toBe('one');
     });
+
+    it('assigning to a webComponent property should preserve data type , and the child element should be passed to A and rendered inside ',()=>{
+      customElements.define('my-element',class extends HTMLElement {
+        $children:any;
+        constructor() {
+          super();
+          this._attachShadow = this.attachShadow({mode:'closed'});
+        }
+
+        setAttribute(qualifiedName, value:any ){
+          //Because the children field is reserved,
+          // so the test is changed to $children fields first
+          qualifiedName = qualifiedName === 'children' ? '$children' : qualifiedName ;
+          this[qualifiedName] = value;
+        }
+
+        connectedCallback() {
+          // this._attachShadow.innerHTML = '<slot></slot>'
+        }
+      });
+      const options = {a:'b'};
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      ReactDOM.render(<my-element options={options}><div>a</div></my-element>, container);
+      const customElement = container.querySelector('my-element');
+      expect(customElement.options).toEqual(options);
+      expect(customElement.$children).toHaveProperty('type');
+    })
   });
 
   describe('deleteValueForProperty', () => {
@@ -550,3 +579,4 @@ describe('DOMPropertyOperations', () => {
     });
   });
 });
+

--- a/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
+++ b/packages/react-dom/src/__tests__/DOMPropertyOperations-test.js
@@ -23,7 +23,6 @@ describe('DOMPropertyOperations', () => {
   });
 
   describe('setValueForProperty', () => {
-
     it('should set values as properties by default', () => {
       const container = document.createElement('div');
       ReactDOM.render(<div title="Tip!" />, container);
@@ -506,33 +505,44 @@ describe('DOMPropertyOperations', () => {
       expect(customElement.getAttribute('foo')).toBe('one');
     });
 
-    it('assigning to a webComponent property should preserve data type , and the child element should be passed to A and rendered inside ',()=>{
-      customElements.define('my-element',class extends HTMLElement {
-        $children:any;
-        constructor() {
-          super();
-          this._attachShadow = this.attachShadow({mode:'closed'});
-        }
+    it('assigning to a webComponent property should preserve data type , and the child element should be passed to A and rendered inside ', () => {
+      if (typeof customElements !== 'undefined') {
+        customElements.define(
+          'my-element',
+          class extends HTMLElement {
+            $children: any;
+            constructor() {
+              super();
+              this._attachShadow = this.attachShadow({mode: 'closed'});
+            }
 
-        setAttribute(qualifiedName, value:any ){
-          //Because the children field is reserved,
-          // so the test is changed to $children fields first
-          qualifiedName = qualifiedName === 'children' ? '$children' : qualifiedName ;
-          this[qualifiedName] = value;
-        }
+            setAttribute(qualifiedName, value: any) {
+              //Because the children field is reserved,
+              // so the test is changed to $children fields first
+              qualifiedName =
+                qualifiedName === 'children' ? '$children' : qualifiedName;
+              this[qualifiedName] = value;
+            }
 
-        connectedCallback() {
-          // this._attachShadow.innerHTML = '<slot></slot>'
-        }
-      });
-      const options = {a:'b'};
-      const container = document.createElement('div');
-      document.body.appendChild(container);
-      ReactDOM.render(<my-element options={options}><div>a</div></my-element>, container);
-      const customElement = container.querySelector('my-element');
-      expect(customElement.options).toEqual(options);
-      expect(customElement.$children).toHaveProperty('type');
-    })
+            connectedCallback() {
+              // this._attachShadow.innerHTML = '<slot></slot>'
+            }
+          },
+        );
+        const options = {a: 'b'};
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        ReactDOM.render(
+          <my-element options={options}>
+            <div>a</div>
+          </my-element>,
+          container,
+        );
+        const customElement = container.querySelector('my-element');
+        expect(customElement.options).toEqual(options);
+        expect(customElement.$children).toHaveProperty('type');
+      }
+    });
   });
 
   describe('deleteValueForProperty', () => {
@@ -579,4 +589,3 @@ describe('DOMPropertyOperations', () => {
     });
   });
 });
-

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -25,6 +25,7 @@ import {checkAttributeStringCoercion} from 'shared/CheckStringCoercion';
 import {getFiberCurrentPropsFromNode} from './ReactDOMComponentTree';
 
 import type {PropertyInfo} from '../shared/DOMProperty';
+import isWebComponent from '../shared/isWebComponent';
 
 /**
  * Get the value for a property on a node. Only used in DEV for SSR validation.
@@ -150,7 +151,7 @@ export function setValueForProperty(
   const propertyInfo = getPropertyInfo(name);
 
   //customElements retain data types
-  if (node.tagName && window.customElements.get(node.tagName.toLowerCase())) {
+  if (isWebComponent(node.tagName.toLowerCase())) {
     node.setAttribute(name, value);
     return;
   }
@@ -191,6 +192,10 @@ export function setValueForProperty(
     }
   }
 
+  if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
+    value = null;
+  }
+
   if (
     enableCustomElementPropertySupport &&
     isCustomComponentTag &&
@@ -198,10 +203,6 @@ export function setValueForProperty(
   ) {
     (node: any)[name] = value;
     return;
-  }
-
-  if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
-    value = null;
   }
 
   // If the prop isn't in the special list, treat it as a simple attribute.

--- a/packages/react-dom/src/client/DOMPropertyOperations.js
+++ b/packages/react-dom/src/client/DOMPropertyOperations.js
@@ -148,6 +148,13 @@ export function setValueForProperty(
   isCustomComponentTag: boolean,
 ) {
   const propertyInfo = getPropertyInfo(name);
+
+  //customElements retain data types
+  if (node.tagName && window.customElements.get(node.tagName.toLowerCase())) {
+    node.setAttribute(name, value);
+    return;
+  }
+
   if (shouldIgnoreAttribute(name, propertyInfo, isCustomComponentTag)) {
     return;
   }
@@ -184,10 +191,6 @@ export function setValueForProperty(
     }
   }
 
-  if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
-    value = null;
-  }
-
   if (
     enableCustomElementPropertySupport &&
     isCustomComponentTag &&
@@ -195,6 +198,10 @@ export function setValueForProperty(
   ) {
     (node: any)[name] = value;
     return;
+  }
+
+  if (shouldRemoveAttribute(name, value, propertyInfo, isCustomComponentTag)) {
+    value = null;
   }
 
   // If the prop isn't in the special list, treat it as a simple attribute.

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -77,6 +77,7 @@ import {
   mediaEventTypes,
   listenToNonDelegatedEvent,
 } from '../events/DOMPluginEventSystem';
+import isWebComponent from '../shared/isWebComponent';
 
 let didWarnInvalidHydration = false;
 let didWarnScriptTags = false;
@@ -299,11 +300,16 @@ function setInitialDOMProperties(
         setInnerHTML(domElement, nextHtml);
       }
     } else if (propKey === CHILDREN) {
-      //  Handle custom element
-      //  If it is a customElement,
+      //  Handle webComponent
+      //  If it is a webComponent,
       //  Pass the child object to it
-      if (tag && window.customElements.get(tag) && nextProp) {
-        setValueForProperty(domElement, propKey, nextProp, isCustomComponentTag);
+      if (tag && isWebComponent(tag)) {
+        setValueForProperty(
+          domElement,
+          propKey,
+          nextProp,
+          isCustomComponentTag,
+        );
       } else {
         if (typeof nextProp === 'string') {
           // Avoid setting initial textContent when the text is empty. In IE11 setting

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -299,17 +299,24 @@ function setInitialDOMProperties(
         setInnerHTML(domElement, nextHtml);
       }
     } else if (propKey === CHILDREN) {
-      if (typeof nextProp === 'string') {
-        // Avoid setting initial textContent when the text is empty. In IE11 setting
-        // textContent on a <textarea> will cause the placeholder to not
-        // show within the <textarea> until it has been focused and blurred again.
-        // https://github.com/facebook/react/issues/6731#issuecomment-254874553
-        const canSetTextContent = tag !== 'textarea' || nextProp !== '';
-        if (canSetTextContent) {
-          setTextContent(domElement, nextProp);
+      //  Handle custom element
+      //  If it is a customElement,
+      //  Pass the child object to it
+      if (tag && window.customElements.get(tag) && nextProp) {
+        setValueForProperty(domElement, propKey, nextProp, isCustomComponentTag);
+      } else {
+        if (typeof nextProp === 'string') {
+          // Avoid setting initial textContent when the text is empty. In IE11 setting
+          // textContent on a <textarea> will cause the placeholder to not
+          // show within the <textarea> until it has been focused and blurred again.
+          // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+          const canSetTextContent = tag !== 'textarea' || nextProp !== '';
+          if (canSetTextContent) {
+            setTextContent(domElement, nextProp);
+          }
+        } else if (typeof nextProp === 'number') {
+          setTextContent(domElement, '' + nextProp);
         }
-      } else if (typeof nextProp === 'number') {
-        setTextContent(domElement, '' + nextProp);
       }
     } else if (
       propKey === SUPPRESS_CONTENT_EDITABLE_WARNING ||

--- a/packages/react-dom/src/shared/isWebComponent.js
+++ b/packages/react-dom/src/shared/isWebComponent.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default function isWebComponent(tag) {
+  if (tag && global.customElements) {
+    return !!global.customElements.get(tag);
+  }
+  return false;
+}

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -42,6 +42,7 @@ import {isCompatibleFamilyForHotReloading} from './ReactFiberHotReloading.new';
 import {StrictLegacyMode} from './ReactTypeOfMode';
 import {getIsHydrating} from './ReactFiberHydrationContext.new';
 import {pushTreeFork} from './ReactFiberTreeContext.new';
+import isWebComponent from 'react-dom/src/shared/isWebComponent';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
@@ -74,7 +75,7 @@ if (__DEV__) {
     if (typeof child._store !== 'object') {
       throw new Error(
         'React Component in warnForMissingKey should have a _store. ' +
-        'This error is likely caused by a bug in React. Please file an issue.',
+          'This error is likely caused by a bug in React. Please file an issue.',
       );
     }
 
@@ -89,8 +90,8 @@ if (__DEV__) {
 
     console.error(
       'Each child in a list should have a unique ' +
-      '"key" prop. See https://reactjs.org/link/warning-keys for ' +
-      'more information.',
+        '"key" prop. See https://reactjs.org/link/warning-keys for ' +
+        'more information.',
     );
   };
 }
@@ -126,20 +127,20 @@ function coerceRef(
           if (warnAboutStringRefs) {
             console.error(
               'Component "%s" contains the string ref "%s". Support for string refs ' +
-              'will be removed in a future major release. We recommend using ' +
-              'useRef() or createRef() instead. ' +
-              'Learn more about using refs safely here: ' +
-              'https://reactjs.org/link/strict-mode-string-ref',
+                'will be removed in a future major release. We recommend using ' +
+                'useRef() or createRef() instead. ' +
+                'Learn more about using refs safely here: ' +
+                'https://reactjs.org/link/strict-mode-string-ref',
               componentName,
               mixedRef,
             );
           } else {
             console.error(
               'A string ref, "%s", has been found within a strict mode tree. ' +
-              'String refs are a source of potential bugs and should be avoided. ' +
-              'We recommend using useRef() or createRef() instead. ' +
-              'Learn more about using refs safely here: ' +
-              'https://reactjs.org/link/strict-mode-string-ref',
+                'String refs are a source of potential bugs and should be avoided. ' +
+                'We recommend using useRef() or createRef() instead. ' +
+                'Learn more about using refs safely here: ' +
+                'https://reactjs.org/link/strict-mode-string-ref',
               mixedRef,
             );
           }
@@ -157,9 +158,9 @@ function coerceRef(
         if (ownerFiber.tag !== ClassComponent) {
           throw new Error(
             'Function components cannot have string refs. ' +
-            'We recommend using useRef() instead. ' +
-            'Learn more about using refs safely here: ' +
-            'https://reactjs.org/link/strict-mode-string-ref',
+              'We recommend using useRef() instead. ' +
+              'Learn more about using refs safely here: ' +
+              'https://reactjs.org/link/strict-mode-string-ref',
           );
         }
 
@@ -169,7 +170,7 @@ function coerceRef(
       if (!inst) {
         throw new Error(
           `Missing owner for string ref ${mixedRef}. This error is likely caused by a ` +
-          'bug in React. Please file an issue.',
+            'bug in React. Please file an issue.',
         );
       }
       // Assigning this to a const so Flow knows it won't change in the closure
@@ -212,11 +213,11 @@ function coerceRef(
       if (!element._owner) {
         throw new Error(
           `Element ref was specified as a string (${mixedRef}) but no owner was set. This could happen for one of` +
-          ' the following reasons:\n' +
-          '1. You may be adding a ref to a function component\n' +
-          "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
-          '3. You have multiple copies of React loaded\n' +
-          'See https://reactjs.org/link/refs-must-have-owner for more information.',
+            ' the following reasons:\n' +
+            '1. You may be adding a ref to a function component\n' +
+            "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
+            '3. You have multiple copies of React loaded\n' +
+            'See https://reactjs.org/link/refs-must-have-owner for more information.',
         );
       }
     }
@@ -233,8 +234,8 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
         : childString
     }). ` +
-    'If you meant to render a collection of children, use an array ' +
-    'instead.',
+      'If you meant to render a collection of children, use an array ' +
+      'instead.',
   );
 }
 
@@ -249,8 +250,8 @@ function warnOnFunctionType(returnFiber: Fiber) {
 
     console.error(
       'Functions are not valid as a React child. This may happen if ' +
-      'you return a Component instead of <Component /> from render. ' +
-      'Or maybe you meant to call this function rather than return it.',
+        'you return a Component instead of <Component /> from render. ' +
+        'Or maybe you meant to call this function rather than return it.',
     );
   }
 }
@@ -724,10 +725,10 @@ function ChildReconciler(shouldTrackSideEffects) {
           }
           console.error(
             'Encountered two children with the same key, `%s`. ' +
-            'Keys should be unique so that components maintain their identity ' +
-            'across updates. Non-unique keys may cause children to be ' +
-            'duplicated and/or omitted — the behavior is unsupported and ' +
-            'could change in a future version.',
+              'Keys should be unique so that components maintain their identity ' +
+              'across updates. Non-unique keys may cause children to be ' +
+              'duplicated and/or omitted — the behavior is unsupported and ' +
+              'could change in a future version.',
             key,
           );
           break;
@@ -928,7 +929,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (typeof iteratorFn !== 'function') {
       throw new Error(
         'An object is not an iterable. This error is likely caused by a bug in ' +
-        'React. Please file an issue.',
+          'React. Please file an issue.',
       );
     }
 
@@ -943,10 +944,10 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (!didWarnAboutGenerators) {
           console.error(
             'Using Generators as children is unsupported and will likely yield ' +
-            'unexpected results because enumerating a generator mutates it. ' +
-            'You may convert it to an array with `Array.from()` or the ' +
-            '`[...spread]` operator before rendering. Keep in mind ' +
-            'you might need to polyfill these features for older browsers.',
+              'unexpected results because enumerating a generator mutates it. ' +
+              'You may convert it to an array with `Array.from()` or the ' +
+              '`[...spread]` operator before rendering. Keep in mind ' +
+              'you might need to polyfill these features for older browsers.',
           );
         }
         didWarnAboutGenerators = true;
@@ -957,7 +958,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (!didWarnAboutMaps) {
           console.error(
             'Using Maps as children is not supported. ' +
-            'Use an array of keyed ReactElements instead.',
+              'Use an array of keyed ReactElements instead.',
           );
         }
         didWarnAboutMaps = true;
@@ -1280,11 +1281,13 @@ function ChildReconciler(shouldTrackSideEffects) {
       newChild = newChild.props.children;
     }
 
-    //  Handle custom element
-    //  If it is a customElement,
-    //  rendering is skipped and control of rendering is handed over to the customElement
-    const type = returnFiber?.elementType || '';
-    if (type && typeof type === 'string' && window?.customElements?.get(type)) {
+    //  Handle webComponent
+    //  If it is a webComponent,
+    //  rendering is skipped and control of rendering is handed over to the webComponent
+    if (
+      typeof returnFiber.elementType === 'string' &&
+      isWebComponent(returnFiber.elementType)
+    ) {
       newChild = null;
     }
 

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -74,7 +74,7 @@ if (__DEV__) {
     if (typeof child._store !== 'object') {
       throw new Error(
         'React Component in warnForMissingKey should have a _store. ' +
-          'This error is likely caused by a bug in React. Please file an issue.',
+        'This error is likely caused by a bug in React. Please file an issue.',
       );
     }
 
@@ -89,8 +89,8 @@ if (__DEV__) {
 
     console.error(
       'Each child in a list should have a unique ' +
-        '"key" prop. See https://reactjs.org/link/warning-keys for ' +
-        'more information.',
+      '"key" prop. See https://reactjs.org/link/warning-keys for ' +
+      'more information.',
     );
   };
 }
@@ -126,20 +126,20 @@ function coerceRef(
           if (warnAboutStringRefs) {
             console.error(
               'Component "%s" contains the string ref "%s". Support for string refs ' +
-                'will be removed in a future major release. We recommend using ' +
-                'useRef() or createRef() instead. ' +
-                'Learn more about using refs safely here: ' +
-                'https://reactjs.org/link/strict-mode-string-ref',
+              'will be removed in a future major release. We recommend using ' +
+              'useRef() or createRef() instead. ' +
+              'Learn more about using refs safely here: ' +
+              'https://reactjs.org/link/strict-mode-string-ref',
               componentName,
               mixedRef,
             );
           } else {
             console.error(
               'A string ref, "%s", has been found within a strict mode tree. ' +
-                'String refs are a source of potential bugs and should be avoided. ' +
-                'We recommend using useRef() or createRef() instead. ' +
-                'Learn more about using refs safely here: ' +
-                'https://reactjs.org/link/strict-mode-string-ref',
+              'String refs are a source of potential bugs and should be avoided. ' +
+              'We recommend using useRef() or createRef() instead. ' +
+              'Learn more about using refs safely here: ' +
+              'https://reactjs.org/link/strict-mode-string-ref',
               mixedRef,
             );
           }
@@ -157,9 +157,9 @@ function coerceRef(
         if (ownerFiber.tag !== ClassComponent) {
           throw new Error(
             'Function components cannot have string refs. ' +
-              'We recommend using useRef() instead. ' +
-              'Learn more about using refs safely here: ' +
-              'https://reactjs.org/link/strict-mode-string-ref',
+            'We recommend using useRef() instead. ' +
+            'Learn more about using refs safely here: ' +
+            'https://reactjs.org/link/strict-mode-string-ref',
           );
         }
 
@@ -169,7 +169,7 @@ function coerceRef(
       if (!inst) {
         throw new Error(
           `Missing owner for string ref ${mixedRef}. This error is likely caused by a ` +
-            'bug in React. Please file an issue.',
+          'bug in React. Please file an issue.',
         );
       }
       // Assigning this to a const so Flow knows it won't change in the closure
@@ -212,11 +212,11 @@ function coerceRef(
       if (!element._owner) {
         throw new Error(
           `Element ref was specified as a string (${mixedRef}) but no owner was set. This could happen for one of` +
-            ' the following reasons:\n' +
-            '1. You may be adding a ref to a function component\n' +
-            "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
-            '3. You have multiple copies of React loaded\n' +
-            'See https://reactjs.org/link/refs-must-have-owner for more information.',
+          ' the following reasons:\n' +
+          '1. You may be adding a ref to a function component\n' +
+          "2. You may be adding a ref to a component that was not created inside a component's render method\n" +
+          '3. You have multiple copies of React loaded\n' +
+          'See https://reactjs.org/link/refs-must-have-owner for more information.',
         );
       }
     }
@@ -233,8 +233,8 @@ function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
         ? 'object with keys {' + Object.keys(newChild).join(', ') + '}'
         : childString
     }). ` +
-      'If you meant to render a collection of children, use an array ' +
-      'instead.',
+    'If you meant to render a collection of children, use an array ' +
+    'instead.',
   );
 }
 
@@ -249,8 +249,8 @@ function warnOnFunctionType(returnFiber: Fiber) {
 
     console.error(
       'Functions are not valid as a React child. This may happen if ' +
-        'you return a Component instead of <Component /> from render. ' +
-        'Or maybe you meant to call this function rather than return it.',
+      'you return a Component instead of <Component /> from render. ' +
+      'Or maybe you meant to call this function rather than return it.',
     );
   }
 }
@@ -724,10 +724,10 @@ function ChildReconciler(shouldTrackSideEffects) {
           }
           console.error(
             'Encountered two children with the same key, `%s`. ' +
-              'Keys should be unique so that components maintain their identity ' +
-              'across updates. Non-unique keys may cause children to be ' +
-              'duplicated and/or omitted — the behavior is unsupported and ' +
-              'could change in a future version.',
+            'Keys should be unique so that components maintain their identity ' +
+            'across updates. Non-unique keys may cause children to be ' +
+            'duplicated and/or omitted — the behavior is unsupported and ' +
+            'could change in a future version.',
             key,
           );
           break;
@@ -928,7 +928,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     if (typeof iteratorFn !== 'function') {
       throw new Error(
         'An object is not an iterable. This error is likely caused by a bug in ' +
-          'React. Please file an issue.',
+        'React. Please file an issue.',
       );
     }
 
@@ -943,10 +943,10 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (!didWarnAboutGenerators) {
           console.error(
             'Using Generators as children is unsupported and will likely yield ' +
-              'unexpected results because enumerating a generator mutates it. ' +
-              'You may convert it to an array with `Array.from()` or the ' +
-              '`[...spread]` operator before rendering. Keep in mind ' +
-              'you might need to polyfill these features for older browsers.',
+            'unexpected results because enumerating a generator mutates it. ' +
+            'You may convert it to an array with `Array.from()` or the ' +
+            '`[...spread]` operator before rendering. Keep in mind ' +
+            'you might need to polyfill these features for older browsers.',
           );
         }
         didWarnAboutGenerators = true;
@@ -957,7 +957,7 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (!didWarnAboutMaps) {
           console.error(
             'Using Maps as children is not supported. ' +
-              'Use an array of keyed ReactElements instead.',
+            'Use an array of keyed ReactElements instead.',
           );
         }
         didWarnAboutMaps = true;
@@ -1278,6 +1278,14 @@ function ChildReconciler(shouldTrackSideEffects) {
       newChild.key === null;
     if (isUnkeyedTopLevelFragment) {
       newChild = newChild.props.children;
+    }
+
+    //  Handle custom element
+    //  If it is a customElement,
+    //  rendering is skipped and control of rendering is handed over to the customElement
+    const type = returnFiber?.elementType || '';
+    if (type && typeof type === 'string' && window?.customElements?.get(type)) {
+      newChild = null;
     }
 
     // Handle object types


### PR DESCRIPTION

WebComponent can receive reference type data;

When rendering the WebComponent, pass the children's virtual DOM to the WebComponent, giving it control of rendering. 

This will better solve the nested rendering problem and not repeat rendering in the ReactComponent.

I added the test, and the file path is packages/react-dom/src/__tests__/DOMPropertyOperations-test.js