### PR TITLE
test(devools): Fix unnecessarily deep console stack trace

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -32,6 +32,9 @@ if (compactConsole) {
   global.console = new CustomConsole(process.stdout, process.stderr, formatter);
 }
 
+let originalConsoleError;
+let originalConsoleWarn;
+
 const env = jasmine.getEnv();
 env.beforeEach(() => {
   global.mockClipboardCopy = jest.fn();
@@ -71,7 +74,7 @@ env.beforeEach(() => {
     });
   }
 
-  const originalConsoleError = console.error;
+  originalConsoleError = console.error;
   // $FlowFixMe
   console.error = (...args) => {
     const firstArg = args[0];
@@ -94,7 +97,7 @@ env.beforeEach(() => {
     }
     originalConsoleError.apply(console, args);
   };
-  const originalConsoleWarn = console.warn;
+  originalConsoleWarn = console.warn;
   // $FlowFixMe
   console.warn = (...args) => {
     if (shouldIgnoreConsoleErrorOrWarn(args)) {
@@ -161,4 +164,7 @@ env.afterEach(() => {
   // It's also important to reset after tests, rather than before,
   // so that we don't disconnect the ReactCurrentDispatcher ref.
   jest.resetModules();
+
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
 });


### PR DESCRIPTION
Currently `yarn test-build-devtools` has a bunch of console errors related to (missing) act.

They revealed that `console.error` mocking was not cleaned up and resulted in multiple stack frames for `console.error` e.g. 

```bash
$ yarn test-build-devtools console-test` 
...
  console.error
    Warning: The current testing environment is not configured to support act(...)

      93 |       return;
      94 |     }
    > 95 |     originalConsoleError.apply(console, args);
         |                          ^
      96 |   };
      97 |   const originalConsoleWarn = console.warn;
      98 |   // $FlowFixMe

      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:95:26)
      at console.overrideMethod [as error] (packages/react-devtools-shared/src/backend/console.js:275:26)
      at printWarning (build/oss-experimental/react-dom/cjs/react-dom.development.js:87:30)
      at error (build/oss-experimental/react-dom/cjs/react-dom.development.js:61:7)
...
```

Now we only get a single frame for `console.error`:

```bash
$ yarn test-build-devtools console-test` 
...
  console.error
    Warning: The current testing environment is not configured to support act(...)

       96 |       return;
       97 |     }
    >  98 |     originalConsoleError.apply(console, args);
          |                          ^
       99 |   };
      100 |   originalConsoleWarn = console.warn;
      101 |   // $FlowFixMe

      at console.error (packages/react-devtools-shared/src/__tests__/setupTests.js:98:26)
      at console.overrideMethod [as error] (packages/react-devtools-shared/src/backend/console.js:275:26)
      at printWarning (build/oss-experimental/react-dom/cjs/react-dom.development.js:87:30)
...
```
 