### PR TITLE
Fix context propagation for offscreen/fallback trees

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2754,15 +2754,17 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleSuspenseWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleSuspenseWorkOnFiber(
+  fiber: Fiber,
+  renderLanes: Lanes,
+  propagationRoot: Fiber,
+) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  // Guaranteed to be non-empty since the fiber is not a root.
-  const parentFiber: Fiber = (fiber.return: any);
-  scheduleContextWorkOnParentPath(parentFiber, renderLanes, parentFiber);
+  scheduleContextWorkOnParentPath(fiber.return, renderLanes, propagationRoot);
 }
 
 function propagateSuspenseContextChange(
@@ -2778,7 +2780,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleSuspenseWorkOnFiber(node, renderLanes);
+        scheduleSuspenseWorkOnFiber(node, renderLanes, workInProgress);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2786,7 +2788,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleSuspenseWorkOnFiber(node, renderLanes);
+      scheduleSuspenseWorkOnFiber(node, renderLanes, workInProgress);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2754,13 +2754,15 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleContextWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleSuspenseWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleContextWorkOnParentPath(fiber.return, renderLanes, null);
+  // Guaranteed to be non-empty since the fiber is not a root.
+  const parentFiber: Fiber = (fiber.return: any);
+  scheduleContextWorkOnParentPath(parentFiber, renderLanes, parentFiber);
 }
 
 function propagateSuspenseContextChange(
@@ -2776,7 +2778,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleContextWorkOnFiber(node, renderLanes);
+        scheduleSuspenseWorkOnFiber(node, renderLanes);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2784,7 +2786,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleContextWorkOnFiber(node, renderLanes);
+      scheduleSuspenseWorkOnFiber(node, renderLanes);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -173,7 +173,7 @@ import {
   checkIfContextChanged,
   readContext,
   prepareToReadContext,
-  scheduleWorkOnParentPath,
+  scheduleContextWorkOnParentPath,
 } from './ReactFiberNewContext.new';
 import {
   renderWithHooks,
@@ -2754,13 +2754,13 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleContextWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleWorkOnParentPath(fiber.return, renderLanes, null);
+  scheduleContextWorkOnParentPath(fiber.return, renderLanes, null);
 }
 
 function propagateSuspenseContextChange(
@@ -2776,7 +2776,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleWorkOnFiber(node, renderLanes);
+        scheduleContextWorkOnFiber(node, renderLanes);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2784,7 +2784,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleWorkOnFiber(node, renderLanes);
+      scheduleContextWorkOnFiber(node, renderLanes);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -2760,7 +2760,7 @@ function scheduleWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleWorkOnParentPath(fiber.return, renderLanes);
+  scheduleWorkOnParentPath(fiber.return, renderLanes, null);
 }
 
 function propagateSuspenseContextChange(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2754,15 +2754,17 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleSuspenseWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleSuspenseWorkOnFiber(
+  fiber: Fiber,
+  renderLanes: Lanes,
+  propagationRoot: Fiber,
+) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  // Guaranteed to be non-empty since the fiber is not a root.
-  const parentFiber: Fiber = (fiber.return: any);
-  scheduleContextWorkOnParentPath(parentFiber, renderLanes, parentFiber);
+  scheduleContextWorkOnParentPath(fiber.return, renderLanes, propagationRoot);
 }
 
 function propagateSuspenseContextChange(
@@ -2778,7 +2780,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleSuspenseWorkOnFiber(node, renderLanes);
+        scheduleSuspenseWorkOnFiber(node, renderLanes, workInProgress);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2786,7 +2788,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleSuspenseWorkOnFiber(node, renderLanes);
+      scheduleSuspenseWorkOnFiber(node, renderLanes, workInProgress);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2754,13 +2754,15 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleContextWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleSuspenseWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleContextWorkOnParentPath(fiber.return, renderLanes, null);
+  // Guaranteed to be non-empty since the fiber is not a root.
+  const parentFiber: Fiber = (fiber.return: any);
+  scheduleContextWorkOnParentPath(parentFiber, renderLanes, parentFiber);
 }
 
 function propagateSuspenseContextChange(
@@ -2776,7 +2778,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleContextWorkOnFiber(node, renderLanes);
+        scheduleSuspenseWorkOnFiber(node, renderLanes);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2784,7 +2786,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleContextWorkOnFiber(node, renderLanes);
+      scheduleSuspenseWorkOnFiber(node, renderLanes);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -2760,7 +2760,7 @@ function scheduleWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleWorkOnParentPath(fiber.return, renderLanes);
+  scheduleWorkOnParentPath(fiber.return, renderLanes, null);
 }
 
 function propagateSuspenseContextChange(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -173,7 +173,7 @@ import {
   checkIfContextChanged,
   readContext,
   prepareToReadContext,
-  scheduleWorkOnParentPath,
+  scheduleContextWorkOnParentPath,
 } from './ReactFiberNewContext.old';
 import {
   renderWithHooks,
@@ -2754,13 +2754,13 @@ function updateDehydratedSuspenseComponent(
   }
 }
 
-function scheduleWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
+function scheduleContextWorkOnFiber(fiber: Fiber, renderLanes: Lanes) {
   fiber.lanes = mergeLanes(fiber.lanes, renderLanes);
   const alternate = fiber.alternate;
   if (alternate !== null) {
     alternate.lanes = mergeLanes(alternate.lanes, renderLanes);
   }
-  scheduleWorkOnParentPath(fiber.return, renderLanes, null);
+  scheduleContextWorkOnParentPath(fiber.return, renderLanes, null);
 }
 
 function propagateSuspenseContextChange(
@@ -2776,7 +2776,7 @@ function propagateSuspenseContextChange(
     if (node.tag === SuspenseComponent) {
       const state: SuspenseState | null = node.memoizedState;
       if (state !== null) {
-        scheduleWorkOnFiber(node, renderLanes);
+        scheduleContextWorkOnFiber(node, renderLanes);
       }
     } else if (node.tag === SuspenseListComponent) {
       // If the tail is hidden there might not be an Suspense boundaries
@@ -2784,7 +2784,7 @@ function propagateSuspenseContextChange(
       // list itself.
       // We don't have to traverse to the children of the list since
       // the list will propagate the change when it rerenders.
-      scheduleWorkOnFiber(node, renderLanes);
+      scheduleContextWorkOnFiber(node, renderLanes);
     } else if (node.child !== null) {
       node.child.return = node;
       node = node.child;

--- a/packages/react-reconciler/src/ReactFiberNewContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.new.js
@@ -168,14 +168,6 @@ export function scheduleContextWorkOnParentPath(
     if (node === propagationRoot) {
       break;
     }
-    if (__DEV__) {
-      if (node === propagationRoot.alternate) {
-        console.error(
-          'Did not expect to encounter a propagation root alternate when scheduling context work. ' +
-            'This error is likely caused by a bug in React. Please file an issue.',
-        );
-      }
-    }
     node = node.return;
   }
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.new.js
@@ -141,7 +141,7 @@ export function popProvider(
 export function scheduleContextWorkOnParentPath(
   parent: Fiber | null,
   renderLanes: Lanes,
-  propagationRoot: Fiber | null,
+  propagationRoot: Fiber,
 ) {
   // Update the child lanes of all the ancestors, including the alternates.
   let node = parent;
@@ -169,7 +169,7 @@ export function scheduleContextWorkOnParentPath(
       break;
     }
     if (__DEV__) {
-      if (propagationRoot !== null && node === propagationRoot.alternate) {
+      if (node === propagationRoot.alternate) {
         console.error(
           'Did not expect to encounter a propagation root alternate when scheduling context work. ' +
             'This error is likely caused by a bug in React. Please file an issue.',

--- a/packages/react-reconciler/src/ReactFiberNewContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.new.js
@@ -178,6 +178,14 @@ export function scheduleContextWorkOnParentPath(
     }
     node = node.return;
   }
+  if (__DEV__) {
+    if (node !== propagationRoot) {
+      console.error(
+        'Expected to find the propagation root when scheduling context work. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+    }
+  }
 }
 
 export function propagateContextChange<T>(

--- a/packages/react-reconciler/src/ReactFiberNewContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.old.js
@@ -168,14 +168,6 @@ export function scheduleContextWorkOnParentPath(
     if (node === propagationRoot) {
       break;
     }
-    if (__DEV__) {
-      if (node === propagationRoot.alternate) {
-        console.error(
-          'Did not expect to encounter a propagation root alternate when scheduling context work. ' +
-            'This error is likely caused by a bug in React. Please file an issue.',
-        );
-      }
-    }
     node = node.return;
   }
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.old.js
@@ -141,7 +141,7 @@ export function popProvider(
 export function scheduleContextWorkOnParentPath(
   parent: Fiber | null,
   renderLanes: Lanes,
-  propagationRoot: Fiber | null,
+  propagationRoot: Fiber,
 ) {
   // Update the child lanes of all the ancestors, including the alternates.
   let node = parent;
@@ -169,7 +169,7 @@ export function scheduleContextWorkOnParentPath(
       break;
     }
     if (__DEV__) {
-      if (propagationRoot !== null && node === propagationRoot.alternate) {
+      if (node === propagationRoot.alternate) {
         console.error(
           'Did not expect to encounter a propagation root alternate when scheduling context work. ' +
             'This error is likely caused by a bug in React. Please file an issue.',

--- a/packages/react-reconciler/src/ReactFiberNewContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.old.js
@@ -178,6 +178,14 @@ export function scheduleContextWorkOnParentPath(
     }
     node = node.return;
   }
+  if (__DEV__) {
+    if (node !== propagationRoot) {
+      console.error(
+        'Expected to find the propagation root when scheduling context work. ' +
+          'This error is likely caused by a bug in React. Please file an issue.',
+      );
+    }
+  }
 }
 
 export function propagateContextChange<T>(

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -1543,7 +1543,9 @@ describe('ReactSuspense', () => {
         return (
           <ValueContext.Consumer>
             {value => {
-              Scheduler.unstable_yieldValue(`Received context value [${value}]`);
+              Scheduler.unstable_yieldValue(
+                `Received context value [${value}]`,
+              );
               if (value === 'default') return <Text text="default" />;
               throw promiseThatNeverResolves;
             }}
@@ -1573,15 +1575,24 @@ describe('ReactSuspense', () => {
       }
 
       const root = ReactTestRenderer.create(<App />);
-      expect(Scheduler).toHaveYielded(['Received context value [default]', 'default']);
+      expect(Scheduler).toHaveYielded([
+        'Received context value [default]',
+        'default',
+      ]);
       expect(root).toMatchRenderedOutput('default');
 
       act(() => setValue('new value'));
-      expect(Scheduler).toHaveYielded(['Received context value [new value]', 'Loading...']);
+      expect(Scheduler).toHaveYielded([
+        'Received context value [new value]',
+        'Loading...',
+      ]);
       expect(root).toMatchRenderedOutput('Loading...');
 
       act(() => setValue('default'));
-      expect(Scheduler).toHaveYielded(['Received context value [default]', 'default']);
+      expect(Scheduler).toHaveYielded([
+        'Received context value [default]',
+        'default',
+      ]);
       expect(root).toMatchRenderedOutput('default');
     });
   });

--- a/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspense-test.internal.js
@@ -1532,5 +1532,57 @@ describe('ReactSuspense', () => {
       expect(Scheduler).toFlushUntilNextPaint(['new value']);
       expect(root).toMatchRenderedOutput('new value');
     });
+
+    it('updates context consumer within child of suspended suspense component when context updates', () => {
+      const {createContext, useState} = React;
+
+      const ValueContext = createContext(null);
+
+      const promiseThatNeverResolves = new Promise(() => {});
+      function Child() {
+        return (
+          <ValueContext.Consumer>
+            {value => {
+              Scheduler.unstable_yieldValue(`Received context value [${value}]`);
+              if (value === 'default') return <Text text="default" />;
+              throw promiseThatNeverResolves;
+            }}
+          </ValueContext.Consumer>
+        );
+      }
+
+      let setValue;
+      function Wrapper({children}) {
+        const [value, _setValue] = useState('default');
+        setValue = _setValue;
+        return (
+          <ValueContext.Provider value={value}>
+            {children}
+          </ValueContext.Provider>
+        );
+      }
+
+      function App() {
+        return (
+          <Wrapper>
+            <Suspense fallback={<Text text="Loading..." />}>
+              <Child />
+            </Suspense>
+          </Wrapper>
+        );
+      }
+
+      const root = ReactTestRenderer.create(<App />);
+      expect(Scheduler).toHaveYielded(['Received context value [default]', 'default']);
+      expect(root).toMatchRenderedOutput('default');
+
+      act(() => setValue('new value'));
+      expect(Scheduler).toHaveYielded(['Received context value [new value]', 'Loading...']);
+      expect(root).toMatchRenderedOutput('Loading...');
+
+      act(() => setValue('default'));
+      expect(Scheduler).toHaveYielded(['Received context value [default]', 'default']);
+      expect(root).toMatchRenderedOutput('default');
+    });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/19701.

As https://github.com/facebook/react/pull/19702 shows, this assumption is not always true:

https://github.com/facebook/react/blob/9a7e6bf0d0cf08114b74c9fe45c06e60a5e496e4/packages/react-reconciler/src/ReactFiberNewContext.new.js#L160-L162

In particular, commenting out this `break;` fixes https://github.com/facebook/react/issues/19701.

@acdlite told me this is because inside Offscreen/fallback trees, `childLanes` may not necessarily be consistent with surroundings because we commit surroundings without the children.

If I just comment out that `break;` we'll always traverse to the root. This seems bad, especially inside deep trees. Since this function is used during propagation. So I'm changing this to stop at the _propagation root_.

Aside from fixing what happens inside Offscreen/fallback trees, we also need to consider what happens when the loop goes outside the propagation root. Implementation-wise, this change is **not** a no-op for nodes outside. You can verify that we _used to_ traverse upwards (past the propagation root) in some cases and modify the `childLanes` of ancestors. However, @acdlite said that from the model perspective, this shouldn't be necessary to do — we wouldn't have reached the propagation root if there weren't work already scheduled on it. And a parent of a propagation root doesn't need to have dirty `childLanes`.

So this adds some extra traversal to propagation but buys back some of the cost where we used to do deeper unnecessary traversal upwards past the propagation root. (But now we always stop at the propagation root.) Suspense call from `beginWork` is an exception though, as it will now always traverse to the root but it used to be able to bail out in the middle.

I've included a failing test from https://github.com/facebook/react/pull/19702 to show it now passes. I imagine there may be other cases we don't know about where context failed to propagate so it's not just about this bug alone. My concern isn't so much `Consumer` API but the flaw in modeling. The assumption seems fundamentally flawed and I'm worried how else it might bite us.