### PR TITLE
[failing] add failing test for Context providers are reset to initial value in SSR during rendering

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -341,18 +341,17 @@ describe('ReactDOMFizzServer', () => {
 
   // @gate experimental
   it('should be able to get context value when promise resloved.', async () => {
-
     class DelayClient {
       get() {
         if (this.resolved) return this.resolved;
         if (this.pending) return this.pending;
-        return this.pending = new Promise(resolve => {
+        return (this.pending = new Promise(resolve => {
           setTimeout(() => {
             delete this.pending;
             this.resolved = 'OK';
             resolve();
           }, 500);
-        });
+        }));
       }
     }
 
@@ -367,16 +366,16 @@ describe('ReactDOMFizzServer', () => {
         return result;
       }
       throw result;
-    }
+    };
 
     const client = new DelayClient();
-    const {writable, output, completed } = getTestWritable();
+    const {writable, output, completed} = getTestWritable();
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client}>
         <Suspense fallback="loading">
           <Component />
         </Suspense>
-      </DelayContext.Provider>
+      </DelayContext.Provider>,
     ).pipe(writable);
 
     jest.runAllTimers();
@@ -397,13 +396,13 @@ describe('ReactDOMFizzServer', () => {
       get() {
         if (this.resolved) return this.resolved;
         if (this.pending) return this.pending;
-        return this.pending = new Promise(resolve => {
+        return (this.pending = new Promise(resolve => {
           setTimeout(() => {
             delete this.pending;
             this.resolved = 'OK';
             resolve();
           }, 500);
-        });
+        }));
       }
     }
     const DelayContext = React.createContext(undefined);
@@ -417,26 +416,34 @@ describe('ReactDOMFizzServer', () => {
         return result;
       }
       throw result;
-    }
+    };
 
     const client0 = new DelayClient();
-    const {writable: writable0, output: output0, completed: completed0 } = getTestWritable();
+    const {
+      writable: writable0,
+      output: output0,
+      completed: completed0,
+    } = getTestWritable();
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client0}>
         <Suspense fallback="loading">
           <Component />
         </Suspense>
-      </DelayContext.Provider>
+      </DelayContext.Provider>,
     ).pipe(writable0);
 
     const client1 = new DelayClient();
-    const {writable: writable1, output: output1, completed: completed1 } = getTestWritable();
+    const {
+      writable: writable1,
+      output: output1,
+      completed: completed1,
+    } = getTestWritable();
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client1}>
         <Suspense fallback="loading">
           <Component />
         </Suspense>
-      </DelayContext.Provider>
+      </DelayContext.Provider>,
     ).pipe(writable1);
 
     jest.runAllTimers();
@@ -457,5 +464,4 @@ describe('ReactDOMFizzServer', () => {
     expect(output1.result).not.toContain('context never found');
     expect(output1.result).toContain('OK');
   });
-
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -349,7 +349,7 @@ describe('ReactDOMFizzServer', () => {
         return this.pending = new Promise(resolve => {
           setTimeout(() => {
             delete this.pending;
-            this.resolved = "OK";
+            this.resolved = 'OK';
             resolve();
           }, 500);
         });
@@ -360,10 +360,10 @@ describe('ReactDOMFizzServer', () => {
     const Component = () => {
       const client = React.useContext(DelayContext);
       if (!client) {
-        return "context not found.";
+        return 'context not found.';
       }
       const result = client.get();
-      if (typeof result === "string") {
+      if (typeof result === 'string') {
         return result;
       }
       throw result;
@@ -374,7 +374,7 @@ describe('ReactDOMFizzServer', () => {
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client}>
         <Suspense fallback="loading">
-          <Component/>
+          <Component />
         </Suspense>
       </DelayContext.Provider>
     ).pipe(writable);
@@ -400,7 +400,7 @@ describe('ReactDOMFizzServer', () => {
         return this.pending = new Promise(resolve => {
           setTimeout(() => {
             delete this.pending;
-            this.resolved = "OK";
+            this.resolved = 'OK';
             resolve();
           }, 500);
         });
@@ -410,10 +410,10 @@ describe('ReactDOMFizzServer', () => {
     const Component = () => {
       const client = React.useContext(DelayContext);
       if (!client) {
-        return "context never found";
+        return 'context never found';
       }
       const result = client.get();
-      if (typeof result === "string") {
+      if (typeof result === 'string') {
         return result;
       }
       throw result;
@@ -424,7 +424,7 @@ describe('ReactDOMFizzServer', () => {
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client0}>
         <Suspense fallback="loading">
-          <Component/>
+          <Component />
         </Suspense>
       </DelayContext.Provider>
     ).pipe(writable0);
@@ -434,7 +434,7 @@ describe('ReactDOMFizzServer', () => {
     ReactDOMFizzServer.renderToPipeableStream(
       <DelayContext.Provider value={client1}>
         <Suspense fallback="loading">
-          <Component/>
+          <Component />
         </Suspense>
       </DelayContext.Provider>
     ).pipe(writable1);

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -338,4 +338,124 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toContain('Loading');
     expect(isCompleteCalls).toBe(1);
   });
+
+  // @gate experimental
+  it('should be able to get context value when promise resloved.', async () => {
+
+    class DelayClient {
+      get() {
+        if (this.resolved) return this.resolved;
+        if (this.pending) return this.pending;
+        return this.pending = new Promise(resolve => {
+          setTimeout(() => {
+            delete this.pending;
+            this.resolved = "OK";
+            resolve();
+          }, 500);
+        });
+      }
+    }
+
+    const DelayContext = React.createContext(undefined);
+    const Component = () => {
+      const client = React.useContext(DelayContext);
+      if (!client) {
+        return "context not found.";
+      }
+      const result = client.get();
+      if (typeof result === "string") {
+        return result;
+      }
+      throw result;
+    }
+
+    const client = new DelayClient();
+    const {writable, output, completed } = getTestWritable();
+    ReactDOMFizzServer.renderToPipeableStream(
+      <DelayContext.Provider value={client}>
+        <Suspense fallback="loading">
+          <Component/>
+        </Suspense>
+      </DelayContext.Provider>
+    ).pipe(writable);
+
+    jest.runAllTimers();
+
+    expect(output.error).toBe(undefined);
+    expect(output.result).toContain('loading');
+
+    await completed;
+
+    expect(output.error).toBe(undefined);
+    expect(output.result).not.toContain('context never found');
+    expect(output.result).toContain('OK');
+  });
+
+  // @gate experimental
+  it('should be able to get context value when calls renderToPipeableStream twice at the same time', async () => {
+    class DelayClient {
+      get() {
+        if (this.resolved) return this.resolved;
+        if (this.pending) return this.pending;
+        return this.pending = new Promise(resolve => {
+          setTimeout(() => {
+            delete this.pending;
+            this.resolved = "OK";
+            resolve();
+          }, 500);
+        });
+      }
+    }
+    const DelayContext = React.createContext(undefined);
+    const Component = () => {
+      const client = React.useContext(DelayContext);
+      if (!client) {
+        return "context never found";
+      }
+      const result = client.get();
+      if (typeof result === "string") {
+        return result;
+      }
+      throw result;
+    }
+
+    const client0 = new DelayClient();
+    const {writable: writable0, output: output0, completed: completed0 } = getTestWritable();
+    ReactDOMFizzServer.renderToPipeableStream(
+      <DelayContext.Provider value={client0}>
+        <Suspense fallback="loading">
+          <Component/>
+        </Suspense>
+      </DelayContext.Provider>
+    ).pipe(writable0);
+
+    const client1 = new DelayClient();
+    const {writable: writable1, output: output1, completed: completed1 } = getTestWritable();
+    ReactDOMFizzServer.renderToPipeableStream(
+      <DelayContext.Provider value={client1}>
+        <Suspense fallback="loading">
+          <Component/>
+        </Suspense>
+      </DelayContext.Provider>
+    ).pipe(writable1);
+
+    jest.runAllTimers();
+
+    expect(output0.error).toBe(undefined);
+    expect(output0.result).toContain('loading');
+
+    expect(output1.error).toBe(undefined);
+    expect(output1.result).toContain('loading');
+
+    await Promise.all([completed0, completed1]);
+
+    expect(output0.error).toBe(undefined);
+    expect(output0.result).not.toContain('context never found');
+    expect(output0.result).toContain('OK');
+
+    expect(output1.error).toBe(undefined);
+    expect(output1.result).not.toContain('context never found');
+    expect(output1.result).toContain('OK');
+  });
+
 });


### PR DESCRIPTION
add failing test for Context providers are reset to initial value in SSR during rendering.

Follow up to #23089 

Context value worked if only renderToPipeableStream called once during piping.  when 2 or  more piping at the same time, Context value could be lost.
