### PR TITLE
Fix deprecated folder mappings in package.json

### DIFF
--- a/packages/react-fs/package.json
+++ b/packages/react-fs/package.json
@@ -26,7 +26,8 @@
     },
     "./index.node.server": "./index.node.server.js",
     "./index.browser.server": "./index.browser.server.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": "./*"
   },
   "peerDependencies": {
     "react": "^17.0.0"

--- a/packages/react-pg/package.json
+++ b/packages/react-pg/package.json
@@ -26,7 +26,8 @@
     },
     "./index.node.server": "./index.node.server.js",
     "./index.browser.server": "./index.browser.server.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": "./*"
   },
   "peerDependencies": {
     "react": "^17.0.0",

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -36,7 +36,8 @@
     "./writer.browser.server": "./writer.browser.server.js",
     "./node-loader": "./esm/react-server-dom-webpack-node-loader.js",
     "./node-register": "./node-register.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./*": "./*"
   },
   "main": "index.js",
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,7 @@
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js",
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-    "./": "./"
+    "./*": "./*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node v16 deprecated the use of trailing "/" to define subpath folder mappings in the "exports" field of package.json.

The recommendation is to explicitly list all our exports. We already do that for all our public modules. I believe the only reason we have a wildcard pattern is because our package.json files are also used at build time (by Rollup) to resolve internal source modules that don't appear in the final npm artifact.

Changing trailing "" to "/*" fixes the warnings. See https://nodejs.org/api/packages.html#subpath-patterns for more info.

We should consider some other way to address this, like by using separate package.jsons for building versus publishing, ideally without having to duplicate the whole thing, since they're identical except for this.