### PR TITLE
DevTools only records Timeline data when Profiling

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -73,6 +73,11 @@ describe('Timeline profiler', () => {
     utils = require('./utils');
     utils.beforeEachProfiling();
 
+    const store = global.store;
+
+    // Start profiling so that data will actually be recorded.
+    utils.act(() => store.profilerStore.startProfiling());
+
     React = require('react');
     ReactDOM = require('react-dom');
     Scheduler = require('scheduler');


### PR DESCRIPTION
React will call the DevTools profiling hooks unconditionally (for DEV and profiling builds) but DevTools will only log the data to the User Timing API when DevTools is profiling.

Related to #22529

---

Note that this PR (in isolation) makes the Timeline profiler feature unusable. It will be part of a stack of PRs that will be merged together once finished.