### PR TITLE
Enable scheduling profiler flag in react-dom/testing builds

### DIFF
--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -75,7 +75,7 @@ export function createProfilingHooks({
   reactVersion,
 }: {|
   getDisplayNameForFiber: (fiber: Fiber) => string | null,
-  getLaneLabelMap?: () => Map<Lane, string>,
+  getLaneLabelMap?: () => Map<Lane, string> | null,
   reactVersion: string,
 |}): DevToolsProfilingHooks {
   function markMetadata() {
@@ -108,8 +108,10 @@ export function createProfilingHooks({
 
     if (typeof getLaneLabelMap === 'function') {
       const map = getLaneLabelMap();
-      const labels = Array.from(map.values()).join(',');
-      markAndClear(`--react-lane-labels-${labels}`);
+      if (map != null) {
+        const labels = Array.from(map.values()).join(',');
+        markAndClear(`--react-lane-labels-${labels}`);
+      }
     }
   }
 

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -152,7 +152,7 @@ export type ReactRenderer = {
   scheduleRefresh?: Function,
   // 18.0+
   injectProfilingHooks?: (profilingHooks: DevToolsProfilingHooks) => void,
-  getLaneLabelMap?: () => Map<Lane, string>,
+  getLaneLabelMap?: () => Map<Lane, string> | null,
   ...
 };
 

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -230,17 +230,21 @@ function injectProfilingHooks(profilingHooks: DevToolsProfilingHooks): void {
   injectedProfilingHooks = profilingHooks;
 }
 
-function getLaneLabelMap(): Map<Lane, string> {
-  const map: Map<Lane, string> = new Map();
+function getLaneLabelMap(): Map<Lane, string> | null {
+  if (enableSchedulingProfiler) {
+    const map: Map<Lane, string> = new Map();
 
-  let lane = 1;
-  for (let index = 0; index < TotalLanes; index++) {
-    const label = ((getLabelForLane(lane): any): string);
-    map.set(lane, label);
-    lane *= 2;
+    let lane = 1;
+    for (let index = 0; index < TotalLanes; index++) {
+      const label = ((getLabelForLane(lane): any): string);
+      map.set(lane, label);
+      lane *= 2;
+    }
+
+    return map;
+  } else {
+    return null;
   }
-
-  return map;
 }
 
 export function markCommitStarted(lanes: Lanes): void {

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
@@ -230,17 +230,21 @@ function injectProfilingHooks(profilingHooks: DevToolsProfilingHooks): void {
   injectedProfilingHooks = profilingHooks;
 }
 
-function getLaneLabelMap(): Map<Lane, string> {
-  const map: Map<Lane, string> = new Map();
+function getLaneLabelMap(): Map<Lane, string> | null {
+  if (enableSchedulingProfiler) {
+    const map: Map<Lane, string> = new Map();
 
-  let lane = 1;
-  for (let index = 0; index < TotalLanes; index++) {
-    const label = ((getLabelForLane(lane): any): string);
-    map.set(lane, label);
-    lane *= 2;
+    let lane = 1;
+    for (let index = 0; index < TotalLanes; index++) {
+      const label = ((getLabelForLane(lane): any): string);
+      map.set(lane, label);
+      lane *= 2;
+    }
+
+    return map;
+  } else {
+    return null;
   }
-
-  return map;
 }
 
 export function markCommitStarted(lanes: Lanes): void {

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -12,7 +12,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.testing';
 
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
-export const enableSchedulingProfiler = false;
+export const enableSchedulingProfiler = __PROFILE__;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;


### PR DESCRIPTION
DevTools uses the "unstable_testing" entry point for ReactDOM so that our tests can use the experimental Test Selector API. Unfortunately this means that our test shell couldn't be used to test Timeline data, because the `enableSchedulingProfiler` was always false for that build. This PR updates that flag to match the other profiling-related flags (setting it to `__PROFILE__`).

It also updates the `getLaneLabelMap` to return `null` (instead of an empty `Map`) when the flag is not enabled.

## [View change with whitespace ignored](https://github.com/facebook/react/pull/23142/files?w=1)

Relates to #22529. Builds on top of #23102.