### PR TITLE
Don't inject timeline hooks unless React supports profiling

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -74,11 +74,19 @@ export function injectInternals(internals: Object): boolean {
     return true;
   }
   try {
-    rendererID = hook.inject({
-      ...internals,
-      getLaneLabelMap,
-      injectProfilingHooks,
-    });
+    if (enableSchedulingProfiler) {
+      // Conditionally inject these hooks only if Timeline profiler is supported by this build.
+      // This gives DevTools a way to feature detect that isn't tied to version number
+      // (since profiling and timeline are controlled by different feature flags).
+      internals = {
+        ...internals,
+        getLaneLabelMap,
+        injectProfilingHooks,
+      };
+    }
+
+    rendererID = hook.inject(internals);
+
     // We have successfully injected, so now it is safe to set up hooks.
     injectedHook = hook;
   } catch (err) {

--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.old.js
@@ -74,11 +74,19 @@ export function injectInternals(internals: Object): boolean {
     return true;
   }
   try {
-    rendererID = hook.inject({
-      ...internals,
-      getLaneLabelMap,
-      injectProfilingHooks,
-    });
+    if (enableSchedulingProfiler) {
+      // Conditionally inject these hooks only if Timeline profiler is supported by this build.
+      // This gives DevTools a way to feature detect that isn't tied to version number
+      // (since profiling and timeline are controlled by different feature flags).
+      internals = {
+        ...internals,
+        getLaneLabelMap,
+        injectProfilingHooks,
+      };
+    }
+
+    rendererID = hook.inject(internals);
+
     // We have successfully injected, so now it is safe to set up hooks.
     injectedHook = hook;
   } catch (err) {


### PR DESCRIPTION
This gives DevTools a way to detect whether the current React renderer supports Timeline profiling. (Version alone isn't enough to detect this, neither is general profiling support– since these two are controlled by different feature flags.)

Relates to #22529.