### PR TITLE
Include other build types when building for CodeSandbox CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "publish-prereleases": "node ./scripts/release/publish-using-ci-workflow.js",
     "download-build": "node ./scripts/release/download-experimental-build.js",
     "download-build-for-head": "node ./scripts/release/download-experimental-build.js --commit=$(git rev-parse HEAD)",
-    "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head || yarn build-combined --type=node react/index react-dom scheduler",
+    "download-build-in-codesandbox-ci": "cd scripts/release && yarn install && cd ../../ && yarn download-build-for-head || yarn build-combined --type=node react/index react-dom/index react-dom/src/server react-dom/test-utils scheduler/index react/jsx-runtime react/jsx-dev-runtime",
     "check-release-dependencies": "node ./scripts/release/check-release-dependencies"
   },
   "resolutions": {


### PR DESCRIPTION
Whenever the fetching of artifacts to CircleCI times out in CodeSandbox CI, we build the packages ourselves. However, not all necessary components are in there, this adds them.

## How did you test this change?
Ran `yarn build-combined --type=node react/index react-dom/index react-dom/src/server react-dom/test-utils scheduler/index react/jsx-runtime react/jsx-dev-runtime` to verify that all files are in there.