### PR TITLE
styles: replace Array.isArray with module isArray

### DIFF
--- a/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
+++ b/packages/react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor.js
@@ -9,6 +9,7 @@
 
 import Agent from 'react-devtools-shared/src/backend/agent';
 import resolveBoxStyle from './resolveBoxStyle';
+import isArray from 'react-devtools-shared/src/isArray';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {RendererID} from '../types';
@@ -210,11 +211,11 @@ function renameStyle(
     }
     // TODO Fabric does not support setNativeProps; chat with Sebastian or Eli
     instance.setNativeProps({style: newStyle});
-  } else if (Array.isArray(style)) {
+  } else if (isArray(style)) {
     const lastIndex = style.length - 1;
     if (
       typeof style[lastIndex] === 'object' &&
-      !Array.isArray(style[lastIndex])
+      !isArray(style[lastIndex])
     ) {
       customStyle = shallowClone(style[lastIndex]);
       delete customStyle[oldName];
@@ -296,11 +297,11 @@ function setStyle(
     }
     // TODO Fabric does not support setNativeProps; chat with Sebastian or Eli
     instance.setNativeProps({style: newStyle});
-  } else if (Array.isArray(style)) {
+  } else if (isArray(style)) {
     const lastLength = style.length - 1;
     if (
       typeof style[lastLength] === 'object' &&
-      !Array.isArray(style[lastLength])
+      !isArray(style[lastLength])
     ) {
       agent.overrideValueAtPath({
         type: 'props',

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -8,6 +8,7 @@
  */
 
 import type {StyleXPlugin} from 'react-devtools-shared/src/types';
+import isArray from 'react-devtools-shared/src/isArray';
 
 const cachedStyleNameToValueMap: Map<string, string> = new Map();
 
@@ -28,9 +29,9 @@ export function crawlData(
   sources: Set<string>,
   resolvedStyles: Object,
 ): void {
-  if (Array.isArray(data)) {
+  if (isArray(data)) {
     data.forEach(entry => {
-      if (Array.isArray(entry)) {
+      if (isArray(entry)) {
         crawlData(entry, sources, resolvedStyles);
       } else {
         crawlObjectProperties(entry, sources, resolvedStyles);

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementHooksTree.js
@@ -27,6 +27,7 @@ import {
   enableProfilerChangedHookIndices,
 } from 'react-devtools-feature-flags';
 import HookNamesModuleLoaderContext from 'react-devtools-shared/src/devtools/views/Components/HookNamesModuleLoaderContext';
+import isArray from 'react-devtools-shared/src/isArray';
 
 import type {InspectedElement} from './types';
 import type {HooksNode, HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
@@ -269,7 +270,7 @@ function HookView({
     displayValue = 'null';
   } else if (value === undefined) {
     displayValue = null;
-  } else if (Array.isArray(value)) {
+  } else if (isArray(value)) {
     isComplexDisplayValue = true;
     displayValue = 'Array';
   } else if (type === 'object') {
@@ -278,7 +279,7 @@ function HookView({
   }
 
   if (isCustomHook) {
-    const subHooksView = Array.isArray(subHooks) ? (
+    const subHooksView = isArray(subHooks) ? (
       <InnerHooksTreeView
         element={element}
         hooks={subHooks}

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -24,6 +24,7 @@ import {parseHookPathForEdit} from './utils';
 import styles from './KeyValue.css';
 import Button from 'react-devtools-shared/src/devtools/views/Button';
 import ButtonIcon from 'react-devtools-shared/src/devtools/views/ButtonIcon';
+import isArray from 'react-devtools-shared/src/isArray';
 import {InspectedElementContext} from './InspectedElementContext';
 import {PROTOCOLS_SUPPORTED_AS_LINKS_IN_KEY_VALUE} from './constants';
 
@@ -327,7 +328,7 @@ export default function KeyValue({
       );
     }
   } else {
-    if (Array.isArray(value)) {
+    if (isArray(value)) {
       const hasChildren = value.length > 0 || canEditValues;
       const displayName = getMetaValueLabel(value);
 

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -10,6 +10,7 @@
 import escapeStringRegExp from 'escape-string-regexp';
 import {meta} from '../../hydration';
 import {formatDataForPreview} from '../../utils';
+import isArray from 'react-devtools-shared/src/isArray';
 
 import type {HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
 
@@ -107,7 +108,7 @@ function sanitize(data: Object): void {
     if (value && value[meta.type]) {
       data[key] = getMetaValueLabel(value);
     } else if (value != null) {
-      if (Array.isArray(value)) {
+      if (isArray(value)) {
         sanitize(value);
       } else if (typeof value === 'object') {
         sanitize(value);


### PR DESCRIPTION
## Summary
We always use isArray as a module in codebase instead of `Array.isArray`, I found some `Array.isArray` and replaced

## How did you test this change?
`yarn test`

@bvaughn 