### PR TITLE
Suppress act() warnings in DevTools tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/editing-test.js
+++ b/packages/react-devtools-shared/src/__tests__/editing-test.js
@@ -19,7 +19,7 @@ describe('editing interface', () => {
   let utils;
 
   const flushPendingUpdates = () => {
-    jest.runOnlyPendingTimers();
+    utils.act(() => jest.runOnlyPendingTimers());
   };
 
   beforeEach(() => {

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -71,8 +71,10 @@ describe('InspectedElement', () => {
       .TreeContextController;
 
     // Used by inspectElementAtIndex() helper function
-    testRendererInstance = TestRenderer.create(null, {
-      unstable_isConcurrent: true,
+    utils.act(() => {
+      testRendererInstance = TestRenderer.create(null, {
+        unstable_isConcurrent: true,
+      });
     });
 
     errorBoundaryInstance = null;
@@ -299,9 +301,14 @@ describe('InspectedElement', () => {
       // from props like defaultSelectedElementID and it's easier to reset here than
       // to read the TreeDispatcherContext and update the selected ID that way.
       // We're testing the inspected values here, not the context wiring, so that's ok.
-      testRendererInstance = TestRenderer.create(null, {
-        unstable_isConcurrent: true,
-      });
+      utils.withErrorsOrWarningsIgnored(
+        ['An update to %s inside a test was not wrapped in act'],
+        () => {
+          testRendererInstance = TestRenderer.create(null, {
+            unstable_isConcurrent: true,
+          });
+        },
+      );
 
       const inspectedElement = await inspectElementAtIndex(index);
 
@@ -460,9 +467,14 @@ describe('InspectedElement', () => {
     // The backend still thinks the most recently-inspected element is still cached,
     // so the frontend needs to tell it to resend a full value.
     // We can verify this by asserting that the component is re-rendered again.
-    testRendererInstance = TestRenderer.create(null, {
-      unstable_isConcurrent: true,
-    });
+    utils.withErrorsOrWarningsIgnored(
+      ['An update to %s inside a test was not wrapped in act'],
+      () => {
+        testRendererInstance = TestRenderer.create(null, {
+          unstable_isConcurrent: true,
+        });
+      },
+    );
 
     const {
       clearCacheForTests,
@@ -2024,9 +2036,14 @@ describe('InspectedElement', () => {
     // from props like defaultSelectedElementID and it's easier to reset here than
     // to read the TreeDispatcherContext and update the selected ID that way.
     // We're testing the inspected values here, not the context wiring, so that's ok.
-    testRendererInstance = TestRenderer.create(null, {
-      unstable_isConcurrent: true,
-    });
+    utils.withErrorsOrWarningsIgnored(
+      ['An update to %s inside a test was not wrapped in act'],
+      () => {
+        testRendererInstance = TestRenderer.create(null, {
+          unstable_isConcurrent: true,
+        });
+      },
+    );
 
     // Select/inspect the same element again
     inspectedElement = await inspectElementAtIndex(0);
@@ -2743,11 +2760,15 @@ describe('InspectedElement', () => {
         0,
       ): any): number);
       const inspect = index => {
-        // HACK: Recreate TestRenderer instance so we can inspect different
-        // elements
-        testRendererInstance = TestRenderer.create(null, {
-          unstable_isConcurrent: true,
-        });
+        // HACK: Recreate TestRenderer instance so we can inspect different elements
+        utils.withErrorsOrWarningsIgnored(
+          ['An update to %s inside a test was not wrapped in act'],
+          () => {
+            testRendererInstance = TestRenderer.create(null, {
+              unstable_isConcurrent: true,
+            });
+          },
+        );
         return inspectElementAtIndex(index);
       };
       const toggleError = async forceError => {

--- a/packages/react-devtools-shared/src/__tests__/setupTests.js
+++ b/packages/react-devtools-shared/src/__tests__/setupTests.js
@@ -66,9 +66,13 @@ env.beforeEach(() => {
     if (typeof firstArg !== 'string') {
       return false;
     }
-    return global._ignoredErrorOrWarningMessages.some(errorOrWarningMessage => {
-      return firstArg.indexOf(errorOrWarningMessage) !== -1;
-    });
+    const shouldFilter = global._ignoredErrorOrWarningMessages.some(
+      errorOrWarningMessage => {
+        return firstArg.indexOf(errorOrWarningMessage) !== -1;
+      },
+    );
+
+    return shouldFilter;
   }
 
   const originalConsoleError = console.error;
@@ -82,7 +86,15 @@ env.beforeEach(() => {
       throw args[1];
     } else if (
       typeof firstArg === 'string' &&
-      firstArg.startsWith("Warning: It looks like you're using the wrong act()")
+      (firstArg.startsWith(
+        "Warning: It looks like you're using the wrong act()",
+      ) ||
+        firstArg.startsWith(
+          'Warning: The current testing environment is not configured to support act',
+        ) ||
+        firstArg.startsWith(
+          'Warning: You seem to have overlapping act() calls',
+        ))
     ) {
       // DevTools intentionally wraps updates with acts from both DOM and test-renderer,
       // since test updates are expected to impact both renderers.


### PR DESCRIPTION
These warnings are not useful for DevTools tests– and sometimes may mask other, important warnings. This commit disables them.