### PR TITLE
ReactART:-Added unit Tests in the ReactART, increasing the code coverage

### DIFF
--- a/packages/react-art/src/__tests__/ReactART-test.js
+++ b/packages/react-art/src/__tests__/ReactART-test.js
@@ -440,6 +440,60 @@ describe('ReactARTComponents', () => {
     expect(rectangle.toJSON()).toMatchSnapshot();
   });
 
+  it('should generate a <Shape> with positive width when width prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle width={-50} height={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> with positive height when height prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle height={-50} width={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> with a radius property of 0 when top left radius prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle radiusTopLeft={-25} width={50} height={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> with a radius property of 0 when top right radius prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle radiusTopRight={-25} width={50} height={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> with a radius property of 0 when bottom right radius prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle radiusBottomRight={-30} width={50} height={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> with a radius property of 0 when bottom left radius prop is negative', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle radiusBottomLeft={-25} width={50} height={50} />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
+  it('should generate a <Shape> where top radius is 0 if the sum of the top radius is greater than width', () => {
+    const rectangle = ReactTestRenderer.create(
+      <Rectangle
+        radiusTopRight={25}
+        radiusTopLeft={26}
+        width={50}
+        height={40}
+      />,
+    );
+    expect(rectangle.toJSON()).toMatchSnapshot();
+  });
+
   it('should warn if width/height is missing on a Rectangle component', () => {
     expect(() =>
       ReactTestRenderer.create(<Rectangle stroke="green" fill="blue" />),

--- a/packages/react-art/src/__tests__/__snapshots__/ReactART-test.js.snap
+++ b/packages/react-art/src/__tests__/__snapshots__/ReactART-test.js.snap
@@ -1,5 +1,174 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ReactARTComponents should generate a <Shape> where top radius is 0 if the sum of the top radius is greater than width 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": 0,
+      "penX": 0,
+      "penY": 0,
+    }
+  }
+  height={40}
+  radiusTopLeft={26}
+  radiusTopRight={25}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with a radius property of 0 when bottom left radius prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": 0,
+      "penX": 0,
+      "penY": 0,
+    }
+  }
+  height={50}
+  radiusBottomLeft={-25}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with a radius property of 0 when bottom right radius prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": 0,
+      "penX": 0,
+      "penY": 0,
+    }
+  }
+  height={50}
+  radiusBottomRight={-30}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with a radius property of 0 when top left radius prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": 0,
+      "penX": 0,
+      "penY": 0,
+    }
+  }
+  height={50}
+  radiusTopLeft={-25}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with a radius property of 0 when top right radius prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": 0,
+      "penX": 0,
+      "penY": 0,
+    }
+  }
+  height={50}
+  radiusTopRight={-25}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with positive height when height prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": 0,
+      "_pivotY": -50,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": 0,
+      "penDownY": -50,
+      "penX": 0,
+      "penY": -50,
+    }
+  }
+  height={-50}
+  width={50}
+/>
+`;
+exports[`ReactARTComponents should generate a <Shape> with positive width when width prop is negative 1`] = `
+<Shape
+  d={
+    Object {
+      "_pivotX": -50,
+      "_pivotY": 0,
+      "path": Array [
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "penDownX": -50,
+      "penDownY": 0,
+      "penX": -50,
+      "penY": 0,
+    }
+  }
+  height={50}
+  width={-50}
+/>
+`;
 exports[`ReactARTComponents should generate a <Shape> with props for drawing the Circle 1`] = `
 <Shape
   d={


### PR DESCRIPTION
This PR added unit tests around the `ReactART` which has also increased the coverage

Test and coverage before the PR:-
![Windows PowerShell 27-01-2022 11 23 47 AM](https://user-images.githubusercontent.com/72331432/151301977-713cd899-8205-41e3-a7c5-6a3b02ce536e.png)
![Windows PowerShell 27-01-2022 11 26 21 AM](https://user-images.githubusercontent.com/72331432/151301999-11f2f39f-b760-4e28-8323-bb57bd276c13.png)


Test and coverage after the PR:-

![Windows PowerShell 27-01-2022 11 21 16 AM](https://user-images.githubusercontent.com/72331432/151302124-9b301da5-97d4-4220-a8b4-afdbcffad844.png)
![Windows PowerShell 27-01-2022 11 26 08 AM](https://user-images.githubusercontent.com/72331432/151302271-dd9072ef-e9a6-42de-9dd0-652d696ce58d.png)

