### PR TITLE
ReactTestUtils -Added a test for finding rendered component, increasing the code cove…

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -503,4 +503,19 @@ describe('ReactTestUtils', () => {
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(mockArgs.length).toEqual(0);
   });
+  it('should find rendered component with type in document', () => {
+    class MyComponent extends React.Component {
+      render() {
+        return true;
+      }
+    }
+
+    const instance = ReactTestUtils.renderIntoDocument(<MyComponent />);
+    const renderedComponentType = ReactTestUtils.findRenderedComponentWithType(
+      instance,
+      MyComponent,
+    );
+
+    expect(renderedComponentType).toBe(instance);
+  });
 });


### PR DESCRIPTION
I added a small test which checks for the rendered component with document in type.

code coverage before this pr-
![Windows PowerShell 27-01-2022 1 54 11 PM](https://user-images.githubusercontent.com/72331432/151320479-841d96fe-b9dd-44ee-b12d-8c0fd0d6ab3d.png)

code coverage after this pr-
![Windows PowerShell 27-01-2022 1 48 19 PM](https://user-images.githubusercontent.com/72331432/151320497-9dee3ab8-a093-4017-8954-8fdf2e081d1d.png)


