### PR TITLE
Remove logic for multiple error recovery attempts

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -894,23 +894,7 @@ function recoverFromConcurrentError(root, errorRetryLanes) {
     }
   }
 
-  let exitStatus;
-
-  const MAX_ERROR_RETRY_ATTEMPTS = 50;
-  for (let i = 0; i < MAX_ERROR_RETRY_ATTEMPTS; i++) {
-    exitStatus = renderRootSync(root, errorRetryLanes);
-    if (
-      exitStatus === RootErrored &&
-      workInProgressRootRenderPhaseUpdatedLanes !== NoLanes
-    ) {
-      // There was a render phase update during this render. Some internal React
-      // implementation details may use this as a trick to schedule another
-      // render pass. To protect against an inifinite loop, eventually
-      // we'll give up.
-      continue;
-    }
-    break;
-  }
+  const exitStatus = renderRootSync(root, errorRetryLanes);
 
   executionContext = prevExecutionContext;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -894,23 +894,7 @@ function recoverFromConcurrentError(root, errorRetryLanes) {
     }
   }
 
-  let exitStatus;
-
-  const MAX_ERROR_RETRY_ATTEMPTS = 50;
-  for (let i = 0; i < MAX_ERROR_RETRY_ATTEMPTS; i++) {
-    exitStatus = renderRootSync(root, errorRetryLanes);
-    if (
-      exitStatus === RootErrored &&
-      workInProgressRootRenderPhaseUpdatedLanes !== NoLanes
-    ) {
-      // There was a render phase update during this render. Some internal React
-      // implementation details may use this as a trick to schedule another
-      // render pass. To protect against an inifinite loop, eventually
-      // we'll give up.
-      continue;
-    }
-    break;
-  }
+  const exitStatus = renderRootSync(root, errorRetryLanes);
 
   executionContext = prevExecutionContext;
 


### PR DESCRIPTION
This deletes some internal behavior that was only used by useOpaqueIdentifier, as an implementation detail: if an update is
scheduled during the render phase, and something threw an error, we would try rendering again, either until there were no more errors or until there were no more render phase updates. This was not a publicly defined behavior — regular render phase updates are accompanied by a warning.

Because useOpaqueIdentifier has been replaced by useId, and does not rely on this implementation detail, we can delete this code.