### PR TITLE
Unhidden Offscreen fibers Can Have Memoized State

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -247,6 +247,7 @@ import {
   pushTreeId,
   pushMaterializedTreeId,
 } from './ReactFiberTreeContext.old';
+import {offscreenFiberIsHidden} from './ReactFiberOffscreenComponent';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
@@ -650,6 +651,7 @@ function updateOffscreenComponent(
       const nextState: OffscreenState = {
         baseLanes: NoLanes,
         cachePool: null,
+        isHidden: true,
       };
       workInProgress.memoizedState = nextState;
       pushRenderLanes(workInProgress, renderLanes);
@@ -657,7 +659,11 @@ function updateOffscreenComponent(
       // We're hidden, and we're not rendering at Offscreen. We will bail out
       // and resume this tree later.
       let nextBaseLanes;
-      if (prevState !== null) {
+      if (
+        current !== null &&
+        prevState !== null &&
+        offscreenFiberIsHidden(current)
+      ) {
         const prevBaseLanes = prevState.baseLanes;
         nextBaseLanes = mergeLanes(prevBaseLanes, renderLanes);
         if (enableCache) {
@@ -678,6 +684,7 @@ function updateOffscreenComponent(
       const nextState: OffscreenState = {
         baseLanes: nextBaseLanes,
         cachePool: spawnedCachePool,
+        isHidden: true,
       };
       workInProgress.memoizedState = nextState;
       workInProgress.updateQueue = null;
@@ -718,17 +725,20 @@ function updateOffscreenComponent(
       const nextState: OffscreenState = {
         baseLanes: NoLanes,
         cachePool: null,
+        isHidden: true,
       };
       workInProgress.memoizedState = nextState;
       // Push the lanes that were skipped when we bailed out.
       const subtreeRenderLanes =
-        prevState !== null ? prevState.baseLanes : renderLanes;
+        prevState !== null && offscreenFiberIsHidden(current)
+          ? prevState.baseLanes
+          : renderLanes;
       pushRenderLanes(workInProgress, subtreeRenderLanes);
     }
   } else {
     // Rendering a visible tree.
     let subtreeRenderLanes;
-    if (prevState !== null) {
+    if (prevState !== null && offscreenFiberIsHidden(current)) {
       // We're going from hidden -> visible.
 
       subtreeRenderLanes = mergeLanes(prevState.baseLanes, renderLanes);
@@ -1890,6 +1900,7 @@ function mountSuspenseOffscreenState(renderLanes: Lanes): OffscreenState {
   return {
     baseLanes: renderLanes,
     cachePool: getSuspendedCachePool(),
+    isHidden: true,
   };
 }
 
@@ -1924,6 +1935,7 @@ function updateSuspenseOffscreenState(
   return {
     baseLanes: mergeLanes(prevOffscreenState.baseLanes, renderLanes),
     cachePool,
+    isHidden: true,
   };
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -22,7 +22,6 @@ import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 import type {UpdateQueue} from './ReactUpdateQueue.old';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.old';
 import type {Wakeable} from 'shared/ReactTypes';
-import type {OffscreenState} from './ReactFiberOffscreenComponent';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {Cache} from './ReactFiberCacheComponent.old';
 
@@ -156,6 +155,7 @@ import {
   onCommitUnmount,
 } from './ReactFiberDevToolsHook.old';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.old';
+import {offscreenFiberIsHidden} from './ReactFiberOffscreenComponent';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -1078,7 +1078,7 @@ function hideOrUnhideAllChildren(finishedWork, isHidden) {
       } else if (
         (node.tag === OffscreenComponent ||
           node.tag === LegacyHiddenComponent) &&
-        (node.memoizedState: OffscreenState) !== null &&
+        offscreenFiberIsHidden(node) &&
         node !== finishedWork
       ) {
         // Found a nested Offscreen component that is hidden.
@@ -2222,11 +2222,10 @@ function commitMutationEffectsOnFiber(finishedWork: Fiber, root: FiberRoot) {
   if (flags & Visibility) {
     switch (finishedWork.tag) {
       case SuspenseComponent: {
-        const newState: OffscreenState | null = finishedWork.memoizedState;
-        const isHidden = newState !== null;
+        const isHidden = offscreenFiberIsHidden(finishedWork);
         if (isHidden) {
           const current = finishedWork.alternate;
-          const wasHidden = current !== null && current.memoizedState !== null;
+          const wasHidden = current !== null && offscreenFiberIsHidden(current);
           if (!wasHidden) {
             // TODO: Move to passive phase
             markCommitTimeOfFallback();
@@ -2235,10 +2234,9 @@ function commitMutationEffectsOnFiber(finishedWork: Fiber, root: FiberRoot) {
         break;
       }
       case OffscreenComponent: {
-        const newState: OffscreenState | null = finishedWork.memoizedState;
-        const isHidden = newState !== null;
+        const isHidden = offscreenFiberIsHidden(finishedWork);
         const current = finishedWork.alternate;
-        const wasHidden = current !== null && current.memoizedState !== null;
+        const wasHidden = current !== null && offscreenFiberIsHidden(current);
         const offscreenBoundary: Fiber = finishedWork;
 
         if (supportsMutation) {
@@ -2351,7 +2349,7 @@ function commitLayoutEffects_begin(
       isModernRoot
     ) {
       // Keep track of the current Offscreen stack's state.
-      const isHidden = fiber.memoizedState !== null;
+      const isHidden = offscreenFiberIsHidden(fiber);
       const newOffscreenSubtreeIsHidden = isHidden || offscreenSubtreeIsHidden;
       if (newOffscreenSubtreeIsHidden) {
         // The Offscreen tree is hidden. Skip over its layout effects.
@@ -2360,7 +2358,7 @@ function commitLayoutEffects_begin(
       } else {
         // TODO (Offscreen) Also check: subtreeFlags & LayoutMask
         const current = fiber.alternate;
-        const wasHidden = current !== null && current.memoizedState !== null;
+        const wasHidden = current !== null && offscreenFiberIsHidden(current);
         const newOffscreenSubtreeWasHidden =
           wasHidden || offscreenSubtreeWasHidden;
         const prevOffscreenSubtreeIsHidden = offscreenSubtreeIsHidden;
@@ -2485,7 +2483,7 @@ function disappearLayoutEffects_begin(subtreeRoot: Fiber) {
       }
       case OffscreenComponent: {
         // Check if this is a
-        const isHidden = fiber.memoizedState !== null;
+        const isHidden = offscreenFiberIsHidden(fiber);
         if (isHidden) {
           // Nested Offscreen tree is already hidden. Don't disappear
           // its effects.
@@ -2532,7 +2530,7 @@ function reappearLayoutEffects_begin(subtreeRoot: Fiber) {
     const firstChild = fiber.child;
 
     if (fiber.tag === OffscreenComponent) {
-      const isHidden = fiber.memoizedState !== null;
+      const isHidden = offscreenFiberIsHidden(fiber);
       if (isHidden) {
         // Nested Offscreen tree is still hidden. Don't re-appear its effects.
         reappearLayoutEffects_complete(subtreeRoot);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -27,7 +27,6 @@ import type {
   SuspenseListRenderState,
 } from './ReactFiberSuspenseComponent.new';
 import type {SuspenseContext} from './ReactFiberSuspenseContext.new';
-import type {OffscreenState} from './ReactFiberOffscreenComponent';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent.new';
 import {
   enableClientRenderFallbackOnHydrationMismatch,
@@ -165,6 +164,7 @@ import {
   popCachePool,
 } from './ReactFiberCacheComponent.new';
 import {popTreeContext} from './ReactFiberTreeContext.new';
+import {offscreenFiberIsHidden} from './ReactFiberOffscreenComponent';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -338,7 +338,7 @@ if (supportsMutation) {
         // the portal directly.
       } else if (
         node.tag === OffscreenComponent &&
-        node.memoizedState !== null
+        offscreenFiberIsHidden(node)
       ) {
         // The children in this boundary are hidden. Toggle their visibility
         // before appending.
@@ -407,7 +407,7 @@ if (supportsMutation) {
         // the portal directly.
       } else if (
         node.tag === OffscreenComponent &&
-        node.memoizedState !== null
+        offscreenFiberIsHidden(node)
       ) {
         // The children in this boundary are hidden. Toggle their visibility
         // before appending.
@@ -1485,12 +1485,10 @@ function completeWork(
     case OffscreenComponent:
     case LegacyHiddenComponent: {
       popRenderLanes(workInProgress);
-      const nextState: OffscreenState | null = workInProgress.memoizedState;
-      const nextIsHidden = nextState !== null;
+      const nextIsHidden = offscreenFiberIsHidden(workInProgress);
 
       if (current !== null) {
-        const prevState: OffscreenState | null = current.memoizedState;
-        const prevIsHidden = prevState !== null;
+        const prevIsHidden = offscreenFiberIsHidden(current);
         if (
           prevIsHidden !== nextIsHidden &&
           newProps.mode !== 'unstable-defer-without-hiding' &&

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -27,7 +27,6 @@ import type {
   SuspenseListRenderState,
 } from './ReactFiberSuspenseComponent.old';
 import type {SuspenseContext} from './ReactFiberSuspenseContext.old';
-import type {OffscreenState} from './ReactFiberOffscreenComponent';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent.old';
 import {
   enableClientRenderFallbackOnHydrationMismatch,
@@ -165,6 +164,7 @@ import {
   popCachePool,
 } from './ReactFiberCacheComponent.old';
 import {popTreeContext} from './ReactFiberTreeContext.old';
+import {offscreenFiberIsHidden} from './ReactFiberOffscreenComponent';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -338,7 +338,7 @@ if (supportsMutation) {
         // the portal directly.
       } else if (
         node.tag === OffscreenComponent &&
-        node.memoizedState !== null
+        offscreenFiberIsHidden(node)
       ) {
         // The children in this boundary are hidden. Toggle their visibility
         // before appending.
@@ -407,7 +407,7 @@ if (supportsMutation) {
         // the portal directly.
       } else if (
         node.tag === OffscreenComponent &&
-        node.memoizedState !== null
+        offscreenFiberIsHidden(node)
       ) {
         // The children in this boundary are hidden. Toggle their visibility
         // before appending.
@@ -1485,12 +1485,10 @@ function completeWork(
     case OffscreenComponent:
     case LegacyHiddenComponent: {
       popRenderLanes(workInProgress);
-      const nextState: OffscreenState | null = workInProgress.memoizedState;
-      const nextIsHidden = nextState !== null;
+      const nextIsHidden = offscreenFiberIsHidden(workInProgress);
 
       if (current !== null) {
-        const prevState: OffscreenState | null = current.memoizedState;
-        const prevIsHidden = prevState !== null;
+        const prevIsHidden = offscreenFiberIsHidden(current);
         if (
           prevIsHidden !== nextIsHidden &&
           newProps.mode !== 'unstable-defer-without-hiding' &&

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -30,4 +30,10 @@ export type OffscreenState = {|
   // order to unhide the component.
   baseLanes: Lanes,
   cachePool: SpawnedCachePool | null,
+  isHidden: boolean,
 |};
+
+export function offscreenFiberIsHidden(fiber: Fiber): boolean {
+  const state: OffscreenState | null = fiber.memoizedState;
+  return state !== null && state.isHidden;
+}


### PR DESCRIPTION
**Reasoning**

Sometimes on Offscreen fibers, we need to be able to store state. For example, for the new interaction tracing API, we want to be able to store all parent tracing markers onto the the offscreen component whenever it hides or unhides so that we can call the appropriate tracing marker callback when Suspense boundaries or unsuspend or an Offscreen component hides. However, in the reconciler, we currently use the absence of memoized state to mean that the offscreen fiber is no longer hidden. We change this so that is no longer true by giving the offscreen state a `isHidden` flag. Now, the offscreen fiber is in a hidden state if it doesn't have a memoized state **or** if the `isHidden` flag in the state is true