### PR TITLE
bump node.js version for CI, fixing `useSyncExternalStoreShared-test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 aliases:
   - &docker
-    - image: cimg/openjdk:17.0.0-node
+    - image: cimg/openjdk:17.0.2-node
 
   - &environment
     TZ: /usr/share/zoneinfo/America/Los_Angeles

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -899,7 +899,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
         store.set({});
       });
       expect(container.textContent).toEqual(
-        "Cannot read property 'toUpperCase' of undefined",
+        "Cannot read properties of undefined (reading 'toUpperCase')",
       );
     });
 
@@ -935,7 +935,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
         store.set({});
       });
       expect(container.textContent).toEqual(
-        "Cannot read property 'trim' of undefined",
+        "Cannot read properties of undefined (reading 'trim')",
       );
     });
   });


### PR DESCRIPTION

## Summary

`useSyncExternalStoreShared-test` fails locally for me  because TypeError message has changed for node.js 16.

<img width="1064" alt="Screenshot 2022-02-06 at 22 07 17" src="https://user-images.githubusercontent.com/2394070/152703344-df89246f-3517-46b1-bed7-c552c40a10f6.png">

currently `cimg/openjdk:17.0.0` still use node.js 14 so bumped it to `cimg/openjdk:17.0.2` which has node.js 16
<img width="686" alt="Screenshot 2022-02-06 at 22 08 17" src="https://user-images.githubusercontent.com/2394070/152703455-e30de54a-5720-4dea-931d-939cea8b5b40.png">


## How did you test this change?

<img width="1067" alt="Screenshot 2022-02-06 at 22 04 55" src="https://user-images.githubusercontent.com/2394070/152703287-b17cf182-bffe-440d-b058-1ac25aaf2dcd.png">
