### PR TITLE
update node.js version for CI to 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 aliases:
   - &docker
-    - image: cimg/openjdk:17.0.0-node
+    - image: cimg/openjdk:17.0.2-node
 
   - &environment
     TZ: /usr/share/zoneinfo/America/Los_Angeles

--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -503,9 +503,13 @@ function runActTests(label, render, unmount, rerender) {
         spyOnDevAndProd(console, 'error');
         // let's try to cheat and spin off a 'thread' with an act call
         (async () => {
-          await act(async () => {
-            await sleep(50);
-          });
+          try {
+            await act(async () => {
+              await sleep(50);
+            });
+          } catch (e) {
+            // suppress ERR_UNHANDLED_REJECTION
+          }
         })();
 
         await act(async () => {

--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -899,7 +899,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
         store.set({});
       });
       expect(container.textContent).toEqual(
-        "Cannot read property 'toUpperCase' of undefined",
+        "Cannot read properties of undefined (reading 'toUpperCase')",
       );
     });
 
@@ -935,7 +935,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
         store.set({});
       });
       expect(container.textContent).toEqual(
-        "Cannot read property 'trim' of undefined",
+        "Cannot read properties of undefined (reading 'trim')",
       );
     });
   });


### PR DESCRIPTION

## Summary

PR again for #23236 (one test fix missed for prev PR)

this diff bumps node.js version used CI to 16 to improve the developer experience.
Accordingly some tests needs to be modified.


## How did you test this change?
```
> yarn prettier
> yarn lint
> yarn flow
> yarn test
> yarn test --prod
```


