### PR TITLE
Add exports field to react-dom (including configuring Cloudflare and Deno)

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -38,6 +38,19 @@
     "cjs/",
     "umd/"
   ],
+  "exports": {
+    ".": "./index.js",
+    "./server": {
+      "deno": "./server.browser.js",
+      "worker": "./server.browser.js",
+      "browser": "./server.browser.js",
+      "default": "./server.node.js"
+    },
+    "./profiling": "./profiling.js",
+    "./test-utils": "./test-utils.js",
+    "./package.json": "./package.json",
+    "./": "./"
+  },
   "browser": {
     "./server.js": "./server.browser.js"
   },


### PR DESCRIPTION
This configures the exports field for react-dom.

Notably there are some conditions for the /server entry point where we pick the export based on environments. Most environments now support Web Streams which is preferred in those environments.

We already do this using the "browser" field so the "browser" condition applies here too.

I also specified "worker" explicitly since this is for Service Workers and those are often targeted with Webpack's "webworker" target, which is also [what Cloudflare currently recommends](https://developers.cloudflare.com/workers/cli-wrangler/webpack). I don't think this is necessary because Webpack includes the "browser" field for this case. However, it seems more accurate. Although I'm not sure if this would break if you use a Worker in Node.js.

I also added "deno" but Deno is a bit special because this only works if you run with the node compatibility on since otherwise you have to specify absolute URLs for the imports anyway. Currently the node compatibility doesn't work well from real ESM and the built-in JSX support doesn't work outside of real ESM. So this is a bit of a mess.

I wasn't able to add fixtures and test any of this yet. It ended up being kind of messy and a lot of work to create a real environment. This seems like the aspirational goal we want though and to avoid breaking changes it seems worth landing. For example, Deno in Node compat mode should still use the browser build.
