### PR TITLE
Fix deprecated folder mappings in package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,8 @@
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js",
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-    "./": "./"
+    "./src/*": "./src/*",
+    "./unstable-shared-subset": "./unstable-shared-subset.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node v16 deprecated the use of trailing "/" to define subpath folder mappings in the "exports" field of package.json.

The recommendation is to explicitly list all our exports. We already do that for all our public modules. I believe the only reason we have a wildcard pattern is because our package.json files are also used at
build time (by Rollup) to resolve internal source modules that don't appear in the final npm artifact.

Changing "./" to "./src/*" fixes the warnings. See https://nodejs.org/api/packages.html#subpath-patterns for more info.

In the future, we should consider removing the wildcard pattern and explicitly listing out all our public entry points.