### PR TITLE
Remove path resolution from internal forks plugin

### DIFF
--- a/scripts/rollup/plugins/use-forks-plugin.js
+++ b/scripts/rollup/plugins/use-forks-plugin.js
@@ -30,15 +30,19 @@ let resolveCache = new Map();
 function useForks(forks) {
   let resolvedForks = new Map();
   Object.keys(forks).forEach(srcModule => {
+    // Fork paths are relative to the project root. They must include the full
+    // path, including the extension. We intentionally don't use Node's module
+    // resolution algorithm because 1) require.resolve doesn't work with ESM
+    // modules, and 2) the behavior is easier to predict.
     const targetModule = forks[srcModule];
     resolvedForks.set(
-      require.resolve(srcModule),
+      path.resolve(process.cwd(), srcModule),
       // targetModule could be a string (a file path),
       // or an error (which we'd throw if it gets used).
       // Don't try to "resolve" errors, but cache
       // resolved file paths.
       typeof targetModule === 'string'
-        ? require.resolve(targetModule)
+        ? path.resolve(process.cwd(), targetModule)
         : targetModule
     );
   });


### PR DESCRIPTION
Alternative to #23254

Our build script has a custom plugin to resolve internal module forks. Currently, it uses require.resolve to resolve the path to a real file on disk.

Instead, I've updated all the forked module paths to match their location on disk, relative to the project root, to remove the need to resolve them in the build script's runtime.

The main motivation is because require.resolve doesn't work with ESM modules, but aside from that, hardcoding the relative paths is more predictable — the Node module resolution algorithm is complicated, and we don't really need its features for this purpose.