### PR TITLE
Remove deprecated wildcard folder mapping

### DIFF
--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -50,8 +50,9 @@
     "./profiling": "./profiling.js",
     "./test-utils": "./test-utils.js",
     "./unstable_testing": "./unstable_testing.js",
-    "./package.json": "./package.json",
-    "./": "./"
+    "./umd/*": "./umd/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
   "browser": {
     "./server.js": "./server.browser.js"

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -50,7 +50,6 @@
     "./profiling": "./profiling.js",
     "./test-utils": "./test-utils.js",
     "./unstable_testing": "./unstable_testing.js",
-    "./umd/*": "./umd/*",
     "./src/*": "./src/*",
     "./package.json": "./package.json"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,9 @@
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js",
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-    "./": "./"
+    "./umd/*": "./umd/*",
+    "./unstable-shared-subset": "./unstable-shared-subset.js"
+
   },
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,7 +27,6 @@
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js",
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",
-    "./umd/*": "./umd/*",
     "./unstable-shared-subset": "./unstable-shared-subset.js"
 
   },

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -269,7 +269,7 @@ const bundles = [
       FB_WWW_PROD,
     ],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMLegacyServerBrowser',
+    entry: 'react-dom/src/server/ReactDOMLegacyServerBrowser.js',
     name: 'react-dom-server-legacy.browser',
     global: 'ReactDOMServer',
     minifyWithProdErrorCodes: true,
@@ -285,7 +285,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMLegacyServerNode',
+    entry: 'react-dom/src/server/ReactDOMLegacyServerNode.js',
     name: 'react-dom-server-legacy.node',
     externals: ['react', 'stream'],
     minifyWithProdErrorCodes: false,
@@ -302,7 +302,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD, UMD_DEV, UMD_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerBrowser',
+    entry: 'react-dom/src/server/ReactDOMFizzServerBrowser.js',
     name: 'react-dom-server.browser',
     global: 'ReactDOMServer',
     minifyWithProdErrorCodes: true,
@@ -312,7 +312,7 @@ const bundles = [
   {
     bundleTypes: [NODE_DEV, NODE_PROD],
     moduleType: RENDERER,
-    entry: 'react-dom/src/server/ReactDOMFizzServerNode',
+    entry: 'react-dom/src/server/ReactDOMFizzServerNode.js',
     name: 'react-dom-server.node',
     global: 'ReactDOMServer',
     minifyWithProdErrorCodes: false,
@@ -322,7 +322,7 @@ const bundles = [
   {
     bundleTypes: __EXPERIMENTAL__ ? [FB_WWW_DEV, FB_WWW_PROD] : [],
     moduleType: RENDERER,
-    entry: 'react-server-dom-relay/src/ReactDOMServerFB',
+    entry: 'react-server-dom-relay/src/ReactDOMServerFB.js',
     global: 'ReactDOMServerStreaming',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -12,7 +12,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/unstable_testing',
-      'react-dom/src/server/ReactDOMFizzServerNode',
+      'react-dom/src/server/ReactDOMFizzServerNode.js',
       'react-server-dom-webpack/writer.node.server',
       'react-server-dom-webpack',
     ],
@@ -34,7 +34,7 @@ module.exports = [
     entryPoints: [
       'react-dom',
       'react-dom/unstable_testing',
-      'react-dom/src/server/ReactDOMFizzServerBrowser',
+      'react-dom/src/server/ReactDOMFizzServerBrowser.js',
       'react-server-dom-webpack/writer.browser.server',
       'react-server-dom-webpack',
     ],
@@ -53,8 +53,8 @@ module.exports = [
   {
     shortName: 'dom-legacy',
     entryPoints: [
-      'react-dom/src/server/ReactDOMLegacyServerBrowser', // react-dom/server.browser
-      'react-dom/src/server/ReactDOMLegacyServerNode', // react-dom/server.node
+      'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
+      'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
     ],
     paths: [
       'react-dom',
@@ -99,7 +99,7 @@ module.exports = [
     entryPoints: [
       'react-server-dom-relay',
       'react-server-dom-relay/server',
-      'react-server-dom-relay/src/ReactDOMServerFB',
+      'react-server-dom-relay/src/ReactDOMServerFB.js',
     ],
     paths: ['react-dom', 'react-server-dom-relay'],
     isFlowTyped: true,


### PR DESCRIPTION
Node v16 deprecated the use of trailing "/" to define subpath folder mappings in the "exports" field of package.json.

The recommendation is to explicitly list all our exports. We already do that for all our public modules. I believe the only reason we have a wildcard pattern is because our package.json files are also used at build time (by Rollup) to resolve internal source modules that don't appear in the final npm artifact.

Changing trailing "/" to "/*" fixes the warnings. See https://nodejs.org/api/packages.html#subpath-patterns for more info.

Since the wildcard pattern only exists so our build script has access to internal at build time, I've scoped the wildcard to "/src/*". Because our public modules are located outside the "src" directory, this means deep imports of our modules will no longer work: only packages that are listed in the "exports" field.

The only two affected packages are react-dom and react. We need to be sure that all our public modules are still reachable. I audited the exports by comparing the entries to the "files" field in package.json, which represents a complete list of the files that are included in the final release artifact.

At some point, we should add an e2e packaging test to prevent regressions; for now, we should have decent coverage because in CI we run our Jest test suite against the release artifacts.