### PR TITLE
Update the exports field

### DIFF
--- a/packages/create-subscription/package.json
+++ b/packages/create-subscription/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/"
   ],

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs"
   ],

--- a/packages/jest-mock-scheduler/package.json
+++ b/packages/jest-mock-scheduler/package.json
@@ -25,7 +25,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/"
   ]

--- a/packages/jest-react/package.json
+++ b/packages/jest-react/package.json
@@ -29,7 +29,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/"
   ]

--- a/packages/react-art/package.json
+++ b/packages/react-art/package.json
@@ -34,7 +34,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/",
     "umd/",

--- a/packages/react-cache/package.json
+++ b/packages/react-cache/package.json
@@ -11,7 +11,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/",
     "umd/"

--- a/packages/react-debug-tools/package.json
+++ b/packages/react-debug-tools/package.json
@@ -12,7 +12,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/"
   ],

--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -12,7 +12,6 @@
   "files": [
     "dist",
     "backend.js",
-    "build-info.json",
     "standalone.js"
   ],
   "scripts": {

--- a/packages/react-devtools-inline/package.json
+++ b/packages/react-devtools-inline/package.json
@@ -12,7 +12,6 @@
   "files": [
     "dist",
     "backend.js",
-    "build-info.json",
     "frontend.js",
     "hookNames.js"
   ],

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -27,7 +27,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "profiling.js",
     "server.js",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -46,8 +46,11 @@
       "browser": "./server.browser.js",
       "default": "./server.node.js"
     },
+    "./server.browser": "./server.browser.js",
+    "./server.node": "./server.node.js",
     "./profiling": "./profiling.js",
     "./test-utils": "./test-utils.js",
+    "./unstable_testing": "./unstable_testing.js",
     "./package.json": "./package.json",
     "./": "./"
   },

--- a/packages/react-fetch/package.json
+++ b/packages/react-fetch/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "index.node.js",
     "index.browser.js",

--- a/packages/react-fs/package.json
+++ b/packages/react-fs/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "index.node.server.js",
     "index.browser.server.js",

--- a/packages/react-interactions/package.json
+++ b/packages/react-interactions/package.json
@@ -21,7 +21,6 @@
     "events/press.js",
     "events/press-legacy.js",
     "events/tap.js",
-    "build-info.json",
     "cjs/",
     "umd/"
   ],

--- a/packages/react-is/package.json
+++ b/packages/react-is/package.json
@@ -19,7 +19,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/",
     "umd/"

--- a/packages/react-noop-renderer/package.json
+++ b/packages/react-noop-renderer/package.json
@@ -22,7 +22,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "persistent.js",
     "server.js",

--- a/packages/react-pg/package.json
+++ b/packages/react-pg/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "index.node.server.js",
     "index.browser.server.js",

--- a/packages/react-reconciler/package.json
+++ b/packages/react-reconciler/package.json
@@ -11,7 +11,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "constants.js",
     "index.js",
     "reflection.js",

--- a/packages/react-refresh/package.json
+++ b/packages/react-refresh/package.json
@@ -13,7 +13,6 @@
     "README.md",
     "babel.js",
     "runtime.js",
-    "build-info.json",
     "cjs/",
     "umd/"
   ],

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -11,7 +11,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "plugin.js",
     "writer.js",

--- a/packages/react-test-renderer/package.json
+++ b/packages/react-test-renderer/package.json
@@ -30,7 +30,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "shallow.js",
     "cjs/",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,10 +24,6 @@
       "react-server": "./unstable-shared-subset.js",
       "default": "./index.js"
     },
-    "./index": {
-      "react-server": "./unstable-shared-subset.js",
-      "default": "./index.js"
-    },
     "./package.json": "./package.json",
     "./jsx-runtime": "./jsx-runtime.js",
     "./jsx-dev-runtime": "./jsx-dev-runtime.js",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -23,7 +23,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "unstable_mock.js",
     "unstable_post_task.js",

--- a/packages/use-subscription/package.json
+++ b/packages/use-subscription/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs/"
   ],

--- a/packages/use-sync-external-store/package.json
+++ b/packages/use-sync-external-store/package.json
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "index.native.js",
     "with-selector.js",


### PR DESCRIPTION
This removes "build-info.json" from files since we don't include those anymore.

It adds a couple missing exports so you can explicitly import server.node or server.browser.

I also added unstable_testing but I think maybe we meant to remove that?

I also removed `react/index`. I'm not sure why I added that in the first place tbh. I guess if someone used that pattern without the file extension before.