### PR TITLE
Gracefully handle empty "xstyle" prop values (Part 2)

### DIFF
--- a/packages/react-devtools-shared/src/backend/StyleX/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/__tests__/utils-test.js
@@ -54,6 +54,13 @@ describe('Stylex plugin utils', () => {
         "sources": Array [],
       }
     `);
+
+    expect(getStyleXData([undefined])).toMatchInlineSnapshot(`
+      Object {
+        "resolvedStyles": Object {},
+        "sources": Array [],
+      }
+    `);
   });
 
   it('should support simple style objects', () => {

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -35,6 +35,10 @@ export function crawlData(
 
   if (isArray(data)) {
     data.forEach(entry => {
+      if (entry == null) {
+        return;
+      }
+
       if (isArray(entry)) {
         crawlData(entry, sources, resolvedStyles);
       } else {


### PR DESCRIPTION
#23190 misses if entry is undefined or null. This fixes this issue.