### PR TITLE
Fixed that parameter name described in JSDoc does not appear in function signature

### DIFF
--- a/packages/react/src/ReactNoopUpdateQueue.js
+++ b/packages/react/src/ReactNoopUpdateQueue.js
@@ -94,7 +94,7 @@ const ReactNoopUpdateQueue = {
    * @param {ReactClass} publicInstance The instance that should rerender.
    * @param {object} partialState Next partial state to be merged with state.
    * @param {?function} callback Called after component is updated.
-   * @param {?string} Name of the calling function in the public API.
+   * @param {?string} callerName name of the calling function in the public API.
    * @internal
    */
   enqueueSetState: function(


### PR DESCRIPTION
## Summary

Looking at the file, I found the parameter name described in JSDoc does not appear in function signature.
So I fixed that. I hope it helps.
