### PR TITLE
fix:typo path

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "linc": "node ./scripts/tasks/linc.js",
     "lint": "node ./scripts/tasks/eslint.js",
     "lint-build": "node ./scripts/rollup/validate/index.js",
-    "extract-errors": "node scripts/error-codes/extract-errors.js",
+    "extract-errors": "node ./scripts/error-codes/extract-errors.js",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && node ./scripts/flow/createFlowConfigs.js && node ./scripts/yarn/downloadReactIsForPrettyFormat.js",
     "debug-test": "yarn test --deprecated 'yarn test --debug'",
     "test": "node ./scripts/jest/jest-cli.js",


### PR DESCRIPTION
"extract-errors": "node scripts/error-codes/extract-errors.js" -> "extract-errors": "node ./scripts/error-codes/extract-errors.js"