### PR TITLE
Remove createMutableSource from stable exports

### DIFF
--- a/packages/react/index.stable.js
+++ b/packages/react/index.stable.js
@@ -21,7 +21,6 @@ export {
   createContext,
   createElement,
   createFactory,
-  createMutableSource as unstable_createMutableSource,
   createRef,
   forwardRef,
   isValidElement,


### PR DESCRIPTION
I removed useMutableSource in a previous PR but forgot to remove createMutableSource.

We still export it in the FB builds until we can migrate the internal callers (Recoil).