### PR TITLE
Remove hacky stream.locked check, declare as byte stream instead

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -43,14 +43,9 @@ function renderToReadableStream(
   return new Promise((resolve, reject) => {
     function onCompleteShell() {
       const stream = new ReadableStream({
+        type: 'bytes',
         pull(controller) {
-          // Pull is called immediately even if the stream is not passed to anything.
-          // That's buffering too early. We want to start buffering once the stream
-          // is actually used by something so we can give it the best result possible
-          // at that point.
-          if (stream.locked) {
-            startFlowing(request, controller);
-          }
+          startFlowing(request, controller);
         },
         cancel(reason) {},
       });

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -31,17 +31,12 @@ function renderToReadableStream(
     options ? options.onError : undefined,
   );
   const stream = new ReadableStream({
+    type: 'bytes',
     start(controller) {
       startWork(request);
     },
     pull(controller) {
-      // Pull is called immediately even if the stream is not passed to anything.
-      // That's buffering too early. We want to start buffering once the stream
-      // is actually used by something so we can give it the best result possible
-      // at that point.
-      if (stream.locked) {
-        startFlowing(request, controller);
-      }
+      startFlowing(request, controller);
     },
     cancel(reason) {},
   });


### PR DESCRIPTION
We used to check for stream.locked in pull to see if we've been passed to something that reads yet.

This was a bad hack because it won't actually call pull again if that changes.

The source of this is because the default for "highWaterMark" is 1 on some streams. So it always wants to add one "chunk" (of size 1).

If we leave our high water mark as 0, we won't fill up any buffers unless we're asked for more.

This web API is somewhat odd because it would be way more efficient if it just told us how much the recipient wants instead of calling us once per chunk.

Anyway, I turns out that if we define ourselves as a "bytes" type of stream, the default also happens to be a high water mark of 0 so we can just use that instead.