### PR TITLE
reassign src from props not the dom element src property

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -442,7 +442,7 @@ export function commitMount(
       return;
     case 'img': {
       if ((newProps: any).src) {
-        ((domElement: any): HTMLImageElement).src = ((domElement: any): HTMLImageElement).src;
+        ((domElement: any): HTMLImageElement).src = (newProps: any).src;
       }
       return;
     }


### PR DESCRIPTION
regression fix for https://github.com/mui/material-ui/pull/31263

The src property on the dom element will return a fully qualified name and this does not match the dom
src attribute or the props provided to react. instead of reading from the element and re-assigning the property we
assign the property from props which is how it was initially assigned during the render

I've added a test to guard against future regression
