### PR TITLE
Fizz: Prevent `UnhandledPromiseRejectionWarning` if `renderToReadableStream` throws

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -67,6 +67,10 @@ function renderToReadableStream(
       resolve(stream);
     }
     function onShellError(error: mixed) {
+      // If the shell errors the caller of `renderToReadableStream` won't have access to `allReady`.
+      // However, `allReady` will be rejected by `onFatalError` as well.
+      // So we need to catch the duplicate, uncatchable fatal error in `allReady` to prevent a `UnhandledPromiseRejection`.
+      allReady.catch(() => {});
       reject(error);
     }
     const request = createRequest(


### PR DESCRIPTION
## Summary

I noticed a `UnhandledPromiseRejectionWarning` when running tests (e.g. https://app.circleci.com/pipelines/github/facebook/react/24649/workflows/5b1b67a2-eb4b-4e7e-9dd8-d531328eff6e/jobs/448950/parallel-runs/16).
It seems to me that `stream.allReady` is not accessible when the shell errors (i.e. `renderToReadableStream` throws) which means `stream.allReady` will be left rejected and unhandled.

## How did you test this change?

- [x] `yarn test ReactDOMFizzServerBrowser` logs no `UnhandledPromiseRejectionWarning`
- [x] `ReactDOMFizzServerBrowser` logs no `UnhandledPromiseRejectionWarning` in CI: https://app.circleci.com/pipelines/github/facebook/react/24655/workflows/ad4851cf-0530-4a69-8c36-e7a9bcaf7daa/jobs/449075/parallel-runs/14
- [x] CI

## Follow-up?

- [ ] fail tests if rejected promises are not handled?