### PR TITLE
[Fizz] Don't flush empty segments

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -495,6 +495,10 @@ describe('ReactDOMFizzServer', () => {
       pipe(writable);
     });
     expect(getVisibleChildren(container)).toEqual(<div>Loading...</div>);
+    // Because there is no content inside the Suspense boundary that could've
+    // been written, we expect to not see any additional partial data flushed
+    // yet.
+    expect(container.firstChild.nextSibling).toBe(null);
     await act(async () => {
       resolveElement({default: <Text text="Hello" />});
     });


### PR DESCRIPTION
Before this change, we would sometimes write segments without any content in them. For example for a Suspense boundary that immediately suspends we might emit something like:

```js
<div hidden id="123">
  <template id="456"></template>
</div>
```

Where the outer div is just a temporary wrapper and the inner one is a placeholder for something to be added later.

This serves no purpose.

We should ideally have a heuristic that holds back segments based on byte size and time. However, this is a straight forward clear win for now.

The root most completed segments of a boundary are queued onto it. I simply avoid queuing the segment if it's empty and instead queue its child or waits for it to complete.