### PR TITLE
[Flight] add support for Lazy components in Flight server

### DIFF
--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -210,11 +210,6 @@ function attemptResolveElement(
         const render = type.render;
         return render(props, undefined);
       }
-      case REACT_ELEMENT_TYPE: {
-        // this can happen when a lazy component resolves to an element instead of
-        // a Component.
-        return attemptResolveElement(type.type, type.key, type.ref, type.props);
-      }
       case REACT_MEMO_TYPE: {
         return attemptResolveElement(type.type, key, ref, props);
       }
@@ -508,7 +503,9 @@ export function resolveModelToJSON(
           break;
         }
         case REACT_LAZY_TYPE: {
-          value = attemptResolveElement(value, null, null, {});
+          const payload = (value: any)._payload;
+          const init = (value: any)._init;
+          value = init(payload);
           break;
         }
       }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -200,6 +200,12 @@ function attemptResolveElement(
       return [REACT_ELEMENT_TYPE, type, key, props];
     }
     switch (type.$$typeof) {
+      case REACT_LAZY_TYPE: {
+        const payload = type._payload;
+        const init = type._init;
+        const wrappedType = init(payload);
+        return attemptResolveElement(wrappedType, key, ref, props);
+      }
       case REACT_FORWARD_REF_TYPE: {
         const render = type.render;
         return render(props, undefined);
@@ -452,10 +458,6 @@ export function resolveModelToJSON(
   switch (value) {
     case REACT_ELEMENT_TYPE:
       return '$';
-    case REACT_LAZY_TYPE:
-      throw new Error(
-        'React Lazy Components are not yet supported on the server.',
-      );
   }
 
   if (__DEV__) {


### PR DESCRIPTION
Lazy components suspend until resolved just like in Fizz. Add tests to confirm Lazy works with Shared Components and Client Component references.
