### PR TITLE
Don't hide console error|warn in inspectedElement-test

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -459,7 +459,7 @@ describe('InspectedElement', () => {
     const prevInspectedElement = inspectedElement;
 
     // This test causes an intermediate error to be logged but we can ignore it.
-    console.error = () => {};
+    jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // Wait for our check-for-updates poll to get the new data.
     jest.runOnlyPendingTimers();
@@ -2804,16 +2804,18 @@ describe('InspectedElement', () => {
       );
 
       // Suppress expected error and warning.
-      const originalError = console.error;
-      const originalWarn = console.warn;
-      console.error = () => {};
-      console.warn = () => {};
+      const consoleErrorMock = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const consoleWarnMock = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
 
       // now force error state on <Example />
       await toggleError(true);
 
-      console.error = originalError;
-      console.warn = originalWarn;
+      consoleErrorMock.mockRestore();
+      consoleWarnMock.mockRestore();
 
       // we are in error state now, <Example /> won't show up
       withErrorsOrWarningsIgnored(['Invalid index'], () => {


### PR DESCRIPTION
## Summary

Use `jest.spyOn` instead of `console.error = () => {}`. The former will ensure that `jest.restoreAllMocks()` restores console methods.The latter will result in console error|warn in subsequent tests to be hidden.

## How did you test this change?

- [x] [CI without https://github.com/facebook/react/pull/24084 logs error](https://app.circleci.com/pipelines/github/facebook/react/24858/workflows/026a8190-a19c-4f26-9fcf-ff7047072ae7/jobs/451955/parallel-runs/7?filterBy=ALL)
- [x] [CI based on `main` errors not](https://app.circleci.com/pipelines/github/facebook/react/24859/workflows/6dd5f764-d23a-4414-a074-be25ba1b9910/jobs/451985/parallel-runs/7?filterBy=ALL)

## Follow-up

- [ ] What's up with these [deep stack traces for console.error calls](https://app.circleci.com/pipelines/github/facebook/react/24858/workflows/026a8190-a19c-4f26-9fcf-ff7047072ae7/jobs/451955/parallel-runs/7?filterBy=ALL)?