### PR TITLE
Fix test-build-devtools if build was generated by build-for-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "test-prod-build": "yarn test --deprecated 'yarn test --prod --build'",
     "test-build": "yarn test --deprecated 'yarn test --build'",
     "test-build-prod": "yarn test --deprecated 'yarn test --build --prod'",
-    "test-build-devtools": "yarn test --build --project devtools",
+    "test-build-devtools": "node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental",
     "debug-test-build-devtools": "yarn test --deprecated 'yarn test-build-devtools --debug'",
     "test-dom-fixture": "cd fixtures/dom && yarn && yarn prestart && yarn test",
     "flow": "node ./scripts/tasks/flow.js",

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -220,7 +220,7 @@ export function getInternalReactConstants(
   // Keep it in sync, and add version guards if it changes.
   //
   // TODO Update the gt() check below to be gte() whichever the next version number is.
-  // Currently the version in Git is 17.0.2 (but that version has not been/may not end up being released).
+  // Currently the version in Git is 18.0.0 (but that version has not been/may not end up being released).
   if (gt(version, '17.0.1')) {
     ReactTypeOfWork = {
       CacheComponent: 24, // Experimental

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -220,7 +220,7 @@ export function getInternalReactConstants(
   // Keep it in sync, and add version guards if it changes.
   //
   // TODO Update the gt() check below to be gte() whichever the next version number is.
-  // Currently the version in Git is 18.0.0 (but that version has not been/may not end up being released).
+  // Currently the version in Git is 17.0.2 (but that version has not been/may not end up being released).
   if (gt(version, '17.0.1')) {
     ReactTypeOfWork = {
       CacheComponent: 24, // Experimental

--- a/packages/shared/ReactVersion.js
+++ b/packages/shared/ReactVersion.js
@@ -7,10 +7,10 @@
 
 // TODO: this is special because it gets imported during build.
 //
-// TODO: 17.0.3 has not been released to NPM;
+// TODO: 18.0.0 has not been released to NPM;
 // It exists as a placeholder so that DevTools can support work tag changes between releases.
-// When we next publish a release (either 17.0.3 or 17.1.0), update the matching TODO in backend/renderer.js
+// When we next publish a release, update the matching TODO in backend/renderer.js
 // TODO: This module is used both by the release scripts and to expose a version
 // at runtime. We should instead inject the version number as part of the build
 // process, and use the ReactVersions.js module as the single source of truth.
-export default '17.0.3';
+export default '18.0.0';


### PR DESCRIPTION
## Summary

I couldn't get `yarn test-build-devtools` to run for me locally even though CI passed. "Store › StrictMode compliance › should mark non strict root elements as not strict" and "Store › StrictMode compliance › should mark non strict root elements as not strict" were failing.
First I thought the difference in build variants was the issue (first commit) but this didn't fix tests locally.

The issue was that I was using `yarn build-for-devtools` while CI was using `yarn build-combined`. `yarn build-combined` updates `ReactVersion.js` which is used by Devtools to [determine what bits are set in the Fiber mode if StrictMode is enabled](https://github.com/facebook/react/blob/061ac27bc9c30e758301d9db823677a0803938c8/packages/react-devtools-shared/src/backend/renderer.js#L204-L214).  Since `yarn build-for-devtools` resulted in 17.0.3, Devtools didn't determine the correct StrictMode bits.

## How did you test this change?

- [x] `git clean -fdx; yarn; yarn build-for-devtools; yarn test-build-devtools`
- [x] CI