### PR TITLE
Guard against global variables named after properties in DOM interfaces

### DIFF
--- a/packages/react-dom-bindings/src/events/isTextInputElement.js
+++ b/packages/react-dom-bindings/src/events/isTextInputElement.js
@@ -28,8 +28,8 @@ const supportedInputTypes: {[key: string]: true | void, ...} = {
   week: true,
 };
 
-function isTextInputElement(elem: ?HTMLElement): boolean {
-  const nodeName = elem && elem.nodeName && elem.nodeName.toLowerCase();
+function isTextInputElement(elem: Element | Text | null): boolean {
+  const nodeName = elem && elem.nodeName.toLowerCase();
 
   if (nodeName === 'input') {
     return !!supportedInputTypes[((elem: any): HTMLInputElement).type];

--- a/packages/react-dom-bindings/src/events/isTextInputElement.js
+++ b/packages/react-dom-bindings/src/events/isTextInputElement.js
@@ -29,13 +29,13 @@ const supportedInputTypes: {[key: string]: true | void, ...} = {
 };
 
 function isTextInputElement(elem: Element | Text | null): boolean {
-  const nodeName = elem && elem.nodeName.toLowerCase();
+  const localName = elem && elem.nodeName.toLowerCase();
 
-  if (nodeName === 'input') {
+  if (localName === 'input') {
     return !!supportedInputTypes[((elem: any): HTMLInputElement).type];
   }
 
-  if (nodeName === 'textarea') {
+  if (localName === 'textarea') {
     return true;
   }
 

--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -230,9 +230,9 @@ function shouldUseClickEvent(elem: Element | Text | null) {
   // Use the `click` event to detect changes to checkbox and radio inputs.
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.
-  const nodeName = elem !== null && elem.nodeName.toLowerCase();
+  const localName = elem !== null && elem.nodeName.toLowerCase();
   return (
-    nodeName === 'input' &&
+    localName === 'input' &&
     ((elem: any).type === 'checkbox' || (elem: any).type === 'radio')
   );
 }

--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -79,8 +79,8 @@ let activeElementInst = null;
 /**
  * SECTION: handle `change` event
  */
-function shouldUseChangeEvent(elem) {
-  const nodeName = elem.nodeName && elem.nodeName.toLowerCase();
+function shouldUseChangeEvent(elem: Element | Text | null) {
+  const nodeName = elem && elem.nodeName.toLowerCase();
   return (
     nodeName === 'select' ||
     (nodeName === 'input' && (elem: any).type === 'file')
@@ -226,15 +226,15 @@ function getTargetInstForInputEventPolyfill(
 /**
  * SECTION: handle `click` event
  */
-function shouldUseClickEvent(elem) {
+function shouldUseClickEvent(elem: Element | Text | null) {
   // Use the `click` event to detect changes to checkbox and radio inputs.
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.
-  const nodeName = elem.nodeName;
+  const nodeName = elem !== null && elem.nodeName;
   return (
     nodeName &&
     nodeName.toLowerCase() === 'input' &&
-    (elem.type === 'checkbox' || elem.type === 'radio')
+    ((elem: any).type === 'checkbox' || (elem: any).type === 'radio')
   );
 }
 
@@ -285,12 +285,12 @@ function extractEvents(
   eventSystemFlags: EventSystemFlags,
   targetContainer: null | EventTarget,
 ) {
-  const targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
+  const targetNode = targetInst ? getNodeFromInstance(targetInst) : null;
 
   let getTargetInstFunc, handleEventFunc;
   if (shouldUseChangeEvent(targetNode)) {
     getTargetInstFunc = getTargetInstForChangeEvent;
-  } else if (isTextInputElement(((targetNode: any): HTMLElement))) {
+  } else if (isTextInputElement(targetNode)) {
     if (isInputEventSupported) {
       getTargetInstFunc = getTargetInstForInputOrChangeEvent;
     } else {
@@ -325,7 +325,7 @@ function extractEvents(
   }
 
   // When blurring, set the value attribute for number inputs
-  if (domEventName === 'focusout') {
+  if (domEventName === 'focusout' && targetNode !== null) {
     handleControlledInputBlur(((targetNode: any): HTMLInputElement));
   }
 }

--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -230,10 +230,9 @@ function shouldUseClickEvent(elem: Element | Text | null) {
   // Use the `click` event to detect changes to checkbox and radio inputs.
   // This approach works across all browsers, whereas `change` does not fire
   // until `blur` in IE8.
-  const nodeName = elem !== null && elem.nodeName;
+  const nodeName = elem !== null && elem.nodeName.toLowerCase();
   return (
-    nodeName &&
-    nodeName.toLowerCase() === 'input' &&
+    nodeName === 'input' &&
     ((elem: any).type === 'checkbox' || (elem: any).type === 'radio')
   );
 }

--- a/packages/react-dom-bindings/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SelectEventPlugin.js
@@ -153,14 +153,14 @@ function extractEvents(
   eventSystemFlags: EventSystemFlags,
   targetContainer: EventTarget,
 ) {
-  const targetNode = targetInst ? getNodeFromInstance(targetInst) : window;
+  const targetNode = targetInst ? getNodeFromInstance(targetInst) : null;
 
   switch (domEventName) {
     // Track the input node that has focus.
     case 'focusin':
       if (
-        isTextInputElement((targetNode: any)) ||
-        targetNode.contentEditable === 'true'
+        isTextInputElement(targetNode) ||
+        (targetNode !== null && (targetNode: any).contentEditable === 'true')
       ) {
         activeElement = targetNode;
         activeElementInst = targetInst;


### PR DESCRIPTION
## Summary

- Closes https://github.com/facebook/react/issues/23324
- [Improves Flow coverage](https://gist.github.com/eps1lon/bfeec06c292d40d4004204053b1997d8)
   - `isTextInputElement.js`: +-0%
   - `ChangeEventPlugin.js`: +12% (74% -> 84%)
   - `SelectEventPlugin.js`: +7% (71% -> 78%)


## How did you test this change?

- [x] CodeSandbox from https://github.com/facebook/react/issues/23324#issuecomment-1073267698 with a build from this PR: https://codesandbox.io/s/fixed-window-nodename-extractevents-forked-4uzwt2?file=/src/index.js
- [x] CI
- [x] traced usage of `targetNode` to make sure it's never used as a `Window`