### PR TITLE
Add details in READMEs for react-devtools local developement

### DIFF
--- a/packages/react-devtools-inline/README.md
+++ b/packages/react-devtools-inline/README.md
@@ -350,8 +350,11 @@ yarn build-for-devtools
 ### Download from CI
 To use the latest build from CI, run the following command from the root of the repository:
 ```sh
-./scripts/release/download-experimental-build.js
+./scripts/release/download-experimental-build.js --commit=main
 ```
+
+Please note that you might need to [create a API Token for Circle CI](https://circleci.com/docs/2.0/managing-api-tokens/) and set up an environment variable `CIRCLE_CI_API_TOKEN`.
+
 ## Build steps
 Once the above packages have been built or downloaded, you can watch for changes made to the source code and automatically rebuild by running:
 ```sh

--- a/packages/react-devtools-shell/README.md
+++ b/packages/react-devtools-shell/README.md
@@ -2,7 +2,7 @@ Harness for testing local changes to the `react-devtools-inline` and `react-devt
 
 ## Development
 
-This target should be run in parallel with the `react-devtools-inline` package. The first step then is to run that target following the instructions in the [`react-devtools-inline` README](https://github.com/facebook/react/blob/main/packages/react-devtools-inline/README.md).
+This target should be run in parallel with the `react-devtools-inline` package. The first step then is to run that target following the instructions in the [`react-devtools-inline` README's local development section](https://github.com/facebook/react/tree/main/packages/react-devtools-inline#local-development).
 
 The test harness can then be run as follows:
 ```sh
@@ -10,3 +10,5 @@ cd packages/react-devtools-shell
 
 yarn start
 ```
+
+Once you set both up, you can view the test harness with inlined devtools in browser at http://localhost:8080/


### PR DESCRIPTION
When I was trying to run `react-devtools-shell` locally, I hit some small blockers. Adding some details to the README so it's easier for next person.