### PR TITLE
Release script prompts to stop running DEV scripts

### DIFF
--- a/scripts/devtools/build-and-test.js
+++ b/scripts/devtools/build-and-test.js
@@ -21,6 +21,26 @@ const {
 async function main() {
   clear();
 
+  await confirm('Have you stopped all NPM DEV scripts?', () => {
+    const packagesPath = relative(process.cwd(), join(__dirname, 'packages'));
+
+    console.log('Stop all NPM DEV scripts in the following directories:');
+    console.log(
+      chalk.bold('  ' + join(packagesPath, 'react-devtools-core')),
+      chalk.gray('(start:backend, start:standalone)')
+    );
+    console.log(
+      chalk.bold('  ' + join(packagesPath, 'react-devtools-inline')),
+      chalk.gray('(start)')
+    );
+
+    const buildAndTestScriptPath = join(__dirname, 'build-and-test.js');
+    const pathToPrint = relative(process.cwd(), buildAndTestScriptPath);
+
+    console.log('\nThen restart this release step:');
+    console.log(chalk.bold.green('  ' + pathToPrint));
+  });
+
   await confirm('Have you run the prepare-release script?', () => {
     const prepareReleaseScriptPath = join(__dirname, 'prepare-release.js');
     const pathToPrint = relative(process.cwd(), prepareReleaseScriptPath);


### PR DESCRIPTION
Wouldn't want a _watch_ script to accidentally modify the contents of the build directory before we publish to NPM.

![Screen Shot 2022-03-24 at 11 20 46 AM](https://user-images.githubusercontent.com/29597/159950273-5100b076-a7e1-4358-814e-84eb8224e406.png)
