### PR TITLE
Print attributes in hydration errors

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1846,7 +1846,7 @@ describe('ReactDOMFizzServer', () => {
       }).toErrorDev(
         [
           'Warning: An error occurred during hydration. The server HTML was replaced with client content in <div>.',
-          'Warning: Expected server HTML to contain a matching <div> in <div>.\n' +
+          'Warning: Expected server HTML to contain a matching <div> in <div id="container">.\n' +
             '    in div (at **)\n' +
             '    in App (at **)',
         ],
@@ -1947,7 +1947,7 @@ describe('ReactDOMFizzServer', () => {
       }).toErrorDev(
         [
           'Warning: An error occurred during hydration. The server HTML was replaced with client content',
-          'Warning: Expected server HTML to contain a matching <div> in <div>.\n' +
+          'Warning: Expected server HTML to contain a matching <div> in <div id="container">.\n' +
             '    in div (at **)\n' +
             '    in App (at **)',
         ],

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -361,9 +361,9 @@ describe('ReactDOMServerPartialHydration', () => {
 
       if (__DEV__) {
         expect(mockError.mock.calls[0]).toEqual([
-          'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
+          'Warning: Expected server HTML to contain a matching <%s> in %s.%s',
           'div',
-          'div',
+          '<div>',
           '\n' +
             '    in div (at **)\n' +
             '    in Component (at **)\n' +
@@ -610,9 +610,9 @@ describe('ReactDOMServerPartialHydration', () => {
       }
       if (__DEV__) {
         expect(mockError).toHaveBeenCalledWith(
-          'Warning: Did not expect server HTML to contain a <%s> in <%s>.%s',
-          'span',
-          'div',
+          'Warning: Did not expect server HTML to contain a %s in %s.%s',
+          '<span>',
+          '<div>',
           '\n' +
             '    in Suspense (at **)\n' +
             '    in div (at **)\n' +

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -222,7 +222,9 @@ describe('rendering React components at document', () => {
       // getTestDocument() has an extra <meta> that we didn't render.
       expect(() =>
         ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toErrorDev('Did not expect server HTML to contain a <meta> in <head>.');
+      ).toErrorDev(
+        'Did not expect server HTML to contain a <meta charset="utf-8"> in <head>.',
+      );
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -100,6 +100,7 @@ let warnForInvalidEventListener;
 let canDiffStyleForHydrationWarning;
 
 let normalizeHTML;
+let formatTagDEV;
 
 if (__DEV__) {
   warnedUnknownTags = {
@@ -205,6 +206,26 @@ if (__DEV__) {
           );
     testElement.innerHTML = html;
     return testElement.innerHTML;
+  };
+
+  formatTagDEV = function(node: Element): string {
+    let str = '<' + node.nodeName.toLowerCase();
+    const attributeNames = node.getAttributeNames();
+    for (let i = 0; i < attributeNames.length; i++) {
+      if (i > 30) {
+        str += ' ...';
+        break;
+      }
+      const attributeName = attributeNames[i];
+      const value = node.getAttribute(attributeName);
+      let trimmedValue = value;
+      if (value.length > 30) {
+        trimmedValue = value.substr(0, 30) + '...';
+      }
+      str += ' ' + attributeName + '="' + trimmedValue + '"';
+    }
+    str += '>';
+    return str;
   };
 }
 
@@ -1209,9 +1230,9 @@ export function warnForDeletedHydratableElement(
     }
     didWarnInvalidHydration = true;
     console.error(
-      'Did not expect server HTML to contain a <%s> in <%s>.',
-      child.nodeName.toLowerCase(),
-      parentNode.nodeName.toLowerCase(),
+      'Did not expect server HTML to contain a %s in %s.',
+      formatTagDEV(child),
+      formatTagDEV(parentNode),
     );
   }
 }
@@ -1226,9 +1247,9 @@ export function warnForDeletedHydratableText(
     }
     didWarnInvalidHydration = true;
     console.error(
-      'Did not expect server HTML to contain the text node "%s" in <%s>.',
+      'Did not expect server HTML to contain the text node "%s" in %s.',
       child.nodeValue,
-      parentNode.nodeName.toLowerCase(),
+      formatTagDEV(parentNode),
     );
   }
 }
@@ -1244,9 +1265,9 @@ export function warnForInsertedHydratedElement(
     }
     didWarnInvalidHydration = true;
     console.error(
-      'Expected server HTML to contain a matching <%s> in <%s>.',
+      'Expected server HTML to contain a matching <%s> in %s.',
       tag,
-      parentNode.nodeName.toLowerCase(),
+      formatTagDEV(parentNode),
     );
   }
 }
@@ -1268,9 +1289,9 @@ export function warnForInsertedHydratedText(
     }
     didWarnInvalidHydration = true;
     console.error(
-      'Expected server HTML to contain a matching text node for "%s" in <%s>.',
+      'Expected server HTML to contain a matching text node for "%s" in %s.',
       text,
-      parentNode.nodeName.toLowerCase(),
+      formatTagDEV(parentNode),
     );
   }
 }

--- a/packages/react-dom/src/client/ReactDOMComponent.js
+++ b/packages/react-dom/src/client/ReactDOMComponent.js
@@ -62,7 +62,7 @@ import {
   shouldRemoveAttribute,
 } from '../shared/DOMProperty';
 import assertValidProps from '../shared/assertValidProps';
-import {DOCUMENT_NODE} from '../shared/HTMLNodeType';
+import {DOCUMENT_NODE, ELEMENT_NODE} from '../shared/HTMLNodeType';
 import isCustomComponent from '../shared/isCustomComponent';
 import possibleStandardNames from '../shared/possibleStandardNames';
 import {validateProperties as validateARIAProperties} from '../shared/ReactDOMInvalidARIAHook';
@@ -208,21 +208,26 @@ if (__DEV__) {
     return testElement.innerHTML;
   };
 
-  formatTagDEV = function(node: Element): string {
+  formatTagDEV = function(node: Element | Document | DocumentFragment): string {
     let str = '<' + node.nodeName.toLowerCase();
-    const attributeNames = node.getAttributeNames();
-    for (let i = 0; i < attributeNames.length; i++) {
-      if (i > 30) {
-        str += ' ...';
-        break;
+    if (node.nodeType === ELEMENT_NODE) {
+      const element = ((node: any): Element);
+      const attributes = element.attributes;
+      for (let i = 0; i < attributes.length; i++) {
+        if (i > 30) {
+          str += ' ...';
+          break;
+        }
+        const attributeName = attributes[i].name;
+        const value = attributes[i].value;
+        if (value != null) {
+          let trimmedValue = value;
+          if (value.length > 30) {
+            trimmedValue = value.substr(0, 30) + '...';
+          }
+          str += ' ' + attributeName + '="' + trimmedValue + '"';
+        }
       }
-      const attributeName = attributeNames[i];
-      const value = node.getAttribute(attributeName);
-      let trimmedValue = value;
-      if (value.length > 30) {
-        trimmedValue = value.substr(0, 30) + '...';
-      }
-      str += ' ' + attributeName + '="' + trimmedValue + '"';
     }
     str += '>';
     return str;


### PR DESCRIPTION
The mildest version I can think of that still adds something useful to the messages. Doesn't require any extra wiring but should help when you have class names or styles. This primarily annotates the parent so it's not as helpful as it would be if we said which child didn't match. But I think it's better than status quo.