### PR TITLE
Fix usage of console.error to prevent transform

### DIFF
--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -81,8 +81,8 @@ const defaultOnRecoverableError =
       reportError
     : (error: mixed) => {
         // In older browsers and test environments, fallback to console.error.
-        // eslint-disable-next-line react-internal/no-production-logging, react-internal/warning-args
-        console.error(error);
+        // eslint-disable-next-line react-internal/no-production-logging
+        console['error'](error);
       };
 
 function ReactDOMRoot(internalRoot: FiberRoot) {


### PR DESCRIPTION
## Summary

We were suppressing the `react-internals/warning-args` lint rule for the call to `console.error` in `defaultOnRecoverableError` which was leading to a bug on dev builds. See below.

As far as I could tell, the lint rule exists because on dev builds, we replace all calls to `console.error` with [this error
function](https://github.com/facebook/react/blob/main/packages/shared/consoleWithStackDev.js#L31-L37) which expects a format string + args and nothing else. We were trying to pass in an `Error` object directly. After this commit's change, we will still be passing in an `Error` object but the `console.error` call won't be transformed.

## How did you test this change?

Tested via

```
$ yarn flow dom
$ yarn linc
```