### PR TITLE
Accept HTMLElement as a container in createRoot

### DIFF
--- a/packages/react-dom/client.js
+++ b/packages/react-dom/client.js
@@ -23,7 +23,7 @@ import {
 } from './';
 
 export function createRoot(
-  container: Element | DocumentFragment,
+  container: Element | DocumentFragment | HTMLElement,
   options?: CreateRootOptions,
 ): RootType {
   if (__DEV__) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Motivation: 
To allow createRoot to accept HTMLElement as a container in createRoot, so it doesn't throw a type error when used to initialize with `document.getElementById('root')`


## How did you test this change?

`yarn test && yarn test-build && yarn test-build-prod`