### PR TITLE
[ReactDebugTools] wrap uncaught error from rendering user's component

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -366,7 +366,7 @@ const DispatcherProxyHandler = {
     const error = new Error('Missing method in Dispatcher: ' + prop);
     // Note: This error name needs to stay in sync with react-devtools-shared
     // TODO: refactor this if we ever combine the devtools and debug tools packages
-    error.name = 'UnsupportedFeatureError';
+    error.name = 'ReactDebugToolsUnsupportedFeatureError';
     throw error;
   },
 };
@@ -670,7 +670,7 @@ function processDebugValues(
 function handleRenderFunctionError(error: any): void {
   // original error might be any type.
   const isError = error instanceof Error;
-  if (isError && error.name === 'UnsupportedFeatureError') {
+  if (isError && error.name === 'ReactDebugToolsUnsupportedFeatureError') {
     throw error;
   }
   // If the error is not caused by an unsupported feature, it means
@@ -685,7 +685,7 @@ function handleRenderFunctionError(error: any): void {
   const wrapperError = new Error(messgae, {cause: error});
   // Note: This error name needs to stay in sync with react-devtools-shared
   // TODO: refactor this if we ever combine the devtools and debug tools packages
-  wrapperError.name = 'RenderFunctionError';
+  wrapperError.name = 'ReactDebugToolsRenderFunctionError';
   throw wrapperError;
 }
 

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -680,7 +680,7 @@ function handleRenderFunctionError(error: any): void {
   const messgae: string =
     isError && error.message
       ? error.message
-      : 'Error rendering inspected component'
+      : 'Error rendering inspected component';
   // $FlowFixMe: Flow doesn't know about 2nd argument of Error constructor
   const wrapperError = new Error(messgae, {cause: error});
   // Note: This error name needs to stay in sync with react-devtools-shared

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -685,7 +685,7 @@ function handleRenderFunctionError(error: any): void {
   });
   // Note: This error name needs to stay in sync with react-devtools-shared
   // TODO: refactor this if we ever combine the devtools and debug tools packages
-  wrapperError.name = 'ReactDebugToolsRenderFunctionError';
+  wrapperError.name = 'ReactDebugToolsRenderError';
   throw wrapperError;
 }
 

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -366,7 +366,7 @@ const DispatcherProxyHandler = {
     const error = new Error('Missing method in Dispatcher: ' + prop);
     // Note: This error name needs to stay in sync with react-devtools-shared
     // TODO: refactor this if we ever combine the devtools and debug tools packages
-    error.name = 'ReactDebugToolsUnsupportedFeatureError';
+    error.name = 'ReactDebugToolsUnsupportedHookError';
     throw error;
   },
 };
@@ -669,20 +669,20 @@ function processDebugValues(
 
 function handleRenderFunctionError(error: any): void {
   // original error might be any type.
-  const isError = error instanceof Error;
-  if (isError && error.name === 'ReactDebugToolsUnsupportedFeatureError') {
+  if (
+    error instanceof Error &&
+    error.name === 'ReactDebugToolsUnsupportedHookError'
+  ) {
     throw error;
   }
   // If the error is not caused by an unsupported feature, it means
   // that the error is caused by user's code in renderFunction.
   // In this case, we should wrap the original error inside a custom error
-  // so that devtools can show a clear message for it.
-  const messgae: string =
-    isError && error.message
-      ? error.message
-      : 'Error rendering inspected component';
+  // so that devtools can give a clear message about it.
   // $FlowFixMe: Flow doesn't know about 2nd argument of Error constructor
-  const wrapperError = new Error(messgae, {cause: error});
+  const wrapperError = new Error('Error rendering inspected component', {
+    cause: error,
+  });
   // Note: This error name needs to stay in sync with react-devtools-shared
   // TODO: refactor this if we ever combine the devtools and debug tools packages
   wrapperError.name = 'ReactDebugToolsRenderFunctionError';

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -686,6 +686,8 @@ function handleRenderFunctionError(error: any): void {
   // Note: This error name needs to stay in sync with react-devtools-shared
   // TODO: refactor this if we ever combine the devtools and debug tools packages
   wrapperError.name = 'ReactDebugToolsRenderError';
+  // this stage-4 proposal is not supported by all environments yet.
+  wrapperError.cause = error;
   throw wrapperError;
 }
 

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -296,7 +296,7 @@ describe('ReactHooksInspection', () => {
       // original error
       expect(lastCall[1].cause).toBeInstanceOf(OriginalError);
       expect(lastCall[1].cause.message).toBe(
-        "Cannot read properties of null (reading 'useState')",
+        "Cannot read property 'useState' of null",
       );
     }).toErrorDev(
       'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -286,10 +286,14 @@ describe('ReactHooksInspection', () => {
       }).toThrow(MockError);
       expect(MockError.mock.calls.length).toBe(1);
       // first argument is the error message
-      expect(MockError.mock.calls[0][0]).toBe('Error rendering inspected component');
+      expect(MockError.mock.calls[0][0]).toBe(
+        'Error rendering inspected component',
+      );
       // The second arg of the first call to the function was 'second arg'
       expect(MockError.mock.calls[0][1]).toBeInstanceOf(OriginalError);
-      expect(MockError.mock.calls[0][1].message).toBe("Cannot read property 'useState' of null");
+      expect(MockError.mock.calls[0][1].message).toBe(
+        "Cannot read property 'useState' of null",
+      );
     }).toErrorDev(
       'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
         ' one of the following reasons:\n' +

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -276,6 +276,7 @@ describe('ReactHooksInspection', () => {
       },
     };
 
+    let didCatch = false;
     expect(() => {
       // mock the Error constructor to check the internal of the error instance
       try {
@@ -288,6 +289,7 @@ describe('ReactHooksInspection', () => {
           "Cannot read property 'useState' of null",
         );
       }
+      didCatch = true;
     }).toErrorDev(
       'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
         ' one of the following reasons:\n' +
@@ -297,6 +299,8 @@ describe('ReactHooksInspection', () => {
         'See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.',
       {withoutStack: true},
     );
+    // avoid false positive if no error was thrown at all
+    expect(didCatch).toBe(true);
 
     expect(getterCalls).toBe(1);
     expect(setterCalls).toHaveLength(2);

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -261,6 +261,10 @@ describe('ReactHooksInspection', () => {
       return <div>{state}</div>;
     }
 
+    const OriginalError = global.Error;
+    const MockError = jest.fn();
+    global.Error = MockError;
+
     const initial = {};
     let current = initial;
     let getterCalls = 0;
@@ -279,7 +283,13 @@ describe('ReactHooksInspection', () => {
     expect(() => {
       expect(() => {
         ReactDebugTools.inspectHooks(Foo, {}, FakeDispatcherRef);
-      }).toThrow("Cannot read property 'useState' of null");
+      }).toThrow(MockError);
+      expect(MockError.mock.calls.length).toBe(1);
+      // first argument is the error message
+      expect(MockError.mock.calls[0][0]).toBe('Error rendering inspected component');
+      // The second arg of the first call to the function was 'second arg'
+      expect(MockError.mock.calls[0][1]).toBeInstanceOf(OriginalError);
+      expect(MockError.mock.calls[0][1].message).toBe("Cannot read property 'useState' of null");
     }).toErrorDev(
       'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
         ' one of the following reasons:\n' +
@@ -294,6 +304,8 @@ describe('ReactHooksInspection', () => {
     expect(setterCalls).toHaveLength(2);
     expect(setterCalls[0]).not.toBe(initial);
     expect(setterCalls[1]).toBe(initial);
+
+    global.Error = OriginalError;
   });
 
   describe('useDebugValue', () => {

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -291,9 +291,7 @@ describe('ReactHooksInspection', () => {
       // expect the thrown Error is the last one to call the MockError
       const lastCall = MockError.mock.calls[MockError.mock.calls.length - 1];
       // first argument is the error message
-      expect(lastCall[0]).toBe(
-        'Error rendering inspected component',
-      );
+      expect(lastCall[0]).toBe('Error rendering inspected component');
       // The second arg is the options object with the cause, which is the
       // original error
       expect(lastCall[1].cause).toBeInstanceOf(OriginalError);
@@ -314,7 +312,6 @@ describe('ReactHooksInspection', () => {
     expect(setterCalls).toHaveLength(2);
     expect(setterCalls[0]).not.toBe(initial);
     expect(setterCalls[1]).toBe(initial);
-
   });
 
   describe('useDebugValue', () => {

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -281,10 +281,8 @@ describe('ReactHooksInspection', () => {
       try {
         ReactDebugTools.inspectHooks(Foo, {}, FakeDispatcherRef);
       } catch (error) {
-        // first argument is the error message
         expect(error.message).toBe('Error rendering inspected component');
-        // The second arg is the options object with the cause, which is the
-        // original error
+        // error.cause is the original error
         expect(error.cause).toBeInstanceOf(Error);
         expect(error.cause.message).toBe(
           "Cannot read property 'useState' of null",

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspection-test.js
@@ -278,26 +278,18 @@ describe('ReactHooksInspection', () => {
 
     expect(() => {
       // mock the Error constructor to check the internal of the error instance
-      const OriginalError = global.Error;
-      const MockError = jest.fn();
-      global.Error = MockError;
-
-      expect(() => {
+      try {
         ReactDebugTools.inspectHooks(Foo, {}, FakeDispatcherRef);
-      }).toThrow(MockError);
-      // clean up
-      global.Error = OriginalError;
-
-      // expect the thrown Error is the last one to call the MockError
-      const lastCall = MockError.mock.calls[MockError.mock.calls.length - 1];
-      // first argument is the error message
-      expect(lastCall[0]).toBe('Error rendering inspected component');
-      // The second arg is the options object with the cause, which is the
-      // original error
-      expect(lastCall[1].cause).toBeInstanceOf(OriginalError);
-      expect(lastCall[1].cause.message).toBe(
-        "Cannot read property 'useState' of null",
-      );
+      } catch (error) {
+        // first argument is the error message
+        expect(error.message).toBe('Error rendering inspected component');
+        // The second arg is the options object with the cause, which is the
+        // original error
+        expect(error.cause).toBeInstanceOf(Error);
+        expect(error.cause.message).toBe(
+          "Cannot read property 'useState' of null",
+        );
+      }
     }).toErrorDev(
       'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
         ' one of the following reasons:\n' +

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -920,17 +920,24 @@ describe('ReactHooksInspectionIntegration', () => {
 
     const renderer = ReactTestRenderer.create(<Foo />);
     const childFiber = renderer.root._currentFiber();
-    expect(() => {
-      ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
-    }).toThrow(
-      'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
-        ' one of the following reasons:\n' +
-        '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
-        '2. You might be breaking the Rules of Hooks\n' +
-        '3. You might have more than one copy of React in the same app\n' +
-        'See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.',
-    );
 
+    try {
+      ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
+    } catch (error) {
+      // first argument is the error message
+      expect(error.message).toBe('Error rendering inspected component');
+      // The second arg is the options object with the cause, which is the
+      // original error
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.cause.message).toBe(
+        'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +
+          ' one of the following reasons:\n' +
+          '1. You might have mismatching versions of React and the renderer (such as React DOM)\n' +
+          '2. You might be breaking the Rules of Hooks\n' +
+          '3. You might have more than one copy of React in the same app\n' +
+          'See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.',
+      );
+    }
     expect(getterCalls).toBe(1);
     expect(setterCalls).toHaveLength(2);
     expect(setterCalls[0]).not.toBe(initial);

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -924,10 +924,7 @@ describe('ReactHooksInspectionIntegration', () => {
     try {
       ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
     } catch (error) {
-      // first argument is the error message
       expect(error.message).toBe('Error rendering inspected component');
-      // The second arg is the options object with the cause, which is the
-      // original error
       expect(error.cause).toBeInstanceOf(Error);
       expect(error.cause.message).toBe(
         'Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for' +

--- a/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactHooksInspectionIntegration-test.js
@@ -921,6 +921,8 @@ describe('ReactHooksInspectionIntegration', () => {
     const renderer = ReactTestRenderer.create(<Foo />);
     const childFiber = renderer.root._currentFiber();
 
+    let didCatch = false;
+
     try {
       ReactDebugTools.inspectHooksOfFiber(childFiber, FakeDispatcherRef);
     } catch (error) {
@@ -934,7 +936,11 @@ describe('ReactHooksInspectionIntegration', () => {
           '3. You might have more than one copy of React in the same app\n' +
           'See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.',
       );
+      didCatch = true;
     }
+    // avoid false positive if no error was thrown at all
+    expect(didCatch).toBe(true);
+
     expect(getterCalls).toBe(1);
     expect(setterCalls).toHaveLength(2);
     expect(setterCalls[0]).not.toBe(initial);

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -2145,7 +2145,7 @@ describe('InspectedElement', () => {
     expect(value).toBe(null);
 
     const error = errorBoundaryInstance.state.error;
-    expect(error.message).toBe('Expected');
+    expect(error.message).toBe('Error rendering inspected component');
     expect(error.stack).toContain('inspectHooksOfFiber');
   });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

This PR adds ability to detect error thrown from user's code, and wrap it inside an error with custom name, so Dev Tools is able to caught it and show custom error view.

This is to unblock https://github.com/mondaychen/react/pull/2

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I'm testing it with a user's code from #24096


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
