### PR TITLE
Add 4.4.0 release to eslint rules CHANGELOG

### DIFF
--- a/packages/eslint-plugin-react-hooks/CHANGELOG.md
+++ b/packages/eslint-plugin-react-hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.0
+
+* No changes, this was an automated release together with React 18.
+
 ## 4.3.0
 
 * Support ESLint 8. ([@MichaelDeBoey](https://github.com/MichaelDeBoey) in [#22248](https://github.com/facebook/react/pull/22248))


### PR DESCRIPTION
Resolves #24233

Looking at what's changed in the `eslint-plugin-react-hooks` package between the 4.3.0 release and Monday's 4.4.0 "release" I see...

```sh
git diff c3f34e4beb67a4ddd85a9456ebc9013d123aa6ee 34aa5cfe0d9b6ec4667e02bf46ab34d83dfb2d6d packages/eslint-plugin-react-hooks/
```

```diff
diff --git a/packages/eslint-plugin-react-hooks/package.json b/packages/eslint-plugin-react-hooks/package.json
index 6bf810a77..1c99c2ffd 100644
--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-react-hooks",
   "description": "ESLint rules for React Hooks",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/react.git",
@@ -10,7 +10,6 @@
   "files": [
     "LICENSE",
     "README.md",
-    "build-info.json",
     "index.js",
     "cjs"
   ],
```