### PR TITLE
Rename Controls to PipeableStream

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -46,7 +46,7 @@ type Options = {|
   onError?: (error: mixed) => void,
 |};
 
-type Controls = {|
+type PipeableStream = {|
   // Cancel any pending I/O and put anything remaining into
   // client rendered mode.
   abort(): void,
@@ -76,7 +76,7 @@ function createRequestImpl(children: ReactNodeList, options: void | Options) {
 function renderToPipeableStream(
   children: ReactNodeList,
   options?: Options,
-): Controls {
+): PipeableStream {
   const request = createRequestImpl(children, options);
   let hasStartedFlowing = false;
   startWork(request);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -26,7 +26,7 @@ type Options = {
   onError?: (error: mixed) => void,
 };
 
-type Controls = {|
+type PipeableStream = {|
   pipe<T: Writable>(destination: T): T,
 |};
 
@@ -35,7 +35,7 @@ function renderToPipeableStream(
   webpackMap: BundlerConfig,
   options?: Options,
   context?: Array<[string, ServerContextJSONValue]>,
-): Controls {
+): PipeableStream {
   const request = createRequest(
     model,
     webpackMap,


### PR DESCRIPTION
This type isn't exported so it's technically not public.

This object mimics a ReadableStream signature but it's a subset of it.

Currently this is safe to destructure and call each function without the `this`. That's what the tests do. But I'm not sure that's even guaranteed. It should probably be treated as a class with a prototype in docs/examples.
