### PR TITLE
Switched RulesOfHooks.js to use BigInt. Added test and updated .eslin…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,9 @@ module.exports = {
 
   // Stop ESLint from looking for a configuration file in parent folders
   root: true,
+  env: {
+    es2020: 'true',
+  },
 
   plugins: [
     'jest',

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -326,6 +326,75 @@ const tests = {
       }
     `,
     `
+      // Valid because the neither the conditions before or after the hook affect the hook call
+      // Failed prior to implementing BigInt because pathsFromStartToEnd and allPathsFromStartToEnd were too big and had rounding errors
+      const useSomeHook = () => {};
+
+      const SomeName = () => {
+        const filler = FILLER ?? FILLER ?? FILLER;
+        const filler2 = FILLER ?? FILLER ?? FILLER;
+        const filler3 = FILLER ?? FILLER ?? FILLER;
+        const filler4 = FILLER ?? FILLER ?? FILLER;
+        const filler5 = FILLER ?? FILLER ?? FILLER;
+        const filler6 = FILLER ?? FILLER ?? FILLER;
+        const filler7 = FILLER ?? FILLER ?? FILLER;
+        const filler8 = FILLER ?? FILLER ?? FILLER;
+
+        useSomeHook();
+
+        if (anyConditionCanEvenBeFalse) {
+          return null;
+        }
+
+        return (
+          <React.Fragment>
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+            {FILLER ? FILLER : FILLER}
+          </React.Fragment>
+        );
+      };
+    `,
+    `
       // Valid because the neither the condition nor the loop affect the hook call.
       function App(props) {
         const someObject = {propA: true};

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -175,7 +175,7 @@ export default {
               cyclic.add(cyclicSegment);
             }
 
-            return 0;
+            return BigInt('0');
           }
 
           // add the current segment to pathList
@@ -187,11 +187,11 @@ export default {
           }
 
           if (codePath.thrownSegments.includes(segment)) {
-            paths = 0;
+            paths = BigInt('0');
           } else if (segment.prevSegments.length === 0) {
-            paths = 1;
+            paths = BigInt('1');
           } else {
-            paths = 0;
+            paths = BigInt('0');
             for (const prevSegment of segment.prevSegments) {
               paths += countPathsFromStart(prevSegment, pathList);
             }
@@ -199,7 +199,7 @@ export default {
 
           // If our segment is reachable then there should be at least one path
           // to it from the start of our code path.
-          if (segment.reachable && paths === 0) {
+          if (segment.reachable && paths === BigInt('0')) {
             cache.delete(segment.id);
           } else {
             cache.set(segment.id, paths);
@@ -246,7 +246,7 @@ export default {
               cyclic.add(cyclicSegment);
             }
 
-            return 0;
+            return BigInt('0');
           }
 
           // add the current segment to pathList
@@ -258,11 +258,11 @@ export default {
           }
 
           if (codePath.thrownSegments.includes(segment)) {
-            paths = 0;
+            paths = BigInt('0');
           } else if (segment.nextSegments.length === 0) {
-            paths = 1;
+            paths = BigInt('1');
           } else {
-            paths = 0;
+            paths = BigInt('0');
             for (const nextSegment of segment.nextSegments) {
               paths += countPathsToEnd(nextSegment, pathList);
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13629,7 +13629,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     prop-types "^15.6.2"
     scheduler "^0.13.0"
 
-react-is@^16.8.1, "react-is@npm:react-is":
+"react-is@^16.12.0 || ^17.0.0", react-is@^16.8.1, react-is@^17.0.1, "react-is@npm:react-is":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==


### PR DESCRIPTION
…trc.js to use es2020.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
-->
Fixes #24279. JavaScript could not handle the large integer when there were numerous conditional statements before and after the hook. This was causing rounding errors which resulted in a conditional being evaluated incorrectly. I switched the functions to use BigInts instead and updated the eslintrc.js. If using BigInts is not acceptable, I'll be happy to try and find a different solution. 

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
The user who created the issue linked to a repository that showed the bug. I copied that exact code and pasted into the tests file. This test now passes.
Link to repository: https://github.com/SanderRonde/eslint-hook-bug

Now when I open that file in my local instance, there is no error message for the hook.
![image](https://user-images.githubusercontent.com/63068182/162086280-bae69c58-2285-4813-a10a-9c0d03a8a770.png)

When I run all tests in ESLintRulesOfHooks-test.js, everything passes.
![image](https://user-images.githubusercontent.com/63068182/162086653-d428aec6-b953-4d7b-9020-7647259ff629.png)

Unfortunately, when I ran yarn test --prod, I got several errors that were unrelated to ESLintRulesOfHooks. I am not sure if this is normal. 