### PR TITLE
Remove superfluous arguments of ReactPartialRenderer

### DIFF
--- a/packages/react-dom/src/server/ReactDOMStringRenderer.js
+++ b/packages/react-dom/src/server/ReactDOMStringRenderer.js
@@ -14,7 +14,7 @@ import ReactPartialRenderer from './ReactPartialRenderer';
  * See https://reactjs.org/docs/react-dom-server.html#rendertostring
  */
 export function renderToString(element, options?: ServerOptions) {
-  const renderer = new ReactPartialRenderer(element, false, options);
+  const renderer = new ReactPartialRenderer(element, false);
   try {
     const markup = renderer.read(Infinity);
     return markup;
@@ -29,7 +29,7 @@ export function renderToString(element, options?: ServerOptions) {
  * See https://reactjs.org/docs/react-dom-server.html#rendertostaticmarkup
  */
 export function renderToStaticMarkup(element, options?: ServerOptions) {
-  const renderer = new ReactPartialRenderer(element, true, options);
+  const renderer = new ReactPartialRenderer(element, true);
   try {
     const markup = renderer.read(Infinity);
     return markup;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

The construtor of [ReactPartialRenderer](https://github.com/facebook/react/blob/main/packages/react-dom/src/server/ReactPartialRenderer.js#L784) receives two arguments now, but three arguments are passed here. So we can remove superfluous arguments.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

It does not need addtional test.