### PR TITLE
Update renderToPipeableStream#options.onShellError to match usage

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -41,7 +41,7 @@ type Options = {|
   bootstrapModules?: Array<string>,
   progressiveChunkSize?: number,
   onShellReady?: () => void,
-  onShellError?: () => void,
+  onShellError?: (error: mixed) => void,
   onAllReady?: () => void,
   onError?: (error: mixed) => void,
 |};


### PR DESCRIPTION


## Summary

`onShellError` is called with the error ([tests](https://github.com/facebook/react/blob/14c2be8dac2d5482fda8a0906a31d239df8551fc/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js#L182), [docs](https://reactjs.org/docs/react-dom-server.html#rendertopipeablestream)).

The changed line is linked from the docs to refer to as the "full list of options".

## How did you test this change?

- [x] CI