### PR TITLE
Allow react-devtools-inline createStore() to override Store config params

### DIFF
--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -18,7 +18,9 @@ import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {Props} from 'react-devtools-shared/src/devtools/views/DevTools';
 
 type Config = {|
+  checkBridgeProtocolCompatibility?: boolean,
   supportsNativeInspection?: boolean,
+  supportsProfiling?: boolean,
 |};
 
 export function createStore(bridge: FrontendBridge, config?: Config): Store {
@@ -26,7 +28,8 @@ export function createStore(bridge: FrontendBridge, config?: Config): Store {
     checkBridgeProtocolCompatibility: true,
     supportsTraceUpdates: true,
     supportsTimeline: true,
-    supportsNativeInspection: config?.supportsNativeInspection !== false,
+    supportsNativeInspection: true,
+    ...config,
   });
 }
 


### PR DESCRIPTION
It was an oversight when I originally wrote the `createStore` method not to allow more Store config params to be customizable. This change should have no impact on pre-existing users.