### PR TITLE
WIP: Improve console dimming on second StrictMode render

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -159,7 +159,6 @@ export function serializeToString(data: any): string {
 // based on https://github.com/tmpfs/format-util/blob/0e62d430efb0a1c51448709abd3e2406c14d8401/format.js#L1
 // based on https://developer.mozilla.org/en-US/docs/Web/API/console#Using_string_substitutions
 // Implements s, d, i and f placeholders
-// NOTE: KEEP IN SYNC with src/hook.js
 export function format(
   maybeMessage: any,
   ...inputArgs: $ReadOnlyArray<any>


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react/issues/24302. The goal is to apply dimming only to string values to avoid interfering with printing and introspection of complex values.

This PR isn't ready for review yet. Putting it up to show a working implementation, but:
1. It can probably be simplified.
2. It needs tests.
3. I need to figure out what to do with the synchronized `format` implementation in the `backend/` directory. The one in `hook.js` has only one callsite but the one in `backend/` has several, some of which seem unrelated to browser console formatting. I don't have any knowledge of the devtools architecture so it'll take me some time to understand.
4. I'm a bit concerned that this implementation only works when it agrees with the runtime about the list of placeholder symbols. This is also true of the existing implementation, but it would be nice to find a way around that, or at least to double check that this list is consistent across browsers + Node.

### Implementation notes

The console API has two forms:
1. Placeholder form, where the first N+1 arguments are a string containing N placeholders and N placeholder values, followed by any number of arbitrary values, e.g., `['%cA %s', 'color: blue', 'B', 'C']`.
2. Non-placeholder form, where all arguments are arbitrary values, e.g., `['A', 'B', 'C']`.

Colors can only be applied using the first form, and only to the contents of the placeholder string. So the basic idea is to coerce the argument list into the placeholder form, apply the color directives, and append additional placeholders for all arguments without one. Some examples of this translation:
- `['A', 1, 'B']` => `['%c%s %o %s', 'color: X', 'A', 1, 'B']`
- `['A %d', 1, 'B']` => `['%cA %d %c%s', 'color: X', 1, 'color: X', 'B']`
- `['A%cB', 'color: blue', 'C']` => `['%cA%cB %c%s', 'color: X', 'color: blue', 'color: X', 'C']`

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

TBD
