### PR TITLE
Unnecessary conditions removed

### DIFF
--- a/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
+++ b/packages/react-reconciler/src/ReactFiberDevToolsHook.new.js
@@ -117,7 +117,7 @@ export function onScheduleRoot(root: FiberRoot, children: ReactNodeList) {
       try {
         injectedHook.onScheduleFiberRoot(rendererID, root, children);
       } catch (err) {
-        if (__DEV__ && !hasLoggedError) {
+        if (!hasLoggedError) {
           hasLoggedError = true;
           console.error('React instrumentation encountered an error: %s', err);
         }

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -323,9 +323,9 @@ export function updateContainer(
   parentComponent: ?React$Component<any, any>,
   callback: ?Function,
 ): Lane {
-  if (__DEV__) {
-    onScheduleRoot(container, element);
-  }
+  // Works only dev mode
+  onScheduleRoot(container, element);
+ 
   const current = container.current;
   const eventTime = requestEventTime();
   const lane = requestUpdateLane(current);


### PR DESCRIPTION
* __DEV__ condition removed from update container because onScheduleRoot has already a __DEV__ condition.

* Removed __DEV__ condition in catch scope because __DEV__ already has a condition before.
