### PR TITLE
Fix file path separator compatibility in scripts/babel

### DIFF
--- a/scripts/babel/transform-object-assign.js
+++ b/scripts/babel/transform-object-assign.js
@@ -28,7 +28,7 @@ module.exports = function autoImporter(babel) {
 
     visitor: {
       CallExpression: function(path, file) {
-        if (file.filename.indexOf('shared/assign') !== -1) {
+        if (/shared(\/|\\)assign/.test(file.filename)) {
           // Don't replace Object.assign if we're transforming shared/assign
           return;
         }
@@ -40,7 +40,7 @@ module.exports = function autoImporter(babel) {
       },
 
       MemberExpression: function(path, file) {
-        if (file.filename.indexOf('shared/assign') !== -1) {
+        if (/shared(\/|\\)assign/.test(file.filename)) {
           // Don't replace Object.assign if we're transforming shared/assign
           return;
         }


### PR DESCRIPTION
The problem in scripts\babel\transform-object-assign.js is that file path separator has '/' and '\' between Linux, MacOS and Windows, which causes yarn build error. See https://github.com/facebook/react/issues/24103

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
