### PR TITLE
[Transition Tracing] Remove console.error in clearTransitionForLanes

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -859,13 +859,6 @@ export function clearTransitionsForLanes(root: FiberRoot, lanes: Lane | Lanes) {
     const transitions = root.transitionLanes[index];
     if (transitions !== null) {
       root.transitionLanes[index] = null;
-    } else {
-      if (__DEV__) {
-        console.error(
-          'React Bug: transition lanes accessed out of bounds index: %s',
-          index.toString(),
-        );
-      }
     }
 
     lanes &= ~lane;

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -859,13 +859,6 @@ export function clearTransitionsForLanes(root: FiberRoot, lanes: Lane | Lanes) {
     const transitions = root.transitionLanes[index];
     if (transitions !== null) {
       root.transitionLanes[index] = null;
-    } else {
-      if (__DEV__) {
-        console.error(
-          'React Bug: transition lanes accessed out of bounds index: %s',
-          index.toString(),
-        );
-      }
     }
 
     lanes &= ~lane;


### PR DESCRIPTION
We changed the implementation of `root.transitionLanes` so that, if there is no transitions for a given lane, we use null instead of an array. This means that this error is no longer valid, so we are removing it 