### PR TITLE
Use FB specific stream config for native-relay

### DIFF
--- a/packages/react-server/src/forks/ReactServerStreamConfig.native-relay.js
+++ b/packages/react-server/src/forks/ReactServerStreamConfig.native-relay.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from '../ReactServerStreamConfigNode';
+ export * from 'react-server-dom-relay/src/ReactServerStreamConfigFB';


### PR DESCRIPTION
This is not really used yet but for parity with the dom-relay implementation this should use the FB-specific fake stream protocol and not the Node protocol. For Server Components for Native.