### PR TITLE
let react-hooks/exhaustive-deps additionalHooks have a callback in a different position from 0

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -51,7 +51,7 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 ## Advanced Configuration
 
 `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
-This option accepts a regex to match the names of custom Hooks that have dependencies.
+This option accepts a regex to match the names of custom Hooks that have dependencies or an array of [regex, index?] tuples where the regex matches the names of custom Hooks and index is a number indicating the position of the callback (defaults to 0). The dependency array is always callback index + 1.
 
 ```js
 {
@@ -59,6 +59,19 @@ This option accepts a regex to match the names of custom Hooks that have depende
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
       "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+    }]
+  }
+}
+```
+
+or
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "additionalHooks": [["(useMyCustomHook|useMyOtherCustomHook)"], ["(myThirdCustomHook)", 1]]
     }]
   }
 }

--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -71,7 +71,7 @@ or
   "rules": {
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": [["(useMyCustomHook|useMyOtherCustomHook)"], ["(myThirdCustomHook)", 1]]
+      "additionalHooks": [["(useMyCustomHook|useMyOtherCustomHook)"], ["(useMyThirdCustomHook)", 1]]
     }]
   }
 }

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -535,6 +535,26 @@ const tests = {
     {
       code: normalizeIndent`
         function MyComponent(props) {
+          useCustomOrderEffect(null, () => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{additionalHooks: [['useCustomOrderEffect', 1]]}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomOrderEffect(() => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{additionalHooks: [['useCustomOrderEffect', 0]]}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
           useWithoutEffectSuffix(() => {
             console.log(props.foo);
           }, []);
@@ -3552,6 +3572,42 @@ const tests = {
               `,
             },
           ],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomOrderEffect(null, () => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{additionalHooks: [['useCustomOrderEffect', 0]]}],
+      errors: [
+        {
+          message:
+            'React Hook useCustomOrderEffect received a function whose dependencies ' +
+            'are unknown. Pass an inline function instead.',
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useCustomOrderEffect(() => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{additionalHooks: [['useCustomOrderEffect', 1]]}],
+      errors: [
+        {
+          message:
+            'React Hook useCustomOrderEffect received a function whose dependencies ' +
+            'are unknown. Pass an inline function instead.',
+          suggestions: [],
         },
       ],
     },

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -27,7 +27,18 @@ export default {
         enableDangerousAutofixThisMayCauseInfiniteLoops: false,
         properties: {
           additionalHooks: {
-            type: 'string',
+            anyOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'array',
+                  items: [{type: 'string'}, {type: 'number'}],
+                },
+              },
+            ],
           },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
@@ -42,7 +53,12 @@ export default {
       context.options &&
       context.options[0] &&
       context.options[0].additionalHooks
-        ? new RegExp(context.options[0].additionalHooks)
+        ? typeof context.options[0].additionalHooks === 'string'
+          ? [[new RegExp(context.options[0].additionalHooks), 0]]
+          : context.options[0].additionalHooks.map(([regex, callbackIndex]) => [
+              new RegExp(regex),
+              callbackIndex,
+            ])
         : undefined;
 
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
@@ -1722,7 +1738,12 @@ function getReactiveHookCallbackIndex(calleeNode, options) {
             throw error;
           }
         }
-        return options.additionalHooks.test(name) ? 0 : -1;
+        for (const [regex, callbackIndex] of options.additionalHooks) {
+          if (regex.test(name)) {
+            return callbackIndex || 0;
+          }
+        }
+        return -1;
       } else {
         return -1;
       }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This pull request allows Hooks specified in react-hooks/exhaustive-deps additionalHooks have a callback parameter in a position other than 0. 

In my case, I have a hook where the callback is in position 1 rather than 0:

```typescript
function useDerrivedState<T>(initialState:T,  asyncEffect: () =>  Promise<T>, deps: DependencyList) {
  const [state, setState] = useState(initialState);
  useEffect(() => asyncEffect().then(result => setState(result)), deps);
  return [state];
}
```
(simplified version, real version handles aborts/errors/etc but not relevant to this change)

I could refactor the hook and put `initialState` after the callback/deps (at pos 2 rather than 0) but I feel like it reads out of order/more difficult to reason about.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Added valid/invalid tests. Ran tests with `yarn test --watch ESLintRuleExhaustiveDeps`. Existing and new tests pass.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
