### PR TITLE
Warn for duplicate DevTools installations 

### DIFF
--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -6,6 +6,8 @@ const ports = {};
 
 const IS_FIREFOX = navigator.userAgent.indexOf('Firefox') >= 0;
 
+import {EXTENSION_INSTALL_CHECK_MESSAGE} from './constants';
+
 chrome.runtime.onConnect.addListener(function(port) {
   let tab = null;
   let name = null;
@@ -115,6 +117,14 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     checkAndHandleRestrictedPageIfSo(tab);
   }
 });
+
+chrome.runtime.onMessageExternal.addListener(
+  (request, sender, sendResponse) => {
+    if (request === EXTENSION_INSTALL_CHECK_MESSAGE) {
+      sendResponse(true);
+    }
+  },
+);
 
 chrome.runtime.onMessage.addListener((request, sender) => {
   const tab = sender.tab;

--- a/packages/react-devtools-extensions/src/checkForDuplicateInstallations.js
+++ b/packages/react-devtools-extensions/src/checkForDuplicateInstallations.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+declare var chrome: any;
+
+import {__DEBUG__} from 'react-devtools-shared/src/constants';
+import {
+  EXTENSION_INSTALL_CHECK_MESSAGE,
+  EXTENSION_INSTALLATION_TYPE,
+  INTERNAL_EXTENSION_ID,
+  LOCAL_EXTENSION_ID,
+} from './constants';
+
+export function checkForDuplicateInstallations(callback: boolean => void) {
+  switch (EXTENSION_INSTALLATION_TYPE) {
+    case 'public': {
+      // If this is the public extension (e.g. from Chrome Web Store), check if an internal
+      // or local build of the extension is also installed, and if so, return true.
+      checkForInstalledExtensions([
+        INTERNAL_EXTENSION_ID,
+        LOCAL_EXTENSION_ID,
+      ]).then(areExtensionsInstalled => {
+        if (areExtensionsInstalled.some(isInstalled => isInstalled)) {
+          callback(true);
+        } else {
+          callback(false);
+        }
+      });
+      break;
+    }
+    case 'internal': {
+      // If this is the internal extension, check if a local build of the extension
+      // is also installed, and if so, return true.
+      checkForInstalledExtension(LOCAL_EXTENSION_ID).then(isInstalled => {
+        if (isInstalled) {
+          callback(true);
+        } else {
+          callback(false);
+        }
+      });
+      break;
+    }
+    case 'local': {
+      if (__DEV__) {
+        // If this is the local extension (i.e. built locally during development),
+        // return false
+        callback(false);
+        break;
+      }
+
+      // If this extension wasn't built locally during development, we can't reliably
+      // detect if there are other installations of DevTools present.
+      // In this case, assume there are no duplicate extensions
+      callback(false);
+      break;
+    }
+    case 'unknown': {
+      // If we don't know how this extension was built, we can't reliably detect if there
+      // are other installations of DevTools present.
+      // In this case, assume there are no duplicate exensions
+      callback(false);
+      break;
+    }
+    default: {
+      (EXTENSION_INSTALLATION_TYPE: empty);
+    }
+  }
+}
+
+function checkForInstalledExtensions(
+  extensionIds: string[],
+): Promise<boolean[]> {
+  return Promise.all(
+    extensionIds.map(extensionId => checkForInstalledExtension(extensionId)),
+  );
+}
+
+function checkForInstalledExtension(extensionId: string): Promise<boolean> {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage(
+      extensionId,
+      EXTENSION_INSTALL_CHECK_MESSAGE,
+      response => {
+        if (__DEBUG__) {
+          console.log(
+            'checkForDuplicateInstallations: Duplicate installation check responded with',
+            {
+              response,
+              error: chrome.runtime.lastError?.message,
+              currentExtension: EXTENSION_INSTALLATION_TYPE,
+              checkingExtension: extensionId,
+            },
+          );
+        }
+        if (chrome.runtime.lastError != null) {
+          resolve(false);
+        } else {
+          resolve(true);
+        }
+      },
+    );
+  });
+}

--- a/packages/react-devtools-extensions/src/constants.js
+++ b/packages/react-devtools-extensions/src/constants.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+declare var chrome: any;
+
+export const CURRENT_EXTENSION_ID = chrome.runtime.id;
+
+export const EXTENSION_INSTALL_CHECK_MESSAGE = 'extension-install-check';
+
+// test extension ids
+// export const CURRENT_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
+// export const CHROME_WEBSTORE_EXTENSION_ID = 'fmkadmapgofadopljbjfkapdkoienihi';
+// export const INTERNAL_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
+// export const LOCAL_EXTENSION_ID = 'obdaoiocnilldddkfgjekefmglfhlncn';
+
+export const CHROME_WEBSTORE_EXTENSION_ID = 'fmkadmapgofadopljbjfkapdkoienihi';
+export const INTERNAL_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
+export const LOCAL_EXTENSION_ID = 'ikiahnapldjmdmpkmfhjdjilojjhgcbf';
+
+export const EXTENSION_INSTALLATION_TYPE:
+  | 'public'
+  | 'internal'
+  | 'local'
+  | 'unknown' =
+  CURRENT_EXTENSION_ID === CHROME_WEBSTORE_EXTENSION_ID
+    ? 'public'
+    : CURRENT_EXTENSION_ID === INTERNAL_EXTENSION_ID
+    ? 'internal'
+    : CURRENT_EXTENSION_ID === LOCAL_EXTENSION_ID
+    ? 'local'
+    : 'unknown';

--- a/packages/react-devtools-extensions/src/constants.js
+++ b/packages/react-devtools-extensions/src/constants.js
@@ -13,12 +13,6 @@ export const CURRENT_EXTENSION_ID = chrome.runtime.id;
 
 export const EXTENSION_INSTALL_CHECK_MESSAGE = 'extension-install-check';
 
-// test extension ids
-// export const CURRENT_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
-// export const CHROME_WEBSTORE_EXTENSION_ID = 'fmkadmapgofadopljbjfkapdkoienihi';
-// export const INTERNAL_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
-// export const LOCAL_EXTENSION_ID = 'obdaoiocnilldddkfgjekefmglfhlncn';
-
 export const CHROME_WEBSTORE_EXTENSION_ID = 'fmkadmapgofadopljbjfkapdkoienihi';
 export const INTERNAL_EXTENSION_ID = 'dnjnjgbfilfphmojnmhliehogmojhclc';
 export const LOCAL_EXTENSION_ID = 'ikiahnapldjmdmpkmfhjdjilojjhgcbf';

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -77,15 +77,14 @@ function createPanelIfReactLoaded() {
 
   // If duplicate extension detected, display warning message and write to local storage
   checkForDuplicateInstallations(hasDuplicateInstallation => {
-    if (
-      hasDuplicateInstallation &&
-      !localStorageGetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION)
-    ) {
-      console.warn(DUPLICATE_EXTENSION_WARNING);
-      chrome.devtools.inspectedWindow.eval(
-        `console.warn("${DUPLICATE_EXTENSION_WARNING}")`,
-      );
-      localStorageSetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION, 'true');
+    if (hasDuplicateInstallation) {
+      if (!localStorageGetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION)) {
+        console.warn(DUPLICATE_EXTENSION_WARNING);
+        chrome.devtools.inspectedWindow.eval(
+          `console.warn("${DUPLICATE_EXTENSION_WARNING}")`,
+        );
+        localStorageSetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION, 'true');
+      }
     } else {
       localStorageRemoveItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION);
     }

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -79,9 +79,9 @@ function createPanelIfReactLoaded() {
   checkForDuplicateInstallations(hasDuplicateInstallation => {
     if (hasDuplicateInstallation) {
       if (!localStorageGetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION)) {
-        console.error(DUPLICATE_EXTENSION_WARNING);
+        console.warn(DUPLICATE_EXTENSION_WARNING);
         chrome.devtools.inspectedWindow.eval(
-          `console.error("${DUPLICATE_EXTENSION_WARNING}")`,
+          `console.warn("${DUPLICATE_EXTENSION_WARNING}")`,
         );
         localStorageSetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION, 'true');
       }

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -77,14 +77,15 @@ function createPanelIfReactLoaded() {
 
   // If duplicate extension detected, display warning message and write to local storage
   checkForDuplicateInstallations(hasDuplicateInstallation => {
-    if (hasDuplicateInstallation) {
-      if (!localStorageGetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION)) {
-        console.warn(DUPLICATE_EXTENSION_WARNING);
-        chrome.devtools.inspectedWindow.eval(
-          `console.warn("${DUPLICATE_EXTENSION_WARNING}")`,
-        );
-        localStorageSetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION, 'true');
-      }
+    if (
+      hasDuplicateInstallation &&
+      !localStorageGetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION)
+    ) {
+      console.warn(DUPLICATE_EXTENSION_WARNING);
+      chrome.devtools.inspectedWindow.eval(
+        `console.warn("${DUPLICATE_EXTENSION_WARNING}")`,
+      );
+      localStorageSetItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION, 'true');
     } else {
       localStorageRemoveItem(LOCAL_STORAGE_WARNED_DUPLICATE_EXTENSION);
     }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This completes the tasks in issue #24157. It checks for duplicate installations using the extension ids (basically the same code from the previous pull request). If duplicate installations are detected, display a warning message to the user and write to local storage.

To check for duplicate installations, we take advantage of the constant extension ids for React DevTools. First, we get the current id of whatever extension we are in. If that extension is the chrome webstore extension, we check if the internal or local extension is installed. If it is the internal extension, we check the local extension is installed. If it is the local or an unknown extension, we can't reliably detect if other extensions are installed. To note, if it is the local extension and __DEV__ is true, we do not need to check for other extensions because they will automatically disable. 

Within the switch statement for 'local', I left in the separate if statement from the previous PR code. I can get rid of it, but I thought it would be good to keep in case we want to add separate handlers. I also removed the warning message if it is an unknown extension saying 'We cannot accurately detect separate extensions. You may have duplicate extensions installed which could cause errors'. Now we only display an error if a duplicate extension is actually detected.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
Testing this change was tricky because I obviously can't make changes to the published versions of devtools. Instead, I copied the unpacked build within the chrome extension folder and loaded it as a separate extension into chrome. I got rid of all content scripts and adjusted the background script to only respond to a message. I had to do this because chrome kept crashing when I had both installed.

First, I installed that extension into chrome. 
<img width="645" alt="Screen Shot 2022-04-12 at 8 23 48 AM" src="https://user-images.githubusercontent.com/63068182/162966649-0d7f6994-a296-4e2e-8a53-4afdf0a73f68.png">

Then I adjusted the extension ids in constants.js to reflect the test scenario. As you can see in the screenshot below, I set the CURRENT_EXTENSION_ID to the internal devtools and set the LOCAL_EXTENSION_ID to the sample extension I just installed. This way the function checkForDuplicateInstallations will believe it is currently in an internal installation, check if a local installation (my sample installation) exists, and since it is installed, print a warning message.

<img width="769" alt="Screen Shot 2022-04-12 at 8 23 58 AM" src="https://user-images.githubusercontent.com/63068182/162966991-0294242f-7d88-4edc-ae16-879d8c0aa84e.png">
<img width="731" alt="Screen Shot 2022-04-12 at 8 24 16 AM" src="https://user-images.githubusercontent.com/63068182/162967413-bfe765eb-04cb-4e8e-bab9-9646aef97f25.png">

I then removed the installation and ran chrome again. The error message did not appear. 
<img width="739" alt="Screen Shot 2022-04-12 at 8 24 47 AM" src="https://user-images.githubusercontent.com/63068182/162967547-2e62a9bb-55ef-4141-b69d-924e30a57213.png">


I also ran tests to check the following scenarios, but I did not take screenshots for all of them and was not sure how to automate the tests.

* Current extension id is the chrome webstore id and set local extension id to sample installation.
* Current extension id is the chrome webstore id and set internal extension id to sample installation
* Restart chrome after showing an warning message to see if it shows again
* Delete sample installation, rerun chrome and install installation again, rerun chrome and see the warning message.