### PR TITLE
[DevTools] Add Gating for DevTools tests on React Versions

### DIFF
--- a/scripts/babel/__tests__/transform-test-gate-pragma-test.js
+++ b/scripts/babel/__tests__/transform-test-gate-pragma-test.js
@@ -6,6 +6,8 @@
  */
 'use strict';
 
+const semver = require('semver');
+
 describe('transform-test-gate-pragma', () => {
   // Fake runtime
   // eslint-disable-next-line no-unused-vars
@@ -23,6 +25,23 @@ describe('transform-test-gate-pragma', () => {
     // to focus something, swap the following `test` call for `test.only`.
     test(testName, (...args) => {
       shouldPass = gateFn(context);
+      isFocused = true;
+      return cb(...args);
+    });
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  const _test_gate_semver_for_devtools = (range, testName, cb) => {
+    test(testName, (...args) => {
+      shouldPass = semver.satisfies('18.0.0', range);
+      return cb(...args);
+    });
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  const _test_gate_semver_focus_for_devtools = (range, testName, cb) => {
+    test(testName, (...args) => {
+      shouldPass = semver.satisfies('18.0.0', range + '     ');
       isFocused = true;
       return cb(...args);
     });
@@ -164,6 +183,30 @@ describe('transform-test-gate-pragma', () => {
   // @gate flagThatIsOn // This is a comment
   test('line comment', () => {
     expect(shouldPass).toBe(true);
+  });
+
+  // @gate react_version >= 18.1
+  test('react_version flag is off', () => {
+    expect(shouldPass).toBe(false);
+  });
+
+  // @gate react_version <= 18.1
+  test('react_version flag is on', () => {
+    expect(shouldPass).toBe(true);
+  });
+
+  /* eslint-disable jest/no-focused-tests */
+
+  // @gate react_version >= 18.1
+  fit('react_version fit', () => {
+    expect(shouldPass).toBe(false);
+    expect(isFocused).toBe(true);
+  });
+
+  // @gate react_version <= 18.1
+  test.only('react_version test.only', () => {
+    expect(shouldPass).toBe(true);
+    expect(isFocused).toBe(true);
   });
 });
 

--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -104,6 +104,12 @@ const argv = yargs
       type: 'boolean',
       default: false,
     },
+    version: {
+      describe: 'Current React version we are testing (for DevTools)',
+      requiresArg: true,
+      type: 'string',
+      default: false,
+    },
   }).argv;
 
 function logError(message) {
@@ -169,6 +175,11 @@ function validateOptions() {
   } else {
     if (argv.compactConsole) {
       logError('Only DevTool tests support compactConsole flag.');
+      success = false;
+    }
+
+    if (argv.version) {
+      logError('Only DevTools tests support version flag.');
       success = false;
     }
   }
@@ -312,6 +323,10 @@ function getEnvars() {
 
   if (argv.variant) {
     envars.VARIANT = true;
+  }
+
+  if (argv.version) {
+    envars.REACT_VERSION = argv.version;
   }
 
   return envars;


### PR DESCRIPTION
This PR:
* Modifies the `transform-test-gate-pragma` test to add a `version` type (that is triggered by the `react_version` name`). When this name is detected, we use `_test_gate_semver_focus_for_devtools` and `_test_gate_semver_for_devtools` to gate our tests (rather than `_test_gate` and `_test_gate_focus`
* Adds the `_test_gate_semver_focus_for_devtools` and `_test_gate_semver_for_devtools` functions to the `setupTests` file
* Adds an optional `version` CLI option that you can use to specific the current version (for use with Circle CI to know which version we are using)