### PR TITLE
Test :Add a small test for ReactTestUtils to find rendered component with type in document

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtils-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtils-test.js
@@ -503,4 +503,19 @@ describe('ReactTestUtils', () => {
     ReactTestUtils.renderIntoDocument(<Component />);
     expect(mockArgs.length).toEqual(0);
   });
+  it('should find rendered component with type in document', () => {
+    class MyComponent extends React.Component {
+      render() {
+        return true;
+      }
+    }
+
+    const instance = ReactTestUtils.renderIntoDocument(<MyComponent />);
+    const renderedComponentType = ReactTestUtils.findRenderedComponentWithType(
+      instance,
+      MyComponent,
+    );
+
+    expect(renderedComponentType).toBe(instance);
+  });
 });


### PR DESCRIPTION
I tried to write  test for the   ReactTestUtils to find rendered component with type in document

Tests before this PR

![Windows PowerShell 4_13_2022 11_35_24 PM](https://user-images.githubusercontent.com/72331432/163243620-40eb753c-4136-4793-a628-efcf9e004562.png)


Tests after this PR 

![Windows PowerShell 4_13_2022 11_35_30 PM](https://user-images.githubusercontent.com/72331432/163244704-cd17f0e3-7289-4794-895a-be03753e46de.png)

