### PR TITLE
Add feature/openInVscode

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -30,7 +30,7 @@ import type {InspectedElement} from './types';
 
 export type Props = {||};
 
-// TODO Make edits and deletes also use transition API!
+// TODO Make edits and deletes also use transition APIè
 
 export default function InspectedElementWrapper(_: Props) {
   const {inspectedElementID} = useContext(TreeStateContext);
@@ -97,6 +97,17 @@ export default function InspectedElementWrapper(_: Props) {
     }
   }, [inspectedElement, viewElementSourceFunction]);
 
+  const openInVscode = useCallback(() => {
+    if (inspectedElement !== null) {
+      const path = inspectedElement.props['data-inspector-relative-path'];
+      const line = inspectedElement.props['data-inspector-line'];
+      const column = inspectedElement.props['data-inspector-column'];
+      chrome.devtools.inspectedWindow.eval(`
+      fetch('/__open-stack-frame-in-editor/relative?fileName=${path}&lineNumber=${line}&colNumber=${column}')
+      `);
+    }
+  }, [inspectedElement]);
+
   // In some cases (e.g. FB internal usage) the standalone shell might not be able to view the source.
   // To detect this case, we defer to an injected helper function (if present).
   const canViewSource =
@@ -105,6 +116,10 @@ export default function InspectedElementWrapper(_: Props) {
     viewElementSourceFunction !== null &&
     (canViewElementSourceFunction === null ||
       canViewElementSourceFunction(inspectedElement));
+
+  const canOpenInVscode=
+  inspectedElement !== null &&
+  inspectedElement.props['data-inspector-relative-path']!==undefined;
 
   const isErrored = inspectedElement != null && inspectedElement.isErrored;
   const targetErrorBoundaryID =
@@ -334,6 +349,13 @@ export default function InspectedElementWrapper(_: Props) {
             <ButtonIcon type="view-source" />
           </Button>
         )}
+        <Button
+          className={styles.IconButton}
+          disabled={!canOpenInVscode}
+          onClick={openInVscode}
+          title="open source in vscode">
+          <ButtonIcon type="up" />
+        </Button>
       </div>
 
       {inspectedElement === null && (


### PR DESCRIPTION

![openInVscode](https://user-images.githubusercontent.com/54257412/163405637-5b4775a5-465c-4680-928b-326d1947743e.gif)
this is new feature for react-devtools.
By clicking the openInVscode button on devtool Compents panel, vscode will opens the component file automatically.
for use this feature，you must add some configuration in your module bundler(such as webpack)
Detail:[react-dev-inspector](https://github.com/zthxxx/react-dev-inspector)
