### PR TITLE
Suppress hydration warnings when a preceding sibling suspends

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2891,7 +2891,7 @@ describe('ReactDOMFizzServer', () => {
       </div>,
     );
 
-    // the client app is rendered with an intentionally incorrect text. The still Suspended component causes
+    // The client app is rendered with an intentionally incorrect text. The still Suspended component causes
     // hydration to fail silently (allowing for cache warming but otherwise skipping this boundary) until it
     // resolves.
     const [ClientApp, clientResolve] = makeApp();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3011,7 +3011,7 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental && enableClientRenderFallbackOnTextMismatch
+  // @gate experimental
   it('supresses hydration warnings when an error occurs within a Suspense boundary', async () => {
     let isClient = false;
     let shouldThrow = true;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3037,9 +3037,9 @@ describe('ReactDOMFizzServer', () => {
             <ThrowUntilOnClient>
               <h1>one</h1>
             </ThrowUntilOnClient>
-            <StopThrowingOnClient />
             <h2>two</h2>
-            <h3>three</h3>
+            <h3>{isClient ? 'five' : 'three'}</h3>
+            <StopThrowingOnClient />
           </Suspense>
         </div>
       );
@@ -3067,20 +3067,18 @@ describe('ReactDOMFizzServer', () => {
         );
       },
     });
-    await act(async () => {
-      expect(Scheduler).toFlushAndYieldThrough([
-        'Logged recoverable error: uh oh',
-        'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
-        'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
-        'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
-      ]);
-    });
+    expect(Scheduler).toFlushAndYield([
+      'Logged recoverable error: uh oh',
+      'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
+      'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
+      'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
+    ]);
 
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <h1>one</h1>
         <h2>two</h2>
-        <h3>three</h3>
+        <h3>five</h3>
       </div>,
     );
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2842,7 +2842,7 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
-  // @gate experimental && enableClientRenderFallbackOnTextMismatch && enableClientRenderFallbackOnHydrationMismatch
+  // @gate experimental && enableClientRenderFallbackOnTextMismatch
   it('#24384: Suspending should halt hydration warnings while still allowing siblings to warm up', async () => {
     const makeApp = () => {
       let resolve, resolved;
@@ -2932,7 +2932,7 @@ describe('ReactDOMFizzServer', () => {
     expect(Scheduler).toFlushAndYield([]);
   });
 
-  // @gate experimental && enableClientRenderFallbackOnTextMismatch && enableClientRenderFallbackOnHydrationMismatch
+  // @gate experimental && enableClientRenderFallbackOnTextMismatch
   it('only warns once on hydration mismatch while within a suspense boundary', async () => {
     const originalConsoleError = console.error;
     const mockError = jest.fn();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2842,7 +2842,7 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
-  // @gate experimental
+  // @gate experimental && enableClientRenderFallbackOnTextMismatch && enableClientRenderFallbackOnHydrationMismatch
   it('#24384: Suspending should halt hydration warnings while still allowing siblings to warm up', async () => {
     const makeApp = () => {
       let resolve, resolved;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -12,7 +12,6 @@
 let JSDOM;
 let Stream;
 let Scheduler;
-let Suspense;
 let React;
 let ReactDOMClient;
 let ReactDOMFizzServer;
@@ -29,7 +28,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     JSDOM = require('jsdom').JSDOM;
     Scheduler = require('scheduler');
     React = require('react');
-    Suspense = React.Suspense;
     ReactDOMClient = require('react-dom/client');
     if (__EXPERIMENTAL__) {
       ReactDOMFizzServer = require('react-dom/server');
@@ -59,18 +57,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
       fatalError = error;
     });
   });
-
-  function normalizeCodeLocInfo(strOrErr) {
-    if (strOrErr && strOrErr.replace) {
-      return strOrErr.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(
-        m,
-        name,
-      ) {
-        return '\n    in ' + name + ' (at **)';
-      });
-    }
-    return strOrErr;
-  }
 
   async function act(callback) {
     await callback();
@@ -680,174 +666,5 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         <p>Client and server</p>
       </div>,
     );
-  });
-
-  // @gate experimental && enableClientRenderFallbackOnTextMismatch && enableClientRenderFallbackOnHydrationMismatch
-  it('#24384: Suspending should halt hydration warnings while still allowing siblings to warm up', async () => {
-    const makeApp = () => {
-      let resolve, resolved;
-      const promise = new Promise(r => {
-        resolve = () => {
-          resolved = true;
-          return r();
-        };
-      });
-      function ComponentThatSuspends() {
-        if (!resolved) {
-          throw promise;
-        }
-        return <p>A</p>;
-      }
-
-      const App = ({text}) => {
-        return (
-          <div>
-            <Suspense fallback={<h1>Loading...</h1>}>
-              <ComponentThatSuspends />
-              <h2 name={text}>{text}</h2>
-            </Suspense>
-          </div>
-        );
-      };
-
-      return [App, resolve];
-    };
-
-    const [ServerApp, serverResolve] = makeApp();
-    await act(async () => {
-      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-        <ServerApp text="initial" />,
-      );
-      pipe(writable);
-    });
-    await act(() => {
-      serverResolve();
-    });
-
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <p>A</p>
-        <h2 name="initial">initial</h2>
-      </div>,
-    );
-
-    // the client app is rendered with an intentionally incorrect text. The still Suspended component causes
-    // hydration to fail silently (allowing for cache warming but otherwise skipping this boundary) until it
-    // resolves.
-    const [ClientApp, clientResolve] = makeApp();
-    ReactDOMClient.hydrateRoot(container, <ClientApp text="replaced" />, {
-      onRecoverableError(error) {
-        Scheduler.unstable_yieldValue(
-          'Logged recoverable error: ' + error.message,
-        );
-      },
-    });
-    Scheduler.unstable_flushAll();
-
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <p>A</p>
-        <h2 name="initial">initial</h2>
-      </div>,
-    );
-
-    // Now that the boundary resolves to it's children the hydration completes and discovers that there is a mismatch requiring
-    // client-side rendering.
-    await clientResolve();
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
-      ]);
-    }).toErrorDev(
-      'Warning: Prop `name` did not match. Server: "initial" Client: "replaced"',
-    );
-    expect(getVisibleChildren(container)).toEqual(
-      <div>
-        <p>A</p>
-        <h2 name="replaced">replaced</h2>
-      </div>,
-    );
-
-    expect(Scheduler).toFlushAndYield([]);
-  });
-
-  // @gate experimental && enableClientRenderFallbackOnTextMismatch && enableClientRenderFallbackOnHydrationMismatch
-  it('only warns once on hydration mismatch while within a suspense boundary', async () => {
-    const originalConsoleError = console.error;
-    const mockError = jest.fn();
-    console.error = (...args) => {
-      mockError(...args.map(normalizeCodeLocInfo));
-    };
-
-    const App = ({text}) => {
-      return (
-        <div>
-          <Suspense fallback={<h1>Loading...</h1>}>
-            <h2>{text}</h2>
-            <h2>{text}</h2>
-            <h2>{text}</h2>
-          </Suspense>
-        </div>
-      );
-    };
-
-    try {
-      await act(async () => {
-        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-          <App text="initial" />,
-        );
-        pipe(writable);
-      });
-
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <h2>initial</h2>
-          <h2>initial</h2>
-          <h2>initial</h2>
-        </div>,
-      );
-
-      ReactDOMClient.hydrateRoot(container, <App text="replaced" />, {
-        onRecoverableError(error) {
-          Scheduler.unstable_yieldValue(
-            'Logged recoverable error: ' + error.message,
-          );
-        },
-      });
-      expect(Scheduler).toFlushAndYield([
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
-      ]);
-
-      expect(getVisibleChildren(container)).toEqual(
-        <div>
-          <h2>replaced</h2>
-          <h2>replaced</h2>
-          <h2>replaced</h2>
-        </div>,
-      );
-
-      expect(Scheduler).toFlushAndYield([]);
-      if (__DEV__) {
-        expect(mockError.mock.calls.length).toBe(1);
-        expect(mockError.mock.calls[0]).toEqual([
-          'Warning: Text content did not match. Server: "%s" Client: "%s"%s',
-          'initial',
-          'replaced',
-          '\n' +
-            '    in h2 (at **)\n' +
-            '    in Suspense (at **)\n' +
-            '    in div (at **)\n' +
-            '    in App (at **)',
-        ]);
-      } else {
-        expect(mockError.mock.calls.length).toBe(0);
-      }
-    } finally {
-      console.error = originalConsoleError;
-    }
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -831,17 +831,21 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
       );
 
       expect(Scheduler).toFlushAndYield([]);
-      expect(mockError.mock.calls.length).toBe(1);
-      expect(mockError.mock.calls[0]).toEqual([
-        'Warning: Text content did not match. Server: "%s" Client: "%s"%s',
-        'initial',
-        'replaced',
-        '\n' +
-          '    in h2 (at **)\n' +
-          '    in Suspense (at **)\n' +
-          '    in div (at **)\n' +
-          '    in App (at **)',
-      ]);
+      if (__DEV__) {
+        expect(mockError.mock.calls.length).toBe(1);
+        expect(mockError.mock.calls[0]).toEqual([
+          'Warning: Text content did not match. Server: "%s" Client: "%s"%s',
+          'initial',
+          'replaced',
+          '\n' +
+            '    in h2 (at **)\n' +
+            '    in Suspense (at **)\n' +
+            '    in div (at **)\n' +
+            '    in App (at **)',
+        ]);
+      } else {
+        expect(mockError.mock.calls.length).toBe(0);
+      }
     } finally {
       console.error = originalConsoleError;
     }

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -285,7 +285,7 @@ describe('ReactDOMServerPartialHydration', () => {
     }
     try {
       const finalHTML = ReactDOMServer.renderToString(<App />);
-      const container = document.createElement('div');
+      const container = document.createElement('section');
       container.innerHTML = finalHTML;
       expect(Scheduler).toHaveYielded([
         'Hello',
@@ -350,12 +350,14 @@ describe('ReactDOMServerPartialHydration', () => {
       );
 
       if (__DEV__) {
-        expect(mockError.mock.calls[0]).toEqual([
+        const secondToLastCall =
+          mockError.mock.calls[mockError.mock.calls.length - 2];
+        expect(secondToLastCall).toEqual([
           'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
-          'div',
-          'div',
+          'article',
+          'section',
           '\n' +
-            '    in div (at **)\n' +
+            '    in article (at **)\n' +
             '    in Component (at **)\n' +
             '    in Suspense (at **)\n' +
             '    in App (at **)',

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -80,7 +80,10 @@ import {queueRecoverableErrors} from './ReactFiberWorkLoop.new';
 let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
-let didSuspend: boolean = false;
+
+// this flag allows for warning supression when we expect there to be mismatches due to
+// earlier mismatches or a suspended fiber.
+let didSuspendOrError: boolean = false;
 
 // Hydration errors that were thrown inside this boundary
 let hydrationErrors: Array<mixed> | null = null;
@@ -95,9 +98,9 @@ function warnIfHydrating() {
   }
 }
 
-export function markDidSuspendWhileHydratingDEV() {
+export function markDidThrowWhileHydratingDEV() {
   if (__DEV__) {
-    didSuspend = true;
+    didSuspendOrError = true;
   }
 }
 
@@ -113,7 +116,7 @@ function enterHydrationState(fiber: Fiber): boolean {
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspend = false;
+  didSuspendOrError = false;
   return true;
 }
 
@@ -131,7 +134,7 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspend = false;
+  didSuspendOrError = false;
   if (treeContext !== null) {
     restoreSuspendedTreeContext(fiber, treeContext);
   }
@@ -196,7 +199,7 @@ function deleteHydratableInstance(
 
 function warnNonhydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   if (__DEV__) {
-    if (didSuspend) {
+    if (didSuspendOrError) {
       // Inside a boundary that already suspended. We're currently rendering the
       // siblings of a suspended node. The mismatch may be due to the missing
       // data, so it's probably a false positive.
@@ -444,7 +447,7 @@ function prepareToHydrateHostInstance(
   }
 
   const instance: Instance = fiber.stateNode;
-  const shouldWarnIfMismatchDev = !didSuspend;
+  const shouldWarnIfMismatchDev = !didSuspendOrError;
   const updatePayload = hydrateInstance(
     instance,
     fiber.type,
@@ -474,7 +477,7 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
 
   const textInstance: TextInstance = fiber.stateNode;
   const textContent: string = fiber.memoizedProps;
-  const shouldWarnIfMismatchDev = !didSuspend;
+  const shouldWarnIfMismatchDev = !didSuspendOrError;
   const shouldUpdate = hydrateTextInstance(
     textInstance,
     textContent,
@@ -653,7 +656,7 @@ function resetHydrationState(): void {
   hydrationParentFiber = null;
   nextHydratableInstance = null;
   isHydrating = false;
-  didSuspend = false;
+  didSuspendOrError = false;
 }
 
 export function upgradeHydrationErrorsToRecoverable(): void {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -83,7 +83,7 @@ let isHydrating: boolean = false;
 
 // this flag allows for warning supression when we expect there to be mismatches due to
 // earlier mismatches or a suspended fiber.
-let didSuspendOrError: boolean = false;
+let didSuspendOrErrorDEV: boolean = false;
 
 // Hydration errors that were thrown inside this boundary
 let hydrationErrors: Array<mixed> | null = null;
@@ -100,7 +100,7 @@ function warnIfHydrating() {
 
 export function markDidThrowWhileHydratingDEV() {
   if (__DEV__) {
-    didSuspendOrError = true;
+    didSuspendOrErrorDEV = true;
   }
 }
 
@@ -116,7 +116,7 @@ function enterHydrationState(fiber: Fiber): boolean {
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
   return true;
 }
 
@@ -134,7 +134,7 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
   if (treeContext !== null) {
     restoreSuspendedTreeContext(fiber, treeContext);
   }
@@ -199,7 +199,7 @@ function deleteHydratableInstance(
 
 function warnNonhydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   if (__DEV__) {
-    if (didSuspendOrError) {
+    if (didSuspendOrErrorDEV) {
       // Inside a boundary that already suspended. We're currently rendering the
       // siblings of a suspended node. The mismatch may be due to the missing
       // data, so it's probably a false positive.
@@ -447,7 +447,7 @@ function prepareToHydrateHostInstance(
   }
 
   const instance: Instance = fiber.stateNode;
-  const shouldWarnIfMismatchDev = !didSuspendOrError;
+  const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
   const updatePayload = hydrateInstance(
     instance,
     fiber.type,
@@ -477,7 +477,7 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
 
   const textInstance: TextInstance = fiber.stateNode;
   const textContent: string = fiber.memoizedProps;
-  const shouldWarnIfMismatchDev = !didSuspendOrError;
+  const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
   const shouldUpdate = hydrateTextInstance(
     textInstance,
     textContent,
@@ -656,7 +656,7 @@ function resetHydrationState(): void {
   hydrationParentFiber = null;
   nextHydratableInstance = null;
   isHydrating = false;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
 }
 
 export function upgradeHydrationErrorsToRecoverable(): void {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -81,8 +81,8 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// this flag allows for warning supression when we expect there to be mismatches due to
-// earlier mismatches or a suspended fiber.
+// This flag allows for warning supression when we expect there to be mismatches
+// due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 
 // Hydration errors that were thrown inside this boundary

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -83,7 +83,7 @@ let isHydrating: boolean = false;
 
 // this flag allows for warning supression when we expect there to be mismatches due to
 // earlier mismatches or a suspended fiber.
-let didSuspendOrError: boolean = false;
+let didSuspendOrErrorDEV: boolean = false;
 
 // Hydration errors that were thrown inside this boundary
 let hydrationErrors: Array<mixed> | null = null;
@@ -100,7 +100,7 @@ function warnIfHydrating() {
 
 export function markDidThrowWhileHydratingDEV() {
   if (__DEV__) {
-    didSuspendOrError = true;
+    didSuspendOrErrorDEV = true;
   }
 }
 
@@ -116,7 +116,7 @@ function enterHydrationState(fiber: Fiber): boolean {
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
   return true;
 }
 
@@ -134,7 +134,7 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
   if (treeContext !== null) {
     restoreSuspendedTreeContext(fiber, treeContext);
   }
@@ -199,7 +199,7 @@ function deleteHydratableInstance(
 
 function warnNonhydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   if (__DEV__) {
-    if (didSuspendOrError) {
+    if (didSuspendOrErrorDEV) {
       // Inside a boundary that already suspended. We're currently rendering the
       // siblings of a suspended node. The mismatch may be due to the missing
       // data, so it's probably a false positive.
@@ -447,7 +447,7 @@ function prepareToHydrateHostInstance(
   }
 
   const instance: Instance = fiber.stateNode;
-  const shouldWarnIfMismatchDev = !didSuspendOrError;
+  const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
   const updatePayload = hydrateInstance(
     instance,
     fiber.type,
@@ -477,7 +477,7 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
 
   const textInstance: TextInstance = fiber.stateNode;
   const textContent: string = fiber.memoizedProps;
-  const shouldWarnIfMismatchDev = !didSuspendOrError;
+  const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
   const shouldUpdate = hydrateTextInstance(
     textInstance,
     textContent,
@@ -656,7 +656,7 @@ function resetHydrationState(): void {
   hydrationParentFiber = null;
   nextHydratableInstance = null;
   isHydrating = false;
-  didSuspendOrError = false;
+  didSuspendOrErrorDEV = false;
 }
 
 export function upgradeHydrationErrorsToRecoverable(): void {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -80,7 +80,10 @@ import {queueRecoverableErrors} from './ReactFiberWorkLoop.old';
 let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
-let didSuspend: boolean = false;
+
+// this flag allows for warning supression when we expect there to be mismatches due to
+// earlier mismatches or a suspended fiber.
+let didSuspendOrError: boolean = false;
 
 // Hydration errors that were thrown inside this boundary
 let hydrationErrors: Array<mixed> | null = null;
@@ -95,9 +98,9 @@ function warnIfHydrating() {
   }
 }
 
-export function markDidSuspendWhileHydratingDEV() {
+export function markDidThrowWhileHydratingDEV() {
   if (__DEV__) {
-    didSuspend = true;
+    didSuspendOrError = true;
   }
 }
 
@@ -113,7 +116,7 @@ function enterHydrationState(fiber: Fiber): boolean {
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspend = false;
+  didSuspendOrError = false;
   return true;
 }
 
@@ -131,7 +134,7 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   hydrationParentFiber = fiber;
   isHydrating = true;
   hydrationErrors = null;
-  didSuspend = false;
+  didSuspendOrError = false;
   if (treeContext !== null) {
     restoreSuspendedTreeContext(fiber, treeContext);
   }
@@ -196,7 +199,7 @@ function deleteHydratableInstance(
 
 function warnNonhydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   if (__DEV__) {
-    if (didSuspend) {
+    if (didSuspendOrError) {
       // Inside a boundary that already suspended. We're currently rendering the
       // siblings of a suspended node. The mismatch may be due to the missing
       // data, so it's probably a false positive.
@@ -444,7 +447,7 @@ function prepareToHydrateHostInstance(
   }
 
   const instance: Instance = fiber.stateNode;
-  const shouldWarnIfMismatchDev = !didSuspend;
+  const shouldWarnIfMismatchDev = !didSuspendOrError;
   const updatePayload = hydrateInstance(
     instance,
     fiber.type,
@@ -474,7 +477,7 @@ function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
 
   const textInstance: TextInstance = fiber.stateNode;
   const textContent: string = fiber.memoizedProps;
-  const shouldWarnIfMismatchDev = !didSuspend;
+  const shouldWarnIfMismatchDev = !didSuspendOrError;
   const shouldUpdate = hydrateTextInstance(
     textInstance,
     textContent,
@@ -653,7 +656,7 @@ function resetHydrationState(): void {
   hydrationParentFiber = null;
   nextHydratableInstance = null;
   isHydrating = false;
-  didSuspend = false;
+  didSuspendOrError = false;
 }
 
 export function upgradeHydrationErrorsToRecoverable(): void {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -81,8 +81,8 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// this flag allows for warning supression when we expect there to be mismatches due to
-// earlier mismatches or a suspended fiber.
+// This flag allows for warning supression when we expect there to be mismatches
+// due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 
 // Hydration errors that were thrown inside this boundary

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -83,7 +83,7 @@ import {
 } from './ReactFiberLane.new';
 import {
   getIsHydrating,
-  markDidSuspendWhileHydratingDEV,
+  markDidThrowWhileHydratingDEV,
   queueHydrationError,
 } from './ReactFiberHydrationContext.new';
 
@@ -453,8 +453,10 @@ function throwException(
     const wakeable: Wakeable = (value: any);
     resetSuspendedComponent(sourceFiber, rootRenderLanes);
 
-    if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-      markDidSuspendWhileHydratingDEV();
+    if (__DEV__) {
+      if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+        markDidThrowWhileHydratingDEV();
+      }
     }
 
     if (__DEV__) {
@@ -518,6 +520,7 @@ function throwException(
   } else {
     // This is a regular error, not a Suspense wakeable.
     if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+      markDidThrowWhileHydratingDEV();
       const suspenseBoundary = getNearestSuspenseBoundaryToCapture(returnFiber);
       // If the error was thrown during hydration, we may be able to recover by
       // discarding the dehydrated content and switching to a client render.

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -444,10 +444,6 @@ function throwException(
     }
   }
 
-  if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-    markDidSuspendWhileHydratingDEV();
-  }
-
   if (
     value !== null &&
     typeof value === 'object' &&
@@ -456,6 +452,10 @@ function throwException(
     // This is a wakeable. The component suspended.
     const wakeable: Wakeable = (value: any);
     resetSuspendedComponent(sourceFiber, rootRenderLanes);
+
+    if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+      markDidSuspendWhileHydratingDEV();
+    }
 
     if (__DEV__) {
       if (enableDebugTracing) {

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -444,6 +444,10 @@ function throwException(
     }
   }
 
+  if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+    markDidSuspendWhileHydratingDEV();
+  }
+
   if (
     value !== null &&
     typeof value === 'object' &&
@@ -514,8 +518,6 @@ function throwException(
   } else {
     // This is a regular error, not a Suspense wakeable.
     if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-      markDidSuspendWhileHydratingDEV();
-
       const suspenseBoundary = getNearestSuspenseBoundaryToCapture(returnFiber);
       // If the error was thrown during hydration, we may be able to recover by
       // discarding the dehydrated content and switching to a client render.

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -457,6 +457,10 @@ function throwException(
     const wakeable: Wakeable = (value: any);
     resetSuspendedComponent(sourceFiber, rootRenderLanes);
 
+    if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+      markDidSuspendWhileHydratingDEV();
+    }
+
     if (__DEV__) {
       if (enableDebugTracing) {
         if (sourceFiber.mode & DebugTracingMode) {

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -444,6 +444,10 @@ function throwException(
     }
   }
 
+  if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+    markDidSuspendWhileHydratingDEV();
+  }
+
   if (
     value !== null &&
     typeof value === 'object' &&
@@ -514,8 +518,6 @@ function throwException(
   } else {
     // This is a regular error, not a Suspense wakeable.
     if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-      markDidSuspendWhileHydratingDEV();
-
       const suspenseBoundary = getNearestSuspenseBoundaryToCapture(returnFiber);
       // If the error was thrown during hydration, we may be able to recover by
       // discarding the dehydrated content and switching to a client render.

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -83,7 +83,7 @@ import {
 } from './ReactFiberLane.old';
 import {
   getIsHydrating,
-  markDidSuspendWhileHydratingDEV,
+  markDidThrowWhileHydratingDEV,
   queueHydrationError,
 } from './ReactFiberHydrationContext.old';
 
@@ -444,10 +444,6 @@ function throwException(
     }
   }
 
-  if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-    markDidSuspendWhileHydratingDEV();
-  }
-
   if (
     value !== null &&
     typeof value === 'object' &&
@@ -457,8 +453,10 @@ function throwException(
     const wakeable: Wakeable = (value: any);
     resetSuspendedComponent(sourceFiber, rootRenderLanes);
 
-    if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
-      markDidSuspendWhileHydratingDEV();
+    if (__DEV__) {
+      if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+        markDidThrowWhileHydratingDEV();
+      }
     }
 
     if (__DEV__) {
@@ -522,6 +520,7 @@ function throwException(
   } else {
     // This is a regular error, not a Suspense wakeable.
     if (getIsHydrating() && sourceFiber.mode & ConcurrentMode) {
+      markDidThrowWhileHydratingDEV();
       const suspenseBoundary = getNearestSuspenseBoundaryToCapture(returnFiber);
       // If the error was thrown during hydration, we may be able to recover by
       // discarding the dehydrated content and switching to a client render.


### PR DESCRIPTION
Before this PR if there was a hydration error thrown in a ConcurrentMode tree the hydration procerss would enter a didSuspend state where further errors would be suppressed.

This did not previously happen however when a promise was thrown which would cause a Suspense boundary to suspend. Since it is typical for there to be hydration errors if a preceding sibling suspends because the server rendered content represented by that suspending component is not being claimed the didSuspend state is likely to follow quickly after (on the first non-promise thrown value)

This PR moves where the didSuspend state is activated to be for both Error and Promise thrown values.

closes #24384 