### PR TITLE
Fix: useDeferredValue should reuse previous value, not revert to initial value

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1993,6 +1993,7 @@ function updateDeferredValueImpl<T>(hook: Hook, prevValue: T, value: T): T {
       markWorkInProgressReceivedUpdate();
     }
 
+    hook.memoizedState = value;
     return value;
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1993,6 +1993,7 @@ function updateDeferredValueImpl<T>(hook: Hook, prevValue: T, value: T): T {
       markWorkInProgressReceivedUpdate();
     }
 
+    hook.memoizedState = value;
     return value;
   }
 }


### PR DESCRIPTION
During an urgent update, useDeferredValue should reuse the previous value. The regression test I added shows that it was reverting to the initial value instead.

The cause of the bug was trivial: the update path doesn't update the hook's `memoizedState` field. Only the mount path.

None of the existing tests happened to catch this because to trigger the bug, you have to do an urgent update that isn't the first update after initial render. In all of the existing tests that included an urgent update, it was the first update, so the "previous" value and the initial value happened to be the same thing.