### PR TITLE
Avoid accumulating hydration mismatch errors after the first hydration error

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2977,8 +2977,6 @@ describe('ReactDOMFizzServer', () => {
       });
       expect(Scheduler).toFlushAndYield([
         'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
-        'Logged recoverable error: Text content does not match server-rendered HTML.',
         'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
       ]);
 
@@ -3069,8 +3067,6 @@ describe('ReactDOMFizzServer', () => {
     });
     expect(Scheduler).toFlushAndYield([
       'Logged recoverable error: uh oh',
-      'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
-      'Logged recoverable error: Hydration failed because the initial UI does not match what was rendered on the server.',
       'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
     ]);
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3160,7 +3160,7 @@ describe('ReactDOMFizzServer', () => {
     expect(Scheduler).toFlushAndYield([]);
   });
 
-  // @gate __DEV__
+  // @gate experimental && __DEV__
   it('does not invokeGuardedCallback for errors after the first hydration error', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;
@@ -3262,8 +3262,7 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // This test is not gated to __DEV__ because in prod there is no iGC call for these errors and so it passes
-  // there too
+  // @gate experimental
   it('does not invokeGuardedCallback for errors after a preceding fiber suspends', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3261,7 +3261,9 @@ describe('ReactDOMFizzServer', () => {
       console.error = originalConsoleError;
     }
   });
-  // @gate __DEV__
+
+  // This test is not gated to __DEV__ because in prod there is no iGC call for these errors and so it passes
+  // there too
   it('does not invokeGuardedCallback for errors after a preceding fiber suspends', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3235,8 +3235,6 @@ describe('ReactDOMFizzServer', () => {
       });
       expect(Scheduler).toFlushAndYield([
         'Logged recoverable error: first error',
-        'Logged recoverable error: second error',
-        'Logged recoverable error: third error',
         'Logged recoverable error: There was an error while hydrating this Suspense boundary. Switched to client rendering.',
       ]);
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -350,9 +350,7 @@ describe('ReactDOMServerPartialHydration', () => {
       );
 
       if (__DEV__) {
-        const secondToLastCall =
-          mockError.mock.calls[mockError.mock.calls.length - 2];
-        expect(secondToLastCall).toEqual([
+        expect(mockError.mock.calls[0]).toEqual([
           'Warning: Expected server HTML to contain a matching <%s> in <%s>.%s',
           'article',
           'section',

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -125,6 +125,7 @@ function enterHydrationState(fiber: Fiber): boolean {
   isHydrating = true;
   hydrationErrors = null;
   didSuspendOrErrorDEV = false;
+  didThrowNotYetQueuedHydrationMismatchError = false;
   return true;
 }
 
@@ -143,6 +144,7 @@ function reenterHydrationStateFromDehydratedSuspenseInstance(
   isHydrating = true;
   hydrationErrors = null;
   didSuspendOrErrorDEV = false;
+  didThrowNotYetQueuedHydrationMismatchError = false;
   if (treeContext !== null) {
     restoreSuspendedTreeContext(fiber, treeContext);
   }

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -88,10 +88,6 @@ let didSuspendOrErrorDEV: boolean = false;
 // Hydration errors that were thrown inside this boundary
 let hydrationErrors: Array<mixed> | null = null;
 
-// When true we expect the next queued hydration error to be a mismatch error.
-// These errors are handled differently than other errors that occurr during hydration
-let didThrowNotYetQueuedHydrationMismatchError = false;
-
 export function hydrationDidSuspendOrErrorDEV() {
   return didSuspendOrErrorDEV;
 }
@@ -394,7 +390,6 @@ function shouldClientRenderOnMismatch(fiber: Fiber) {
 }
 
 function throwOnHydrationMismatch(fiber: Fiber) {
-  didThrowNotYetQueuedHydrationMismatchError = true;
   throw new Error(
     'Hydration failed because the initial UI does not match what was ' +
       'rendered on the server.',
@@ -457,29 +452,24 @@ function prepareToHydrateHostInstance(
 
   const instance: Instance = fiber.stateNode;
   const shouldWarnIfMismatchDev = !didSuspendOrErrorDEV;
-  try {
-    const updatePayload = hydrateInstance(
-      instance,
-      fiber.type,
-      fiber.memoizedProps,
-      rootContainerInstance,
-      hostContext,
-      fiber,
-      shouldWarnIfMismatchDev,
-    );
+  const updatePayload = hydrateInstance(
+    instance,
+    fiber.type,
+    fiber.memoizedProps,
+    rootContainerInstance,
+    hostContext,
+    fiber,
+    shouldWarnIfMismatchDev,
+  );
 
-    // TODO: Type this specific to this type of component.
-    fiber.updateQueue = (updatePayload: any);
-    // If the update payload indicates that there is a change or if there
-    // is a new ref we mark this as an update.
-    if (updatePayload !== null) {
-      return true;
-    }
-    return false;
-  } catch (error) {
-    didThrowNotYetQueuedHydrationMismatchError = true;
-    throw error;
+  // TODO: Type this specific to this type of component.
+  fiber.updateQueue = (updatePayload: any);
+  // If the update payload indicates that there is a change or if there
+  // is a new ref we mark this as an update.
+  if (updatePayload !== null) {
+    return true;
   }
+  return false;
 }
 
 function prepareToHydrateHostTextInstance(fiber: Fiber): boolean {
@@ -688,24 +678,18 @@ function getIsHydrating(): boolean {
   return isHydrating;
 }
 
-export function queueHydrationError(error: mixed): void {
+function queueIfFirstHydrationError(error: mixed): void {
   if (hydrationErrors === null) {
-    // We always queue the first hydration error
+    hydrationErrors = [error];
+  }
+}
+
+function queueHydrationError(error: mixed): void {
+  if (hydrationErrors === null) {
     hydrationErrors = [error];
   } else {
-    // didThrowNotYetQueuedHydrationMismatchError will be true if we just threw
-    // a hydration mismatch error. In those cases we do not want to queue the
-    // error because there is a more useful error related to hydration that
-    // was already queued.
-    if (!didThrowNotYetQueuedHydrationMismatchError) {
-      // this error came from somewhere other than a hydration mismatch so we
-      // queue it even though other errors have also been queued. The user
-      // should see these errors if a recovery is made
-      hydrationErrors.push(error);
-    }
+    hydrationErrors.push(error);
   }
-  // Now that we have handled the queueing request we reset this
-  didThrowNotYetQueuedHydrationMismatchError = false;
 }
 
 export {
@@ -721,4 +705,6 @@ export {
   popHydrationState,
   hasUnhydratedTailNodes,
   warnIfUnhydratedTailNodes,
+  queueIfFirstHydrationError,
+  queueHydrationError,
 };

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -84,7 +84,7 @@ import {
 import {
   getIsHydrating,
   markDidThrowWhileHydratingDEV,
-  queueHydrationError,
+  queueIfFirstHydrationError,
 } from './ReactFiberHydrationContext.new';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
@@ -542,7 +542,7 @@ function throwException(
 
         // Even though the user may not be affected by this error, we should
         // still log it so it can be fixed.
-        queueHydrationError(value);
+        queueIfFirstHydrationError(value);
         return;
       }
     } else {

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -84,13 +84,8 @@ import {
 import {
   getIsHydrating,
   markDidThrowWhileHydratingDEV,
-<<<<<<< packages/react-reconciler/src/ReactFiberThrow.old.js
-  queueHydrationError,
-} from './ReactFiberHydrationContext.old';
-=======
   queueIfFirstHydrationError,
-} from './ReactFiberHydrationContext.new';
->>>>>>> packages/react-reconciler/src/ReactFiberThrow.new.js
+} from './ReactFiberHydrationContext.old';
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -84,8 +84,13 @@ import {
 import {
   getIsHydrating,
   markDidThrowWhileHydratingDEV,
+<<<<<<< packages/react-reconciler/src/ReactFiberThrow.old.js
   queueHydrationError,
 } from './ReactFiberHydrationContext.old';
+=======
+  queueIfFirstHydrationError,
+} from './ReactFiberHydrationContext.new';
+>>>>>>> packages/react-reconciler/src/ReactFiberThrow.new.js
 
 const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
@@ -542,7 +547,7 @@ function throwException(
 
         // Even though the user may not be affected by this error, we should
         // still log it so it can be fixed.
-        queueHydrationError(value);
+        queueIfFirstHydrationError(value);
         return;
       }
     } else {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -88,6 +88,7 @@ import {
   assignFiberPropertiesInDEV,
 } from './ReactFiber.new';
 import {isRootDehydrated} from './ReactFiberShellHydration';
+import {hydrationDidSuspendOrErrorDEV} from './ReactFiberHydrationContext.new';
 import {NoMode, ProfileMode, ConcurrentMode} from './ReactTypeOfMode';
 import {
   HostRoot,
@@ -3001,11 +3002,13 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
       return originalBeginWork(current, unitOfWork, lanes);
     } catch (originalError) {
       if (
-        originalError !== null &&
-        typeof originalError === 'object' &&
-        typeof originalError.then === 'function'
+        hydrationDidSuspendOrErrorDEV() ||
+        (originalError !== null &&
+          typeof originalError === 'object' &&
+          typeof originalError.then === 'function')
       ) {
-        // Don't replay promises. Treat everything else like an error.
+        // Don't replay promises.
+        // Don't replay when hydration has suspended or errored already
         throw originalError;
       }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -88,7 +88,7 @@ import {
   assignFiberPropertiesInDEV,
 } from './ReactFiber.old';
 import {isRootDehydrated} from './ReactFiberShellHydration';
-import {hydrationDidSuspendOrErrorDEV} from './ReactFiberHydrationContext.new';
+import {hydrationDidSuspendOrErrorDEV} from './ReactFiberHydrationContext.old';
 import {NoMode, ProfileMode, ConcurrentMode} from './ReactTypeOfMode';
 import {
   HostRoot,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -88,6 +88,7 @@ import {
   assignFiberPropertiesInDEV,
 } from './ReactFiber.old';
 import {isRootDehydrated} from './ReactFiberShellHydration';
+import {hydrationDidSuspendOrErrorDEV} from './ReactFiberHydrationContext.new';
 import {NoMode, ProfileMode, ConcurrentMode} from './ReactTypeOfMode';
 import {
   HostRoot,
@@ -3001,11 +3002,13 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
       return originalBeginWork(current, unitOfWork, lanes);
     } catch (originalError) {
       if (
-        originalError !== null &&
-        typeof originalError === 'object' &&
-        typeof originalError.then === 'function'
+        hydrationDidSuspendOrErrorDEV() ||
+        (originalError !== null &&
+          typeof originalError === 'object' &&
+          typeof originalError.then === 'function')
       ) {
-        // Don't replay promises. Treat everything else like an error.
+        // Don't replay promises.
+        // Don't replay when hydration has suspended or errored already
         throw originalError;
       }
 


### PR DESCRIPTION
This PR attempts to make reasonably simple interventions to improve the situation with error logging / reporting for hydration errors without introducing significant new runtime costs. It is clear that the larger refactor of hydration is where the most gains will come from in simplifying the error pathways for hydration.

The general hueristic is

1. [dev only] If hydrating in a suspense boundary and something suspends stop replaying later errors using invokeGuardedCallback.
  - Rationale: Later errors are likely caused by earlier suspend and are not likely useful. if they are genuine errors they should show up once the boundary unsuspends

1. If hydrating in a suspense boundary and something errors then queue it if it is the first error otherwise discard it. Additionally [dev only] replay this error with invokeGuardedCallback but do not replay later errors
  - Rationale: The first error can easily cause any kind of subsequent errors and while we won't always be correct in that they are contingent on the first the debugging process
