### PR TITLE
Refactor getLanesToRetrySynchronouslyOnError by removing unreachable code

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -439,9 +439,6 @@ export function getLanesToRetrySynchronouslyOnError(root: FiberRoot): Lanes {
   if (everythingButOffscreen !== NoLanes) {
     return everythingButOffscreen;
   }
-  if (everythingButOffscreen & OffscreenLane) {
-    return OffscreenLane;
-  }
   return NoLanes;
 }
 

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -439,9 +439,6 @@ export function getLanesToRetrySynchronouslyOnError(root: FiberRoot): Lanes {
   if (everythingButOffscreen !== NoLanes) {
     return everythingButOffscreen;
   }
-  if (everythingButOffscreen & OffscreenLane) {
-    return OffscreenLane;
-  }
   return NoLanes;
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The deleted code is unreachable.

`everythingButOffscreen` is `pendingLanes` with `OffscreenLane` excluded. So `everythingButOffscreen & OffscreenLane` will always be `false`.

## How did you test this change?

You can see that `getLanesToRetrySynchronouslyOnError` never logs `return OffscreenLane` In the following code example.

```js
const NoLanes = 0b0000000000000000000000000000000;
const OffscreenLane = 0b1000000000000000000000000000000;

function getLanesToRetrySynchronouslyOnError(pendingLanes) {
  const everythingButOffscreen = pendingLanes & ~OffscreenLane;
  if (everythingButOffscreen !== NoLanes) {
    console.log('return everythingButOffscreen');
    return;
  }
  if (everythingButOffscreen & OffscreenLane) {
    console.log('return OffscreenLane');
    return;
  }
  console.log('return NoLanes');
}

[
    0b0000000000000000000000000000000,
    0b1000000000000000000000000000000,
    0b0111111111111111111111111111111,
    0b1111111111111111111111111111111,
    0b0000000000000001111111111111111,
    0b1111111111111110000000000000000,
].forEach(getLanesToRetrySynchronouslyOnError)
```

![Screen Shot 2022-04-27 at 10 02 52 PM](https://user-images.githubusercontent.com/16910748/165536645-6e30b500-1d9d-44ad-83ed-cc9f995e2f06.png)


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->


