### PR TITLE
AttemptContinuousHydration only when blockedOn is new

### DIFF
--- a/packages/react-dom/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom/src/events/ReactDOMEventReplaying.js
@@ -281,7 +281,12 @@ function accumulateOrCreateContinuousQueuedReplayableEvent(
       const fiber = getInstanceFromNode(blockedOn);
       if (fiber !== null) {
         // Attempt to increase the priority of this target.
-        attemptContinuousHydration(fiber);
+        if (
+          existingQueuedEvent === null ||
+          existingQueuedEvent.blockedOn !== blockedOn
+        ) {
+          attemptContinuousHydration(fiber);
+        }
       }
     }
     return queuedEvent;


### PR DESCRIPTION
Prior to this change accumulateOrCreateContinuousQueuedReplayableEvent would repeatedly AttemptContinuousHydration even if the existingQueuedEvent was blocked on the same boundary as the current event. This led to a cascade of hydration attempts when there should be just one (unless of the blocking boundary changes). this change fixes that issue.
