### PR TITLE
Warn when using one-shot iterators as children

### DIFF
--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -334,10 +334,10 @@ describe('ReactMultiChild', () => {
     expect(() => {
       ReactDOM.render(<Foo />, div);
     }).toErrorDev(
-      'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
-        'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+      'Warning: Using an iterator such as `[].values()` as children is unsupported and will likely yield ' +
+        'unexpected results because enumerating such an iterator mutates it. ' +
         'You may convert it to an array with `Array.from()` or the ' +
-        '`[...spread]` operator before rendering. Keep in mind ' +
+        '`[...spread]` operator before rendering. Keep in mind that ' +
         'you might need to polyfill these features for older browsers.\n' +
         '    in Foo (at **)',
     );

--- a/packages/react-dom/src/__tests__/ReactMultiChild-test.js
+++ b/packages/react-dom/src/__tests__/ReactMultiChild-test.js
@@ -323,6 +323,29 @@ describe('ReactMultiChild', () => {
     ReactDOM.render(<Foo />, div);
   });
 
+  it('should warn when using one-shot iterators as children', () => {
+    function Foo() {
+      const iterator = [<h1 key="1">Hello</h1>, <h1 key="2">Dave</h1>].values();
+
+      return iterator;
+    }
+
+    const div = document.createElement('div');
+    expect(() => {
+      ReactDOM.render(<Foo />, div);
+    }).toErrorDev(
+      'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
+        'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+        'You may convert it to an array with `Array.from()` or the ' +
+        '`[...spread]` operator before rendering. Keep in mind ' +
+        'you might need to polyfill these features for older browsers.\n' +
+        '    in Foo (at **)',
+    );
+
+    // Test de-duplication
+    ReactDOM.render(<Foo />, div);
+  });
+
   it('should not warn for using generators in legacy iterables', () => {
     const fooIterable = {
       '@@iterator': function*() {

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -950,10 +950,10 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (isOneShotIterator) {
           if (!didWarnAboutOneShotIterators) {
             console.error(
-              'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
-                'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+              'Using an iterator such as `[].values()` as children is unsupported and will likely yield ' +
+                'unexpected results because enumerating such an iterator mutates it. ' +
                 'You may convert it to an array with `Array.from()` or the ' +
-                '`[...spread]` operator before rendering. Keep in mind ' +
+                '`[...spread]` operator before rendering. Keep in mind that ' +
                 'you might need to polyfill these features for older browsers.',
             );
           }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -943,6 +943,22 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutGenerators = true;
+      } else {
+        // Warn about using one-shot iterators as children
+        const isOneShotIterator =
+          iteratorFn.call(newChildrenIterable) === newChildrenIterable;
+        if (isOneShotIterator) {
+          if (!didWarnAboutOneShotIterators) {
+            console.error(
+              'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
+                'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+                'You may convert it to an array with `Array.from()` or the ' +
+                '`[...spread]` operator before rendering. Keep in mind ' +
+                'you might need to polyfill these features for older browsers.',
+            );
+          }
+          didWarnAboutOneShotIterators = true;
+        }
       }
 
       // Warn about using Maps as children
@@ -954,22 +970,6 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutMaps = true;
-      }
-
-      // Warn about using one-shot iterators as children
-      const isOneShotIterator =
-        iteratorFn.call(newChildrenIterable) === newChildrenIterable;
-      if (isOneShotIterator) {
-        if (!didWarnAboutOneShotIterators) {
-          console.error(
-            'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
-              'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
-              'You may convert it to an array with `Array.from()` or the ' +
-              '`[...spread]` operator before rendering. Keep in mind ' +
-              'you might need to polyfill these features for older browsers.',
-          );
-        }
-        didWarnAboutOneShotIterators = true;
       }
 
       // First, validate keys.

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -47,6 +47,7 @@ import {pushTreeFork} from './ReactFiberTreeContext.new';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
+let didWarnAboutOneShotIterators;
 let didWarnAboutStringRefs;
 let ownerHasKeyUseWarning;
 let ownerHasFunctionTypeWarning;
@@ -953,6 +954,22 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutMaps = true;
+      }
+
+      // Warn about using one-shot iterators as children
+      const isOneShotIterator =
+        iteratorFn.call(newChildrenIterable) === newChildrenIterable;
+      if (isOneShotIterator) {
+        if (!didWarnAboutOneShotIterators) {
+          console.error(
+            'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
+              'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+              'You may convert it to an array with `Array.from()` or the ' +
+              '`[...spread]` operator before rendering. Keep in mind ' +
+              'you might need to polyfill these features for older browsers.',
+          );
+        }
+        didWarnAboutOneShotIterators = true;
       }
 
       // First, validate keys.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -950,10 +950,10 @@ function ChildReconciler(shouldTrackSideEffects) {
         if (isOneShotIterator) {
           if (!didWarnAboutOneShotIterators) {
             console.error(
-              'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
-                'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+              'Using an iterator such as `[].values()` as children is unsupported and will likely yield ' +
+                'unexpected results because enumerating such an iterator mutates it. ' +
                 'You may convert it to an array with `Array.from()` or the ' +
-                '`[...spread]` operator before rendering. Keep in mind ' +
+                '`[...spread]` operator before rendering. Keep in mind that ' +
                 'you might need to polyfill these features for older browsers.',
             );
           }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -47,6 +47,7 @@ import {pushTreeFork} from './ReactFiberTreeContext.old';
 
 let didWarnAboutMaps;
 let didWarnAboutGenerators;
+let didWarnAboutOneShotIterators;
 let didWarnAboutStringRefs;
 let ownerHasKeyUseWarning;
 let ownerHasFunctionTypeWarning;
@@ -953,6 +954,22 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutMaps = true;
+      }
+
+      // Warn about using one-shot iterators as children
+      const isOneShotIterator =
+        iteratorFn.call(newChildrenIterable) === newChildrenIterable;
+      if (isOneShotIterator) {
+        if (!didWarnAboutOneShotIterators) {
+          console.error(
+            'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
+              'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+              'You may convert it to an array with `Array.from()` or the ' +
+              '`[...spread]` operator before rendering. Keep in mind ' +
+              'you might need to polyfill these features for older browsers.',
+          );
+        }
+        didWarnAboutOneShotIterators = true;
       }
 
       // First, validate keys.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -943,6 +943,22 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutGenerators = true;
+      } else {
+        // Warn about using one-shot iterators as children
+        const isOneShotIterator =
+          iteratorFn.call(newChildrenIterable) === newChildrenIterable;
+        if (isOneShotIterator) {
+          if (!didWarnAboutOneShotIterators) {
+            console.error(
+              'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
+                'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
+                'You may convert it to an array with `Array.from()` or the ' +
+                '`[...spread]` operator before rendering. Keep in mind ' +
+                'you might need to polyfill these features for older browsers.',
+            );
+          }
+          didWarnAboutOneShotIterators = true;
+        }
       }
 
       // Warn about using Maps as children
@@ -954,22 +970,6 @@ function ChildReconciler(shouldTrackSideEffects) {
           );
         }
         didWarnAboutMaps = true;
-      }
-
-      // Warn about using one-shot iterators as children
-      const isOneShotIterator =
-        iteratorFn.call(newChildrenIterable) === newChildrenIterable;
-      if (isOneShotIterator) {
-        if (!didWarnAboutOneShotIterators) {
-          console.error(
-            'Using a TOOD-understandable-term as children is unsupported and will likely yield ' +
-              'unexpected results because enumerating a TOOD-understandable-term mutates it. ' +
-              'You may convert it to an array with `Array.from()` or the ' +
-              '`[...spread]` operator before rendering. Keep in mind ' +
-              'you might need to polyfill these features for older browsers.',
-          );
-        }
-        didWarnAboutOneShotIterators = true;
       }
 
       // First, validate keys.


### PR DESCRIPTION

## Summary

Closes https://github.com/facebook/react/issues/20707 by adding a warning when using one-shot iterators.

## How did you test this change?

- [x] https://codesandbox.io/s/one-shot-iterators-as-children-cgdvzg issues warning with build from this PR (based on the linked issue + forward porting to React 18)
- [x] CI
