### PR TITLE
Fixed wrong method call for LRU cache

### DIFF
--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -102,7 +102,7 @@ export function inspectElement({
       case 'not-found':
         // This is effectively a no-op.
         // If the Element is still in the Store, we can eagerly remove it from the Map.
-        inspectedElementCache.remove(id);
+        inspectedElementCache.del(id);
 
         throw Error(`Element "${id}" not found`);
 

--- a/packages/react-devtools-shared/src/types.js
+++ b/packages/react-devtools-shared/src/types.js
@@ -86,9 +86,9 @@ export type HookSourceLocationKey = string;
 export type HookNames = Map<HookSourceLocationKey, HookName>;
 
 export type LRUCache<K, V> = {|
+  del: (key: K) => void,
   get: (key: K) => V,
   has: (key: K) => boolean,
-  remove: (key: K) => void,
   reset: () => void,
   set: (key: K, value: V) => void,
 |};


### PR DESCRIPTION
Noticed this bug when inspecting a downstream issue problem. DevTools calls a `remove` method but the LRU cache library doesn't actually define a "remove" method, rather it has a `del` method. (Newer versions of the library have a `delete` method.)

Related to https://github.com/RecordReplay/devtools/issues/6318