### PR TITLE
[React DevTools] Fix `didFiberRender`

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1570,6 +1570,7 @@ export function attach(
       case ContextConsumer:
       case MemoComponent:
       case SimpleMemoComponent:
+      case ForwardRef:
         // For types that execute user code, we check PerformedWork effect.
         // We don't reflect bailouts (either referential or sCU) in DevTools.
         // eslint-disable-next-line no-bitwise


### PR DESCRIPTION
Resolves #24428 

---

For fiber types that render user code, we check the `PerformedWork` flag rather than the props, ref, and state to see if the fiber rendered (rather than bailing out/etc.) so we know whether we need to do things like record profile durations. ForwardRef wasn't added to this list, which caused  #24428. 

After this fix:
<img width="838" alt="image" src="https://user-images.githubusercontent.com/2735514/166803372-789081cc-2eb5-4097-a9c1-ec819a5e44f0.png">