### PR TITLE
Constrain the container type of createPortal

### DIFF
--- a/packages/react-dom/src/client/ReactDOM.js
+++ b/packages/react-dom/src/client/ReactDOM.js
@@ -107,7 +107,7 @@ setBatchingImplementation(
 
 function createPortal(
   children: ReactNodeList,
-  container: Container,
+  container: Element | DocumentFragment,
   key: ?string = null,
 ): React$Portal {
   if (!isValidContainer(container)) {


### PR DESCRIPTION
We already constrained the type of createRoot (can't take document) and hydrateRoot (can't take shadow roots aka fragments).