### PR TITLE
Fixed possible undefined error in TreeContext reducer

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -377,11 +377,10 @@ function reduceTreeState(store: Store, state: State, action: Action): State {
         }
         break;
       case 'SELECT_PREVIOUS_ELEMENT_WITH_ERROR_OR_WARNING_IN_TREE': {
-        if (store.errorCount === 0 && store.warningCount === 0) {
+        const elementIndicesWithErrorsOrWarnings = store.getElementsWithErrorsAndWarnings();
+        if (elementIndicesWithErrorsOrWarnings.length === 0) {
           return state;
         }
-
-        const elementIndicesWithErrorsOrWarnings = store.getElementsWithErrorsAndWarnings();
 
         let flatIndex = 0;
         if (selectedElementIndex !== null) {
@@ -419,11 +418,10 @@ function reduceTreeState(store: Store, state: State, action: Action): State {
         break;
       }
       case 'SELECT_NEXT_ELEMENT_WITH_ERROR_OR_WARNING_IN_TREE': {
-        if (store.errorCount === 0 && store.warningCount === 0) {
+        const elementIndicesWithErrorsOrWarnings = store.getElementsWithErrorsAndWarnings();
+        if (elementIndicesWithErrorsOrWarnings.length === 0) {
           return state;
         }
-
-        const elementIndicesWithErrorsOrWarnings = store.getElementsWithErrorsAndWarnings();
 
         let flatIndex = -1;
         if (selectedElementIndex !== null) {


### PR DESCRIPTION
Resolves #24441

I don't have a repro for this bug. It's just something that was found in Sentry logs.

Tracing through the `Store` code, I didn't spot how this case would occur– since it seems like it should only be possible if the cached errors/warnings didn't align with the most recent errors/warnings:
https://github.com/facebook/react/blob/024a7274fb07f154676ec6443b83a4e31f259c22/packages/react-devtools-shared/src/devtools/store.js#L109-L112

But I'm not sure how that would happen, since we clear the cache whenever the tree is mutated (which is the only time when the error/warning counts could change):
https://github.com/facebook/react/blob/024a7274fb07f154676ec6443b83a4e31f259c22/packages/react-devtools-shared/src/devtools/store.js#L1265-L1279

That being said, I think it still seems worth tightening up the logic in `TreeContext` so that it's not possible for this code to try to reference an item in an empty `elementIndicesWithErrorsOrWarnings` array.
https://github.com/facebook/react/blob/024a7274fb07f154676ec6443b83a4e31f259c22/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js#L405-L416

I don't feel strongly about this. Just wanted to share it for your consideration.