### PR TITLE
Gate missing static flag check

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -33,6 +33,7 @@ import {
   enableSuspenseLayoutEffectSemantics,
   enableUseMutableSource,
   enableTransitionTracing,
+  enableStaticFlagMissingCheck,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -495,25 +496,27 @@ export function renderWithHooks<Props, SecondArg>(
     hookTypesDev = null;
     hookTypesUpdateIndexDev = -1;
 
-    // Confirm that a static flag was not added or removed since the last
-    // render. If this fires, it suggests that we incorrectly reset the static
-    // flags in some other part of the codebase. This has happened before, for
-    // example, in the SuspenseList implementation.
-    if (
-      current !== null &&
-      (current.flags & StaticMaskEffect) !==
-        (workInProgress.flags & StaticMaskEffect) &&
-      // Disable this warning in legacy mode, because legacy Suspense is weird
-      // and creates false positives. To make this work in legacy mode, we'd
-      // need to mark fibers that commit in an incomplete state, somehow. For
-      // now I'll disable the warning that most of the bugs that would trigger
-      // it are either exclusive to concurrent mode or exist in both.
-      (current.mode & ConcurrentMode) !== NoMode
-    ) {
-      console.error(
-        'Internal React error: Expected static flag was missing. Please ' +
-          'notify the React team.',
-      );
+    if (enableStaticFlagMissingCheck) {
+      // Confirm that a static flag was not added or removed since the last
+      // render. If this fires, it suggests that we incorrectly reset the static
+      // flags in some other part of the codebase. This has happened before, for
+      // example, in the SuspenseList implementation.
+      if (
+        current !== null &&
+        (current.flags & StaticMaskEffect) !==
+          (workInProgress.flags & StaticMaskEffect) &&
+        // Disable this warning in legacy mode, because legacy Suspense is weird
+        // and creates false positives. To make this work in legacy mode, we'd
+        // need to mark fibers that commit in an incomplete state, somehow. For
+        // now I'll disable the warning that most of the bugs that would trigger
+        // it are either exclusive to concurrent mode or exist in both.
+        (current.mode & ConcurrentMode) !== NoMode
+      ) {
+        console.error(
+          'Internal React error: Expected static flag was missing. Please ' +
+            'notify the React team.',
+        );
+      }
     }
   }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -33,6 +33,7 @@ import {
   enableSuspenseLayoutEffectSemantics,
   enableUseMutableSource,
   enableTransitionTracing,
+  enableStaticFlagMissingCheck,
 } from 'shared/ReactFeatureFlags';
 
 import {
@@ -495,25 +496,27 @@ export function renderWithHooks<Props, SecondArg>(
     hookTypesDev = null;
     hookTypesUpdateIndexDev = -1;
 
-    // Confirm that a static flag was not added or removed since the last
-    // render. If this fires, it suggests that we incorrectly reset the static
-    // flags in some other part of the codebase. This has happened before, for
-    // example, in the SuspenseList implementation.
-    if (
-      current !== null &&
-      (current.flags & StaticMaskEffect) !==
-        (workInProgress.flags & StaticMaskEffect) &&
-      // Disable this warning in legacy mode, because legacy Suspense is weird
-      // and creates false positives. To make this work in legacy mode, we'd
-      // need to mark fibers that commit in an incomplete state, somehow. For
-      // now I'll disable the warning that most of the bugs that would trigger
-      // it are either exclusive to concurrent mode or exist in both.
-      (current.mode & ConcurrentMode) !== NoMode
-    ) {
-      console.error(
-        'Internal React error: Expected static flag was missing. Please ' +
-          'notify the React team.',
-      );
+    if (enableStaticFlagMissingCheck) {
+      // Confirm that a static flag was not added or removed since the last
+      // render. If this fires, it suggests that we incorrectly reset the static
+      // flags in some other part of the codebase. This has happened before, for
+      // example, in the SuspenseList implementation.
+      if (
+        current !== null &&
+        (current.flags & StaticMaskEffect) !==
+          (workInProgress.flags & StaticMaskEffect) &&
+        // Disable this warning in legacy mode, because legacy Suspense is weird
+        // and creates false positives. To make this work in legacy mode, we'd
+        // need to mark fibers that commit in an incomplete state, somehow. For
+        // now I'll disable the warning that most of the bugs that would trigger
+        // it are either exclusive to concurrent mode or exist in both.
+        (current.mode & ConcurrentMode) !== NoMode
+      ) {
+        console.error(
+          'Internal React error: Expected static flag was missing. Please ' +
+            'notify the React team.',
+        );
+      }
     }
   }
 

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -112,6 +112,9 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 
 export const enableCPUSuspense = __EXPERIMENTAL__;
 
+// Tracking the error internally to catch mistakes.
+export const enableStaticFlagMissingCheck = false;
+
 // When a node is unmounted, recurse into the Fiber subtree and clean out
 // references. Each level cleans up more fiber fields than the previous level.
 // As far as we know, React itself doesn't leak, but because the Fiber contains

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -50,6 +50,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = true;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -40,6 +40,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -40,6 +40,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -51,6 +51,7 @@ export const deferRenderPhaseUpdateToNextBatch = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableStrictEffects = false;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -40,6 +40,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -40,6 +40,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = false;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = false;
+export const enableStaticFlagMissingCheck = false;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -40,6 +40,7 @@ export const warnAboutSpreadingKeyToJSX = false;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = true;
+export const enableStaticFlagMissingCheck = true;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay = true;
 export const enableClientRenderFallbackOnTextMismatch = true;
 export const enableComponentStackLocations = true;

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -53,6 +53,7 @@ export const enableSuspenseLayoutEffectSemantics = true;
 export const enableSuspenseAvoidThisFallback = true;
 export const enableSuspenseAvoidThisFallbackFizz = false;
 export const enableCPUSuspense = true;
+export const enableStaticFlagMissingCheck = true;
 
 // Logs additional User Timing API marks for use with an experimental profiling tool.
 export const enableSchedulingProfiler =


### PR DESCRIPTION
# Overview

This check was added in https://github.com/facebook/react/pull/20807 and is intended for in progress static flag work.

Currently, it fires even when hook counts change from 0 to n > 0. We should warn for that separately, but it also shouldn't fire this warning.

 Related: https://github.com/facebook/react/issues/24391