### PR TITLE
Fix select default option

### DIFF
--- a/packages/react-dom/src/client/ReactDOMSelect.js
+++ b/packages/react-dom/src/client/ReactDOMSelect.js
@@ -99,7 +99,6 @@ function updateOptions(
     // Do not set `select.value` as exact behavior isn't consistent across all
     // browsers for all cases.
     const selectedValue = toString(getToStringValue((propValue: any)));
-    let defaultSelected = null;
     for (let i = 0; i < options.length; i++) {
       if (options[i].value === selectedValue) {
         options[i].selected = true;
@@ -108,12 +107,6 @@ function updateOptions(
         }
         return;
       }
-      if (defaultSelected === null && !options[i].disabled) {
-        defaultSelected = options[i];
-      }
-    }
-    if (defaultSelected !== null) {
-      defaultSelected.selected = true;
     }
   }
 }


### PR DESCRIPTION
This is related to #24469 

I'm not sure, but this changes from 2016 set default selection for the first non-disabled option, which is lead to inconsistency between pure html and react.

Also there are passed tests which should covered the right logic (we should have unselected options). But the actual browser behavior is the different :(  