### PR TITLE
[devtools] fix a bug in console.log with non-string args

### DIFF
--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -181,8 +181,9 @@ export function formatWithStyles(
     inputArgs === undefined ||
     inputArgs === null ||
     inputArgs.length === 0 ||
+    typeof inputArgs[0] !== 'string' ||
     // Matches any of %c but not %%c
-    (typeof inputArgs[0] === 'string' && inputArgs[0].match(/([^%]|^)(%c)/g)) ||
+    inputArgs[0].match(/([^%]|^)(%c)/g) ||
     style === undefined
   ) {
     return inputArgs;

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -180,9 +180,9 @@ export function installHook(target: any): DevToolsHook | null {
       inputArgs === undefined ||
       inputArgs === null ||
       inputArgs.length === 0 ||
+      typeof inputArgs[0] !== 'string' ||
       // Matches any of %c but not %%c
-      (typeof inputArgs[0] === 'string' &&
-        inputArgs[0].match(/([^%]|^)(%c)/g)) ||
+      inputArgs[0].match(/([^%]|^)(%c)/g) ||
       style === undefined
     ) {
       return inputArgs;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
resolves #24543

## How did you test this change?

The bug is reproduced in https://lt7w95.csb.app/
<img width="944" alt="image" src="https://user-images.githubusercontent.com/1001890/168096197-85cce1e4-4884-4b95-abb3-2847b72c5d44.png">

With this fix, the local build no longer has this issue
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/1001890/168096306-ffea8e89-5cb0-4b25-9fe6-e273b2ffb0e4.png">


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
