### PR TITLE
Improve the performance of `performance`.

### DIFF
--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -46,7 +46,7 @@ const hasPerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
 
 if (hasPerformanceNow) {
-  getCurrentTime = performance.now.bind(performance)
+  getCurrentTime = performance.now.bind(performance);
 } else {
   const initialTime = Date.now();
   getCurrentTime = () => Date.now() - initialTime;

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -46,12 +46,10 @@ const hasPerformanceNow =
   typeof performance === 'object' && typeof performance.now === 'function';
 
 if (hasPerformanceNow) {
-  const localPerformance = performance;
-  getCurrentTime = () => localPerformance.now();
+  getCurrentTime = performance.now.bind(performance)
 } else {
-  const localDate = Date;
-  const initialTime = localDate.now();
-  getCurrentTime = () => localDate.now() - initialTime;
+  const initialTime = Date.now();
+  getCurrentTime = () => Date.now() - initialTime;
 }
 
 // Max 31 bit integer. The max integer size in V8 for 32-bit systems.


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
```js
function test(f) {
    console.time()
    let i = 0
    while (i++ < 1e6) {
        f()
    }
    console.timeEnd()
}
test(performance.now.bind(performance))
test(()=>performance.now())

// VM2470:7 default: 120.751220703125 ms
// VM2470:7 default: 453.26416015625 ms
```
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
