### PR TITLE
Handle Github rate-limiting response in download-experimental-build.js

### DIFF
--- a/scripts/release/shared-commands/get-build-id-for-commit.js
+++ b/scripts/release/shared-commands/get-build-id-for-commit.js
@@ -23,7 +23,14 @@ async function getBuildIdForCommit(sha) {
     );
 
     if (!statusesResponse.ok) {
-      throw Error('Could not find commit for: ' + sha);
+      if (statusesResponse.status === 404) {
+        throw Error('Could not find commit for: ' + sha);
+      }
+      const {message, documentation_url} = await statusesResponse.json();
+      const msg = documentation_url
+        ? `${message}\n\t${documentation_url}`
+        : message;
+      throw Error(msg);
     }
 
     const {statuses, state} = await statusesResponse.json();


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When running the `download-experimental-build.js`, fetching the `build-id` for the commit uses a Github API.  The code currently assumes that failure is due to the commit not existing.  I hit rate limiting (working over a VPN), but the error reported the commit could not be found for `main`.

This change surfaces the API error message should it not be a `404`, in which case the previous error message worked well:

![rate-limit](https://user-images.githubusercontent.com/49578/169038003-85c05492-825a-4bad-8d1d-afd92a3479d2.png)

## How did you test this change?

Ran the change while I was being rate limited:
```bash
❯ ./download-experimental-build.js --commit=main
Error: API rate limit exceeded for XXX.XXX.XXX.XXX. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
        https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
```
Confirmed that I was actually being rate limited:
```
❯ curl -I https://api.github.com/users/octocat 2>&1 | grep remaining
x-ratelimit-remaining: 0
```

Ran the change when I wasn't being rate limited:
```bash
❯ ./download-experimental-build.js --commit=foobar
Error: Could not find commit for: foobar
```

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

Ran the change on my local machine while I was being rate limited.  Waited for the 