### PR TITLE
[DevTools] Add React Version Pragma to Tests

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
+++ b/packages/react-devtools-shared/src/__tests__/FastRefreshDevToolsIntegration-test.js
@@ -123,6 +123,7 @@ describe('Fast Refresh', () => {
     return ReactFreshRuntime.createSignatureFunctionForTransform();
   }
 
+  // @reactVersion >= 16.9
   it('should not break the DevTools store', () => {
     render(`
       function Parent() {
@@ -186,6 +187,7 @@ describe('Fast Refresh', () => {
     expect(container.firstChild).not.toBe(element);
   });
 
+  // @reactVersion >= 16.9
   it('should not break when there are warnings in between patching', () => {
     withErrorsOrWarningsIgnored(['Expected:'], () => {
       render(`

--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -124,6 +124,7 @@ describe('Timeline profiler', () => {
       setPerformanceMock(null);
     });
 
+    // @reactVersion >=18.0
     it('should mark sync render without suspends or state updates', () => {
       renderHelper(<div />);
 
@@ -145,6 +146,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark concurrent render without suspends or state updates', () => {
       renderRootHelper(<div />);
 
@@ -175,6 +177,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark render yields', async () => {
       function Bar() {
         Scheduler.unstable_yieldValue('Bar');
@@ -204,6 +207,7 @@ describe('Timeline profiler', () => {
         `);
     });
 
+    // @reactVersion >=18.0
     it('should mark sync render with suspense that resolves', async () => {
       const fakeSuspensePromise = Promise.resolve(true);
       function Example() {
@@ -246,6 +250,7 @@ describe('Timeline profiler', () => {
           `);
     });
 
+    // @reactVersion >=18.0
     it('should mark sync render with suspense that rejects', async () => {
       const fakeSuspensePromise = Promise.reject(new Error('error'));
       function Example() {
@@ -284,6 +289,7 @@ describe('Timeline profiler', () => {
       expect(clearedMarks).toContain(`--suspense-rejected-0-Example`);
     });
 
+    // @reactVersion >=18.0
     it('should mark concurrent render with suspense that resolves', async () => {
       const fakeSuspensePromise = Promise.resolve(true);
       function Example() {
@@ -335,6 +341,7 @@ describe('Timeline profiler', () => {
         `);
     });
 
+    // @reactVersion >=18.0
     it('should mark concurrent render with suspense that rejects', async () => {
       const fakeSuspensePromise = Promise.reject(new Error('error'));
       function Example() {
@@ -386,6 +393,7 @@ describe('Timeline profiler', () => {
           `);
     });
 
+    // @reactVersion >=18.0
     it('should mark cascading class component state updates', () => {
       class Example extends React.Component {
         state = {didMount: false};
@@ -440,6 +448,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark cascading class component force updates', () => {
       class Example extends React.Component {
         componentDidMount() {
@@ -493,6 +502,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark render phase state updates for class component', () => {
       class Example extends React.Component {
         state = {didRender: false};
@@ -546,6 +556,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark render phase force updates for class component', () => {
       let forced = false;
       class Example extends React.Component {
@@ -600,6 +611,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark cascading layout updates', () => {
       function Example() {
         const [didMount, setDidMount] = React.useState(false);
@@ -654,6 +666,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark cascading passive updates', () => {
       function Example() {
         const [didMount, setDidMount] = React.useState(false);
@@ -703,6 +716,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark render phase updates', () => {
       function Example() {
         const [didRender, setDidRender] = React.useState(false);
@@ -737,6 +751,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark sync render that throws', async () => {
       spyOn(console, 'error');
 
@@ -799,6 +814,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark concurrent render that throws', async () => {
       spyOn(console, 'error');
 
@@ -879,6 +895,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >=18.0
     it('should mark passive and layout effects', async () => {
       function ComponentWithEffects() {
         React.useLayoutEffect(() => {
@@ -1015,6 +1032,7 @@ describe('Timeline profiler', () => {
     });
 
     describe('lane labels', () => {
+      // @reactVersion >=18.0
       it('regression test SyncLane', () => {
         renderHelper(<div />);
 
@@ -1036,6 +1054,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('regression test DefaultLane', () => {
         renderRootHelper(<div />);
         expect(clearedMarks).toMatchInlineSnapshot(`
@@ -1045,6 +1064,7 @@ describe('Timeline profiler', () => {
               `);
       });
 
+      // @reactVersion >=18.0
       it('regression test InputDiscreteLane', async () => {
         const targetRef = React.createRef(null);
 
@@ -1086,6 +1106,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('regression test InputContinuousLane', async () => {
         const targetRef = React.createRef(null);
 
@@ -1170,6 +1191,7 @@ describe('Timeline profiler', () => {
         utils.act(() => store.profilerStore.startProfiling());
       });
 
+      // @reactVersion >=18.0
       it('should mark sync render without suspends or state updates', () => {
         renderHelper(<div />);
 
@@ -1186,6 +1208,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark concurrent render without suspends or state updates', () => {
         utils.act(() => renderRootHelper(<div />));
 
@@ -1202,6 +1225,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark concurrent render without suspends or state updates', () => {
         let updaterFn;
 
@@ -1281,6 +1305,7 @@ describe('Timeline profiler', () => {
         expect(timelineData.batchUIDToMeasuresMap.size).toBe(2);
       });
 
+      // @reactVersion >=18.0
       it('should mark render yields', async () => {
         function Bar() {
           Scheduler.unstable_yieldValue('Bar');
@@ -1365,6 +1390,7 @@ describe('Timeline profiler', () => {
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
 
+      // @reactVersion >=18.0
       it('should mark sync render with suspense that rejects', async () => {
         let rejectFn;
         let rejected = false;
@@ -1422,6 +1448,7 @@ describe('Timeline profiler', () => {
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
 
+      // @reactVersion >=18.0
       it('should mark concurrent render with suspense that resolves', async () => {
         let resolveFn;
         let resolved = false;
@@ -1479,6 +1506,7 @@ describe('Timeline profiler', () => {
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
 
+      // @reactVersion >=18.0
       it('should mark concurrent render with suspense that rejects', async () => {
         let rejectFn;
         let rejected = false;
@@ -1536,6 +1564,7 @@ describe('Timeline profiler', () => {
         expect(timelineData.componentMeasures).toHaveLength(2);
       });
 
+      // @reactVersion >=18.0
       it('should mark cascading class component state updates', () => {
         class Example extends React.Component {
           state = {didMount: false};
@@ -1594,6 +1623,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark cascading class component force updates', () => {
         let forced = false;
         class Example extends React.Component {
@@ -1651,6 +1681,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark render phase state updates for class component', () => {
         class Example extends React.Component {
           state = {didRender: false};
@@ -1719,6 +1750,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark render phase force updates for class component', () => {
         let forced = false;
         class Example extends React.Component {
@@ -1786,6 +1818,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark cascading layout updates', () => {
         function Example() {
           const [didMount, setDidMount] = React.useState(false);
@@ -1848,6 +1881,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark cascading passive updates', () => {
         function Example() {
           const [didMount, setDidMount] = React.useState(false);
@@ -1909,6 +1943,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark render phase updates', () => {
         function Example() {
           const [didRender, setDidRender] = React.useState(false);
@@ -1956,6 +1991,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark sync render that throws', async () => {
         spyOn(console, 'error');
 
@@ -2049,6 +2085,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark concurrent render that throws', async () => {
         spyOn(console, 'error');
 
@@ -2167,6 +2204,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >=18.0
       it('should mark passive and layout effects', async () => {
         function ComponentWithEffects() {
           React.useLayoutEffect(() => {
@@ -2406,6 +2444,7 @@ describe('Timeline profiler', () => {
     });
 
     describe('when not profiling', () => {
+      // @reactVersion >=18.0
       it('should not log any marks', () => {
         renderHelper(<div />);
 

--- a/packages/react-devtools-shared/src/__tests__/bridge-test.js
+++ b/packages/react-devtools-shared/src/__tests__/bridge-test.js
@@ -14,6 +14,7 @@ describe('Bridge', () => {
     Bridge = require('react-devtools-shared/src/bridge').default;
   });
 
+  // @reactVersion >=16.0
   it('should shutdown properly', () => {
     const wall = {
       listen: jest.fn(() => () => {}),

--- a/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
+++ b/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
@@ -49,6 +49,7 @@ describe('component stack', () => {
     React = require('react');
   });
 
+  // @reactVersion >=16.9
   it('should log the current component stack along with an error or warning', () => {
     const Grandparent = () => <Parent />;
     const Parent = () => <Child />;

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -69,6 +69,7 @@ describe('console', () => {
     );
   }
 
+  // @reactVersion >=18.0
   it('should not patch console methods that are not explicitly overridden', () => {
     expect(fakeConsole.error).not.toBe(mockError);
     expect(fakeConsole.info).toBe(mockInfo);
@@ -76,6 +77,7 @@ describe('console', () => {
     expect(fakeConsole.warn).not.toBe(mockWarn);
   });
 
+  // @reactVersion >=18.0
   it('should patch the console when appendComponentStack is enabled', () => {
     unpatchConsole();
 
@@ -92,6 +94,7 @@ describe('console', () => {
     expect(fakeConsole.warn).not.toBe(mockWarn);
   });
 
+  // @reactVersion >=18.0
   it('should patch the console when breakOnConsoleErrors is enabled', () => {
     unpatchConsole();
 
@@ -108,6 +111,7 @@ describe('console', () => {
     expect(fakeConsole.warn).not.toBe(mockWarn);
   });
 
+  // @reactVersion >=18.0
   it('should patch the console when showInlineWarningsAndErrors is enabled', () => {
     unpatchConsole();
 
@@ -124,6 +128,7 @@ describe('console', () => {
     expect(fakeConsole.warn).not.toBe(mockWarn);
   });
 
+  // @reactVersion >=18.0
   it('should only patch the console once', () => {
     const {error, warn} = fakeConsole;
 
@@ -137,6 +142,7 @@ describe('console', () => {
     expect(fakeConsole.warn).toBe(warn);
   });
 
+  // @reactVersion >=18.0
   it('should un-patch when requested', () => {
     expect(fakeConsole.error).not.toBe(mockError);
     expect(fakeConsole.warn).not.toBe(mockWarn);
@@ -147,6 +153,7 @@ describe('console', () => {
     expect(fakeConsole.warn).toBe(mockWarn);
   });
 
+  // @reactVersion >=18.0
   it('should pass through logs when there is no current fiber', () => {
     expect(mockLog).toHaveBeenCalledTimes(0);
     expect(mockWarn).toHaveBeenCalledTimes(0);
@@ -165,6 +172,7 @@ describe('console', () => {
     expect(mockError.mock.calls[0][0]).toBe('error');
   });
 
+  // @reactVersion >=18.0
   it('should not append multiple stacks', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = true;
 
@@ -187,6 +195,7 @@ describe('console', () => {
     expect(mockError.mock.calls[0][1]).toBe('\n    in Child (at fake.js:123)');
   });
 
+  // @reactVersion >=18.0
   it('should append component stacks to errors and warnings logged during render', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = true;
 
@@ -222,6 +231,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should append component stacks to errors and warnings logged from effects', () => {
     const Intermediate = ({children}) => children;
     const Parent = ({children}) => (
@@ -274,6 +284,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should append component stacks to errors and warnings logged from commit hooks', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = true;
 
@@ -332,6 +343,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should append component stacks to errors and warnings logged from gDSFP', () => {
     const Intermediate = ({children}) => children;
     const Parent = ({children}) => (
@@ -371,6 +383,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should append stacks after being uninstalled and reinstalled', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = false;
 
@@ -410,6 +423,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should be resilient to prepareStackTrace', () => {
     global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ = true;
 
@@ -459,6 +473,7 @@ describe('console', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should correctly log Symbols', () => {
     const Component = ({children}) => {
       fakeConsole.warn('Symbol:', Symbol(''));
@@ -753,6 +768,7 @@ describe('console error', () => {
     legacyRender = utils.legacyRender;
   });
 
+  // @reactVersion >=18.0
   it('error in console log throws without interfering with logging', () => {
     const container = document.createElement('div');
     const root = ReactDOMClient.createRoot(container);

--- a/packages/react-devtools-shared/src/__tests__/editing-test.js
+++ b/packages/react-devtools-shared/src/__tests__/editing-test.js
@@ -109,6 +109,7 @@ describe('editing interface', () => {
       expect(inputRef.current.value).toBe('initial');
     }
 
+    // @reactVersion >= 16.9
     it('should have editable values', async () => {
       await mountTestApp();
 
@@ -175,6 +176,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     // Tests the combination of older frontend (DevTools UI) with newer backend (embedded within a renderer).
     it('should still support overriding prop values with legacy backend methods', async () => {
       await mountTestApp();
@@ -209,6 +211,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 17.0
     it('should have editable paths', async () => {
       await mountTestApp();
 
@@ -259,6 +262,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -339,6 +343,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 17.0
     it('should have deletable keys', async () => {
       await mountTestApp();
 
@@ -390,6 +395,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should support editing host component values', async () => {
       await mountTestApp();
 
@@ -453,6 +459,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.9
     it('should have editable values', async () => {
       await mountTestApp();
 
@@ -490,6 +497,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     // Tests the combination of older frontend (DevTools UI) with newer backend (embedded within a renderer).
     it('should still support overriding state values with legacy backend methods', async () => {
       await mountTestApp();
@@ -513,6 +521,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should have editable paths', async () => {
       await mountTestApp();
 
@@ -547,6 +556,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -595,6 +605,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should have deletable keys', async () => {
       await mountTestApp();
 
@@ -668,6 +679,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.9
     it('should have editable values', async () => {
       await mountTestApp();
 
@@ -712,6 +724,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     // Tests the combination of older frontend (DevTools UI) with newer backend (embedded within a renderer).
     it('should still support overriding hook values with legacy backend methods', async () => {
       await mountTestApp();
@@ -738,6 +751,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 17.0
     it('should have editable paths', async () => {
       await mountTestApp();
 
@@ -773,6 +787,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -822,6 +837,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 17.0
     it('should have deletable keys', async () => {
       await mountTestApp();
 
@@ -925,6 +941,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.9
     it('should have editable values', async () => {
       await mountTestApp();
 
@@ -973,6 +990,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     // Tests the combination of older frontend (DevTools UI) with newer backend (embedded within a renderer).
     it('should still support overriding context values with legacy backend methods', async () => {
       await mountTestApp();
@@ -1003,6 +1021,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should have editable paths', async () => {
       await mountTestApp();
 
@@ -1043,6 +1062,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -1096,6 +1116,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.9
     it('should have deletable keys', async () => {
       await mountTestApp();
 

--- a/packages/react-devtools-shared/src/__tests__/events-test.js
+++ b/packages/react-devtools-shared/src/__tests__/events-test.js
@@ -16,10 +16,12 @@ describe('events', () => {
     dispatcher = new EventEmitter();
   });
 
+  // @reactVersion >=16
   it('can dispatch an event with no listeners', () => {
     dispatcher.emit('event', 123);
   });
 
+  // @reactVersion >=16
   it('handles a listener being attached multiple times', () => {
     const callback = jest.fn();
 
@@ -31,6 +33,7 @@ describe('events', () => {
     expect(callback).toHaveBeenCalledWith(123);
   });
 
+  // @reactVersion >=16
   it('notifies all attached listeners of events', () => {
     const callback1 = jest.fn();
     const callback2 = jest.fn();
@@ -48,6 +51,7 @@ describe('events', () => {
     expect(callback3).not.toHaveBeenCalled();
   });
 
+  // @reactVersion >= 16.0
   it('calls later listeners before re-throwing if an earlier one throws', () => {
     const callbackThatThrows = jest.fn(() => {
       throw Error('expected');
@@ -67,6 +71,7 @@ describe('events', () => {
     expect(callback).toHaveBeenCalledWith(123);
   });
 
+  // @reactVersion >= 16.0
   it('removes attached listeners', () => {
     const callback1 = jest.fn();
     const callback2 = jest.fn();
@@ -81,6 +86,7 @@ describe('events', () => {
     expect(callback2).toHaveBeenCalledWith(123);
   });
 
+  // @reactVersion >= 16.0
   it('removes all listeners', () => {
     const callback1 = jest.fn();
     const callback2 = jest.fn();
@@ -98,6 +104,7 @@ describe('events', () => {
     expect(callback3).not.toHaveBeenCalled();
   });
 
+  // @reactVersion >= 16.0
   it('should call the initial listeners even if others are added or removed during a dispatch', () => {
     const callback1 = jest.fn(() => {
       dispatcher.removeListener('event', callback2);

--- a/packages/react-devtools-shared/src/__tests__/legacy/editing-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/editing-test.js
@@ -84,6 +84,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.0
     it('should have editable values', () => {
       mountTestApp();
 
@@ -125,6 +126,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have editable paths', () => {
       mountTestApp();
 
@@ -158,6 +160,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -206,6 +209,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have deletable keys', () => {
       mountTestApp();
 
@@ -282,6 +286,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.0
     it('should have editable values', () => {
       mountTestApp();
 
@@ -319,6 +324,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have editable paths', () => {
       mountTestApp();
 
@@ -353,6 +359,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -401,6 +408,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have deletable keys', () => {
       mountTestApp();
 
@@ -502,6 +510,7 @@ describe('editing interface', () => {
       });
     }
 
+    // @reactVersion >= 16.0
     it('should have editable values', () => {
       mountTestApp();
 
@@ -546,6 +555,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have editable paths', () => {
       mountTestApp();
 
@@ -581,6 +591,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should enable adding new object properties and array values', async () => {
       await mountTestApp();
 
@@ -630,6 +641,7 @@ describe('editing interface', () => {
       });
     });
 
+    // @reactVersion >= 16.0
     it('should have deletable keys', () => {
       mountTestApp();
 

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -62,6 +62,7 @@ describe('InspectedElementContext', () => {
     ReactDOM = require('react-dom');
   });
 
+  // @reactVersion >= 16.0
   it('should inspect the currently selected element', async () => {
     const Example = () => null;
 
@@ -89,6 +90,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should support simple data types', async () => {
     const Example = () => null;
 
@@ -140,6 +142,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should support complex data types', async () => {
     const Immutable = require('immutable');
 
@@ -324,6 +327,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should support objects with no prototype', async () => {
     const Example = () => null;
 
@@ -353,6 +357,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should support objects with overridden hasOwnProperty', async () => {
     const Example = () => null;
 
@@ -377,6 +382,7 @@ describe('InspectedElementContext', () => {
     expect(inspectedElement.props.object.hasOwnProperty).toBe(true);
   });
 
+  // @reactVersion >= 16.0
   it('should not consume iterables while inspecting', async () => {
     const Example = () => null;
 
@@ -421,6 +427,7 @@ describe('InspectedElementContext', () => {
     expect(iteratable.next().value).toBeUndefined();
   });
 
+  // @reactVersion >= 16.0
   it('should support custom objects with enumerable properties and getters', async () => {
     class CustomData {
       _number = 42;
@@ -470,6 +477,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should support objects with with inherited keys', async () => {
     const Example = () => null;
 
@@ -562,6 +570,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should allow component prop value and value`s prototype has same name params.', async () => {
     const testData = Object.create(
       {
@@ -621,6 +630,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should not dehydrate nested values until explicitly requested', async () => {
     const Example = () => null;
 
@@ -723,6 +733,7 @@ describe('InspectedElementContext', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should enable inspected values to be stored as global variables', () => {
     const Example = () => null;
 
@@ -778,6 +789,7 @@ describe('InspectedElementContext', () => {
     expect(global.$reactTemp1).toBe(nestedObject.a.b);
   });
 
+  // @reactVersion >= 16.0
   it('should enable inspected values to be copied to the clipboard', () => {
     const Example = () => null;
 
@@ -834,6 +846,7 @@ describe('InspectedElementContext', () => {
     );
   });
 
+  // @reactVersion >= 16.0
   it('should enable complex values to be copied to the clipboard', () => {
     const Immutable = require('immutable');
 

--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -107,6 +107,7 @@ describe('Timeline profiler', () => {
           .getLanesFromTransportDecimalBitmask;
       });
 
+      // @reactVersion >= 18.0
       it('should return array of lane numbers from bitmask string', () => {
         expect(getLanesFromTransportDecimalBitmask('1')).toEqual([0]);
         expect(getLanesFromTransportDecimalBitmask('512')).toEqual([9]);
@@ -126,6 +127,7 @@ describe('Timeline profiler', () => {
         ).toEqual(Array.from(Array(31).keys()));
       });
 
+      // @reactVersion >= 18.0
       it('should return empty array if laneBitmaskString is not a bitmask', () => {
         expect(getLanesFromTransportDecimalBitmask('')).toEqual([]);
         expect(getLanesFromTransportDecimalBitmask('hello')).toEqual([]);
@@ -133,6 +135,7 @@ describe('Timeline profiler', () => {
         expect(getLanesFromTransportDecimalBitmask('-0')).toEqual([]);
       });
 
+      // @reactVersion >= 18.0
       it('should ignore lanes outside REACT_TOTAL_NUM_LANES', () => {
         const REACT_TOTAL_NUM_LANES = require('react-devtools-timeline/src/constants')
           .REACT_TOTAL_NUM_LANES;
@@ -258,10 +261,12 @@ describe('Timeline profiler', () => {
         startTime = 0;
       });
 
+      // @reactVersion >= 18.0
       it('should throw given an empty timeline', async () => {
         await expect(async () => preprocessData([])).rejects.toThrow();
       });
 
+      // @reactVersion >= 18.0
       it('should throw given a timeline with no Profile event', async () => {
         const randomSample = createUserTimingEntry({
           dur: 100,
@@ -277,6 +282,7 @@ describe('Timeline profiler', () => {
         ).rejects.toThrow();
       });
 
+      // @reactVersion >= 18.0
       it('should throw given a timeline without an explicit profiler version mark nor any other React marks', async () => {
         const cpuProfilerSample = creactCpuProfilerSample();
 
@@ -287,6 +293,7 @@ describe('Timeline profiler', () => {
         );
       });
 
+      // @reactVersion >= 18.0
       it('should throw given a timeline with React scheduling marks, but without an explicit profiler version mark', async () => {
         const cpuProfilerSample = creactCpuProfilerSample();
         const scheduleRenderSample = createUserTimingEntry({
@@ -300,6 +307,7 @@ describe('Timeline profiler', () => {
         );
       });
 
+      // @reactVersion >= 18.0
       it('should return empty data given a timeline with no React scheduling profiling marks', async () => {
         const cpuProfilerSample = creactCpuProfilerSample();
         const randomSample = createUserTimingEntry({
@@ -403,6 +411,7 @@ describe('Timeline profiler', () => {
           `);
       });
 
+      // @reactVersion >= 18.0
       it('should process legacy data format (before lane labels were added)', async () => {
         const cpuProfilerSample = creactCpuProfilerSample();
 
@@ -602,6 +611,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >= 18.0
       it('should process a sample legacy render sequence', async () => {
         utils.legacyRender(<div />, document.createElement('div'));
 
@@ -788,6 +798,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >= 18.0
       it('should process a sample createRoot render sequence', async () => {
         function App() {
           const [didMount, setDidMount] = React.useState(false);
@@ -1119,6 +1130,7 @@ describe('Timeline profiler', () => {
         `);
       });
 
+      // @reactVersion >= 18.0
       it('should error if events and measures are incomplete', async () => {
         const container = document.createElement('div');
         utils.legacyRender(<div />, container);
@@ -1136,6 +1148,7 @@ describe('Timeline profiler', () => {
         expect(error).toHaveBeenCalled();
       });
 
+      // @reactVersion >= 18.0
       it('should error if work is completed without being started', async () => {
         const container = document.createElement('div');
         utils.legacyRender(<div />, container);
@@ -1153,6 +1166,7 @@ describe('Timeline profiler', () => {
         expect(error).toHaveBeenCalled();
       });
 
+      // @reactVersion >= 18.0
       it('should populate other user timing marks', async () => {
         const userTimingData = createUserTimingData([]);
         userTimingData.push(
@@ -1202,6 +1216,7 @@ describe('Timeline profiler', () => {
           `);
       });
 
+      // @reactVersion >= 18.0
       it('should include a suspended resource "displayName" if one is set', async () => {
         let promise = null;
         let resolvedValue = null;
@@ -1245,6 +1260,7 @@ describe('Timeline profiler', () => {
 
       describe('warnings', () => {
         describe('long event handlers', () => {
+          // @reactVersion >= 18.0
           it('should not warn when React scedules a (sync) update inside of a short event handler', async () => {
             function App() {
               return null;
@@ -1267,6 +1283,7 @@ describe('Timeline profiler', () => {
             expect(event.warning).toBe(null);
           });
 
+          // @reactVersion >= 18.0
           it('should not warn about long events if the cause was non-React JavaScript', async () => {
             function App() {
               return null;
@@ -1291,6 +1308,7 @@ describe('Timeline profiler', () => {
             expect(event.warning).toBe(null);
           });
 
+          // @reactVersion >= 18.0
           it('should warn when React scedules a long (sync) update inside of an event', async () => {
             function App() {
               return null;
@@ -1330,6 +1348,7 @@ describe('Timeline profiler', () => {
             );
           });
 
+          // @reactVersion >= 18.0
           it('should not warn when React finishes a previously long (async) update with a short (sync) update inside of an event', async () => {
             function Yield({id, value}) {
               Scheduler.unstable_yieldValue(`${id}:${value}`);
@@ -1390,6 +1409,7 @@ describe('Timeline profiler', () => {
         });
 
         describe('nested updates', () => {
+          // @reactVersion >= 18.0
           it('should not warn about short nested (state) updates during layout effects', async () => {
             function Component() {
               const [didMount, setDidMount] = React.useState(false);
@@ -1425,6 +1445,7 @@ describe('Timeline profiler', () => {
             expect(event.warning).toBe(null);
           });
 
+          // @reactVersion >= 18.0
           it('should not warn about short (forced) updates during layout effects', async () => {
             class Component extends React.Component {
               _didMount: boolean = false;
@@ -1588,6 +1609,7 @@ describe('Timeline profiler', () => {
             );
           });
 
+          // @reactVersion >= 18.0
           it('should not warn about transition updates scheduled during commit phase', async () => {
             function Component() {
               const [value, setValue] = React.useState(0);
@@ -1729,6 +1751,7 @@ describe('Timeline profiler', () => {
         });
 
         describe('errors thrown while rendering', () => {
+          // @reactVersion >= 18.0
           it('shoult parse Errors thrown during render', async () => {
             spyOn(console, 'error');
 
@@ -1776,6 +1799,7 @@ describe('Timeline profiler', () => {
         describe('suspend during an update', () => {
           // This also tests an edge case where the a component suspends while profiling
           // before the first commit is logged (so the lane-to-labels map will not yet exist).
+          // @reactVersion >= 18.0
           it('should warn about suspending during an udpate', async () => {
             let promise = null;
             let resolvedValue = null;
@@ -1833,6 +1857,7 @@ describe('Timeline profiler', () => {
             );
           });
 
+          // @reactVersion >= 18.0
           it('should not warn about suspending during an transition', async () => {
             let promise = null;
             let resolvedValue = null;
@@ -1920,6 +1945,7 @@ describe('Timeline profiler', () => {
       global.IS_REACT_ACT_ENVIRONMENT = true;
     });
 
+    // @reactVersion >= 18.0
     it('should process a sample legacy render sequence', async () => {
       utils.legacyRender(<div />, document.createElement('div'));
       utils.act(() => store.profilerStore.stopProfiling());
@@ -2089,6 +2115,7 @@ describe('Timeline profiler', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should process a sample createRoot render sequence', async () => {
       function App() {
         const [didMount, setDidMount] = React.useState(false);

--- a/packages/react-devtools-shared/src/__tests__/profilerChangeDescriptions-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerChangeDescriptions-test.js
@@ -26,6 +26,7 @@ describe('Profiler change descriptions', () => {
     React = require('react');
   });
 
+  // @reactVersion >=18.0
   it('should identify useContext as the cause for a re-render', () => {
     const Context = React.createContext(0);
 

--- a/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilerStore-test.js
@@ -30,6 +30,7 @@ describe('ProfilerStore', () => {
     ReactDOM = require('react-dom');
   });
 
+  // @reactVersion >= 16.9
   it('should not remove profiling data when roots are unmounted', async () => {
     const Parent = ({count}) =>
       new Array(count)
@@ -66,6 +67,7 @@ describe('ProfilerStore', () => {
     expect(store.profilerStore.getDataForRoot(rootB)).not.toBeNull();
   });
 
+  // @reactVersion >= 16.9
   it('should not allow new/saved profiling data to be set while profiling is in progress', () => {
     utils.act(() => store.profilerStore.startProfiling());
     const fauxProfilingData = {
@@ -83,6 +85,7 @@ describe('ProfilerStore', () => {
     expect(store.profilerStore.profilingData).toBe(fauxProfilingData);
   });
 
+  // @reactVersion >= 16.9
   // This test covers current broken behavior (arguably) with the synthetic event system.
   it('should filter empty commits', () => {
     const inputRef = React.createRef();
@@ -124,6 +127,7 @@ describe('ProfilerStore', () => {
     expect(data.operations).toHaveLength(1);
   });
 
+  // @reactVersion >= 16.9
   it('should filter empty commits alt', () => {
     let commitCount = 0;
 
@@ -175,6 +179,7 @@ describe('ProfilerStore', () => {
     expect(data.operations).toHaveLength(1);
   });
 
+  // @reactVersion >= 16.9
   it('should throw if component filters are modified while profiling', () => {
     utils.act(() => store.profilerStore.startProfiling());
 
@@ -190,6 +195,7 @@ describe('ProfilerStore', () => {
     }).toThrow('Cannot modify filter preferences while profiling');
   });
 
+  // @reactVersion >= 16.9
   it('should not throw if state contains a property hasOwnProperty ', () => {
     let setStateCallback;
     const ControlledInput = () => {
@@ -222,6 +228,7 @@ describe('ProfilerStore', () => {
     expect(data.operations).toHaveLength(1);
   });
 
+  // @reactVersion >= 18.0
   it('should not throw while initializing context values for Fibers within a not-yet-mounted subtree', () => {
     const promise = new Promise(resolve => {});
     const SuspendingView = () => {

--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -39,6 +39,7 @@ describe('ProfilingCache', () => {
     Scheduler = require('scheduler');
   });
 
+  // @reactVersion >= 16.9
   it('should collect data for each root (including ones added or mounted after profiling started)', () => {
     const Parent = ({count}) => {
       Scheduler.unstable_advanceTime(10);
@@ -150,6 +151,7 @@ describe('ProfilingCache', () => {
     });
   });
 
+  // @reactVersion >= 16.9
   it('should collect data for each commit', () => {
     const Parent = ({count}) => {
       Scheduler.unstable_advanceTime(10);
@@ -194,6 +196,7 @@ describe('ProfilingCache', () => {
     });
   });
 
+  // @reactVersion >= 16.9
   it('should record changed props/state/context/hooks', () => {
     let instance = null;
 
@@ -512,6 +515,7 @@ describe('ProfilingCache', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should properly detect changed hooks', () => {
     const Context = React.createContext(0);
 
@@ -730,6 +734,7 @@ describe('ProfilingCache', () => {
     }
   });
 
+  // @reactVersion >= 16.9
   it('should calculate durations based on actual children (not filtered children)', () => {
     store.componentFilters = [utils.createDisplayNameFilter('^Parent$')];
 
@@ -788,6 +793,7 @@ describe('ProfilingCache', () => {
     `);
   });
 
+  // @reactVersion >= 17.0
   it('should calculate durations correctly for suspended views', async () => {
     let data;
     const getData = () => {
@@ -857,6 +863,7 @@ describe('ProfilingCache', () => {
     `);
   });
 
+  // @reactVersion >= 16.9
   it('should collect data for each rendered fiber', () => {
     const Parent = ({count}) => {
       Scheduler.unstable_advanceTime(10);
@@ -934,6 +941,7 @@ describe('ProfilingCache', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should handle unexpectedly shallow suspense trees', () => {
     const container = document.createElement('div');
 
@@ -975,6 +983,7 @@ describe('ProfilingCache', () => {
   });
 
   // See https://github.com/facebook/react/issues/18831
+  // @reactVersion >= 16.9
   it('should not crash during route transitions with Suspense', () => {
     const RouterContext = React.createContext();
 
@@ -1063,6 +1072,7 @@ describe('ProfilingCache', () => {
     expect(container.textContent).toBe('About');
   });
 
+  // @reactVersion >= 18.0
   it('components that were deleted and added to updaters during the layout phase should not crash', () => {
     let setChildUnmounted;
     function Child() {
@@ -1093,6 +1103,7 @@ describe('ProfilingCache', () => {
     expect(updaters[0].displayName).toEqual('App');
   });
 
+  // @reactVersion >= 18.0
   it('components in a deleted subtree and added to updaters during the layout phase should not crash', () => {
     let setChildUnmounted;
     function Child() {
@@ -1127,6 +1138,7 @@ describe('ProfilingCache', () => {
     expect(updaters[0].displayName).toEqual('App');
   });
 
+  // @reactVersion >= 18.0
   it('components that were deleted should not be added to updaters during the passive phase', () => {
     let setChildUnmounted;
     function Child() {

--- a/packages/react-devtools-shared/src/__tests__/profilingCharts-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCharts-test.js
@@ -59,6 +59,7 @@ describe('profiling charts', () => {
   }
 
   describe('flamegraph chart', () => {
+    // @reactVersion >= 16.9
     it('should contain valid data', () => {
       const Parent = (_: {||}) => {
         Scheduler.unstable_advanceTime(10);
@@ -208,6 +209,7 @@ describe('profiling charts', () => {
   });
 
   describe('ranked chart', () => {
+    // @reactVersion >= 16.9
     it('should contain valid data', () => {
       const Parent = (_: {||}) => {
         Scheduler.unstable_advanceTime(10);

--- a/packages/react-devtools-shared/src/__tests__/profilingCommitTreeBuilder-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCommitTreeBuilder-test.js
@@ -32,6 +32,7 @@ describe('commit tree', () => {
     Scheduler = require('scheduler');
   });
 
+  // @reactVersion >= 16.9
   it('should be able to rebuild the store tree for each commit', () => {
     const Parent = ({count}) => {
       Scheduler.unstable_advanceTime(10);
@@ -116,6 +117,7 @@ describe('commit tree', () => {
       LazyComponent = React.lazy(() => fakeImport(LazyInnerComponent));
     });
 
+    // @reactVersion >= 16.9
     it('should support Lazy components (legacy render)', async () => {
       const container = document.createElement('div');
 
@@ -157,6 +159,7 @@ describe('commit tree', () => {
       expect(commitTrees[2].nodes.size).toBe(2); // <Root> + <App>
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components (createRoot)', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
@@ -199,6 +202,7 @@ describe('commit tree', () => {
       expect(commitTrees[2].nodes.size).toBe(2); // <Root> + <App>
     });
 
+    // @reactVersion >= 16.9
     it('should support Lazy components that are unmounted before resolving (legacy render)', async () => {
       const container = document.createElement('div');
 
@@ -231,6 +235,7 @@ describe('commit tree', () => {
       expect(commitTrees[1].nodes.size).toBe(2); // <Root> + <App>
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components that are unmounted before resolving (createRoot)', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);

--- a/packages/react-devtools-shared/src/__tests__/profilingHostRoot-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingHostRoot-test.js
@@ -49,6 +49,7 @@ describe('profiling HostRoot', () => {
     };
   });
 
+  // @reactVersion >=18.0
   it('should expose passive and layout effect durations for render()', () => {
     function App() {
       React.useEffect(() => {
@@ -77,6 +78,7 @@ describe('profiling HostRoot', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should expose passive and layout effect durations for createRoot()', () => {
     function App() {
       React.useEffect(() => {
@@ -106,6 +108,7 @@ describe('profiling HostRoot', () => {
     );
   });
 
+  // @reactVersion >=18.0
   it('should properly reset passive and layout effect durations between commits', () => {
     function App({shouldCascade}) {
       const [, setState] = React.useState(false);

--- a/packages/react-devtools-shared/src/__tests__/store-test.js
+++ b/packages/react-devtools-shared/src/__tests__/store-test.js
@@ -35,6 +35,7 @@ describe('Store', () => {
     withErrorsOrWarningsIgnored = utils.withErrorsOrWarningsIgnored;
   });
 
+  // @reactVersion >= 18.0
   it('should not allow a root node to be collapsed', () => {
     const Component = () => <div>Hi</div>;
 
@@ -55,6 +56,7 @@ describe('Store', () => {
     );
   });
 
+  // @reactVersion >= 18.0
   it('should properly handle a root with no visible nodes', () => {
     const Root = ({children}) => children;
 
@@ -75,6 +77,7 @@ describe('Store', () => {
   // Thec ase below is admittedly contrived and relies on side effects.
   // I'mnot yet sure of how to reduce the GitHub reported production case to a test though.
   // See https://github.com/facebook/react/issues/21445
+  // @reactVersion >= 18.0
   it('should handle when a component mounts before its owner', () => {
     const promise = new Promise(resolve => {});
 
@@ -109,6 +112,7 @@ describe('Store', () => {
     `);
   });
 
+  // @reactVersion >= 18.0
   it('should handle multibyte character strings', () => {
     const Component = () => null;
     Component.displayName = '🟩💜🔵';
@@ -139,6 +143,7 @@ describe('Store', () => {
       expect(store.getElementAtIndex(1).isStrictModeNonCompliant).toBe(false);
     });
 
+    // @reactVersion >= 18.0
     it('should mark non strict root elements as not strict', () => {
       const App = () => <Component />;
       const Component = () => null;
@@ -177,6 +182,7 @@ describe('Store', () => {
       store.collapseNodesByDefault = false;
     });
 
+    // @reactVersion >= 18.0
     it('should support mount and update operations', () => {
       const Grandparent = ({count}) => (
         <React.Fragment>
@@ -222,6 +228,7 @@ describe('Store', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
+    // @reactVersion >= 18.0
     it('should support mount and update operations for multiple roots', () => {
       const Parent = ({count}) =>
         new Array(count).fill(true).map((_, index) => <Child key={index} />);
@@ -276,6 +283,7 @@ describe('Store', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
+    // @reactVersion >= 18.0
     it('should filter DOM nodes from the store tree', () => {
       const Grandparent = () => (
         <div>
@@ -305,6 +313,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should display Suspense nodes properly in various states', () => {
       const Loading = () => <div>Loading...</div>;
       const SuspendingComponent = () => {
@@ -348,6 +357,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support nested Suspense nodes', () => {
       const Component = () => null;
       const Loading = () => <div>Loading...</div>;
@@ -719,6 +729,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support collapsing parts of the tree', () => {
       const Grandparent = ({count}) => (
         <React.Fragment>
@@ -793,6 +804,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support reordering of children', () => {
       const Root = ({children}) => children;
       const Component = () => null;
@@ -850,6 +862,7 @@ describe('Store', () => {
       store.collapseNodesByDefault = true;
     });
 
+    // @reactVersion >= 18.0
     it('should support mount and update operations', () => {
       const Parent = ({count}) =>
         new Array(count).fill(true).map((_, index) => <Child key={index} />);
@@ -891,6 +904,7 @@ describe('Store', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
+    // @reactVersion >= 18.0
     it('should support mount and update operations for multiple roots', () => {
       const Parent = ({count}) =>
         new Array(count).fill(true).map((_, index) => <Child key={index} />);
@@ -931,6 +945,7 @@ describe('Store', () => {
       expect(store).toMatchInlineSnapshot(``);
     });
 
+    // @reactVersion >= 18.0
     it('should filter DOM nodes from the store tree', () => {
       const Grandparent = () => (
         <div>
@@ -973,6 +988,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should display Suspense nodes properly in various states', () => {
       const Loading = () => <div>Loading...</div>;
       const SuspendingComponent = () => {
@@ -1024,6 +1040,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support expanding parts of the tree', () => {
       const Grandparent = ({count}) => (
         <React.Fragment>
@@ -1103,6 +1120,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support expanding deep parts of the tree', () => {
       const Wrapper = ({forwardedRef}) => (
         <Nested depth={3} forwardedRef={forwardedRef} />
@@ -1177,6 +1195,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support reordering of children', () => {
       const Root = ({children}) => children;
       const Component = () => null;
@@ -1229,6 +1248,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should not add new nodes when suspense is toggled', () => {
       const SuspenseTree = () => {
         return (
@@ -1295,6 +1315,7 @@ describe('Store', () => {
       store.collapseNodesByDefault = false;
     });
 
+    // @reactVersion >= 18.0
     it('should support a single root with a single child', () => {
       const Grandparent = () => (
         <React.Fragment>
@@ -1312,6 +1333,7 @@ describe('Store', () => {
       }
     });
 
+    // @reactVersion >= 18.0
     it('should support multiple roots with one children each', () => {
       const Grandparent = () => <Parent />;
       const Parent = () => <Child />;
@@ -1327,6 +1349,7 @@ describe('Store', () => {
       }
     });
 
+    // @reactVersion >= 18.0
     it('should support a single root with multiple top level children', () => {
       const Grandparent = () => <Parent />;
       const Parent = () => <Child />;
@@ -1347,6 +1370,7 @@ describe('Store', () => {
       }
     });
 
+    // @reactVersion >= 18.0
     it('should support multiple roots with multiple top level children', () => {
       const Grandparent = () => <Parent />;
       const Parent = () => <Child />;
@@ -1375,6 +1399,7 @@ describe('Store', () => {
     });
   });
 
+  // @reactVersion >= 18.0
   it('detects and updates profiling support based on the attached roots', () => {
     const Component = () => null;
 
@@ -1394,6 +1419,7 @@ describe('Store', () => {
     expect(store.rootSupportsBasicProfiling).toBe(false);
   });
 
+  // @reactVersion >= 18.0
   it('should properly serialize non-string key values', () => {
     const Child = () => null;
 
@@ -1516,6 +1542,7 @@ describe('Store', () => {
       LazyComponent = React.lazy(() => fakeImport(LazyInnerComponent));
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components (legacy render)', async () => {
       const container = document.createElement('div');
 
@@ -1549,6 +1576,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components in (createRoot)', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
@@ -1583,6 +1611,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components that are unmounted before they finish loading (legacy render)', async () => {
       const container = document.createElement('div');
 
@@ -1604,6 +1633,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('should support Lazy components that are unmounted before they finish loading in (createRoot)', async () => {
       const container = document.createElement('div');
       const root = ReactDOMClient.createRoot(container);
@@ -1628,6 +1658,7 @@ describe('Store', () => {
   });
 
   describe('inline errors and warnings', () => {
+    // @reactVersion >= 18.0
     it('during render are counted', () => {
       function Example() {
         console.error('test-only: render error');
@@ -1657,6 +1688,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('during layout get counted', () => {
       function Example() {
         React.useLayoutEffect(() => {
@@ -1698,6 +1730,7 @@ describe('Store', () => {
         jest.advanceTimersByTime(1000);
       }
 
+      // @reactVersion >= 18.0
       it('are counted (after a delay)', () => {
         function Example() {
           React.useEffect(() => {
@@ -1731,6 +1764,7 @@ describe('Store', () => {
         expect(store).toMatchInlineSnapshot(``);
       });
 
+      // @reactVersion >= 18.0
       it('are flushed early when there is a new commit', () => {
         function Example() {
           React.useEffect(() => {
@@ -1794,6 +1828,7 @@ describe('Store', () => {
       });
     });
 
+    // @reactVersion >= 18.0
     it('from react get counted', () => {
       const container = document.createElement('div');
       function Example() {
@@ -1818,6 +1853,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('can be cleared for the whole app', () => {
       function Example() {
         console.error('test-only: render error');
@@ -1859,6 +1895,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('can be cleared for particular Fiber (only warnings)', () => {
       function Example() {
         console.error('test-only: render error');
@@ -1904,6 +1941,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('can be cleared for a particular Fiber (only errors)', () => {
       function Example() {
         console.error('test-only: render error');
@@ -1949,6 +1987,7 @@ describe('Store', () => {
       `);
     });
 
+    // @reactVersion >= 18.0
     it('are updated when fibers are removed from the tree', () => {
       function ComponentWithWarning() {
         console.warn('test-only: render warning');

--- a/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeComponentFilters-test.js
@@ -41,6 +41,7 @@ describe('Store component filters', () => {
     legacyRender = utils.legacyRender;
   });
 
+  // @reactVersion >= 16.0
   it('should throw if filters are updated while profiling', () => {
     act(() => store.profilerStore.startProfiling());
     expect(() => (store.componentFilters = [])).toThrow(
@@ -48,6 +49,7 @@ describe('Store component filters', () => {
     );
   });
 
+  // @reactVersion >= 16.0
   it('should support filtering by element type', () => {
     class ClassComponent extends React.Component<{|children: React$Node|}> {
       render() {
@@ -135,6 +137,7 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should ignore invalid ElementTypeRoot filter', () => {
     const Component = () => <div>Hi</div>;
 
@@ -159,6 +162,7 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 16.2
   it('should filter by display name', () => {
     const Text = ({label}) => label;
     const Foo = () => <Text label="foo" />;
@@ -219,6 +223,7 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should filter by path', () => {
     const Component = () => <div>Hi</div>;
 
@@ -252,6 +257,7 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should filter HOCs', () => {
     const Component = () => <div>Hi</div>;
     const Foo = () => <Component />;
@@ -285,6 +291,7 @@ describe('Store component filters', () => {
     `);
   });
 
+  // @reactVersion >= 16.0
   it('should not send a bridge update if the set of enabled filters has not changed', () => {
     act(() => (store.componentFilters = [utils.createHOCFilter(true)]));
 
@@ -315,6 +322,7 @@ describe('Store component filters', () => {
     );
   });
 
+  // @reactVersion >= 18.0
   it('should not break when Suspense nodes are filtered from the tree', () => {
     const promise = new Promise(() => {});
 
@@ -363,6 +371,7 @@ describe('Store component filters', () => {
   });
 
   describe('inline errors and warnings', () => {
+    // @reactVersion >= 17.0
     it('only counts for unfiltered components', () => {
       function ComponentWithWarning() {
         console.warn('test-only: render warning');

--- a/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressSync-test.js
@@ -33,6 +33,7 @@ describe('StoreStress (Legacy Mode)', () => {
 
   // This is a stress test for the tree mount/update/unmount traversal.
   // It renders different trees that should produce the same output.
+  // @reactVersion >= 16.9
   it('should handle a stress test with different tree operations (Legacy Mode)', () => {
     let setShowX;
     const A = () => 'a';
@@ -174,6 +175,7 @@ describe('StoreStress (Legacy Mode)', () => {
     expect(print(store)).toBe('');
   });
 
+  // @reactVersion >= 16.9
   it('should handle stress test with reordering (Legacy Mode)', () => {
     const A = () => 'a';
     const B = () => 'b';
@@ -274,6 +276,7 @@ describe('StoreStress (Legacy Mode)', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should handle a stress test for Suspense (Legacy Mode)', async () => {
     const A = () => 'a';
     const B = () => 'b';
@@ -667,6 +670,7 @@ describe('StoreStress (Legacy Mode)', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should handle a stress test for Suspense without type change (Legacy Mode)', () => {
     const A = () => 'a';
     const B = () => 'b';

--- a/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
+++ b/packages/react-devtools-shared/src/__tests__/storeStressTestConcurrent-test.js
@@ -39,6 +39,7 @@ describe('StoreStressConcurrent', () => {
 
   // This is a stress test for the tree mount/update/unmount traversal.
   // It renders different trees that should produce the same output.
+  // @reactVersion >= 18.0
   it('should handle a stress test with different tree operations (Concurrent Mode)', () => {
     let setShowX;
     const A = () => 'a';
@@ -207,6 +208,7 @@ describe('StoreStressConcurrent', () => {
     expect(print(store)).toBe('');
   });
 
+  // @reactVersion >= 18.0
   it('should handle stress test with reordering (Concurrent Mode)', () => {
     const A = () => 'a';
     const B = () => 'b';
@@ -368,6 +370,7 @@ describe('StoreStressConcurrent', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should handle a stress test for Suspense (Concurrent Mode)', async () => {
     const A = () => 'a';
     const B = () => 'b';
@@ -841,6 +844,7 @@ describe('StoreStressConcurrent', () => {
     }
   });
 
+  // @reactVersion >= 18.0
   it('should handle a stress test for Suspense without type change (Concurrent Mode)', async () => {
     const A = () => 'a';
     const B = () => 'b';

--- a/packages/react-devtools-shared/src/__tests__/utils-test.js
+++ b/packages/react-devtools-shared/src/__tests__/utils-test.js
@@ -23,27 +23,32 @@ import {createElement} from 'react/src/ReactElement';
 
 describe('utils', () => {
   describe('getDisplayName', () => {
+    // @reactVersion >= 16.0
     it('should return a function name', () => {
       function FauxComponent() {}
       expect(getDisplayName(FauxComponent)).toEqual('FauxComponent');
     });
 
+    // @reactVersion >= 16.0
     it('should return a displayName name if specified', () => {
       function FauxComponent() {}
       FauxComponent.displayName = 'OverrideDisplayName';
       expect(getDisplayName(FauxComponent)).toEqual('OverrideDisplayName');
     });
 
+    // @reactVersion >= 16.0
     it('should return the fallback for anonymous functions', () => {
       expect(getDisplayName(() => {}, 'Fallback')).toEqual('Fallback');
     });
 
+    // @reactVersion >= 16.0
     it('should return Anonymous for anonymous functions without a fallback', () => {
       expect(getDisplayName(() => {})).toEqual('Anonymous');
     });
 
     // Simulate a reported bug:
     // https://github.com/facebook/react/issues/16685
+    // @reactVersion >= 16.0
     it('should return a fallback when the name prop is not a string', () => {
       const FauxComponent = {name: {}};
       expect(getDisplayName(FauxComponent, 'Fallback')).toEqual('Fallback');
@@ -51,6 +56,7 @@ describe('utils', () => {
   });
 
   describe('getDisplayNameForReactElement', () => {
+    // @reactVersion >= 16.0
     it('should return correct display name for an element with function type', () => {
       function FauxComponent() {}
       FauxComponent.displayName = 'OverrideDisplayName';
@@ -60,16 +66,19 @@ describe('utils', () => {
       );
     });
 
+    // @reactVersion >= 16.0
     it('should return correct display name for an element with a type of StrictMode', () => {
       const element = createElement(StrictMode);
       expect(getDisplayNameForReactElement(element)).toEqual('StrictMode');
     });
 
+    // @reactVersion >= 16.0
     it('should return correct display name for an element with a type of SuspenseList', () => {
       const element = createElement(SuspenseList);
       expect(getDisplayNameForReactElement(element)).toEqual('SuspenseList');
     });
 
+    // @reactVersion >= 16.0
     it('should return NotImplementedInDevtools for an element with invalid symbol type', () => {
       const element = createElement(Symbol('foo'));
       expect(getDisplayNameForReactElement(element)).toEqual(
@@ -77,6 +86,7 @@ describe('utils', () => {
       );
     });
 
+    // @reactVersion >= 16.0
     it('should return NotImplementedInDevtools for an element with invalid type', () => {
       const element = createElement(true);
       expect(getDisplayNameForReactElement(element)).toEqual(
@@ -84,6 +94,7 @@ describe('utils', () => {
       );
     });
 
+    // @reactVersion >= 16.0
     it('should return Element for null type', () => {
       const element = createElement();
       expect(getDisplayNameForReactElement(element)).toEqual('Element');
@@ -91,42 +102,50 @@ describe('utils', () => {
   });
 
   describe('format', () => {
+    // @reactVersion >= 16.0
     it('should format simple strings', () => {
       expect(format('a', 'b', 'c')).toEqual('a b c');
     });
 
+    // @reactVersion >= 16.0
     it('should format multiple argument types', () => {
       expect(format('abc', 123, true)).toEqual('abc 123 true');
     });
 
+    // @reactVersion >= 16.0
     it('should support string substitutions', () => {
       expect(format('a %s b %s c', 123, true)).toEqual('a 123 b true c');
     });
 
+    // @reactVersion >= 16.0
     it('should gracefully handle Symbol types', () => {
       expect(format(Symbol('a'), 'b', Symbol('c'))).toEqual(
         'Symbol(a) b Symbol(c)',
       );
     });
 
+    // @reactVersion >= 16.0
     it('should gracefully handle Symbol type for the first argument', () => {
       expect(format(Symbol('abc'), 123)).toEqual('Symbol(abc) 123');
     });
   });
 
   describe('formatWithStyles', () => {
+    // @reactVersion >= 16.0
     it('should format empty arrays', () => {
       expect(formatWithStyles([])).toEqual([]);
       expect(formatWithStyles([], 'gray')).toEqual([]);
       expect(formatWithStyles(undefined)).toEqual(undefined);
     });
 
+    // @reactVersion >= 16.0
     it('should bail out of strings with styles', () => {
       expect(
         formatWithStyles(['%ca', 'color: green', 'b', 'c'], 'color: gray'),
       ).toEqual(['%ca', 'color: green', 'b', 'c']);
     });
 
+    // @reactVersion >= 16.0
     it('should format simple strings', () => {
       expect(formatWithStyles(['a'])).toEqual(['a']);
 
@@ -145,6 +164,7 @@ describe('utils', () => {
       ]);
     });
 
+    // @reactVersion >= 16.0
     it('should format string substituions', () => {
       expect(
         formatWithStyles(['%s %s %s', 'a', 'b', 'c'], 'color: gray'),
@@ -157,6 +177,7 @@ describe('utils', () => {
       ).toEqual(['%c%s %s', 'color: gray', 'a', 'b', 'c']);
     });
 
+    // @reactVersion >= 16.0
     it('should support multiple argument types', () => {
       const symbol = Symbol('a');
       expect(
@@ -176,6 +197,7 @@ describe('utils', () => {
       ]);
     });
 
+    // @reactVersion >= 16.0
     it('should properly format escaped string substituions', () => {
       expect(formatWithStyles(['%%s'], 'color: gray')).toEqual([
         '%c%s',
@@ -190,6 +212,7 @@ describe('utils', () => {
       expect(formatWithStyles(['%%c%c'], 'color: gray')).toEqual(['%%c%c']);
     });
 
+    // @reactVersion >= 16.0
     it('should format non string inputs as the first argument', () => {
       expect(formatWithStyles([{foo: 'bar'}])).toEqual([{foo: 'bar'}]);
       expect(formatWithStyles([[1, 2, 3]])).toEqual([[1, 2, 3]]);


### PR DESCRIPTION
This PR adds the `reactVersion` pragma to tests.

Tests without the `reactVersion` pragma won't be run if the `reactVersion` pragma isn't specified.

Tested each React version manually with the pragma to make sure the tests pass