### PR TITLE
Add option for source maps when running tests

### DIFF
--- a/scripts/jest/jest-cli.js
+++ b/scripts/jest/jest-cli.js
@@ -110,6 +110,12 @@ const argv = yargs
       requiresArg: true,
       type: 'string',
     },
+    sourceMaps: {
+      describe:
+        'Enable inline source maps when tranforming source files with Jest. Useful for debugging, but makes it slower.',
+      type: 'boolean',
+      default: false,
+    },
   }).argv;
 
 function logError(message) {
@@ -331,6 +337,12 @@ function getEnvars() {
 
   if (argv.reactVersion) {
     envars.REACT_VERSION = semver.coerce(argv.reactVersion);
+  }
+
+  if (argv.sourceMaps) {
+    // This is off by default because it slows down the test runner, but it's
+    // super useful when running the debugger.
+    envars.JEST_ENABLE_SOURCE_MAPS = 'inline';
   }
 
   return envars;

--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -93,6 +93,9 @@ module.exports = {
           babelOptions,
           {
             plugins,
+            sourceMaps: process.env.JEST_ENABLE_SOURCE_MAPS
+              ? process.env.JEST_ENABLE_SOURCE_MAPS
+              : false,
           }
         )
       );


### PR DESCRIPTION
I added a `--sourceMaps` option to our test command that enables inline source maps. I've kept it disabled by default, since it makes the tests run slower. But it's super useful when attaching to a debugger.