### PR TITLE
[devtools-ish] Release script missing node-fetch@2 dependency

### DIFF
--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -15,6 +15,7 @@
     "folder-hash": "^2.1.2",
     "fs-extra": "^4.0.2",
     "log-update": "^2.1.0",
+    "node-fetch": "^2",
     "progress-estimator": "^0.2.1",
     "prompt-promise": "^1.0.3",
     "puppeteer": "^1.11.0",

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -775,6 +775,13 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
+node-fetch@^2:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-version@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
@@ -1133,6 +1140,11 @@ tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -1187,6 +1199,19 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Explicitly add node-fetch as a dependency to run `download-experimental-build.js`

> Accidentally closed out #24571, by nuking my fork.  This is identical.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

If you follow the [react-devtools CONTRIBUTING](https://github.com/facebook/react/blob/main/packages/react-devtools/CONTRIBUTING.md#build-react-and-react-dom) docs, it fails:

```
yarn && ./download-experimental-build.js --commit=main
yarn install v1.22.18
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.07s.
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'node-fetch'
...
``` 

This is because `node-fetch` is a transient dependency hoisted to the root, and I'd argue it should be explicit for the download-experimental-build script to execute:

```
(src/react) $ yarn why node-fetch
yarn why v1.22.18
[1/4] 🤔  Why do we have the module "node-fetch"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "node-fetch@2.6.0"
info Has been hoisted to "node-fetch"
info Reasons this module exists
   - "workspace-aggregator-979001d4-5396-4963-b362-bf1f539edc50" depends on it
   - Hoisted from "_project_#danger#node-fetch"
   - Hoisted from "_project_#danger#@octokit#rest#@octokit#request#node-fetch"
   - Hoisted from "_project_#danger#gitlab#ky-universal#node-fetch"
=> Found "isomorphic-fetch#node-fetch@1.7.3"
info This module exists because "_project_#fbjs#isomorphic-fetch" depends on it.
=> Found "cross-fetch#node-fetch@2.6.1"
info This module exists because "_project_#react-devtools-extensions#jest-fetch-mock#cross-fetch" depends on it.
✨  Done in 0.43s.

```

## How did you test this change?

```
Your branch is up to date with 'origin/missing_dep'.
❯ yarn && ./download-experimental-build.js --commit=main
yarn install v1.22.18
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

✨  Done in 0.30s.
✓ Getting build ID for commit "main" 314 ms
✓ Downloading artifacts from Circle CI for commit main (build 484032) 5.7 secs
An experimental build has been downloaded!

You can download this build again by running:
  download-experimental-build.js --build=484032
```

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
