### PR TITLE
Tests assertion message fix

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -496,17 +496,17 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         name,
       );
     }
-    if (typeof instance.componentWillRecieveProps === 'function') {
+    if (typeof instance.componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+          'componentWillReceiveProps(). Did you mean componentWillReceiveProps()?',
         name,
       );
     }
-    if (typeof instance.UNSAFE_componentWillRecieveProps === 'function') {
+    if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
+          'UNSAFE_componentWillReceiveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
         name,
       );
     }

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -496,17 +496,17 @@ function checkClassInstance(workInProgress: Fiber, ctor: any, newProps: any) {
         name,
       );
     }
-    if (typeof instance.componentWillRecieveProps === 'function') {
+    if (typeof instance.componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+          'componentWillReceiveProps(). Did you mean componentWillReceiveProps()?',
         name,
       );
     }
-    if (typeof instance.UNSAFE_componentWillRecieveProps === 'function') {
+    if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
+          'UNSAFE_componentWillReceiveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
         name,
       );
     }

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -449,17 +449,17 @@ function checkClassInstance(instance: any, ctor: any, newProps: any) {
         name,
       );
     }
-    if (typeof instance.componentWillRecieveProps === 'function') {
+    if (typeof instance.componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'componentWillRecieveProps(). Did you mean componentWillReceiveProps()?',
+          'componentWillReceiveProps(). Did you mean componentWillReceiveProps()?',
         name,
       );
     }
-    if (typeof instance.UNSAFE_componentWillRecieveProps === 'function') {
+    if (typeof instance.UNSAFE_componentWillReceiveProps === 'function') {
       console.error(
         '%s has a method called ' +
-          'UNSAFE_componentWillRecieveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
+          'UNSAFE_componentWillReceiveProps(). Did you mean UNSAFE_componentWillReceiveProps()?',
         name,
       );
     }

--- a/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
+++ b/packages/react/src/__tests__/ReactCoffeeScriptClass-test.coffee
@@ -463,7 +463,7 @@ describe 'ReactCoffeeScriptClass', ->
 
   it 'should warn when misspelling componentWillReceiveProps', ->
     class NamedComponent extends React.Component
-      componentWillRecieveProps: ->
+      componentWillReceiveProps: ->
         false
 
       render: ->
@@ -474,13 +474,13 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toErrorDev(
-      'Warning: NamedComponent has a method called componentWillRecieveProps().
+      'Warning: NamedComponent has a method called componentWillReceiveProps().
        Did you mean componentWillReceiveProps()?'
     )
 
   it 'should warn when misspelling UNSAFE_componentWillReceiveProps', ->
     class NamedComponent extends React.Component
-      UNSAFE_componentWillRecieveProps: ->
+      UNSAFE_componentWillReceiveProps: ->
         false
 
       render: ->
@@ -491,7 +491,7 @@ describe 'ReactCoffeeScriptClass', ->
     expect(->
       test React.createElement(NamedComponent), 'SPAN', 'foo'
     ).toErrorDev(
-      'Warning: NamedComponent has a method called UNSAFE_componentWillRecieveProps().
+      'Warning: NamedComponent has a method called UNSAFE_componentWillReceiveProps().
        Did you mean UNSAFE_componentWillReceiveProps()?'
     )
 

--- a/packages/react/src/__tests__/ReactES6Class-test.js
+++ b/packages/react/src/__tests__/ReactES6Class-test.js
@@ -500,7 +500,7 @@ describe('ReactES6Class', () => {
 
   it('should warn when misspelling componentWillReceiveProps', () => {
     class NamedComponent extends React.Component {
-      componentWillRecieveProps() {
+      componentWillReceiveProps() {
         return false;
       }
       render() {
@@ -510,14 +510,14 @@ describe('ReactES6Class', () => {
 
     expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
       'Warning: ' +
-        'NamedComponent has a method called componentWillRecieveProps(). Did ' +
+        'NamedComponent has a method called componentWillReceiveProps(). Did ' +
         'you mean componentWillReceiveProps()?',
     );
   });
 
   it('should warn when misspelling UNSAFE_componentWillReceiveProps', () => {
     class NamedComponent extends React.Component {
-      UNSAFE_componentWillRecieveProps() {
+      UNSAFE_componentWillReceiveProps() {
         return false;
       }
       render() {
@@ -527,7 +527,7 @@ describe('ReactES6Class', () => {
 
     expect(() => test(<NamedComponent />, 'SPAN', 'foo')).toErrorDev(
       'Warning: ' +
-        'NamedComponent has a method called UNSAFE_componentWillRecieveProps(). ' +
+        'NamedComponent has a method called UNSAFE_componentWillReceiveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
     );
   });

--- a/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
+++ b/packages/react/src/__tests__/ReactTypeScriptClass-test.ts
@@ -272,7 +272,7 @@ class MisspelledComponent1 extends React.Component {
 
 // it should warn when misspelling componentWillReceiveProps
 class MisspelledComponent2 extends React.Component {
-  componentWillRecieveProps() {
+  componentWillReceiveProps() {
     return false;
   }
   render() {
@@ -282,7 +282,7 @@ class MisspelledComponent2 extends React.Component {
 
 // it should warn when misspelling UNSAFE_componentWillReceiveProps
 class MisspelledComponent3 extends React.Component {
-  UNSAFE_componentWillRecieveProps() {
+  UNSAFE_componentWillReceiveProps() {
     return false;
   }
   render() {
@@ -650,7 +650,7 @@ describe('ReactTypeScriptClass', function() {
       test(React.createElement(MisspelledComponent2), 'SPAN', 'foo')
     ).toErrorDev(
       'Warning: ' +
-        'MisspelledComponent2 has a method called componentWillRecieveProps(). ' +
+        'MisspelledComponent2 has a method called componentWillReceiveProps(). ' +
         'Did you mean componentWillReceiveProps()?'
     );
   });
@@ -660,7 +660,7 @@ describe('ReactTypeScriptClass', function() {
       test(React.createElement(MisspelledComponent3), 'SPAN', 'foo')
     ).toErrorDev(
       'Warning: ' +
-        'MisspelledComponent3 has a method called UNSAFE_componentWillRecieveProps(). ' +
+        'MisspelledComponent3 has a method called UNSAFE_componentWillReceiveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?'
     );
   });

--- a/packages/react/src/__tests__/createReactClassIntegration-test.js
+++ b/packages/react/src/__tests__/createReactClassIntegration-test.js
@@ -144,7 +144,7 @@ describe('create-react-class-integration', () => {
   it('should warn when misspelling componentWillReceiveProps', () => {
     expect(() =>
       createReactClass({
-        componentWillRecieveProps: function() {
+        componentWillReceiveProps: function() {
           return false;
         },
         render: function() {
@@ -152,7 +152,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: A component has a method called componentWillRecieveProps(). Did you ' +
+      'Warning: A component has a method called componentWillReceiveProps(). Did you ' +
         'mean componentWillReceiveProps()?',
       {withoutStack: true},
     );
@@ -161,7 +161,7 @@ describe('create-react-class-integration', () => {
   it('should warn when misspelling UNSAFE_componentWillReceiveProps', () => {
     expect(() =>
       createReactClass({
-        UNSAFE_componentWillRecieveProps: function() {
+        UNSAFE_componentWillReceiveProps: function() {
           return false;
         },
         render: function() {
@@ -169,7 +169,7 @@ describe('create-react-class-integration', () => {
         },
       }),
     ).toErrorDev(
-      'Warning: A component has a method called UNSAFE_componentWillRecieveProps(). ' +
+      'Warning: A component has a method called UNSAFE_componentWillReceiveProps(). ' +
         'Did you mean UNSAFE_componentWillReceiveProps()?',
       {withoutStack: true},
     );


### PR DESCRIPTION
Some tests had typos in naming that could confuse developers when trying to copy them.
Tested the changes with the PR steps one by one.
Filled the CLA.