### PR TITLE
[DevTools] Fix moduleNameMapper Order in DevTools Config

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
+++ b/packages/react-devtools-shared/src/__tests__/profilingCache-test.js
@@ -734,7 +734,7 @@ describe('ProfilingCache', () => {
     }
   });
 
-  // @reactVersion >= 16.9
+  // @reactVersion >= 18.0
   it('should calculate durations based on actual children (not filtered children)', () => {
     store.componentFilters = [utils.createDisplayNameFilter('^Parent$')];
 

--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -51,8 +51,8 @@ moduleNameMapper['^react-reconciler/([^/]+)$'] =
 module.exports = Object.assign({}, baseConfig, {
   // Redirect imports to the compiled bundles
   moduleNameMapper: {
-    ...moduleNameMapper,
     ...devtoolsRegressionConfig.moduleNameMapper,
+    ...moduleNameMapper,
   },
   // Don't run bundle tests on -test.internal.* files
   testPathIgnorePatterns: ['/node_modules/', '-test.internal.js$'],


### PR DESCRIPTION
We need the regression config `moduleNameMapper` to come before the current `moduleNameMapper` so when it tries to map `"/^react-dom\/([^/]+)$/` it doesn't get confused.