### PR TITLE
[DevTools] Add `--replaceBuild` option to Older React Builds Download Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
       - run:
           name: Install nested packages from Yarn cache
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
-      - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >>
+      - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
       - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
 
   yarn_lint_build:


### PR DESCRIPTION
This PR adds a `--replaceBuild` option to the script that downloads older React version builds. If this flag is true, we will replace the contents of the `build` folder with the contents of the `build-regression` folder and remove the `build-regression` folder after, which was the original behavior.

However, for e2e tests, we need both the original build (for DevTools) and the new build (for the React Apps), so we need both the `build` and the `build-regression` folders. Not adding the `--replaceBuild` option will do this.

This PR also modifies the circle CI config to reflect this change.