### PR TITLE
[Fizz] Improve text separator byte efficiency

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -3592,6 +3592,7 @@ describe('ReactDOMFizzServer', () => {
       });
     }
 
+    // @gate experimental
     it('it only includes separators between adjacent text nodes', async () => {
       function App({name}) {
         return (
@@ -3626,6 +3627,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('it does not insert text separators even when adjacent text is in a delayed segment', async () => {
       function App({name}) {
         return (
@@ -3681,6 +3683,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('it works with multiple adjacent segments', async () => {
       function App() {
         return (
@@ -3726,6 +3729,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('it works when some segments are flushed and others are patched', async () => {
       function App() {
         return (
@@ -3768,6 +3772,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('it does not prepend a text separators if the segment follows a non-Text Node', async () => {
       function App() {
         return (
@@ -3808,6 +3813,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('it does not prepend a text separators if the segments first emission is a non-Text Node', async () => {
       function App() {
         return (
@@ -3846,6 +3852,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('should not insert separators for text inside Suspense boundaries even if they would otherwise be considered text-embedded', async () => {
       function App() {
         return (
@@ -3930,6 +3937,7 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
+    // @gate experimental
     it('(only) includes extraneous text separators in segments that complete before flushing, followed by nothing or a non-Text node', async () => {
       function App() {
         return (

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js
@@ -101,7 +101,7 @@ describe('ReactDOMServerIntegration', () => {
         ) {
           // For plain server markup result we have comments between.
           // If we're able to hydrate, they remain.
-          expect(e.childNodes.length).toBe(render === streamRender ? 6 : 5);
+          expect(e.childNodes.length).toBe(5);
           expectTextNode(e.childNodes[0], ' ');
           expectTextNode(e.childNodes[2], ' ');
           expectTextNode(e.childNodes[4], ' ');
@@ -119,8 +119,8 @@ describe('ReactDOMServerIntegration', () => {
             Text<span>More Text</span>
           </div>,
         );
-        expect(e.childNodes.length).toBe(render === streamRender ? 3 : 2);
-        const spanNode = e.childNodes[render === streamRender ? 2 : 1];
+        expect(e.childNodes.length).toBe(2);
+        const spanNode = e.childNodes[1];
         expectTextNode(e.childNodes[0], 'Text');
         expect(spanNode.tagName).toBe('SPAN');
         expect(spanNode.childNodes.length).toBe(1);
@@ -147,19 +147,19 @@ describe('ReactDOMServerIntegration', () => {
       itRenders('a custom element with text', async render => {
         const e = await render(<custom-element>Text</custom-element>);
         expect(e.tagName).toBe('CUSTOM-ELEMENT');
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectNode(e.firstChild, TEXT_NODE_TYPE, 'Text');
       });
 
       itRenders('a leading blank child with a text sibling', async render => {
         const e = await render(<div>{''}foo</div>);
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectTextNode(e.childNodes[0], 'foo');
       });
 
       itRenders('a trailing blank child with a text sibling', async render => {
         const e = await render(<div>foo{''}</div>);
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectTextNode(e.childNodes[0], 'foo');
       });
 
@@ -176,7 +176,7 @@ describe('ReactDOMServerIntegration', () => {
           render === streamRender
         ) {
           // In the server render output there's a comment between them.
-          expect(e.childNodes.length).toBe(render === streamRender ? 4 : 3);
+          expect(e.childNodes.length).toBe(3);
           expectTextNode(e.childNodes[0], 'foo');
           expectTextNode(e.childNodes[2], 'bar');
         } else {
@@ -203,7 +203,7 @@ describe('ReactDOMServerIntegration', () => {
             render === streamRender
           ) {
             // In the server render output there's a comment between them.
-            expect(e.childNodes.length).toBe(render === streamRender ? 6 : 5);
+            expect(e.childNodes.length).toBe(5);
             expectTextNode(e.childNodes[0], 'a');
             expectTextNode(e.childNodes[2], 'b');
             expectTextNode(e.childNodes[4], 'c');
@@ -240,7 +240,11 @@ describe('ReactDOMServerIntegration', () => {
             e
           </div>,
         );
-        if (render === serverRender || render === clientRenderOnServerString) {
+        if (
+          render === serverRender ||
+          render === streamRender ||
+          render === clientRenderOnServerString
+        ) {
           // In the server render output there's comments between text nodes.
           expect(e.childNodes.length).toBe(5);
           expectTextNode(e.childNodes[0], 'a');
@@ -249,15 +253,6 @@ describe('ReactDOMServerIntegration', () => {
           expectTextNode(e.childNodes[3].childNodes[0], 'c');
           expectTextNode(e.childNodes[3].childNodes[2], 'd');
           expectTextNode(e.childNodes[4], 'e');
-        } else if (render === streamRender) {
-          // In the server render output there's comments after each text node.
-          expect(e.childNodes.length).toBe(7);
-          expectTextNode(e.childNodes[0], 'a');
-          expectTextNode(e.childNodes[2], 'b');
-          expect(e.childNodes[4].childNodes.length).toBe(4);
-          expectTextNode(e.childNodes[4].childNodes[0], 'c');
-          expectTextNode(e.childNodes[4].childNodes[2], 'd');
-          expectTextNode(e.childNodes[5], 'e');
         } else {
           expect(e.childNodes.length).toBe(4);
           expectTextNode(e.childNodes[0], 'a');
@@ -296,7 +291,7 @@ describe('ReactDOMServerIntegration', () => {
           render === streamRender
         ) {
           // In the server markup there's a comment between.
-          expect(e.childNodes.length).toBe(render === streamRender ? 4 : 3);
+          expect(e.childNodes.length).toBe(3);
           expectTextNode(e.childNodes[0], 'foo');
           expectTextNode(e.childNodes[2], '40');
         } else {
@@ -335,13 +330,13 @@ describe('ReactDOMServerIntegration', () => {
 
       itRenders('null children as blank', async render => {
         const e = await render(<div>{null}foo</div>);
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectTextNode(e.childNodes[0], 'foo');
       });
 
       itRenders('false children as blank', async render => {
         const e = await render(<div>{false}foo</div>);
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectTextNode(e.childNodes[0], 'foo');
       });
 
@@ -353,7 +348,7 @@ describe('ReactDOMServerIntegration', () => {
             {false}
           </div>,
         );
-        expect(e.childNodes.length).toBe(render === streamRender ? 2 : 1);
+        expect(e.childNodes.length).toBe(1);
         expectTextNode(e.childNodes[0], 'foo');
       });
 
@@ -740,10 +735,10 @@ describe('ReactDOMServerIntegration', () => {
             </div>,
           );
           expect(e.id).toBe('parent');
-          expect(e.childNodes.length).toBe(render === streamRender ? 4 : 3);
+          expect(e.childNodes.length).toBe(3);
           const child1 = e.childNodes[0];
           const textNode = e.childNodes[1];
-          const child2 = e.childNodes[render === streamRender ? 3 : 2];
+          const child2 = e.childNodes[2];
           expect(child1.id).toBe('child1');
           expect(child1.childNodes.length).toBe(0);
           expectTextNode(textNode, ' ');
@@ -757,10 +752,10 @@ describe('ReactDOMServerIntegration', () => {
         async render => {
           // prettier-ignore
           const e = await render(<div id="parent">  <div id="child" />   </div>); // eslint-disable-line no-multi-spaces
-          expect(e.childNodes.length).toBe(render === streamRender ? 5 : 3);
+          expect(e.childNodes.length).toBe(3);
           const textNode1 = e.childNodes[0];
-          const child = e.childNodes[render === streamRender ? 2 : 1];
-          const textNode2 = e.childNodes[render === streamRender ? 3 : 2];
+          const child = e.childNodes[1];
+          const textNode2 = e.childNodes[2];
           expect(e.id).toBe('parent');
           expectTextNode(textNode1, '  ');
           expect(child.id).toBe('child');
@@ -783,9 +778,7 @@ describe('ReactDOMServerIntegration', () => {
         ) {
           // For plain server markup result we have comments between.
           // If we're able to hydrate, they remain.
-          expect(parent.childNodes.length).toBe(
-            render === streamRender ? 6 : 5,
-          );
+          expect(parent.childNodes.length).toBe(5);
           expectTextNode(parent.childNodes[0], 'a');
           expectTextNode(parent.childNodes[2], 'b');
           expectTextNode(parent.childNodes[4], 'c');
@@ -817,7 +810,7 @@ describe('ReactDOMServerIntegration', () => {
           render === clientRenderOnServerString ||
           render === streamRender
         ) {
-          expect(e.childNodes.length).toBe(render === streamRender ? 4 : 3);
+          expect(e.childNodes.length).toBe(3);
           expectTextNode(e.childNodes[0], '<span>Text1&quot;</span>');
           expectTextNode(e.childNodes[2], '<span>Text2&quot;</span>');
         } else {
@@ -868,7 +861,7 @@ describe('ReactDOMServerIntegration', () => {
           );
           if (render === serverRender || render === streamRender) {
             // We have three nodes because there is a comment between them.
-            expect(e.childNodes.length).toBe(render === streamRender ? 4 : 3);
+            expect(e.childNodes.length).toBe(3);
             // Everything becomes LF when parsed from server HTML.
             // Null character is ignored.
             expectNode(e.childNodes[0], TEXT_NODE_TYPE, 'foo\nbar');

--- a/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMUseId-test.js
@@ -343,7 +343,6 @@ describe('useId', () => {
         id="container"
       >
         :R0:, :R0H1:, :R0H2:
-        <!-- -->
       </div>
     `);
   });
@@ -369,7 +368,6 @@ describe('useId', () => {
         id="container"
       >
         :R0:
-        <!-- -->
       </div>
     `);
   });

--- a/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -36,16 +36,6 @@ export function writeChunkAndReturn(
   destination: Destination,
   chunk: Chunk | PrecomputedChunk,
 ): boolean {
-  if (prevWasCommentSegmenter) {
-    prevWasCommentSegmenter = false;
-    if (chunk[0] !== '<') {
-      destination.push('<!-- -->');
-    }
-  }
-  if (chunk === '<!-- -->') {
-    prevWasCommentSegmenter = true;
-    return true;
-  }
   return destination.push(chunk);
 }
 

--- a/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -24,7 +24,6 @@ export function flushBuffered(destination: Destination) {}
 
 export function beginWriting(destination: Destination) {}
 
-let prevWasCommentSegmenter = false;
 export function writeChunk(
   destination: Destination,
   chunk: Chunk | PrecomputedChunk,

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -307,17 +307,16 @@ export function pushTextInstance(
 // advanced with the tracking and drop the trailing edge in some cases when we know a segment
 // is followed by a Text or non-Text Node explicitly vs followed by another Segment
 export opaque type TextEmbedding = number;
-type Embeddable = {textEmbedding: TextEmbedding, ...};
 
-const NO_TEXT_EMBED = /*                 */ 0b0000;
+const NO_TEXT_EMBED = /*                    */ 0b0000;
 
-const LEADING_SEPARATOR_NEEDED = /*      */ 0b0011;
-const LEADING_TEXT_EMBED_KNOWN = /*      */ 0b0001;
+const LEADING_SEPARATOR_NEEDED = /*         */ 0b0011;
+const LEADING_TEXT_EMBED_KNOWN = /*         */ 0b0001;
 // const LEADING_TEXT_EMBED_POSSIBLE = /*   */ 0b0010;
 
-const TRAILING_SEPARATOR_NEEDED = /*     */ 0b1100;
+const TRAILING_SEPARATOR_NEEDED = /*        */ 0b1100;
 // const TRAILING_TEXT_EMBED_KNOWN = /*     */ 0b0100;
-const TRAILING_TEXT_EMBED_POSSIBLE = /*  */ 0b1000;
+const TRAILING_TEXT_EMBED_POSSIBLE = /*     */ 0b1000;
 
 // Suspense boundaries always emit a comment node at the leading and trailing edge and thus need
 // no additional separators. we also use this for the root segment even though it isn't a Boundary
@@ -327,12 +326,20 @@ export function textEmbeddingForBoundarySegment(): TextEmbedding {
   return NO_TEXT_EMBED;
 }
 
+// Segments that are not the boundary segment can be truly embedded in Text. we determine the leading edge
+// based on what was last pushed. We cannot know the trailing edge so we conservatively assume we are embedded there
 export function textEmbeddingForSegment(): TextEmbedding {
   let embedding = TRAILING_TEXT_EMBED_POSSIBLE;
   embedding |= lastPushedText ? LEADING_TEXT_EMBED_KNOWN : NO_TEXT_EMBED;
 
   lastPushedText = false;
   return embedding;
+}
+
+// If a Segment is going to be flushed later than it's parent text separators arent needed
+// because the DOM patch will leavee the adjacent text as separate nodes
+export function textEmbeddingForDelayedSegment(): TextEmbedding {
+  return NO_TEXT_EMBED;
 }
 
 // Called when a segment is about to be rendered by a Task

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -284,7 +284,7 @@ export function pushTextInstance(
   target: Array<Chunk | PrecomputedChunk>,
   text: string,
   responseState: ResponseState,
-  textEmbedded?: boolean,
+  textEmbedded: boolean,
 ): boolean {
   if (text === '') {
     // Empty text doesn't have a DOM node representation and the hydration is aware of this.
@@ -302,8 +302,8 @@ export function pushTextInstance(
 export function pushSegmentFinale(
   target: Array<Chunk | PrecomputedChunk>,
   responseState: ResponseState,
-  lastPushedText: Boolean,
-  textEmbedded: Boolean,
+  lastPushedText: boolean,
+  textEmbedded: boolean,
 ): void {
   if (lastPushedText && textEmbedded) {
     target.push(textSeparator);

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -75,6 +75,7 @@ export function createRootFormatContext(): FormatContext {
 export type {
   FormatContext,
   SuspenseBoundaryID,
+  TextEmbedding,
 } from './ReactDOMServerFormatConfig';
 
 export {
@@ -97,6 +98,7 @@ export {
   writeCompletedRoot,
   textEmbeddingForBoundarySegment,
   textEmbeddingForSegment,
+  textEmbeddingForDelayedSegment,
   prepareForSegment,
   finalizeForSegment,
 } from './ReactDOMServerFormatConfig';

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -95,6 +95,10 @@ export {
   writeEndPendingSuspenseBoundary,
   writePlaceholder,
   writeCompletedRoot,
+  textEmbeddingForBoundarySegment,
+  textEmbeddingForSegment,
+  prepareForSegment,
+  finalizeForSegment,
 } from './ReactDOMServerFormatConfig';
 
 import {stringToChunk} from 'react-server/src/ReactServerStreamConfig';

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -12,6 +12,7 @@ import type {FormatContext} from './ReactDOMServerFormatConfig';
 import {
   createResponseState as createResponseStateImpl,
   pushTextInstance as pushTextInstanceImpl,
+  pushSegmentFinale as pushSegmentFinaleImpl,
   writeStartCompletedSuspenseBoundary as writeStartCompletedSuspenseBoundaryImpl,
   writeStartClientRenderedSuspenseBoundary as writeStartClientRenderedSuspenseBoundaryImpl,
   writeEndCompletedSuspenseBoundary as writeEndCompletedSuspenseBoundaryImpl,
@@ -86,7 +87,6 @@ export {
   pushEndInstance,
   pushStartCompletedSuspenseBoundary,
   pushEndCompletedSuspenseBoundary,
-  pushSegmentFinale,
   writeStartSegment,
   writeEndSegment,
   writeCompletedSegmentInstruction,
@@ -113,6 +113,24 @@ export function pushTextInstance(
     return false;
   } else {
     return pushTextInstanceImpl(target, text, responseState, textEmbedded);
+  }
+}
+
+export function pushSegmentFinale(
+  target: Array<Chunk | PrecomputedChunk>,
+  responseState: ResponseState,
+  lastPushedText: boolean,
+  textEmbedded: boolean,
+): void {
+  if (responseState.generateStaticMarkup) {
+    return;
+  } else {
+    return pushSegmentFinaleImpl(
+      target,
+      responseState,
+      lastPushedText,
+      textEmbedded,
+    );
   }
 }
 

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -87,6 +87,7 @@ export {
   pushEndInstance,
   pushStartCompletedSuspenseBoundary,
   pushEndCompletedSuspenseBoundary,
+  pushSegmentFinale,
   writeStartSegment,
   writeEndSegment,
   writeCompletedSegmentInstruction,
@@ -96,11 +97,6 @@ export {
   writeEndPendingSuspenseBoundary,
   writePlaceholder,
   writeCompletedRoot,
-  textEmbeddingForBoundarySegment,
-  textEmbeddingForSegment,
-  textEmbeddingForDelayedSegment,
-  prepareForSegment,
-  finalizeForSegment,
 } from './ReactDOMServerFormatConfig';
 
 import {stringToChunk} from 'react-server/src/ReactServerStreamConfig';
@@ -111,11 +107,13 @@ export function pushTextInstance(
   target: Array<Chunk | PrecomputedChunk>,
   text: string,
   responseState: ResponseState,
-): void {
+  textEmbedded: boolean,
+): boolean {
   if (responseState.generateStaticMarkup) {
     target.push(stringToChunk(escapeTextForBrowser(text)));
+    return false;
   } else {
-    pushTextInstanceImpl(target, text, responseState);
+    return pushTextInstanceImpl(target, text, responseState, textEmbedded);
   }
 }
 

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -75,7 +75,6 @@ export function createRootFormatContext(): FormatContext {
 export type {
   FormatContext,
   SuspenseBoundaryID,
-  TextEmbedding,
 } from './ReactDOMServerFormatConfig';
 
 export {

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -156,6 +156,15 @@ export function pushEndInstance(
   target.push(END);
 }
 
+export function textEmbeddingForBoundarySegment() {
+  return null;
+}
+export function textEmbeddingForSegment() {
+  return null;
+}
+export function prepareForSegment() {}
+export function finalizeForSegment() {}
+
 export function writeCompletedRoot(
   destination: Destination,
   responseState: ResponseState,

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -155,12 +155,8 @@ export function pushEndInstance(
 ): void {
   target.push(END);
 }
-export opaque type TextEmbedding = void;
-export function textEmbeddingForBoundarySegment() {}
-export function textEmbeddingForSegment() {}
-export function textEmbeddingForDelayedSegment() {}
-export function prepareForSegment() {}
-export function finalizeForSegment() {}
+
+export function pushSegmentFinale() {}
 
 export function writeCompletedRoot(
   destination: Destination,

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -122,7 +122,9 @@ export function pushTextInstance(
   target: Array<Chunk | PrecomputedChunk>,
   text: string,
   responseState: ResponseState,
-): void {
+  // This Renderer does not use this argument
+  textEmbedded: mixed,
+): boolean {
   target.push(
     INSTANCE,
     RAW_TEXT, // Type
@@ -130,6 +132,7 @@ export function pushTextInstance(
     // TODO: props { text: text }
     END, // End of children
   );
+  return false;
 }
 
 export function pushStartInstance(
@@ -156,7 +159,8 @@ export function pushEndInstance(
   target.push(END);
 }
 
-export function pushSegmentFinale() {}
+// In this Renderer this is a noop
+export function pushSegmentFinale(a: mixed, b: mixed, c: mixed, d: mixed) {}
 
 export function writeCompletedRoot(
   destination: Destination,

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -155,13 +155,10 @@ export function pushEndInstance(
 ): void {
   target.push(END);
 }
-
-export function textEmbeddingForBoundarySegment() {
-  return null;
-}
-export function textEmbeddingForSegment() {
-  return null;
-}
+export opaque type TextEmbedding = void;
+export function textEmbeddingForBoundarySegment() {}
+export function textEmbeddingForSegment() {}
+export function textEmbeddingForDelayedSegment() {}
 export function prepareForSegment() {}
 export function finalizeForSegment() {}
 

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -123,7 +123,7 @@ export function pushTextInstance(
   text: string,
   responseState: ResponseState,
   // This Renderer does not use this argument
-  textEmbedded: mixed,
+  textEmbedded: boolean,
 ): boolean {
   target.push(
     INSTANCE,
@@ -160,7 +160,12 @@ export function pushEndInstance(
 }
 
 // In this Renderer this is a noop
-export function pushSegmentFinale(a: mixed, b: mixed, c: mixed, d: mixed) {}
+export function pushSegmentFinale(
+  target: Array<Chunk | PrecomputedChunk>,
+  responseState: ResponseState,
+  lastPushedText: boolean,
+  textEmbedded: boolean,
+): void {}
 
 export function writeCompletedRoot(
   destination: Destination,

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -128,14 +128,7 @@ const ReactNoopServer = ReactFizzServer({
     target.push(POP);
   },
 
-  textEmbeddingForBoundarySegment() {
-    return null;
-  },
-  textEmbeddingForSegment() {
-    return null;
-  },
-  prepareForSegment() {},
-  finalizeForSegment() {},
+  pushSegmentFinale() {},
 
   writeCompletedRoot(
     destination: Destination,

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -128,6 +128,15 @@ const ReactNoopServer = ReactFizzServer({
     target.push(POP);
   },
 
+  textEmbeddingForBoundarySegment() {
+    return null;
+  },
+  textEmbeddingForSegment() {
+    return null;
+  },
+  prepareForSegment() {},
+  finalizeForSegment() {},
+
   writeCompletedRoot(
     destination: Destination,
     responseState: ResponseState,

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -98,12 +98,18 @@ const ReactNoopServer = ReactFizzServer({
     return null;
   },
 
-  pushTextInstance(target: Array<Uint8Array>, text: string): void {
+  pushTextInstance(
+    target: Array<Uint8Array>,
+    text: string,
+    responseState: ResponseState,
+    textEmbedded: boolean,
+  ): boolean {
     const textInstance: TextInstance = {
       text,
       hidden: false,
     };
     target.push(Buffer.from(JSON.stringify(textInstance), 'utf8'), POP);
+    return false;
   },
   pushStartInstance(
     target: Array<Uint8Array>,
@@ -128,7 +134,13 @@ const ReactNoopServer = ReactFizzServer({
     target.push(POP);
   },
 
-  pushSegmentFinale() {},
+  // This is a noop in ReactNoop
+  pushSegmentFinale(
+    target: Array<Uint8Array>,
+    responseState: ResponseState,
+    lastPushedText: boolean,
+    textEmbedded: boolean,
+  ): void {},
 
   writeCompletedRoot(
     destination: Destination,

--- a/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -93,9 +93,7 @@ describe('ReactDOMServerFB', () => {
     await jest.runAllTimers();
 
     const result = readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
-    );
+    expect(result).toMatchInlineSnapshot(`"<div><!--$-->Done<!--/$--></div>"`);
   });
 
   it('should throw an error when an error is thrown at the root', () => {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -60,11 +60,6 @@ import {
   UNINITIALIZED_SUSPENSE_BOUNDARY_ID,
   assignSuspenseBoundaryID,
   getChildFormatContext,
-  textEmbeddingForBoundarySegment,
-  textEmbeddingForSegment,
-  textEmbeddingForDelayedSegment,
-  prepareForSegment,
-  finalizeForSegment,
 } from './ReactServerFormatConfig';
 import {
   constructClassInstance,
@@ -1254,7 +1249,7 @@ function renderNodeDestructive(
   }
 
   if (typeof node === 'string') {
-    let segment = task.blockedSegment;
+    const segment = task.blockedSegment;
     segment.lastPushedText = pushTextInstance(
       task.blockedSegment.chunks,
       node,
@@ -1265,7 +1260,7 @@ function renderNodeDestructive(
   }
 
   if (typeof node === 'number') {
-    let segment = task.blockedSegment;
+    const segment = task.blockedSegment;
     segment.lastPushedText = pushTextInstance(
       task.blockedSegment.chunks,
       '' + node,

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -62,6 +62,7 @@ import {
   getChildFormatContext,
   textEmbeddingForBoundarySegment,
   textEmbeddingForSegment,
+  textEmbeddingForDelayedSegment,
   prepareForSegment,
   finalizeForSegment,
 } from './ReactServerFormatConfig';
@@ -175,7 +176,7 @@ type Segment = {
   // If this segment represents a fallback, this is the content that will replace that fallback.
   +boundary: null | SuspenseBoundary,
   // opaque data that tells the formatter uses to modify output based on how the Segment is embedded in other output
-  +textEmbedding: TextEmbedding,
+  textEmbedding: TextEmbedding,
 };
 
 const OPEN = 0;
@@ -1652,6 +1653,7 @@ function flushSubtree(
       // We're emitting a placeholder for this segment to be filled in later.
       // Therefore we'll need to assign it an ID - to refer to it by.
       const segmentID = (segment.id = request.nextSegmentId++);
+      segment.textEmbedding = textEmbeddingForDelayedSegment();
       return writePlaceholder(destination, request.responseState, segmentID);
     }
     case COMPLETED: {

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -43,6 +43,11 @@ export const pushStartCompletedSuspenseBoundary =
   $$$hostConfig.pushStartCompletedSuspenseBoundary;
 export const pushEndCompletedSuspenseBoundary =
   $$$hostConfig.pushEndCompletedSuspenseBoundary;
+export const textEmbeddingForBoundarySegment =
+  $$$hostConfig.textEmbeddingForBoundarySegment;
+export const textEmbeddingForSegment = $$$hostConfig.textEmbeddingForSegment;
+export const prepareForSegment = $$$hostConfig.prepareForSegment;
+export const finalizeForSegment = $$$hostConfig.finalizeForSegment;
 export const writeCompletedRoot = $$$hostConfig.writeCompletedRoot;
 export const writePlaceholder = $$$hostConfig.writePlaceholder;
 export const writeStartCompletedSuspenseBoundary =

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -45,6 +45,8 @@ export const pushEndCompletedSuspenseBoundary =
   $$$hostConfig.pushEndCompletedSuspenseBoundary;
 export const textEmbeddingForBoundarySegment =
   $$$hostConfig.textEmbeddingForBoundarySegment;
+export const textEmbeddingForDelayedSegment =
+  $$$hostConfig.textEmbeddingForDelayedSegment;
 export const textEmbeddingForSegment = $$$hostConfig.textEmbeddingForSegment;
 export const prepareForSegment = $$$hostConfig.prepareForSegment;
 export const finalizeForSegment = $$$hostConfig.finalizeForSegment;

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -43,13 +43,7 @@ export const pushStartCompletedSuspenseBoundary =
   $$$hostConfig.pushStartCompletedSuspenseBoundary;
 export const pushEndCompletedSuspenseBoundary =
   $$$hostConfig.pushEndCompletedSuspenseBoundary;
-export const textEmbeddingForBoundarySegment =
-  $$$hostConfig.textEmbeddingForBoundarySegment;
-export const textEmbeddingForDelayedSegment =
-  $$$hostConfig.textEmbeddingForDelayedSegment;
-export const textEmbeddingForSegment = $$$hostConfig.textEmbeddingForSegment;
-export const prepareForSegment = $$$hostConfig.prepareForSegment;
-export const finalizeForSegment = $$$hostConfig.finalizeForSegment;
+export const pushSegmentFinale = $$$hostConfig.pushSegmentFinale;
 export const writeCompletedRoot = $$$hostConfig.writeCompletedRoot;
 export const writePlaceholder = $$$hostConfig.writePlaceholder;
 export const writeStartCompletedSuspenseBoundary =


### PR DESCRIPTION
[Fizz] Improve text separator byte efficiency

Previously text separators were inserted following any Text node in Fizz. This increases bytes sent when streaming and in some cases such as title elements these separators are not interpreted as comment nodes and leak into the visual aspects of a page as escaped text.

The reason simple tracking on the last pushed type doesn't work is that Segments can be filled in asynchronously later and so you cannot know in a single pass whether the preceding content was a text node or not. This commit adds a concept of TextEmbedding which provides a best effort signal to Segments on whether they are embedded within text. This allows the later resolution of that Segment to add text separators when possibly necessary but avoid them when they are surely not.

The current implementation can only "peek" head if the segment is a the Root Segment or a Suspense Boundary Segment. In these cases we know there is no trailing text embedding and we can eliminate the separator at the end of the segment if the last emitted element was Text. In normal Segments we cannot peek and thus have to assume there might be a trailing text embedding and we issue a separator defensively. This should be rare in practice as it is assumed most components that will cause segment creation will also emit some markup at the edges.

Another strategy employed is  to take advantage of the two methods by which we get Nodes into the DOM. The method by which we get segment markup into the DOM differs depending on when the Segment resolves.

If a Segment resovles before flushing begins for it's parent it will be emitted inline with the parent markup. In these cases separators may be necessary because they are how we clue the browser into breakup up text into distinct nodes that will later match up with what will be hydrated on the client.

If a Segment resolves after flushing has happened a script will be used to patch up the DOM in the client. when this happens if there are any text nodes on the boundary of the patch they won't be "merged" and thus will continue to have distinct representation as Nodes in the DOM. Thus we can avoid doing any separators at the boudnaries in these cases.

After applying these changes the only time you will get text separators as follows

* in between serial text nodes that emmit at the same time - these are necessary and cannot be eliminated unless we stop relying on the browser to automatically parse the correct text nodes when processing this HTML
* after a final text node in a non-boundary segment that resolves before it's parent has flushed - these are sometimes extraneous, like when the next emitted thing is a non-Text node.

In all other cases text separators should be omitted which means the general byte efficiency of this approach should be pretty good