### PR TITLE
Fix typo in `useSyncExternalStore()` main entry point error

### DIFF
--- a/packages/use-sync-external-store/src/useSyncExternalStore.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStore.js
@@ -22,7 +22,7 @@ if (__DEV__) {
       'it only works with React 18+.' +
       '\n\n' +
       'If you wish to support React 16 and 17, import from ' +
-      "'use-sync-external-store/shim' instead. It will fall back to a shimmed" +
+      "'use-sync-external-store/shim' instead. It will fall back to a shimmed " +
       'implementation when the native one is not available.' +
       '\n\n' +
       "If you only support React 18+, you can import directly from 'react'.",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The error displayed when importing `useSyncExternalStore` directly from `use-sync-external-store` had a missing space between "shimmed" and "implementation".

![image](https://user-images.githubusercontent.com/6137112/170786312-fa7de238-41c8-4781-ae48-1047f7f25911.png)


## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

This code path wasn't tested, I just updated the message.