### PR TITLE
Feat:-Generated aria attributes using an array

### DIFF
--- a/packages/react-dom/src/shared/validAriaProperties.js
+++ b/packages/react-dom/src/shared/validAriaProperties.js
@@ -5,60 +5,66 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const ariaProperties = {
-  'aria-current': 0, // state
-  'aria-description': 0,
-  'aria-details': 0,
-  'aria-disabled': 0, // state
-  'aria-hidden': 0, // state
-  'aria-invalid': 0, // state
-  'aria-keyshortcuts': 0,
-  'aria-label': 0,
-  'aria-roledescription': 0,
+const properties = [
+  'current', // state
+  'description',
+  'details',
+  'disabled', // state
+  'hidden', // state
+  'invalid', // state
+  'keyshortcuts',
+  'label',
+  'roledescription',
   // Widget Attributes
-  'aria-autocomplete': 0,
-  'aria-checked': 0,
-  'aria-expanded': 0,
-  'aria-haspopup': 0,
-  'aria-level': 0,
-  'aria-modal': 0,
-  'aria-multiline': 0,
-  'aria-multiselectable': 0,
-  'aria-orientation': 0,
-  'aria-placeholder': 0,
-  'aria-pressed': 0,
-  'aria-readonly': 0,
-  'aria-required': 0,
-  'aria-selected': 0,
-  'aria-sort': 0,
-  'aria-valuemax': 0,
-  'aria-valuemin': 0,
-  'aria-valuenow': 0,
-  'aria-valuetext': 0,
+  'autocomplete',
+  'checked',
+  'expanded',
+  'haspopup',
+  'level',
+  'modal',
+  'multiline',
+  'multiselectable',
+  'orientation',
+  'placeholder',
+  'pressed',
+  'readonly',
+  'required',
+  'selected',
+  'sort',
+  'valuemax',
+  'valuemin',
+  'valuenow',
+  'valuetext',
   // Live Region Attributes
-  'aria-atomic': 0,
-  'aria-busy': 0,
-  'aria-live': 0,
-  'aria-relevant': 0,
+  'atomic',
+  'busy',
+  'live',
+  'relevant',
   // Drag-and-Drop Attributes
-  'aria-dropeffect': 0,
-  'aria-grabbed': 0,
+  'dropeffect',
+  'grabbed',
   // Relationship Attributes
-  'aria-activedescendant': 0,
-  'aria-colcount': 0,
-  'aria-colindex': 0,
-  'aria-colspan': 0,
-  'aria-controls': 0,
-  'aria-describedby': 0,
-  'aria-errormessage': 0,
-  'aria-flowto': 0,
-  'aria-labelledby': 0,
-  'aria-owns': 0,
-  'aria-posinset': 0,
-  'aria-rowcount': 0,
-  'aria-rowindex': 0,
-  'aria-rowspan': 0,
-  'aria-setsize': 0,
-};
+  'activedescendant',
+  'colcount',
+  'colindex',
+  'colspan',
+  'controls',
+  'describedby',
+  'errormessage',
+  'flowto',
+  'labelledby',
+  'owns',
+  'posinset',
+  'rowcount',
+  'rowindex',
+  'rowspan',
+  'setsize',
+];
+
+const ariaProperties = {};
+
+properties.forEach(property => {
+  ariaProperties['aria-' + property] = 0;
+});
 
 export default ariaProperties;


### PR DESCRIPTION

The aria attribute defined in the file has a large number of duplicate strings, and this PR saves a lot of space.

After the Pr, this is what it looks like

![133935177-77b610f6-1b46-4dab-8885-24645eb5bab0](https://user-images.githubusercontent.com/72331432/170856569-8d225d0c-3675-4622-bbf2-d0a394c9b298.png)



