### PR TITLE
[eslint-plugin-react-hooks] warn on unexpanded object dependencies

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -42,7 +42,9 @@ If you want more fine-grained configuration, you can instead add a snippet like 
   "rules": {
     // ...
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": ["warn", {
+      "avoidObjects": true
+    }]
   }
 }
 ```
@@ -58,7 +60,8 @@ This option accepts a regex to match the names of custom Hooks that have depende
   "rules": {
     // ...
     "react-hooks/exhaustive-deps": ["warn", {
-      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)"
+      "additionalHooks": "(useMyCustomHook|useMyOtherCustomHook)",
+      "avoidObjects": true
     }]
   }
 }

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7475,6 +7475,57 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        function MyComponent(obj) {
+          useEffect(() => {}, [obj]);
+          useLayoutEffect(() => {}, [obj]);
+          useCallback(() => {}, [obj]);
+          useMemo(() => {}, [obj]);
+        }
+      `,
+      // const { value } = query;
+      // console.log(value);
+      errors: [
+        {
+          message:
+            "React Hook useEffect has an object in its dependency array: 'obj'. " +
+            'Non-primitive dependencies may cause the hook to execute unnecessarily. ' +
+            'Consider destructuring the object outside the useEffect call or using ' +
+            'property accessors to refer to primitive values within the dependency ' +
+            'array.',
+          suggestions: undefined,
+        },
+        {
+          message:
+            "React Hook useLayoutEffect has an object in its dependency array: 'obj'. " +
+            'Non-primitive dependencies may cause the hook to execute unnecessarily. ' +
+            'Consider destructuring the object outside the useLayoutEffect call or ' +
+            'using property accessors to refer to primitive values within the ' +
+            'dependency array.',
+          suggestions: undefined,
+        },
+        {
+          message:
+            "React Hook useCallback has an object in its dependency array: 'obj'. " +
+            'Non-primitive dependencies may cause the hook to execute unnecessarily. ' +
+            'Consider destructuring the object outside the useCallback call or ' +
+            'using property accessors to refer to primitive values within the ' +
+            'dependency array.',
+          suggestions: undefined,
+        },
+        {
+          message:
+            "React Hook useMemo has an object in its dependency array: 'obj'. " +
+            'Non-primitive dependencies may cause the hook to execute unnecessarily. ' +
+            'Consider destructuring the object outside the useMemo call or ' +
+            'using property accessors to refer to primitive values within the ' +
+            'dependency array.',
+          suggestions: undefined,
+        },
+      ],
+      options: [{avoidObjects: true}],
+    },
+    {
+      code: normalizeIndent`
         function Foo() {
           const foo = <>Hi!</>;
           useMemo(() => {

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -49,9 +49,7 @@ export default {
         : undefined;
 
     const avoidObjects =
-      context.options &&
-      context.options[0] &&
-      context.options[0].avoidObjects;
+      context.options && context.options[0] && context.options[0].avoidObjects;
 
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
       (context.options &&
@@ -632,7 +630,11 @@ export default {
             return;
           }
           // If we see an object then add a special warning if the avoidObjects option is true.
-          if (declaredDependencyNode.type === 'Identifier' && options && options.avoidObjects) {
+          if (
+            declaredDependencyNode.type === 'Identifier' &&
+            options &&
+            options.avoidObjects
+          ) {
             reportProblem({
               node: declaredDependencyNode,
               message:

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -29,6 +29,9 @@ export default {
           additionalHooks: {
             type: 'string',
           },
+          avoidObjects: {
+            type: 'boolean',
+          },
           enableDangerousAutofixThisMayCauseInfiniteLoops: {
             type: 'boolean',
           },
@@ -45,6 +48,11 @@ export default {
         ? new RegExp(context.options[0].additionalHooks)
         : undefined;
 
+    const avoidObjects =
+      context.options &&
+      context.options[0] &&
+      context.options[0].avoidObjects;
+
     const enableDangerousAutofixThisMayCauseInfiniteLoops =
       (context.options &&
         context.options[0] &&
@@ -53,6 +61,7 @@ export default {
 
     const options = {
       additionalHooks,
+      avoidObjects,
       enableDangerousAutofixThisMayCauseInfiniteLoops,
     };
 
@@ -620,6 +629,20 @@ export default {
         declaredDependenciesNode.elements.forEach(declaredDependencyNode => {
           // Skip elided elements.
           if (declaredDependencyNode === null) {
+            return;
+          }
+          // If we see an object then add a special warning if the avoidObjects option is true.
+          if (declaredDependencyNode.type === 'Identifier' && options && options.avoidObjects) {
+            reportProblem({
+              node: declaredDependencyNode,
+              message:
+                `React Hook ${context.getSource(reactiveHook)} has an object ` +
+                `in its dependency array: '${declaredDependencyNode.name}'. ` +
+                'Non-primitive dependencies may cause the hook to execute ' +
+                'unnecessarily. Consider destructuring the object outside ' +
+                `the ${reactiveHookName} call or using property accessors ` +
+                'to refer to primitive values within the dependency array.',
+            });
             return;
           }
           // If we see a spread element then add a special warning.

--- a/packages/eslint-plugin-react-hooks/src/index.js
+++ b/packages/eslint-plugin-react-hooks/src/index.js
@@ -15,7 +15,9 @@ export const configs = {
     plugins: ['react-hooks'],
     rules: {
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'warn',
+      'react-hooks/exhaustive-deps': ['warn', {
+        'avoidObjects': true,
+      }],
     },
   },
 };

--- a/packages/eslint-plugin-react-hooks/src/index.js
+++ b/packages/eslint-plugin-react-hooks/src/index.js
@@ -15,9 +15,12 @@ export const configs = {
     plugins: ['react-hooks'],
     rules: {
       'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': ['warn', {
-        'avoidObjects': true,
-      }],
+      'react-hooks/exhaustive-deps': [
+        'warn',
+        {
+          avoidObjects: true,
+        },
+      ],
     },
   },
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR expands upon the existing logic which reports functions and constructors defined inside the render function as invalid hook dependencies (#19590) to allowing a developer to receive warning about *any* object present in a dependencies array when an `avoidObjects` option is set to `true` in the `exhaustive-deps` rule.

This is necessary because current rules do not cover the case where an object that will be referentially unique on each render is passed into the component as a parameter and used as a dependency, only objects created within the component.

It has been my experience in code reviews that the referential inequality of objects causing side-effects to execute unnecessarily is a particularly common cause of unnecessary memory use, especially when combined with XHR requests (a common useEffect action). Confoundingly There is no mention of object comparison by referential equality or warning thereto in the React Handbook Hooks API Reference.

This PR aims to provide a flexible way for developers to opt-in to receiving a detailed message regarding potential unintended side effects arising from the use of an object in a dependency array, and tips to resolve the issue (by destructuring or using property accessors - not deep equality checks [as Dan Abramov is on the record against them](https://twitter.com/dan_abramov/status/1104414469629898754?lang=en)).

This is also a feature [that has been requested elsewhere](https://stackoverflow.com/questions/67875833/eslint-rule-for-object-array-dependencies-in-the-react-useeffect-hook).

## How did you test this change?

I created a [derivative implementation](https://github.com/gnowland/eslint-plugin-react-hooks-unreliable-deps), used it in a couple of existing React projects, and wrote tests and ran `yarn test` in this repo.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

```js
interface AnObj {
    prop: string;
}

export const useAddPlotData = (
  obj: AnObj,
) -> {
    useEffect(() => {
       console.log(obj)
    }, [obj]);
}
```
```txt
  10:5   warning  React Hook useEffect has an object in its dependency array: 'obj'. Non-primitive dependencies can result in triggering the callback unnecessarily due to referential equality comparison. Consider destructuring the object outside the useEffect call or using property accessors to refer to primitive values within the dependency array         react-hooks-unreliable-deps/reference-deps
```
![Screen Shot 2022-05-29 at 7 16 34 AM](https://user-images.githubusercontent.com/4430119/170874108-bbb3ffaa-2dd9-4adb-9731-e057b73e8127.png)
