### PR TITLE
[Fizz] deterministic text separators

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -4216,8 +4216,8 @@ describe('ReactDOMFizzServer', () => {
         pipe(writable);
       });
 
-      let helloWorld = '<div>hello<!-- -->world</div>';
-      let testcases = 6;
+      const helloWorld = '<div>hello<!-- -->world</div>';
+      const testcases = 6;
 
       expect(container.firstElementChild.outerHTML).toEqual(
         '<div><!--$-->' +

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -119,9 +119,7 @@ describe('ReactDOMFizzServer', () => {
     expect(isComplete).toBe(true);
 
     const result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
-    );
+    expect(result).toMatchInlineSnapshot(`"<div><!--$-->Done<!--/$--></div>"`);
   });
 
   // @gate experimental

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -161,7 +161,7 @@ describe('ReactDOMFizzServer', () => {
     // Then React starts writing.
     pipe(writable);
     expect(output.result).toMatchInlineSnapshot(
-      `"<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!-- --><!--/$--></div>"`,
+      `"<!doctype html><html><head><title>test</title><head><body><div><!--$-->Done<!--/$--></div>"`,
     );
   });
 

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -280,6 +280,7 @@ function encodeHTMLTextNode(text: string): string {
 
 const textSeparator = stringToPrecomputedChunk('<!-- -->');
 
+// Returns a boolean signifying whether text was actually pushed.
 export function pushTextInstance(
   target: Array<Chunk | PrecomputedChunk>,
   text: string,
@@ -288,26 +289,13 @@ export function pushTextInstance(
 ): boolean {
   if (text === '') {
     // Empty text doesn't have a DOM node representation and the hydration is aware of this.
-    return textEmbedded;
+    return false;
   }
   if (textEmbedded) {
     target.push(textSeparator);
   }
   target.push(stringToChunk(encodeHTMLTextNode(text)));
   return true;
-}
-
-// Called when Fizz is done with a Segment. Currently the only purpose is to conditionally
-// emit a text separator when we don't know for sure it is safe to omit
-export function pushSegmentFinale(
-  target: Array<Chunk | PrecomputedChunk>,
-  responseState: ResponseState,
-  lastPushedText: boolean,
-  textEmbedded: boolean,
-): void {
-  if (lastPushedText && textEmbedded) {
-    target.push(textSeparator);
-  }
 }
 
 const styleNameCache: Map<string, PrecomputedChunk> = new Map();
@@ -1711,6 +1699,13 @@ export function writeEndSegment(
       throw new Error('Unknown insertion mode. This is a bug in React.');
     }
   }
+}
+
+export function writeTextSeparator(
+  destination: Destination,
+  responseState: ResponseState,
+): boolean {
+  return writeChunkAndReturn(destination, textSeparator);
 }
 
 // Instruction Set

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -12,11 +12,11 @@ import type {FormatContext} from './ReactDOMServerFormatConfig';
 import {
   createResponseState as createResponseStateImpl,
   pushTextInstance as pushTextInstanceImpl,
-  pushSegmentFinale as pushSegmentFinaleImpl,
   writeStartCompletedSuspenseBoundary as writeStartCompletedSuspenseBoundaryImpl,
   writeStartClientRenderedSuspenseBoundary as writeStartClientRenderedSuspenseBoundaryImpl,
   writeEndCompletedSuspenseBoundary as writeEndCompletedSuspenseBoundaryImpl,
   writeEndClientRenderedSuspenseBoundary as writeEndClientRenderedSuspenseBoundaryImpl,
+  writeTextSeparator as writeTextSeparatorImpl,
   HTML_MODE,
 } from './ReactDOMServerFormatConfig';
 
@@ -116,24 +116,6 @@ export function pushTextInstance(
   }
 }
 
-export function pushSegmentFinale(
-  target: Array<Chunk | PrecomputedChunk>,
-  responseState: ResponseState,
-  lastPushedText: boolean,
-  textEmbedded: boolean,
-): void {
-  if (responseState.generateStaticMarkup) {
-    return;
-  } else {
-    return pushSegmentFinaleImpl(
-      target,
-      responseState,
-      lastPushedText,
-      textEmbedded,
-    );
-  }
-}
-
 export function writeStartCompletedSuspenseBoundary(
   destination: Destination,
   responseState: ResponseState,
@@ -176,4 +158,13 @@ export function writeEndClientRenderedSuspenseBoundary(
     return true;
   }
   return writeEndClientRenderedSuspenseBoundaryImpl(destination, responseState);
+}
+export function writeTextSeparator(
+  destination: Destination,
+  responseState: ResponseState,
+): boolean {
+  if (responseState.generateStaticMarkup) {
+    return true;
+  }
+  return writeTextSeparatorImpl(destination, responseState);
 }

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -159,14 +159,6 @@ export function pushEndInstance(
   target.push(END);
 }
 
-// In this Renderer this is a noop
-export function pushSegmentFinale(
-  target: Array<Chunk | PrecomputedChunk>,
-  responseState: ResponseState,
-  lastPushedText: boolean,
-  textEmbedded: boolean,
-): void {}
-
 export function writeCompletedRoot(
   destination: Destination,
   responseState: ResponseState,
@@ -266,6 +258,12 @@ export function writeEndSegment(
   formatContext: FormatContext,
 ): boolean {
   return writeChunkAndReturn(destination, END);
+}
+export function writeTextSeparator(
+  destination: Destination,
+  responseState: ResponseState,
+): boolean {
+  return true;
 }
 
 // Instruction Set

--- a/packages/react-noop-renderer/src/ReactNoopServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopServer.js
@@ -134,14 +134,6 @@ const ReactNoopServer = ReactFizzServer({
     target.push(POP);
   },
 
-  // This is a noop in ReactNoop
-  pushSegmentFinale(
-    target: Array<Uint8Array>,
-    responseState: ResponseState,
-    lastPushedText: boolean,
-    textEmbedded: boolean,
-  ): void {},
-
   writeCompletedRoot(
     destination: Destination,
     responseState: ResponseState,
@@ -219,6 +211,8 @@ const ReactNoopServer = ReactFizzServer({
   writeEndSegment(destination: Destination, formatContext: null): boolean {
     destination.stack.pop();
   },
+
+  writeTextSeparator(destination: Destination, responseState: ResponseState) {},
 
   writeCompletedSegmentInstruction(
     destination: Destination,

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -179,7 +179,7 @@ type Segment = {
   // used to discern when text separator boundaries are needed
   preEdge: SegmentEdge,
   leadEdge: SegmentEdge,
-  trailEdge: SegmentEdge,
+  currentEdge: SegmentEdge,
   postEdge: SegmentEdge,
 };
 
@@ -1793,7 +1793,7 @@ function flushSegmentInline(
 
     // We might have emitted Text or Nodes since the last segment to flush. set the value accordingly or
     // retain the existing value if no Edges were emitted
-    let precedingEdge = segment.preEdge;
+    const precedingEdge = segment.preEdge;
     lastText =
       precedingEdge === TEXT_EDGE
         ? true
@@ -1808,7 +1808,7 @@ function flushSegmentInline(
 
     // We might have emitted Text or Nodes following this segment. set the value accordingly or
     // retain teh existing valeu if no Edges were emitted
-    let lastEdge = segment.currentEdge;
+    const lastEdge = segment.currentEdge;
     lastText =
       lastEdge === TEXT_EDGE ? true : lastEdge === NODE_EDGE ? false : lastText;
     if (parentFlushed === false && lastText && segment.postEdge === TEXT_EDGE) {

--- a/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
+++ b/packages/react-server/src/forks/ReactServerFormatConfig.custom.js
@@ -43,7 +43,6 @@ export const pushStartCompletedSuspenseBoundary =
   $$$hostConfig.pushStartCompletedSuspenseBoundary;
 export const pushEndCompletedSuspenseBoundary =
   $$$hostConfig.pushEndCompletedSuspenseBoundary;
-export const pushSegmentFinale = $$$hostConfig.pushSegmentFinale;
 export const writeCompletedRoot = $$$hostConfig.writeCompletedRoot;
 export const writePlaceholder = $$$hostConfig.writePlaceholder;
 export const writeStartCompletedSuspenseBoundary =
@@ -60,6 +59,7 @@ export const writeEndClientRenderedSuspenseBoundary =
   $$$hostConfig.writeEndClientRenderedSuspenseBoundary;
 export const writeStartSegment = $$$hostConfig.writeStartSegment;
 export const writeEndSegment = $$$hostConfig.writeEndSegment;
+export const writeTextSeparator = $$$hostConfig.writeTextSeparator;
 export const writeCompletedSegmentInstruction =
   $$$hostConfig.writeCompletedSegmentInstruction;
 export const writeCompletedBoundaryInstruction =


### PR DESCRIPTION
This change addresses two related flaws in the current approach to text separators in Fizz.

First text separators can be emitted more often than necessary. This is because Segments don't know whether they will be followed by text and so if they end in text they assume they are and insert a separators

Second, because of the flaw above, Fizz output is not deterministic. If you wait for everything to be ready before flushing you could still end up with different output depending on whether certain segments are created or rendered inline based on the particular behavior of Suspendable components for any given run. If a Segment emits an unnecessary text separator in one pass and in another the Segment is never created because that Component did not Suspend the string output would differ for otherwise identical content

This change fixes both issues by decorating Segments with additional metadata about what kinds of emitted content is at it's bounds. These are called Edges and can be NODE, TEXT, or a Segment. NODE and TEXT are type identifiers that refer generically to these mutually exclusive concepts. if an edge is a Segment however it is the actual reference to the Segment object, which allows us to make inferences at flushing time as to whether additional text separators are needed.

There are 2 tracked edges per Segment

currentEdge - a pointer to type of the prior thing emitted for a Segment. If the segment has not yet been worked on this will be the Edge just before the Segment start. If the Segment is currently being rendered it will be the type or reference of the last thing this Segment emitted. If the Segment is complete it definitionally be the trailing edge of the Segment representing the type emitted at the boundary.

followingEdge - this edge is set by later Segments when the currentEdge of that segment is a Segment. If the currentEdge is a Segment and a new Edge is identified it is saved to the followingEdge of the currentEdge segment.

Finally, when flushing 2 things happen

If the just written Segment ends with text (currentEdge is TEXT_NODE) and if the followingEdge is also text, then a separator is written in between. If the followingEdge is instead another Completed Segment this segment is empty and we walk to that Segment's followingEdge and continue looking for Text.