### PR TITLE
Explicitly set `highWaterMark` to 0 for `ReadableStream`

### DIFF
--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -53,15 +53,21 @@ function renderToReadableStream(
     });
 
     function onShellReady() {
-      const stream: ReactDOMServerReadableStream = (new ReadableStream({
-        type: 'bytes',
-        pull(controller) {
-          startFlowing(request, controller);
+      const stream: ReactDOMServerReadableStream = (new ReadableStream(
+        {
+          type: 'bytes',
+          pull(controller) {
+            startFlowing(request, controller);
+          },
+          cancel(reason) {
+            abort(request);
+          },
         },
-        cancel(reason) {
-          abort(request);
+        {
+          highWaterMark: 0,
+          size: () => 1,
         },
-      }): any);
+      ): any);
       // TODO: Move to sub-classing ReadableStream.
       stream.allReady = allReady;
       resolve(stream);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -33,16 +33,22 @@ function renderToReadableStream(
     options ? options.onError : undefined,
     context,
   );
-  const stream = new ReadableStream({
-    type: 'bytes',
-    start(controller) {
-      startWork(request);
+  const stream = new ReadableStream(
+    {
+      type: 'bytes',
+      start(controller) {
+        startWork(request);
+      },
+      pull(controller) {
+        startFlowing(request, controller);
+      },
+      cancel(reason) {},
     },
-    pull(controller) {
-      startFlowing(request, controller);
+    {
+      highWaterMark: 0,
+      size: () => 1,
     },
-    cancel(reason) {},
-  });
+  );
   return stream;
 }
 


### PR DESCRIPTION
## Summary

This is because not all streaming implementations (e.g. Cloudflare) respect the default behavior of settings `highWaterMark` to 0 for byte streams: https://github.com/facebook/react/commit/75662d6a7d135df9d10055f49c3a4ca09fe4efcc 

Being explicit guarantees the intended behavior across runtimes. Cloudflare is working on fixing this in their implementation in the meantime.

## How did you test this change?

- Added the `highWaterMark` manually in the compiled source code
- Deployed to e.g. Cloudflare and observed the intended results
