### PR TITLE
[DevTools] Modify DevTools e2e test script for regression tests

### DIFF
--- a/scripts/circleci/run_devtools_e2e_tests.js
+++ b/scripts/circleci/run_devtools_e2e_tests.js
@@ -6,7 +6,7 @@ const {spawn} = require('child_process');
 const {join} = require('path');
 
 const ROOT_PATH = join(__dirname, '..', '..');
-
+const reactVersion = process.argv[2];
 const inlinePackagePath = join(ROOT_PATH, 'packages', 'react-devtools-inline');
 const shellPackagePath = join(ROOT_PATH, 'packages', 'react-devtools-shell');
 
@@ -74,7 +74,15 @@ function runTestShell() {
 
   logBright('Starting testing shell server');
 
-  serverProcess = spawn('yarn', ['start'], {cwd: shellPackagePath});
+  if (!reactVersion) {
+    serverProcess = spawn('yarn', ['start'], {cwd: shellPackagePath});
+  } else {
+    serverProcess = spawn('yarn', ['start'], {
+      cwd: shellPackagePath,
+      env: {...process.env, REACT_VERSION: reactVersion},
+    });
+  }
+
   serverProcess.stdout.on('data', data => {
     if (`${data}`.includes('Compiled successfully.')) {
       logBright('Testing shell server running');
@@ -106,8 +114,15 @@ function runTestShell() {
 
 async function runEndToEndTests() {
   logBright('Running e2e tests');
+  if (!reactVersion) {
+    testProcess = spawn('yarn', ['test:e2e'], {cwd: inlinePackagePath});
+  } else {
+    testProcess = spawn('yarn', ['test:e2e'], {
+      cwd: inlinePackagePath,
+      env: {...process.env, REACT_VERSION: reactVersion},
+    });
+  }
 
-  testProcess = spawn('yarn', ['test:e2e'], {cwd: inlinePackagePath});
   testProcess.stdout.on('data', data => {
     // Log without formatting because Playwright applies its own formatting.
     const formatted = format(data);


### PR DESCRIPTION
Modified the `run_devtools_e2e_tests` script so that you can pass in a React version. If you pass in a version, it will build the DevTools shell and run the e2e tests with that version.