### PR TITLE
[DevTools] devtools-test-shell Regression App fixes

### DIFF
--- a/packages/react-devtools-shell/src/e2e-regression/app.js
+++ b/packages/react-devtools-shell/src/e2e-regression/app.js
@@ -22,4 +22,10 @@ function mountTestApp() {
 mountTestApp();
 
 // ReactDOM Test Selector APIs used by Playwright e2e tests
-window.parent.REACT_DOM_APP = ReactDOM;
+// If they don't exist, we mock them
+window.parent.REACT_DOM_APP = {
+  createTestNameSelector: name => `[data-testname="${name}"]`,
+  findAllNodes: (container, nodes) =>
+    container.querySelectorAll(nodes.join(' ')),
+  ...ReactDOM,
+};

--- a/packages/react-devtools-shell/webpack.config.js
+++ b/packages/react-devtools-shell/webpack.config.js
@@ -193,7 +193,7 @@ const e2eRegressionApp = semver.lt(REACT_VERSION, '18.0.0')
       {
         react: resolve(E2E_APP_BUILD_DIR, 'react'),
         'react-dom': resolve(E2E_APP_BUILD_DIR, 'react-dom'),
-        'react-dom/client': resolve(E2E_APP_BUILD_DIR, 'react-dom'),
+        'react-dom/client': resolve(E2E_APP_BUILD_DIR, 'react-dom/client'),
         scheduler: resolve(E2E_APP_BUILD_DIR, 'scheduler'),
       },
     );


### PR DESCRIPTION
Made a couple of fixes to the `devtools-test-shell`
* test selectors aren't available in > React v18.0 either, so we'll need to mock the test selector functions there as well
* `react-dom/client` should map to `react-dom/client` and not `react-dom`