### PR TITLE
[DevTools] find best renderer when inspecting

### DIFF
--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -332,7 +332,12 @@ export default class Agent extends EventEmitter<{|
   getIDForNode(node: Object): number | null {
     const rendererInterface = this.getBestMatchingRendererInterface(node);
     if (rendererInterface != null) {
-      return rendererInterface.getFiberIDForNative(node, true);
+      try {
+        return rendererInterface.getFiberIDForNative(node, true);
+      } catch (error) {
+        // Some old React versions might throw if they can't find a match.
+        // If so we should ignore it...
+      }
     }
     return null;
   }

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -316,16 +316,16 @@ export default class Agent extends EventEmitter<{|
         (rendererID: any)
       ]: any): RendererInterface);
       const fiber = renderer.getFiberForNative(node);
-      if (fiber != null) {
+      if (fiber !== null) {
         // check if fiber.stateNode is matching the original hostInstance
         if (fiber.stateNode === node) {
           return renderer;
-        } else {
+        } else if (bestMatch === null) {
           bestMatch = renderer;
         }
       }
     }
-    // if an exact match is not found, return the best match as fallback
+    // if an exact match is not found, return the first valid renderer as fallback
     return bestMatch;
   }
 
@@ -333,14 +333,6 @@ export default class Agent extends EventEmitter<{|
     const rendererInterface = this.getBestMatchingRendererInterface(node);
     if (rendererInterface != null) {
       return rendererInterface.getFiberIDForNative(node, true);
-    }
-    return null;
-  }
-
-  getDisplayNameForNode(node: Object): string | null {
-    const rendererInterface = this.getBestMatchingRendererInterface(node);
-    if (rendererInterface != null) {
-      return rendererInterface.getDisplayNameForFiberID(node, true);
     }
     return null;
   }

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -40,6 +40,7 @@ import {decorateMany, forceUpdate, restoreMany} from './utils';
 import type {
   DevToolsHook,
   GetFiberIDForNative,
+  GetFiberForNative,
   InspectedElementPayload,
   InstanceAndStyle,
   NativeType,
@@ -148,6 +149,10 @@ export function attach(
 
   let getInternalIDForNative: GetFiberIDForNative = ((null: any): GetFiberIDForNative);
   let findNativeNodeForInternalID: (id: number) => ?NativeType;
+  let getFiberForNative: GetFiberForNative = (node) => {
+    // Not implemented.
+    return null;
+  };
 
   if (renderer.ComponentTree) {
     getInternalIDForNative = (node, findNearestUnfilteredAncestor) => {
@@ -159,6 +164,11 @@ export function attach(
     findNativeNodeForInternalID = (id: number) => {
       const internalInstance = idToInternalInstanceMap.get(id);
       return renderer.ComponentTree.getNodeFromInstance(internalInstance);
+    };
+    getFiberForNative = (node) => {
+      return renderer.ComponentTree.getClosestInstanceFromNode(
+        node,
+      );
     };
   } else if (renderer.Mount.getID && renderer.Mount.getNode) {
     getInternalIDForNative = (node, findNearestUnfilteredAncestor) => {
@@ -1083,11 +1093,6 @@ export function attach(
   function patchConsoleForStrictMode() {}
 
   function unpatchConsoleForStrictMode() {}
-
-  function getFiberForNative() {
-    // Not implemented
-    return null;
-  }
 
   return {
     clearErrorsAndWarnings,

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -40,7 +40,6 @@ import {decorateMany, forceUpdate, restoreMany} from './utils';
 import type {
   DevToolsHook,
   GetFiberIDForNative,
-  GetFiberForNative,
   InspectedElementPayload,
   InstanceAndStyle,
   NativeType,
@@ -149,7 +148,7 @@ export function attach(
 
   let getInternalIDForNative: GetFiberIDForNative = ((null: any): GetFiberIDForNative);
   let findNativeNodeForInternalID: (id: number) => ?NativeType;
-  let getFiberForNative: GetFiberForNative = node => {
+  let getFiberForNative = (node: NativeType) => {
     // Not implemented.
     return null;
   };
@@ -165,7 +164,7 @@ export function attach(
       const internalInstance = idToInternalInstanceMap.get(id);
       return renderer.ComponentTree.getNodeFromInstance(internalInstance);
     };
-    getFiberForNative = node => {
+    getFiberForNative = (node: NativeType) => {
       return renderer.ComponentTree.getClosestInstanceFromNode(node);
     };
   } else if (renderer.Mount.getID && renderer.Mount.getNode) {

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -1084,6 +1084,11 @@ export function attach(
 
   function unpatchConsoleForStrictMode() {}
 
+  function getFiberForNative() {
+    // Not implemented
+    return null;
+  }
+
   return {
     clearErrorsAndWarnings,
     clearErrorsForFiberID,
@@ -1094,6 +1099,7 @@ export function attach(
     flushInitialOperations,
     getBestMatchForTrackedPath,
     getDisplayNameForFiberID,
+    getFiberForNative,
     getFiberIDForNative: getInternalIDForNative,
     getInstanceAndStyle,
     findNativeNodesForFiberID: (id: number) => {

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -149,7 +149,7 @@ export function attach(
 
   let getInternalIDForNative: GetFiberIDForNative = ((null: any): GetFiberIDForNative);
   let findNativeNodeForInternalID: (id: number) => ?NativeType;
-  let getFiberForNative: GetFiberForNative = (node) => {
+  let getFiberForNative: GetFiberForNative = node => {
     // Not implemented.
     return null;
   };
@@ -165,10 +165,8 @@ export function attach(
       const internalInstance = idToInternalInstanceMap.get(id);
       return renderer.ComponentTree.getNodeFromInstance(internalInstance);
     };
-    getFiberForNative = (node) => {
-      return renderer.ComponentTree.getClosestInstanceFromNode(
-        node,
-      );
+    getFiberForNative = node => {
+      return renderer.ComponentTree.getClosestInstanceFromNode(node);
     };
   } else if (renderer.Mount.getID && renderer.Mount.getNode) {
     getInternalIDForNative = (node, findNearestUnfilteredAncestor) => {

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2818,6 +2818,10 @@ export function attach(
     return fiber != null ? getDisplayNameForFiber(((fiber: any): Fiber)) : null;
   }
 
+  function getFiberForNative(hostInstance) {
+    return renderer.findFiberByHostInstance(hostInstance);
+  }
+
   function getFiberIDForNative(
     hostInstance,
     findNearestUnfilteredAncestor = false,
@@ -4490,6 +4494,7 @@ export function attach(
     flushInitialOperations,
     getBestMatchForTrackedPath,
     getDisplayNameForFiberID,
+    getFiberForNative,
     getFiberIDForNative,
     getInstanceAndStyle,
     getOwnersList,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -81,6 +81,9 @@ export type GetFiberIDForNative = (
   component: NativeType,
   findNearestUnfilteredAncestor?: boolean,
 ) => number | null;
+export type GetFiberForNative = (
+  component: NativeType,
+) => Fiber | null;
 export type FindNativeNodesForFiberID = (id: number) => ?Array<NativeType>;
 
 export type ReactProviderType<T> = {
@@ -93,7 +96,7 @@ export type Lane = number;
 export type Lanes = number;
 
 export type ReactRenderer = {
-  findFiberByHostInstance: (hostInstance: NativeType) => ?Fiber,
+  findFiberByHostInstance: (hostInstance: NativeType) => Fiber | null,
   version: string,
   rendererPackageName: string,
   bundleType: BundleType,
@@ -350,7 +353,7 @@ export type RendererInterface = {
   findNativeNodesForFiberID: FindNativeNodesForFiberID,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,
-  getFiberForNative: (hostInstance: NativeType) => ?Fiber,
+  getFiberForNative: GetFiberForNative,
   getFiberIDForNative: GetFiberIDForNative,
   getDisplayNameForFiberID: GetDisplayNameForFiberID,
   getInstanceAndStyle(id: number): InstanceAndStyle,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -81,9 +81,7 @@ export type GetFiberIDForNative = (
   component: NativeType,
   findNearestUnfilteredAncestor?: boolean,
 ) => number | null;
-export type GetFiberForNative = (
-  component: NativeType,
-) => Fiber | null;
+export type GetFiberForNative = (component: NativeType) => Fiber | null;
 export type FindNativeNodesForFiberID = (id: number) => ?Array<NativeType>;
 
 export type ReactProviderType<T> = {

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -81,7 +81,6 @@ export type GetFiberIDForNative = (
   component: NativeType,
   findNearestUnfilteredAncestor?: boolean,
 ) => number | null;
-export type GetFiberForNative = (component: NativeType) => Fiber | null;
 export type FindNativeNodesForFiberID = (id: number) => ?Array<NativeType>;
 
 export type ReactProviderType<T> = {
@@ -351,7 +350,7 @@ export type RendererInterface = {
   findNativeNodesForFiberID: FindNativeNodesForFiberID,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,
-  getFiberForNative: GetFiberForNative,
+  getFiberForNative: (component: NativeType) => Fiber | null,
   getFiberIDForNative: GetFiberIDForNative,
   getDisplayNameForFiberID: GetDisplayNameForFiberID,
   getInstanceAndStyle(id: number): InstanceAndStyle,

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -350,6 +350,7 @@ export type RendererInterface = {
   findNativeNodesForFiberID: FindNativeNodesForFiberID,
   flushInitialOperations: () => void,
   getBestMatchForTrackedPath: () => PathMatch | null,
+  getFiberForNative: (hostInstance: NativeType) => ?Fiber,
   getFiberIDForNative: GetFiberIDForNative,
   getDisplayNameForFiberID: GetDisplayNameForFiberID,
   getInstanceAndStyle(id: number): InstanceAndStyle,

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -274,24 +274,3 @@ export function isSynchronousXHRSupported(): boolean {
     window.document.featurePolicy.allowsFeature('sync-xhr')
   );
 }
-
-export function getBestMatchingRendererInterface(
-  rendererInterfaces: Iterable<RendererInterface>,
-  node: Object,
-): RendererInterface | null {
-  let bestMatch = null;
-  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-  for (const renderer of rendererInterfaces) {
-    const fiber = renderer.getFiberForNative(node);
-    if (fiber != null) {
-      // check if fiber.stateNode is matching the original hostInstance
-      if (fiber.stateNode === node) {
-        return renderer;
-      } else {
-        bestMatch = renderer;
-      }
-    }
-  }
-  // if an exact match is not found, return the best match as fallback
-  return bestMatch;
-}

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -11,6 +11,7 @@
 import {copy} from 'clipboard-js';
 import {dehydrate} from '../hydration';
 import isArray from 'shared/isArray';
+import type {RendererInterface} from './types';
 
 import type {DehydratedData} from 'react-devtools-shared/src/devtools/views/Components/types';
 
@@ -272,4 +273,24 @@ export function isSynchronousXHRSupported(): boolean {
     window.document.featurePolicy &&
     window.document.featurePolicy.allowsFeature('sync-xhr')
   );
+}
+
+export function getBestMatchingRendererInterface(
+  rendererInterfaces: Iterable<RendererInterface>,
+  node: Object,
+): RendererInterface | null {
+  let bestMatch = null;
+  for (const renderer of rendererInterfaces) {
+    const fiber = renderer.getFiberForNative(node);
+    if (fiber != null) {
+      // check if fiber.stateNode is matching the original hostInstance
+      if (fiber.stateNode === node) {
+        return renderer;
+      } else {
+        bestMatch = renderer;
+      }
+    }
+  }
+  // if an exact match is not found, return the best match as fallback
+  return bestMatch;
 }

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -280,6 +280,7 @@ export function getBestMatchingRendererInterface(
   node: Object,
 ): RendererInterface | null {
   let bestMatch = null;
+  // eslint-disable-next-line no-for-of-loops/no-for-of-loops
   for (const renderer of rendererInterfaces) {
     const fiber = renderer.getFiberForNative(node);
     if (fiber != null) {

--- a/packages/react-devtools-shared/src/backend/utils.js
+++ b/packages/react-devtools-shared/src/backend/utils.js
@@ -11,7 +11,6 @@
 import {copy} from 'clipboard-js';
 import {dehydrate} from '../hydration';
 import isArray from 'shared/isArray';
-import type {RendererInterface} from './types';
 
 import type {DehydratedData} from 'react-devtools-shared/src/devtools/views/Components/types';
 

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Highlighter.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Highlighter.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type Agent from 'react-devtools-shared/src/backend/agent';
+
 import Overlay from './Overlay';
 
 const SHOW_DURATION = 2000;
@@ -26,6 +28,7 @@ export function hideOverlay() {
 export function showOverlay(
   elements: Array<HTMLElement> | null,
   componentName: string | null,
+  agent: Agent,
   hideAfterTimeout: boolean,
 ) {
   // TODO (npm-packages) Detect RN and support it somehow
@@ -42,7 +45,7 @@ export function showOverlay(
   }
 
   if (overlay === null) {
-    overlay = new Overlay();
+    overlay = new Overlay(agent);
   }
 
   overlay.inspect(elements, componentName);

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -233,10 +233,15 @@ export default class Overlay {
       name = elements[0].nodeName.toLowerCase();
 
       const node = elements[0];
-      const ownerName = this.agent.getDisplayNameForNode(node);
-
-      if (ownerName) {
-        name += ' (in ' + ownerName + ')';
+      const rendererInterface = this.agent.getBestMatchingRendererInterface(node);
+      if (rendererInterface) {
+        const id = rendererInterface.getFiberIDForNative(node, true);
+        if (id) {
+          const ownerName = rendererInterface.getDisplayNameForFiberID(id, true);
+          if (ownerName) {
+            name += ' (in ' + ownerName + ')';
+          }
+        }
       }
     }
 

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -8,6 +8,7 @@
  */
 
 import {getElementDimensions, getNestedBoundingClientRect} from '../utils';
+import {getBestMatchingRendererInterface} from '../../utils';
 
 const assign = Object.assign;
 
@@ -233,13 +234,15 @@ export default class Overlay {
       const hook: DevToolsHook =
         node.ownerDocument.defaultView.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       if (hook != null && hook.rendererInterfaces != null) {
+        const rendererInterface = getBestMatchingRendererInterface(
+          hook.rendererInterfaces.values(),
+          node,
+        );
         let ownerName = null;
-        // eslint-disable-next-line no-for-of-loops/no-for-of-loops
-        for (const rendererInterface of hook.rendererInterfaces.values()) {
+        if (rendererInterface !== null) {
           const id = rendererInterface.getFiberIDForNative(node, true);
           if (id !== null) {
             ownerName = rendererInterface.getDisplayNameForFiberID(id, true);
-            break;
           }
         }
 

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -233,11 +233,16 @@ export default class Overlay {
       name = elements[0].nodeName.toLowerCase();
 
       const node = elements[0];
-      const rendererInterface = this.agent.getBestMatchingRendererInterface(node);
+      const rendererInterface = this.agent.getBestMatchingRendererInterface(
+        node,
+      );
       if (rendererInterface) {
         const id = rendererInterface.getFiberIDForNative(node, true);
         if (id) {
-          const ownerName = rendererInterface.getDisplayNameForFiberID(id, true);
+          const ownerName = rendererInterface.getDisplayNameForFiberID(
+            id,
+            true,
+          );
           if (ownerName) {
             name += ' (in ' + ownerName + ')';
           }

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -118,7 +118,7 @@ export default function setupHighlighter(
         node.scrollIntoView({block: 'nearest', inline: 'nearest'});
       }
 
-      showOverlay(nodes, displayName, hideAfterTimeout);
+      showOverlay(nodes, displayName, agent, hideAfterTimeout);
 
       if (openNativeElementsPanel) {
         window.__REACT_DEVTOOLS_GLOBAL_HOOK__.$0 = node;
@@ -171,7 +171,7 @@ export default function setupHighlighter(
 
     // Don't pass the name explicitly.
     // It will be inferred from DOM tag and Fiber owner.
-    showOverlay([target], null, false);
+    showOverlay([target], null, agent, false);
 
     selectFiberForNode(target);
   }


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
resolves #24539

When inspecting with DevTools, originally we use the first renderer where we can found a fiber with inspected element. However, if two or more renderers are nested (see the example in the issue #24539), this might cause a mismatch. 
In this PR, we now always go through all renderers until we find an exact match (where the inspected element is exactly the same `stateNode` linked to the fiber). If we cannot find an exact match, we fallback to the original logic and return a renderer where we find a non-exact matching fiber.

## How did you test this change?

I built the extension and tested with the same URL the issue author provided. You can see the inspecting tool can now correctly select the "MicroFeRoot" node (and the element inside)

https://user-images.githubusercontent.com/1001890/171740973-c1b546b0-5269-40fa-b0b9-bf04dd7ddd52.mov


