### PR TITLE
Allow aritfacts download even if CI is broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           command: |
               git fetch origin main
               cd ./scripts/release && yarn && cd ../../
-              scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/main)
+              scripts/release/download-experimental-build.js --commit=$(git merge-base HEAD origin/main) --allowBrokenCI
               mv ./build ./base-build
       - run:
           # TODO: The `download-experimental-build` script copies the npm
@@ -570,7 +570,7 @@ workflows:
                 - "16.0"
                 - "16.5" # schedule package
                 - "16.8" # hooks
-                - "17.0" 
+                - "17.0"
                 - "18.0"
       - run_devtools_e2e_tests_for_versions:
           requires:
@@ -581,7 +581,7 @@ workflows:
                 - "16.0"
                 - "16.5" # schedule package
                 - "16.8" # hooks
-                - "17.0" 
+                - "17.0"
                 - "18.0"
 
   # Used to publish a prerelease manually via the command line

--- a/scripts/release/shared-commands/get-build-id-for-commit.js
+++ b/scripts/release/shared-commands/get-build-id-for-commit.js
@@ -15,7 +15,7 @@ function scrapeBuildIDFromStatus(status) {
   return /\/facebook\/react\/([0-9]+)/.exec(status.target_url)[1];
 }
 
-async function getBuildIdForCommit(sha) {
+async function getBuildIdForCommit(sha, allowBrokenCI = false) {
   const retryLimit = Date.now() + RETRY_TIMEOUT;
   retry: while (true) {
     const statusesResponse = await fetch(
@@ -34,7 +34,7 @@ async function getBuildIdForCommit(sha) {
     }
 
     const {statuses, state} = await statusesResponse.json();
-    if (state === 'failure') {
+    if (!allowBrokenCI && state === 'failure') {
       throw new Error(`Base commit is broken: ${sha}`);
     }
     for (let i = 0; i < statuses.length; i++) {

--- a/scripts/release/shared-commands/parse-params.js
+++ b/scripts/release/shared-commands/parse-params.js
@@ -34,6 +34,13 @@ const paramDefinitions = [
     type: String,
     description: 'Release channel (stable, experimental, or latest)',
   },
+  {
+    name: 'allowBrokenCI',
+    type: Boolean,
+    description:
+      'Continue even if CI is failing. Useful if you need to debug a broken build.',
+    defaultValue: false,
+  },
 ];
 
 module.exports = async () => {
@@ -61,7 +68,7 @@ module.exports = async () => {
   try {
     if (params.build === null) {
       params.build = await logPromise(
-        getBuildIdForCommit(params.commit),
+        getBuildIdForCommit(params.commit, params.allowBrokenCI),
         theme`Getting build ID for commit "${params.commit}"`
       );
     }


### PR DESCRIPTION
Adds an option to the download script to disable the CI check and continue downloading the artifacts even if CI is broken. I often rely on this to debug broken build artifacts.

I also updated sizebot to use this new option. Sizebot works by downloading the build artifacts for the base revision and comparing the file sizes, but the download script will fail if the base revision has a failing CI job. This happens more often than it should because of flaky cron jobs, but even when it does, we shouldn't let it affect sizebot — for the purposes of tracking sizes, it doesn't really matter whether the base revision is broken.