### PR TITLE
Track revs that intentionally fork the reconciler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
           name: Confirm reconciler forks are the same
           command: |
             yarn replace-fork
-            git diff --quiet || (echo "Reconciler forks are not the same! Run yarn replace-fork. Or, if this was intentional, disable this CI check." && false)
+            git diff --quiet || (echo "Reconciler forks are not the same! Run yarn replace-fork. Or, if this was intentional, add the commit SHA to scripts/merge-fork/forked-revisions." && false)
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,19 @@ jobs:
       - run: yarn workspaces info | head -n -1 > workspace_info.txt
       - *restore_node_modules
       - run:
+          name: Fetch revisions that contain an intentional fork
+          # This will fetch each revision listed in the `forked-revisions` file,
+          # which may be necessary if it's not part of main. For example, it
+          # may have been part of a PR branch that was squashed on merge.
+          command: |
+            cut -d " " -f 1 scripts/merge-fork/forked-revisions | xargs -r git fetch origin
+      - run:
+          name: Revert forked revisions
+          # This will revert the changes without committing. At the end, it's
+          # expected that both forks will be identical.
+          command: |
+            cut -d " " -f 1 scripts/merge-fork/forked-revisions | xargs -r git revert --no-commit
+      - run:
           name: Confirm reconciler forks are the same
           command: |
             yarn replace-fork

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -7,9 +7,6 @@
  * @flow
  */
 
-// Intentional divergence between "old" and "new" reconciler files to see
-// if CI detects it.
-
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.new';

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -7,6 +7,9 @@
  * @flow
  */
 
+// Intentional divergence between "old" and "new" reconciler files to see
+// if CI detects it.
+
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.new';

--- a/scripts/merge-fork/forked-revisions
+++ b/scripts/merge-fork/forked-revisions
@@ -1,0 +1,1 @@
+f230ea9e9d1ffb1265e08e2d12eaed2e63d8cba0              [TEST] Add trivial divergence between forks

--- a/scripts/merge-fork/forked-revisions
+++ b/scripts/merge-fork/forked-revisions
@@ -1,1 +1,0 @@
-f230ea9e9d1ffb1265e08e2d12eaed2e63d8cba0              [TEST] Add trivial divergence between forks


### PR DESCRIPTION
Just an idea I had to improve the reconciler fork infra a bit, as I consider using it again for an ongoing refactor. Opening for discussion purposes.

---

When we fork the the "old" and "new" reconciler implementations, it can be difficult to keep track of which commits introduced the delta in behavior. This makes bisecting difficult if one of the changes introduces a bug.

I've added a new file called `forked-revisions` that contains the list of commits that intentionally forked the reconcilers.

In CI, we'll confirm that the reconcilers are identical except for the changes in the listed revisions. This also ensures that the revisions can be cleanly reverted.

## Test Plan

- In this PR, I made a trivial fork to the reconciler. This caused CI to fail.
- In the next commit, I added the previous revision to the list of forked revisions. This fixed CI.
- Then I reverted both temporary commits.

This shows that introducing an intentional fork in behavior always requires at least two commits: one to make the change, another to add that commit's SHA to the list of revisions. You can squash the commits when merging to main, though: as long as the revision was pushed to GitHub, it doesn't matter whether it's part of the main history.