### PR TITLE
DevTools e2e workflow: Download build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,12 +555,12 @@ workflows:
                 - main
     jobs:
       - setup
-      - yarn_build_combined:
+      - get_base_build:
           requires:
             - setup
       - build_devtools_and_process_artifacts:
           requires:
-            - yarn_build_combined
+            - get_base_build
       - run_devtools_tests_for_versions:
           requires:
             - build_devtools_and_process_artifacts


### PR DESCRIPTION
When running the hourly DevTools testing workflow, we don't need to build React from scratch each time; we can download its build artifacts, like we do for sizebot and the release workflow.