### PR TITLE
[DevTools] Run Devtools Regression Tests Once a Day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,8 +583,8 @@ workflows:
     unless: << pipeline.parameters.prerelease_commit_sha >>
     triggers:
       - schedule:
-          # DevTools regression tests run hourly
-          cron: "0 * * * *"
+          # DevTools regression tests run once a day
+          cron: "0 0 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
We don't need to run DevTools regression tests once an hour, and also it makes getting the most recent react build or react devtools build really annoying, so run them once a day instead 