### PR TITLE
[Fizz] Support abort reasons

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1106,7 +1106,13 @@ describe('ReactDOMFizzServer', () => {
     expect(Scheduler).toFlushAndYield([]);
     expectErrors(
       errors,
-      [['This Suspense boundary was aborted by the server.', expectedDigest]],
+      [
+        [
+          'The server did not finish this Suspense boundary: signal is aborted without reason',
+          expectedDigest,
+          componentStack(['h1', 'Suspense', 'div', 'App']),
+        ],
+      ],
       [
         [
           'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
@@ -3054,6 +3060,178 @@ describe('ReactDOMFizzServer', () => {
         <li>a</li>
         <li>b</li>
       </ul>,
+    );
+  });
+
+  // @gate experimental
+  it('Supports custom abort reasons with a string', async () => {
+    function App() {
+      return (
+        <div>
+          <p>
+            <Suspense fallback={'p'}>
+              <AsyncText text={'hello'} />
+            </Suspense>
+          </p>
+          <span>
+            <Suspense fallback={'span'}>
+              <AsyncText text={'world'} />
+            </Suspense>
+          </span>
+        </div>
+      );
+    }
+
+    let abort;
+    const loggedErrors = [];
+    await act(async () => {
+      const {
+        pipe,
+        abort: abortImpl,
+      } = ReactDOMFizzServer.renderToPipeableStream(<App />, {
+        onError(error) {
+          // In this test we contrive erroring with strings so we push the error whereas in most
+          // other tests we contrive erroring with Errors and push the message.
+          loggedErrors.push(error);
+          return 'a digest';
+        },
+      });
+      abort = abortImpl;
+      pipe(writable);
+    });
+
+    expect(loggedErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <p>p</p>
+        <span>span</span>
+      </div>,
+    );
+
+    await act(() => {
+      abort('foobar');
+    });
+
+    expect(loggedErrors).toEqual(['foobar', 'foobar']);
+
+    const errors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error, errorInfo) {
+        errors.push({error, errorInfo});
+      },
+    });
+
+    expect(Scheduler).toFlushAndYield([]);
+
+    expectErrors(
+      errors,
+      [
+        [
+          'The server did not finish this Suspense boundary: foobar',
+          'a digest',
+          componentStack(['Suspense', 'p', 'div', 'App']),
+        ],
+        [
+          'The server did not finish this Suspense boundary: foobar',
+          'a digest',
+          componentStack(['Suspense', 'span', 'div', 'App']),
+        ],
+      ],
+      [
+        [
+          'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          'a digest',
+        ],
+        [
+          'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          'a digest',
+        ],
+      ],
+    );
+  });
+
+  // @gate experimental
+  it('Supports custom abort reasons with an Error', async () => {
+    function App() {
+      return (
+        <div>
+          <p>
+            <Suspense fallback={'p'}>
+              <AsyncText text={'hello'} />
+            </Suspense>
+          </p>
+          <span>
+            <Suspense fallback={'span'}>
+              <AsyncText text={'world'} />
+            </Suspense>
+          </span>
+        </div>
+      );
+    }
+
+    let abort;
+    const loggedErrors = [];
+    await act(async () => {
+      const {
+        pipe,
+        abort: abortImpl,
+      } = ReactDOMFizzServer.renderToPipeableStream(<App />, {
+        onError(error) {
+          loggedErrors.push(error.message);
+          return 'a digest';
+        },
+      });
+      abort = abortImpl;
+      pipe(writable);
+    });
+
+    expect(loggedErrors).toEqual([]);
+    expect(getVisibleChildren(container)).toEqual(
+      <div>
+        <p>p</p>
+        <span>span</span>
+      </div>,
+    );
+
+    await act(() => {
+      abort(new Error('uh oh'));
+    });
+
+    expect(loggedErrors).toEqual(['uh oh', 'uh oh']);
+
+    const errors = [];
+    ReactDOMClient.hydrateRoot(container, <App />, {
+      onRecoverableError(error, errorInfo) {
+        errors.push({error, errorInfo});
+      },
+    });
+
+    expect(Scheduler).toFlushAndYield([]);
+
+    expectErrors(
+      errors,
+      [
+        [
+          'The server did not finish this Suspense boundary: uh oh',
+          'a digest',
+          componentStack(['Suspense', 'p', 'div', 'App']),
+        ],
+        [
+          'The server did not finish this Suspense boundary: uh oh',
+          'a digest',
+          componentStack(['Suspense', 'span', 'div', 'App']),
+        ],
+      ],
+      [
+        [
+          'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          'a digest',
+        ],
+        [
+          'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+          'a digest',
+        ],
+      ],
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -1108,7 +1108,7 @@ describe('ReactDOMFizzServer', () => {
       errors,
       [
         [
-          'The server did not finish this Suspense boundary: signal is aborted without reason',
+          'The server did not finish this Suspense boundary: The render was aborted by the server without a reason.',
           expectedDigest,
           componentStack(['h1', 'Suspense', 'div', 'App']),
         ],

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -397,7 +397,6 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
-  // @gate experimental
   describe('renderToString', () => {
     beforeEach(() => {
       JSDOM = require('jsdom').JSDOM;
@@ -413,6 +412,7 @@ describe('ReactDOMFizzServer', () => {
       container = document.getElementById('container');
     });
 
+    // @gate experimental
     it('refers users to apis that support Suspense when somethign suspends', () => {
       function App({isClient}) {
         return (

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -14,13 +14,20 @@ global.ReadableStream = require('web-streams-polyfill/ponyfill/es6').ReadableStr
 global.TextEncoder = require('util').TextEncoder;
 
 let React;
+let ReactDOMClient;
 let ReactDOMFizzServer;
 let Suspense;
+let Scheduler;
+let JSDOM;
+let document;
+let container;
 
 describe('ReactDOMFizzServer', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    Scheduler = require('scheduler');
     if (__EXPERIMENTAL__) {
       ReactDOMFizzServer = require('react-dom/server.browser');
     }
@@ -48,113 +55,136 @@ describe('ReactDOMFizzServer', () => {
     }
   }
 
-  // @gate experimental
-  it('should call renderToReadableStream', async () => {
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>hello world</div>,
-    );
-    const result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
-  });
+  describe('renderToReadableStream', () => {
+    // @gate experimental
+    it('should call renderToReadableStream', async () => {
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <div>hello world</div>,
+      );
+      const result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
+    });
 
-  // @gate experimental
-  it('should emit DOCTYPE at the root of the document', async () => {
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <html>
-        <body>hello world</body>
-      </html>,
-    );
-    const result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<!DOCTYPE html><html><body>hello world</body></html>"`,
-    );
-  });
+    // @gate experimental
+    it('should emit DOCTYPE at the root of the document', async () => {
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <html>
+          <body>hello world</body>
+        </html>,
+      );
+      const result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(
+        `"<!DOCTYPE html><html><body>hello world</body></html>"`,
+      );
+    });
 
-  // @gate experimental
-  it('should emit bootstrap script src at the end', async () => {
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>hello world</div>,
-      {
-        bootstrapScriptContent: 'INIT();',
-        bootstrapScripts: ['init.js'],
-        bootstrapModules: ['init.mjs'],
-      },
-    );
-    const result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<div>hello world</div><script>INIT();</script><script src=\\"init.js\\" async=\\"\\"></script><script type=\\"module\\" src=\\"init.mjs\\" async=\\"\\"></script>"`,
-    );
-  });
-
-  // @gate experimental
-  it('emits all HTML as one unit if we wait until the end to start', async () => {
-    let hasLoaded = false;
-    let resolve;
-    const promise = new Promise(r => (resolve = r));
-    function Wait() {
-      if (!hasLoaded) {
-        throw promise;
-      }
-      return 'Done';
-    }
-    let isComplete = false;
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>
-        <Suspense fallback="Loading">
-          <Wait />
-        </Suspense>
-      </div>,
-    );
-
-    stream.allReady.then(() => (isComplete = true));
-
-    await jest.runAllTimers();
-    expect(isComplete).toBe(false);
-    // Resolve the loading.
-    hasLoaded = true;
-    await resolve();
-
-    await jest.runAllTimers();
-
-    expect(isComplete).toBe(true);
-
-    const result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
-    );
-  });
-
-  // @gate experimental
-  it('should reject the promise when an error is thrown at the root', async () => {
-    const reportedErrors = [];
-    let caughtError = null;
-    try {
-      await ReactDOMFizzServer.renderToReadableStream(
-        <div>
-          <Throw />
-        </div>,
+    // @gate experimental
+    it('should emit bootstrap script src at the end', async () => {
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <div>hello world</div>,
         {
-          onError(x) {
-            reportedErrors.push(x);
-          },
+          bootstrapScriptContent: 'INIT();',
+          bootstrapScripts: ['init.js'],
+          bootstrapModules: ['init.mjs'],
         },
       );
-    } catch (error) {
-      caughtError = error;
-    }
-    expect(caughtError).toBe(theError);
-    expect(reportedErrors).toEqual([theError]);
-  });
+      const result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(
+        `"<div>hello world</div><script>INIT();</script><script src=\\"init.js\\" async=\\"\\"></script><script type=\\"module\\" src=\\"init.mjs\\" async=\\"\\"></script>"`,
+      );
+    });
 
-  // @gate experimental
-  it('should reject the promise when an error is thrown inside a fallback', async () => {
-    const reportedErrors = [];
-    let caughtError = null;
-    try {
-      await ReactDOMFizzServer.renderToReadableStream(
+    // @gate experimental
+    it('emits all HTML as one unit if we wait until the end to start', async () => {
+      let hasLoaded = false;
+      let resolve;
+      const promise = new Promise(r => (resolve = r));
+      function Wait() {
+        if (!hasLoaded) {
+          throw promise;
+        }
+        return 'Done';
+      }
+      let isComplete = false;
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
         <div>
-          <Suspense fallback={<Throw />}>
-            <InfiniteSuspend />
+          <Suspense fallback="Loading">
+            <Wait />
+          </Suspense>
+        </div>,
+      );
+
+      stream.allReady.then(() => (isComplete = true));
+
+      await jest.runAllTimers();
+      expect(isComplete).toBe(false);
+      // Resolve the loading.
+      hasLoaded = true;
+      await resolve();
+
+      await jest.runAllTimers();
+
+      expect(isComplete).toBe(true);
+
+      const result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(
+        `"<div><!--$-->Done<!-- --><!--/$--></div>"`,
+      );
+    });
+
+    // @gate experimental
+    it('should reject the promise when an error is thrown at the root', async () => {
+      const reportedErrors = [];
+      let caughtError = null;
+      try {
+        await ReactDOMFizzServer.renderToReadableStream(
+          <div>
+            <Throw />
+          </div>,
+          {
+            onError(x) {
+              reportedErrors.push(x);
+            },
+          },
+        );
+      } catch (error) {
+        caughtError = error;
+      }
+      expect(caughtError).toBe(theError);
+      expect(reportedErrors).toEqual([theError]);
+    });
+
+    // @gate experimental
+    it('should reject the promise when an error is thrown inside a fallback', async () => {
+      const reportedErrors = [];
+      let caughtError = null;
+      try {
+        await ReactDOMFizzServer.renderToReadableStream(
+          <div>
+            <Suspense fallback={<Throw />}>
+              <InfiniteSuspend />
+            </Suspense>
+          </div>,
+          {
+            onError(x) {
+              reportedErrors.push(x);
+            },
+          },
+        );
+      } catch (error) {
+        caughtError = error;
+      }
+      expect(caughtError).toBe(theError);
+      expect(reportedErrors).toEqual([theError]);
+    });
+
+    // @gate experimental
+    it('should not error the stream when an error is thrown inside suspense boundary', async () => {
+      const reportedErrors = [];
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <div>
+          <Suspense fallback={<div>Loading</div>}>
+            <Throw />
           </Suspense>
         </div>,
         {
@@ -163,148 +193,259 @@ describe('ReactDOMFizzServer', () => {
           },
         },
       );
-    } catch (error) {
-      caughtError = error;
-    }
-    expect(caughtError).toBe(theError);
-    expect(reportedErrors).toEqual([theError]);
-  });
 
-  // @gate experimental
-  it('should not error the stream when an error is thrown inside suspense boundary', async () => {
-    const reportedErrors = [];
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>
-        <Suspense fallback={<div>Loading</div>}>
-          <Throw />
-        </Suspense>
-      </div>,
-      {
-        onError(x) {
-          reportedErrors.push(x);
+      const result = await readResult(stream);
+      expect(result).toContain('Loading');
+      expect(reportedErrors).toEqual([theError]);
+    });
+
+    // @gate experimental
+    it('should be able to complete by aborting even if the promise never resolves', async () => {
+      const errors = [];
+      const controller = new AbortController();
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <div>
+          <Suspense fallback={<div>Loading</div>}>
+            <InfiniteSuspend />
+          </Suspense>
+        </div>,
+        {
+          signal: controller.signal,
+          onError(x) {
+            errors.push(x.message);
+          },
         },
-      },
-    );
+      );
 
-    const result = await readResult(stream);
-    expect(result).toContain('Loading');
-    expect(reportedErrors).toEqual([theError]);
-  });
+      controller.abort();
 
-  // @gate experimental
-  it('should be able to complete by aborting even if the promise never resolves', async () => {
-    const errors = [];
-    const controller = new AbortController();
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>
-        <Suspense fallback={<div>Loading</div>}>
-          <InfiniteSuspend />
-        </Suspense>
-      </div>,
-      {
+      const result = await readResult(stream);
+      expect(result).toContain('Loading');
+
+      expect(errors).toEqual(['signal is aborted without reason']);
+    });
+
+    // @gate experimental
+    it('should not continue rendering after the reader cancels', async () => {
+      let hasLoaded = false;
+      let resolve;
+      let isComplete = false;
+      let rendered = false;
+      const promise = new Promise(r => (resolve = r));
+      function Wait() {
+        if (!hasLoaded) {
+          throw promise;
+        }
+        rendered = true;
+        return 'Done';
+      }
+      const errors = [];
+      const stream = await ReactDOMFizzServer.renderToReadableStream(
+        <div>
+          <Suspense fallback={<div>Loading</div>}>
+            <Wait /> />
+          </Suspense>
+        </div>,
+        {
+          onError(x) {
+            errors.push(x.message);
+          },
+        },
+      );
+
+      stream.allReady.then(() => (isComplete = true));
+
+      expect(rendered).toBe(false);
+      expect(isComplete).toBe(false);
+
+      const reader = stream.getReader();
+      reader.cancel();
+
+      expect(errors).toEqual(['signal is aborted without reason']);
+
+      hasLoaded = true;
+      resolve();
+
+      await jest.runAllTimers();
+
+      expect(rendered).toBe(false);
+      expect(isComplete).toBe(true);
+    });
+
+    // @gate experimental
+    it('should stream large contents that might overlow individual buffers', async () => {
+      const str492 = `(492) This string is intentionally 492 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux q :: total count (492)`;
+      const str2049 = `(2049) This string is intentionally 2049 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy  :: total count (2049)`;
+
+      // this specific layout is somewhat contrived to exercise the landing on
+      // an exact view boundary. it's not critical to test this edge case but
+      // since we are setting up a test in general for larger chunks I contrived it
+      // as such for now. I don't think it needs to be maintained if in the future
+      // the view sizes change or become dynamic becasue of the use of byobRequest
+      let stream;
+      stream = await ReactDOMFizzServer.renderToReadableStream(
+        <>
+          <div>
+            <span>{''}</span>
+          </div>
+          <div>{str492}</div>
+          <div>{str492}</div>
+        </>,
+      );
+
+      let result;
+      result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(
+        `"<div><span></span></div><div>${str492}</div><div>${str492}</div>"`,
+      );
+
+      // this size 2049 was chosen to be a couple base 2 orders larger than the current view
+      // size. if the size changes in the future hopefully this will still exercise
+      // a chunk that is too large for the view size.
+      stream = await ReactDOMFizzServer.renderToReadableStream(
+        <>
+          <div>{str2049}</div>
+        </>,
+      );
+
+      result = await readResult(stream);
+      expect(result).toMatchInlineSnapshot(`"<div>${str2049}</div>"`);
+    });
+
+    // @gate experimental
+    it('Supports custom abort reasons with a string', async () => {
+      const promise = new Promise(r => {});
+      function Wait() {
+        throw promise;
+      }
+      function App() {
+        return (
+          <div>
+            <p>
+              <Suspense fallback={'p'}>
+                <Wait />
+              </Suspense>
+            </p>
+            <span>
+              <Suspense fallback={'span'}>
+                <Wait />
+              </Suspense>
+            </span>
+          </div>
+        );
+      }
+
+      const errors = [];
+      const controller = new AbortController();
+      await ReactDOMFizzServer.renderToReadableStream(<App />, {
+        signal: controller.signal,
+        onError(x) {
+          errors.push(x);
+          return 'a digest';
+        },
+      });
+
+      // @TODO this is a hack to work around lack of support for abortSignal.reason in node
+      // The abort call itself should set this property but since we are testing in node we
+      // set it here manually
+      controller.signal.reason = 'foobar';
+      controller.abort('foobar');
+
+      expect(errors).toEqual(['foobar', 'foobar']);
+    });
+
+    // @gate experimental
+    it('Supports custom abort reasons with an Error', async () => {
+      const promise = new Promise(r => {});
+      function Wait() {
+        throw promise;
+      }
+      function App() {
+        return (
+          <div>
+            <p>
+              <Suspense fallback={'p'}>
+                <Wait />
+              </Suspense>
+            </p>
+            <span>
+              <Suspense fallback={'span'}>
+                <Wait />
+              </Suspense>
+            </span>
+          </div>
+        );
+      }
+
+      const errors = [];
+      const controller = new AbortController();
+      await ReactDOMFizzServer.renderToReadableStream(<App />, {
         signal: controller.signal,
         onError(x) {
           errors.push(x.message);
+          return 'a digest';
         },
-      },
-    );
+      });
 
-    controller.abort();
+      // @TODO this is a hack to work around lack of support for abortSignal.reason in node
+      // The abort call itself should set this property but since we are testing in node we
+      // set it here manually
+      controller.signal.reason = new Error('uh oh');
+      controller.abort(new Error('uh oh'));
 
-    const result = await readResult(stream);
-    expect(result).toContain('Loading');
-
-    expect(errors).toEqual([
-      'This Suspense boundary was aborted by the server.',
-    ]);
+      expect(errors).toEqual(['uh oh', 'uh oh']);
+    });
   });
 
   // @gate experimental
-  it('should not continue rendering after the reader cancels', async () => {
-    let hasLoaded = false;
-    let resolve;
-    let isComplete = false;
-    let rendered = false;
-    const promise = new Promise(r => (resolve = r));
-    function Wait() {
-      if (!hasLoaded) {
-        throw promise;
+  describe('renderToString', () => {
+    beforeEach(() => {
+      JSDOM = require('jsdom').JSDOM;
+
+      // Test Environment
+      const jsdom = new JSDOM(
+        '<!DOCTYPE html><html><head></head><body><div id="container">',
+        {
+          runScripts: 'dangerously',
+        },
+      );
+      document = jsdom.window.document;
+      container = document.getElementById('container');
+    });
+
+    it('refers users to apis that support Suspense when somethign suspends', () => {
+      function App({isClient}) {
+        return (
+          <div>
+            <Suspense fallback={'fallback'}>
+              {isClient ? 'resolved' : <InfiniteSuspend />}
+            </Suspense>
+          </div>
+        );
       }
-      rendered = true;
-      return 'Done';
-    }
-    const errors = [];
-    const stream = await ReactDOMFizzServer.renderToReadableStream(
-      <div>
-        <Suspense fallback={<div>Loading</div>}>
-          <Wait /> />
-        </Suspense>
-      </div>,
-      {
-        onError(x) {
-          errors.push(x.message);
+      container.innerHTML = ReactDOMFizzServer.renderToString(
+        <App isClient={false} />,
+      );
+
+      const errors = [];
+      ReactDOMClient.hydrateRoot(container, <App isClient={true} />, {
+        onRecoverableError(error, errorInfo) {
+          errors.push(error.message);
         },
-      },
-    );
+      });
 
-    stream.allReady.then(() => (isComplete = true));
-
-    expect(rendered).toBe(false);
-    expect(isComplete).toBe(false);
-
-    const reader = stream.getReader();
-    reader.cancel();
-
-    expect(errors).toEqual([
-      'This Suspense boundary was aborted by the server.',
-    ]);
-
-    hasLoaded = true;
-    resolve();
-
-    await jest.runAllTimers();
-
-    expect(rendered).toBe(false);
-    expect(isComplete).toBe(true);
-  });
-
-  // @gate experimental
-  it('should stream large contents that might overlow individual buffers', async () => {
-    const str492 = `(492) This string is intentionally 492 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux q :: total count (492)`;
-    const str2049 = `(2049) This string is intentionally 2049 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy  :: total count (2049)`;
-
-    // this specific layout is somewhat contrived to exercise the landing on
-    // an exact view boundary. it's not critical to test this edge case but
-    // since we are setting up a test in general for larger chunks I contrived it
-    // as such for now. I don't think it needs to be maintained if in the future
-    // the view sizes change or become dynamic becasue of the use of byobRequest
-    let stream;
-    stream = await ReactDOMFizzServer.renderToReadableStream(
-      <>
-        <div>
-          <span>{''}</span>
-        </div>
-        <div>{str492}</div>
-        <div>{str492}</div>
-      </>,
-    );
-
-    let result;
-    result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(
-      `"<div><span></span></div><div>${str492}</div><div>${str492}</div>"`,
-    );
-
-    // this size 2049 was chosen to be a couple base 2 orders larger than the current view
-    // size. if the size changes in the future hopefully this will still exercise
-    // a chunk that is too large for the view size.
-    stream = await ReactDOMFizzServer.renderToReadableStream(
-      <>
-        <div>{str2049}</div>
-      </>,
-    );
-
-    result = await readResult(stream);
-    expect(result).toMatchInlineSnapshot(`"<div>${str2049}</div>"`);
+      expect(Scheduler).toFlushAndYield([]);
+      expect(errors.length).toBe(1);
+      if (__DEV__) {
+        expect(errors[0]).toBe(
+          'The server did not finish this Suspense boundary: The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToReadableStream" which supports Suspense on the server',
+        );
+      } else {
+        expect(errors[0]).toBe(
+          'The server could not finish this Suspense boundary, likely due to ' +
+            'an error during server rendering. Switched to client rendering.',
+        );
+      }
+    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -222,7 +222,9 @@ describe('ReactDOMFizzServer', () => {
       const result = await readResult(stream);
       expect(result).toContain('Loading');
 
-      expect(errors).toEqual(['signal is aborted without reason']);
+      expect(errors).toEqual([
+        'The render was aborted by the server without a reason.',
+      ]);
     });
 
     // @gate experimental
@@ -261,7 +263,9 @@ describe('ReactDOMFizzServer', () => {
       const reader = stream.getReader();
       reader.cancel();
 
-      expect(errors).toEqual(['signal is aborted without reason']);
+      expect(errors).toEqual([
+        'The render was aborted by the server without a reason.',
+      ]);
 
       hasLoaded = true;
       resolve();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -363,8 +363,8 @@ describe('ReactDOMFizzServer', () => {
 
     expect(errors).toEqual([
       // There are two boundaries that abort
-      'signal is aborted without reason',
-      'signal is aborted without reason',
+      'The render was aborted by the server without a reason.',
+      'The render was aborted by the server without a reason.',
     ]);
     expect(output.error).toBe(undefined);
     expect(output.result).toContain('Loading');

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -226,7 +226,7 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toBe('');
     expect(reportedErrors).toEqual([
       theError.message,
-      'This Suspense boundary was aborted by the server.',
+      'The destination stream errored while writing data.',
     ]);
     expect(reportedShellErrors).toEqual([theError]);
   });
@@ -317,13 +317,11 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toContain('Loading');
     expect(isCompleteCalls).toBe(0);
 
-    abort();
+    abort(new Error('uh oh'));
 
     await completed;
 
-    expect(errors).toEqual([
-      'This Suspense boundary was aborted by the server.',
-    ]);
+    expect(errors).toEqual(['uh oh']);
     expect(output.error).toBe(undefined);
     expect(output.result).toContain('Loading');
     expect(isCompleteCalls).toBe(1);
@@ -365,8 +363,8 @@ describe('ReactDOMFizzServer', () => {
 
     expect(errors).toEqual([
       // There are two boundaries that abort
-      'This Suspense boundary was aborted by the server.',
-      'This Suspense boundary was aborted by the server.',
+      'signal is aborted without reason',
+      'signal is aborted without reason',
     ]);
     expect(output.error).toBe(undefined);
     expect(output.result).toContain('Loading');
@@ -603,7 +601,7 @@ describe('ReactDOMFizzServer', () => {
     await completed;
 
     expect(errors).toEqual([
-      'This Suspense boundary was aborted by the server.',
+      'The destination stream errored while writing data.',
     ]);
     expect(rendered).toBe(false);
     expect(isComplete).toBe(true);

--- a/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMHydrationDiff-test.js
@@ -830,7 +830,7 @@ describe('ReactDOMServerHydration', () => {
         } else {
           expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
             Array [
-              "Caught [This Suspense boundary was aborted by the server.]",
+              "Caught [The server did not finish this Suspense boundary: The server used \\"renderToString\\" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to \\"renderToPipeableStream\\" which supports Suspense on the server]",
             ]
           `);
         }
@@ -865,7 +865,7 @@ describe('ReactDOMServerHydration', () => {
         } else {
           expect(testMismatch(Mismatch)).toMatchInlineSnapshot(`
             Array [
-              "Caught [This Suspense boundary was aborted by the server.]",
+              "Caught [The server did not finish this Suspense boundary: The server used \\"renderToString\\" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to \\"renderToPipeableStream\\" which supports Suspense on the server]",
             ]
           `);
         }

--- a/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerPartialHydration-test.internal.js
@@ -1674,11 +1674,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // we exclude fb bundles with partial renderer
     if (__DEV__ && !usingPartialRenderer) {
       expect(Scheduler).toFlushAndYield([
-        'This Suspense boundary was aborted by the server.',
+        'The server did not finish this Suspense boundary: The server used' +
+          ' "renderToString" which does not support Suspense. If you intended' +
+          ' for this Suspense boundary to render the fallback content on the' +
+          ' server consider throwing an Error somewhere within the Suspense boundary.' +
+          ' If you intended to have the server wait for the suspended component' +
+          ' please switch to "renderToPipeableStream" which supports Suspense on the server',
       ]);
     } else {
       expect(Scheduler).toFlushAndYield([
-        'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+        'The server could not finish this Suspense boundary, likely due to ' +
+          'an error during server rendering. Switched to client rendering.',
       ]);
     }
     jest.runAllTimers();
@@ -1742,11 +1748,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // we exclude fb bundles with partial renderer
     if (__DEV__ && !usingPartialRenderer) {
       expect(Scheduler).toFlushAndYield([
-        'This Suspense boundary was aborted by the server.',
+        'The server did not finish this Suspense boundary: The server used' +
+          ' "renderToString" which does not support Suspense. If you intended' +
+          ' for this Suspense boundary to render the fallback content on the' +
+          ' server consider throwing an Error somewhere within the Suspense boundary.' +
+          ' If you intended to have the server wait for the suspended component' +
+          ' please switch to "renderToPipeableStream" which supports Suspense on the server',
       ]);
     } else {
       expect(Scheduler).toFlushAndYield([
-        'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+        'The server could not finish this Suspense boundary, likely due to ' +
+          'an error during server rendering. Switched to client rendering.',
       ]);
     }
     // This will have exceeded the suspended time so we should timeout.
@@ -1815,11 +1827,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // we exclude fb bundles with partial renderer
     if (__DEV__ && !usingPartialRenderer) {
       expect(Scheduler).toFlushAndYield([
-        'This Suspense boundary was aborted by the server.',
+        'The server did not finish this Suspense boundary: The server used' +
+          ' "renderToString" which does not support Suspense. If you intended' +
+          ' for this Suspense boundary to render the fallback content on the' +
+          ' server consider throwing an Error somewhere within the Suspense boundary.' +
+          ' If you intended to have the server wait for the suspended component' +
+          ' please switch to "renderToPipeableStream" which supports Suspense on the server',
       ]);
     } else {
       expect(Scheduler).toFlushAndYield([
-        'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+        'The server could not finish this Suspense boundary, likely due to ' +
+          'an error during server rendering. Switched to client rendering.',
       ]);
     }
     // This will have exceeded the suspended time so we should timeout.
@@ -2139,11 +2157,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // we exclude fb bundles with partial renderer
     if (__DEV__ && !usingPartialRenderer) {
       expect(Scheduler).toFlushAndYield([
-        'This Suspense boundary was aborted by the server.',
+        'The server did not finish this Suspense boundary: The server used' +
+          ' "renderToString" which does not support Suspense. If you intended' +
+          ' for this Suspense boundary to render the fallback content on the' +
+          ' server consider throwing an Error somewhere within the Suspense boundary.' +
+          ' If you intended to have the server wait for the suspended component' +
+          ' please switch to "renderToPipeableStream" which supports Suspense on the server',
       ]);
     } else {
       expect(Scheduler).toFlushAndYield([
-        'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+        'The server could not finish this Suspense boundary, likely due to ' +
+          'an error during server rendering. Switched to client rendering.',
       ]);
     }
 
@@ -2208,11 +2232,17 @@ describe('ReactDOMServerPartialHydration', () => {
     // we exclude fb bundles with partial renderer
     if (__DEV__ && !usingPartialRenderer) {
       expect(Scheduler).toFlushAndYield([
-        'This Suspense boundary was aborted by the server.',
+        'The server did not finish this Suspense boundary: The server used' +
+          ' "renderToString" which does not support Suspense. If you intended' +
+          ' for this Suspense boundary to render the fallback content on the' +
+          ' server consider throwing an Error somewhere within the Suspense boundary.' +
+          ' If you intended to have the server wait for the suspended component' +
+          ' please switch to "renderToPipeableStream" which supports Suspense on the server',
       ]);
     } else {
       expect(Scheduler).toFlushAndYield([
-        'The server could not finish this Suspense boundary, likely due to an error during server rendering. Switched to client rendering.',
+        'The server could not finish this Suspense boundary, likely due to ' +
+          'an error during server rendering. Switched to client rendering.',
       ]);
     }
     jest.runAllTimers();

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -562,6 +562,19 @@ describe('ReactDOMServer', () => {
         'Bad lazy',
       );
     });
+
+    it('aborts synchronously any suspended tasks and renders their fallbacks', () => {
+      const promise = new Promise(res => {});
+      function Suspender() {
+        throw promise;
+      }
+      const response = ReactDOMServer.renderToStaticMarkup(
+        <React.Suspense fallback={'fallback'}>
+          <Suspender />
+        </React.Suspense>,
+      );
+      expect(response).toEqual('fallback');
+    });
   });
 
   describe('renderToNodeStream', () => {
@@ -617,6 +630,41 @@ describe('ReactDOMServer', () => {
         });
         expect(response.read()).toBeNull();
       });
+    });
+
+    it('should refer users to new apis when using suspense', async () => {
+      let resolve = null;
+      const promise = new Promise(res => {
+        resolve = () => {
+          resolved = true;
+          res();
+        };
+      });
+      let resolved = false;
+      function Suspender() {
+        if (resolved) {
+          return 'resolved';
+        }
+        throw promise;
+      }
+
+      let response;
+      expect(() => {
+        response = ReactDOMServer.renderToNodeStream(
+          <div>
+            <React.Suspense fallback={'fallback'}>
+              <Suspender />
+            </React.Suspense>
+          </div>,
+        );
+      }).toErrorDev(
+        'renderToNodeStream is deprecated. Use renderToPipeableStream instead.',
+        {withoutStack: true},
+      );
+      await resolve();
+      expect(response.read().toString()).toEqual(
+        '<div><!--$-->resolved<!-- --><!--/$--></div>',
+      );
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -14,6 +14,7 @@ let React;
 let ReactDOMServer;
 let PropTypes;
 let ReactCurrentDispatcher;
+let useingPartialRenderer;
 
 describe('ReactDOMServer', () => {
   beforeEach(() => {
@@ -24,6 +25,8 @@ describe('ReactDOMServer', () => {
     ReactCurrentDispatcher =
       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
         .ReactCurrentDispatcher;
+
+    useingPartialRenderer = global.__WWW__ && !__EXPERIMENTAL__;
   });
 
   describe('renderToString', () => {
@@ -573,7 +576,11 @@ describe('ReactDOMServer', () => {
           <Suspender />
         </React.Suspense>,
       );
-      expect(response).toEqual('fallback');
+      if (useingPartialRenderer) {
+        expect(response).toEqual('<!--$!-->fallback<!--/$-->');
+      } else {
+        expect(response).toEqual('fallback');
+      }
     });
   });
 

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -97,7 +97,7 @@ function renderToReadableStream(
     if (options && options.signal) {
       const signal = options.signal;
       const listener = () => {
-        abort(request);
+        abort(request, (signal: any).reason);
         signal.removeEventListener('abort', listener);
       };
       signal.addEventListener('abort', listener);

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -7,104 +7,36 @@
  * @flow
  */
 
-import ReactVersion from 'shared/ReactVersion';
-
 import type {ReactNodeList} from 'shared/ReactTypes';
 
-import {
-  createRequest,
-  startWork,
-  startFlowing,
-  abort,
-} from 'react-server/src/ReactFizzServer';
-
-import {
-  createResponseState,
-  createRootFormatContext,
-} from './ReactDOMServerLegacyFormatConfig';
+import {version, renderToStringImpl} from './ReactDOMLegacyServerImpl';
 
 type ServerOptions = {
   identifierPrefix?: string,
 };
 
-function onError() {
-  // Non-fatal errors are ignored.
-}
-
-function renderToStringImpl(
-  children: ReactNodeList,
-  options: void | ServerOptions,
-  generateStaticMarkup: boolean,
-): string {
-  let didFatal = false;
-  let fatalError = null;
-  let result = '';
-  const destination = {
-    push(chunk) {
-      if (chunk !== null) {
-        result += chunk;
-      }
-      return true;
-    },
-    destroy(error) {
-      didFatal = true;
-      fatalError = error;
-    },
-  };
-
-  let readyToStream = false;
-  function onShellReady() {
-    readyToStream = true;
-  }
-  const request = createRequest(
-    children,
-    createResponseState(
-      generateStaticMarkup,
-      options ? options.identifierPrefix : undefined,
-    ),
-    createRootFormatContext(),
-    Infinity,
-    onError,
-    undefined,
-    onShellReady,
-    undefined,
-    undefined,
-  );
-  startWork(request);
-  // If anything suspended and is still pending, we'll abort it before writing.
-  // That way we write only client-rendered boundaries from the start.
-  abort(request);
-  startFlowing(request, destination);
-  if (didFatal) {
-    throw fatalError;
-  }
-
-  if (!readyToStream) {
-    // Note: This error message is the one we use on the client. It doesn't
-    // really make sense here. But this is the legacy server renderer, anyway.
-    // We're going to delete it soon.
-    throw new Error(
-      'A component suspended while responding to synchronous input. This ' +
-        'will cause the UI to be replaced with a loading indicator. To fix, ' +
-        'updates that suspend should be wrapped with startTransition.',
-    );
-  }
-
-  return result;
-}
-
 function renderToString(
   children: ReactNodeList,
   options?: ServerOptions,
 ): string {
-  return renderToStringImpl(children, options, false);
+  return renderToStringImpl(
+    children,
+    options,
+    false,
+    'The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToReadableStream" which supports Suspense on the server',
+  );
 }
 
 function renderToStaticMarkup(
   children: ReactNodeList,
   options?: ServerOptions,
 ): string {
-  return renderToStringImpl(children, options, true);
+  return renderToStringImpl(
+    children,
+    options,
+    true,
+    'The server used "renderToStaticMarkup" which does not support Suspense. If you intended to have the server wait for the suspended component please switch to "renderToReadableStream" which supports Suspense on the server',
+  );
 }
 
 function renderToNodeStream() {
@@ -126,5 +58,5 @@ export {
   renderToStaticMarkup,
   renderToNodeStream,
   renderToStaticNodeStream,
-  ReactVersion as version,
+  version,
 };

--- a/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import ReactVersion from 'shared/ReactVersion';
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+import {
+  createRequest,
+  startWork,
+  startFlowing,
+  abort,
+} from 'react-server/src/ReactFizzServer';
+
+import {
+  createResponseState,
+  createRootFormatContext,
+} from './ReactDOMServerLegacyFormatConfig';
+
+type ServerOptions = {
+  identifierPrefix?: string,
+};
+
+function onError() {
+  // Non-fatal errors are ignored.
+}
+
+function renderToStringImpl(
+  children: ReactNodeList,
+  options: void | ServerOptions,
+  generateStaticMarkup: boolean,
+  abortReason: string,
+): string {
+  let didFatal = false;
+  let fatalError = null;
+  let result = '';
+  const destination = {
+    push(chunk) {
+      if (chunk !== null) {
+        result += chunk;
+      }
+      return true;
+    },
+    destroy(error) {
+      didFatal = true;
+      fatalError = error;
+    },
+  };
+
+  let readyToStream = false;
+  function onShellReady() {
+    readyToStream = true;
+  }
+  const request = createRequest(
+    children,
+    createResponseState(
+      generateStaticMarkup,
+      options ? options.identifierPrefix : undefined,
+    ),
+    createRootFormatContext(),
+    Infinity,
+    onError,
+    undefined,
+    onShellReady,
+    undefined,
+    undefined,
+  );
+  startWork(request);
+  // If anything suspended and is still pending, we'll abort it before writing.
+  // That way we write only client-rendered boundaries from the start.
+  abort(request, abortReason);
+  startFlowing(request, destination);
+  if (didFatal) {
+    throw fatalError;
+  }
+
+  if (!readyToStream) {
+    // Note: This error message is the one we use on the client. It doesn't
+    // really make sense here. But this is the legacy server renderer, anyway.
+    // We're going to delete it soon.
+    throw new Error(
+      'A component suspended while responding to synchronous input. This ' +
+        'will cause the UI to be replaced with a loading indicator. To fix, ' +
+        'updates that suspend should be wrapped with startTransition.',
+    );
+  }
+
+  return result;
+}
+
+export {renderToStringImpl, ReactVersion as version};

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.classic.fb.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.classic.fb.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {
+  renderToString,
+  renderToStaticMarkup,
+  version,
+} from './ReactDOMServerLegacyPartialRendererBrowser';
+
+export {
+  renderToNodeStream,
+  renderToStaticNodeStream,
+} from './ReactDOMLegacyServerNodeStream';

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
@@ -23,11 +23,7 @@ import {
   createRootFormatContext,
 } from './ReactDOMServerLegacyFormatConfig';
 
-import {
-  version,
-  renderToString,
-  renderToStaticMarkup,
-} from './ReactDOMLegacyServerBrowser';
+import {version, renderToStringImpl} from './ReactDOMLegacyServerImpl';
 
 import {Readable} from 'stream';
 
@@ -107,6 +103,30 @@ function renderToStaticNodeStream(
   options?: ServerOptions,
 ): Readable {
   return renderToNodeStreamImpl(children, options, true);
+}
+
+function renderToString(
+  children: ReactNodeList,
+  options?: ServerOptions,
+): string {
+  return renderToStringImpl(
+    children,
+    options,
+    false,
+    'The server used "renderToString" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server',
+  );
+}
+
+function renderToStaticMarkup(
+  children: ReactNodeList,
+  options?: ServerOptions,
+): string {
+  return renderToStringImpl(
+    children,
+    options,
+    true,
+    'The server used "renderToStaticMarkup" which does not support Suspense. If you intended to have the server wait for the suspended component please switch to "renderToPipeableStream" which supports Suspense on the server',
+  );
 }
 
 export {

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
@@ -9,101 +9,15 @@
 
 import type {ReactNodeList} from 'shared/ReactTypes';
 
-import type {Request} from 'react-server/src/ReactFizzServer';
-
-import {
-  createRequest,
-  startWork,
-  startFlowing,
-  abort,
-} from 'react-server/src/ReactFizzServer';
-
-import {
-  createResponseState,
-  createRootFormatContext,
-} from './ReactDOMServerLegacyFormatConfig';
-
 import {version, renderToStringImpl} from './ReactDOMLegacyServerImpl';
-
-import {Readable} from 'stream';
+import {
+  renderToNodeStream,
+  renderToStaticNodeStream,
+} from './ReactDOMLegacyServerNodeStream';
 
 type ServerOptions = {
   identifierPrefix?: string,
 };
-
-class ReactMarkupReadableStream extends Readable {
-  request: Request;
-  startedFlowing: boolean;
-  constructor() {
-    // Calls the stream.Readable(options) constructor. Consider exposing built-in
-    // features like highWaterMark in the future.
-    super({});
-    this.request = (null: any);
-    this.startedFlowing = false;
-  }
-
-  _destroy(err, callback) {
-    abort(this.request);
-    // $FlowFixMe: The type definition for the callback should allow undefined and null.
-    callback(err);
-  }
-
-  _read(size) {
-    if (this.startedFlowing) {
-      startFlowing(this.request, this);
-    }
-  }
-}
-
-function onError() {
-  // Non-fatal errors are ignored.
-}
-
-function renderToNodeStreamImpl(
-  children: ReactNodeList,
-  options: void | ServerOptions,
-  generateStaticMarkup: boolean,
-): Readable {
-  function onAllReady() {
-    // We wait until everything has loaded before starting to write.
-    // That way we only end up with fully resolved HTML even if we suspend.
-    destination.startedFlowing = true;
-    startFlowing(request, destination);
-  }
-  const destination = new ReactMarkupReadableStream();
-  const request = createRequest(
-    children,
-    createResponseState(false, options ? options.identifierPrefix : undefined),
-    createRootFormatContext(),
-    Infinity,
-    onError,
-    onAllReady,
-    undefined,
-    undefined,
-  );
-  destination.request = request;
-  startWork(request);
-  return destination;
-}
-
-function renderToNodeStream(
-  children: ReactNodeList,
-  options?: ServerOptions,
-): Readable {
-  if (__DEV__) {
-    console.error(
-      'renderToNodeStream is deprecated. Use renderToPipeableStream instead.',
-    );
-  }
-  return renderToNodeStreamImpl(children, options, false);
-}
-
-function renderToStaticNodeStream(
-  children: ReactNodeList,
-  options?: ServerOptions,
-): Readable {
-  return renderToNodeStreamImpl(children, options, true);
-}
 
 function renderToString(
   children: ReactNodeList,

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ReactNodeList} from 'shared/ReactTypes';
+
+import type {Request} from 'react-server/src/ReactFizzServer';
+
+import {
+  createRequest,
+  startWork,
+  startFlowing,
+  abort,
+} from 'react-server/src/ReactFizzServer';
+
+import {
+  createResponseState,
+  createRootFormatContext,
+} from './ReactDOMServerLegacyFormatConfig';
+
+import {Readable} from 'stream';
+
+type ServerOptions = {
+  identifierPrefix?: string,
+};
+
+class ReactMarkupReadableStream extends Readable {
+  request: Request;
+  startedFlowing: boolean;
+  constructor() {
+    // Calls the stream.Readable(options) constructor. Consider exposing built-in
+    // features like highWaterMark in the future.
+    super({});
+    this.request = (null: any);
+    this.startedFlowing = false;
+  }
+
+  _destroy(err, callback) {
+    abort(this.request);
+    // $FlowFixMe: The type definition for the callback should allow undefined and null.
+    callback(err);
+  }
+
+  _read(size) {
+    if (this.startedFlowing) {
+      startFlowing(this.request, this);
+    }
+  }
+}
+
+function onError() {
+  // Non-fatal errors are ignored.
+}
+
+function renderToNodeStreamImpl(
+  children: ReactNodeList,
+  options: void | ServerOptions,
+  generateStaticMarkup: boolean,
+): Readable {
+  function onAllReady() {
+    // We wait until everything has loaded before starting to write.
+    // That way we only end up with fully resolved HTML even if we suspend.
+    destination.startedFlowing = true;
+    startFlowing(request, destination);
+  }
+  const destination = new ReactMarkupReadableStream();
+  const request = createRequest(
+    children,
+    createResponseState(false, options ? options.identifierPrefix : undefined),
+    createRootFormatContext(),
+    Infinity,
+    onError,
+    onAllReady,
+    undefined,
+    undefined,
+  );
+  destination.request = request;
+  startWork(request);
+  return destination;
+}
+
+function renderToNodeStream(
+  children: ReactNodeList,
+  options?: ServerOptions,
+): Readable {
+  if (__DEV__) {
+    console.error(
+      'renderToNodeStream is deprecated. Use renderToPipeableStream instead.',
+    );
+  }
+  return renderToNodeStreamImpl(children, options, false);
+}
+
+function renderToStaticNodeStream(
+  children: ReactNodeList,
+  options?: ServerOptions,
+): Readable {
+  return renderToNodeStreamImpl(children, options, true);
+}
+
+export {renderToNodeStream, renderToStaticNodeStream};

--- a/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -191,6 +191,8 @@ describe('ReactDOMServerFB', () => {
     const remaining = readResult(stream);
     expect(remaining).toEqual('');
 
-    expect(errors).toEqual(['signal is aborted without reason']);
+    expect(errors).toEqual([
+      'The render was aborted by the server without a reason.',
+    ]);
   });
 });

--- a/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -191,8 +191,6 @@ describe('ReactDOMServerFB', () => {
     const remaining = readResult(stream);
     expect(remaining).toEqual('');
 
-    expect(errors).toEqual([
-      'This Suspense boundary was aborted by the server.',
-    ]);
+    expect(errors).toEqual(['signal is aborted without reason']);
   });
 });

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1530,10 +1530,9 @@ function abortTaskSoft(task: Task): void {
   finishedTask(request, boundary, segment);
 }
 
-function abortTask(task: Task): void {
+function abortTask(task: Task, request: Request, reason: mixed): void {
   // This aborts the task and aborts the parent that it blocks, putting it into
   // client rendered mode.
-  const request: Request = this;
   const boundary = task.blockedBoundary;
   const segment = task.blockedSegment;
   segment.status = ABORTED;
@@ -1553,12 +1552,28 @@ function abortTask(task: Task): void {
 
     if (!boundary.forceClientRender) {
       boundary.forceClientRender = true;
-      const error = new Error(
-        'This Suspense boundary was aborted by the server.',
-      );
+      let error =
+        reason === undefined
+          ? // eslint-disable-next-line react-internal/prod-error-codes
+            new Error('signal is aborted without reason')
+          : reason;
       boundary.errorDigest = request.onError(error);
       if (__DEV__) {
-        captureBoundaryErrorDetailsDev(boundary, error);
+        const errorPrefix =
+          'The server did not finish this Suspense boundary: ';
+        if (error && typeof error.message === 'string') {
+          error = errorPrefix + error.message;
+        } else {
+          // eslint-disable-next-line react-internal/safe-string-coercion
+          error = errorPrefix + String(error);
+        }
+        const previousTaskInDev = currentTaskInDEV;
+        currentTaskInDEV = task;
+        try {
+          captureBoundaryErrorDetailsDev(boundary, error);
+        } finally {
+          currentTaskInDEV = previousTaskInDev;
+        }
       }
       if (boundary.parentFlushed) {
         request.clientRenderedBoundaries.push(boundary);
@@ -1567,7 +1582,9 @@ function abortTask(task: Task): void {
 
     // If this boundary was still pending then we haven't already cancelled its fallbacks.
     // We'll need to abort the fallbacks, which will also error that parent boundary.
-    boundary.fallbackAbortableTasks.forEach(abortTask, request);
+    boundary.fallbackAbortableTasks.forEach(fallbackTask =>
+      abortTask(fallbackTask, request, reason),
+    );
     boundary.fallbackAbortableTasks.clear();
 
     request.allPendingTasks--;
@@ -2159,10 +2176,10 @@ export function startFlowing(request: Request, destination: Destination): void {
 }
 
 // This is called to early terminate a request. It puts all pending boundaries in client rendered state.
-export function abort(request: Request): void {
+export function abort(request: Request, reason: mixed): void {
   try {
     const abortableTasks = request.abortableTasks;
-    abortableTasks.forEach(abortTask, request);
+    abortableTasks.forEach(task => abortTask(task, request, reason));
     abortableTasks.clear();
     if (request.destination !== null) {
       flushCompletedQueues(request, request.destination);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1554,8 +1554,7 @@ function abortTask(task: Task, request: Request, reason: mixed): void {
       boundary.forceClientRender = true;
       let error =
         reason === undefined
-          ? // eslint-disable-next-line react-internal/prod-error-codes
-            new Error('signal is aborted without reason')
+          ? new Error('The render was aborted by the server without a reason.')
           : reason;
       boundary.errorDigest = request.onError(error);
       if (__DEV__) {

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -419,5 +419,6 @@
   "431": "React elements are not allowed in ServerContext",
   "432": "This Suspense boundary was aborted by the server.",
   "433": "useId can only be used while React is rendering",
-  "434": "`dangerouslySetInnerHTML` does not make sense on <title>."
+  "434": "`dangerouslySetInnerHTML` does not make sense on <title>.",
+  "435": "The server did not finish this Suspense boundary. The server used \"%s\" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to \"%s\" which supports Suspense on the server"
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -417,8 +417,7 @@
   "429": "ServerContext: %s already defined",
   "430": "ServerContext can only have a value prop and children. Found: %s",
   "431": "React elements are not allowed in ServerContext",
-  "432": "This Suspense boundary was aborted by the server.",
+  "432": "The render was aborted by the server without a reason.",
   "433": "useId can only be used while React is rendering",
-  "434": "`dangerouslySetInnerHTML` does not make sense on <title>.",
-  "435": "The server did not finish this Suspense boundary. The server used \"%s\" which does not support Suspense. If you intended for this Suspense boundary to render the fallback content on the server consider throwing an Error somewhere within the Suspense boundary. If you intended to have the server wait for the suspended component please switch to \"%s\" which supports Suspense on the server"
+  "434": "`dangerouslySetInnerHTML` does not make sense on <title>."
 }

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -69,6 +69,7 @@ module.exports = [
     paths: [
       'react-dom',
       'react-server-dom-webpack',
+      'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Brower and *Node files
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
       'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -72,6 +72,7 @@ module.exports = [
       'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Brower and *Node files
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
+      'react-dom/src/server/ReactDOMLegacyServerNode.classic.fb.js',
       'react-dom/src/server/ReactDOMLegacyServerNodeStream.js', // file indirection to support partial forking of some methods in *Node
       'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.
     ],

--- a/scripts/shared/inlinedHostConfigs.js
+++ b/scripts/shared/inlinedHostConfigs.js
@@ -72,6 +72,7 @@ module.exports = [
       'react-dom/src/server/ReactDOMLegacyServerImpl.js', // not an entrypoint, but only usable in *Brower and *Node files
       'react-dom/src/server/ReactDOMLegacyServerBrowser.js', // react-dom/server.browser
       'react-dom/src/server/ReactDOMLegacyServerNode.js', // react-dom/server.node
+      'react-dom/src/server/ReactDOMLegacyServerNodeStream.js', // file indirection to support partial forking of some methods in *Node
       'react-client/src/ReactFlightClientStream.js', // We can only type check this in streaming configurations.
     ],
     isFlowTyped: true,


### PR DESCRIPTION
Fizz supports aborting the render but does not currently accept a reason. The various render functions that use Fizz have some automatic and some user-controlled abort semantics that can be useful to communicate with the running program and users about why an Abort happened.

This change implements abort reasons for renderToReadableStream and renderToPipeable stream as well as legacy renderers such as renderToString and related implementations.

For AbortController implementations the reason passed to the abort method is forwarded to Fizz and sent to the onError handler. If no reason is provided the AbortController should construct an AbortError DOMException and as a fallback Fizz will generate a similar error in the absence of a reason

For pipeable  streams, an abort function is returned alongside pipe which already accepted a reason. That reason is now forwarded to Fizz and the implementation described above.

For legacy renderers there is no exposed abort functionality but it is used internally and the reasons provided give useful context to, for instance to the fact that Suspense is not supported in renderToString-like renderers

Some notable special case reasons are included below
If no reason is provided then a manufactured reason "signal is aborted without reason"
If a writable stream errors then a reason "The destination stream errored while writing data."
If a writable stream closes early then a reason "The destination stream closed early."