### PR TITLE
[DevTools] ensure an interval between sending logger events

### DIFF
--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -13,18 +13,19 @@ import {registerEventLogger} from 'react-devtools-shared/src/Logger';
 import {enableLogger} from 'react-devtools-feature-flags';
 
 let loggingIFrame = null;
-let missedEvents = [];
 
 const LOGGING_INTERVAL = 500;
 
 function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 // We need to create a queue to ensure an interval between sending events
 // otherwise Meta's logging system will drop some of them.
-function createLoggingQueue<T>(logFunc: T => void): {
-  push: (T) => void,
+function createLoggingQueue<T>(
+  logFunc: T => void,
+): {
+  push: T => void,
   process: () => void,
 } {
   const eventQueue: Array<T> = [];
@@ -55,8 +56,8 @@ function createLoggingQueue<T>(logFunc: T => void): {
 
   return {
     push: pushEvent,
-    process: processQueue
-  }
+    process: processQueue,
+  };
 }
 
 export function registerDevToolsEventLogger(surface: string) {

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -16,10 +16,6 @@ let loggingIFrame = null;
 
 const LOGGING_INTERVAL = 500;
 
-function delay(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 // We need to create a queue to ensure an interval between sending events
 // otherwise Meta's logging system will drop some of them.
 function createLoggingQueue<T>(
@@ -43,11 +39,11 @@ function createLoggingQueue<T>(
     pending = true;
     const event = eventQueue.shift();
     logFunc(event);
-    delay(LOGGING_INTERVAL).then(() => {
+    setTimeout(() => {
       // process the next event in the queue
       pending = false;
       processQueue();
-    });
+    }, LOGGING_INTERVAL);
   }
 
   function pushEvent(event: T) {


### PR DESCRIPTION
## Summary

In internal logging, we noticed the amount of "selected-components-tab" and "selected-profiler-tab" events are far less than "loaded-dev-tools".
This is because of how the server's logging sample rate is set up. When two events are too close to each other, the 2nd one is likely to be dropped.
This only happens for "selected-components-tab" and "selected-profiler-tab" now, because when the tab is activated for the first time, the logger needs to wait for an iframe to be created, and the event are sent right after "loaded-dev-tools" as "missed events". If the user then switch to another tab (components to profiler or the other way around), we are able to successfully log the event. That's why the numbers are low but not zero.
In the future, if we add more events that are close enough to another one, this can cause other events to be dropped.

This PR creates a queue to ensure an interval between events, to make sure this won't happen anymore.

## How did you test this change?

Tested with temporary `console.log` with an internal build. 
In the screenshot, you can see the two "missed" events are both sent, and the second one ("selected-components-tab") is sent after some delay.
When both of them are processed, if `logEvent` is called again, the event is sent immediately.
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/1001890/172739698-dbc9b4c0-61d9-4564-b41a-0271cf639fbd.png">


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
