### PR TITLE
[Transition Tracing] Push Transition When Offscreen Becomes Visible

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -779,7 +779,17 @@ function updateOffscreenComponent(
         prevCachePool = prevState.cachePool;
       }
 
-      pushTransition(workInProgress, prevCachePool, null);
+      let transitions = null;
+      if (
+        workInProgress.memoizedState !== null &&
+        workInProgress.memoizedState.transitions !== null
+      ) {
+        // We have now gone from hidden to visible, so any transitions should
+        // be added to the stack to get added to any Offscreen/suspense children
+        transitions = workInProgress.memoizedState.transitions;
+      }
+
+      pushTransition(workInProgress, prevCachePool, transitions);
 
       // Since we're not hidden anymore, reset the state
       workInProgress.memoizedState = null;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -779,7 +779,17 @@ function updateOffscreenComponent(
         prevCachePool = prevState.cachePool;
       }
 
-      pushTransition(workInProgress, prevCachePool, null);
+      let transitions = null;
+      if (
+        workInProgress.memoizedState !== null &&
+        workInProgress.memoizedState.transitions !== null
+      ) {
+        // We have now gone from hidden to visible, so any transitions should
+        // be added to the stack to get added to any Offscreen/suspense children
+        transitions = workInProgress.memoizedState.transitions;
+      }
+
+      pushTransition(workInProgress, prevCachePool, transitions);
 
       // Since we're not hidden anymore, reset the state
       workInProgress.memoizedState = null;


### PR DESCRIPTION
This PR pushes all of a suspense boundary's transitions onto the transition stack when it goes from hidden to visible so we can pass it to any child suspense boundaries or tracing markers.
