### PR TITLE
[Transition Tracing] Fix Cache and Transitions Pop Order

### DIFF
--- a/packages/react-reconciler/src/ReactFiberTransition.new.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.new.js
@@ -139,12 +139,12 @@ export function pushTransition(
 
 export function popTransition(workInProgress: Fiber, current: Fiber | null) {
   if (current !== null) {
-    if (enableCache) {
-      pop(resumedCache, workInProgress);
-    }
-
     if (enableTransitionTracing) {
       pop(transitionStack, workInProgress);
+    }
+
+    if (enableCache) {
+      pop(resumedCache, workInProgress);
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberTransition.old.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.old.js
@@ -139,12 +139,12 @@ export function pushTransition(
 
 export function popTransition(workInProgress: Fiber, current: Fiber | null) {
   if (current !== null) {
-    if (enableCache) {
-      pop(resumedCache, workInProgress);
-    }
-
     if (enableTransitionTracing) {
       pop(transitionStack, workInProgress);
+    }
+
+    if (enableCache) {
+      pop(resumedCache, workInProgress);
     }
   }
 }


### PR DESCRIPTION
We push the Cache before the transition so we should pop the transition before the cache. This PR fixes this issue.