### PR TITLE
Activate Fizz Streaming Tests in all Channels

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -37,9 +37,7 @@ describe('ReactDOMFizzServer', () => {
     Scheduler = require('scheduler');
     React = require('react');
     ReactDOMClient = require('react-dom/client');
-    if (__EXPERIMENTAL__) {
-      ReactDOMFizzServer = require('react-dom/server');
-    }
+    ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
     Suspense = React.Suspense;
     if (gate(flags => flags.enableSuspenseList)) {
@@ -263,7 +261,6 @@ describe('ReactDOMFizzServer', () => {
     return <As>{readText(text)}</As>;
   }
 
-  // @gate experimental
   it('should asynchronously load a lazy component', async () => {
     let resolveA;
     const LazyA = React.lazy(() => {
@@ -330,7 +327,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('#23331: does not warn about hydration mismatches if something suspended in an earlier sibling', async () => {
     const makeApp = () => {
       let resolve;
@@ -396,7 +392,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should support nonce scripts', async () => {
     CSPnonce = 'R4nd0m';
     try {
@@ -428,7 +423,6 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental
   it('should client render a boundary if a lazy component rejects', async () => {
     let rejectComponent;
     const LazyComponent = React.lazy(() => {
@@ -522,7 +516,6 @@ describe('ReactDOMFizzServer', () => {
     expect(loggedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should asynchronously load a lazy element', async () => {
     let resolveElement;
     const lazyElement = React.lazy(() => {
@@ -552,7 +545,6 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
   });
 
-  // @gate experimental
   it('should client render a boundary if a lazy element rejects', async () => {
     let rejectElement;
     const element = <Text text="Hello" />;
@@ -642,7 +634,6 @@ describe('ReactDOMFizzServer', () => {
     expect(loggedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('Errors in boundaries should be sent to the client and reported on client render - Error before flushing', async () => {
     function Indirection({level, children}) {
       if (level > 0) {
@@ -719,7 +710,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('Errors in boundaries should be sent to the client and reported on client render - Error after flushing', async () => {
     let rejectComponent;
     const LazyComponent = React.lazy(() => {
@@ -802,7 +792,6 @@ describe('ReactDOMFizzServer', () => {
     expect(loggedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should asynchronously load the suspense boundary', async () => {
     await act(async () => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -821,7 +810,6 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Hello World</div>);
   });
 
-  // @gate experimental
   it('waits for pending content to come in from the server and then hydrates it', async () => {
     const ref = React.createRef();
 
@@ -885,7 +873,6 @@ describe('ReactDOMFizzServer', () => {
     expect(ref.current).toBe(h1);
   });
 
-  // @gate experimental
   it('handles an error on the client if the server ends up erroring', async () => {
     const ref = React.createRef();
 
@@ -967,7 +954,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // @gate enableSuspenseList
-  // @gate experimental
+
   it('shows inserted items before pending in a SuspenseList as fallbacks while hydrating', async () => {
     const ref = React.createRef();
 
@@ -1056,7 +1043,6 @@ describe('ReactDOMFizzServer', () => {
     expect(ref.current).toBe(span);
   });
 
-  // @gate experimental
   it('client renders a boundary if it does not resolve before aborting', async () => {
     function App() {
       return (
@@ -1134,7 +1120,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should allow for two containers to be written to the same document', async () => {
     // We create two passthrough streams for each container to write into.
     // Notably we don't implement a end() call for these. Because we don't want to
@@ -1225,7 +1210,6 @@ describe('ReactDOMFizzServer', () => {
     ]);
   });
 
-  // @gate experimental
   it('can resolve async content in esoteric parents', async () => {
     function AsyncOption({text}) {
       return <option>{readText(text)}</option>;
@@ -1323,7 +1307,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('can resolve async content in table parents', async () => {
     function AsyncTableBody({className, children}) {
       return <tbody className={readText(className)}>{children}</tbody>;
@@ -1396,7 +1379,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('can stream into an SVG container', async () => {
     function AsyncPath({id}) {
       return <path id={readText(id)} />;
@@ -1461,7 +1443,6 @@ describe('ReactDOMFizzServer', () => {
     );
   }
 
-  // @gate experimental
   it('should include a component stack across suspended boundaries', async () => {
     function B() {
       const children = [readText('Hello'), readText('World')];
@@ -1561,7 +1542,6 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental
   it('should can suspend in a class component with legacy context', async () => {
     class TestProvider extends React.Component {
       static childContextTypes = {
@@ -1629,7 +1609,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should resume the context from where it left off', async () => {
     const ContextA = React.createContext('A0');
     const ContextB = React.createContext('B0');
@@ -1694,7 +1673,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should recover the outer context when an error happens inside a provider', async () => {
     const ContextA = React.createContext('A0');
     const ContextB = React.createContext('B0');
@@ -1761,7 +1739,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('client renders a boundary if it errors before finishing the fallback', async () => {
     function App({isClient}) {
       return (
@@ -1869,7 +1846,6 @@ describe('ReactDOMFizzServer', () => {
     expect(loggedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should be able to abort the fallback if the main content finishes first', async () => {
     await act(async () => {
       const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -1899,7 +1875,7 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>Hello</div>);
   });
 
-  // @gate experimental && enableSuspenseAvoidThisFallbackFizz
+  // @gate enableSuspenseAvoidThisFallbackFizz
   it('should respect unstable_avoidThisFallback', async () => {
     const resolved = {
       0: false,
@@ -2046,7 +2022,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('calls getServerSnapshot instead of getSnapshot', async () => {
     const ref = React.createRef();
 
@@ -2127,7 +2102,7 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // The selector implementation uses the lazy ref initialization pattern
-  // @gate experimental
+
   it('calls getServerSnapshot instead of getSnapshot (with selector and isEqual)', async () => {
     // Same as previous test, but with a selector that returns a complex object
     // that is memoized with a custom `isEqual` function.
@@ -2212,7 +2187,6 @@ describe('ReactDOMFizzServer', () => {
     expect(getVisibleChildren(container)).toEqual(<div>client</div>);
   });
 
-  // @gate experimental
   it(
     'errors during hydration in the shell force a client render at the ' +
       'root, and during the client render it recovers',
@@ -2295,7 +2269,6 @@ describe('ReactDOMFizzServer', () => {
     },
   );
 
-  // @gate experimental
   it(
     'errors during hydration force a client render at the nearest Suspense ' +
       'boundary, and during the client render it recovers',
@@ -2389,7 +2362,6 @@ describe('ReactDOMFizzServer', () => {
     },
   );
 
-  // @gate experimental
   it(
     'errors during hydration force a client render at the nearest Suspense ' +
       'boundary, and during the client render it fails again',
@@ -2464,7 +2436,7 @@ describe('ReactDOMFizzServer', () => {
 
   // Disabled because of a WWW late mutations regression.
   // We may want to re-enable this if we figure out why.
-  // @gate experimental
+
   // @gate FIXME
   it('does not recreate the fallback if server errors and hydration suspends', async () => {
     let isClient = false;
@@ -2546,7 +2518,7 @@ describe('ReactDOMFizzServer', () => {
 
   // Disabled because of a WWW late mutations regression.
   // We may want to re-enable this if we figure out why.
-  // @gate experimental
+
   // @gate FIXME
   it(
     'does not recreate the fallback if server errors and hydration suspends ' +
@@ -2645,7 +2617,7 @@ describe('ReactDOMFizzServer', () => {
 
   // Disabled because of a WWW late mutations regression.
   // We may want to re-enable this if we figure out why.
-  // @gate experimental
+
   // @gate FIXME
   it(
     'recreates the fallback if server errors and hydration suspends but ' +
@@ -2751,7 +2723,6 @@ describe('ReactDOMFizzServer', () => {
     },
   );
 
-  // @gate experimental
   it(
     'errors during hydration force a client render at the nearest Suspense ' +
       'boundary, and during the client render it recovers, then a deeper ' +
@@ -2921,7 +2892,6 @@ describe('ReactDOMFizzServer', () => {
     expect(container.textContent).toEqual('AB');
   });
 
-  // @gate experimental
   it('logs multiple hydration errors in the same render', async () => {
     let isClient = false;
 
@@ -2991,7 +2961,7 @@ describe('ReactDOMFizzServer', () => {
     ]);
   });
 
-  // @gate enableServerContext && experimental
+  // @gate enableServerContext
   it('supports ServerContext', async () => {
     let ServerContext;
     function inlineLazyServerContextInitialization() {
@@ -3040,7 +3010,6 @@ describe('ReactDOMFizzServer', () => {
     ]);
   });
 
-  // @gate experimental
   it('Supports iterable', async () => {
     const Immutable = require('immutable');
 
@@ -3063,7 +3032,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('Supports custom abort reasons with a string', async () => {
     function App() {
       return (
@@ -3150,7 +3118,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('Supports custom abort reasons with an Error', async () => {
     function App() {
       return (
@@ -3236,7 +3203,6 @@ describe('ReactDOMFizzServer', () => {
   });
 
   describe('error escaping', () => {
-    //@gate experimental
     it('escapes error hash, message, and component stack values in directly flushed errors (html escaping)', async () => {
       window.__outlet = {};
 
@@ -3281,7 +3247,7 @@ describe('ReactDOMFizzServer', () => {
       });
       expect(window.__outlet).toEqual({});
     });
-    //@gate experimental
+
     it('escapes error hash, message, and component stack values in clientRenderInstruction (javascript escaping)', async () => {
       window.__outlet = {};
 
@@ -3333,7 +3299,7 @@ describe('ReactDOMFizzServer', () => {
       });
       expect(window.__outlet).toEqual({});
     });
-    //@gate experimental
+
     it('escapes such that attributes cannot be masked', async () => {
       const dangerousErrorString = '" data-msg="bad message" data-foo="';
       const theError = new Error(dangerousErrorString);
@@ -3399,7 +3365,6 @@ describe('ReactDOMFizzServer', () => {
   });
 
   describe('bootstrapScriptContent escaping', () => {
-    // @gate experimental
     it('the "S" in "</?[Ss]cript" strings are replaced with unicode escaped lowercase s or S depending on case, preserving case sensitivity of nearby characters', async () => {
       window.__test_outlet = '';
       const stringWithScriptsInIt =
@@ -3416,7 +3381,6 @@ describe('ReactDOMFizzServer', () => {
       expect(window.__test_outlet).toMatch(stringWithScriptsInIt);
     });
 
-    // @gate experimental
     it('does not escape \\u2028, or \\u2029 characters', async () => {
       // these characters are ignored in engines support https://github.com/tc39/proposal-json-superset
       // in this test with JSDOM the characters are silently dropped and thus don't need to be encoded.
@@ -3441,7 +3405,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('does not escape <, >, or & characters', async () => {
       // these characters valid javascript and may be necessary in scripts and won't be interpretted properly
       // escaped outside of a string context within javascript
@@ -3459,7 +3422,6 @@ describe('ReactDOMFizzServer', () => {
     });
   });
 
-  // @gate experimental
   it('#24384: Suspending should halt hydration warnings and not emit any if hydration completes successfully after unsuspending', async () => {
     const makeApp = () => {
       let resolve, resolved;
@@ -3535,7 +3497,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('#24384: Suspending should halt hydration warnings but still emit hydration warnings after unsuspending if mismatches are genuine', async () => {
     const makeApp = () => {
       let resolve, resolved;
@@ -3625,7 +3586,6 @@ describe('ReactDOMFizzServer', () => {
     expect(Scheduler).toFlushAndYield([]);
   });
 
-  // @gate experimental
   it('only warns once on hydration mismatch while within a suspense boundary', async () => {
     const originalConsoleError = console.error;
     const mockError = jest.fn();
@@ -3704,7 +3664,6 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental
   it('supresses hydration warnings when an error occurs within a Suspense boundary', async () => {
     let isClient = false;
     let shouldThrow = true;
@@ -3778,7 +3737,7 @@ describe('ReactDOMFizzServer', () => {
     expect(Scheduler).toFlushAndYield([]);
   });
 
-  // @gate experimental && __DEV__
+  // @gate __DEV__
   it('does not invokeGuardedCallback for errors after the first hydration error', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;
@@ -3890,7 +3849,6 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental
   it('does not invokeGuardedCallback for errors after a preceding fiber suspends', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;
@@ -4013,7 +3971,7 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental && __DEV__
+  // @gate __DEV__
   it('suspending after erroring will cause errors previously queued to be silenced until the boundary resolves', async () => {
     // We can't use the toErrorDev helper here because this is async.
     const originalConsoleError = console.error;
@@ -4141,7 +4099,6 @@ describe('ReactDOMFizzServer', () => {
     }
   });
 
-  // @gate experimental
   it('#24578 Hydration errors caused by a suspending component should not become recoverable when nested in an ancestor Suspense that is showing primary content', async () => {
     // this test failed before because hydration errors on the inner boundary were upgraded to recoverable by
     // a codepath of the outer boundary
@@ -4196,7 +4153,6 @@ describe('ReactDOMFizzServer', () => {
       });
     }
 
-    // @gate experimental
     it('it only includes separators between adjacent text nodes', async () => {
       function App({name}) {
         return (
@@ -4231,7 +4187,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('it does not insert text separators even when adjacent text is in a delayed segment', async () => {
       function App({name}) {
         return (
@@ -4287,7 +4242,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('it works with multiple adjacent segments', async () => {
       function App() {
         return (
@@ -4333,7 +4287,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('it works when some segments are flushed and others are patched', async () => {
       function App() {
         return (
@@ -4376,7 +4329,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('it does not prepend a text separators if the segment follows a non-Text Node', async () => {
       function App() {
         return (
@@ -4417,7 +4369,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('it does not prepend a text separators if the segments first emission is a non-Text Node', async () => {
       function App() {
         return (
@@ -4456,7 +4407,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('should not insert separators for text inside Suspense boundaries even if they would otherwise be considered text-embedded', async () => {
       function App() {
         return (
@@ -4541,7 +4491,6 @@ describe('ReactDOMFizzServer', () => {
       );
     });
 
-    // @gate experimental
     it('(only) includes extraneous text separators in segments that complete before flushing, followed by nothing or a non-Text node', async () => {
       function App() {
         return (
@@ -4615,7 +4564,6 @@ describe('ReactDOMFizzServer', () => {
       container = document.getElementsByTagName('head')[0];
     }
 
-    // @gate experimental
     it('should accept a single string child', async () => {
       // a Single string child
       function App() {
@@ -4640,7 +4588,6 @@ describe('ReactDOMFizzServer', () => {
       expect(getVisibleChildren(container)).toEqual(<title>hello</title>);
     });
 
-    // @gate experimental
     it('should accept children array of length 1 containing a string', async () => {
       // a Single string child
       function App() {
@@ -4665,7 +4612,6 @@ describe('ReactDOMFizzServer', () => {
       expect(getVisibleChildren(container)).toEqual(<title>hello</title>);
     });
 
-    // @gate experimental
     it('should warn in dev when given an array of length 2 or more', async () => {
       const originalConsoleError = console.error;
       const mockError = jest.fn();
@@ -4728,7 +4674,6 @@ describe('ReactDOMFizzServer', () => {
       }
     });
 
-    // @gate experimental
     it('should warn in dev if you pass a React Component as a child to <title>', async () => {
       const originalConsoleError = console.error;
       const mockError = jest.fn();

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerBrowser-test.js
@@ -21,9 +21,7 @@ describe('ReactDOMFizzServer', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    if (__EXPERIMENTAL__) {
-      ReactDOMFizzServer = require('react-dom/server.browser');
-    }
+    ReactDOMFizzServer = require('react-dom/server.browser');
     Suspense = React.Suspense;
   });
 
@@ -48,7 +46,6 @@ describe('ReactDOMFizzServer', () => {
     }
   }
 
-  // @gate experimental
   it('should call renderToReadableStream', async () => {
     const stream = await ReactDOMFizzServer.renderToReadableStream(
       <div>hello world</div>,
@@ -57,7 +54,6 @@ describe('ReactDOMFizzServer', () => {
     expect(result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
   });
 
-  // @gate experimental
   it('should emit DOCTYPE at the root of the document', async () => {
     const stream = await ReactDOMFizzServer.renderToReadableStream(
       <html>
@@ -70,7 +66,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should emit bootstrap script src at the end', async () => {
     const stream = await ReactDOMFizzServer.renderToReadableStream(
       <div>hello world</div>,
@@ -86,7 +81,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('emits all HTML as one unit if we wait until the end to start', async () => {
     let hasLoaded = false;
     let resolve;
@@ -124,7 +118,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should reject the promise when an error is thrown at the root', async () => {
     const reportedErrors = [];
     let caughtError = null;
@@ -146,7 +139,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should reject the promise when an error is thrown inside a fallback', async () => {
     const reportedErrors = [];
     let caughtError = null;
@@ -170,7 +162,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
     const stream = await ReactDOMFizzServer.renderToReadableStream(
@@ -191,7 +182,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should be able to complete by aborting even if the promise never resolves', async () => {
     const errors = [];
     const controller = new AbortController();
@@ -219,7 +209,6 @@ describe('ReactDOMFizzServer', () => {
     ]);
   });
 
-  // @gate experimental
   it('should not continue rendering after the reader cancels', async () => {
     let hasLoaded = false;
     let resolve;
@@ -268,7 +257,6 @@ describe('ReactDOMFizzServer', () => {
     expect(isComplete).toBe(true);
   });
 
-  // @gate experimental
   it('should stream large contents that might overlow individual buffers', async () => {
     const str492 = `(492) This string is intentionally 492 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux q :: total count (492)`;
     const str2049 = `(2049) This string is intentionally 2049 bytes long because we want to make sure we process chunks that will overflow buffer boundaries. It will repeat to fill out the bytes required (inclusive of this prompt):: foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy thud foo bar qux quux corge grault garply waldo fred plugh xyzzy  :: total count (2049)`;
@@ -308,7 +296,6 @@ describe('ReactDOMFizzServer', () => {
     expect(result).toMatchInlineSnapshot(`"<div>${str2049}</div>"`);
   });
 
-  // @gate experimental
   it('Supports custom abort reasons with a string', async () => {
     const promise = new Promise(r => {});
     function Wait() {
@@ -350,7 +337,6 @@ describe('ReactDOMFizzServer', () => {
     expect(errors).toEqual(['foobar', 'foobar']);
   });
 
-  // @gate experimental
   it('Supports custom abort reasons with an Error', async () => {
     const promise = new Promise(r => {});
     function Wait() {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -19,9 +19,7 @@ describe('ReactDOMFizzServer', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
-    if (__EXPERIMENTAL__) {
-      ReactDOMFizzServer = require('react-dom/server');
-    }
+    ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
     Suspense = React.Suspense;
   });
@@ -56,7 +54,6 @@ describe('ReactDOMFizzServer', () => {
     throw theInfinitePromise;
   }
 
-  // @gate experimental
   it('should call renderToPipeableStream', () => {
     const {writable, output} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -67,7 +64,6 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toMatchInlineSnapshot(`"<div>hello world</div>"`);
   });
 
-  // @gate experimental
   it('should emit DOCTYPE at the root of the document', () => {
     const {writable, output} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -82,7 +78,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should emit bootstrap script src at the end', () => {
     const {writable, output} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -100,7 +95,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should start writing after pipe', () => {
     const {writable, output} = getTestWritable();
     const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -117,7 +111,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('emits all HTML as one unit if we wait until the end to start', async () => {
     let hasLoaded = false;
     let resolve;
@@ -165,7 +158,6 @@ describe('ReactDOMFizzServer', () => {
     );
   });
 
-  // @gate experimental
   it('should error the stream when an error is thrown at the root', async () => {
     const reportedErrors = [];
     const reportedShellErrors = [];
@@ -197,7 +189,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedShellErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should error the stream when an error is thrown inside a fallback', async () => {
     const reportedErrors = [];
     const reportedShellErrors = [];
@@ -231,7 +222,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedShellErrors).toEqual([theError]);
   });
 
-  // @gate experimental
   it('should not error the stream when an error is thrown inside suspense boundary', async () => {
     const reportedErrors = [];
     const reportedShellErrors = [];
@@ -263,7 +253,6 @@ describe('ReactDOMFizzServer', () => {
     expect(reportedShellErrors).toEqual([]);
   });
 
-  // @gate experimental
   it('should not attempt to render the fallback if the main content completes first', async () => {
     const {writable, output, completed} = getTestWritable();
 
@@ -289,7 +278,6 @@ describe('ReactDOMFizzServer', () => {
     expect(renderedFallback).toBe(false);
   });
 
-  // @gate experimental
   it('should be able to complete by aborting even if the promise never resolves', async () => {
     let isCompleteCalls = 0;
     const errors = [];
@@ -327,7 +315,6 @@ describe('ReactDOMFizzServer', () => {
     expect(isCompleteCalls).toBe(1);
   });
 
-  // @gate experimental
   it('should be able to complete by abort when the fallback is also suspended', async () => {
     let isCompleteCalls = 0;
     const errors = [];
@@ -371,7 +358,6 @@ describe('ReactDOMFizzServer', () => {
     expect(isCompleteCalls).toBe(1);
   });
 
-  // @gate experimental
   it('should be able to get context value when promise resolves', async () => {
     class DelayClient {
       get() {
@@ -422,7 +408,6 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toContain('OK');
   });
 
-  // @gate experimental
   it('should be able to get context value when calls renderToPipeableStream twice at the same time', async () => {
     class DelayClient {
       get() {
@@ -497,7 +482,6 @@ describe('ReactDOMFizzServer', () => {
     expect(output1.result).toContain('OK');
   });
 
-  // @gate experimental
   it('should be able to pop context after suspending', async () => {
     class DelayClient {
       get() {
@@ -555,7 +539,6 @@ describe('ReactDOMFizzServer', () => {
     expect(output.result).toContain('OK');
   });
 
-  // @gate experimental
   it('should not continue rendering after the writable ends unexpectedly', async () => {
     let hasLoaded = false;
     let resolve;

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -29,9 +29,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     Scheduler = require('scheduler');
     React = require('react');
     ReactDOMClient = require('react-dom/client');
-    if (__EXPERIMENTAL__) {
-      ReactDOMFizzServer = require('react-dom/server');
-    }
+    ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
 
     // Test Environment
@@ -127,7 +125,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
       : children;
   }
 
-  // @gate experimental
   it('suppresses and fixes text mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -167,7 +164,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('suppresses and fixes multiple text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -209,7 +205,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on text-to-element mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -261,7 +256,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('suppresses and fixes client-only single text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -297,7 +291,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
   });
 
   // TODO: This behavior is not consistent with client-only single text node.
-  // @gate experimental
+
   it('errors on server-only single text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -343,7 +337,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on client-only extra text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -395,7 +388,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on server-only extra text node mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -446,7 +438,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on element-to-text mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -499,7 +490,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('suppresses and does not fix attribute mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -538,7 +528,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('suppresses and does not fix html mismatches with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -576,7 +565,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on insertions with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (
@@ -622,7 +610,6 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     );
   });
 
-  // @gate experimental
   it('errors on deletions with suppressHydrationWarning', async () => {
     function App({isClient}) {
       return (


### PR DESCRIPTION
Builds on top of https://github.com/facebook/react/pull/24724

These were not running on the stable channel because we avoided requiring the module outside of EXPERIMENTAL.

Notably these don't technically work in `www-classic` since it's the partial renderer but neither do the other tests since they're using the Node and Browser APIs instead of the HaaS APIs. Jest already side-steps this problem by not running against the HaaS builds and we don't run tests against www builds anyway.