### PR TITLE
React DOM: Add support for `hidden="until-found"`

### DIFF
--- a/fixtures/attribute-behavior/AttributeTableSnapshot.md
+++ b/fixtures/attribute-behavior/AttributeTableSnapshot.md
@@ -4926,21 +4926,21 @@
 ## `hidden` (on `<div>` inside `<div>`)
 | Test Case | Flags | Result |
 | --- | --- | --- |
-| `hidden=(string)`| (changed)| `<boolean: true>` |
-| `hidden=(empty string)`| (initial)| `<boolean: false>` |
-| `hidden=(array with string)`| (changed)| `<boolean: true>` |
+| `hidden=(string)`| (changed)| `"until-found"` |
+| `hidden=(empty string)`| (changed)| `<boolean: true>` |
+| `hidden=(array with string)`| (changed)| `"until-found"` |
 | `hidden=(empty array)`| (changed)| `<boolean: true>` |
 | `hidden=(object)`| (changed)| `<boolean: true>` |
 | `hidden=(numeric string)`| (changed)| `<boolean: true>` |
 | `hidden=(-1)`| (changed)| `<boolean: true>` |
-| `hidden=(0)`| (initial)| `<boolean: false>` |
+| `hidden=(0)`| (changed)| `<boolean: true>` |
 | `hidden=(integer)`| (changed)| `<boolean: true>` |
-| `hidden=(NaN)`| (initial, warning)| `<boolean: false>` |
+| `hidden=(NaN)`| (changed, warning)| `<boolean: true>` |
 | `hidden=(float)`| (changed)| `<boolean: true>` |
 | `hidden=(true)`| (changed)| `<boolean: true>` |
 | `hidden=(false)`| (initial)| `<boolean: false>` |
-| `hidden=(string 'true')`| (changed, warning)| `<boolean: true>` |
-| `hidden=(string 'false')`| (changed, warning)| `<boolean: true>` |
+| `hidden=(string 'true')`| (changed)| `<boolean: true>` |
+| `hidden=(string 'false')`| (changed)| `<boolean: true>` |
 | `hidden=(string 'on')`| (changed)| `<boolean: true>` |
 | `hidden=(string 'off')`| (changed)| `<boolean: true>` |
 | `hidden=(symbol)`| (initial, warning)| `<boolean: false>` |

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -722,7 +722,6 @@ function setProp(
     case 'disablePictureInPicture':
     case 'disableRemotePlayback':
     case 'formNoValidate':
-    case 'hidden':
     case 'loop':
     case 'noModule':
     case 'noValidate':
@@ -743,6 +742,7 @@ function setProp(
     }
     // Overloaded Boolean
     case 'capture':
+    case 'hidden':
     case 'download': {
       // An attribute that can be used as a flag as well as with a value.
       // When true, it should be present (set either to an empty string or its name).
@@ -2507,7 +2507,6 @@ function diffHydratedGenericElement(
       case 'disablePictureInPicture':
       case 'disableRemotePlayback':
       case 'formNoValidate':
-      case 'hidden':
       case 'loop':
       case 'noModule':
       case 'noValidate':
@@ -2530,6 +2529,7 @@ function diffHydratedGenericElement(
         continue;
       }
       case 'capture':
+      case 'hidden':
       case 'download': {
         hydrateOverloadedBooleanAttribute(
           domElement,

--- a/packages/react-dom-bindings/src/events/DOMEventNames.js
+++ b/packages/react-dom-bindings/src/events/DOMEventNames.js
@@ -18,6 +18,7 @@ export type DOMEventName =
   // 'animationstart' |
   | 'beforeblur' // Not a real event. This is used by event experiments.
   | 'beforeinput'
+  | 'beforematch'
   | 'blur'
   | 'canplay'
   | 'canplaythrough'

--- a/packages/react-dom-bindings/src/events/DOMEventProperties.js
+++ b/packages/react-dom-bindings/src/events/DOMEventProperties.js
@@ -34,6 +34,7 @@ export const topLevelEventsToReactNames: Map<DOMEventName, string | null> =
 const simpleEventPluginEvents = [
   'abort',
   'auxClick',
+  'beforematch',
   'cancel',
   'canPlay',
   'canPlayThrough',

--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -53,6 +53,7 @@ import {
 } from 'react-reconciler/src/ReactEventPriorities';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {isRootDehydrated} from 'react-reconciler/src/ReactFiberShellHydration';
+import {enableNewDOMProps} from 'shared/ReactFeatureFlags';
 
 const {ReactCurrentBatchConfig} = ReactSharedInternals;
 
@@ -386,6 +387,11 @@ export function getEventPriority(domEventName: DOMEventName): EventPriority {
           return DefaultEventPriority;
       }
     }
+    case 'beforematch':
+      if (enableNewDOMProps) {
+        return DiscreteEventPriority;
+      }
+    // fall through without enableNewDOMProps
     default:
       return DefaultEventPriority;
   }

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -1290,7 +1290,6 @@ function pushAttribute(
     case 'disablePictureInPicture':
     case 'disableRemotePlayback':
     case 'formNoValidate':
-    case 'hidden':
     case 'loop':
     case 'noModule':
     case 'noValidate':
@@ -1313,6 +1312,7 @@ function pushAttribute(
       return;
     }
     case 'capture':
+    case 'hidden':
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
@@ -5189,7 +5189,10 @@ function writeStyleResourceAttributeInAttr(
       if (value === false) {
         return;
       }
-      attributeValue = '';
+      if (__DEV__) {
+        checkAttributeStringCoercion(value, attributeName);
+      }
+      attributeValue = '' + (value: any);
       break;
     }
 

--- a/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
+++ b/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js
@@ -34,6 +34,7 @@ import {
   enableFloat,
   enableFormActions,
   enableFizzExternalRuntime,
+  enableNewDOMProps,
 } from 'shared/ReactFeatureFlags';
 
 import type {
@@ -1311,8 +1312,19 @@ function pushAttribute(
       }
       return;
     }
-    case 'capture':
     case 'hidden':
+      if (!enableNewDOMProps) {
+        // Boolean
+        if (value && typeof value !== 'function' && typeof value !== 'symbol') {
+          target.push(
+            attributeSeparator,
+            stringToChunk(name),
+            attributeEmptyString,
+          );
+        }
+      }
+    // fallthrough to overloaded boolean with enableNewDOMProps
+    case 'capture':
     case 'download': {
       // Overloaded Boolean
       if (value === true) {
@@ -4994,7 +5006,16 @@ function writeStyleResourceAttributeInJS(
       if (value === false) {
         return;
       }
-      attributeValue = '';
+      if (enableNewDOMProps) {
+        // overloaded Boolean
+        if (__DEV__) {
+          checkAttributeStringCoercion(value, attributeName);
+        }
+        attributeValue = '' + (value: any);
+      } else {
+        // just Boolean
+        attributeValue = '';
+      }
       break;
     }
     // Santized URLs
@@ -5189,10 +5210,16 @@ function writeStyleResourceAttributeInAttr(
       if (value === false) {
         return;
       }
-      if (__DEV__) {
-        checkAttributeStringCoercion(value, attributeName);
+      if (enableNewDOMProps) {
+        // overloaded Boolean
+        if (__DEV__) {
+          checkAttributeStringCoercion(value, attributeName);
+        }
+        attributeValue = '' + (value: any);
+      } else {
+        // just Boolean
+        attributeValue = '';
       }
-      attributeValue = '' + (value: any);
       break;
     }
 

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -12,6 +12,7 @@ import hasOwnProperty from 'shared/hasOwnProperty';
 import {
   enableCustomElementPropertySupport,
   enableFormActions,
+  enableNewDOMProps,
 } from 'shared/ReactFeatureFlags';
 
 const warnedProperties = {};
@@ -223,6 +224,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'disablePictureInPicture':
           case 'disableRemotePlayback':
           case 'formNoValidate':
+          case 'hidden':
           case 'loop':
           case 'noModule':
           case 'noValidate':
@@ -235,7 +237,6 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'seamless':
           case 'itemScope':
           case 'capture':
-          case 'hidden':
           case 'download': {
             // Boolean properties can accept boolean values
             return true;
@@ -313,6 +314,12 @@ function validateProperty(tagName, name, value, eventRegistry) {
             case 'itemScope': {
               break;
             }
+            case 'hidden': {
+              if (!enableNewDOMProps) {
+                break;
+              }
+            }
+            // fallthrough to overloaded boolean with enableNewDOMProps
             default: {
               return true;
             }

--- a/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMUnknownPropertyHook.js
@@ -223,7 +223,6 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'disablePictureInPicture':
           case 'disableRemotePlayback':
           case 'formNoValidate':
-          case 'hidden':
           case 'loop':
           case 'noModule':
           case 'noValidate':
@@ -236,6 +235,7 @@ function validateProperty(tagName, name, value, eventRegistry) {
           case 'seamless':
           case 'itemScope':
           case 'capture':
+          case 'hidden':
           case 'download': {
             // Boolean properties can accept boolean values
             return true;
@@ -300,7 +300,6 @@ function validateProperty(tagName, name, value, eventRegistry) {
             case 'disablePictureInPicture':
             case 'disableRemotePlayback':
             case 'formNoValidate':
-            case 'hidden':
             case 'loop':
             case 'noModule':
             case 'noValidate':

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -3452,15 +3452,15 @@ describe('ReactDOMComponent', () => {
         const root = ReactDOMClient.createRoot(container);
 
         await act(() => {
-          root.render(<div hidden="false" ref={current => (el = current)} />);
+          root.render(<div disabled="false" ref={current => (el = current)} />);
         });
       }).toErrorDev(
-        'Received the string `false` for the boolean attribute `hidden`. ' +
+        'Received the string `false` for the boolean attribute `disabled`. ' +
           'The browser will interpret it as a truthy value. ' +
-          'Did you mean hidden={false}?',
+          'Did you mean disabled={false}?',
       );
 
-      expect(el.getAttribute('hidden')).toBe('');
+      expect(el.getAttribute('disabled')).toBe('');
     });
 
     it('warns on the potentially-ambiguous string value "true"', async function () {
@@ -3470,15 +3470,15 @@ describe('ReactDOMComponent', () => {
         const root = ReactDOMClient.createRoot(container);
 
         await act(() => {
-          root.render(<div hidden="true" ref={current => (el = current)} />);
+          root.render(<div disabled="true" ref={current => (el = current)} />);
         });
       }).toErrorDev(
-        'Received the string `true` for the boolean attribute `hidden`. ' +
+        'Received the string `true` for the boolean attribute `disabled`. ' +
           'Although this works, it will not work as expected if you pass the string "false". ' +
-          'Did you mean hidden={true}?',
+          'Did you mean disabled={true}?',
       );
 
-      expect(el.getAttribute('hidden')).toBe('');
+      expect(el.getAttribute('disabled')).toBe('');
     });
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -124,6 +124,23 @@ describe('ReactDOMEventListener', () => {
       });
     });
 
+    it('onBeforeMatch', async () => {
+      await testNativeBubblingEvent({
+        type: 'div',
+        reactEvent: 'onBeforeMatch',
+        reactEventType: 'beforematch',
+        nativeEvent: 'beforematch',
+        dispatch(node) {
+          node.dispatchEvent(
+            new KeyboardEvent('beforematch', {
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        },
+      });
+    });
+
     it('onBlur', async () => {
       await testNativeBubblingEvent({
         type: 'input',

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -33,8 +33,14 @@ function initModules() {
   };
 }
 
-const {resetModules, itRenders, clientCleanRender} =
-  ReactDOMServerIntegrationUtils(initModules);
+const {
+  resetModules,
+  itRenders,
+  clientCleanRender,
+  clientRenderOnServerString,
+  serverRender,
+  streamRender,
+} = ReactDOMServerIntegrationUtils(initModules);
 
 describe('ReactDOMServerIntegration', () => {
   beforeEach(() => {
@@ -227,6 +233,77 @@ describe('ReactDOMServerIntegration', () => {
       itRenders('no download prop with symbol value', async render => {
         const e = await render(<div download={Symbol('foo')} />, 1);
         expect(e.hasAttribute('download')).toBe(false);
+      });
+    });
+
+    describe('hidden property (combined boolean/string attribute)', function () {
+      itRenders('hidden prop with true value', async render => {
+        const e = await render(<div hidden={true} />);
+        expect(e.getAttribute('hidden')).toBe('');
+      });
+
+      itRenders('hidden prop with false value', async render => {
+        const e = await render(<div hidden={false} />);
+        expect(e.getAttribute('hidden')).toBe(null);
+      });
+
+      itRenders('hidden prop with string value', async render => {
+        const e = await render(<div hidden="until-found" />);
+        expect(e.getAttribute('hidden')).toBe(
+          ReactFeatureFlags.enableNewDOMProps ? 'until-found' : '',
+        );
+      });
+
+      itRenders('hidden prop with string "false" value', async render => {
+        const e = await render(
+          <div hidden="false" />,
+          ReactFeatureFlags.enableNewDOMProps ? 0 : 1,
+        );
+        expect(e.getAttribute('hidden')).toBe(
+          ReactFeatureFlags.enableNewDOMProps ? 'false' : '',
+        );
+      });
+
+      itRenders('hidden prop with string "true" value', async render => {
+        const e = await render(
+          <div hidden={'true'} />,
+          ReactFeatureFlags.enableNewDOMProps ? 0 : 1,
+        );
+        expect(e.getAttribute('hidden')).toBe(
+          ReactFeatureFlags.enableNewDOMProps ? 'true' : '',
+        );
+      });
+
+      itRenders('hidden prop with number 0 value', async render => {
+        const e = await render(<div hidden={0} />);
+        expect(e.getAttribute('hidden')).toBe(
+          ReactFeatureFlags.enableNewDOMProps ||
+            render === clientRenderOnServerString ||
+            render === serverRender ||
+            render === streamRender
+            ? '0'
+            : null,
+        );
+      });
+
+      itRenders('no hidden prop with null value', async render => {
+        const e = await render(<div hidden={null} />);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
+
+      itRenders('no hidden prop with undefined value', async render => {
+        const e = await render(<div hidden={undefined} />);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
+
+      itRenders('no hidden prop with function value', async render => {
+        const e = await render(<div hidden={function () {}} />, 1);
+        expect(e.hasAttribute('hidden')).toBe(false);
+      });
+
+      itRenders('no hidden prop with symbol value', async render => {
+        const e = await render(<div hidden={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('hidden')).toBe(false);
       });
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -113,71 +113,68 @@ describe('ReactDOMServerIntegration', () => {
 
     describe('boolean properties', function () {
       itRenders('boolean prop with true value', async render => {
-        const e = await render(<div hidden={true} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled={true} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       itRenders('boolean prop with false value', async render => {
-        const e = await render(<div hidden={false} />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<div disabled={false} />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       itRenders('boolean prop with self value', async render => {
-        const e = await render(<div hidden="hidden" />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled="disabled" />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
-      // this does not seem like correct behavior, since hidden="" in HTML indicates
-      // that the boolean property is present. however, it is how the current code
-      // behaves, so the test is included here.
       itRenders('boolean prop with "" value', async render => {
-        const e = await render(<div hidden="" />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<div disabled="" />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with string value', async render => {
-        const e = await render(<div hidden="foo" />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled="foo" />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with array value', async render => {
-        const e = await render(<div hidden={['foo', 'bar']} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled={['foo', 'bar']} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with object value', async render => {
-        const e = await render(<div hidden={{foo: 'bar'}} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled={{foo: 'bar'}} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with non-zero number value', async render => {
-        const e = await render(<div hidden={10} />);
-        expect(e.getAttribute('hidden')).toBe('');
+        const e = await render(<div disabled={10} />);
+        expect(e.getAttribute('disabled')).toBe('');
       });
 
       // this seems like it might mask programmer error, but it's existing behavior.
       itRenders('boolean prop with zero value', async render => {
-        const e = await render(<div hidden={0} />);
-        expect(e.getAttribute('hidden')).toBe(null);
+        const e = await render(<div disabled={0} />);
+        expect(e.getAttribute('disabled')).toBe(null);
       });
 
       itRenders('no boolean prop with null value', async render => {
-        const e = await render(<div hidden={null} />);
-        expect(e.hasAttribute('hidden')).toBe(false);
+        const e = await render(<div disabled={null} />);
+        expect(e.hasAttribute('disabled')).toBe(false);
       });
 
       itRenders('no boolean prop with function value', async render => {
-        const e = await render(<div hidden={function () {}} />, 1);
-        expect(e.hasAttribute('hidden')).toBe(false);
+        const e = await render(<div disabled={function () {}} />, 1);
+        expect(e.hasAttribute('disabled')).toBe(false);
       });
 
       itRenders('no boolean prop with symbol value', async render => {
-        const e = await render(<div hidden={Symbol('foo')} />, 1);
-        expect(e.hasAttribute('hidden')).toBe(false);
+        const e = await render(<div disabled={Symbol('foo')} />, 1);
+        expect(e.hasAttribute('disabled')).toBe(false);
       });
     });
 

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -627,6 +627,7 @@ function makeSimulator(eventType) {
 
 // A one-time snapshot with no plans to update. We'll probably want to deprecate Simulate API.
 const simulatedEventTypes = [
+  'beforematch',
   'blur',
   'cancel',
   'click',

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -195,6 +195,12 @@ export const disableStringRefs = __NEXT_MAJOR__;
 // Warn on any usage of ReactTestRenderer
 export const enableReactTestRendererWarning = false;
 
+/**
+ * Catch-all for all changes to how we treat new HTML attributes.
+ * When attributes are newly recognized by React, or change their type, the rendered output changes.
+ */
+export const enableNewDOMProps = __NEXT_MAJOR__;
+
 // -----------------------------------------------------------------------------
 // Chopping Block
 //

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -107,5 +107,7 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 
+export const enableNewDOMProps = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -98,5 +98,7 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 
+export const enableNewDOMProps = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -101,6 +101,7 @@ export const enableRefAsProp = __NEXT_MAJOR__;
 export const disableStringRefs = __NEXT_MAJOR__;
 export const enableReactTestRendererWarning = false;
 export const enableBigIntSupport = __NEXT_MAJOR__;
+export const enableNewDOMProps = __NEXT_MAJOR__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -94,5 +94,7 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 
+export const enableNewDOMProps = true;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -97,5 +97,7 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 
+export const enableNewDOMProps = false;
+
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): FeatureFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -122,6 +122,8 @@ export const enableReactTestRendererWarning = false;
 
 export const enableBigIntSupport = false;
 
+export const enableNewDOMProps = false;
+
 // TODO: Roll out with GK. Don't keep as dynamic flag for too long, though,
 // because JSX is an extremely hot path.
 export const disableStringRefs = false;


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/24740

Adds support for the experimental `hidden="until-found"` as well as the correspondig TODO `onBeforeMatch` event handler.

Keep in mind that these new browser APIs are only implemented in Chrome and Edge at the moment. Safari and Firefox have no support for this API yet (see [`hidden` browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#browser_compatibility). 

I haven't checked if we can polyfill the API or maybe we shouldn't even do that? Otherwise landing this would take more time and block experimentation in UIs targetting Chromium exclusively

## How did you test this change?


- [x] Attribute fixture (commited changes with non-experimental build since this is the build we were using before)
- [x] [Codesandbox from repro](https://codesandbox.io/s/lingering-river-4jor1y) will contain matching behavior of DOM and React: https://codesandbox.io/s/lucid-benz-u2oksw
