### PR TITLE
Add test gate alias for Offscreen

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -30,7 +30,7 @@ describe('ReactOffscreen', () => {
     return <span prop={props.text} />;
   }
 
-  // @gate www
+  // @gate enableLegacyHidden
   it('unstable-defer-without-hiding should never toggle the visibility of its children', async () => {
     function App({mode}) {
       return (
@@ -180,7 +180,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('mounts without layout effects when hidden', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -218,7 +218,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('mounts/unmounts layout effects when visibility changes (starting visible)', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -264,7 +264,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('mounts/unmounts layout effects when visibility changes (starting hidden)', async () => {
     function Child({text}) {
       useLayoutEffect(() => {
@@ -311,7 +311,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('hides children of offscreen after layout effects are destroyed', async () => {
     const root = ReactNoop.createRoot();
     function Child({text}) {
@@ -350,7 +350,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span hidden={true} prop="Child" />);
   });
 
-  // @gate www
+  // @gate enableLegacyHidden
   it('does not toggle effects for LegacyHidden component', async () => {
     // LegacyHidden is meant to be the same as offscreen except it doesn't
     // do anything to effects. Only used by www, as a temporary migration step.
@@ -398,7 +398,7 @@ describe('ReactOffscreen', () => {
     expect(Scheduler).toHaveYielded(['Unmount layout']);
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('hides new insertions into an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
     await act(async () => {
@@ -428,7 +428,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('hides updated nodes inside an already hidden tree', async () => {
     const root = ReactNoop.createRoot();
     await act(async () => {
@@ -474,7 +474,7 @@ describe('ReactOffscreen', () => {
     expect(root).toMatchRenderedOutput(<span>Hi</span>);
   });
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('revealing a hidden tree at high priority does not cause tearing', async () => {
     // When revealing an offscreen tree, we need to include updates that were
     // previously deferred because the tree was hidden, even if they are lower
@@ -593,8 +593,7 @@ describe('ReactOffscreen', () => {
     );
   });
 
-  // TODO: Create TestFlag alias for Offscreen
-  // @gate experimental || www
+  // @gate enableOffscreen
   it('regression: Offscreen instance is sometimes null during setState', async () => {
     let setState;
     function Child() {

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenSuspense-test.js
@@ -86,7 +86,7 @@ describe('ReactOffscreen', () => {
     return text;
   }
 
-  // @gate experimental || www
+  // @gate enableOffscreen
   test('detect updates to a hidden tree during a concurrent event', async () => {
     // This is a pretty complex test case. It relates to how we detect if an
     // update is made to a hidden tree: when scheduling the update, we walk up

--- a/scripts/jest/TestFlags.js
+++ b/scripts/jest/TestFlags.js
@@ -87,6 +87,8 @@ function getTestFlags() {
       // This isn't a flag, just a useful alias for tests.
       enableUseSyncExternalStoreShim: !__VARIANT__,
       enableSuspenseList: releaseChannel === 'experimental' || www,
+      enableOffscreen: releaseChannel === 'experimental' || www,
+      enableLegacyHidden: www,
 
       // If there's a naming conflict between scheduler and React feature flags, the
       // React ones take precedence.


### PR DESCRIPTION
Offscreen is only enabled in the www and experimental channels. Instead of listing these on every Offscreen test, I added a test gate alias called `enableOffscreen`. Makes it easier to grep for these, and edit or remove the channels later.