### PR TITLE
[Transition Tracing] Refactor Transition Tracing Root Code

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -27,6 +27,7 @@ import type {
   OffscreenProps,
   OffscreenState,
   OffscreenQueue,
+  OffscreenInstance,
 } from './ReactFiberOffscreenComponent';
 import type {
   Cache,
@@ -785,7 +786,10 @@ function updateOffscreenComponent(
       if (enableTransitionTracing) {
         // We have now gone from hidden to visible, so any transitions should
         // be added to the stack to get added to any Offscreen/suspense children
-        transitions = workInProgress.stateNode.transitions;
+        const instance: OffscreenInstance | null = workInProgress.stateNode;
+        if (instance !== null && instance.transitions != null) {
+          transitions = Array.from(instance.transitions);
+        }
       }
 
       pushTransition(workInProgress, prevCachePool, transitions);
@@ -910,7 +914,7 @@ function updateTracingMarkerComponent(
     }
   }
 
-  const instance = workInProgress.stateNode;
+  const instance: TracingMarkerInstance | null = workInProgress.stateNode;
   if (instance !== null) {
     pushMarkerInstance(workInProgress, instance);
   }
@@ -3714,7 +3718,7 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        const instance: TracingMarkerInstance = workInProgress.stateNode;
+        const instance: TracingMarkerInstance | null = workInProgress.stateNode;
         if (instance !== null) {
           pushMarkerInstance(workInProgress, instance);
         }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -259,8 +259,9 @@ import {
   getPendingTransitions,
 } from './ReactFiberTransition.new';
 import {
-  getTracingMarkers,
-  pushTracingMarker,
+  getMarkerInstances,
+  pushMarkerInstance,
+  pushRootMarkerInstance,
 } from './ReactFiberTracingMarkerComponent.new';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
@@ -909,7 +910,14 @@ function updateTracingMarkerComponent(
     }
   }
 
-  pushTracingMarker(workInProgress);
+  const instance = workInProgress.stateNode;
+  if (instance !== null) {
+    pushMarkerInstance(
+      workInProgress,
+      instance.transitions,
+      instance.pendingSuspenseBoundaries,
+    );
+  }
   const nextChildren = workInProgress.pendingProps.children;
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;
@@ -1312,6 +1320,10 @@ function updateHostRoot(current, workInProgress, renderLanes) {
   const nextState: RootState = workInProgress.memoizedState;
   const root: FiberRoot = workInProgress.stateNode;
   pushRootTransition(workInProgress, root, renderLanes);
+
+  if (enableTransitionTracing) {
+    pushRootMarkerInstance(workInProgress);
+  }
 
   if (enableCache) {
     const nextCache: Cache = nextState.cache;
@@ -2114,10 +2126,10 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
         const currentTransitions = getPendingTransitions();
         if (currentTransitions !== null) {
           // If there are no transitions, we don't need to keep track of tracing markers
-          const currentTracingMarkers = getTracingMarkers();
+          const parentMarkerInstances = getMarkerInstances();
           const primaryChildUpdateQueue: OffscreenQueue = {
             transitions: currentTransitions,
-            tracingMarkers: currentTracingMarkers,
+            markerInstances: parentMarkerInstances,
           };
           primaryChildFragment.updateQueue = primaryChildUpdateQueue;
         }
@@ -2200,10 +2212,10 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
       if (enableTransitionTracing) {
         const currentTransitions = getPendingTransitions();
         if (currentTransitions !== null) {
-          const currentTracingMarkers = getTracingMarkers();
+          const parentMarkerInstances = getMarkerInstances();
           const primaryChildUpdateQueue: OffscreenQueue = {
             transitions: currentTransitions,
-            tracingMarkers: currentTracingMarkers,
+            markerInstances: parentMarkerInstances,
           };
           primaryChildFragment.updateQueue = primaryChildUpdateQueue;
         }
@@ -3510,6 +3522,10 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       const root: FiberRoot = workInProgress.stateNode;
       pushRootTransition(workInProgress, root, renderLanes);
 
+      if (enableTransitionTracing) {
+        pushRootMarkerInstance(workInProgress);
+      }
+
       if (enableCache) {
         const cache: Cache = current.memoizedState.cache;
         pushCacheProvider(workInProgress, cache);
@@ -3702,7 +3718,14 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        pushTracingMarker(workInProgress);
+        const instance: TracingMarkerInstance = workInProgress.stateNode;
+        if (instance !== null) {
+          pushMarkerInstance(
+            workInProgress,
+            instance.transitions,
+            instance.pendingSuspenseBoundaries,
+          );
+        }
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -912,11 +912,7 @@ function updateTracingMarkerComponent(
 
   const instance = workInProgress.stateNode;
   if (instance !== null) {
-    pushMarkerInstance(
-      workInProgress,
-      instance.transitions,
-      instance.pendingSuspenseBoundaries,
-    );
+    pushMarkerInstance(workInProgress, instance);
   }
   const nextChildren = workInProgress.pendingProps.children;
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
@@ -3720,11 +3716,7 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       if (enableTransitionTracing) {
         const instance: TracingMarkerInstance = workInProgress.stateNode;
         if (instance !== null) {
-          pushMarkerInstance(
-            workInProgress,
-            instance.transitions,
-            instance.pendingSuspenseBoundaries,
-          );
+          pushMarkerInstance(workInProgress, instance);
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -27,6 +27,7 @@ import type {
   OffscreenProps,
   OffscreenState,
   OffscreenQueue,
+  OffscreenInstance,
 } from './ReactFiberOffscreenComponent';
 import type {
   Cache,
@@ -785,7 +786,10 @@ function updateOffscreenComponent(
       if (enableTransitionTracing) {
         // We have now gone from hidden to visible, so any transitions should
         // be added to the stack to get added to any Offscreen/suspense children
-        transitions = workInProgress.stateNode.transitions;
+        const instance: OffscreenInstance | null = workInProgress.stateNode;
+        if (instance !== null && instance.transitions != null) {
+          transitions = Array.from(instance.transitions);
+        }
       }
 
       pushTransition(workInProgress, prevCachePool, transitions);
@@ -910,7 +914,7 @@ function updateTracingMarkerComponent(
     }
   }
 
-  const instance = workInProgress.stateNode;
+  const instance: TracingMarkerInstance | null = workInProgress.stateNode;
   if (instance !== null) {
     pushMarkerInstance(workInProgress, instance);
   }
@@ -3714,7 +3718,7 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        const instance: TracingMarkerInstance = workInProgress.stateNode;
+        const instance: TracingMarkerInstance | null = workInProgress.stateNode;
         if (instance !== null) {
           pushMarkerInstance(workInProgress, instance);
         }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -259,8 +259,9 @@ import {
   getPendingTransitions,
 } from './ReactFiberTransition.old';
 import {
-  getTracingMarkers,
-  pushTracingMarker,
+  getMarkerInstances,
+  pushMarkerInstance,
+  pushRootMarkerInstance,
 } from './ReactFiberTracingMarkerComponent.old';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
@@ -909,7 +910,14 @@ function updateTracingMarkerComponent(
     }
   }
 
-  pushTracingMarker(workInProgress);
+  const instance = workInProgress.stateNode;
+  if (instance !== null) {
+    pushMarkerInstance(
+      workInProgress,
+      instance.transitions,
+      instance.pendingSuspenseBoundaries,
+    );
+  }
   const nextChildren = workInProgress.pendingProps.children;
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
   return workInProgress.child;
@@ -1312,6 +1320,10 @@ function updateHostRoot(current, workInProgress, renderLanes) {
   const nextState: RootState = workInProgress.memoizedState;
   const root: FiberRoot = workInProgress.stateNode;
   pushRootTransition(workInProgress, root, renderLanes);
+
+  if (enableTransitionTracing) {
+    pushRootMarkerInstance(workInProgress);
+  }
 
   if (enableCache) {
     const nextCache: Cache = nextState.cache;
@@ -2114,10 +2126,10 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
         const currentTransitions = getPendingTransitions();
         if (currentTransitions !== null) {
           // If there are no transitions, we don't need to keep track of tracing markers
-          const currentTracingMarkers = getTracingMarkers();
+          const parentMarkerInstances = getMarkerInstances();
           const primaryChildUpdateQueue: OffscreenQueue = {
             transitions: currentTransitions,
-            tracingMarkers: currentTracingMarkers,
+            markerInstances: parentMarkerInstances,
           };
           primaryChildFragment.updateQueue = primaryChildUpdateQueue;
         }
@@ -2200,10 +2212,10 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
       if (enableTransitionTracing) {
         const currentTransitions = getPendingTransitions();
         if (currentTransitions !== null) {
-          const currentTracingMarkers = getTracingMarkers();
+          const parentMarkerInstances = getMarkerInstances();
           const primaryChildUpdateQueue: OffscreenQueue = {
             transitions: currentTransitions,
-            tracingMarkers: currentTracingMarkers,
+            markerInstances: parentMarkerInstances,
           };
           primaryChildFragment.updateQueue = primaryChildUpdateQueue;
         }
@@ -3510,6 +3522,10 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       const root: FiberRoot = workInProgress.stateNode;
       pushRootTransition(workInProgress, root, renderLanes);
 
+      if (enableTransitionTracing) {
+        pushRootMarkerInstance(workInProgress);
+      }
+
       if (enableCache) {
         const cache: Cache = current.memoizedState.cache;
         pushCacheProvider(workInProgress, cache);
@@ -3702,7 +3718,14 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        pushTracingMarker(workInProgress);
+        const instance: TracingMarkerInstance = workInProgress.stateNode;
+        if (instance !== null) {
+          pushMarkerInstance(
+            workInProgress,
+            instance.transitions,
+            instance.pendingSuspenseBoundaries,
+          );
+        }
       }
     }
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -912,11 +912,7 @@ function updateTracingMarkerComponent(
 
   const instance = workInProgress.stateNode;
   if (instance !== null) {
-    pushMarkerInstance(
-      workInProgress,
-      instance.transitions,
-      instance.pendingSuspenseBoundaries,
-    );
+    pushMarkerInstance(workInProgress, instance);
   }
   const nextChildren = workInProgress.pendingProps.children;
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
@@ -3720,11 +3716,7 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       if (enableTransitionTracing) {
         const instance: TracingMarkerInstance = workInProgress.stateNode;
         if (instance !== null) {
-          pushMarkerInstance(
-            workInProgress,
-            instance.transitions,
-            instance.pendingSuspenseBoundaries,
-          );
+          pushMarkerInstance(workInProgress, instance);
         }
       }
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2819,30 +2819,25 @@ function commitPassiveMountOnFiber(
               transitionName: transition.name,
               startTime: transition.startTime,
             });
-
-            if (!incompleteTransitions.has(transition)) {
-              incompleteTransitions.set(transition, null);
-            }
           });
 
           clearTransitionsForLanes(finishedRoot, committedLanes);
         }
 
-        if (incompleteTransitions !== null) {
-          incompleteTransitions.forEach((pendingBoundaries, transition) => {
-            if (pendingBoundaries === null || pendingBoundaries.size === 0) {
+        incompleteTransitions.forEach(
+          ({pendingSuspenseBoundaries}, transition) => {
+            if (
+              pendingSuspenseBoundaries === null ||
+              pendingSuspenseBoundaries.size === 0
+            ) {
               addTransitionCompleteCallbackToPendingTransition({
                 transitionName: transition.name,
                 startTime: transition.startTime,
               });
               incompleteTransitions.delete(transition);
             }
-          });
-
-          if (incompleteTransitions.size === 0) {
-            root.incompleteTransitions = null;
-          }
-        }
+          },
+        );
 
         clearTransitionsForLanes(finishedRoot, committedLanes);
       }
@@ -2908,6 +2903,10 @@ function commitPassiveMountOnFiber(
             const markerInstances = queue.markerInstances;
             if (markerInstances !== null) {
               markerInstances.forEach(markerInstance => {
+                if (markerInstance.pendingSuspenseBoundaries === null) {
+                  markerInstance.pendingSuspenseBoundaries = new Map();
+                }
+
                 const markerTransitions = markerInstance.transitions;
                 // There should only be a few tracing marker transitions because
                 // they should be only associated with the transition that

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2811,13 +2811,9 @@ function commitPassiveMountOnFiber(
         // Get the transitions that were initiatized during the render
         // and add a start transition callback for each of them
         const root = finishedWork.stateNode;
-        let incompleteTransitions = root.incompleteTransitions;
+        const incompleteTransitions = root.incompleteTransitions;
         // Initial render
         if (committedTransitions !== null) {
-          if (incompleteTransitions === null) {
-            root.incompleteTransitions = incompleteTransitions = new Map();
-          }
-
           committedTransitions.forEach(transition => {
             addTransitionStartCallbackToPendingTransition({
               transitionName: transition.name,
@@ -2842,16 +2838,13 @@ function commitPassiveMountOnFiber(
               incompleteTransitions.delete(transition);
             }
           });
+
+          if (incompleteTransitions.size === 0) {
+            root.incompleteTransitions = null;
+          }
         }
 
-        // If there are no more pending suspense boundaries we
-        // clear the transitions because they are all complete.
-        if (
-          incompleteTransitions === null ||
-          incompleteTransitions.size === 0
-        ) {
-          root.incompleteTransitions = null;
-        }
+        clearTransitionsForLanes(finishedRoot, committedLanes);
       }
       break;
     }
@@ -2896,14 +2889,6 @@ function commitPassiveMountOnFiber(
           if (isFallback) {
             const transitions = queue.transitions;
             let prevTransitions = instance.transitions;
-            let rootIncompleteTransitions = finishedRoot.incompleteTransitions;
-
-            // We lazily instantiate transition tracing relevant maps
-            // and sets in the commit phase as we need to use them. We only
-            // instantiate them in the fallback phase on an as needed basis
-            if (rootIncompleteTransitions === null) {
-              finishedRoot.incompleteTransitions = rootIncompleteTransitions = new Map();
-            }
             if (instance.pendingMarkers === null) {
               instance.pendingMarkers = new Set();
             }
@@ -2911,56 +2896,39 @@ function commitPassiveMountOnFiber(
               instance.transitions = prevTransitions = new Set();
             }
 
-            // TODO(luna): Combine the root code with the tracing marker code
             if (transitions !== null) {
               transitions.forEach(transition => {
                 // Add all the transitions saved in the update queue during
                 // the render phase (ie the transitions associated with this boundary)
                 // into the transitions set.
                 prevTransitions.add(transition);
-
-                // Add the root transition's pending suspense boundary set to
-                // the queue's marker set. We will iterate through the marker
-                // set when we toggle state on the suspense boundary and
-                // add or remove the pending suspense boundaries as needed.
-                if (rootIncompleteTransitions !== null) {
-                  if (!rootIncompleteTransitions.has(transition)) {
-                    rootIncompleteTransitions.set(transition, new Map());
-                  }
-                  instance.pendingMarkers.add(
-                    rootIncompleteTransitions.get(transition),
-                  );
-                }
               });
             }
 
-            const tracingMarkers = queue.tracingMarkers;
-            if (tracingMarkers !== null) {
-              tracingMarkers.forEach(marker => {
-                const markerInstance = marker.stateNode;
+            const markerInstances = queue.markerInstances;
+            if (markerInstances !== null) {
+              markerInstances.forEach(markerInstance => {
+                const markerTransitions = markerInstance.transitions;
                 // There should only be a few tracing marker transitions because
                 // they should be only associated with the transition that
                 // caused them
-                markerInstance.transitions.forEach(transition => {
-                  if (instance.transitions.has(transition)) {
-                    instance.pendingMarkers.add(
-                      markerInstance.pendingSuspenseBoundaries,
-                    );
-                  }
-                });
+                if (markerTransitions !== null) {
+                  markerTransitions.forEach(transition => {
+                    if (instance.transitions.has(transition)) {
+                      instance.pendingMarkers.add(
+                        markerInstance.pendingSuspenseBoundaries,
+                      );
+                    }
+                  });
+                }
               });
             }
           }
 
-          commitTransitionProgress(finishedWork);
-
-          if (
-            instance.pendingMarkers === null ||
-            instance.pendingMarkers.size === 0
-          ) {
-            finishedWork.updateQueue = null;
-          }
+          finishedWork.updateQueue = null;
         }
+
+        commitTransitionProgress(finishedWork);
       }
 
       break;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2819,30 +2819,25 @@ function commitPassiveMountOnFiber(
               transitionName: transition.name,
               startTime: transition.startTime,
             });
-
-            if (!incompleteTransitions.has(transition)) {
-              incompleteTransitions.set(transition, null);
-            }
           });
 
           clearTransitionsForLanes(finishedRoot, committedLanes);
         }
 
-        if (incompleteTransitions !== null) {
-          incompleteTransitions.forEach((pendingBoundaries, transition) => {
-            if (pendingBoundaries === null || pendingBoundaries.size === 0) {
+        incompleteTransitions.forEach(
+          ({pendingSuspenseBoundaries}, transition) => {
+            if (
+              pendingSuspenseBoundaries === null ||
+              pendingSuspenseBoundaries.size === 0
+            ) {
               addTransitionCompleteCallbackToPendingTransition({
                 transitionName: transition.name,
                 startTime: transition.startTime,
               });
               incompleteTransitions.delete(transition);
             }
-          });
-
-          if (incompleteTransitions.size === 0) {
-            root.incompleteTransitions = null;
-          }
-        }
+          },
+        );
 
         clearTransitionsForLanes(finishedRoot, committedLanes);
       }
@@ -2908,6 +2903,10 @@ function commitPassiveMountOnFiber(
             const markerInstances = queue.markerInstances;
             if (markerInstances !== null) {
               markerInstances.forEach(markerInstance => {
+                if (markerInstance.pendingSuspenseBoundaries === null) {
+                  markerInstance.pendingSuspenseBoundaries = new Map();
+                }
+
                 const markerTransitions = markerInstance.transitions;
                 // There should only be a few tracing marker transitions because
                 // they should be only associated with the transition that

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2811,13 +2811,9 @@ function commitPassiveMountOnFiber(
         // Get the transitions that were initiatized during the render
         // and add a start transition callback for each of them
         const root = finishedWork.stateNode;
-        let incompleteTransitions = root.incompleteTransitions;
+        const incompleteTransitions = root.incompleteTransitions;
         // Initial render
         if (committedTransitions !== null) {
-          if (incompleteTransitions === null) {
-            root.incompleteTransitions = incompleteTransitions = new Map();
-          }
-
           committedTransitions.forEach(transition => {
             addTransitionStartCallbackToPendingTransition({
               transitionName: transition.name,
@@ -2842,16 +2838,13 @@ function commitPassiveMountOnFiber(
               incompleteTransitions.delete(transition);
             }
           });
+
+          if (incompleteTransitions.size === 0) {
+            root.incompleteTransitions = null;
+          }
         }
 
-        // If there are no more pending suspense boundaries we
-        // clear the transitions because they are all complete.
-        if (
-          incompleteTransitions === null ||
-          incompleteTransitions.size === 0
-        ) {
-          root.incompleteTransitions = null;
-        }
+        clearTransitionsForLanes(finishedRoot, committedLanes);
       }
       break;
     }
@@ -2896,14 +2889,6 @@ function commitPassiveMountOnFiber(
           if (isFallback) {
             const transitions = queue.transitions;
             let prevTransitions = instance.transitions;
-            let rootIncompleteTransitions = finishedRoot.incompleteTransitions;
-
-            // We lazily instantiate transition tracing relevant maps
-            // and sets in the commit phase as we need to use them. We only
-            // instantiate them in the fallback phase on an as needed basis
-            if (rootIncompleteTransitions === null) {
-              finishedRoot.incompleteTransitions = rootIncompleteTransitions = new Map();
-            }
             if (instance.pendingMarkers === null) {
               instance.pendingMarkers = new Set();
             }
@@ -2911,56 +2896,39 @@ function commitPassiveMountOnFiber(
               instance.transitions = prevTransitions = new Set();
             }
 
-            // TODO(luna): Combine the root code with the tracing marker code
             if (transitions !== null) {
               transitions.forEach(transition => {
                 // Add all the transitions saved in the update queue during
                 // the render phase (ie the transitions associated with this boundary)
                 // into the transitions set.
                 prevTransitions.add(transition);
-
-                // Add the root transition's pending suspense boundary set to
-                // the queue's marker set. We will iterate through the marker
-                // set when we toggle state on the suspense boundary and
-                // add or remove the pending suspense boundaries as needed.
-                if (rootIncompleteTransitions !== null) {
-                  if (!rootIncompleteTransitions.has(transition)) {
-                    rootIncompleteTransitions.set(transition, new Map());
-                  }
-                  instance.pendingMarkers.add(
-                    rootIncompleteTransitions.get(transition),
-                  );
-                }
               });
             }
 
-            const tracingMarkers = queue.tracingMarkers;
-            if (tracingMarkers !== null) {
-              tracingMarkers.forEach(marker => {
-                const markerInstance = marker.stateNode;
+            const markerInstances = queue.markerInstances;
+            if (markerInstances !== null) {
+              markerInstances.forEach(markerInstance => {
+                const markerTransitions = markerInstance.transitions;
                 // There should only be a few tracing marker transitions because
                 // they should be only associated with the transition that
                 // caused them
-                markerInstance.transitions.forEach(transition => {
-                  if (instance.transitions.has(transition)) {
-                    instance.pendingMarkers.add(
-                      markerInstance.pendingSuspenseBoundaries,
-                    );
-                  }
-                });
+                if (markerTransitions !== null) {
+                  markerTransitions.forEach(transition => {
+                    if (instance.transitions.has(transition)) {
+                      instance.pendingMarkers.add(
+                        markerInstance.pendingSuspenseBoundaries,
+                      );
+                    }
+                  });
+                }
               });
             }
           }
 
-          commitTransitionProgress(finishedWork);
-
-          if (
-            instance.pendingMarkers === null ||
-            instance.pendingMarkers.size === 0
-          ) {
-            finishedWork.updateQueue = null;
-          }
+          finishedWork.updateQueue = null;
         }
+
+        commitTransitionProgress(finishedWork);
       }
 
       break;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -164,7 +164,10 @@ import {transferActualDuration} from './ReactProfilerTimer.new';
 import {popCacheProvider} from './ReactFiberCacheComponent.new';
 import {popTreeContext} from './ReactFiberTreeContext.new';
 import {popRootTransition, popTransition} from './ReactFiberTransition.new';
-import {popTracingMarker} from './ReactFiberTracingMarkerComponent.new';
+import {
+  popMarkerInstance,
+  popRootMarkerInstance,
+} from './ReactFiberTracingMarkerComponent.new';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -900,6 +903,11 @@ function completeWork(
         }
         popCacheProvider(workInProgress, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(workInProgress);
+      }
+
       popRootTransition(workInProgress, fiberRoot, renderLanes);
       popHostContainer(workInProgress);
       popTopLevelLegacyContextObject(workInProgress);
@@ -1581,7 +1589,9 @@ function completeWork(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        popTracingMarker(workInProgress);
+        if (workInProgress.stateNode !== null) {
+          popMarkerInstance(workInProgress);
+        }
         bubbleProperties(workInProgress);
 
         if (

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -29,6 +29,7 @@ import type {
 } from './ReactFiberSuspenseComponent.new';
 import type {SuspenseContext} from './ReactFiberSuspenseContext.new';
 import type {OffscreenState} from './ReactFiberOffscreenComponent';
+import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.new';
 import type {Cache} from './ReactFiberCacheComponent.new';
 import {
   enableSuspenseAvoidThisFallback,
@@ -1589,7 +1590,8 @@ function completeWork(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        if (workInProgress.stateNode !== null) {
+        const instance: TracingMarkerInstance | null = workInProgress.stateNode;
+        if (instance !== null) {
           popMarkerInstance(workInProgress);
         }
         bubbleProperties(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -164,7 +164,10 @@ import {transferActualDuration} from './ReactProfilerTimer.old';
 import {popCacheProvider} from './ReactFiberCacheComponent.old';
 import {popTreeContext} from './ReactFiberTreeContext.old';
 import {popRootTransition, popTransition} from './ReactFiberTransition.old';
-import {popTracingMarker} from './ReactFiberTracingMarkerComponent.old';
+import {
+  popMarkerInstance,
+  popRootMarkerInstance,
+} from './ReactFiberTracingMarkerComponent.old';
 
 function markUpdate(workInProgress: Fiber) {
   // Tag the fiber with an update effect. This turns a Placement into
@@ -900,6 +903,11 @@ function completeWork(
         }
         popCacheProvider(workInProgress, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(workInProgress);
+      }
+
       popRootTransition(workInProgress, fiberRoot, renderLanes);
       popHostContainer(workInProgress);
       popTopLevelLegacyContextObject(workInProgress);
@@ -1581,7 +1589,9 @@ function completeWork(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        popTracingMarker(workInProgress);
+        if (workInProgress.stateNode !== null) {
+          popMarkerInstance(workInProgress);
+        }
         bubbleProperties(workInProgress);
 
         if (

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -29,6 +29,7 @@ import type {
 } from './ReactFiberSuspenseComponent.old';
 import type {SuspenseContext} from './ReactFiberSuspenseContext.old';
 import type {OffscreenState} from './ReactFiberOffscreenComponent';
+import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
 import type {Cache} from './ReactFiberCacheComponent.old';
 import {
   enableSuspenseAvoidThisFallback,
@@ -1589,7 +1590,8 @@ function completeWork(
     }
     case TracingMarkerComponent: {
       if (enableTransitionTracing) {
-        if (workInProgress.stateNode !== null) {
+        const instance: TracingMarkerInstance | null = workInProgress.stateNode;
+        if (instance !== null) {
           popMarkerInstance(workInProgress);
         }
         bubbleProperties(workInProgress);

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -8,12 +8,12 @@
  */
 
 import type {ReactNodeList, OffscreenMode} from 'shared/ReactTypes';
-import type {Fiber} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {SpawnedCachePool} from './ReactFiberCacheComponent.new';
 import type {
   Transition,
   PendingSuspenseBoundaries,
+  TracingMarkerInstance,
 } from './ReactFiberTracingMarkerComponent.new';
 
 export type OffscreenProps = {|
@@ -39,7 +39,7 @@ export type OffscreenState = {|
 
 export type OffscreenQueue = {|
   transitions: Array<Transition> | null,
-  tracingMarkers: Array<Fiber> | null,
+  markerInstances: Array<TracingMarkerInstance> | null,
 |} | null;
 
 export type OffscreenInstance = {|

--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -92,13 +92,13 @@ function FiberRootNode(
     this.hydrationCallbacks = null;
   }
 
+  this.incompleteTransitions = new Map();
   if (enableTransitionTracing) {
     this.transitionCallbacks = null;
     const transitionLanesMap = (this.transitionLanes = []);
     for (let i = 0; i < TotalLanes; i++) {
       transitionLanesMap.push(null);
     }
-    this.incompleteTransitions = null;
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -90,13 +90,13 @@ function FiberRootNode(
     this.hydrationCallbacks = null;
   }
 
+  this.incompleteTransitions = new Map();
   if (enableTransitionTracing) {
     this.transitionCallbacks = null;
     const transitionLanesMap = (this.transitionLanes = []);
     for (let i = 0; i < TotalLanes; i++) {
       transitionLanesMap.push(null);
     }
-    this.incompleteTransitions = null;
   }
 
   if (enableProfilerTimer && enableProfilerCommitHooks) {

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
@@ -13,6 +13,7 @@ import type {StackCursor} from './ReactFiberStack.new';
 
 import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack.new';
+import {getWorkInProgressTransitions} from './ReactFiberWorkLoop.new';
 
 export type SuspenseInfo = {name: string | null};
 
@@ -100,31 +101,75 @@ export function processTransitionCallbacks(
 // tracing marker can be logged as complete
 // This code lives separate from the ReactFiberTransition code because
 // we push and pop on the tracing marker, not the suspense boundary
-const tracingMarkerStack: StackCursor<Array<Fiber> | null> = createCursor(null);
+const markerInstanceStack: StackCursor<Array<TracingMarkerInstance> | null> = createCursor(
+  null,
+);
 
-export function pushTracingMarker(workInProgress: Fiber): void {
+export function pushRootMarkerInstance(workInProgress: Fiber): void {
   if (enableTransitionTracing) {
-    if (tracingMarkerStack.current === null) {
-      push(tracingMarkerStack, [workInProgress], workInProgress);
+    const transitions = getWorkInProgressTransitions();
+    const root = workInProgress.stateNode;
+    let incompleteTransitions = root.incompleteTransitions;
+    if (transitions !== null) {
+      if (incompleteTransitions === null) {
+        root.incompleteTransitions = incompleteTransitions = new Map();
+      }
+
+      transitions.forEach(transition => {
+        incompleteTransitions.set(transition, new Map());
+      });
+    }
+
+    if (incompleteTransitions === null) {
+      push(markerInstanceStack, null, workInProgress);
+    } else {
+      const markerInstances = [];
+      incompleteTransitions.forEach((pendingSuspenseBoundaries, transition) => {
+        markerInstances.push({
+          transitions: new Set([transition]),
+          pendingSuspenseBoundaries,
+        });
+      });
+      push(markerInstanceStack, markerInstances, workInProgress);
+    }
+  }
+}
+
+export function popRootMarkerInstance(workInProgress: Fiber) {
+  if (enableTransitionTracing) {
+    pop(markerInstanceStack, workInProgress);
+  }
+}
+
+export function pushMarkerInstance(
+  workInProgress: Fiber,
+  transitions: Set<Transition> | null,
+  pendingSuspenseBoundaries: PendingSuspenseBoundaries | null,
+): void {
+  if (enableTransitionTracing) {
+    const markerInstance = {transitions, pendingSuspenseBoundaries};
+
+    if (markerInstanceStack.current === null) {
+      push(markerInstanceStack, [markerInstance], workInProgress);
     } else {
       push(
-        tracingMarkerStack,
-        tracingMarkerStack.current.concat(workInProgress),
+        markerInstanceStack,
+        markerInstanceStack.current.concat(markerInstance),
         workInProgress,
       );
     }
   }
 }
 
-export function popTracingMarker(workInProgress: Fiber): void {
+export function popMarkerInstance(workInProgress: Fiber): void {
   if (enableTransitionTracing) {
-    pop(tracingMarkerStack, workInProgress);
+    pop(markerInstanceStack, workInProgress);
   }
 }
 
-export function getTracingMarkers(): Array<Fiber> | null {
+export function getMarkerInstances(): Array<TracingMarkerInstance> | null {
   if (enableTransitionTracing) {
-    return tracingMarkerStack.current;
+    return markerInstanceStack.current;
   }
   return null;
 }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -49,7 +49,10 @@ import {popCacheProvider} from './ReactFiberCacheComponent.new';
 import {transferActualDuration} from './ReactProfilerTimer.new';
 import {popTreeContext} from './ReactFiberTreeContext.new';
 import {popRootTransition, popTransition} from './ReactFiberTransition.new';
-import {popTracingMarker} from './ReactFiberTracingMarkerComponent.new';
+import {
+  popMarkerInstance,
+  popRootMarkerInstance,
+} from './ReactFiberTracingMarkerComponent.new';
 
 function unwindWork(
   current: Fiber | null,
@@ -86,6 +89,11 @@ function unwindWork(
         const cache: Cache = workInProgress.memoizedState.cache;
         popCacheProvider(workInProgress, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(workInProgress);
+      }
+
       popRootTransition(workInProgress, root, renderLanes);
       popHostContainer(workInProgress);
       popTopLevelLegacyContextObject(workInProgress);
@@ -162,7 +170,9 @@ function unwindWork(
       return null;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        popTracingMarker(workInProgress);
+        if (workInProgress.stateNode !== null) {
+          popMarkerInstance(workInProgress);
+        }
       }
       return null;
     default:
@@ -194,6 +204,11 @@ function unwindInterruptedWork(
         const cache: Cache = interruptedWork.memoizedState.cache;
         popCacheProvider(interruptedWork, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(interruptedWork);
+      }
+
       popRootTransition(interruptedWork, root, renderLanes);
       popHostContainer(interruptedWork);
       popTopLevelLegacyContextObject(interruptedWork);
@@ -230,7 +245,9 @@ function unwindInterruptedWork(
       break;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        popTracingMarker(interruptedWork);
+        if (interruptedWork.stateNode !== null) {
+          popMarkerInstance(interruptedWork);
+        }
       }
       break;
     default:

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -12,6 +12,7 @@ import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.new';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
 import type {Cache} from './ReactFiberCacheComponent.new';
+import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.new';
 
 import {resetWorkInProgressVersions as resetMutableSourceWorkInProgressVersions} from './ReactMutableSource.new';
 import {
@@ -245,7 +246,9 @@ function unwindInterruptedWork(
       break;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        if (interruptedWork.stateNode !== null) {
+        const instance: TracingMarkerInstance | null =
+          interruptedWork.stateNode;
+        if (instance !== null) {
           popMarkerInstance(interruptedWork);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
@@ -12,6 +12,7 @@ import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 import type {Cache} from './ReactFiberCacheComponent.old';
+import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
 
 import {resetWorkInProgressVersions as resetMutableSourceWorkInProgressVersions} from './ReactMutableSource.old';
 import {
@@ -245,7 +246,9 @@ function unwindInterruptedWork(
       break;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        if (interruptedWork.stateNode !== null) {
+        const instance: TracingMarkerInstance | null =
+          interruptedWork.stateNode;
+        if (instance !== null) {
           popMarkerInstance(interruptedWork);
         }
       }

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
@@ -49,7 +49,10 @@ import {popCacheProvider} from './ReactFiberCacheComponent.old';
 import {transferActualDuration} from './ReactProfilerTimer.old';
 import {popTreeContext} from './ReactFiberTreeContext.old';
 import {popRootTransition, popTransition} from './ReactFiberTransition.old';
-import {popTracingMarker} from './ReactFiberTracingMarkerComponent.old';
+import {
+  popMarkerInstance,
+  popRootMarkerInstance,
+} from './ReactFiberTracingMarkerComponent.old';
 
 function unwindWork(
   current: Fiber | null,
@@ -86,6 +89,11 @@ function unwindWork(
         const cache: Cache = workInProgress.memoizedState.cache;
         popCacheProvider(workInProgress, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(workInProgress);
+      }
+
       popRootTransition(workInProgress, root, renderLanes);
       popHostContainer(workInProgress);
       popTopLevelLegacyContextObject(workInProgress);
@@ -162,7 +170,9 @@ function unwindWork(
       return null;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        popTracingMarker(workInProgress);
+        if (workInProgress.stateNode !== null) {
+          popMarkerInstance(workInProgress);
+        }
       }
       return null;
     default:
@@ -194,6 +204,11 @@ function unwindInterruptedWork(
         const cache: Cache = interruptedWork.memoizedState.cache;
         popCacheProvider(interruptedWork, cache);
       }
+
+      if (enableTransitionTracing) {
+        popRootMarkerInstance(interruptedWork);
+      }
+
       popRootTransition(interruptedWork, root, renderLanes);
       popHostContainer(interruptedWork);
       popTopLevelLegacyContextObject(interruptedWork);
@@ -230,7 +245,9 @@ function unwindInterruptedWork(
       break;
     case TracingMarkerComponent:
       if (enableTransitionTracing) {
-        popTracingMarker(interruptedWork);
+        if (interruptedWork.stateNode !== null) {
+          popMarkerInstance(interruptedWork);
+        }
       }
       break;
     default:

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -335,7 +335,7 @@ type TransitionTracingOnlyFiberRootProperties = {|
   // are considered complete when the pending suspense boundaries set is
   // empty. We can represent this as a Map of transitions to suspense
   // boundary sets
-  incompleteTransitions: Map<Transition, PendingSuspenseBoundaries> | null,
+  incompleteTransitions: Map<Transition, PendingSuspenseBoundaries>,
 |};
 
 // Exported FiberRoot type includes all properties,


### PR DESCRIPTION
This PR refactors the transition tracing root code by reusing the tracing marker code. Namely it:
* Refactors the tracing marker code so that it takes a tracing marker instance instead of a tracing marker fiber and rename the stack to `markerInstance` instead of `tracingMarker`
* Pushes the root code onto the stack
* Moves the instantiation of `root.incompleteTransitions` to the begin phase when we are pushing the root to the stack rather than in the commit phase

Depends on #24686 only the [`refactor root` commit](https://github.com/facebook/react/pull/24766/commits/1b4644a7f74e7f10ec09d6f4d8b0c557a328684d) should be looked at here