### PR TITLE
[DevTools] Clean Up DevTools Code

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
+++ b/packages/react-devtools-shared/src/__tests__/TimelineProfiler-test.js
@@ -9,14 +9,7 @@
 
 'use strict';
 
-function normalizeCodeLocInfo(str) {
-  return (
-    typeof str === 'string' &&
-    str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
-      return '\n    in ' + name + ' (at **)';
-    })
-  );
-}
+import {normalizeCodeLocInfo} from './utils';
 
 describe('Timeline profiler', () => {
   let React;

--- a/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
+++ b/packages/react-devtools-shared/src/__tests__/componentStacks-test.js
@@ -7,21 +7,7 @@
  * @flow
  */
 
-function normalizeCodeLocInfo(str) {
-  if (typeof str !== 'string') {
-    return str;
-  }
-  // This special case exists only for the special source location in
-  // ReactElementValidator. That will go away if we remove source locations.
-  str = str.replace(/Check your code at .+?:\d+/g, 'Check your code at **');
-  // V8 format:
-  //  at Component (/path/filename.js:123:45)
-  // React format:
-  //    in Component (at filename.js:123)
-  return str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
-    return '\n    in ' + name + ' (at **)';
-  });
-}
+import {normalizeCodeLocInfo} from './utils';
 
 describe('component stack', () => {
   let React;

--- a/packages/react-devtools-shared/src/__tests__/console-test.js
+++ b/packages/react-devtools-shared/src/__tests__/console-test.js
@@ -6,6 +6,9 @@
  *
  * @flow
  */
+
+import {normalizeCodeLocInfo} from './utils';
+
 let React;
 let ReactDOMClient;
 let act;
@@ -59,15 +62,6 @@ describe('console', () => {
     act = utils.act;
     legacyRender = utils.legacyRender;
   });
-
-  function normalizeCodeLocInfo(str) {
-    return (
-      str &&
-      str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
-        return '\n    in ' + name + ' (at **)';
-      })
-    );
-  }
 
   // @reactVersion >=18.0
   it('should not patch console methods that are not explicitly overridden', () => {

--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -9,14 +9,7 @@
 
 'use strict';
 
-function normalizeCodeLocInfo(str) {
-  return (
-    typeof str === 'string' &&
-    str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
-      return '\n    in ' + name + ' (at **)';
-    })
-  );
-}
+import {normalizeCodeLocInfo} from './utils';
 
 describe('Timeline profiler', () => {
   let React;

--- a/packages/react-devtools-shared/src/__tests__/utils.js
+++ b/packages/react-devtools-shared/src/__tests__/utils.js
@@ -289,3 +289,19 @@ export function overrideFeatureFlags(overrideFlags) {
     };
   });
 }
+
+export function normalizeCodeLocInfo(str) {
+  if (typeof str !== 'string') {
+    return str;
+  }
+  // This special case exists only for the special source location in
+  // ReactElementValidator. That will go away if we remove source locations.
+  str = str.replace(/Check your code at .+?:\d+/g, 'Check your code at **');
+  // V8 format:
+  //  at Component (/path/filename.js:123:45)
+  // React format:
+  //    in Component (at filename.js:123)
+  return str.replace(/\n +(?:at|in) ([\S]+)[^\n]*/g, function(m, name) {
+    return '\n    in ' + name + ' (at **)';
+  });
+}

--- a/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsComponentStackFrame.js
@@ -12,7 +12,6 @@
 // while still maintaining support for multiple renderer versions
 // (which use different values for ReactTypeOfWork).
 
-import type {Source} from 'shared/ReactElementType';
 import type {LazyComponent} from 'react/src/ReactLazy';
 import type {CurrentDispatcherRef} from './types';
 
@@ -36,7 +35,6 @@ import {disableLogs, reenableLogs} from './DevToolsConsolePatching';
 let prefix;
 export function describeBuiltInComponentFrame(
   name: string,
-  source: void | null | Source,
   ownerFn: void | null | Function,
 ): string {
   if (prefix === undefined) {
@@ -204,7 +202,6 @@ export function describeNativeComponentFrame(
 
 export function describeClassComponentFrame(
   ctor: Function,
-  source: void | null | Source,
   ownerFn: void | null | Function,
   currentDispatcherRef: CurrentDispatcherRef,
 ): string {
@@ -213,7 +210,6 @@ export function describeClassComponentFrame(
 
 export function describeFunctionComponentFrame(
   fn: Function,
-  source: void | null | Source,
   ownerFn: void | null | Function,
   currentDispatcherRef: CurrentDispatcherRef,
 ): string {
@@ -227,7 +223,6 @@ function shouldConstruct(Component: Function) {
 
 export function describeUnknownElementTypeFrameInDEV(
   type: any,
-  source: void | null | Source,
   ownerFn: void | null | Function,
   currentDispatcherRef: CurrentDispatcherRef,
 ): string {
@@ -245,15 +240,15 @@ export function describeUnknownElementTypeFrameInDEV(
     );
   }
   if (typeof type === 'string') {
-    return describeBuiltInComponentFrame(type, source, ownerFn);
+    return describeBuiltInComponentFrame(type, ownerFn);
   }
   switch (type) {
     case SUSPENSE_NUMBER:
     case SUSPENSE_SYMBOL_STRING:
-      return describeBuiltInComponentFrame('Suspense', source, ownerFn);
+      return describeBuiltInComponentFrame('Suspense', ownerFn);
     case SUSPENSE_LIST_NUMBER:
     case SUSPENSE_LIST_SYMBOL_STRING:
-      return describeBuiltInComponentFrame('SuspenseList', source, ownerFn);
+      return describeBuiltInComponentFrame('SuspenseList', ownerFn);
   }
   if (typeof type === 'object') {
     switch (type.$$typeof) {
@@ -261,7 +256,6 @@ export function describeUnknownElementTypeFrameInDEV(
       case FORWARD_REF_SYMBOL_STRING:
         return describeFunctionComponentFrame(
           type.render,
-          source,
           ownerFn,
           currentDispatcherRef,
         );
@@ -270,7 +264,6 @@ export function describeUnknownElementTypeFrameInDEV(
         // Memo may contain any component type so we recursively resolve it.
         return describeUnknownElementTypeFrameInDEV(
           type.type,
-          source,
           ownerFn,
           currentDispatcherRef,
         );
@@ -283,7 +276,6 @@ export function describeUnknownElementTypeFrameInDEV(
           // Lazy may contain any component type so we recursively resolve it.
           return describeUnknownElementTypeFrameInDEV(
             init(payload),
-            source,
             ownerFn,
             currentDispatcherRef,
           );

--- a/packages/react-devtools-shared/src/backend/DevToolsFiberComponentStack.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsFiberComponentStack.js
@@ -43,36 +43,32 @@ export function describeFiber(
       ? workInProgress._debugOwner.type
       : null
     : null;
-  const source = __DEV__ ? workInProgress._debugSource : null;
   switch (workInProgress.tag) {
     case HostComponent:
-      return describeBuiltInComponentFrame(workInProgress.type, source, owner);
+      return describeBuiltInComponentFrame(workInProgress.type, owner);
     case LazyComponent:
-      return describeBuiltInComponentFrame('Lazy', source, owner);
+      return describeBuiltInComponentFrame('Lazy', owner);
     case SuspenseComponent:
-      return describeBuiltInComponentFrame('Suspense', source, owner);
+      return describeBuiltInComponentFrame('Suspense', owner);
     case SuspenseListComponent:
-      return describeBuiltInComponentFrame('SuspenseList', source, owner);
+      return describeBuiltInComponentFrame('SuspenseList', owner);
     case FunctionComponent:
     case IndeterminateComponent:
     case SimpleMemoComponent:
       return describeFunctionComponentFrame(
         workInProgress.type,
-        source,
         owner,
         currentDispatcherRef,
       );
     case ForwardRef:
       return describeFunctionComponentFrame(
         workInProgress.type.render,
-        source,
         owner,
         currentDispatcherRef,
       );
     case ClassComponent:
       return describeClassComponentFrame(
         workInProgress.type,
-        source,
         owner,
         currentDispatcherRef,
       );


### PR DESCRIPTION
This PR cleans up the DevTools codebase by:
* Consolidating `normalizeCodeLocInfo` into one place
* Remove unused source argument in the DevTools component stacks code