### PR TITLE
[sizebot] Add link to diff view

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -84,9 +84,10 @@ const header = `
   | Name | +/- | Base | Current | +/- gzip | Base gzip | Current gzip |
   | ---- | --- | ---- | ------- | -------- | --------- | ------------ |`;
 
-function row(result) {
+function row(result, baseSha, headSha) {
+  const diffViewUrl = `https://react-builds.vercel.app/commits/${headSha}/files/${result.path}?compare=${baseSha}`;
   // prettier-ignore
-  return `| ${result.path} | **${change(result.change)}** | ${kbs(result.baseSize)} | ${kbs(result.headSize)} | ${change(result.changeGzip)} | ${kbs(result.baseSizeGzip)} | ${kbs(result.headSizeGzip)}`;
+  return `| [${result.path}](${diffViewUrl}) | **${change(result.change)}** | ${kbs(result.baseSize)} | ${kbs(result.headSize)} | ${change(result.changeGzip)} | ${kbs(result.baseSizeGzip)} | ${kbs(result.headSizeGzip)}`;
 }
 
 (async function() {
@@ -196,7 +197,7 @@ function row(result) {
           artifactPath
       );
     }
-    criticalResults.push(row(result));
+    criticalResults.push(row(result, baseSha, headSha));
   }
 
   let significantResults = [];
@@ -212,7 +213,7 @@ function row(result) {
       // Skip critical artifacts. We added those earlier, in a fixed order.
       !CRITICAL_ARTIFACT_PATHS.has(result.path)
     ) {
-      criticalResults.push(row(result));
+      criticalResults.push(row(result, baseSha, headSha));
     }
 
     // Do the same for results that exceed the significant threshold. These
@@ -224,7 +225,7 @@ function row(result) {
       result.change === Infinity ||
       result.change === -1
     ) {
-      significantResults.push(row(result));
+      significantResults.push(row(result, baseSha, headSha));
     }
   }
 


### PR DESCRIPTION
Updates the sizebot output so that the file names link to a diff view of the corresponding build artifact.

Example diff view: https://react-builds.vercel.app/commits/955cad9bcc6d755b2a672f8038fe9754e0fe5108/files/oss-stable-semver/react-dom/cjs/react-dom.production.min.js?compare=c3d7a7e3d72937443ef75b7e29335c98ad0f1424

The diff view itself is rendered by a Next.js app that I built as a side project and is hosted at https://react-builds.vercel.app. If we find this useful enough I could move the app to a React-owned repo but since this isn't a critical feature it might be OK to leave it separate for now, so we don't need to commit to supporting it indefinitely.