### PR TITLE
[Transition Tracing] Fix excess calls to the transition start callback

### DIFF
--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -846,9 +846,9 @@ export function addTransitionToLanesMap(
     const index = laneToIndex(lane);
     let transitions = transitionLanesMap[index];
     if (transitions === null) {
-      transitions = [];
+      transitions = new Set();
     }
-    transitions.push(transition);
+    transitions.add(transition);
 
     transitionLanesMap[index] = transitions;
   }

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -813,9 +813,9 @@ export function addTransitionToLanesMap(
     const index = laneToIndex(lane);
     let transitions = transitionLanesMap[index];
     if (transitions === null) {
-      transitions = [];
+      transitions = new Set();
     }
-    transitions.push(transition);
+    transitions.add(transition);
 
     transitionLanesMap[index] = transitions;
   }

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -328,7 +328,7 @@ export type TransitionTracingCallbacks = {
 // The following fields are only used in transition tracing in Profile builds
 type TransitionTracingOnlyFiberRootProperties = {|
   transitionCallbacks: null | TransitionTracingCallbacks,
-  transitionLanes: Array<Array<Transition> | null>,
+  transitionLanes: Array<Set<Transition> | null>,
   // Transitions on the root can be represented as a bunch of tracing markers.
   // Each entangled group of transitions can be treated as a tracing marker.
   // It will have a set of pending suspense boundaries. These transitions


### PR DESCRIPTION
This PR fixes a bug where we would add a transition to the lanes map every time an update occurs. However, we didn't factor in that there might be multiple updates in a transition, which would cause the transition to be added multiple times to the transitionLanes map.

This changes the transitionLanes object from an Array of Arrays to an Array of Sets so that we only add a transition if it hasn't been added before, avoiding duplicates