### PR TITLE
[DevTools] Add column number to viewSourceLineFunction

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -245,8 +245,8 @@ function createPanelIfReactLoaded() {
           }
         };
 
-        const viewSourceLineFunction = (url, line) => {
-          chrome.devtools.panels.openResource(url, line);
+        const viewUrlSourceFunction = (url, line, col) => {
+          chrome.devtools.panels.openResource(url, line, col);
         };
 
         let debugIDCounter = 0;
@@ -385,7 +385,7 @@ function createPanelIfReactLoaded() {
               warnIfUnsupportedVersionDetected: true,
               viewAttributeSourceFunction,
               viewElementSourceFunction,
-              viewSourceLineFunction,
+              viewUrlSourceFunction,
             }),
           );
         };

--- a/packages/react-devtools-shared/src/devtools/views/Components/ViewSourceContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ViewSourceContext.js
@@ -9,10 +9,10 @@
 
 import {createContext} from 'react';
 
-import type {ViewSourceLine} from 'react-devtools-shared/src/devtools/views/DevTools';
+import type {ViewUrlSource} from 'react-devtools-shared/src/devtools/views/DevTools';
 
 export type Context = {|
-  viewSourceLineFunction: ViewSourceLine | null,
+  viewUrlSourceFunction: ViewUrlSource | null,
 |};
 
 const ViewSourceContext = createContext<Context>(((null: any): Context));

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -58,7 +58,7 @@ export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
-export type ViewSourceLine = (url: string, row: number, column: number) => void;
+export type ViewUrlSource = (url: string, row: number, column: number) => void;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,
@@ -79,7 +79,7 @@ export type Props = {|
   warnIfUnsupportedVersionDetected?: boolean,
   viewAttributeSourceFunction?: ?ViewAttributeSource,
   viewElementSourceFunction?: ?ViewElementSource,
-  viewSourceLineFunction?: ?ViewSourceLine,
+  viewUrlSourceFunction?: ?ViewUrlSource,
   readOnly?: boolean,
   hideSettings?: boolean,
   hideToggleErrorAction?: boolean,
@@ -139,7 +139,7 @@ export default function DevTools({
   warnIfUnsupportedVersionDetected = false,
   viewAttributeSourceFunction,
   viewElementSourceFunction,
-  viewSourceLineFunction,
+  viewUrlSourceFunction,
   readOnly,
   hideSettings,
   hideToggleErrorAction,
@@ -205,11 +205,11 @@ export default function DevTools({
 
   const viewSource = useMemo(
     () => ({
-      viewSourceLineFunction: viewSourceLineFunction || null,
+      viewUrlSourceFunction: viewUrlSourceFunction || null,
       // todo(blakef): Add inspect(...) method here and remove viewElementSource
       // to consolidate source code inspection.
     }),
-    [viewSourceLineFunction],
+    [viewUrlSourceFunction],
   );
 
   const contextMenu = useMemo(

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
@@ -22,7 +22,7 @@ export type Props = {||};
 
 export default function SidebarEventInfo(_: Props) {
   const {profilingData, selectedCommitIndex} = useContext(ProfilerContext);
-  const {viewSourceLineFunction} = useContext(ViewSourceContext);
+  const {viewUrlSourceFunction} = useContext(ViewSourceContext);
 
   const {stack} = useMemo(() => {
     if (
@@ -55,8 +55,8 @@ export default function SidebarEventInfo(_: Props) {
       const hasSource = source != null;
 
       const onClick = () => {
-        if (viewSourceLineFunction != null && source != null) {
-          viewSourceLineFunction(...source);
+        if (viewUrlSourceFunction != null && source != null) {
+          viewUrlSourceFunction(...source);
         }
       };
 


### PR DESCRIPTION
Add column number for `viewSourceLineFunction` and renamed the function to `viewUrlSourceFunction` to match the other source function naming conventions