### PR TITLE
[DevTools] Resign Timeline Profiler Sidebar

### DIFF
--- a/packages/react-devtools-shared/src/devtools/views/Button.css
+++ b/packages/react-devtools-shared/src/devtools/views/Button.css
@@ -5,6 +5,7 @@
   padding: 0;
   border-radius: 0.25rem;
   flex: 0 0 auto;
+  cursor: pointer;
 }
 .ButtonContent {
   display: inline-flex;

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.css
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.css
@@ -20,18 +20,15 @@
 }
 
 .ListItem {
-  margin: 0;
+  flex: 1 1;
+  margin: 0 0 0.5rem;
 }
 
 .Label {
-  display: flex;
-  justify-content: space-between;
-
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-weight: bold;
-}
-
-[data-source="true"]:hover .Label > .Button {
-  background-color: var(--color-background-hover);
+  flex: 1 1;
 }
 
 .Value {
@@ -39,32 +36,31 @@
   font-size: var(--font-size-monospace-normal);
 }
 
-.NothingSelected {
-  display: flex;
+.Row {  
+  display: flex;  
+  flex-direction: row;  
   align-items: center;
-  justify-content: center;
-  height: 100%;
+  border-top: 1px solid var(--color-border);
+} 
+
+.UnclickableSource,
+.ClickableSource {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sans-normal);
+}
+
+.UnclickableSource {
   color: var(--color-dim);
 }
 
-.Button {
-  display: flex;
-  flex: 1;
-
-  max-width: 95%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.ClickableSource {
+  color: var(--color-text);
 }
 
-[data-source="true"] .Button {
-  cursor: pointer;
-}
-
-
-.Button > span {
-  display: block;
-  text-align: left;
-}
-
-.Source {
+.ClickableSource:focus,
+.ClickableSource:hover {
+  background-color: var(--color-background-hover);
 }

--- a/packages/react-devtools-timeline/src/EventTooltip.js
+++ b/packages/react-devtools-timeline/src/EventTooltip.js
@@ -24,7 +24,12 @@ import type {
 } from './types';
 
 import * as React from 'react';
-import {formatDuration, formatTimestamp, trimString} from './utils/formatting';
+import {
+  formatDuration,
+  formatTimestamp,
+  trimString,
+  getSchedulingEventLabel,
+} from './utils/formatting';
 import {getBatchRange} from './utils/getBatchRange';
 import useSmartTooltip from './utils/useSmartTooltip';
 import styles from './EventTooltip.css';
@@ -39,19 +44,6 @@ type Props = {|
   origin: Point,
   width: number,
 |};
-
-function getSchedulingEventLabel(event: SchedulingEvent): string | null {
-  switch (event.type) {
-    case 'schedule-render':
-      return 'render scheduled';
-    case 'schedule-state-update':
-      return 'state update scheduled';
-    case 'schedule-force-update':
-      return 'force update scheduled';
-    default:
-      return null;
-  }
-}
 
 function getReactMeasureLabel(type): string | null {
   switch (type) {

--- a/packages/react-devtools-timeline/src/utils/formatting.js
+++ b/packages/react-devtools-timeline/src/utils/formatting.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {SchedulingEvent} from '../types';
+
 import prettyMilliseconds from 'pretty-ms';
 
 export function formatTimestamp(ms: number) {
@@ -27,4 +29,17 @@ export function trimString(string: string, length: number): string {
     return `${string.substr(0, length - 1)}…`;
   }
   return string;
+}
+
+export function getSchedulingEventLabel(event: SchedulingEvent): string | null {
+  switch (event.type) {
+    case 'schedule-render':
+      return 'render scheduled';
+    case 'schedule-state-update':
+      return 'state update scheduled';
+    case 'schedule-force-update':
+      return 'force update scheduled';
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
This PR:
* Redesigned the sidebar to resemble the flamegraph profiler sidebar and added title and timestamp to the sidebar
* Added ability to copy the component stack (for places where you're unable to link to source)

https://user-images.githubusercontent.com/2735514/176564897-5301d6d4-429a-4ea3-86cd-74427cff4ce6.mov

