### PR TITLE
[Fizz]: Support task priorities

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -4201,7 +4201,7 @@ describe('ReactDOMFizzServer', () => {
 
   it('fallbacks are rendered behind higher priority tasks', async () => {
     function YieldAsyncText({text}) {
-      let value = readText(text);
+      const value = readText(text);
       Scheduler.unstable_yieldValue(value);
       return <span>{value}</span>;
     }

--- a/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactDOMServerFB-test.internal.js
@@ -183,6 +183,11 @@ describe('ReactDOMServerFB', () => {
       },
     );
 
+    // Now that fallback tasks are deprioritized they don't render
+    // synchronously during the first performWork pass if something
+    // Suspends. The second call to renderNextChunk gets the output
+    // of the Suspense boundary slot + fallback
+    ReactDOMServer.renderNextChunk(stream);
     const partial = ReactDOMServer.renderNextChunk(stream);
     expect(partial).toContain('Loading');
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -499,6 +499,10 @@ describe('ReactFlightDOMBrowser', () => {
       return <ClientComponentOnTheClient />;
     }
 
+    function ClientRoot({response}) {
+      return response.readRoot();
+    }
+
     try {
       // For this test we use real timers because the interaction between
       // the readRoot call and idleTasks makes it incredibly cumbersome to
@@ -516,12 +520,8 @@ describe('ReactFlightDOMBrowser', () => {
         moduleMap: translationMap,
       });
 
-      function ClientRoot() {
-        return response.readRoot();
-      }
-
       const ssrStream = await ReactDOMServer.renderToReadableStream(
-        <ClientRoot />,
+        <ClientRoot response={response} />,
       );
       const result = await readResult(ssrStream);
       expect(result).toEqual('<span>Client Component</span>');

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -200,6 +200,7 @@ export opaque type Request = {
   completedRootSegment: null | Segment, // Completed but not yet flushed root segments.
   abortableTasks: Set<Task>,
   pingedTasks: Array<Task>,
+  idleTasks: Array<Task>,
   // Queues to flush in order of priority
   clientRenderedBoundaries: Array<SuspenseBoundary>, // Errored or client rendered but not yet flushed.
   completedBoundaries: Array<SuspenseBoundary>, // Completed but not yet fully flushed boundaries to show.

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -13,7 +13,7 @@ export type PrecomputedChunk = Uint8Array;
 export type Chunk = Uint8Array;
 
 export function scheduleWork(callback: () => void) {
-  callback();
+  setTimeout(callback, 0);
 }
 
 export function flushBuffered(destination: Destination) {


### PR DESCRIPTION
Certain tasks in Fizz are less urgent than others. The only use case today is fallback tasks however there will likely be more kinds in the future.

Before this change if the main content of a Suspense boundary suspends a fallback task is created and put into the pingedTask queue. Since we are already within the work loop this means the fallback will get worked on synchronously before the suspended item has a chance to resolve. This means that in many cases fallbacks are rendered even if they are not going to be used and it lengthens the time before we return to microtask or macrotask queues to process additional work that might unblock actual renderable content

With this change we now have two task queues. the default priority `pingedTasks` queue remains the same. A new lower priority`idleTasks` queue now exists as well. All default priority tasks are worked on synchronously in every `performWork` loop however idleTasks are only worked on if the work loop has not yet created any new pending tasks. If a new pending task is identified the `performWork` routine yields by scheduling a followup `performWork` call. It's important to note however that if the scheduling of work is sync then there will be no actual yield and all idleTasks will get worked on before control is returned to the runtime.

With this change I also updated the default work schedulign for Browser runtimes to use `setTimeout(fn, 0)`. This required some refactoring of tests to use jest.runAllTimers to drive the work loop.

Additionally the implementation for the work loop for FB implementation does not actually schedule anything and as such additional calls to `performWork` are needed.
