### PR TITLE
Add 4.5.0 release to eslint rules CHANGELOG

### DIFF
--- a/packages/eslint-plugin-react-hooks/CHANGELOG.md
+++ b/packages/eslint-plugin-react-hooks/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.0
+
+* Fix false positive error with large number of branches. ([@scyron6](https://github.com/scyron6) in [#24287](https://github.com/facebook/react/pull/24287))
+
 ## 4.4.0
 
 * No changes, this was an automated release together with React 18.


### PR DESCRIPTION


## Summary

Closes https://github.com/facebook/react/issues/24777

## How did you test this change?

Eye-balled from https://app.renovatebot.com/package-diff?name=eslint-plugin-react-hooks&from=4.4.0&to=4.5.0#d2h-042857 which changes were included.