### PR TITLE
Add a failing test case for a case when wakeable pings immediately after yielding and before resuming

### DIFF
--- a/packages/scheduler/src/forks/SchedulerMock.js
+++ b/packages/scheduler/src/forks/SchedulerMock.js
@@ -420,6 +420,10 @@ function cancelHostTimeout(): void {
 }
 
 function shouldYieldToHost(): boolean {
+  if (forcedYield) {
+    forcedYield = false;
+    return true;
+  }
   if (
     (expectedNumberOfYields === 0 && yieldedValues === null) ||
     (expectedNumberOfYields !== -1 &&
@@ -637,7 +641,13 @@ export {
   unstable_advanceTime,
   reset,
   setDisableYieldValue as unstable_setDisableYieldValue,
+  forceYield as unstable_forceYield,
 };
+
+let forcedYield = false;
+function forceYield() {
+  forcedYield = true;
+}
 
 export const unstable_Profiling = enableProfiling
   ? {


### PR DESCRIPTION
related to https://github.com/facebook/react/issues/24864 , explained in https://github.com/facebook/react/issues/24864#issuecomment-1178716544