### PR TITLE
bump AppVeyor Node version from '10.x' to '14.x' (current Maintenance LTS version)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
 environment:
   JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   matrix:
-    - nodejs_version: 10
+    - nodejs_version: 14
 
 # Finish on first failed build
 matrix:


### PR DESCRIPTION
## Summary

For the full deepdive/context, see:

- https://github.com/facebook/react/issues/24891

The below is an excerpt from the above that is specifically relevant to this PR:

> If AppVeyor is still in use, and it's still not possible to migrate the Windows builds to CircleCI, it would be good to upgrade to a modern version of node:
> 
> - https://nodejs.org/en/about/releases/
>   - node 14.x is the current Maintenance LTS
>   - node 16.x is the current Active LTS
> 
> Looking at [`.circleci/config.yml`](https://github.com/facebook/react/blob/main/.circleci/config.yml#L5), the jobs seem to run on the `cimg/openjdk:17.0.0-node` docker container: 
> 
> - https://circleci.com/developer/images/image/cimg/openjdk
>   - `17.0.0-node` uses: node 14.17.6, yarn 1.22.5
> 
> AppVeyor's Windows images include the following versions of node by default:
> 
> - https://www.appveyor.com/docs/windows-images-software/#node-js
>   - `8.x` is default Node.js installed on build workers
>   - Node.js `16.8.0` (x86 and x64) - use `Current` alias for latest `16.x` release
>   - Node.js `15.0.0` - 15.14.0 (x86 and x64)
>   - Node.js `14.17.6` (x86 and x64) - default on VS 2019 image. Use `LTS` alias for latest `14.x` release
>   - etc
> 
> So I think that either we should upgrade both AppVeyor and CircleCI to use a `16.x` version of node, or at the very least, should upgrade AppVeyor to use the `14.x` version (i'm unsure if there is any official list of node versions that React is intended to support being built on, but if so, then should probably test against all of those versions)
> 
> While this may not be too important currently (as presumably all of the build tools work at the moment), it will likely become more of an issue as time goes on, and the build tooling is upgraded to versions that will require newer versions of the node runtime:
> 
> eg. An improvement that would allow generating source maps for React would ideally be able to use a version of the `magic-string` library (which is used by a number of the Rollup plugins) that supports `s.replace`, but this version requires Node `12.x` or higher, which currently would presumably break on AppVeyor as it uses node `10.x`:
> 
> - https://github.com/facebook/react/issues/20186
>   - https://github.com/facebook/react/pull/21946#discussion_r918677066
> - https://github.com/Rich-Harris/magic-string/blob/master/CHANGELOG.md#0260-2022-03-03
> - https://github.com/rollup/plugins/search?q=magic-string&type=code

## How did you test this change?

I haven't.. but hopefully it will run automagically (or someone else can trigger it to run since AppVeyor is only set up to run on the `main` branch)