### PR TITLE
Refactor layout phase to use recursion

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -893,6 +893,12 @@ function commitLayoutEffectOnFiber(
           // TODO: revisit this when we implement resuming.
           commitCallbacks(updateQueue, instance);
         }
+
+        if (finishedWork.flags & Ref) {
+          if (!offscreenSubtreeWasHidden) {
+            commitAttachRef(finishedWork);
+          }
+        }
         break;
       }
       case HostRoot: {
@@ -930,6 +936,11 @@ function commitLayoutEffectOnFiber(
           commitMount(instance, type, props, finishedWork);
         }
 
+        if (finishedWork.flags & Ref) {
+          if (!offscreenSubtreeWasHidden) {
+            commitAttachRef(finishedWork);
+          }
+        }
         break;
       }
       case HostText: {
@@ -1018,20 +1029,6 @@ function commitLayoutEffectOnFiber(
           'This unit of work tag should not have side-effects. This error is ' +
             'likely caused by a bug in React. Please file an issue.',
         );
-    }
-  }
-
-  if (!offscreenSubtreeWasHidden) {
-    if (enableScopeAPI) {
-      // TODO: This is a temporary solution that allowed us to transition away
-      // from React Flare on www.
-      if (finishedWork.flags & Ref && finishedWork.tag !== ScopeComponent) {
-        commitAttachRef(finishedWork);
-      }
-    } else {
-      if (finishedWork.flags & Ref) {
-        commitAttachRef(finishedWork);
-      }
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -893,6 +893,12 @@ function commitLayoutEffectOnFiber(
           // TODO: revisit this when we implement resuming.
           commitCallbacks(updateQueue, instance);
         }
+
+        if (finishedWork.flags & Ref) {
+          if (!offscreenSubtreeWasHidden) {
+            commitAttachRef(finishedWork);
+          }
+        }
         break;
       }
       case HostRoot: {
@@ -930,6 +936,11 @@ function commitLayoutEffectOnFiber(
           commitMount(instance, type, props, finishedWork);
         }
 
+        if (finishedWork.flags & Ref) {
+          if (!offscreenSubtreeWasHidden) {
+            commitAttachRef(finishedWork);
+          }
+        }
         break;
       }
       case HostText: {
@@ -1018,20 +1029,6 @@ function commitLayoutEffectOnFiber(
           'This unit of work tag should not have side-effects. This error is ' +
             'likely caused by a bug in React. Please file an issue.',
         );
-    }
-  }
-
-  if (!offscreenSubtreeWasHidden) {
-    if (enableScopeAPI) {
-      // TODO: This is a temporary solution that allowed us to transition away
-      // from React Flare on www.
-      if (finishedWork.flags & Ref && finishedWork.tag !== ScopeComponent) {
-        commitAttachRef(finishedWork);
-      }
-    } else {
-      if (finishedWork.flags & Ref) {
-        commitAttachRef(finishedWork);
-      }
     }
   }
 }


### PR DESCRIPTION
This converts the layout phase to iterate over its effects recursively instead of iteratively. This makes it easier to track 
contextual information, like whether a fiber is inside a hidden tree.

We already made this change for the mutation phase in #24308. This PR follows a similar structure, though is a bit more straightforward.

Because this is largely a structural refactor as opposed to a logical one, I would like to attempt landing this using the same strategy as #24308: land the stack directly in main, without a feature flag. If there's a bug somewhere, it should be easy to bisect and fix forward.

If it turns out to be trickier than expected, we can revert and use the reconciler fork infra instead. I don't want to jump straight to using the fork infra because it will make it harder for other contributors to land changes to the commit phase in the meantime.