### PR TITLE
(fix): beforeinput spellchecking bug on firefox #24882

### DIFF
--- a/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
@@ -360,6 +360,11 @@ function getFallbackBeforeInputChars(
         }
       }
       return null;
+
+    // Firefox fires the 'input' event when a user types an incorrectly spelled
+    // word and uses the spellchecker to correct it
+    case 'input':
+      return nativeEvent.data;
     case 'compositionend':
       return useFallbackCompositionData && !isUsingKoreanIME(nativeEvent)
         ? null


### PR DESCRIPTION
fixed react spellcheking on beforeinput bug

fixed spellcheking bug in firefox

fixed react spellcheking on beforeinput bug

fix spellchecking bug on firefox

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
This resolves https://github.com/facebook/react/issues/24358, in which the beforeInputEvent wasn't firing when triggering a spellchecking in firefox. The problem was in the getFallbackBeforeInputChars function: the spellchecking event is interpreted as an 'input' event in firefox, which the function wasn't handling.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
I tested this change in the fixtures/packaging/babel-standalone/dev.html recreating the exact sandbox that creator of the issue built and the beforeInput fired as expected.
