### PR TITLE
[Transition Tracing] Rename transitionCallbacks to unstable_transitionCallbacks

### DIFF
--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -26,9 +26,9 @@ export type RootType = {
 export type CreateRootOptions = {
   unstable_strictMode?: boolean,
   unstable_concurrentUpdatesByDefault?: boolean,
+  unstable_transitionCallbacks?: TransitionTracingCallbacks,
   identifierPrefix?: string,
   onRecoverableError?: (error: mixed) => void,
-  transitionCallbacks?: TransitionTracingCallbacks,
   ...
 };
 
@@ -216,8 +216,8 @@ export function createRoot(
     if (options.onRecoverableError !== undefined) {
       onRecoverableError = options.onRecoverableError;
     }
-    if (options.transitionCallbacks !== undefined) {
-      transitionCallbacks = options.transitionCallbacks;
+    if (options.unstable_transitionCallbacks !== undefined) {
+      transitionCallbacks = options.unstable_transitionCallbacks;
     }
   }
 

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -68,7 +68,7 @@ type TextInstance = {|
 |};
 type HostContext = Object;
 type CreateRootOptions = {
-  transitionCallbacks?: TransitionTracingCallbacks,
+  unstable_transitionCallbacks?: TransitionTracingCallbacks,
   ...
 };
 
@@ -828,8 +828,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
         false,
         '',
         onRecoverableError,
-        options && options.transitionCallbacks
-          ? options.transitionCallbacks
+        options && options.unstable_transitionCallbacks
+          ? options.unstable_transitionCallbacks
           : null,
       );
       return {

--- a/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
@@ -212,7 +212,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App navigate={false} />);
       ReactNoop.expire(1000);
@@ -276,7 +278,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -333,7 +337,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -404,7 +410,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -497,7 +505,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -602,7 +612,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -717,7 +729,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -846,7 +860,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -1000,7 +1016,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -1085,7 +1103,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -1203,7 +1223,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       root.render(<App />);
       ReactNoop.expire(1000);
@@ -1286,7 +1308,9 @@ describe('ReactInteractionTracing', () => {
       );
     }
 
-    const root = ReactNoop.createRoot({transitionCallbacks});
+    const root = ReactNoop.createRoot({
+      unstable_transitionCallbacks: transitionCallbacks,
+    });
     await act(async () => {
       startTransition(
         () => root.render(<App markerName="one" markerKey="key" />),


### PR DESCRIPTION
Renaming `transitionCallbacks` to `unstable_transitionCallbacks` as per convention