### PR TITLE
[DevTools] enable `enableProfilerComponentTree` flag for all builds

### DIFF
--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.core-oss.js
@@ -19,7 +19,7 @@ export const enableNamedHooksFeature = true;
 export const enableProfilerChangedHookIndices = true;
 export const enableStyleXFeatures = false;
 export const isInternalFacebookBuild = false;
-export const enableProfilerComponentTree = false;
+export const enableProfilerComponentTree = true;
 
 /************************************************************************
  * Do not edit the code below.

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.default.js
@@ -19,4 +19,4 @@ export const enableNamedHooksFeature = true;
 export const enableProfilerChangedHookIndices = true;
 export const enableStyleXFeatures = false;
 export const isInternalFacebookBuild = false;
-export const enableProfilerComponentTree = false;
+export const enableProfilerComponentTree = true;

--- a/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
+++ b/packages/react-devtools-shared/src/config/DevToolsFeatureFlags.extension-oss.js
@@ -19,7 +19,7 @@ export const enableNamedHooksFeature = true;
 export const enableProfilerChangedHookIndices = true;
 export const enableStyleXFeatures = false;
 export const isInternalFacebookBuild = false;
-export const enableProfilerComponentTree = false;
+export const enableProfilerComponentTree = true;
 
 /************************************************************************
  * Do not edit the code below.


### PR DESCRIPTION
This feature is now available for all builds

`yarn build:chrome`

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/1001890/178812032-540d2475-0a23-43dd-8514-563237bb4bd2.png">
