### PR TITLE
test: Throw custom error instead of relying on runtime error

### DIFF
--- a/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
+++ b/packages/use-sync-external-store/src/__tests__/useSyncExternalStoreShared-test.js
@@ -900,7 +900,12 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
 
     it('selector can throw on update', async () => {
       const store = createExternalStore({a: 'a'});
-      const selector = state => state.a.toUpperCase();
+      const selector = state => {
+        if (typeof state.a !== 'string') {
+          throw new TypeError('Malformed state');
+        }
+        return state.a.toUpperCase();
+      };
 
       function App() {
         const a = useSyncExternalStoreWithSelector(
@@ -927,15 +932,18 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       await act(() => {
         store.set({});
       });
-      expect(container.textContent).toEqual(
-        "Cannot read property 'toUpperCase' of undefined",
-      );
+      expect(container.textContent).toEqual('Malformed state');
     });
 
     it('isEqual can throw on update', async () => {
       const store = createExternalStore({a: 'A'});
       const selector = state => state.a;
-      const isEqual = (left, right) => left.a.trim() === right.a.trim();
+      const isEqual = (left, right) => {
+        if (typeof left.a !== 'string' || typeof right.a !== 'string') {
+          throw new TypeError('Malformed state');
+        }
+        return left.a.trim() === right.a.trim();
+      };
 
       function App() {
         const a = useSyncExternalStoreWithSelector(
@@ -963,9 +971,7 @@ describe('Shared useSyncExternalStore behavior (shim and built-in)', () => {
       await act(() => {
         store.set({});
       });
-      expect(container.textContent).toEqual(
-        "Cannot read property 'trim' of undefined",
-      );
+      expect(container.textContent).toEqual('Malformed state');
     });
   });
 });


### PR DESCRIPTION

## Summary

Partial fix for https://github.com/facebook/react/issues/24915

The tests were relying on runtime error messages. These changed between Node 14.x and 16.x. Instead we now throw an error whose message we control

## How did you test this change?

- [x] volta pin node@14.17.0; yarn; yarn test
- [x] volta pin node@16.16.0; yarn; yarn test
- [x] CI
