### PR TITLE
[Transition Tracing] Tracing Marker Deleted

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -772,6 +772,7 @@ export function createFiberFromTracingMarker(
     transitions: null,
     pendingBoundaries: null,
     deletions: null,
+    parents: null,
     name: pendingProps.name,
   };
   fiber.stateNode = tracingMarkerInstance;

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -771,6 +771,8 @@ export function createFiberFromTracingMarker(
   const tracingMarkerInstance: TracingMarkerInstance = {
     transitions: null,
     pendingBoundaries: null,
+    deletions: null,
+    name: pendingProps.name,
   };
   fiber.stateNode = tracingMarkerInstance;
   return fiber;

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -772,6 +772,7 @@ export function createFiberFromTracingMarker(
     transitions: null,
     pendingBoundaries: null,
     deletions: null,
+    parents: null,
     name: pendingProps.name,
   };
   fiber.stateNode = tracingMarkerInstance;

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -771,6 +771,8 @@ export function createFiberFromTracingMarker(
   const tracingMarkerInstance: TracingMarkerInstance = {
     transitions: null,
     pendingBoundaries: null,
+    deletions: null,
+    name: pendingProps.name,
   };
   fiber.stateNode = tracingMarkerInstance;
   return fiber;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -974,11 +974,14 @@ function updateTracingMarkerComponent(
   // or updated it, so we can create a new set of transitions each time
   if (current === null) {
     const currentTransitions = getPendingTransitions();
+    // TODO: What if the parent markers change?
+    const parents = getMarkerInstances();
     if (currentTransitions !== null) {
       const markerInstance: TracingMarkerInstance = {
         transitions: new Set(currentTransitions),
         pendingBoundaries: new Map(),
         name: workInProgress.pendingProps.name,
+        parents,
         deletions: null,
       };
       workInProgress.stateNode = markerInstance;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -979,6 +979,7 @@ function updateTracingMarkerComponent(
         transitions: new Set(currentTransitions),
         pendingBoundaries: new Map(),
         name: workInProgress.pendingProps.name,
+        deletions: null,
       };
       workInProgress.stateNode = markerInstance;
     }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -974,11 +974,14 @@ function updateTracingMarkerComponent(
   // or updated it, so we can create a new set of transitions each time
   if (current === null) {
     const currentTransitions = getPendingTransitions();
+    // TODO: What if the parent markers change?
+    const parents = getMarkerInstances();
     if (currentTransitions !== null) {
       const markerInstance: TracingMarkerInstance = {
         transitions: new Set(currentTransitions),
         pendingBoundaries: new Map(),
         name: workInProgress.pendingProps.name,
+        parents,
         deletions: null,
       };
       workInProgress.stateNode = markerInstance;

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -979,6 +979,7 @@ function updateTracingMarkerComponent(
         transitions: new Set(currentTransitions),
         pendingBoundaries: new Map(),
         name: workInProgress.pendingProps.name,
+        deletions: null,
       };
       workInProgress.stateNode = markerInstance;
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -30,7 +30,10 @@ import type {
 import type {HookFlags} from './ReactHookEffectTags';
 import type {Cache} from './ReactFiberCacheComponent.new';
 import type {RootState} from './ReactFiberRoot.new';
-import type {Transition} from './ReactFiberTracingMarkerComponent.new';
+import type {
+  Transition,
+  TracingMarkerInstance,
+} from './ReactFiberTracingMarkerComponent.new';
 
 import {
   enableCreateEventHandleAPI,
@@ -2063,6 +2066,20 @@ function commitDeletionEffectsOnFiber(
         const prevOffscreenSubtreeWasHidden = offscreenSubtreeWasHidden;
         offscreenSubtreeWasHidden =
           prevOffscreenSubtreeWasHidden || deletedFiber.memoizedState !== null;
+
+        if (enableTransitionTracing) {
+          // We need to mark this fiber's parents as deleted
+          const instance: OffscreenInstance = deletedFiber.stateNode;
+          const markers = instance.pendingMarkers;
+          if (markers !== null) {
+            markers.forEach(marker => {
+              if (marker.pendingBoundaries.has(instance)) {
+                marker.pendingBoundaries.delete(instance);
+              }
+            });
+          }
+        }
+
         recursivelyTraverseDeletionEffects(
           finishedRoot,
           nearestMountedAncestor,
@@ -2077,6 +2094,58 @@ function commitDeletionEffectsOnFiber(
         );
       }
       break;
+    }
+    case TracingMarkerComponent: {
+      if (enableTransitionTracing) {
+        // We need to mark this fiber's parents as deleted
+        const instance: TracingMarkerInstance = deletedFiber.stateNode;
+        const markers = instance.parents;
+        if (instance.transitions !== null) {
+          if (instance.deletions === null) {
+            instance.deletions = [];
+          }
+          instance.deletions.push({
+            type: 'marker',
+            name: deletedFiber.memoizedProps.name,
+            transitions: instance.transitions,
+          });
+
+          addMarkerIncompleteCallbackToPendingTransition(
+            instance.name,
+            instance.transitions,
+            instance.deletions,
+          );
+
+          if (markers !== null) {
+            markers.forEach(marker => {
+              if (marker.deletions === null) {
+                marker.deletions = [];
+
+                if (marker.name !== null) {
+                  addMarkerIncompleteCallbackToPendingTransition(
+                    marker.name,
+                    instance.transitions,
+                    marker.deletions,
+                  );
+                }
+              }
+
+              marker.deletions.push({
+                type: 'marker',
+                name: deletedFiber.memoizedProps.name,
+                transitions: instance.transitions,
+              });
+            });
+          }
+        }
+      }
+
+      recursivelyTraverseDeletionEffects(
+        finishedRoot,
+        nearestMountedAncestor,
+        deletedFiber,
+      );
+      return;
     }
     default: {
       recursivelyTraverseDeletionEffects(
@@ -3104,14 +3173,14 @@ function commitPassiveMountOnFiber(
       break;
     }
     case TracingMarkerComponent: {
-      if (flags & Passive) {
-        if (enableTransitionTracing) {
-          recursivelyTraversePassiveMountEffects(
-            finishedRoot,
-            finishedWork,
-            committedLanes,
-            committedTransitions,
-          );
+      if (enableTransitionTracing) {
+        recursivelyTraversePassiveMountEffects(
+          finishedRoot,
+          finishedWork,
+          committedLanes,
+          committedTransitions,
+        );
+        if (flags & Passive) {
           // Get the transitions that were initiatized during the render
           // and add a start transition callback for each of them
           const instance = finishedWork.stateNode;
@@ -3159,6 +3228,8 @@ function commitPassiveMountOnFiber(
               instance.transitions = null;
               instance.pendingBoundaries = null;
               instance.deletions = null;
+              instance.parents = null;
+              instance.name = null;
             }
           }
         }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -146,6 +146,7 @@ import {
   addTransitionProgressCallbackToPendingTransition,
   addTransitionCompleteCallbackToPendingTransition,
   addMarkerProgressCallbackToPendingTransition,
+  addMarkerIncompleteCallbackToPendingTransition,
   addMarkerCompleteCallbackToPendingTransition,
   setIsRunningInsertionEffect,
 } from './ReactFiberWorkLoop.old';
@@ -2967,7 +2968,9 @@ function commitPassiveMountOnFiber(
           incompleteTransitions.forEach((markerInstance, transition) => {
             const pendingBoundaries = markerInstance.pendingBoundaries;
             if (pendingBoundaries === null || pendingBoundaries.size === 0) {
-              addTransitionCompleteCallbackToPendingTransition(transition);
+              if (markerInstance.deletions === null) {
+                addTransitionCompleteCallbackToPendingTransition(transition);
+              }
               incompleteTransitions.delete(transition);
             }
           });
@@ -3101,30 +3104,62 @@ function commitPassiveMountOnFiber(
       break;
     }
     case TracingMarkerComponent: {
-      if (enableTransitionTracing) {
-        recursivelyTraversePassiveMountEffects(
-          finishedRoot,
-          finishedWork,
-          committedLanes,
-          committedTransitions,
-        );
-        if (flags & Passive) {
+      if (flags & Passive) {
+        if (enableTransitionTracing) {
+          recursivelyTraversePassiveMountEffects(
+            finishedRoot,
+            finishedWork,
+            committedLanes,
+            committedTransitions,
+          );
           // Get the transitions that were initiatized during the render
           // and add a start transition callback for each of them
           const instance = finishedWork.stateNode;
-          if (
-            instance.transitions !== null &&
-            (instance.pendingBoundaries === null ||
-              instance.pendingBoundaries.size === 0)
-          ) {
-            instance.transitions.forEach(transition => {
-              addMarkerCompleteCallbackToPendingTransition(
-                finishedWork.memoizedProps.name,
-                instance.transitions,
-              );
-            });
-            instance.transitions = null;
-            instance.pendingBoundaries = null;
+          if (instance.transitions !== null) {
+            if (finishedWork.alternate !== null) {
+              const prevName = finishedWork.alternate.memoizedProps.name;
+              const nextName = finishedWork.memoizedProps.name;
+
+              // The transition should be marked as incomplete if the name changed
+              if (prevName !== nextName) {
+                if (!instance.deletions) {
+                  instance.deletions = [];
+
+                  addMarkerIncompleteCallbackToPendingTransition(
+                    prevName,
+                    instance.transitions,
+                    instance.deletions,
+                  );
+                }
+
+                const deletion = {
+                  type: 'marker',
+                  name: prevName,
+                  newName: nextName,
+                  // we'll filter the transitions that need to have this deletion
+                  // during the callback stage
+                  transitions: instance.transitions,
+                };
+
+                instance.deletions.push(deletion);
+              }
+            }
+
+            if (
+              instance.transitions !== null &&
+              (instance.pendingBoundaries === null ||
+                instance.pendingBoundaries.size === 0)
+            ) {
+              if (instance.deletions === null) {
+                addMarkerCompleteCallbackToPendingTransition(
+                  finishedWork.memoizedProps.name,
+                  instance.transitions,
+                );
+              }
+              instance.transitions = null;
+              instance.pendingBoundaries = null;
+              instance.deletions = null;
+            }
           }
         }
         break;

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -1605,8 +1605,11 @@ function completeWork(
         }
         bubbleProperties(workInProgress);
 
+        const prevName = current !== null ? current.memoizedProps.name : null;
+        const nextName = workInProgress.memoizedProps.name;
         if (
           current === null ||
+          prevName !== nextName ||
           (workInProgress.subtreeFlags & Visibility) !== NoFlags
         ) {
           // If any of our suspense children toggle visibility, this means that

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -1605,8 +1605,11 @@ function completeWork(
         }
         bubbleProperties(workInProgress);
 
+        const prevName = current !== null ? current.memoizedProps.name : null;
+        const nextName = workInProgress.memoizedProps.name;
         if (
           current === null ||
+          prevName !== nextName ||
           (workInProgress.subtreeFlags & Visibility) !== NoFlags
         ) {
           // If any of our suspense children toggle visibility, this means that

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
@@ -47,6 +47,7 @@ export type TracingMarkerInstance = {|
   pendingBoundaries: PendingBoundaries | null,
   transitions: Set<Transition> | null,
   deletions: Array<TransitionDeletion> | null,
+  parents: Array<TracingMarkerInstance> | null,
   name: string | null,
 |};
 
@@ -212,6 +213,7 @@ export function pushRootMarkerInstance(workInProgress: Fiber): void {
             transitions: new Set([transition]),
             pendingBoundaries: null,
             deletions: null,
+            parents: null,
             name: null,
           };
           root.incompleteTransitions.set(transition, markerInstance);

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
@@ -47,6 +47,7 @@ export type TracingMarkerInstance = {|
   pendingBoundaries: PendingBoundaries | null,
   transitions: Set<Transition> | null,
   deletions: Array<TransitionDeletion> | null,
+  parents: Array<TracingMarkerInstance> | null,
   name: string | null,
 |};
 
@@ -212,6 +213,7 @@ export function pushRootMarkerInstance(workInProgress: Fiber): void {
             transitions: new Set([transition]),
             pendingBoundaries: null,
             deletions: null,
+            parents: null,
             name: null,
           };
           root.incompleteTransitions.set(transition, markerInstance);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -18,6 +18,7 @@ import type {
   PendingTransitionCallbacks,
   PendingBoundaries,
   Transition,
+  TransitionDeletion,
 } from './ReactFiberTracingMarkerComponent.new';
 import type {OffscreenInstance} from './ReactFiberOffscreenComponent';
 
@@ -342,6 +343,7 @@ export function addTransitionStartCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -357,7 +359,7 @@ export function addTransitionStartCallbackToPendingTransition(
 export function addMarkerProgressCallbackToPendingTransition(
   markerName: string,
   transitions: Set<Transition>,
-  pendingBoundaries: PendingBoundaries | null,
+  pendingBoundaries: PendingBoundaries,
 ) {
   if (enableTransitionTracing) {
     if (currentPendingTransitionCallbacks === null) {
@@ -366,6 +368,7 @@ export function addMarkerProgressCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: new Map(),
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -381,6 +384,34 @@ export function addMarkerProgressCallbackToPendingTransition(
   }
 }
 
+export function addMarkerIncompleteCallbackToPendingTransition(
+  markerName: string,
+  transitions: Set<Transition>,
+  deletions: Array<TransitionDeletion>,
+) {
+  if (enableTransitionTracing) {
+    if (currentPendingTransitionCallbacks === null) {
+      currentPendingTransitionCallbacks = {
+        transitionStart: null,
+        transitionProgress: null,
+        transitionComplete: null,
+        markerProgress: null,
+        markerIncomplete: new Map(),
+        markerComplete: null,
+      };
+    }
+
+    if (currentPendingTransitionCallbacks.markerIncomplete === null) {
+      currentPendingTransitionCallbacks.markerIncomplete = new Map();
+    }
+
+    currentPendingTransitionCallbacks.markerIncomplete.set(markerName, {
+      transitions,
+      deletions,
+    });
+  }
+}
+
 export function addMarkerCompleteCallbackToPendingTransition(
   markerName: string,
   transitions: Set<Transition>,
@@ -392,6 +423,7 @@ export function addMarkerCompleteCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: new Map(),
       };
     }
@@ -418,6 +450,7 @@ export function addTransitionProgressCallbackToPendingTransition(
         transitionProgress: new Map(),
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -443,6 +476,7 @@ export function addTransitionCompleteCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: [],
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -18,6 +18,7 @@ import type {
   PendingTransitionCallbacks,
   PendingBoundaries,
   Transition,
+  TransitionDeletion,
 } from './ReactFiberTracingMarkerComponent.old';
 import type {OffscreenInstance} from './ReactFiberOffscreenComponent';
 
@@ -342,6 +343,7 @@ export function addTransitionStartCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -357,7 +359,7 @@ export function addTransitionStartCallbackToPendingTransition(
 export function addMarkerProgressCallbackToPendingTransition(
   markerName: string,
   transitions: Set<Transition>,
-  pendingBoundaries: PendingBoundaries | null,
+  pendingBoundaries: PendingBoundaries,
 ) {
   if (enableTransitionTracing) {
     if (currentPendingTransitionCallbacks === null) {
@@ -366,6 +368,7 @@ export function addMarkerProgressCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: new Map(),
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -381,6 +384,34 @@ export function addMarkerProgressCallbackToPendingTransition(
   }
 }
 
+export function addMarkerIncompleteCallbackToPendingTransition(
+  markerName: string,
+  transitions: Set<Transition>,
+  deletions: Array<TransitionDeletion>,
+) {
+  if (enableTransitionTracing) {
+    if (currentPendingTransitionCallbacks === null) {
+      currentPendingTransitionCallbacks = {
+        transitionStart: null,
+        transitionProgress: null,
+        transitionComplete: null,
+        markerProgress: null,
+        markerIncomplete: new Map(),
+        markerComplete: null,
+      };
+    }
+
+    if (currentPendingTransitionCallbacks.markerIncomplete === null) {
+      currentPendingTransitionCallbacks.markerIncomplete = new Map();
+    }
+
+    currentPendingTransitionCallbacks.markerIncomplete.set(markerName, {
+      transitions,
+      deletions,
+    });
+  }
+}
+
 export function addMarkerCompleteCallbackToPendingTransition(
   markerName: string,
   transitions: Set<Transition>,
@@ -392,6 +423,7 @@ export function addMarkerCompleteCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: new Map(),
       };
     }
@@ -418,6 +450,7 @@ export function addTransitionProgressCallbackToPendingTransition(
         transitionProgress: new Map(),
         transitionComplete: null,
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }
@@ -443,6 +476,7 @@ export function addTransitionCompleteCallbackToPendingTransition(
         transitionProgress: null,
         transitionComplete: [],
         markerProgress: null,
+        markerIncomplete: null,
         markerComplete: null,
       };
     }


### PR DESCRIPTION
Stacked Diff. Only Look at [this commit](https://github.com/facebook/react/pull/24954/commits/dd0e8438290b2acf5142f9e7214cc5f644937dbb)
---
When a tracing marker is deleted:
* We add {type: 'marker', name: markerName, endTime: time} to the tracing marker's deletions array and call the `onMarkerIncomplete` callback
* We also add the same deletion to each parent tracing marker's deletion array and call `onMarkerIncomplete` on the parents
* The deleted tracing marker's parent tracing markers can no longer complete, but onMarkerProgress will still be called for subsequent marker updates
*  