### PR TITLE
Don't fire passive effects during initial mount of a hidden Offscreen tree

### DIFF
--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -61,6 +61,7 @@ import {
   CacheComponent,
   TracingMarkerComponent,
 } from './ReactWorkTags';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 
 import {isDevToolsPresent} from './ReactFiberDevToolsHook.new';
@@ -717,7 +718,7 @@ export function createFiberFromOffscreen(
   fiber.elementType = REACT_OFFSCREEN_TYPE;
   fiber.lanes = lanes;
   const primaryChildInstance: OffscreenInstance = {
-    isHidden: false,
+    visibility: OffscreenVisible,
     pendingMarkers: null,
     retryCache: null,
     transitions: null,
@@ -738,7 +739,7 @@ export function createFiberFromLegacyHidden(
   // Adding a stateNode for legacy hidden because it's currently using
   // the offscreen implementation, which depends on a state node
   const instance: OffscreenInstance = {
-    isHidden: false,
+    visibility: OffscreenVisible,
     pendingMarkers: null,
     transitions: null,
     retryCache: null,

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -61,6 +61,7 @@ import {
   CacheComponent,
   TracingMarkerComponent,
 } from './ReactWorkTags';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 
 import {isDevToolsPresent} from './ReactFiberDevToolsHook.old';
@@ -717,7 +718,7 @@ export function createFiberFromOffscreen(
   fiber.elementType = REACT_OFFSCREEN_TYPE;
   fiber.lanes = lanes;
   const primaryChildInstance: OffscreenInstance = {
-    isHidden: false,
+    visibility: OffscreenVisible,
     pendingMarkers: null,
     retryCache: null,
     transitions: null,
@@ -738,7 +739,7 @@ export function createFiberFromLegacyHidden(
   // Adding a stateNode for legacy hidden because it's currently using
   // the offscreen implementation, which depends on a state node
   const instance: OffscreenInstance = {
-    isHidden: false,
+    visibility: OffscreenVisible,
     pendingMarkers: null,
     transitions: null,
     retryCache: null,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -173,6 +173,7 @@ import {
 } from './ReactFiberDevToolsHook.new';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.new';
 import {clearTransitionsForLanes} from './ReactFiberLane.new';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -2424,14 +2425,8 @@ function commitMutationEffectsOnFiber(
       const offscreenFiber: Fiber = (finishedWork.child: any);
 
       if (offscreenFiber.flags & Visibility) {
-        const offscreenInstance: OffscreenInstance = offscreenFiber.stateNode;
         const newState: OffscreenState | null = offscreenFiber.memoizedState;
         const isHidden = newState !== null;
-
-        // Track the current state on the Offscreen instance so we can
-        // read it during an event
-        offscreenInstance.isHidden = isHidden;
-
         if (isHidden) {
           const wasHidden =
             offscreenFiber.alternate !== null &&
@@ -2485,7 +2480,11 @@ function commitMutationEffectsOnFiber(
 
         // Track the current state on the Offscreen instance so we can
         // read it during an event
-        offscreenInstance.isHidden = isHidden;
+        if (isHidden) {
+          offscreenInstance.visibility &= ~OffscreenVisible;
+        } else {
+          offscreenInstance.visibility |= OffscreenVisible;
+        }
 
         if (isHidden) {
           if (!wasHidden) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -173,6 +173,7 @@ import {
 } from './ReactFiberDevToolsHook.old';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.old';
 import {clearTransitionsForLanes} from './ReactFiberLane.old';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -2424,14 +2425,8 @@ function commitMutationEffectsOnFiber(
       const offscreenFiber: Fiber = (finishedWork.child: any);
 
       if (offscreenFiber.flags & Visibility) {
-        const offscreenInstance: OffscreenInstance = offscreenFiber.stateNode;
         const newState: OffscreenState | null = offscreenFiber.memoizedState;
         const isHidden = newState !== null;
-
-        // Track the current state on the Offscreen instance so we can
-        // read it during an event
-        offscreenInstance.isHidden = isHidden;
-
         if (isHidden) {
           const wasHidden =
             offscreenFiber.alternate !== null &&
@@ -2485,7 +2480,11 @@ function commitMutationEffectsOnFiber(
 
         // Track the current state on the Offscreen instance so we can
         // read it during an event
-        offscreenInstance.isHidden = isHidden;
+        if (isHidden) {
+          offscreenInstance.visibility &= ~OffscreenVisible;
+        } else {
+          offscreenInstance.visibility |= OffscreenVisible;
+        }
 
         if (isHidden) {
           if (!wasHidden) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -173,7 +173,10 @@ import {
 } from './ReactFiberDevToolsHook.old';
 import {releaseCache, retainCache} from './ReactFiberCacheComponent.old';
 import {clearTransitionsForLanes} from './ReactFiberLane.old';
-import {OffscreenVisible} from './ReactFiberOffscreenComponent';
+import {
+  OffscreenVisible,
+  OffscreenPassiveEffectsConnected,
+} from './ReactFiberOffscreenComponent';
 
 let didWarnAboutUndefinedSnapshotBeforeUpdate: Set<mixed> | null = null;
 if (__DEV__) {
@@ -2898,6 +2901,7 @@ function commitHookPassiveMountEffects(
 function commitOffscreenPassiveMountEffects(
   current: Fiber | null,
   finishedWork: Fiber,
+  instance: OffscreenInstance,
 ) {
   if (enableCache) {
     let previousCache: Cache | null = null;
@@ -2935,7 +2939,6 @@ function commitOffscreenPassiveMountEffects(
     // primary metrics.
     const offscreenState: OffscreenState = finishedWork.memoizedState;
     const queue: OffscreenQueue | null = (finishedWork.updateQueue: any);
-    const instance: OffscreenInstance = finishedWork.stateNode;
 
     const isHidden = offscreenState !== null;
     if (queue !== null) {
@@ -3076,6 +3079,9 @@ function commitPassiveMountOnFiber(
   committedLanes: Lanes,
   committedTransitions: Array<Transition> | null,
 ): void {
+  // When updating this function, also update reconnectPassiveEffects, which does
+  // most of the same things when an offscreen tree goes from hidden -> visible,
+  // or when toggling effects inside a hidden tree.
   const flags = finishedWork.flags;
   switch (finishedWork.tag) {
     case FunctionComponent:
@@ -3152,16 +3158,79 @@ function commitPassiveMountOnFiber(
     }
     case LegacyHiddenComponent:
     case OffscreenComponent: {
-      recursivelyTraversePassiveMountEffects(
-        finishedRoot,
-        finishedWork,
-        committedLanes,
-        committedTransitions,
-      );
+      // TODO: Pass `current` as argument to this function
+      const instance: OffscreenInstance = finishedWork.stateNode;
+      const nextState: OffscreenState | null = finishedWork.memoizedState;
+
+      const isHidden = nextState !== null;
+
+      if (isHidden) {
+        if (instance.visibility & OffscreenPassiveEffectsConnected) {
+          // The effects are currently connected. Update them.
+          recursivelyTraversePassiveMountEffects(
+            finishedRoot,
+            finishedWork,
+            committedLanes,
+            committedTransitions,
+          );
+        } else {
+          if (finishedWork.mode & ConcurrentMode) {
+            // The effects are currently disconnected. Since the tree is hidden,
+            // don't connect them. This also applies to the initial render.
+            if (enableCache || enableTransitionTracing) {
+              // "Atomic" effects are ones that need to fire on every commit,
+              // even during pre-rendering. An example is updating the reference
+              // count on cache instances.
+              // TODO: Not yet implemented
+              // recursivelyTraverseAtomicPassiveEffects(
+              //   finishedRoot,
+              //   finishedWork,
+              //   committedLanes,
+              //   committedTransitions,
+              // );
+            }
+          } else {
+            // Legacy Mode: Fire the effects even if the tree is hidden.
+            instance.visibility |= OffscreenPassiveEffectsConnected;
+            recursivelyTraversePassiveMountEffects(
+              finishedRoot,
+              finishedWork,
+              committedLanes,
+              committedTransitions,
+            );
+          }
+        }
+      } else {
+        // Tree is visible
+        if (instance.visibility & OffscreenPassiveEffectsConnected) {
+          // The effects are currently connected. Update them.
+          recursivelyTraversePassiveMountEffects(
+            finishedRoot,
+            finishedWork,
+            committedLanes,
+            committedTransitions,
+          );
+        } else {
+          // The effects are currently disconnected. Reconnect them, while also
+          // firing effects inside newly mounted trees. This also applies to
+          // the initial render.
+          instance.visibility |= OffscreenPassiveEffectsConnected;
+
+          const includeWorkInProgressEffects =
+            (finishedWork.subtreeFlags & PassiveMask) !== NoFlags;
+          recursivelyTraverseReconnectPassiveEffects(
+            finishedRoot,
+            finishedWork,
+            committedLanes,
+            committedTransitions,
+            includeWorkInProgressEffects,
+          );
+        }
+      }
+
       if (flags & Passive) {
-        // TODO: Pass `current` as argument to this function
         const current = finishedWork.alternate;
-        commitOffscreenPassiveMountEffects(current, finishedWork);
+        commitOffscreenPassiveMountEffects(current, finishedWork, instance);
       }
       break;
     }
@@ -3201,6 +3270,184 @@ function commitPassiveMountOnFiber(
         finishedWork,
         committedLanes,
         committedTransitions,
+      );
+      break;
+    }
+  }
+}
+
+function recursivelyTraverseReconnectPassiveEffects(
+  finishedRoot: FiberRoot,
+  parentFiber: Fiber,
+  committedLanes: Lanes,
+  committedTransitions: Array<Transition> | null,
+  includeWorkInProgressEffects: boolean,
+) {
+  // This function visits both newly finished work and nodes that were re-used
+  // from a previously committed tree. We cannot check non-static flags if the
+  // node was reused.
+  const childShouldIncludeWorkInProgressEffects =
+    includeWorkInProgressEffects &&
+    (parentFiber.subtreeFlags & PassiveMask) !== NoFlags;
+
+  // TODO (Offscreen) Check: flags & (RefStatic | LayoutStatic)
+  const prevDebugFiber = getCurrentDebugFiberInDEV();
+  let child = parentFiber.child;
+  while (child !== null) {
+    reconnectPassiveEffects(
+      finishedRoot,
+      child,
+      committedLanes,
+      committedTransitions,
+      childShouldIncludeWorkInProgressEffects,
+    );
+    child = child.sibling;
+  }
+  setCurrentDebugFiberInDEV(prevDebugFiber);
+}
+
+function reconnectPassiveEffects(
+  finishedRoot: FiberRoot,
+  finishedWork: Fiber,
+  committedLanes: Lanes,
+  committedTransitions: Array<Transition> | null,
+  // This function visits both newly finished work and nodes that were re-used
+  // from a previously committed tree. We cannot check non-static flags if the
+  // node was reused.
+  includeWorkInProgressEffects: boolean,
+) {
+  const flags = finishedWork.flags;
+  switch (finishedWork.tag) {
+    case FunctionComponent:
+    case ForwardRef:
+    case SimpleMemoComponent: {
+      recursivelyTraverseReconnectPassiveEffects(
+        finishedRoot,
+        finishedWork,
+        committedLanes,
+        committedTransitions,
+        includeWorkInProgressEffects,
+      );
+      // TODO: Check for PassiveStatic flag
+      commitHookPassiveMountEffects(finishedWork, HookPassive);
+      break;
+    }
+    // Unlike commitPassiveMountOnFiber, we don't need to handle HostRoot
+    // because this function only visits nodes that are inside an
+    // Offscreen fiber.
+    // case HostRoot: {
+    //  ...
+    // }
+    case LegacyHiddenComponent:
+    case OffscreenComponent: {
+      const instance: OffscreenInstance = finishedWork.stateNode;
+      const nextState: OffscreenState | null = finishedWork.memoizedState;
+
+      const isHidden = nextState !== null;
+
+      if (isHidden) {
+        if (instance.visibility & OffscreenPassiveEffectsConnected) {
+          // The effects are currently connected. Update them.
+          recursivelyTraverseReconnectPassiveEffects(
+            finishedRoot,
+            finishedWork,
+            committedLanes,
+            committedTransitions,
+            includeWorkInProgressEffects,
+          );
+        } else {
+          if (finishedWork.mode & ConcurrentMode) {
+            // The effects are currently disconnected. Since the tree is hidden,
+            // don't connect them. This also applies to the initial render.
+            if (enableCache || enableTransitionTracing) {
+              // "Atomic" effects are ones that need to fire on every commit,
+              // even during pre-rendering. An example is updating the reference
+              // count on cache instances.
+              // TODO: Not yet implemented
+              // recursivelyTraverseAtomicPassiveEffects(
+              //   finishedRoot,
+              //   finishedWork,
+              //   committedLanes,
+              //   committedTransitions,
+              // );
+            }
+          } else {
+            // Legacy Mode: Fire the effects even if the tree is hidden.
+            instance.visibility |= OffscreenPassiveEffectsConnected;
+            recursivelyTraverseReconnectPassiveEffects(
+              finishedRoot,
+              finishedWork,
+              committedLanes,
+              committedTransitions,
+              includeWorkInProgressEffects,
+            );
+          }
+        }
+      } else {
+        // Tree is visible
+
+        // Since we're already inside a reconnecting tree, it doesn't matter
+        // whether the effects are currently connected. In either case, we'll
+        // continue traversing the tree and firing all the effects.
+        //
+        // We do need to set the "connected" flag on the instance, though.
+        instance.visibility |= OffscreenPassiveEffectsConnected;
+
+        recursivelyTraverseReconnectPassiveEffects(
+          finishedRoot,
+          finishedWork,
+          committedLanes,
+          committedTransitions,
+          includeWorkInProgressEffects,
+        );
+      }
+
+      if (includeWorkInProgressEffects && flags & Passive) {
+        // TODO: Pass `current` as argument to this function
+        const current: Fiber | null = finishedWork.alternate;
+        commitOffscreenPassiveMountEffects(current, finishedWork, instance);
+      }
+      break;
+    }
+    case CacheComponent: {
+      recursivelyTraverseReconnectPassiveEffects(
+        finishedRoot,
+        finishedWork,
+        committedLanes,
+        committedTransitions,
+        includeWorkInProgressEffects,
+      );
+      if (includeWorkInProgressEffects && flags & Passive) {
+        // TODO: Pass `current` as argument to this function
+        const current = finishedWork.alternate;
+        commitCachePassiveMountEffect(current, finishedWork);
+      }
+      break;
+    }
+    case TracingMarkerComponent: {
+      if (enableTransitionTracing) {
+        recursivelyTraverseReconnectPassiveEffects(
+          finishedRoot,
+          finishedWork,
+          committedLanes,
+          committedTransitions,
+          includeWorkInProgressEffects,
+        );
+        if (includeWorkInProgressEffects && flags & Passive) {
+          commitTracingMarkerPassiveMountEffect(finishedWork);
+        }
+        break;
+      }
+      // Intentional fallthrough to next branch
+    }
+    // eslint-disable-next-line-no-fallthrough
+    default: {
+      recursivelyTraverseReconnectPassiveEffects(
+        finishedRoot,
+        finishedWork,
+        committedLanes,
+        committedTransitions,
+        includeWorkInProgressEffects,
       );
       break;
     }
@@ -3304,6 +3551,11 @@ function commitPassiveUnmountOnFiber(finishedWork: Fiber): void {
       }
       break;
     }
+    // TODO: Disconnect passive effects when a tree is hidden, perhaps after
+    // a delay.
+    // case OffscreenComponent: {
+    //   ...
+    // }
     default: {
       recursivelyTraversePassiveUnmountEffects(finishedWork);
       break;

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
@@ -31,6 +31,7 @@ import {
 } from './ReactFiberLane.new';
 import {NoFlags, Placement, Hydrating} from './ReactFiberFlags';
 import {HostRoot, OffscreenComponent} from './ReactWorkTags';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
 export type ConcurrentUpdate = {
   next: ConcurrentUpdate,
@@ -217,7 +218,10 @@ function markUpdateLaneFromFiberToRoot(
       // account for it. (There may be other cases that we haven't discovered,
       // too.)
       const offscreenInstance: OffscreenInstance | null = parent.stateNode;
-      if (offscreenInstance !== null && offscreenInstance.isHidden) {
+      if (
+        offscreenInstance !== null &&
+        !(offscreenInstance.visibility & OffscreenVisible)
+      ) {
         isHidden = true;
       }
     }

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
@@ -31,6 +31,7 @@ import {
 } from './ReactFiberLane.old';
 import {NoFlags, Placement, Hydrating} from './ReactFiberFlags';
 import {HostRoot, OffscreenComponent} from './ReactWorkTags';
+import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
 export type ConcurrentUpdate = {
   next: ConcurrentUpdate,
@@ -217,7 +218,10 @@ function markUpdateLaneFromFiberToRoot(
       // account for it. (There may be other cases that we haven't discovered,
       // too.)
       const offscreenInstance: OffscreenInstance | null = parent.stateNode;
-      if (offscreenInstance !== null && offscreenInstance.isHidden) {
+      if (
+        offscreenInstance !== null &&
+        !(offscreenInstance.visibility & OffscreenVisible)
+      ) {
         isHidden = true;
       }
     }

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -87,7 +87,7 @@ export const MutationMask =
 export const LayoutMask = Update | Callback | Ref | Visibility;
 
 // TODO: Split into PassiveMountMask and PassiveUnmountMask
-export const PassiveMask = Passive | ChildDeletion;
+export const PassiveMask = Passive | Visibility | ChildDeletion;
 
 // Union of tags that don't get reset on clones.
 // This allows certain concepts to persist without recalculating them,

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -45,9 +45,7 @@ export type OffscreenQueue = {|
 type OffscreenVisibility = number;
 
 export const OffscreenVisible = /*                     */ 0b01;
-
-// TODO
-// export const OffscreenPassiveEffectsConnected = /*     */ 0b01;
+export const OffscreenPassiveEffectsConnected = /*     */ 0b10;
 
 export type OffscreenInstance = {|
   visibility: OffscreenVisibility,

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -42,8 +42,15 @@ export type OffscreenQueue = {|
   wakeables: Set<Wakeable> | null,
 |};
 
+type OffscreenVisibility = number;
+
+export const OffscreenVisible = /*                     */ 0b01;
+
+// TODO
+// export const OffscreenPassiveEffectsConnected = /*     */ 0b01;
+
 export type OffscreenInstance = {|
-  isHidden: boolean,
+  visibility: OffscreenVisibility,
   pendingMarkers: Set<TracingMarkerInstance> | null,
   transitions: Set<Transition> | null,
   retryCache: WeakSet<Wakeable> | Set<Wakeable> | null,

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -486,22 +486,29 @@ describe('ReactOffscreen', () => {
     // hidden tree share the same lane, but are processed at different times
     // because of the timing of when they were scheduled.
 
+    // This functions checks whether the "outer" and "inner" states are
+    // consistent in the rendered output.
+    let currentOuter = null;
+    let currentInner = null;
+    function areOuterAndInnerConsistent() {
+      return (
+        currentOuter === null ||
+        currentInner === null ||
+        currentOuter === currentInner
+      );
+    }
+
     let setInner;
-    function Child({outer}) {
+    function Child() {
       const [inner, _setInner] = useState(0);
       setInner = _setInner;
 
       useEffect(() => {
-        // Inner and outer values are always updated simultaneously, so they
-        // should always be consistent.
-        if (inner !== outer) {
-          Scheduler.unstable_yieldValue(
-            'Tearing! Inner and outer are inconsistent!',
-          );
-        } else {
-          Scheduler.unstable_yieldValue('Inner and outer are consistent');
-        }
-      }, [inner, outer]);
+        currentInner = inner;
+        return () => {
+          currentInner = null;
+        };
+      }, [inner]);
 
       return <Text text={'Inner: ' + inner} />;
     }
@@ -510,11 +517,19 @@ describe('ReactOffscreen', () => {
     function App({show}) {
       const [outer, _setOuter] = useState(0);
       setOuter = _setOuter;
+
+      useEffect(() => {
+        currentOuter = outer;
+        return () => {
+          currentOuter = null;
+        };
+      }, [outer]);
+
       return (
         <>
           <Text text={'Outer: ' + outer} />
           <Offscreen mode={show ? 'visible' : 'hidden'}>
-            <Child outer={outer} />
+            <Child />
           </Offscreen>
         </>
       );
@@ -525,17 +540,14 @@ describe('ReactOffscreen', () => {
     await act(async () => {
       root.render(<App show={false} />);
     });
-    expect(Scheduler).toHaveYielded([
-      'Outer: 0',
-      'Inner: 0',
-      'Inner and outer are consistent',
-    ]);
+    expect(Scheduler).toHaveYielded(['Outer: 0', 'Inner: 0']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: 0" />
         <span hidden={true} prop="Inner: 0" />
       </>,
     );
+    expect(areOuterAndInnerConsistent()).toBe(true);
 
     await act(async () => {
       // Update a value both inside and outside the hidden tree. These values
@@ -570,8 +582,6 @@ describe('ReactOffscreen', () => {
         // update were erroneously processed, then Inner would be inconsistent
         // with Outer.
         'Inner: 1',
-
-        'Inner and outer are consistent',
       ]);
       expect(root).toMatchRenderedOutput(
         <>
@@ -579,18 +589,16 @@ describe('ReactOffscreen', () => {
           <span prop="Inner: 1" />
         </>,
       );
+      expect(areOuterAndInnerConsistent()).toBe(true);
     });
-    expect(Scheduler).toHaveYielded([
-      'Outer: 2',
-      'Inner: 2',
-      'Inner and outer are consistent',
-    ]);
+    expect(Scheduler).toHaveYielded(['Outer: 2', 'Inner: 2']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: 2" />
         <span prop="Inner: 2" />
       </>,
     );
+    expect(areOuterAndInnerConsistent()).toBe(true);
   });
 
   // @gate enableOffscreen
@@ -867,4 +875,125 @@ describe('ReactOffscreen', () => {
       ]);
     },
   );
+
+  it('defer passive effects when prerendering a new Offscreen tree', async () => {
+    function Child({label}) {
+      useEffect(() => {
+        Scheduler.unstable_yieldValue('Mount ' + label);
+        return () => {
+          Scheduler.unstable_yieldValue('Unmount ' + label);
+        };
+      }, [label]);
+      return <Text text={label} />;
+    }
+
+    function App({showMore}) {
+      return (
+        <>
+          <Child label="Shell" />
+          <Offscreen mode={showMore ? 'visible' : 'hidden'}>
+            <Child label="More" />
+          </Offscreen>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+
+    // Mount the app without showing the extra content
+    await act(async () => {
+      root.render(<App showMore={false} />);
+    });
+    expect(Scheduler).toHaveYielded([
+      // First mount the outer visible shell
+      'Shell',
+      'Mount Shell',
+
+      // Then prerender the hidden extra context. The passive effects in the
+      // hidden tree should not fire
+      'More',
+      // Does not fire
+      // 'Mount More',
+    ]);
+    // The hidden content has been prerendered
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span prop="Shell" />
+        <span hidden={true} prop="More" />
+      </>,
+    );
+
+    // Reveal the prerendered tree
+    await act(async () => {
+      root.render(<App showMore={true} />);
+    });
+    expect(Scheduler).toHaveYielded([
+      'Shell',
+      'More',
+
+      // Mount the passive effects in the newly revealed tree, the ones that
+      // were skipped during pre-rendering.
+      'Mount More',
+    ]);
+  });
+
+  it("don't defer passive effects when prerendering in a tree whose effects are already connected", async () => {
+    function Child({label}) {
+      useEffect(() => {
+        Scheduler.unstable_yieldValue('Mount ' + label);
+        return () => {
+          Scheduler.unstable_yieldValue('Unmount ' + label);
+        };
+      }, [label]);
+      return <Text text={label} />;
+    }
+
+    function App({showMore, step}) {
+      return (
+        <>
+          <Child label={'Shell ' + step} />
+          <Offscreen mode={showMore ? 'visible' : 'hidden'}>
+            <Child label={'More ' + step} />
+          </Offscreen>
+        </>
+      );
+    }
+
+    const root = ReactNoop.createRoot();
+
+    // Mount the app, including the extra content
+    await act(async () => {
+      root.render(<App showMore={true} step={1} />);
+    });
+    expect(Scheduler).toHaveYielded([
+      'Shell 1',
+      'More 1',
+      'Mount Shell 1',
+      'Mount More 1',
+    ]);
+    expect(root).toMatchRenderedOutput(
+      <>
+        <span prop="Shell 1" />
+        <span prop="More 1" />
+      </>,
+    );
+
+    // Hide the extra content. while also updating one of its props
+    await act(async () => {
+      root.render(<App showMore={false} step={2} />);
+    });
+    expect(Scheduler).toHaveYielded([
+      // First update the outer visible shell
+      'Shell 2',
+      'Unmount Shell 1',
+      'Mount Shell 2',
+
+      // Then prerender the update to the hidden content. Since the effects
+      // are already connected inside the hidden tree, we don't defer updates
+      // to them.
+      'More 2',
+      'Unmount More 1',
+      'Mount More 2',
+    ]);
+  });
 });

--- a/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreen-test.js
@@ -876,6 +876,7 @@ describe('ReactOffscreen', () => {
     },
   );
 
+  // @gate enableOffscreen
   it('defer passive effects when prerendering a new Offscreen tree', async () => {
     function Child({label}) {
       useEffect(() => {
@@ -937,6 +938,7 @@ describe('ReactOffscreen', () => {
     ]);
   });
 
+  // @gate enableOffscreen
   it("don't defer passive effects when prerendering in a tree whose effects are already connected", async () => {
     function Child({label}) {
       useEffect(() => {


### PR DESCRIPTION
(*You can review commit-by-commit. Pretend the commits are a stack of PRs, please.*)

This changes the behavior of Offscreen so that passive effects do not fire when prerendering a brand new tree. Previously, Offscreen did not affect passive effects at all — only layout effects, which mount or unmount whenever the visibility of the tree changes.

When hiding an already visible tree, the behavior of passive effects is unchanged, for now; unlike layout effects, the passive effects will not get unmounted. Pre-rendered updates to a hidden tree in this state will also fire normally. This is only temporary, though — the plan is for passive effects to act more like layout effects, and unmount them when the tree is hidden. Perhaps after a delay so that if the visibility toggles quickly back and forth, the effects don't need to remount. I'll implement this separately.