### PR TITLE
Support implicit <head> in hydration

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -684,6 +684,10 @@ export function clearContainer(container: Container): void {
 
 export const supportsHydration = true;
 
+export function canSkipHydrateOfImplicitInstance(instance: HydratableInstance) {
+  return instance.nodeType === ELEMENT_NODE && instance.nodeName === 'HEAD';
+}
+
 export function canHydrateInstance(
   instance: HydratableInstance,
   type: string,

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoHydration.js
@@ -21,6 +21,7 @@ function shim(...args: any) {
 // Hydration (when unsupported)
 export type SuspenseInstance = mixed;
 export const supportsHydration = false;
+export const canSkipHydrateOfImplicitInstance = shim;
 export const canHydrateInstance = shim;
 export const canHydrateTextInstance = shim;
 export const canHydrateSuspenseInstance = shim;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -127,6 +127,8 @@ export const cloneHiddenTextInstance = $$$hostConfig.cloneHiddenTextInstance;
 //     Hydration
 //     (optional)
 // -------------------
+export const canSkipHydrateOfImplicitInstance =
+  $$$hostConfig.canSkipHydrateOfImplicitInstance;
 export const canHydrateInstance = $$$hostConfig.canHydrateInstance;
 export const canHydrateTextInstance = $$$hostConfig.canHydrateTextInstance;
 export const canHydrateSuspenseInstance =


### PR DESCRIPTION
When the browser parses html it will create a <head> element even if the tag is not present. If you render at the root (either the document itself or the html element) the hydration will fail becasue this implicitly created head is not matched against the react component tree. Additionally the head will be removed from the document as an extraneous node which means any third party scripts or other tags that were inserted there by browser extensions or other means will be deleted which can break many tools.

This change adds the ability to mark certain instances as implicit and so after attempting to hydrate them they will be skipped over rather than dropped.