### PR TITLE
Removed overwrite to key variable in jsx

### DIFF
--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -222,18 +222,16 @@ export function jsx(type, config, maybeKey) {
   // but as an intermediary step, we will use jsxDEV for everything except
   // <div {...props} key="Hi" />, because we aren't currently able to tell if
   // key is explicitly declared to be undefined or not.
-  if (maybeKey !== undefined) {
-    if (__DEV__) {
-      checkKeyStringCoercion(maybeKey);
-    }
-    key = '' + maybeKey;
-  }
-
   if (hasValidKey(config)) {
     if (__DEV__) {
       checkKeyStringCoercion(config.key);
     }
     key = '' + config.key;
+  } else if (maybeKey !== undefined) {
+    if (__DEV__) {
+      checkKeyStringCoercion(maybeKey);
+    }
+    key = '' + maybeKey;
   }
 
   if (hasValidRef(config)) {


### PR DESCRIPTION
When config.key is not undefined, there is no reason to set key to maybeKey.
