### PR TITLE
Implement HostSingleton type

### DIFF
--- a/packages/react-art/src/ReactARTHostConfig.js
+++ b/packages/react-art/src/ReactARTHostConfig.js
@@ -243,6 +243,7 @@ export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMicrotasks';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoResources';
 
 export function appendInitialChild(parentInstance, child) {
   if (typeof child === 'string') {

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -980,7 +980,6 @@ describe('ReactDOMFizzServer', () => {
   });
 
   // @gate enableSuspenseList
-
   it('shows inserted items before pending in a SuspenseList as fallbacks while hydrating', async () => {
     const ref = React.createRef();
 
@@ -4262,13 +4261,9 @@ describe('ReactDOMFizzServer', () => {
       },
     );
     expect(() => {
-      try {
-        expect(() => {
-          expect(Scheduler).toFlushWithoutYielding();
-        }).toThrow('Invalid insertion of HTML node in #document node.');
-      } catch (e) {
-        console.log('e', e);
-      }
+      expect(() => {
+        expect(Scheduler).toFlushWithoutYielding();
+      }).toThrow('Invalid insertion of TITLE node in #document node.');
     }).toErrorDev(
       [
         'Warning: Expected server HTML to contain a matching <title> in <#document>.',
@@ -4281,7 +4276,12 @@ describe('ReactDOMFizzServer', () => {
       'Hydration failed because the initial UI does not match what was rendered on the server.',
       'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
     ]);
-    expect(getVisibleChildren(document)).toEqual();
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-foo="foo">
+        <head data-bar="bar" />
+        <body />
+      </html>,
+    );
     expect(() => {
       expect(Scheduler).toFlushWithoutYielding();
     }).toThrow('The node to be removed is not a child of this node.');

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -1,0 +1,822 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+let JSDOM;
+let Stream;
+let Scheduler;
+let React;
+let ReactDOMClient;
+let ReactDOMFizzServer;
+let document;
+let writable;
+let container;
+let buffer = '';
+let hasErrored = false;
+let fatalError = undefined;
+
+describe('ReactDOMFizzServer', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    JSDOM = require('jsdom').JSDOM;
+    Scheduler = require('scheduler');
+    React = require('react');
+    ReactDOMClient = require('react-dom/client');
+    ReactDOMFizzServer = require('react-dom/server');
+    Stream = require('stream');
+
+    // Test Environment
+    const jsdom = new JSDOM(
+      '<!DOCTYPE html><html><head></head><body><div id="container">',
+      {
+        runScripts: 'dangerously',
+      },
+    );
+    document = jsdom.window.document;
+    container = document.getElementById('container');
+
+    buffer = '';
+    hasErrored = false;
+
+    writable = new Stream.PassThrough();
+    writable.setEncoding('utf8');
+    writable.on('data', chunk => {
+      buffer += chunk;
+    });
+    writable.on('error', error => {
+      hasErrored = true;
+      fatalError = error;
+    });
+  });
+
+  async function actIntoEmptyDocument(callback) {
+    await callback();
+    // Await one turn around the event loop.
+    // This assumes that we'll flush everything we have so far.
+    await new Promise(resolve => {
+      setImmediate(resolve);
+    });
+    if (hasErrored) {
+      throw fatalError;
+    }
+
+    const bufferedContent = buffer;
+    buffer = '';
+
+    const jsdom = new JSDOM(bufferedContent, {
+      runScripts: 'dangerously',
+    });
+    document = jsdom.window.document;
+    container = document;
+  }
+
+  function getVisibleChildren(element) {
+    const children = [];
+    let node = element.firstChild;
+    while (node) {
+      if (node.nodeType === 1) {
+        if (
+          node.tagName !== 'SCRIPT' &&
+          node.tagName !== 'TEMPLATE' &&
+          node.tagName !== 'template' &&
+          !node.hasAttribute('hidden') &&
+          !node.hasAttribute('aria-hidden')
+        ) {
+          const props = {};
+          const attributes = node.attributes;
+          for (let i = 0; i < attributes.length; i++) {
+            if (
+              attributes[i].name === 'id' &&
+              attributes[i].value.includes(':')
+            ) {
+              // We assume this is a React added ID that's a non-visual implementation detail.
+              continue;
+            }
+            props[attributes[i].name] = attributes[i].value;
+          }
+          props.children = getVisibleChildren(node);
+          children.push(React.createElement(node.tagName.toLowerCase(), props));
+        }
+      } else if (node.nodeType === 3) {
+        children.push(node.data);
+      }
+      node = node.nextSibling;
+    }
+    return children.length === 0
+      ? undefined
+      : children.length === 1
+      ? children[0]
+      : children;
+  }
+
+  // @gate enableFloat
+  it('renders into html, head, and body persistently so the node identities never change and extraneous styles are retained', async () => {
+    gate(flags => {
+      if (flags.enableFloat !== true) {
+        // We throw here because when this test fails it ends up with sync work in a microtask
+        // that throws after the expectTestToFail check asserts the failure. this causes even the
+        // expected failure to fail. This just fails explicitly and early
+        throw new Error('manually opting out of test');
+      }
+    });
+    // Server render some html that will get replaced with a client render
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html data-foo="foo">
+          <head data-bar="bar">
+            <link rel="stylesheet" href="resource" />
+            <title>a server title</title>
+            <link rel="stylesheet" href="3rdparty" />
+            <link rel="stylesheet" href="3rdparty2" />
+          </head>
+          <body data-baz="baz">
+            <div>hello world</div>
+            <style>
+              {`
+                body: {
+                  background-color: red;
+                }`}
+            </style>
+            <div>goodbye</div>
+          </body>
+        </html>,
+      );
+      pipe(writable);
+    });
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-foo="foo">
+        <head data-bar="bar">
+          <link rel="stylesheet" href="resource" />
+          <title>a server title</title>
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-baz="baz">
+          <div>hello world</div>
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+          <div>goodbye</div>
+        </body>
+      </html>,
+    );
+    const {documentElement, head, body} = document;
+    const persistentElements = [documentElement, head, body];
+
+    // Render into the document completely different html. Observe that styles
+    // are retained as are html, body, and head referential identities. Because this was
+    // server rendered and we are not hydrating we lose the semantic placement of the original
+    // head contents and everything gets preprended. In a future update we might emit an insertion
+    // edge from the server and make client rendering reslilient to interstitial placement
+    const root = ReactDOMClient.createRoot(document);
+    root.render(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+        </head>
+        <body data-client-baz="baz">
+          <div>hello client</div>
+        </body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <div>hello client</div>
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // Render new children and assert they append in the correct locations
+    root.render(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <meta />
+        </head>
+        <body data-client-baz="baz">
+          <p>hello client again</p>
+          <div>hello client</div>
+        </body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <meta />
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <p>hello client again</p>
+          <div>hello client</div>
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // Remove some children
+    root.render(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+        </head>
+        <body data-client-baz="baz">
+          <p>hello client again</p>
+        </body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <p>hello client again</p>
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // Remove a persistent component
+    // @TODO figure out whether to clean up attributes. restoring them is likely
+    // not possible.
+    root.render(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+        </head>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // unmount the root
+    root.unmount();
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // Now let's hydrate the document with known mismatching content
+    // We assert that the identities of html, head, and body still haven't changed
+    // and that the embedded styles are still retained
+    const hydrationErrors = [];
+    let hydrateRoot = ReactDOMClient.hydrateRoot(
+      document,
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+        </head>
+        <body data-client-baz="baz">
+          <div>hello client</div>
+        </body>
+      </html>,
+      {
+        onRecoverableError(error, errorInfo) {
+          hydrationErrors.push([
+            error.message,
+            errorInfo.componentStack
+              ? errorInfo.componentStack.split('\n')[1].trim()
+              : null,
+          ]);
+        },
+      },
+    );
+    expect(() => {
+      expect(Scheduler).toFlushWithoutYielding();
+    }).toErrorDev(
+      [
+        `Warning: Expected server HTML to contain a matching <title> in <head>.
+    in title (at **)
+    in head (at **)
+    in html (at **)`,
+        `Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>.`,
+      ],
+      {withoutStack: 1},
+    );
+    expect(hydrationErrors).toEqual([
+      [
+        'Hydration failed because the initial UI does not match what was rendered on the server.',
+        'at title',
+      ],
+      [
+        'Hydration failed because the initial UI does not match what was rendered on the server.',
+        'at body',
+      ],
+      [
+        'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
+        null,
+      ],
+    ]);
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <title>a client title</title>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <div>hello client</div>
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // Reset the tree
+    hydrationErrors.length = 0;
+    hydrateRoot.unmount();
+
+    // Now we try hydrating again with matching nodes and we ensure
+    // the retained styles are bound to the hydrated fibers
+    const link = document.querySelector('link[rel="stylesheet"]');
+    const style = document.querySelector('style');
+    hydrateRoot = ReactDOMClient.hydrateRoot(
+      document,
+      <html data-client-foo="foo">
+        <head>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+      {
+        onRecoverableError(error, errorInfo) {
+          hydrationErrors.push([
+            error.message,
+            errorInfo.componentStack
+              ? errorInfo.componentStack.split('\n')[1].trim()
+              : null,
+          ]);
+        },
+      },
+    );
+    expect(hydrationErrors).toEqual([]);
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect([link, style]).toEqual([
+      document.querySelector('link[rel="stylesheet"]'),
+      document.querySelector('style'),
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head>
+          <link rel="stylesheet" href="resource" />
+          <link rel="stylesheet" href="3rdparty" />
+          <link rel="stylesheet" href="3rdparty2" />
+        </head>
+        <body data-client-baz="baz">
+          <style>
+            {`
+                body: {
+                  background-color: red;
+                }`}
+          </style>
+        </body>
+      </html>,
+    );
+
+    // We unmount a final time and observe that still we retain our persistent nodes
+    // but they style contents which matched in hydration is removed
+    hydrateRoot.unmount();
+    expect(persistentElements).toEqual([
+      document.documentElement,
+      document.head,
+      document.body,
+    ]);
+    expect(getVisibleChildren(document)).toEqual(
+      <html data-client-foo="foo">
+        <head />
+        <body data-client-baz="baz" />
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
+  it('is able to maintain insertions in head and body between tree-adjacent Nodes', async () => {
+    // Server render some html and hydrate on the client
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <head>
+            <title>title</title>
+          </head>
+          <body>
+            <div>hello</div>
+          </body>
+        </html>,
+      );
+      pipe(writable);
+    });
+    const root = ReactDOMClient.hydrateRoot(
+      document,
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <div>hello</div>
+        </body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+
+    // We construct and insert some artificial stylesheets mimicing what a 3rd party script might do
+    // In the future we could hydrate with these already in the document but the rules are restrictive
+    // still so it would fail and fall back to client rendering
+    const [a, b, c, d, e, f, g, h] = 'abcdefgh'.split('').map(letter => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = letter;
+      return link;
+    });
+
+    const head = document.head;
+    const title = head.firstChild;
+    head.insertBefore(a, title);
+    head.insertBefore(b, title);
+    head.appendChild(c);
+    head.appendChild(d);
+
+    const bodyContent = document.body.firstChild;
+    const body = document.body;
+    body.insertBefore(e, bodyContent);
+    body.insertBefore(f, bodyContent);
+    body.appendChild(g);
+    body.appendChild(h);
+
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="stylesheet" href="a" />
+          <link rel="stylesheet" href="b" />
+          <title>title</title>
+          <link rel="stylesheet" href="c" />
+          <link rel="stylesheet" href="d" />
+        </head>
+        <body>
+          <link rel="stylesheet" href="e" />
+          <link rel="stylesheet" href="f" />
+          <div>hello</div>
+          <link rel="stylesheet" href="g" />
+          <link rel="stylesheet" href="h" />
+        </body>
+      </html>,
+    );
+
+    // Unmount head and change children of body
+    root.render(
+      <html>
+        {null}
+        <body>
+          <div>hello</div>
+          <div>world</div>
+        </body>
+      </html>,
+    );
+
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head>
+          <link rel="stylesheet" href="a" />
+          <link rel="stylesheet" href="b" />
+          <link rel="stylesheet" href="c" />
+          <link rel="stylesheet" href="d" />
+        </head>
+        <body>
+          <link rel="stylesheet" href="e" />
+          <link rel="stylesheet" href="f" />
+          <div>hello</div>
+          <div>world</div>
+          <link rel="stylesheet" href="g" />
+          <link rel="stylesheet" href="h" />
+        </body>
+      </html>,
+    );
+
+    // Mount new head and unmount body
+    root.render(
+      <html>
+        <head>
+          <title>a new title</title>
+        </head>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>a new title</title>
+          <link rel="stylesheet" href="a" />
+          <link rel="stylesheet" href="b" />
+          <link rel="stylesheet" href="c" />
+          <link rel="stylesheet" href="d" />
+        </head>
+        <body>
+          <link rel="stylesheet" href="e" />
+          <link rel="stylesheet" href="f" />
+          <link rel="stylesheet" href="g" />
+          <link rel="stylesheet" href="h" />
+        </body>
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
+  it('clears persistent head and body when html is the container', async () => {
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <head>
+            <link rel="stylesheet" href="headbefore" />
+            <title>this should be removed</title>
+            <link rel="stylesheet" href="headafter" />
+          </head>
+          <body>
+            <link rel="stylesheet" href="bodybefore" />
+            <div>this should be removed</div>
+            <link rel="stylesheet" href="bodyafter" />
+          </body>
+        </html>,
+      );
+      pipe(writable);
+    });
+    container = document.documentElement;
+
+    const root = ReactDOMClient.createRoot(container);
+    root.render(
+      <>
+        <head>
+          <title>something new</title>
+        </head>
+        <body>
+          <div>something new</div>
+        </body>
+      </>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>something new</title>
+          <link rel="stylesheet" href="headbefore" />
+          <link rel="stylesheet" href="headafter" />
+        </head>
+        <body>
+          <div>something new</div>
+          <link rel="stylesheet" href="bodybefore" />
+          <link rel="stylesheet" href="bodyafter" />
+        </body>
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
+  it('clears persistent head when it is the container', async () => {
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <head>
+            <link rel="stylesheet" href="before" />
+            <title>this should be removed</title>
+            <link rel="stylesheet" href="after" />
+          </head>
+          <body />
+        </html>,
+      );
+      pipe(writable);
+    });
+    container = document.head;
+
+    const root = ReactDOMClient.createRoot(container);
+    root.render(<title>something new</title>);
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>something new</title>
+          <link rel="stylesheet" href="before" />
+          <link rel="stylesheet" href="after" />
+        </head>
+        <body />
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
+  it('clears persistent body when it is the container', async () => {
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <head />
+          <body>
+            <link rel="stylesheet" href="before" />
+            <div>this should be removed</div>
+            <link rel="stylesheet" href="after" />
+          </body>
+        </html>,
+      );
+      pipe(writable);
+    });
+    container = document.body;
+
+    let root;
+    // Given our new capabilities to render "safely" into the body we should consider removing this warning
+    expect(() => {
+      root = ReactDOMClient.createRoot(container);
+    }).toErrorDev(
+      'Warning: createRoot(): Creating roots directly with document.body is discouraged, since its children are often manipulated by third-party scripts and browser extensions. This may lead to subtle reconciliation issues. Try using a container element created for your app.',
+      {withoutStack: true},
+    );
+    root.render(<div>something new</div>);
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>
+          <div>something new</div>
+          <link rel="stylesheet" href="before" />
+          <link rel="stylesheet" href="after" />
+        </body>
+      </html>,
+    );
+  });
+
+  it('renders single Text children into HostSingletons correctly', async () => {
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <head />
+          <body>foo</body>
+        </html>,
+      );
+      pipe(writable);
+    });
+
+    let root = ReactDOMClient.hydrateRoot(
+      document,
+      <html>
+        <head />
+        <body>foo</body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>foo</body>
+      </html>,
+    );
+
+    root.render(
+      <html>
+        <head />
+        <body>bar</body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>bar</body>
+      </html>,
+    );
+
+    root.unmount();
+
+    root = ReactDOMClient.createRoot(document);
+    root.render(
+      <html>
+        <head />
+        <body>baz</body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>baz</body>
+      </html>,
+    );
+  });
+});

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -62,7 +62,8 @@ describe('rendering React components at document', () => {
       expect(body === testDocument.body).toBe(true);
     });
 
-    it('should not be able to unmount component from document node', () => {
+    // @gate enableFloat
+    it('should be able to unmount component from document node, but leaves persistent nodes intact', () => {
       class Root extends React.Component {
         render() {
           return (
@@ -81,7 +82,40 @@ describe('rendering React components at document', () => {
       ReactDOM.hydrate(<Root />, testDocument);
       expect(testDocument.body.innerHTML).toBe('Hello world');
 
-      // In Fiber this actually works. It might not be a good idea though.
+      const originalDocEl = testDocument.documentElement;
+      const originalHead = testDocument.head;
+      const originalBody = testDocument.body;
+
+      // When we unmount everything is removed except the persistent nodes of html, head, and body
+      ReactDOM.unmountComponentAtNode(testDocument);
+      expect(testDocument.firstChild).toBe(originalDocEl);
+      expect(testDocument.head).toBe(originalHead);
+      expect(testDocument.body).toBe(originalBody);
+      expect(originalBody.firstChild).toEqual(null);
+      expect(originalHead.firstChild).toEqual(null);
+    });
+
+    // @gate !enableFloat
+    it('should be able to unmount component from document node', () => {
+      class Root extends React.Component {
+        render() {
+          return (
+            <html>
+              <head>
+                <title>Hello World</title>
+              </head>
+              <body>Hello world</body>
+            </html>
+          );
+        }
+      }
+
+      const markup = ReactDOMServer.renderToString(<Root />);
+      const testDocument = getTestDocument(markup);
+      ReactDOM.hydrate(<Root />, testDocument);
+      expect(testDocument.body.innerHTML).toBe('Hello world');
+
+      // When we unmount everything is removed except the persistent nodes of html, head, and body
       ReactDOM.unmountComponentAtNode(testDocument);
       expect(testDocument.firstChild).toBe(null);
     });

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -23,6 +23,7 @@ import type {
 
 import {
   HostComponent,
+  HostSingleton,
   HostText,
   HostRoot,
   SuspenseComponent,
@@ -30,7 +31,7 @@ import {
 
 import {getParentSuspenseInstance} from './ReactDOMHostConfig';
 
-import {enableScopeAPI} from 'shared/ReactFeatureFlags';
+import {enableScopeAPI, enableFloat} from 'shared/ReactFeatureFlags';
 
 const randomKey = Math.random()
   .toString(36)
@@ -166,7 +167,8 @@ export function getInstanceFromNode(node: Node): Fiber | null {
       inst.tag === HostComponent ||
       inst.tag === HostText ||
       inst.tag === SuspenseComponent ||
-      inst.tag === HostRoot
+      inst.tag === HostRoot ||
+      (enableFloat && inst.tag === HostSingleton)
     ) {
       return inst;
     } else {
@@ -181,7 +183,11 @@ export function getInstanceFromNode(node: Node): Fiber | null {
  * DOM node.
  */
 export function getNodeFromInstance(inst: Fiber): Instance | TextInstance {
-  if (inst.tag === HostComponent || inst.tag === HostText) {
+  if (
+    inst.tag === HostComponent ||
+    inst.tag === HostText ||
+    (enableFloat && inst.tag === HostSingleton)
+  ) {
     // In Fiber this, is just the state node right now. We assume it will be
     // a host component or host text.
     return inst.stateNode;

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -696,24 +696,34 @@ export function unhideTextInstance(
 }
 
 export function clearContainer(container: Container): void {
-  if (container.nodeType === ELEMENT_NODE) {
-    switch (((container: any): Element).tagName.toLowerCase()) {
-      case 'html': {
-        break;
+  if (enableFloat) {
+    if (container.nodeType === ELEMENT_NODE) {
+      switch (((container: any): Element).tagName.toLowerCase()) {
+        case 'html': {
+          break;
+        }
+        case 'head':
+        case 'body': {
+          resetSingletonInstance(container);
+          break;
+        }
+        default: {
+          ((container: any): Element).textContent = '';
+        }
       }
-      case 'head':
-      case 'body': {
-        resetSingletonInstance(container);
-        break;
-      }
-      default: {
-        ((container: any): Element).textContent = '';
+    }
+    // Implicitly if the container is of type Document we rely on the Persistent HostComponent
+    // semantics to clear these nodes appropriately when being placed so no ahead of time
+    // clearing is necessary
+  } else {
+    if (container.nodeType === ELEMENT_NODE) {
+      ((container: any): Element).textContent = '';
+    } else if (container.nodeType === DOCUMENT_NODE) {
+      if (container.documentElement) {
+        container.removeChild(container.documentElement);
       }
     }
   }
-  // Implicitly if the container is of type Document we rely on the Persistent HostComponent
-  // semantics to clear these nodes appropriately when being placed so no ahead of time
-  // clearing is necessary
 }
 
 // -------------------

--- a/packages/react-dom/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom/src/events/DOMPluginEventSystem.js
@@ -33,6 +33,7 @@ import {
   HostRoot,
   HostPortal,
   HostComponent,
+  HostSingleton,
   HostText,
   ScopeComponent,
 } from 'react-reconciler/src/ReactWorkTags';
@@ -52,6 +53,7 @@ import {
   enableLegacyFBSupport,
   enableCreateEventHandleAPI,
   enableScopeAPI,
+  enableFloat,
 } from 'shared/ReactFeatureFlags';
 import {
   invokeGuardedCallbackAndCatchFirstError,
@@ -621,7 +623,11 @@ export function dispatchEventForPluginEventSystem(
               return;
             }
             const parentTag = parentNode.tag;
-            if (parentTag === HostComponent || parentTag === HostText) {
+            if (
+              parentTag === HostComponent ||
+              parentTag === HostText ||
+              (enableFloat && parentTag === HostSingleton)
+            ) {
               node = ancestorInst = parentNode;
               continue mainLoop;
             }
@@ -675,7 +681,10 @@ export function accumulateSinglePhaseListeners(
   while (instance !== null) {
     const {stateNode, tag} = instance;
     // Handle listeners that are on HostComponents (i.e. <div>)
-    if (tag === HostComponent && stateNode !== null) {
+    if (
+      (tag === HostComponent || (enableFloat && tag === HostSingleton)) &&
+      stateNode !== null
+    ) {
       lastHostComponent = stateNode;
 
       // createEventHandle listeners
@@ -786,7 +795,10 @@ export function accumulateTwoPhaseListeners(
   while (instance !== null) {
     const {stateNode, tag} = instance;
     // Handle listeners that are on HostComponents (i.e. <div>)
-    if (tag === HostComponent && stateNode !== null) {
+    if (
+      (tag === HostComponent || (enableFloat && tag === HostSingleton)) &&
+      stateNode !== null
+    ) {
       const currentTarget = stateNode;
       const captureListener = getListener(instance, captureName);
       if (captureListener != null) {
@@ -817,7 +829,11 @@ function getParent(inst: Fiber | null): Fiber | null {
     // events to their parent. We could also go through parentNode on the
     // host node but that wouldn't work for React Native and doesn't let us
     // do the portal feature.
-  } while (inst && inst.tag !== HostComponent);
+  } while (
+    inst &&
+    inst.tag !== HostComponent &&
+    !(enableFloat && inst.tag === HostSingleton)
+  );
   if (inst) {
     return inst;
   }
@@ -883,7 +899,10 @@ function accumulateEnterLeaveListenersForEvent(
     if (alternate !== null && alternate === common) {
       break;
     }
-    if (tag === HostComponent && stateNode !== null) {
+    if (
+      (tag === HostComponent || (enableFloat && tag === HostSingleton)) &&
+      stateNode !== null
+    ) {
       const currentTarget = stateNode;
       if (inCapturePhase) {
         const captureListener = getListener(instance, registrationName);

--- a/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
+++ b/packages/react-dom/src/events/__tests__/DOMPluginEventSystem-test.internal.js
@@ -58,6 +58,16 @@ describe('DOMPluginEventSystem', () => {
       'enableLegacyFBSupport ' +
         (enableLegacyFBSupport ? 'enabled' : 'disabled'),
       () => {
+        beforeAll(() => {
+          // These tests are run twice, once with legacyFBSupport enabled and once disabled.
+          // The document needs to be cleaned up a bit before the second pass otherwise it is
+          // operating in a non pristine environment
+          document.removeChild(document.documentElement);
+          document.appendChild(document.createElement('html'));
+          document.documentElement.appendChild(document.createElement('head'));
+          document.documentElement.appendChild(document.createElement('body'));
+        });
+
         beforeEach(() => {
           jest.resetModules();
           ReactFeatureFlags = require('shared/ReactFeatureFlags');
@@ -562,7 +572,6 @@ describe('DOMPluginEventSystem', () => {
           }
 
           ReactDOM.render(<Parent />, container);
-
           const second = document.body.lastChild;
           expect(second.textContent).toEqual('second');
           dispatchClickEvent(second);

--- a/packages/react-dom/src/events/plugins/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/EnterLeaveEventPlugin.js
@@ -23,7 +23,12 @@ import {
 import {accumulateEnterLeaveTwoPhaseListeners} from '../DOMPluginEventSystem';
 import type {KnownReactSyntheticEvent} from '../ReactSyntheticEventType';
 
-import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
+import {enableFloat} from 'shared/ReactFeatureFlags';
+import {
+  HostComponent,
+  HostSingleton,
+  HostText,
+} from 'react-reconciler/src/ReactWorkTags';
 import {getNearestMountedFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
 
 function registerEvents() {
@@ -103,7 +108,9 @@ function extractEvents(
       const nearestMounted = getNearestMountedFiber(to);
       if (
         to !== nearestMounted ||
-        (to.tag !== HostComponent && to.tag !== HostText)
+        (to.tag !== HostComponent &&
+          to.tag !== HostText &&
+          !(enableFloat && to.tag === HostSingleton))
       ) {
         to = null;
       }

--- a/packages/react-dom/src/test-utils/ReactTestUtils.js
+++ b/packages/react-dom/src/test-utils/ReactTestUtils.js
@@ -13,6 +13,7 @@ import {
   ClassComponent,
   FunctionComponent,
   HostComponent,
+  HostSingleton,
   HostText,
 } from 'react-reconciler/src/ReactWorkTags';
 import {SyntheticEvent} from '../events/SyntheticEvent';
@@ -23,6 +24,7 @@ import {
 } from 'shared/ReactErrorUtils';
 import assign from 'shared/assign';
 import isArray from 'shared/isArray';
+import {enableFloat} from 'shared/ReactFeatureFlags';
 
 // Keep in sync with ReactDOM.js:
 const SecretInternals =
@@ -59,7 +61,8 @@ function findAllInRenderedFiberTreeInternal(fiber, test) {
       node.tag === HostComponent ||
       node.tag === HostText ||
       node.tag === ClassComponent ||
-      node.tag === FunctionComponent
+      node.tag === FunctionComponent ||
+      (enableFloat && node.tag === HostSingleton)
     ) {
       const publicInst = node.stateNode;
       if (test(publicInst)) {
@@ -412,7 +415,11 @@ function getParent(inst) {
     // events to their parent. We could also go through parentNode on the
     // host node but that wouldn't work for React Native and doesn't let us
     // do the portal feature.
-  } while (inst && inst.tag !== HostComponent);
+  } while (
+    inst &&
+    inst.tag !== HostComponent &&
+    !(enableFloat && inst.tag === HostSingleton)
+  );
   if (inst) {
     return inst;
   }

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -321,6 +321,7 @@ export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMicrotasks';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoResources';
 
 export function appendInitialChild(
   parentInstance: Instance,

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -89,6 +89,7 @@ export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoScopes';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMicrotasks';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoResources';
 
 export function appendInitialChild(
   parentInstance: Instance,

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -272,6 +272,8 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
   }
 
   const sharedHostConfig = {
+    supportsResources: false,
+
     getRootHostContext() {
       return NO_CONTEXT;
     },

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -21,6 +21,7 @@ import type {
 } from './ReactFiberOffscreenComponent';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.new';
 
+import {supportsResources, isHostSingletonType} from './ReactFiberHostConfig';
 import {
   createRootStrictEffectsByDefault,
   enableCache,
@@ -32,6 +33,7 @@ import {
   allowConcurrentByDefault,
   enableTransitionTracing,
   enableDebugTracing,
+  enableFloat,
 } from 'shared/ReactFeatureFlags';
 import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
 import {ConcurrentRoot} from './ReactRootTags';
@@ -42,6 +44,7 @@ import {
   HostComponent,
   HostText,
   HostPortal,
+  HostSingleton,
   ForwardRef,
   Fragment,
   Mode,
@@ -491,7 +494,11 @@ export function createFiberFromTypeAndProps(
       }
     }
   } else if (typeof type === 'string') {
-    fiberTag = HostComponent;
+    if (enableFloat && supportsResources) {
+      fiberTag = isHostSingletonType(type) ? HostSingleton : HostComponent;
+    } else {
+      fiberTag = HostComponent;
+    }
   } else {
     getTag: switch (type) {
       case REACT_FRAGMENT_TYPE:

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -21,6 +21,7 @@ import type {
 } from './ReactFiberOffscreenComponent';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
 
+import {supportsResources, isHostSingletonType} from './ReactFiberHostConfig';
 import {
   createRootStrictEffectsByDefault,
   enableCache,
@@ -32,6 +33,7 @@ import {
   allowConcurrentByDefault,
   enableTransitionTracing,
   enableDebugTracing,
+  enableFloat,
 } from 'shared/ReactFeatureFlags';
 import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
 import {ConcurrentRoot} from './ReactRootTags';
@@ -42,6 +44,7 @@ import {
   HostComponent,
   HostText,
   HostPortal,
+  HostSingleton,
   ForwardRef,
   Fragment,
   Mode,
@@ -491,7 +494,11 @@ export function createFiberFromTypeAndProps(
       }
     }
   } else if (typeof type === 'string') {
-    fiberTag = HostComponent;
+    if (enableFloat && supportsResources) {
+      fiberTag = isHostSingletonType(type) ? HostSingleton : HostComponent;
+    } else {
+      fiberTag = HostComponent;
+    }
   } else {
     getTag: switch (type) {
       case REACT_FRAGMENT_TYPE:

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -37,10 +37,6 @@ import type {
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.old';
 import type {RootState} from './ReactFiberRoot.old';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
-import {
-  enableCPUSuspense,
-  enableUseMutableSource,
-} from 'shared/ReactFeatureFlags';
 
 import checkPropTypes from 'shared/checkPropTypes';
 import {
@@ -54,6 +50,7 @@ import {
   ClassComponent,
   HostRoot,
   HostComponent,
+  HostSingleton,
   HostText,
   HostPortal,
   ForwardRef,
@@ -104,6 +101,9 @@ import {
   enableSchedulingProfiler,
   enableTransitionTracing,
   enableLegacyHidden,
+  enableCPUSuspense,
+  enableUseMutableSource,
+  enableFloat,
 } from 'shared/ReactFeatureFlags';
 import isArray from 'shared/isArray';
 import shallowEqual from 'shared/shallowEqual';
@@ -1567,6 +1567,27 @@ function updateHostComponent(
 
   markRef(current, workInProgress);
   reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+  return workInProgress.child;
+}
+
+function updateHostSingleton(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
+  pushHostContext(workInProgress);
+
+  if (current === null) {
+    tryToClaimNextHydratableInstance(workInProgress);
+  }
+
+  markRef(current, workInProgress);
+  reconcileChildren(
+    current,
+    workInProgress,
+    workInProgress.pendingProps.children,
+    renderLanes,
+  );
   return workInProgress.child;
 }
 
@@ -3641,6 +3662,7 @@ function attemptEarlyBailoutIfNoScheduledUpdate(
       resetHydrationState();
       break;
     case HostComponent:
+    case HostSingleton:
       pushHostContext(workInProgress);
       break;
     case ClassComponent: {
@@ -3976,6 +3998,12 @@ function beginWork(
       return updateHostRoot(current, workInProgress, renderLanes);
     case HostComponent:
       return updateHostComponent(current, workInProgress, renderLanes);
+    case HostSingleton:
+      if (enableFloat) {
+        return updateHostSingleton(current, workInProgress, renderLanes);
+      } else {
+        return null;
+      }
     case HostText:
       return updateHostText(current, workInProgress);
     case SuspenseComponent:

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -33,6 +33,7 @@ import type {Cache} from './ReactFiberCacheComponent.old';
 import {
   enableSuspenseAvoidThisFallback,
   enableLegacyHidden,
+  enableFloat,
 } from 'shared/ReactFeatureFlags';
 
 import {resetWorkInProgressVersions as resetMutableSourceWorkInProgressVersions} from './ReactMutableSource.old';
@@ -45,6 +46,7 @@ import {
   ClassComponent,
   HostRoot,
   HostComponent,
+  HostSingleton,
   HostText,
   HostPortal,
   ContextProvider,
@@ -92,6 +94,7 @@ import {
   prepareUpdate,
   supportsMutation,
   supportsPersistence,
+  supportsResources,
   cloneInstance,
   cloneHiddenInstance,
   cloneHiddenTextInstance,
@@ -224,10 +227,14 @@ if (supportsMutation) {
     while (node !== null) {
       if (node.tag === HostComponent || node.tag === HostText) {
         appendInitialChild(parent, node.stateNode);
-      } else if (node.tag === HostPortal) {
+      } else if (
+        node.tag === HostPortal ||
+        (enableFloat && node.tag === HostSingleton)
+      ) {
         // If we have a portal child, then we don't want to traverse
         // down its children. Instead, we'll get insertions from each child in
         // the portal directly.
+        // If we have a HostSingleton it will be placed independently
       } else if (node.child !== null) {
         node.child.return = node;
         node = node.child;
@@ -999,9 +1006,7 @@ function completeWork(
             currentHostContext,
             workInProgress,
           );
-
           appendAllChildren(instance, workInProgress, false, false);
-
           workInProgress.stateNode = instance;
 
           // Certain renderers require commit-time effects for initial mount.
@@ -1026,6 +1031,81 @@ function completeWork(
       }
       bubbleProperties(workInProgress);
       return null;
+    }
+    case HostSingleton: {
+      if (enableFloat && supportsResources) {
+        popHostContext(workInProgress);
+        const rootContainerInstance = getRootHostContainer();
+        const type = workInProgress.type;
+        if (current !== null && workInProgress.stateNode != null) {
+          updateHostComponent(current, workInProgress, type, newProps);
+
+          if (current.ref !== workInProgress.ref) {
+            markRef(workInProgress);
+          }
+        } else {
+          if (!newProps) {
+            if (workInProgress.stateNode === null) {
+              throw new Error(
+                'We must have new props for new mounts. This error is likely ' +
+                  'caused by a bug in React. Please file an issue.',
+              );
+            }
+
+            // This can happen when we abort work.
+            bubbleProperties(workInProgress);
+            return null;
+          }
+
+          const currentHostContext = getHostContext();
+          // TODO: Move createInstance to beginWork and keep it on a context
+          // "stack" as the parent. Then append children as we go in beginWork
+          // or completeWork depending on whether we want to add them top->down or
+          // bottom->up. Top->down is faster in IE11.
+          const wasHydrated = popHydrationState(workInProgress);
+          if (wasHydrated) {
+            // TODO: Move this and createInstance step into the beginPhase
+            // to consolidate.
+            if (
+              prepareToHydrateHostInstance(workInProgress, currentHostContext)
+            ) {
+              // If changes to the hydrated node need to be applied at the
+              // commit-phase we mark this as such.
+              markUpdate(workInProgress);
+            }
+          } else {
+            const instance = createInstance(
+              type,
+              newProps,
+              rootContainerInstance,
+              currentHostContext,
+              workInProgress,
+            );
+
+            workInProgress.flags |= Placement;
+            workInProgress.stateNode = instance;
+            if (
+              finalizeInitialChildren(
+                instance,
+                type,
+                newProps,
+                currentHostContext,
+              )
+            ) {
+              markUpdate(workInProgress);
+            }
+          }
+
+          if (workInProgress.ref !== null) {
+            // If there is a ref on a host node we need to schedule a callback
+            markRef(workInProgress);
+          }
+        }
+        bubbleProperties(workInProgress);
+        return null;
+      } else {
+        return null;
+      }
     }
     case HostText: {
       const newText = newProps;

--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -11,6 +11,7 @@ import type {Fiber} from './ReactInternalTypes';
 
 import {
   HostComponent,
+  HostSingleton,
   LazyComponent,
   SuspenseComponent,
   SuspenseListComponent,
@@ -34,6 +35,7 @@ function describeFiber(fiber: Fiber): string {
     : null;
   const source = __DEV__ ? fiber._debugSource : null;
   switch (fiber.tag) {
+    case HostSingleton:
     case HostComponent:
       return describeBuiltInComponentFrame(fiber.type, source, owner);
     case LazyComponent:

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoResources.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoResources.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Renderers that don't support mutation
+// can re-export everything from this module.
+
+function shim(...args: any) {
+  throw new Error(
+    'The current renderer does not support Resources. ' +
+      'This error is likely caused by a bug in React. ' +
+      'Please file an issue.',
+  );
+}
+
+import type {Instance} from './ReactFiberHostConfig';
+
+// Resources (when unsupported)
+export type InstanceParent = Instance;
+export type InstanceSibling = Instance;
+export const supportsResources = false;
+export const commitSingletonPlacement = shim;
+export const getInsertionEdge = shim;
+export const isHostSingletonInstance = shim;
+export const isHostSingletonType = shim;

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -15,6 +15,7 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {Instance} from './ReactFiberHostConfig';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
+import {enableFloat} from 'shared/ReactFeatureFlags';
 import {
   flushSync,
   scheduleUpdateOnFiber,
@@ -29,6 +30,7 @@ import {
   FunctionComponent,
   ForwardRef,
   HostComponent,
+  HostSingleton,
   HostPortal,
   HostRoot,
   MemoComponent,
@@ -435,6 +437,7 @@ function findHostInstancesForFiberShallowly(
     let node = fiber;
     while (true) {
       switch (node.tag) {
+        case HostSingleton:
         case HostComponent:
           hostInstances.add(node.stateNode);
           return;
@@ -461,7 +464,10 @@ function findChildHostInstancesForFiberShallowly(
     let node: Fiber = fiber;
     let foundHostInstances = false;
     while (true) {
-      if (node.tag === HostComponent) {
+      if (
+        node.tag === HostComponent ||
+        (enableFloat && node.tag === HostSingleton)
+      ) {
         // We got a match.
         foundHostInstances = true;
         hostInstances.add(node.stateNode);

--- a/packages/react-reconciler/src/ReactFiberHotReloading.old.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.old.js
@@ -15,6 +15,7 @@ import type {FiberRoot} from './ReactInternalTypes';
 import type {Instance} from './ReactFiberHostConfig';
 import type {ReactNodeList} from 'shared/ReactTypes';
 
+import {enableFloat} from 'shared/ReactFeatureFlags';
 import {
   flushSync,
   scheduleUpdateOnFiber,
@@ -29,6 +30,7 @@ import {
   FunctionComponent,
   ForwardRef,
   HostComponent,
+  HostSingleton,
   HostPortal,
   HostRoot,
   MemoComponent,
@@ -435,6 +437,7 @@ function findHostInstancesForFiberShallowly(
     let node = fiber;
     while (true) {
       switch (node.tag) {
+        case HostSingleton:
         case HostComponent:
           hostInstances.add(node.stateNode);
           return;
@@ -461,7 +464,10 @@ function findChildHostInstancesForFiberShallowly(
     let node: Fiber = fiber;
     let foundHostInstances = false;
     while (true) {
-      if (node.tag === HostComponent) {
+      if (
+        node.tag === HostComponent ||
+        (enableFloat && node.tag === HostSingleton)
+      ) {
         // We got a match.
         foundHostInstances = true;
         hostInstances.add(node.stateNode);

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -32,6 +32,7 @@ import {
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import {
   HostComponent,
+  HostSingleton,
   ClassComponent,
   HostRoot,
   SuspenseComponent,
@@ -405,6 +406,7 @@ export function getPublicRootInstance(
     return null;
   }
   switch (containerFiber.child.tag) {
+    case HostSingleton:
     case HostComponent:
       return getPublicInstance(containerFiber.child.stateNode);
     default:

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -32,6 +32,7 @@ import {
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import {
   HostComponent,
+  HostSingleton,
   ClassComponent,
   HostRoot,
   SuspenseComponent,
@@ -405,6 +406,7 @@ export function getPublicRootInstance(
     return null;
   }
   switch (containerFiber.child.tag) {
+    case HostSingleton:
     case HostComponent:
       return getPublicInstance(containerFiber.child.stateNode);
     default:

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -13,10 +13,12 @@ import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 
 import {get as getInstance} from 'shared/ReactInstanceMap';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
+import {enableFloat} from 'shared/ReactFeatureFlags';
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
 import {
   ClassComponent,
   HostComponent,
+  HostSingleton,
   HostRoot,
   HostPortal,
   HostText,
@@ -273,7 +275,11 @@ export function findCurrentHostFiber(parent: Fiber): Fiber | null {
 
 function findCurrentHostFiberImpl(node: Fiber) {
   // Next we'll drill down this component to find the first HostComponent/Text.
-  if (node.tag === HostComponent || node.tag === HostText) {
+  if (
+    node.tag === HostComponent ||
+    node.tag === HostText ||
+    (enableFloat && node.tag === HostSingleton)
+  ) {
     return node;
   }
 
@@ -298,7 +304,11 @@ export function findCurrentHostFiberWithNoPortals(parent: Fiber): Fiber | null {
 
 function findCurrentHostFiberWithNoPortalsImpl(node: Fiber) {
   // Next we'll drill down this component to find the first HostComponent/Text.
-  if (node.tag === HostComponent || node.tag === HostText) {
+  if (
+    node.tag === HostComponent ||
+    node.tag === HostText ||
+    (enableFloat && node.tag === HostSingleton)
+  ) {
     return node;
   }
 

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.new.js
@@ -19,6 +19,7 @@ import {
   ClassComponent,
   HostRoot,
   HostComponent,
+  HostSingleton,
   HostPortal,
   ContextProvider,
   SuspenseComponent,
@@ -115,6 +116,7 @@ function unwindWork(
       // We unwound to the root without completing it. Exit.
       return null;
     }
+    case HostSingleton:
     case HostComponent: {
       // TODO: popHydrationState
       popHostContext(workInProgress);
@@ -233,6 +235,7 @@ function unwindInterruptedWork(
       resetMutableSourceWorkInProgressVersions();
       break;
     }
+    case HostSingleton:
     case HostComponent: {
       popHostContext(interruptedWork);
       break;

--- a/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberUnwindWork.old.js
@@ -19,6 +19,7 @@ import {
   ClassComponent,
   HostRoot,
   HostComponent,
+  HostSingleton,
   HostPortal,
   ContextProvider,
   SuspenseComponent,
@@ -115,6 +116,7 @@ function unwindWork(
       // We unwound to the root without completing it. Exit.
       return null;
     }
+    case HostSingleton:
     case HostComponent: {
       // TODO: popHydrationState
       popHostContext(workInProgress);
@@ -233,6 +235,7 @@ function unwindInterruptedWork(
       resetMutableSourceWorkInProgressVersions();
       break;
     }
+    case HostSingleton:
     case HostComponent: {
       popHostContext(interruptedWork);
       break;

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -10,7 +10,11 @@
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {Instance} from './ReactFiberHostConfig';
 
-import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
+import {
+  HostComponent,
+  HostSingleton,
+  HostText,
+} from 'react-reconciler/src/ReactWorkTags';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 import {
   findFiberRoot,
@@ -150,7 +154,7 @@ function matchSelector(fiber: Fiber, selector: Selector): boolean {
         ((selector: any): HasPseudoClassSelector).value,
       );
     case ROLE_TYPE:
-      if (fiber.tag === HostComponent) {
+      if (fiber.tag === HostComponent || fiber.tag === HostSingleton) {
         const node = fiber.stateNode;
         if (
           matchAccessibilityRole(node, ((selector: any): RoleSelector).value)
@@ -160,7 +164,11 @@ function matchSelector(fiber: Fiber, selector: Selector): boolean {
       }
       break;
     case TEXT_TYPE:
-      if (fiber.tag === HostComponent || fiber.tag === HostText) {
+      if (
+        fiber.tag === HostComponent ||
+        fiber.tag === HostText ||
+        fiber.tag === HostSingleton
+      ) {
         const textContent = getTextContent(fiber);
         if (
           textContent !== null &&
@@ -171,7 +179,7 @@ function matchSelector(fiber: Fiber, selector: Selector): boolean {
       }
       break;
     case TEST_NAME_TYPE:
-      if (fiber.tag === HostComponent) {
+      if (fiber.tag === HostComponent || fiber.tag === HostSingleton) {
         const dataTestID = fiber.memoizedProps['data-testname'];
         if (
           typeof dataTestID === 'string' &&
@@ -217,7 +225,10 @@ function findPaths(root: Fiber, selectors: Array<Selector>): Array<Fiber> {
     let selectorIndex = ((stack[index++]: any): number);
     let selector = selectors[selectorIndex];
 
-    if (fiber.tag === HostComponent && isHiddenSubtree(fiber)) {
+    if (
+      (fiber.tag === HostComponent || fiber.tag === HostSingleton) &&
+      isHiddenSubtree(fiber)
+    ) {
       continue;
     } else {
       while (selector != null && matchSelector(fiber, selector)) {
@@ -249,7 +260,10 @@ function hasMatchingPaths(root: Fiber, selectors: Array<Selector>): boolean {
     let selectorIndex = ((stack[index++]: any): number);
     let selector = selectors[selectorIndex];
 
-    if (fiber.tag === HostComponent && isHiddenSubtree(fiber)) {
+    if (
+      (fiber.tag === HostComponent || fiber.tag === HostSingleton) &&
+      isHiddenSubtree(fiber)
+    ) {
       continue;
     } else {
       while (selector != null && matchSelector(fiber, selector)) {
@@ -289,7 +303,7 @@ export function findAllNodes(
   let index = 0;
   while (index < stack.length) {
     const node = ((stack[index++]: any): Fiber);
-    if (node.tag === HostComponent) {
+    if (node.tag === HostComponent || node.tag === HostSingleton) {
       if (isHiddenSubtree(node)) {
         continue;
       }
@@ -327,7 +341,10 @@ export function getFindAllNodesFailureDescription(
     let selectorIndex = ((stack[index++]: any): number);
     const selector = selectors[selectorIndex];
 
-    if (fiber.tag === HostComponent && isHiddenSubtree(fiber)) {
+    if (
+      (fiber.tag === HostComponent || fiber.tag === HostSingleton) &&
+      isHiddenSubtree(fiber)
+    ) {
       continue;
     } else if (matchSelector(fiber, selector)) {
       matchedNames.push(selectorToString(selector));
@@ -479,7 +496,7 @@ export function focusWithin(
     if (isHiddenSubtree(fiber)) {
       continue;
     }
-    if (fiber.tag === HostComponent) {
+    if (fiber.tag === HostComponent || fiber.tag === HostSingleton) {
       const node = fiber.stateNode;
       if (setFocusIfFocusable(node)) {
         return true;

--- a/packages/react-reconciler/src/ReactWorkTags.js
+++ b/packages/react-reconciler/src/ReactWorkTags.js
@@ -33,7 +33,8 @@ export type WorkTag =
   | 22
   | 23
   | 24
-  | 25;
+  | 25
+  | 26;
 
 export const FunctionComponent = 0;
 export const ClassComponent = 1;
@@ -60,3 +61,4 @@ export const OffscreenComponent = 22;
 export const LegacyHiddenComponent = 23;
 export const CacheComponent = 24;
 export const TracingMarkerComponent = 25;
+export const HostSingleton = 26;

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -28,6 +28,7 @@ export opaque type Type = mixed; // eslint-disable-line no-undef
 export opaque type Props = mixed; // eslint-disable-line no-undef
 export opaque type Container = mixed; // eslint-disable-line no-undef
 export opaque type Instance = mixed; // eslint-disable-line no-undef
+export type InstanceSibling = Instance; // eslint-disable-line no-undef
 export opaque type TextInstance = mixed; // eslint-disable-line no-undef
 export opaque type SuspenseInstance = mixed; // eslint-disable-line no-undef
 export opaque type HydratableInstance = mixed; // eslint-disable-line no-undef
@@ -186,6 +187,17 @@ export const didNotFindHydratableTextInstance =
 export const didNotFindHydratableSuspenseInstance =
   $$$hostConfig.didNotFindHydratableSuspenseInstance;
 export const errorHydratingContainer = $$$hostConfig.errorHydratingContainer;
+// @TODO remove these when Resources supports Hydration indirectly
 export const isHydratableResource = $$$hostConfig.isHydratableResource;
 export const getMatchingResourceInstance =
   $$$hostConfig.getMatchingResourceInstance;
+
+// -------------------
+//     Resources
+//     (optional)
+// -------------------
+export const supportsResources = $$$hostConfig.supportsResources;
+export const commitSingletonPlacement = $$$hostConfig.commitSingletonPlacement;
+export const getInsertionEdge = $$$hostConfig.getInsertionEdge;
+export const isHostSingletonInstance = $$$hostConfig.isHostSingletonInstance;
+export const isHostSingletonType = $$$hostConfig.isHostSingletonType;

--- a/packages/react-reconciler/src/getComponentNameFromFiber.js
+++ b/packages/react-reconciler/src/getComponentNameFromFiber.js
@@ -18,6 +18,7 @@ import {
   HostRoot,
   HostPortal,
   HostComponent,
+  HostSingleton,
   HostText,
   Fragment,
   Mode,
@@ -76,6 +77,7 @@ export default function getComponentNameFromFiber(fiber: Fiber): string | null {
       return getWrappedName(type, type.render, 'ForwardRef');
     case Fragment:
       return 'Fragment';
+    case HostSingleton:
     case HostComponent:
       // Host component type is the display name (e.g. "div", "View")
       return type;

--- a/packages/react-test-renderer/src/ReactTestHostConfig.js
+++ b/packages/react-test-renderer/src/ReactTestHostConfig.js
@@ -46,6 +46,7 @@ export * from 'react-reconciler/src/ReactFiberHostConfigWithNoPersistence';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoHydration';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoTestSelectors';
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMicrotasks';
+export * from 'react-reconciler/src/ReactFiberHostConfigWithNoResources';
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -27,6 +27,7 @@ import {
   FunctionComponent,
   ClassComponent,
   HostComponent,
+  HostSingleton,
   HostPortal,
   HostText,
   HostRoot,
@@ -196,6 +197,7 @@ function toTree(node: ?Fiber) {
         instance: null,
         rendered: childrenToTree(node.child),
       };
+    case HostSingleton:
     case HostComponent: {
       return {
         nodeType: 'host',
@@ -302,7 +304,10 @@ class ReactTestInstance {
   }
 
   get instance() {
-    if (this._fiber.tag === HostComponent) {
+    if (
+      this._fiber.tag === HostComponent ||
+      this._fiber.tag === HostSingleton
+    ) {
       return getPublicInstance(this._fiber.stateNode);
     } else {
       return this._fiber.stateNode;

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -103,6 +103,8 @@ export const enableSuspenseAvoidThisFallbackFizz = false;
 
 export const enableCPUSuspense = __EXPERIMENTAL__;
 
+export const enableFloat = __EXPERIMENTAL__;
+
 // When a node is unmounted, recurse into the Fiber subtree and clean out
 // references. Each level cleans up more fiber fields than the previous level.
 // As far as we know, React itself doesn't leak, but because the Fiber contains
@@ -115,8 +117,6 @@ export const enableCPUSuspense = __EXPERIMENTAL__;
 // It's an enum so that we can experiment with different levels of
 // aggressiveness.
 export const deletedTreeCleanUpLevel = 3;
-
-export const enableFloat = __EXPERIMENTAL__;
 
 // -----------------------------------------------------------------------------
 // Chopping Block

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -109,6 +109,7 @@ export const enableUseMutableSource = true;
 export const enableCustomElementPropertySupport = __EXPERIMENTAL__;
 
 export const enableSymbolFallbackForWWW = true;
+
 // Flow magic to verify the exports of this file match the original version.
 // eslint-disable-next-line no-unused-vars
 type Check<_X, Y: _X, X: Y = _X> = null;

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -422,5 +422,7 @@
   "434": "`dangerouslySetInnerHTML` does not make sense on <title>.",
   "435": "Unexpected Suspense handler tag (%s). This is a bug in React.",
   "436": "Stylesheet resources need a unique representation in the DOM while hydrating and more than one matching DOM Node was found. To fix, ensure you are only rendering one stylesheet link with an href attribute of \"%s\".",
-  "437": "the \"precedence\" prop for links to stylesheets expects to receive a string but received something of type \"%s\" instead."
+  "437": "the \"precedence\" prop for links to stylesheets expects to receive a string but received something of type \"%s\" instead.",
+  "438": "commitSingletonPlacement was called with an element type that is not supported. This is a bug in React.",
+  "439": "The current renderer does not support Resources. This error is likely caused by a bug in React. Please file an issue."
 }


### PR DESCRIPTION
## Background

For a variety of reasons `html`, `head`, and `body` nodes are special in the browser and historically there has not been much heed given to these elements in particular within react-dom which has led to some limitations of interoperability with externals systems such as 3rd party scripts and browser extensions. Additionally new features in React will require some special handling of these instances to be possible.

The main issue has to do with instance lifecycles and React's total ownership of the nodes within it's tree. For the `head` for instance, if there are stylesheet links inserted by 3rd parties, React might unmount those nodes, or reinsert them somewhere else causing a new fetch and temporary style unloading. Additionally useInsertionEffect runs in the mutation phase but if we are going to be replacing the head it will be unmounted during the time these effects are run so you can't always inject styles when you expected to be able to.

The historical advice has been to render into an element in the body that isn't like to be targeted by any external systems however this conflicts with the guidance for using streaming rendering available in React 18 where it is going to be common that React owns the entire document.

## General Approach

To solve these issues, this PR introduces a new fiber type `HostSingleton`. Currently only react-dom has an implementation for this type and all other renderers still only use `HostComponent`.

1. All `HostSingletons` are placed individually, they will not be appended to a parent fiber even if they are part of a tree that is going to be Placed in the same commit.
2. During completeWork `HostSingletons` do not append any `HostComponent` children
3. During commitWork `HostSingletons` if a Placement effect is needed a special Singleton placement method from the HostConfig is used. Child fibers of the fiber are then appended.
4. During commitWork if a `HostSingleton` is having Placement effects appended to it, it will use optional additional semantics for finding an insertion edge. This allows for non-react-controlled children to be siblings of Placed fibers without incorrect ordering.

## react-dom Approach

In the case of react-dom there are three singleton instances, `document.documentElement`, `document.head`, `document.body`. If you render a `<html /> | <head />  | <body />` in your tree they each will bind to the already existing Element and not recreate a new one.

Key Constraints:
* none of the 3 singleton instances will be unmounted at any time
* none of the 3 singleton instances will be ever change referential identity
* Head and Body nodes will never reposition, reorder, or otherwise alter the placement of style-related nodes outside of React

### insertion stability (Body and Head only)

In Body and Head, we expect there to be Nodes that were created by systems other than React. Most items can safely be removed once loaded because they are fire-and-forget, such as scripts. However `<style>` and `<link rel="stylesheet">` nodes need to be retained for proper functioning of a site and as such we expect that these two instances will have a number of Nodes outside the purview of React's runtime which change insertion semantics.
