### PR TITLE
Fix `react-refresh` `injectIntoGlobalHook` error

### DIFF
--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -506,6 +506,18 @@ export function injectIntoGlobalHook(globalObject: any): void {
     // Do the same for any already injected roots.
     // This is useful if ReactDOM has already been initialized.
     // https://github.com/facebook/react/issues/17626
+
+    /**
+     * hook object is existed, but didn't have `renderers` property
+     * it will make react app cannot startup
+     * so, we need to check it and initialize it,
+     * make sure it has the `renderers` property to avoid startup errors
+     * https://github.com/facebook/react/issues/25019
+     */
+    if (!hook.renderers) {
+      hook.renderers = new Map()
+    }
+
     hook.renderers.forEach((injected, id) => {
       if (
         typeof injected.scheduleRefresh === 'function' &&


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

In `react-refresh` package, when `injectIntoGlobalHook` function running in dev environment, we need to check for `hook.renderers` property existence before traversing it

So, before traversing it, check it and initialize it to be a empty `Map` Object:

```js
// ... other code
if (!hook.renderers) {
    hook.renderers = new Map()
}
// ... other code
```
