### PR TITLE
ReactHooks.js - delete emptyObject

### DIFF
--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -157,8 +157,6 @@ export function useDebugValue<T>(
   }
 }
 
-export const emptyObject = {};
-
 export function useTransition(): [
   boolean,
   (callback: () => void, options?: StartTransitionOptions) => void,


### PR DESCRIPTION
It's not mentioned in docs and never used by projects.. should be removed..

## Summary

It's not mentioned in docs and never used by projects.. should be removed..

## How did you test this change?

PR CI