### PR TITLE
Align StrictMode behaviour with production

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -13,7 +13,12 @@ import type {Fiber} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.new';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
-import {Placement, ChildDeletion, Forked} from './ReactFiberFlags';
+import {
+  Placement,
+  ChildDeletion,
+  Forked,
+  PlacementDEV,
+} from './ReactFiberFlags';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
@@ -343,7 +348,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       const oldIndex = current.index;
       if (oldIndex < lastPlacedIndex) {
         // This is a move.
-        newFiber.flags |= Placement;
+        newFiber.flags |= Placement | PlacementDEV;
         return lastPlacedIndex;
       } else {
         // This item can stay in place.
@@ -351,7 +356,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     } else {
       // This is an insertion.
-      newFiber.flags |= Placement;
+      newFiber.flags |= Placement | PlacementDEV;
       return lastPlacedIndex;
     }
   }
@@ -360,7 +365,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
     if (shouldTrackSideEffects && newFiber.alternate === null) {
-      newFiber.flags |= Placement;
+      newFiber.flags |= Placement | PlacementDEV;
     }
     return newFiber;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -13,7 +13,12 @@ import type {Fiber} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
-import {Placement, ChildDeletion, Forked} from './ReactFiberFlags';
+import {
+  Placement,
+  ChildDeletion,
+  Forked,
+  PlacementDEV,
+} from './ReactFiberFlags';
 import {
   getIteratorFn,
   REACT_ELEMENT_TYPE,
@@ -343,7 +348,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       const oldIndex = current.index;
       if (oldIndex < lastPlacedIndex) {
         // This is a move.
-        newFiber.flags |= Placement;
+        newFiber.flags |= Placement | PlacementDEV;
         return lastPlacedIndex;
       } else {
         // This item can stay in place.
@@ -351,7 +356,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     } else {
       // This is an insertion.
-      newFiber.flags |= Placement;
+      newFiber.flags |= Placement | PlacementDEV;
       return lastPlacedIndex;
     }
   }
@@ -360,7 +365,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
     if (shouldTrackSideEffects && newFiber.alternate === null) {
-      newFiber.flags |= Placement;
+      newFiber.flags |= Placement | PlacementDEV;
     }
     return newFiber;
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -201,6 +201,15 @@ let nextEffect: Fiber | null = null;
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
 
+function shouldProfile(current: Fiber): Boolean {
+  return (
+    enableProfilerTimer &&
+    enableProfilerCommitHooks &&
+    current.mode & ProfileMode &&
+    getExecutionContext() & CommitContext
+  );
+}
+
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
   // callback is a bit too slow (https://github.com/facebook/react/pull/21666).
@@ -218,12 +227,7 @@ export function reportUncaughtErrorInDEV(error: mixed) {
 const callComponentWillUnmountWithTimer = function(current, instance) {
   instance.props = current.memoizedProps;
   instance.state = current.memoizedState;
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    current.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(current)) {
     try {
       startLayoutEffectTimer();
       instance.componentWillUnmount();
@@ -263,12 +267,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
     if (typeof ref === 'function') {
       let retVal;
       try {
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          current.mode & ProfileMode &&
-          getExecutionContext() & CommitContext
-        ) {
+        if (shouldProfile(current)) {
           try {
             startLayoutEffectTimer();
             retVal = ref(null);
@@ -701,12 +700,7 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
   // This is done to prevent sibling component effects from interfering with each other,
   // e.g. a destroy function in one component should never override a ref set
   // by a create function in another component during the same commit.
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     try {
       startLayoutEffectTimer();
       commitHookEffectListMount(hookFlags, finishedWork);
@@ -759,12 +753,7 @@ function commitClassLayoutLifecycles(
         }
       }
     }
-    if (
-      enableProfilerTimer &&
-      enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode &&
-      getExecutionContext() & CommitContext
-    ) {
+    if (shouldProfile(finishedWork)) {
       try {
         startLayoutEffectTimer();
         instance.componentDidMount();
@@ -815,12 +804,7 @@ function commitClassLayoutLifecycles(
         }
       }
     }
-    if (
-      enableProfilerTimer &&
-      enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode &&
-      getExecutionContext() & CommitContext
-    ) {
+    if (shouldProfile(finishedWork)) {
       try {
         startLayoutEffectTimer();
         instance.componentDidUpdate(
@@ -1351,12 +1335,7 @@ function commitAttachRef(finishedWork: Fiber) {
     }
     if (typeof ref === 'function') {
       let retVal;
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(finishedWork)) {
         try {
           startLayoutEffectTimer();
           retVal = ref(instanceToUse);
@@ -1395,12 +1374,7 @@ function commitDetachRef(current: Fiber) {
   const currentRef = current.ref;
   if (currentRef !== null) {
     if (typeof currentRef === 'function') {
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        current.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(current)) {
         try {
           startLayoutEffectTimer();
           currentRef(null);
@@ -1926,12 +1900,7 @@ function commitDeletionEffectsOnFiber(
                     markComponentLayoutEffectUnmountStarted(deletedFiber);
                   }
 
-                  if (
-                    enableProfilerTimer &&
-                    enableProfilerCommitHooks &&
-                    deletedFiber.mode & ProfileMode &&
-                    getExecutionContext() & CommitContext
-                  ) {
+                  if (shouldProfile(deletedFiber)) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
                       deletedFiber,
@@ -2250,12 +2219,7 @@ function commitMutationEffectsOnFiber(
         // This prevents sibling component effects from interfering with each other,
         // e.g. a destroy function in one component should never override a ref set
         // by a create function in another component during the same commit.
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          finishedWork.mode & ProfileMode &&
-          getExecutionContext() & CommitContext
-        ) {
+        if (shouldProfile(finishedWork)) {
           try {
             startLayoutEffectTimer();
             commitHookEffectListUnmount(
@@ -2648,12 +2612,7 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
     case MemoComponent:
     case SimpleMemoComponent: {
       // TODO (Offscreen) Check: flags & LayoutStatic
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(finishedWork)) {
         try {
           startLayoutEffectTimer();
           commitHookEffectListUnmount(
@@ -2891,12 +2850,7 @@ function commitHookPassiveMountEffects(
   finishedWork: Fiber,
   hookFlags: HookFlags,
 ) {
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     startPassiveEffectTimer();
     try {
       commitHookEffectListMount(hookFlags, finishedWork);
@@ -3601,12 +3555,7 @@ function commitHookPassiveUnmountEffects(
   nearestMountedAncestor,
   hookFlags: HookFlags,
 ) {
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
       hookFlags,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -147,6 +147,8 @@ import {
   addMarkerProgressCallbackToPendingTransition,
   addMarkerCompleteCallbackToPendingTransition,
   setIsRunningInsertionEffect,
+  getExecutionContext,
+  CommitContext,
 } from './ReactFiberWorkLoop.new';
 import {
   NoFlags as NoHookEffect,
@@ -198,7 +200,6 @@ let nextEffect: Fiber | null = null;
 // Used for Profiling builds to track updaters.
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
-let enableProfilingDEV = true;
 
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
@@ -221,7 +222,7 @@ const callComponentWillUnmountWithTimer = function(current, instance) {
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     current.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     try {
       startLayoutEffectTimer();
@@ -266,7 +267,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
           current.mode & ProfileMode &&
-          enableProfilingDEV
+          getExecutionContext() & CommitContext
         ) {
           try {
             startLayoutEffectTimer();
@@ -643,7 +644,11 @@ export function commitPassiveEffectDurations(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
 ): void {
-  if (enableProfilerTimer && enableProfilerCommitHooks && enableProfilingDEV) {
+  if (
+    enableProfilerTimer &&
+    enableProfilerCommitHooks &&
+    getExecutionContext() & CommitContext
+  ) {
     // Only Profilers with work in their subtree will have an Update effect scheduled.
     if ((finishedWork.flags & Update) !== NoFlags) {
       switch (finishedWork.tag) {
@@ -700,7 +705,7 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     try {
       startLayoutEffectTimer();
@@ -758,7 +763,7 @@ function commitClassLayoutLifecycles(
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
       finishedWork.mode & ProfileMode &&
-      enableProfilingDEV
+      getExecutionContext() & CommitContext
     ) {
       try {
         startLayoutEffectTimer();
@@ -814,7 +819,7 @@ function commitClassLayoutLifecycles(
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
       finishedWork.mode & ProfileMode &&
-      enableProfilingDEV
+      getExecutionContext() & CommitContext
     ) {
       try {
         startLayoutEffectTimer();
@@ -897,7 +902,7 @@ function commitHostComponentMount(finishedWork: Fiber) {
 }
 
 function commitProfilerUpdate(finishedWork: Fiber, current: Fiber | null) {
-  if (enableProfilerTimer && enableProfilingDEV) {
+  if (enableProfilerTimer && getExecutionContext() & CommitContext) {
     try {
       const {onCommit, onRender} = finishedWork.memoizedProps;
       const {effectDuration} = finishedWork.stateNode;
@@ -1350,7 +1355,7 @@ function commitAttachRef(finishedWork: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         finishedWork.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -1394,7 +1399,7 @@ function commitDetachRef(current: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         current.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -1925,7 +1930,7 @@ function commitDeletionEffectsOnFiber(
                     enableProfilerTimer &&
                     enableProfilerCommitHooks &&
                     deletedFiber.mode & ProfileMode &&
-                    enableProfilingDEV
+                    getExecutionContext() & CommitContext
                   ) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
@@ -2249,7 +2254,7 @@ function commitMutationEffectsOnFiber(
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
           finishedWork.mode & ProfileMode &&
-          enableProfilingDEV
+          getExecutionContext() & CommitContext
         ) {
           try {
             startLayoutEffectTimer();
@@ -2647,7 +2652,7 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         finishedWork.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -2890,7 +2895,7 @@ function commitHookPassiveMountEffects(
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     startPassiveEffectTimer();
     try {
@@ -3600,7 +3605,7 @@ function commitHookPassiveUnmountEffects(
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
@@ -3879,12 +3884,6 @@ function commitPassiveUnmountInsideDeletedTreeOnFiber(
       }
       break;
     }
-  }
-}
-
-export function setEnableProfilingDEV(_enableProfilingDEV: boolean) {
-  if (__DEV__) {
-    enableProfilingDEV = _enableProfilingDEV;  
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -149,6 +149,7 @@ import {
   setIsRunningInsertionEffect,
   getExecutionContext,
   CommitContext,
+  NoContext,
 } from './ReactFiberWorkLoop.new';
 import {
   NoFlags as NoHookEffect,
@@ -201,12 +202,12 @@ let nextEffect: Fiber | null = null;
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
 
-function shouldProfile(current: Fiber): Boolean {
+function shouldProfile(current: Fiber): boolean {
   return (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    current.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
+    (current.mode & ProfileMode) !== NoMode &&
+    (getExecutionContext() & CommitContext) !== NoContext
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -40,7 +40,6 @@ import {
   enableSchedulingProfiler,
   enableSuspenseCallback,
   enableScopeAPI,
-  enableStrictEffects,
   deletedTreeCleanUpLevel,
   enableUpdaterTracking,
   enableCache,
@@ -199,6 +198,7 @@ let nextEffect: Fiber | null = null;
 // Used for Profiling builds to track updaters.
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
+let enableProfilingDEV = true;
 
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
@@ -220,7 +220,8 @@ const callComponentWillUnmountWithTimer = function(current, instance) {
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    current.mode & ProfileMode
+    current.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     try {
       startLayoutEffectTimer();
@@ -264,7 +265,8 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         if (
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
-          current.mode & ProfileMode
+          current.mode & ProfileMode &&
+          enableProfilingDEV
         ) {
           try {
             startLayoutEffectTimer();
@@ -641,7 +643,7 @@ export function commitPassiveEffectDurations(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
 ): void {
-  if (enableProfilerTimer && enableProfilerCommitHooks) {
+  if (enableProfilerTimer && enableProfilerCommitHooks && enableProfilingDEV) {
     // Only Profilers with work in their subtree will have an Update effect scheduled.
     if ((finishedWork.flags & Update) !== NoFlags) {
       switch (finishedWork.tag) {
@@ -697,7 +699,8 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     try {
       startLayoutEffectTimer();
@@ -754,7 +757,8 @@ function commitClassLayoutLifecycles(
     if (
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode
+      finishedWork.mode & ProfileMode &&
+      enableProfilingDEV
     ) {
       try {
         startLayoutEffectTimer();
@@ -809,7 +813,8 @@ function commitClassLayoutLifecycles(
     if (
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode
+      finishedWork.mode & ProfileMode &&
+      enableProfilingDEV
     ) {
       try {
         startLayoutEffectTimer();
@@ -892,7 +897,7 @@ function commitHostComponentMount(finishedWork: Fiber) {
 }
 
 function commitProfilerUpdate(finishedWork: Fiber, current: Fiber | null) {
-  if (enableProfilerTimer) {
+  if (enableProfilerTimer && enableProfilingDEV) {
     try {
       const {onCommit, onRender} = finishedWork.memoizedProps;
       const {effectDuration} = finishedWork.stateNode;
@@ -1344,7 +1349,8 @@ function commitAttachRef(finishedWork: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode
+        finishedWork.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -1387,7 +1393,8 @@ function commitDetachRef(current: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        current.mode & ProfileMode
+        current.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -1917,7 +1924,8 @@ function commitDeletionEffectsOnFiber(
                   if (
                     enableProfilerTimer &&
                     enableProfilerCommitHooks &&
-                    deletedFiber.mode & ProfileMode
+                    deletedFiber.mode & ProfileMode &&
+                    enableProfilingDEV
                   ) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
@@ -2240,7 +2248,8 @@ function commitMutationEffectsOnFiber(
         if (
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
-          finishedWork.mode & ProfileMode
+          finishedWork.mode & ProfileMode &&
+          enableProfilingDEV
         ) {
           try {
             startLayoutEffectTimer();
@@ -2627,7 +2636,7 @@ function recursivelyTraverseLayoutEffects(
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function disappearLayoutEffects(finishedWork: Fiber) {
+export function disappearLayoutEffects(finishedWork: Fiber) {
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:
@@ -2637,7 +2646,8 @@ function disappearLayoutEffects(finishedWork: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode
+        finishedWork.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -2709,7 +2719,7 @@ function recursivelyTraverseDisappearLayoutEffects(parentFiber: Fiber) {
   }
 }
 
-function reappearLayoutEffects(
+export function reappearLayoutEffects(
   finishedRoot: FiberRoot,
   current: Fiber | null,
   finishedWork: Fiber,
@@ -2879,7 +2889,8 @@ function commitHookPassiveMountEffects(
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     startPassiveEffectTimer();
     try {
@@ -3304,7 +3315,7 @@ function recursivelyTraverseReconnectPassiveEffects(
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function reconnectPassiveEffects(
+export function reconnectPassiveEffects(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
   committedLanes: Lanes,
@@ -3588,7 +3599,8 @@ function commitHookPassiveUnmountEffects(
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
@@ -3718,7 +3730,7 @@ function recursivelyTraverseDisconnectPassiveEffects(parentFiber: Fiber): void {
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function disconnectPassiveEffect(finishedWork: Fiber): void {
+export function disconnectPassiveEffect(finishedWork: Fiber): void {
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:
@@ -3870,112 +3882,10 @@ function commitPassiveUnmountInsideDeletedTreeOnFiber(
   }
 }
 
-// TODO: Reuse reappearLayoutEffects traversal here?
-function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListMount(HookLayout | HookHasEffect, fiber);
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-      case ClassComponent: {
-        const instance = fiber.stateNode;
-        try {
-          instance.componentDidMount();
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-    }
+export function setEnableProfilingDEV(_enableProfilingDEV: boolean) {
+  if (__DEV__) {
+    enableProfilingDEV = _enableProfilingDEV;  
   }
 }
 
-function invokePassiveEffectMountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListMount(HookPassive | HookHasEffect, fiber);
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-    }
-  }
-}
-
-function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListUnmount(
-            HookLayout | HookHasEffect,
-            fiber,
-            fiber.return,
-          );
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-      case ClassComponent: {
-        const instance = fiber.stateNode;
-        if (typeof instance.componentWillUnmount === 'function') {
-          safelyCallComponentWillUnmount(fiber, fiber.return, instance);
-        }
-        break;
-      }
-    }
-  }
-}
-
-function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListUnmount(
-            HookPassive | HookHasEffect,
-            fiber,
-            fiber.return,
-          );
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-      }
-    }
-  }
-}
-
-export {
-  commitPlacement,
-  commitAttachRef,
-  commitDetachRef,
-  invokeLayoutEffectMountInDEV,
-  invokeLayoutEffectUnmountInDEV,
-  invokePassiveEffectMountInDEV,
-  invokePassiveEffectUnmountInDEV,
-};
+export {commitPlacement, commitAttachRef, commitDetachRef};

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -201,6 +201,15 @@ let nextEffect: Fiber | null = null;
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
 
+function shouldProfile(current: Fiber): Boolean {
+  return (
+    enableProfilerTimer &&
+    enableProfilerCommitHooks &&
+    current.mode & ProfileMode &&
+    getExecutionContext() & CommitContext
+  );
+}
+
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
   // callback is a bit too slow (https://github.com/facebook/react/pull/21666).
@@ -218,12 +227,7 @@ export function reportUncaughtErrorInDEV(error: mixed) {
 const callComponentWillUnmountWithTimer = function(current, instance) {
   instance.props = current.memoizedProps;
   instance.state = current.memoizedState;
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    current.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(current)) {
     try {
       startLayoutEffectTimer();
       instance.componentWillUnmount();
@@ -263,12 +267,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
     if (typeof ref === 'function') {
       let retVal;
       try {
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          current.mode & ProfileMode &&
-          getExecutionContext() & CommitContext
-        ) {
+        if (shouldProfile(current)) {
           try {
             startLayoutEffectTimer();
             retVal = ref(null);
@@ -701,12 +700,7 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
   // This is done to prevent sibling component effects from interfering with each other,
   // e.g. a destroy function in one component should never override a ref set
   // by a create function in another component during the same commit.
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     try {
       startLayoutEffectTimer();
       commitHookEffectListMount(hookFlags, finishedWork);
@@ -759,12 +753,7 @@ function commitClassLayoutLifecycles(
         }
       }
     }
-    if (
-      enableProfilerTimer &&
-      enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode &&
-      getExecutionContext() & CommitContext
-    ) {
+    if (shouldProfile(finishedWork)) {
       try {
         startLayoutEffectTimer();
         instance.componentDidMount();
@@ -815,12 +804,7 @@ function commitClassLayoutLifecycles(
         }
       }
     }
-    if (
-      enableProfilerTimer &&
-      enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode &&
-      getExecutionContext() & CommitContext
-    ) {
+    if (shouldProfile(finishedWork)) {
       try {
         startLayoutEffectTimer();
         instance.componentDidUpdate(
@@ -1351,12 +1335,7 @@ function commitAttachRef(finishedWork: Fiber) {
     }
     if (typeof ref === 'function') {
       let retVal;
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(finishedWork)) {
         try {
           startLayoutEffectTimer();
           retVal = ref(instanceToUse);
@@ -1395,12 +1374,7 @@ function commitDetachRef(current: Fiber) {
   const currentRef = current.ref;
   if (currentRef !== null) {
     if (typeof currentRef === 'function') {
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        current.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(current)) {
         try {
           startLayoutEffectTimer();
           currentRef(null);
@@ -1926,12 +1900,7 @@ function commitDeletionEffectsOnFiber(
                     markComponentLayoutEffectUnmountStarted(deletedFiber);
                   }
 
-                  if (
-                    enableProfilerTimer &&
-                    enableProfilerCommitHooks &&
-                    deletedFiber.mode & ProfileMode &&
-                    getExecutionContext() & CommitContext
-                  ) {
+                  if (shouldProfile(deletedFiber)) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
                       deletedFiber,
@@ -2250,12 +2219,7 @@ function commitMutationEffectsOnFiber(
         // This prevents sibling component effects from interfering with each other,
         // e.g. a destroy function in one component should never override a ref set
         // by a create function in another component during the same commit.
-        if (
-          enableProfilerTimer &&
-          enableProfilerCommitHooks &&
-          finishedWork.mode & ProfileMode &&
-          getExecutionContext() & CommitContext
-        ) {
+        if (shouldProfile(finishedWork)) {
           try {
             startLayoutEffectTimer();
             commitHookEffectListUnmount(
@@ -2648,12 +2612,7 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
     case MemoComponent:
     case SimpleMemoComponent: {
       // TODO (Offscreen) Check: flags & LayoutStatic
-      if (
-        enableProfilerTimer &&
-        enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode &&
-        getExecutionContext() & CommitContext
-      ) {
+      if (shouldProfile(finishedWork)) {
         try {
           startLayoutEffectTimer();
           commitHookEffectListUnmount(
@@ -2891,12 +2850,7 @@ function commitHookPassiveMountEffects(
   finishedWork: Fiber,
   hookFlags: HookFlags,
 ) {
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     startPassiveEffectTimer();
     try {
       commitHookEffectListMount(hookFlags, finishedWork);
@@ -3601,12 +3555,7 @@ function commitHookPassiveUnmountEffects(
   nearestMountedAncestor,
   hookFlags: HookFlags,
 ) {
-  if (
-    enableProfilerTimer &&
-    enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
-  ) {
+  if (shouldProfile(finishedWork)) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
       hookFlags,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -149,6 +149,7 @@ import {
   setIsRunningInsertionEffect,
   getExecutionContext,
   CommitContext,
+  NoContext,
 } from './ReactFiberWorkLoop.old';
 import {
   NoFlags as NoHookEffect,
@@ -201,12 +202,12 @@ let nextEffect: Fiber | null = null;
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
 
-function shouldProfile(current: Fiber): Boolean {
+function shouldProfile(current: Fiber): boolean {
   return (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    current.mode & ProfileMode &&
-    getExecutionContext() & CommitContext
+    (current.mode & ProfileMode) !== NoMode &&
+    (getExecutionContext() & CommitContext) !== NoContext
   );
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -147,6 +147,8 @@ import {
   addMarkerProgressCallbackToPendingTransition,
   addMarkerCompleteCallbackToPendingTransition,
   setIsRunningInsertionEffect,
+  getExecutionContext,
+  CommitContext,
 } from './ReactFiberWorkLoop.old';
 import {
   NoFlags as NoHookEffect,
@@ -198,7 +200,6 @@ let nextEffect: Fiber | null = null;
 // Used for Profiling builds to track updaters.
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
-let enableProfilingDEV = true;
 
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
@@ -221,7 +222,7 @@ const callComponentWillUnmountWithTimer = function(current, instance) {
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     current.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     try {
       startLayoutEffectTimer();
@@ -266,7 +267,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
           current.mode & ProfileMode &&
-          enableProfilingDEV
+          getExecutionContext() & CommitContext
         ) {
           try {
             startLayoutEffectTimer();
@@ -643,7 +644,11 @@ export function commitPassiveEffectDurations(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
 ): void {
-  if (enableProfilerTimer && enableProfilerCommitHooks && enableProfilingDEV) {
+  if (
+    enableProfilerTimer &&
+    enableProfilerCommitHooks &&
+    getExecutionContext() & CommitContext
+  ) {
     // Only Profilers with work in their subtree will have an Update effect scheduled.
     if ((finishedWork.flags & Update) !== NoFlags) {
       switch (finishedWork.tag) {
@@ -700,7 +705,7 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     try {
       startLayoutEffectTimer();
@@ -758,7 +763,7 @@ function commitClassLayoutLifecycles(
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
       finishedWork.mode & ProfileMode &&
-      enableProfilingDEV
+      getExecutionContext() & CommitContext
     ) {
       try {
         startLayoutEffectTimer();
@@ -814,7 +819,7 @@ function commitClassLayoutLifecycles(
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
       finishedWork.mode & ProfileMode &&
-      enableProfilingDEV
+      getExecutionContext() & CommitContext
     ) {
       try {
         startLayoutEffectTimer();
@@ -897,7 +902,7 @@ function commitHostComponentMount(finishedWork: Fiber) {
 }
 
 function commitProfilerUpdate(finishedWork: Fiber, current: Fiber | null) {
-  if (enableProfilerTimer && enableProfilingDEV) {
+  if (enableProfilerTimer && getExecutionContext() & CommitContext) {
     try {
       const {onCommit, onRender} = finishedWork.memoizedProps;
       const {effectDuration} = finishedWork.stateNode;
@@ -1350,7 +1355,7 @@ function commitAttachRef(finishedWork: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         finishedWork.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -1394,7 +1399,7 @@ function commitDetachRef(current: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         current.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -1925,7 +1930,7 @@ function commitDeletionEffectsOnFiber(
                     enableProfilerTimer &&
                     enableProfilerCommitHooks &&
                     deletedFiber.mode & ProfileMode &&
-                    enableProfilingDEV
+                    getExecutionContext() & CommitContext
                   ) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
@@ -2249,7 +2254,7 @@ function commitMutationEffectsOnFiber(
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
           finishedWork.mode & ProfileMode &&
-          enableProfilingDEV
+          getExecutionContext() & CommitContext
         ) {
           try {
             startLayoutEffectTimer();
@@ -2647,7 +2652,7 @@ export function disappearLayoutEffects(finishedWork: Fiber) {
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
         finishedWork.mode & ProfileMode &&
-        enableProfilingDEV
+        getExecutionContext() & CommitContext
       ) {
         try {
           startLayoutEffectTimer();
@@ -2890,7 +2895,7 @@ function commitHookPassiveMountEffects(
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     startPassiveEffectTimer();
     try {
@@ -3600,7 +3605,7 @@ function commitHookPassiveUnmountEffects(
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
     finishedWork.mode & ProfileMode &&
-    enableProfilingDEV
+    getExecutionContext() & CommitContext
   ) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
@@ -3879,12 +3884,6 @@ function commitPassiveUnmountInsideDeletedTreeOnFiber(
       }
       break;
     }
-  }
-}
-
-export function setEnableProfilingDEV(_enableProfilingDEV: boolean) {
-  if (__DEV__) {
-    enableProfilingDEV = _enableProfilingDEV;  
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -40,7 +40,6 @@ import {
   enableSchedulingProfiler,
   enableSuspenseCallback,
   enableScopeAPI,
-  enableStrictEffects,
   deletedTreeCleanUpLevel,
   enableUpdaterTracking,
   enableCache,
@@ -199,6 +198,7 @@ let nextEffect: Fiber | null = null;
 // Used for Profiling builds to track updaters.
 let inProgressLanes: Lanes | null = null;
 let inProgressRoot: FiberRoot | null = null;
+let enableProfilingDEV = true;
 
 export function reportUncaughtErrorInDEV(error: mixed) {
   // Wrapping each small part of the commit phase into a guarded
@@ -220,7 +220,8 @@ const callComponentWillUnmountWithTimer = function(current, instance) {
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    current.mode & ProfileMode
+    current.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     try {
       startLayoutEffectTimer();
@@ -264,7 +265,8 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         if (
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
-          current.mode & ProfileMode
+          current.mode & ProfileMode &&
+          enableProfilingDEV
         ) {
           try {
             startLayoutEffectTimer();
@@ -641,7 +643,7 @@ export function commitPassiveEffectDurations(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
 ): void {
-  if (enableProfilerTimer && enableProfilerCommitHooks) {
+  if (enableProfilerTimer && enableProfilerCommitHooks && enableProfilingDEV) {
     // Only Profilers with work in their subtree will have an Update effect scheduled.
     if ((finishedWork.flags & Update) !== NoFlags) {
       switch (finishedWork.tag) {
@@ -697,7 +699,8 @@ function commitHookLayoutEffects(finishedWork: Fiber, hookFlags: HookFlags) {
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     try {
       startLayoutEffectTimer();
@@ -754,7 +757,8 @@ function commitClassLayoutLifecycles(
     if (
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode
+      finishedWork.mode & ProfileMode &&
+      enableProfilingDEV
     ) {
       try {
         startLayoutEffectTimer();
@@ -809,7 +813,8 @@ function commitClassLayoutLifecycles(
     if (
       enableProfilerTimer &&
       enableProfilerCommitHooks &&
-      finishedWork.mode & ProfileMode
+      finishedWork.mode & ProfileMode &&
+      enableProfilingDEV
     ) {
       try {
         startLayoutEffectTimer();
@@ -892,7 +897,7 @@ function commitHostComponentMount(finishedWork: Fiber) {
 }
 
 function commitProfilerUpdate(finishedWork: Fiber, current: Fiber | null) {
-  if (enableProfilerTimer) {
+  if (enableProfilerTimer && enableProfilingDEV) {
     try {
       const {onCommit, onRender} = finishedWork.memoizedProps;
       const {effectDuration} = finishedWork.stateNode;
@@ -1344,7 +1349,8 @@ function commitAttachRef(finishedWork: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode
+        finishedWork.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -1387,7 +1393,8 @@ function commitDetachRef(current: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        current.mode & ProfileMode
+        current.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -1917,7 +1924,8 @@ function commitDeletionEffectsOnFiber(
                   if (
                     enableProfilerTimer &&
                     enableProfilerCommitHooks &&
-                    deletedFiber.mode & ProfileMode
+                    deletedFiber.mode & ProfileMode &&
+                    enableProfilingDEV
                   ) {
                     startLayoutEffectTimer();
                     safelyCallDestroy(
@@ -2240,7 +2248,8 @@ function commitMutationEffectsOnFiber(
         if (
           enableProfilerTimer &&
           enableProfilerCommitHooks &&
-          finishedWork.mode & ProfileMode
+          finishedWork.mode & ProfileMode &&
+          enableProfilingDEV
         ) {
           try {
             startLayoutEffectTimer();
@@ -2627,7 +2636,7 @@ function recursivelyTraverseLayoutEffects(
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function disappearLayoutEffects(finishedWork: Fiber) {
+export function disappearLayoutEffects(finishedWork: Fiber) {
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:
@@ -2637,7 +2646,8 @@ function disappearLayoutEffects(finishedWork: Fiber) {
       if (
         enableProfilerTimer &&
         enableProfilerCommitHooks &&
-        finishedWork.mode & ProfileMode
+        finishedWork.mode & ProfileMode &&
+        enableProfilingDEV
       ) {
         try {
           startLayoutEffectTimer();
@@ -2709,7 +2719,7 @@ function recursivelyTraverseDisappearLayoutEffects(parentFiber: Fiber) {
   }
 }
 
-function reappearLayoutEffects(
+export function reappearLayoutEffects(
   finishedRoot: FiberRoot,
   current: Fiber | null,
   finishedWork: Fiber,
@@ -2879,7 +2889,8 @@ function commitHookPassiveMountEffects(
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     startPassiveEffectTimer();
     try {
@@ -3304,7 +3315,7 @@ function recursivelyTraverseReconnectPassiveEffects(
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function reconnectPassiveEffects(
+export function reconnectPassiveEffects(
   finishedRoot: FiberRoot,
   finishedWork: Fiber,
   committedLanes: Lanes,
@@ -3588,7 +3599,8 @@ function commitHookPassiveUnmountEffects(
   if (
     enableProfilerTimer &&
     enableProfilerCommitHooks &&
-    finishedWork.mode & ProfileMode
+    finishedWork.mode & ProfileMode &&
+    enableProfilingDEV
   ) {
     startPassiveEffectTimer();
     commitHookEffectListUnmount(
@@ -3718,7 +3730,7 @@ function recursivelyTraverseDisconnectPassiveEffects(parentFiber: Fiber): void {
   setCurrentDebugFiberInDEV(prevDebugFiber);
 }
 
-function disconnectPassiveEffect(finishedWork: Fiber): void {
+export function disconnectPassiveEffect(finishedWork: Fiber): void {
   switch (finishedWork.tag) {
     case FunctionComponent:
     case ForwardRef:
@@ -3870,112 +3882,10 @@ function commitPassiveUnmountInsideDeletedTreeOnFiber(
   }
 }
 
-// TODO: Reuse reappearLayoutEffects traversal here?
-function invokeLayoutEffectMountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListMount(HookLayout | HookHasEffect, fiber);
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-      case ClassComponent: {
-        const instance = fiber.stateNode;
-        try {
-          instance.componentDidMount();
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-    }
+export function setEnableProfilingDEV(_enableProfilingDEV: boolean) {
+  if (__DEV__) {
+    enableProfilingDEV = _enableProfilingDEV;  
   }
 }
 
-function invokePassiveEffectMountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListMount(HookPassive | HookHasEffect, fiber);
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-    }
-  }
-}
-
-function invokeLayoutEffectUnmountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListUnmount(
-            HookLayout | HookHasEffect,
-            fiber,
-            fiber.return,
-          );
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-        break;
-      }
-      case ClassComponent: {
-        const instance = fiber.stateNode;
-        if (typeof instance.componentWillUnmount === 'function') {
-          safelyCallComponentWillUnmount(fiber, fiber.return, instance);
-        }
-        break;
-      }
-    }
-  }
-}
-
-function invokePassiveEffectUnmountInDEV(fiber: Fiber): void {
-  if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
-    switch (fiber.tag) {
-      case FunctionComponent:
-      case ForwardRef:
-      case SimpleMemoComponent: {
-        try {
-          commitHookEffectListUnmount(
-            HookPassive | HookHasEffect,
-            fiber,
-            fiber.return,
-          );
-        } catch (error) {
-          captureCommitPhaseError(fiber, fiber.return, error);
-        }
-      }
-    }
-  }
-}
-
-export {
-  commitPlacement,
-  commitAttachRef,
-  commitDetachRef,
-  invokeLayoutEffectMountInDEV,
-  invokeLayoutEffectUnmountInDEV,
-  invokePassiveEffectMountInDEV,
-  invokePassiveEffectUnmountInDEV,
-};
+export {commitPlacement, commitAttachRef, commitDetachRef};

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -12,52 +12,53 @@ import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 export type Flags = number;
 
 // Don't change these two values. They're used by React Dev Tools.
-export const NoFlags = /*                      */ 0b0000000000000000000000000;
-export const PerformedWork = /*                */ 0b0000000000000000000000001;
+export const NoFlags = /*                      */ 0b00000000000000000000000000;
+export const PerformedWork = /*                */ 0b00000000000000000000000001;
 
 // You can change the rest (and add more).
-export const Placement = /*                    */ 0b0000000000000000000000010;
-export const Update = /*                       */ 0b0000000000000000000000100;
-export const ChildDeletion = /*                */ 0b0000000000000000000001000;
-export const ContentReset = /*                 */ 0b0000000000000000000010000;
-export const Callback = /*                     */ 0b0000000000000000000100000;
-export const DidCapture = /*                   */ 0b0000000000000000001000000;
-export const ForceClientRender = /*            */ 0b0000000000000000010000000;
-export const Ref = /*                          */ 0b0000000000000000100000000;
-export const Snapshot = /*                     */ 0b0000000000000001000000000;
-export const Passive = /*                      */ 0b0000000000000010000000000;
-export const Hydrating = /*                    */ 0b0000000000000100000000000;
-export const Visibility = /*                   */ 0b0000000000001000000000000;
-export const StoreConsistency = /*             */ 0b0000000000010000000000000;
+export const Placement = /*                    */ 0b00000000000000000000000010;
+export const Update = /*                       */ 0b00000000000000000000000100;
+export const ChildDeletion = /*                */ 0b00000000000000000000001000;
+export const ContentReset = /*                 */ 0b00000000000000000000010000;
+export const Callback = /*                     */ 0b00000000000000000000100000;
+export const DidCapture = /*                   */ 0b00000000000000000001000000;
+export const ForceClientRender = /*            */ 0b00000000000000000010000000;
+export const Ref = /*                          */ 0b00000000000000000100000000;
+export const Snapshot = /*                     */ 0b00000000000000001000000000;
+export const Passive = /*                      */ 0b00000000000000010000000000;
+export const Hydrating = /*                    */ 0b00000000000000100000000000;
+export const Visibility = /*                   */ 0b00000000000001000000000000;
+export const StoreConsistency = /*             */ 0b00000000000010000000000000;
 
 export const LifecycleEffectMask =
   Passive | Update | Callback | Ref | Snapshot | StoreConsistency;
 
 // Union of all commit flags (flags with the lifetime of a particular commit)
-export const HostEffectMask = /*               */ 0b0000000000011111111111111;
+export const HostEffectMask = /*               */ 0b00000000000011111111111111;
 
 // These are not really side effects, but we still reuse this field.
-export const Incomplete = /*                   */ 0b0000000000100000000000000;
-export const ShouldCapture = /*                */ 0b0000000001000000000000000;
-export const ForceUpdateForLegacySuspense = /* */ 0b0000000010000000000000000;
-export const DidPropagateContext = /*          */ 0b0000000100000000000000000;
-export const NeedsPropagation = /*             */ 0b0000001000000000000000000;
-export const Forked = /*                       */ 0b0000010000000000000000000;
+export const Incomplete = /*                   */ 0b00000000000100000000000000;
+export const ShouldCapture = /*                */ 0b00000000001000000000000000;
+export const ForceUpdateForLegacySuspense = /* */ 0b00000000010000000000000000;
+export const DidPropagateContext = /*          */ 0b00000000100000000000000000;
+export const NeedsPropagation = /*             */ 0b00000001000000000000000000;
+export const Forked = /*                       */ 0b00000010000000000000000000;
 
 // Static tags describe aspects of a fiber that are not specific to a render,
 // e.g. a fiber uses a passive effect (even if there are no updates on this particular render).
 // This enables us to defer more work in the unmount case,
 // since we can defer traversing the tree during layout to look for Passive effects,
 // and instead rely on the static flag as a signal that there may be cleanup work.
-export const RefStatic = /*                    */ 0b0000100000000000000000000;
-export const LayoutStatic = /*                 */ 0b0001000000000000000000000;
-export const PassiveStatic = /*                */ 0b0010000000000000000000000;
+export const RefStatic = /*                    */ 0b00000100000000000000000000;
+export const LayoutStatic = /*                 */ 0b00001000000000000000000000;
+export const PassiveStatic = /*                */ 0b00010000000000000000000000;
 
 // These flags allow us to traverse to fibers that have effects on mount
 // without traversing the entire tree after every commit for
 // double invoking
-export const MountLayoutDev = /*               */ 0b0100000000000000000000000;
-export const MountPassiveDev = /*              */ 0b1000000000000000000000000;
+export const MountLayoutDev = /*               */ 0b00100000000000000000000000;
+export const MountPassiveDev = /*              */ 0b01000000000000000000000000;
+export const PlacementDEV = /*                 */ 0b10000000000000000000000000;
 
 // Groups of flags that are used in the commit phase to skip over trees that
 // don't contain effects, by checking subtreeFlags.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -3005,10 +3005,12 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   isInStrictMode: boolean,
   hasPassiveEffects: boolean,
 ) {
-  let child = parentFiber.child;
-  while (child !== null) {
-    doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
-    child = child.sibling;
+  if (parentFiber.subtreeFlags & PlacementDEV) {
+    let child = parentFiber.child;
+    while (child !== null) {
+      doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
+      child = child.sibling;
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -2428,7 +2428,7 @@ function commitRootImpl(
 
   if (__DEV__ && enableStrictEffects) {
     if (!rootDidHavePassiveEffects) {
-      commitDoubleInvokeEffectsInDEV(root, false);
+      commitDoubleInvokeEffectsInDEV(root);
     }
   }
 
@@ -2645,7 +2645,7 @@ function flushPassiveEffectsImpl() {
   }
 
   if (__DEV__ && enableStrictEffects) {
-    commitDoubleInvokeEffectsInDEV(root, true);
+    commitDoubleInvokeEffectsInDEV(root);
   }
 
   executionContext = prevExecutionContext;
@@ -3003,12 +3003,11 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   root: FiberRoot,
   parentFiber: Fiber,
   isInStrictMode: boolean,
-  hasPassiveEffects: boolean,
 ) {
   if (parentFiber.subtreeFlags & PlacementDEV) {
     let child = parentFiber.child;
     while (child !== null) {
-      doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
+      doubleInvokeEffectsInDEV(root, child, isInStrictMode);
       child = child.sibling;
     }
   }
@@ -3018,7 +3017,6 @@ function doubleInvokeEffectsInDEV(
   root: FiberRoot,
   fiber: Fiber,
   parentIsInStrictMode: boolean,
-  hasPassiveEffects: boolean,
 ) {
   const isStrictModeFiber = fiber.type === REACT_STRICT_MODE_TYPE;
   const isInStrictMode = parentIsInStrictMode || isStrictModeFiber;
@@ -3026,31 +3024,17 @@ function doubleInvokeEffectsInDEV(
     setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode) {
       disappearLayoutEffects(fiber);
-    }
-    if (hasPassiveEffects && isInStrictMode) {
       disconnectPassiveEffect(fiber);
-    }
-    if (isInStrictMode) {
       reappearLayoutEffects(root, fiber.alternate, fiber, false);
-    }
-    if (hasPassiveEffects && isInStrictMode) {
       reconnectPassiveEffects(root, fiber, NoLanes, null, false);
     }
     resetCurrentDebugFiberInDEV();
   } else {
-    recursivelyTraverseAndDoubleInvokeEffectsInDEV(
-      root,
-      fiber,
-      isInStrictMode,
-      hasPassiveEffects,
-    );
+    recursivelyTraverseAndDoubleInvokeEffectsInDEV(root, fiber, isInStrictMode);
   }
 }
 
-function commitDoubleInvokeEffectsInDEV(
-  root: FiberRoot,
-  hasPassiveEffects: boolean,
-) {
+function commitDoubleInvokeEffectsInDEV(root: FiberRoot) {
   if (__DEV__ && enableStrictEffects) {
     let doubleInvokeEffects = true;
 
@@ -3067,7 +3051,6 @@ function commitDoubleInvokeEffectsInDEV(
       root,
       root.current,
       doubleInvokeEffects,
-      hasPassiveEffects,
     );
   }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -13,7 +13,6 @@ import type {Wakeable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.new';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
-import {PlacementDEV} from './ReactFiberFlags';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.new';
 import type {EventPriority} from './ReactEventPriorities.new';
 import type {
@@ -123,6 +122,7 @@ import {
   MutationMask,
   LayoutMask,
   PassiveMask,
+  PlacementDEV,
 } from './ReactFiberFlags';
 import {
   NoLanes,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -3004,12 +3004,10 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   parentFiber: Fiber,
   isInStrictMode: boolean,
 ) {
-  if (parentFiber.subtreeFlags & PlacementDEV) {
-    let child = parentFiber.child;
-    while (child !== null) {
-      doubleInvokeEffectsInDEV(root, child, isInStrictMode);
-      child = child.sibling;
-    }
+  let child = parentFiber.child;
+  while (child !== null) {
+    doubleInvokeEffectsInDEV(root, child, isInStrictMode);
+    child = child.sibling;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -187,7 +187,6 @@ import {
   reappearLayoutEffects,
   disconnectPassiveEffect,
   reportUncaughtErrorInDEV,
-  setEnableProfilingDEV,
 } from './ReactFiberCommitWork.new';
 import {enqueueUpdate} from './ReactFiberClassUpdateQueue.new';
 import {resetContextDependencies} from './ReactFiberNewContext.new';
@@ -274,7 +273,7 @@ type ExecutionContext = number;
 export const NoContext = /*             */ 0b000;
 const BatchedContext = /*               */ 0b001;
 const RenderContext = /*                */ 0b010;
-const CommitContext = /*                */ 0b100;
+export const CommitContext = /*         */ 0b100;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 const RootInProgress = 0;
@@ -3058,14 +3057,12 @@ function commitDoubleInvokeEffectsInDEV(
     ) {
       doubleInvokeEffects = false;
     }
-    setEnableProfilingDEV(false);
     recursivelyTraverseAndDoubleInvokeEffectsInDEV(
       root,
       root.current,
       hasPassiveEffects,
       doubleInvokeEffects,
     );
-    setEnableProfilingDEV(true);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -3021,6 +3021,7 @@ function doubleInvokeEffectsInDEV(
   const isStrictModeFiber = fiber.type === REACT_STRICT_MODE_TYPE;
   const isInStrictMode = parentIsInStrictMode || isStrictModeFiber;
   if (fiber.flags & PlacementDEV || fiber.tag === OffscreenComponent) {
+    setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode) {
       disappearLayoutEffects(fiber);
     }
@@ -3033,6 +3034,7 @@ function doubleInvokeEffectsInDEV(
     if (hasPassiveEffects && isInStrictMode) {
       reconnectPassiveEffects(root, fiber, NoLanes, null, false);
     }
+    resetCurrentDebugFiberInDEV();
   } else {
     recursivelyTraverseAndDoubleInvokeEffectsInDEV(
       root,

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -3005,10 +3005,12 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   isInStrictMode: boolean,
   hasPassiveEffects: boolean,
 ) {
-  let child = parentFiber.child;
-  while (child !== null) {
-    doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
-    child = child.sibling;
+  if (parentFiber.subtreeFlags & PlacementDEV) {
+    let child = parentFiber.child;
+    while (child !== null) {
+      doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
+      child = child.sibling;
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -2428,7 +2428,7 @@ function commitRootImpl(
 
   if (__DEV__ && enableStrictEffects) {
     if (!rootDidHavePassiveEffects) {
-      commitDoubleInvokeEffectsInDEV(root, false);
+      commitDoubleInvokeEffectsInDEV(root);
     }
   }
 
@@ -2645,7 +2645,7 @@ function flushPassiveEffectsImpl() {
   }
 
   if (__DEV__ && enableStrictEffects) {
-    commitDoubleInvokeEffectsInDEV(root, true);
+    commitDoubleInvokeEffectsInDEV(root);
   }
 
   executionContext = prevExecutionContext;
@@ -3003,12 +3003,11 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   root: FiberRoot,
   parentFiber: Fiber,
   isInStrictMode: boolean,
-  hasPassiveEffects: boolean,
 ) {
   if (parentFiber.subtreeFlags & PlacementDEV) {
     let child = parentFiber.child;
     while (child !== null) {
-      doubleInvokeEffectsInDEV(root, child, isInStrictMode, hasPassiveEffects);
+      doubleInvokeEffectsInDEV(root, child, isInStrictMode);
       child = child.sibling;
     }
   }
@@ -3018,7 +3017,6 @@ function doubleInvokeEffectsInDEV(
   root: FiberRoot,
   fiber: Fiber,
   parentIsInStrictMode: boolean,
-  hasPassiveEffects: boolean,
 ) {
   const isStrictModeFiber = fiber.type === REACT_STRICT_MODE_TYPE;
   const isInStrictMode = parentIsInStrictMode || isStrictModeFiber;
@@ -3026,31 +3024,17 @@ function doubleInvokeEffectsInDEV(
     setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode) {
       disappearLayoutEffects(fiber);
-    }
-    if (hasPassiveEffects && isInStrictMode) {
       disconnectPassiveEffect(fiber);
-    }
-    if (isInStrictMode) {
       reappearLayoutEffects(root, fiber.alternate, fiber, false);
-    }
-    if (hasPassiveEffects && isInStrictMode) {
       reconnectPassiveEffects(root, fiber, NoLanes, null, false);
     }
     resetCurrentDebugFiberInDEV();
   } else {
-    recursivelyTraverseAndDoubleInvokeEffectsInDEV(
-      root,
-      fiber,
-      isInStrictMode,
-      hasPassiveEffects,
-    );
+    recursivelyTraverseAndDoubleInvokeEffectsInDEV(root, fiber, isInStrictMode);
   }
 }
 
-function commitDoubleInvokeEffectsInDEV(
-  root: FiberRoot,
-  hasPassiveEffects: boolean,
-) {
+function commitDoubleInvokeEffectsInDEV(root: FiberRoot) {
   if (__DEV__ && enableStrictEffects) {
     let doubleInvokeEffects = true;
 
@@ -3067,7 +3051,6 @@ function commitDoubleInvokeEffectsInDEV(
       root,
       root.current,
       doubleInvokeEffects,
-      hasPassiveEffects,
     );
   }
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -13,7 +13,6 @@ import type {Wakeable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.old';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
-import {PlacementDEV} from './ReactFiberFlags';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.old';
 import type {EventPriority} from './ReactEventPriorities.old';
 import type {
@@ -123,6 +122,7 @@ import {
   MutationMask,
   LayoutMask,
   PassiveMask,
+  PlacementDEV,
 } from './ReactFiberFlags';
 import {
   NoLanes,
@@ -187,7 +187,6 @@ import {
   reappearLayoutEffects,
   disconnectPassiveEffect,
   reportUncaughtErrorInDEV,
-  setEnableProfilingDEV,
 } from './ReactFiberCommitWork.old';
 import {enqueueUpdate} from './ReactFiberClassUpdateQueue.old';
 import {resetContextDependencies} from './ReactFiberNewContext.old';
@@ -274,7 +273,7 @@ type ExecutionContext = number;
 export const NoContext = /*             */ 0b000;
 const BatchedContext = /*               */ 0b001;
 const RenderContext = /*                */ 0b010;
-const CommitContext = /*                */ 0b100;
+export const CommitContext = /*         */ 0b100;
 
 type RootExitStatus = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 const RootInProgress = 0;
@@ -3058,14 +3057,12 @@ function commitDoubleInvokeEffectsInDEV(
     ) {
       doubleInvokeEffects = false;
     }
-    setEnableProfilingDEV(false);
     recursivelyTraverseAndDoubleInvokeEffectsInDEV(
       root,
       root.current,
       hasPassiveEffects,
       doubleInvokeEffects,
     );
-    setEnableProfilingDEV(true);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -3004,12 +3004,10 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   parentFiber: Fiber,
   isInStrictMode: boolean,
 ) {
-  if (parentFiber.subtreeFlags & PlacementDEV) {
-    let child = parentFiber.child;
-    while (child !== null) {
-      doubleInvokeEffectsInDEV(root, child, isInStrictMode);
-      child = child.sibling;
-    }
+  let child = parentFiber.child;
+  while (child !== null) {
+    doubleInvokeEffectsInDEV(root, child, isInStrictMode);
+    child = child.sibling;
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -7,11 +7,13 @@
  * @flow
  */
 
+import {REACT_STRICT_MODE_TYPE} from 'shared/ReactSymbols';
+
 import type {Wakeable} from 'shared/ReactTypes';
 import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.old';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
-import type {Flags} from './ReactFiberFlags';
+import {PlacementDEV} from './ReactFiberFlags';
 import type {FunctionComponentUpdateQueue} from './ReactFiberHooks.old';
 import type {EventPriority} from './ReactEventPriorities.old';
 import type {
@@ -90,7 +92,13 @@ import {
 } from './ReactFiber.old';
 import {isRootDehydrated} from './ReactFiberShellHydration';
 import {didSuspendOrErrorWhileHydratingDEV} from './ReactFiberHydrationContext.old';
-import {NoMode, ProfileMode, ConcurrentMode} from './ReactTypeOfMode';
+import {
+  NoMode,
+  ProfileMode,
+  ConcurrentMode,
+  StrictLegacyMode,
+  StrictEffectsMode,
+} from './ReactTypeOfMode';
 import {
   HostRoot,
   IndeterminateComponent,
@@ -104,7 +112,7 @@ import {
   SimpleMemoComponent,
   Profiler,
 } from './ReactWorkTags';
-import {LegacyRoot} from './ReactRootTags';
+import {ConcurrentRoot, LegacyRoot} from './ReactRootTags';
 import {
   NoFlags,
   Incomplete,
@@ -115,8 +123,6 @@ import {
   MutationMask,
   LayoutMask,
   PassiveMask,
-  MountPassiveDev,
-  MountLayoutDev,
 } from './ReactFiberFlags';
 import {
   NoLanes,
@@ -176,11 +182,12 @@ import {
   commitPassiveEffectDurations,
   commitPassiveMountEffects,
   commitPassiveUnmountEffects,
-  invokeLayoutEffectMountInDEV,
-  invokePassiveEffectMountInDEV,
-  invokeLayoutEffectUnmountInDEV,
-  invokePassiveEffectUnmountInDEV,
+  disappearLayoutEffects,
+  reconnectPassiveEffects,
+  reappearLayoutEffects,
+  disconnectPassiveEffect,
   reportUncaughtErrorInDEV,
+  setEnableProfilingDEV,
 } from './ReactFiberCommitWork.old';
 import {enqueueUpdate} from './ReactFiberClassUpdateQueue.old';
 import {resetContextDependencies} from './ReactFiberNewContext.old';
@@ -2422,7 +2429,7 @@ function commitRootImpl(
 
   if (__DEV__ && enableStrictEffects) {
     if (!rootDidHavePassiveEffects) {
-      commitDoubleInvokeEffectsInDEV(root.current, false);
+      commitDoubleInvokeEffectsInDEV(root, false);
     }
   }
 
@@ -2639,7 +2646,7 @@ function flushPassiveEffectsImpl() {
   }
 
   if (__DEV__ && enableStrictEffects) {
-    commitDoubleInvokeEffectsInDEV(root.current, true);
+    commitDoubleInvokeEffectsInDEV(root, true);
   }
 
   executionContext = prevExecutionContext;
@@ -2993,64 +3000,72 @@ function flushRenderPhaseStrictModeWarningsInDEV() {
   }
 }
 
-function commitDoubleInvokeEffectsInDEV(
+function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
+  root: FiberRoot,
   fiber: Fiber,
   hasPassiveEffects: boolean,
+  doubleInvokeEffects: boolean,
 ) {
-  if (__DEV__ && enableStrictEffects) {
-    // TODO (StrictEffects) Should we set a marker on the root if it contains strict effects
-    // so we don't traverse unnecessarily? similar to subtreeFlags but just at the root level.
-    // Maybe not a big deal since this is DEV only behavior.
+  if (fiber.type === REACT_STRICT_MODE_TYPE) {
+    doubleInvokeEffects = true;
+  }
 
-    setCurrentDebugFiberInDEV(fiber);
-    invokeEffectsInDev(fiber, MountLayoutDev, invokeLayoutEffectUnmountInDEV);
-    if (hasPassiveEffects) {
-      invokeEffectsInDev(
-        fiber,
-        MountPassiveDev,
-        invokePassiveEffectUnmountInDEV,
-      );
+  if (fiber.flags & PlacementDEV || fiber.tag === OffscreenComponent) {
+    if (doubleInvokeEffects) {
+      disappearLayoutEffects(fiber);
     }
+    if (hasPassiveEffects && doubleInvokeEffects) {
+      disconnectPassiveEffect(fiber);
+    }
+    if (doubleInvokeEffects) {
+      reappearLayoutEffects(root, fiber.alternate, fiber, NoLanes, false);
+    }
+    if (hasPassiveEffects && doubleInvokeEffects) {
+      reconnectPassiveEffects(root, fiber, NoLanes, null, false);
+    }
+  } else if (fiber.child !== null) {
+    recursivelyTraverseAndDoubleInvokeEffectsInDEV(
+      root,
+      fiber.child,
+      hasPassiveEffects,
+      doubleInvokeEffects,
+    );
+  }
 
-    invokeEffectsInDev(fiber, MountLayoutDev, invokeLayoutEffectMountInDEV);
-    if (hasPassiveEffects) {
-      invokeEffectsInDev(fiber, MountPassiveDev, invokePassiveEffectMountInDEV);
-    }
-    resetCurrentDebugFiberInDEV();
+  if (fiber.sibling !== null) {
+    recursivelyTraverseAndDoubleInvokeEffectsInDEV(
+      root,
+      fiber.sibling,
+      hasPassiveEffects,
+      doubleInvokeEffects,
+    );
   }
 }
 
-function invokeEffectsInDev(
-  firstChild: Fiber,
-  fiberFlags: Flags,
-  invokeEffectFn: (fiber: Fiber) => void,
-): void {
+function commitDoubleInvokeEffectsInDEV(
+  root: FiberRoot,
+  hasPassiveEffects: boolean,
+) {
   if (__DEV__ && enableStrictEffects) {
-    // We don't need to re-check StrictEffectsMode here.
-    // This function is only called if that check has already passed.
+    let doubleInvokeEffects = true;
 
-    let current = firstChild;
-    let subtreeRoot = null;
-    while (current !== null) {
-      const primarySubtreeFlag = current.subtreeFlags & fiberFlags;
-      if (
-        current !== subtreeRoot &&
-        current.child !== null &&
-        primarySubtreeFlag !== NoFlags
-      ) {
-        current = current.child;
-      } else {
-        if ((current.flags & fiberFlags) !== NoFlags) {
-          invokeEffectFn(current);
-        }
-
-        if (current.sibling !== null) {
-          current = current.sibling;
-        } else {
-          current = subtreeRoot = current.return;
-        }
-      }
+    if (root.tag === LegacyRoot && !(root.current.mode & StrictLegacyMode)) {
+      doubleInvokeEffects = false;
     }
+    if (
+      root.tag === ConcurrentRoot &&
+      !(root.current.mode & (StrictLegacyMode | StrictEffectsMode))
+    ) {
+      doubleInvokeEffects = false;
+    }
+    setEnableProfilingDEV(false);
+    recursivelyTraverseAndDoubleInvokeEffectsInDEV(
+      root,
+      root.current,
+      hasPassiveEffects,
+      doubleInvokeEffects,
+    );
+    setEnableProfilingDEV(true);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -3021,6 +3021,7 @@ function doubleInvokeEffectsInDEV(
   const isStrictModeFiber = fiber.type === REACT_STRICT_MODE_TYPE;
   const isInStrictMode = parentIsInStrictMode || isStrictModeFiber;
   if (fiber.flags & PlacementDEV || fiber.tag === OffscreenComponent) {
+    setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode) {
       disappearLayoutEffects(fiber);
     }
@@ -3033,6 +3034,7 @@ function doubleInvokeEffectsInDEV(
     if (hasPassiveEffects && isInStrictMode) {
       reconnectPassiveEffects(root, fiber, NoLanes, null, false);
     }
+    resetCurrentDebugFiberInDEV();
   } else {
     recursivelyTraverseAndDoubleInvokeEffectsInDEV(
       root,

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
@@ -1,0 +1,95 @@
+let React;
+let Offscreen;
+let ReactNoop;
+let act;
+let log;
+
+describe('ReactOffscreenStrictMode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    log = [];
+
+    React = require('react');
+    Offscreen = React.unstable_Offscreen;
+    ReactNoop = require('react-noop-renderer');
+    act = require('jest-react').act;
+
+    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
+    ReactFeatureFlags.enableStrictEffects = __DEV__;
+    ReactFeatureFlags.createRootStrictEffectsByDefault = __DEV__;
+  });
+
+  function Component({label}) {
+    React.useEffect(() => {
+      log.push(`${label}: useEffect mount`);
+      return () => log.push(`${label}: useEffect unmount`);
+    });
+
+    React.useLayoutEffect(() => {
+      log.push(`${label}: useLayoutEffect mount`);
+      return () => log.push(`${label}: useLayoutEffect unmount`);
+    });
+
+    log.push(`${label}: render`);
+
+    return <span>label</span>;
+  }
+
+  // @gate enableOffscreen
+  // @gate __DEV__
+  it('should trigger strict effects when offscreen is visible', () => {
+    act(() => {
+      ReactNoop.render(
+        <Offscreen mode="visible">
+          <Component label="A" />
+        </Offscreen>,
+      );
+    });
+
+    expect(log).toEqual([
+      'A: render',
+      'A: render',
+      'A: useLayoutEffect mount',
+      'A: useEffect mount',
+      'A: useLayoutEffect unmount',
+      'A: useEffect unmount',
+      'A: useLayoutEffect mount',
+      'A: useEffect mount',
+    ]);
+  });
+
+  // @gate enableOffscreen
+  // @gate __DEV__
+  it('should not trigger strict effects when offscreen is hidden', () => {
+    act(() => {
+      ReactNoop.render(
+        <Offscreen mode="hidden">
+          <Component label="A" />
+        </Offscreen>,
+      );
+    });
+
+    expect(log).toEqual(['A: render', 'A: render']);
+
+    log = [];
+
+    act(() => {
+      ReactNoop.render(
+        <Offscreen mode="visible">
+          <Component label="A" />
+        </Offscreen>,
+      );
+    });
+
+    expect(log).toEqual([
+      'A: render',
+      'A: render',
+      'A: useLayoutEffect mount',
+      'A: useEffect mount',
+      'A: useLayoutEffect unmount',
+      'A: useEffect unmount',
+      'A: useLayoutEffect mount',
+      'A: useEffect mount',
+    ]);
+  });
+});

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
@@ -13,10 +13,6 @@ describe('ReactOffscreenStrictMode', () => {
     Offscreen = React.unstable_Offscreen;
     ReactNoop = require('react-noop-renderer');
     act = require('jest-react').act;
-
-    const ReactFeatureFlags = require('shared/ReactFeatureFlags');
-    ReactFeatureFlags.enableStrictEffects = __DEV__;
-    ReactFeatureFlags.createRootStrictEffectsByDefault = __DEV__;
   });
 
   function Component({label}) {
@@ -35,14 +31,15 @@ describe('ReactOffscreenStrictMode', () => {
     return <span>label</span>;
   }
 
-  // @gate enableOffscreen
-  // @gate __DEV__
+  // @gate __DEV__ && enableStrictEffects && enableOffscreen
   it('should trigger strict effects when offscreen is visible', () => {
     act(() => {
       ReactNoop.render(
-        <Offscreen mode="visible">
-          <Component label="A" />
-        </Offscreen>,
+        <React.StrictMode>
+          <Offscreen mode="visible">
+            <Component label="A" />
+          </Offscreen>
+        </React.StrictMode>,
       );
     });
 
@@ -58,14 +55,15 @@ describe('ReactOffscreenStrictMode', () => {
     ]);
   });
 
-  // @gate enableOffscreen
-  // @gate __DEV__
+  // @gate __DEV__ && enableStrictEffects && enableOffscreen
   it('should not trigger strict effects when offscreen is hidden', () => {
     act(() => {
       ReactNoop.render(
-        <Offscreen mode="hidden">
-          <Component label="A" />
-        </Offscreen>,
+        <React.StrictMode>
+          <Offscreen mode="hidden">
+            <Component label="A" />
+          </Offscreen>
+        </React.StrictMode>,
       );
     });
 
@@ -75,9 +73,11 @@ describe('ReactOffscreenStrictMode', () => {
 
     act(() => {
       ReactNoop.render(
-        <Offscreen mode="visible">
-          <Component label="A" />
-        </Offscreen>,
+        <React.StrictMode>
+          <Offscreen mode="visible">
+            <Component label="A" />
+          </Offscreen>
+        </React.StrictMode>,
       );
     });
 

--- a/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsModeDefaults-test.internal.js
@@ -153,10 +153,8 @@ describe('StrictEffectsMode defaults', () => {
           </>,
         );
 
-        expect(Scheduler).toFlushAndYieldThrough([
-          'useLayoutEffect mount "one"',
-        ]);
         expect(Scheduler).toFlushAndYield([
+          'useLayoutEffect mount "one"',
           'useEffect mount "one"',
           'useLayoutEffect unmount "one"',
           'useEffect unmount "one"',
@@ -379,6 +377,29 @@ describe('StrictEffectsMode defaults', () => {
       });
 
       expect(Scheduler).toHaveYielded([]);
+    });
+
+    it('disconnects refs during double invoking', () => {
+      const onRefMock = jest.fn();
+      function App({text}) {
+        return (
+          <span
+            ref={ref => {
+              onRefMock(ref);
+            }}>
+            text
+          </span>
+        );
+      }
+
+      act(() => {
+        ReactNoop.render(<App text={'mount'} />);
+      });
+
+      expect(onRefMock.mock.calls.length).toBe(3);
+      expect(onRefMock.mock.calls[0][0]).not.toBeNull();
+      expect(onRefMock.mock.calls[1][0]).toBe(null);
+      expect(onRefMock.mock.calls[2][0]).not.toBeNull();
     });
 
     it('passes the right context to class component lifecycles', () => {

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -67,6 +67,7 @@ describe('ReactStrictMode', () => {
     );
   });
 
+  // @gate enableStrictEffects
   it('should invoke precommit lifecycle methods twice', () => {
     let log = [];
     let shouldComponentUpdate = false;
@@ -115,6 +116,8 @@ describe('ReactStrictMode', () => {
         'getDerivedStateFromProps',
         'render',
         'render',
+        'componentDidMount',
+        'componentWillUnmount',
         'componentDidMount',
       ]);
     } else {

--- a/packages/react/src/__tests__/ReactStrictMode-test.js
+++ b/packages/react/src/__tests__/ReactStrictMode-test.js
@@ -67,7 +67,7 @@ describe('ReactStrictMode', () => {
     );
   });
 
-  // @gate enableStrictEffects
+  // @gate __DEV__ && !enableStrictEffects
   it('should invoke precommit lifecycle methods twice', () => {
     let log = [];
     let shouldComponentUpdate = false;
@@ -108,26 +108,15 @@ describe('ReactStrictMode', () => {
       container,
     );
 
-    if (__DEV__) {
-      expect(log).toEqual([
-        'constructor',
-        'constructor',
-        'getDerivedStateFromProps',
-        'getDerivedStateFromProps',
-        'render',
-        'render',
-        'componentDidMount',
-        'componentWillUnmount',
-        'componentDidMount',
-      ]);
-    } else {
-      expect(log).toEqual([
-        'constructor',
-        'getDerivedStateFromProps',
-        'render',
-        'componentDidMount',
-      ]);
-    }
+    expect(log).toEqual([
+      'constructor',
+      'constructor',
+      'getDerivedStateFromProps',
+      'getDerivedStateFromProps',
+      'render',
+      'render',
+      'componentDidMount',
+    ]);
 
     log = [];
     shouldComponentUpdate = true;
@@ -138,24 +127,15 @@ describe('ReactStrictMode', () => {
       </React.StrictMode>,
       container,
     );
-    if (__DEV__) {
-      expect(log).toEqual([
-        'getDerivedStateFromProps',
-        'getDerivedStateFromProps',
-        'shouldComponentUpdate',
-        'shouldComponentUpdate',
-        'render',
-        'render',
-        'componentDidUpdate',
-      ]);
-    } else {
-      expect(log).toEqual([
-        'getDerivedStateFromProps',
-        'shouldComponentUpdate',
-        'render',
-        'componentDidUpdate',
-      ]);
-    }
+    expect(log).toEqual([
+      'getDerivedStateFromProps',
+      'getDerivedStateFromProps',
+      'shouldComponentUpdate',
+      'shouldComponentUpdate',
+      'render',
+      'render',
+      'componentDidUpdate',
+    ]);
 
     log = [];
     shouldComponentUpdate = false;
@@ -167,19 +147,12 @@ describe('ReactStrictMode', () => {
       container,
     );
 
-    if (__DEV__) {
-      expect(log).toEqual([
-        'getDerivedStateFromProps',
-        'getDerivedStateFromProps',
-        'shouldComponentUpdate',
-        'shouldComponentUpdate',
-      ]);
-    } else {
-      expect(log).toEqual([
-        'getDerivedStateFromProps',
-        'shouldComponentUpdate',
-      ]);
-    }
+    expect(log).toEqual([
+      'getDerivedStateFromProps',
+      'getDerivedStateFromProps',
+      'shouldComponentUpdate',
+      'shouldComponentUpdate',
+    ]);
   });
 
   it('should invoke setState callbacks twice', () => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

PR changes behaviour of StrictMode to better align it what mount/unmount/mount would look like in production.
We change custom traversal function that was previously used for StrictMode to functions used in production.
This has following implications:
- refs are now attached/detached/attached in StrictMode.
- When `<unstable_Offscreen />` is hidden, StrictMode doesn't double invoke effects. StrictMode will double invoke effects when `<unstable_Offscreen />` becomes visible.

## How did you test this change?

I've added tests for how `<unstable_Offscreen />` should behave in <StrictMode /> and a test to verify refs are detached in StrictMode.