### PR TITLE
Remove argument committedLanes from reappearLayoutEffects

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1099,7 +1099,6 @@ function commitLayoutEffectOnFiber(
             recursivelyTraverseReappearLayoutEffects(
               finishedRoot,
               finishedWork,
-              committedLanes,
               includeWorkInProgressEffects,
             );
           } else {
@@ -2704,7 +2703,6 @@ function reappearLayoutEffects(
   finishedRoot: FiberRoot,
   current: Fiber | null,
   finishedWork: Fiber,
-  committedLanes: Lanes,
   // This function visits both newly finished work and nodes that were re-used
   // from a previously committed tree. We cannot check non-static flags if the
   // node was reused.
@@ -2719,7 +2717,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       // TODO: Check flags & LayoutStatic
@@ -2730,7 +2727,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2772,7 +2768,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2792,7 +2787,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       // TODO: Figure out how Profiler updates should work with Offscreen
@@ -2805,7 +2799,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2825,7 +2818,6 @@ function reappearLayoutEffects(
         recursivelyTraverseReappearLayoutEffects(
           finishedRoot,
           finishedWork,
-          committedLanes,
           includeWorkInProgressEffects,
         );
       }
@@ -2835,7 +2827,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       break;
@@ -2846,7 +2837,6 @@ function reappearLayoutEffects(
 function recursivelyTraverseReappearLayoutEffects(
   finishedRoot: FiberRoot,
   parentFiber: Fiber,
-  committedLanes: Lanes,
   includeWorkInProgressEffects: boolean,
 ) {
   // This function visits both newly finished work and nodes that were re-used
@@ -2865,7 +2855,6 @@ function recursivelyTraverseReappearLayoutEffects(
       finishedRoot,
       current,
       child,
-      committedLanes,
       childShouldIncludeWorkInProgressEffects,
     );
     child = child.sibling;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1099,7 +1099,6 @@ function commitLayoutEffectOnFiber(
             recursivelyTraverseReappearLayoutEffects(
               finishedRoot,
               finishedWork,
-              committedLanes,
               includeWorkInProgressEffects,
             );
           } else {
@@ -2704,7 +2703,6 @@ function reappearLayoutEffects(
   finishedRoot: FiberRoot,
   current: Fiber | null,
   finishedWork: Fiber,
-  committedLanes: Lanes,
   // This function visits both newly finished work and nodes that were re-used
   // from a previously committed tree. We cannot check non-static flags if the
   // node was reused.
@@ -2719,7 +2717,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       // TODO: Check flags & LayoutStatic
@@ -2730,7 +2727,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2772,7 +2768,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2792,7 +2787,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       // TODO: Figure out how Profiler updates should work with Offscreen
@@ -2805,7 +2799,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
 
@@ -2825,7 +2818,6 @@ function reappearLayoutEffects(
         recursivelyTraverseReappearLayoutEffects(
           finishedRoot,
           finishedWork,
-          committedLanes,
           includeWorkInProgressEffects,
         );
       }
@@ -2835,7 +2827,6 @@ function reappearLayoutEffects(
       recursivelyTraverseReappearLayoutEffects(
         finishedRoot,
         finishedWork,
-        committedLanes,
         includeWorkInProgressEffects,
       );
       break;
@@ -2846,7 +2837,6 @@ function reappearLayoutEffects(
 function recursivelyTraverseReappearLayoutEffects(
   finishedRoot: FiberRoot,
   parentFiber: Fiber,
-  committedLanes: Lanes,
   includeWorkInProgressEffects: boolean,
 ) {
   // This function visits both newly finished work and nodes that were re-used
@@ -2865,7 +2855,6 @@ function recursivelyTraverseReappearLayoutEffects(
       finishedRoot,
       current,
       child,
-      committedLanes,
       childShouldIncludeWorkInProgressEffects,
     );
     child = child.sibling;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Remove unused argument from `reappearLayoutEffects` and `recursivelyTraverseReappearLayoutEffects`


## How did you test this change?

Run: `yarn flow dom`