### PR TITLE
[DevTools][Draftish] Use original window methods instead of allowing overrides

### DIFF
--- a/packages/react-devtools-extensions/src/backend.js
+++ b/packages/react-devtools-extensions/src/backend.js
@@ -7,6 +7,10 @@
 'use strict';
 
 let welcomeHasInitialized = false;
+const _window = {
+  addEventListener: window.addEventListener.bind(window),
+  removeEventListener: window.removeEventListener.bind(window),
+};
 
 function welcome(event) {
   if (
@@ -83,7 +87,7 @@ function setup(hook) {
     },
   });
 
-  const agent = new Agent(bridge);
+  const agent = new Agent(bridge, _window);
   agent.addListener('shutdown', () => {
     // If we received 'shutdown' from `agent`, we assume the `bridge` is already shutting down,
     // and that caused the 'shutdown' event on the `agent`, so we don't need to call `bridge.shutdown()` here.

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -30,6 +30,7 @@ import {currentBridgeProtocol} from 'react-devtools-shared/src/bridge';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {
+  _Window,
   InstanceAndStyle,
   NativeType,
   OwnersList,
@@ -155,7 +156,7 @@ export default class Agent extends EventEmitter<{|
   _persistedSelectionMatch: PathMatch | null = null;
   _traceUpdatesEnabled: boolean = false;
 
-  constructor(bridge: BackendBridge) {
+  constructor(bridge: BackendBridge, _window?: _Window) {
     super();
 
     if (
@@ -244,7 +245,7 @@ export default class Agent extends EventEmitter<{|
     bridge.send('isBackendStorageAPISupported', isBackendStorageAPISupported);
     bridge.send('isSynchronousXHRSupported', isSynchronousXHRSupported());
 
-    setupHighlighter(bridge, this);
+    setupHighlighter(bridge, this, _window);
     setupTraceUpdates(this);
   }
 

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -26,6 +26,11 @@ export type WorkTag = number;
 export type WorkFlags = number;
 export type ExpirationTime = number;
 
+export type _Window = {|
+  addEventListener: Function,
+  removeEventListener: Function,
+|};
+
 export type WorkTagMap = {|
   CacheComponent: WorkTag,
   ClassComponent: WorkTag,

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -13,6 +13,7 @@ import Agent from 'react-devtools-shared/src/backend/agent';
 import {hideOverlay, showOverlay} from './Highlighter';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
+import type {_Window} from 'react-devtools-shared/src/backend/types';
 
 // This plug-in provides in-page highlighting of the selected element.
 // It is used by the browser extension and the standalone DevTools shell (when connected to a browser).
@@ -24,6 +25,7 @@ let iframesListeningTo: Set<HTMLIFrameElement> = new Set();
 export default function setupHighlighter(
   bridge: BackendBridge,
   agent: Agent,
+  _window?: _Window,
 ): void {
   bridge.addListener(
     'clearNativeElementHighlight',
@@ -40,14 +42,21 @@ export default function setupHighlighter(
 
   function registerListenersOnWindow(window) {
     // This plug-in may run in non-DOM environments (e.g. React Native).
-    if (window && typeof window.addEventListener === 'function') {
-      window.addEventListener('click', onClick, true);
-      window.addEventListener('mousedown', onMouseEvent, true);
-      window.addEventListener('mouseover', onMouseEvent, true);
-      window.addEventListener('mouseup', onMouseEvent, true);
-      window.addEventListener('pointerdown', onPointerDown, true);
-      window.addEventListener('pointerover', onPointerOver, true);
-      window.addEventListener('pointerup', onPointerUp, true);
+    let addEventListener = null;
+    if (_window) {
+      addEventListener = _window.addEventListener;
+    } else if (window && typeof window.addEventListener === 'function') {
+      addEventListener = window.addEventListener;
+    }
+
+    if (addEventListener !== null) {
+      addEventListener('click', onClick, true);
+      addEventListener('mousedown', onMouseEvent, true);
+      addEventListener('mouseover', onMouseEvent, true);
+      addEventListener('mouseup', onMouseEvent, true);
+      addEventListener('pointerdown', onPointerDown, true);
+      addEventListener('pointerover', onPointerOver, true);
+      addEventListener('pointerup', onPointerUp, true);
     }
   }
 
@@ -66,14 +75,21 @@ export default function setupHighlighter(
 
   function removeListenersOnWindow(window) {
     // This plug-in may run in non-DOM environments (e.g. React Native).
-    if (window && typeof window.removeEventListener === 'function') {
-      window.removeEventListener('click', onClick, true);
-      window.removeEventListener('mousedown', onMouseEvent, true);
-      window.removeEventListener('mouseover', onMouseEvent, true);
-      window.removeEventListener('mouseup', onMouseEvent, true);
-      window.removeEventListener('pointerdown', onPointerDown, true);
-      window.removeEventListener('pointerover', onPointerOver, true);
-      window.removeEventListener('pointerup', onPointerUp, true);
+    let removeEventListener = null;
+    if (_window) {
+      removeEventListener = _window.removeEventListener;
+    } else if (window && typeof window.removeEventListener === 'function') {
+      removeEventListener = window.removeEventListener;
+    }
+
+    if (removeEventListener !== null) {
+      removeEventListener('click', onClick, true);
+      removeEventListener('mousedown', onMouseEvent, true);
+      removeEventListener('mouseover', onMouseEvent, true);
+      removeEventListener('mouseup', onMouseEvent, true);
+      removeEventListener('pointerdown', onPointerDown, true);
+      removeEventListener('pointerover', onPointerOver, true);
+      removeEventListener('pointerup', onPointerUp, true);
     }
   }
 


### PR DESCRIPTION
Certain apps will intercept and override window methods to do things like logging. When the override functions aren't implemented correctly, however, it breaks DevTools because the DevTools backend shares the same window object as the app. This is a proof of concept implementation that called the original window methods for `addEventListener` and `removeEventListener` instead of the overridden one.

