### PR TITLE
insertAfter approach for discussion

### DIFF
--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -501,6 +501,18 @@ export function appendChildToContainer(
   }
 }
 
+export function insertAfter(
+  parentInstance: Instance,
+  child: Instance | TextInstance,
+  afterChild: Instance | TextInstance | SuspenseInstance,
+): void {
+  let insertionNode = afterChild.nextSibling;
+  if (afterChild.nodeType === COMMENT_NODE) {
+    console.log('inserting after a Suspense instance', afterChild);
+  }
+  parentInstance.insertBefore(child, insertionNode);
+}
+
 export function insertBefore(
   parentInstance: Instance,
   child: Instance | TextInstance,


### PR DESCRIPTION
This is an incomplete PR. It's demonstrating a technique and if discussion leads to interest it will be updated to be complete

When inserting HostComponents and HostText into a parent HostComponent we search for an Instance to insert before. This works generally but has a few downsides
1. the search algorithm has to loop over multiple placements which can cause exponential growth in the search time
2. if the search exhausts it assumes there is nothing to insert before and it performs an append. In react-dom this is not actually right since Portals and certain HostComponents like <head> have non-react content that may be interleaved with appended child components

Instead of looking for the item to insert before this partially implements a search algorithm to find the component to insertAfter.

The search temporarily reverses the sibling list and works from the last sibling to the first sibling looking for the first sibling (last sibling in dom order) just before the Fiber to be inserted. In react-dom's case it still does an insertBefore but it looks for the `after.nextSibling` which in the case of <head> may be some 3rd party style tag.

This implementation is incomplete
1) does not yet work for HostPortal or HostRoot
2) still does an appendChild if nothing to insert after but this is not correct semantics (should be `insertAfter(... parent.firstChild)`)

In practice this may be slower since most insertions probably happen in tail position and the current algo is probably reasonably fast and does not need to double traverse the tree once it finds the insertion point.