### PR TITLE
fixture: Fix typo from perfomrance to performance

### DIFF
--- a/fixtures/fizz/README.md
+++ b/fixtures/fizz/README.md
@@ -1,6 +1,6 @@
 # Fizz Fixtures
 
-A set of basic tests for Fizz primarily focussed on baseline perfomrance of legacy renderToString and streaming implementations.
+A set of basic tests for Fizz primarily focussed on baseline performance of legacy renderToString and streaming implementations.
 
 ## Setup
 


### PR DESCRIPTION
I fixed typo from perfomrance to performance (line 2) in README.md of fizz