### PR TITLE
make preamble and postamble types explicit and fix typo

### DIFF
--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -1084,7 +1084,7 @@ function pushLink(
               pushAttribute(target, responseState, 'data-rprec', propValue);
             } else if (__DEV__) {
               throw new Error(
-                `the "precedence" prop for links to stylehseets expects to receive a string but received something of type "${typeof propValue}" instead.`,
+                `the "precedence" prop for links to stylesheets expects to receive a string but received something of type "${typeof propValue}" instead.`,
               );
             }
             break;
@@ -1238,27 +1238,27 @@ function pushStartTitle(
 
 function pushStartHead(
   target: Array<Chunk | PrecomputedChunk>,
-  preamble: ?Array<Chunk | PrecomputedChunk>,
+  preamble: Array<Chunk | PrecomputedChunk>,
   props: Object,
   tag: string,
   responseState: ResponseState,
 ): ReactNodeList {
   // Preamble type is nullable for feature off cases but is guaranteed when feature is on
-  target = enableFloat ? (preamble: any) : target;
+  target = enableFloat ? preamble : target;
 
   return pushStartGenericElement(target, props, tag, responseState);
 }
 
 function pushStartHtml(
   target: Array<Chunk | PrecomputedChunk>,
-  preamble: ?Array<Chunk | PrecomputedChunk>,
+  preamble: Array<Chunk | PrecomputedChunk>,
   props: Object,
   tag: string,
   formatContext: FormatContext,
   responseState: ResponseState,
 ): ReactNodeList {
   // Preamble type is nullable for feature off cases but is guaranteed when feature is on
-  target = enableFloat ? (preamble: any) : target;
+  target = enableFloat ? preamble : target;
 
   if (formatContext.insertionMode === ROOT_HTML_MODE) {
     // If we're rendering the html tag and we're at the root (i.e. not in foreignObject)
@@ -1485,7 +1485,7 @@ const DOCTYPE: PrecomputedChunk = stringToPrecomputedChunk('<!DOCTYPE html>');
 
 export function pushStartInstance(
   target: Array<Chunk | PrecomputedChunk>,
-  preamble: ?Array<Chunk | PrecomputedChunk>,
+  preamble: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
   responseState: ResponseState,
@@ -1607,7 +1607,7 @@ const endTag2 = stringToPrecomputedChunk('>');
 
 export function pushEndInstance(
   target: Array<Chunk | PrecomputedChunk>,
-  postamble: ?Array<Chunk | PrecomputedChunk>,
+  postamble: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
 ): void {
@@ -1636,8 +1636,7 @@ export function pushEndInstance(
     // Postamble end tags
     case 'body':
     case 'html':
-      // Preamble type is nullable for feature off cases but is guaranteed when feature is on
-      target = enableFloat ? (postamble: any) : target;
+      target = enableFloat ? postamble : target;
     // Intentional fallthrough
     default: {
       target.push(endTag1, stringToChunk(type), endTag2);

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -137,7 +137,7 @@ export function pushTextInstance(
 
 export function pushStartInstance(
   target: Array<Chunk | PrecomputedChunk>,
-  preamble: ?Array<Chunk | PrecomputedChunk>,
+  preamble: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
   responseState: ResponseState,
@@ -154,7 +154,7 @@ export function pushStartInstance(
 
 export function pushEndInstance(
   target: Array<Chunk | PrecomputedChunk>,
-  postamble: ?Array<Chunk | PrecomputedChunk>,
+  postamble: Array<Chunk | PrecomputedChunk>,
   type: string,
   props: Object,
 ): void {

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -201,8 +201,8 @@ export opaque type Request = {
   clientRenderedBoundaries: Array<SuspenseBoundary>, // Errored or client rendered but not yet flushed.
   completedBoundaries: Array<SuspenseBoundary>, // Completed but not yet fully flushed boundaries to show.
   partialBoundaries: Array<SuspenseBoundary>, // Partially completed boundaries that can flush its segments early.
-  +preamble: ?Array<Chunk | PrecomputedChunk>, // Chunks that need to be emitted before any segment chunks.
-  +postamble: ?Array<Chunk | PrecomputedChunk>, // Chunks that need to be emitted after segments, waiting for all pending root tasks to finish
+  +preamble: Array<Chunk | PrecomputedChunk>, // Chunks that need to be emitted before any segment chunks.
+  +postamble: Array<Chunk | PrecomputedChunk>, // Chunks that need to be emitted after segments, waiting for all pending root tasks to finish
   // onError is called when an error happens anywhere in the tree. It might recover.
   // The return string is used in production  primarily to avoid leaking internals, secondarily to save bytes.
   // Returning null/undefined will cause a defualt error message in production
@@ -275,8 +275,8 @@ export function createRequest(
     clientRenderedBoundaries: [],
     completedBoundaries: [],
     partialBoundaries: [],
-    preamble: enableFloat ? [] : null,
-    postamble: enableFloat ? [] : null,
+    preamble: [],
+    postamble: [],
     onError: onError === undefined ? defaultErrorHandler : onError,
     onAllReady: onAllReady === undefined ? noop : onAllReady,
     onShellReady: onShellReady === undefined ? noop : onShellReady,
@@ -2074,9 +2074,7 @@ function flushCompletedQueues(
     if (completedRootSegment !== null) {
       if (request.pendingRootTasks === 0) {
         if (enableFloat) {
-          const preamble: Array<
-            Chunk | PrecomputedChunk,
-          > = (request.preamble: any);
+          const preamble = request.preamble;
           for (i = 0; i < preamble.length; i++) {
             // we expect the preamble to be tiny and will ignore backpressure
             writeChunk(destination, preamble[i]);
@@ -2167,9 +2165,7 @@ function flushCompletedQueues(
       // either they have pending task or they're complete.
     ) {
       if (enableFloat) {
-        const postamble: Array<
-          Chunk | PrecomputedChunk,
-        > = (request.postamble: any);
+        const postamble = request.postamble;
         for (let i = 0; i < postamble.length; i++) {
           writeChunk(destination, postamble[i]);
         }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -422,5 +422,5 @@
   "434": "`dangerouslySetInnerHTML` does not make sense on <title>.",
   "435": "Unexpected Suspense handler tag (%s). This is a bug in React.",
   "436": "Stylesheet resources need a unique representation in the DOM while hydrating and more than one matching DOM Node was found. To fix, ensure you are only rendering one stylesheet link with an href attribute of \"%s\".",
-  "437": "the \"precedence\" prop for links to stylehseets expects to receive a string but received something of type \"%s\" instead."
+  "437": "the \"precedence\" prop for links to stylesheets expects to receive a string but received something of type \"%s\" instead."
 }


### PR DESCRIPTION
This PR cleans up the typing for preamble and postamble and corrects an error typo introduced in: https://github.com/facebook/react/pull/25060

The pre/post-amble types are now non-nullable and we construct two arrays per request uncoditionally