### PR TITLE
Add more test cases for exhaustive deps check

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7238,8 +7238,8 @@ const tests = {
       errors: [
         {
           message:
-          "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
-          "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+            "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
+            "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
           suggestions: undefined,
         },
       ],
@@ -7254,11 +7254,11 @@ const tests = {
       errors: [
         {
           message:
-          "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
-          "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+            "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
+            "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
           suggestions: undefined,
         },
-      ], 
+      ],
     },
     {
       code: normalizeIndent`

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7215,6 +7215,54 @@ const tests = {
     {
       code: normalizeIndent`
         function Component() {
+          const [foo = {}] = bar;
+          useMemo(() => foo, [foo]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
+            "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {foo = {}} = bar;
+          useMemo(() => foo, [foo]);
+        }
+      `,
+      errors: [
+        {
+          message:
+          "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
+          "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
+          const {baz: {foo = {}}} = bar;
+          useMemo(() => foo, [foo]);
+        }
+      `,
+      errors: [
+        {
+          message:
+          "The 'foo' object makes the dependencies of useMemo Hook (at line 4) change on every render. " +
+          "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+          suggestions: undefined,
+        },
+      ], 
+    },
+    {
+      code: normalizeIndent`
+        function Component() {
           const foo = bar ?? {};
           useMemo(() => foo, [foo]);
         }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1529,11 +1529,12 @@ function scanForConstructions({
       if (
         node.type === 'Variable' &&
         node.node.type === 'VariableDeclarator' &&
-        (node.node.id.type === 'ArrayPattern' || node.node.id.type === 'ObjectPattern') &&
+        (node.node.id.type === 'ArrayPattern' ||
+          node.node.id.type === 'ObjectPattern') &&
         node.name != null &&
         node.name.parent != null &&
         node.name.parent.type === 'AssignmentPattern'
-        ) {
+      ) {
         const constantExpressionType = getConstructionExpressionType(
           node.name.parent.right,
         );

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1523,6 +1523,24 @@ function scanForConstructions({
           return [ref, constantExpressionType];
         }
       }
+      // const {foo = {}} = bar
+      // const [foo = {}] = bar
+      // etc.
+      if (
+        node.type === 'Variable' &&
+        node.node.type === 'VariableDeclarator' &&
+        (node.node.id.type === 'ArrayPattern' || node.node.id.type === 'ObjectPattern') &&
+        node.name != null &&
+        node.name.parent != null &&
+        node.name.parent.type === 'AssignmentPattern'
+        ) {
+        const constantExpressionType = getConstructionExpressionType(
+          node.name.parent.right,
+        );
+        if (constantExpressionType != null) {
+          return [ref, constantExpressionType];
+        }
+      }
       // function handleChange() {}
       if (
         node.type === 'FunctionName' &&


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

There seems to be a discrepancy in `eslint-plugin-react-hooks` when testing exhaustive deps. The following code reports an error:

```js
const foo = bar || {}

useMemo(() => foo, [foo])
```

While the below code does not:

```js
const {foo = {}} = bar

useMemo(() => foo, [foo])
```

I think that this might be a valid edge case which users might run into. Hence, I have added a few test cases as well as extended the eslint plugin logic to catch and report this scenario.