### PR TITLE
Possible missed rule for eslint-plugin-react-hooks?

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -636,7 +636,7 @@ const tests = {
           return props.items.map(useState);
         }
       `,
-      errors: [genericError('useState')],
+      errors: [callbackError('useState')],
     },
     {
       code: `
@@ -1004,6 +1004,15 @@ function genericError(hook) {
   return {
     message:
       `React Hook "${hook}" cannot be called inside a callback. React Hooks ` +
+      'must be called in a React function component or a custom React ' +
+      'Hook function.',
+  };
+}
+
+function callbackError(hook) {
+  return {
+    message:
+      `React Hook "${hook}" cannot be passed as a callback. React Hooks ` +
       'must be called in a React function component or a custom React ' +
       'Hook function.',
   };

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -406,6 +406,13 @@ const tests = {
         const [myState, setMyState] = useState(null);
       }
     `,
+    `
+      // Valid because useNewBehavior is not a hook
+      function MyComponent() {
+        let useNewBehavior = config.behavior === 'new'
+        doStuff(useNewBehavior)
+      }
+    `
   ],
   invalid: [
     {
@@ -637,6 +644,18 @@ const tests = {
         }
       `,
       errors: [callbackError('useState')],
+    },
+    {
+      code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+
+        let useMyHook = () => {};
+        function List(props) {
+          return props.items.map(useMyHook);
+        }
+      `,
+      errors: [callbackError('useMyHook')],
     },
     {
       code: `

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -412,7 +412,7 @@ const tests = {
         let useNewBehavior = config.behavior === 'new'
         doStuff(useNewBehavior)
       }
-    `
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -629,6 +629,17 @@ const tests = {
     },
     {
       code: `
+        // Invalid because it's dangerous and might not warn otherwise.
+        // This *must* be invalid.
+
+        function List(props) {
+          return props.items.map(useState);
+        }
+      `,
+      errors: [genericError('useState')],
+    },
+    {
+      code: `
         // Currently invalid because it violates the convention and removes the "taint"
         // from a hook. We *could* make it valid to avoid some false positives but let's
         // ensure that we don't break the "renderItem" and "normalFunctionWithConditionalHook"

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -526,6 +526,15 @@ export default {
             reactHooksMap.set(codePathSegment, reactHooks);
           }
           reactHooks.push(node.callee);
+        } else if (node.arguments.some(isHook)) {
+          node.arguments.filter(isHook)
+            .forEach(hook => {
+              const message =
+                `React Hook "${context.getSource(hook)}" cannot be called ` +
+                'inside a callback. React Hooks must be called in a ' +
+                'React function component or a custom React Hook function.';
+              context.report({node: hook, message});
+            })
         }
       },
     };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -527,14 +527,13 @@ export default {
           }
           reactHooks.push(node.callee);
         } else if (node.arguments.some(isHook)) {
-          node.arguments.filter(isHook)
-            .forEach(hook => {
-              const message =
-                `React Hook "${context.getSource(hook)}" cannot be called ` +
-                'inside a callback. React Hooks must be called in a ' +
-                'React function component or a custom React Hook function.';
-              context.report({node: hook, message});
-            })
+          node.arguments.filter(isHook).forEach(hook => {
+            const message =
+              `React Hook "${context.getSource(hook)}" cannot be called ` +
+              'inside a callback. React Hooks must be called in a ' +
+              'React function component or a custom React Hook function.';
+            context.report({node: hook, message});
+          });
         }
       },
     };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -528,7 +528,14 @@ export default {
           reactHooks.push(node.callee);
         }
         if (node.arguments.some(isHook)) {
+          const variableDefs = context.getScope().variables.map(variable => variable.defs)
           node.arguments.filter(isHook).forEach(hook => {
+            const hookDefs = variableDefs.find(defs => defs.some(def => def.name.name === hook.name))
+            // Prevent flagging variables within the scope starting with `use` prefix that are not functions
+            if (hookDefs && !hookDefs.some(def => !!getFunctionName(def.node))) {
+              return
+            }
+            
             const message =
               `React Hook "${context.getSource(hook)}" cannot be passed ` +
               'as a callback. React Hooks must be called in a ' +

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -526,7 +526,8 @@ export default {
             reactHooksMap.set(codePathSegment, reactHooks);
           }
           reactHooks.push(node.callee);
-        } else if (node.arguments.some(isHook)) {
+        } 
+        if (node.arguments.some(isHook)) {
           node.arguments.filter(isHook).forEach(hook => {
             const message =
               `React Hook "${context.getSource(hook)}" cannot be called ` +

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -526,7 +526,7 @@ export default {
             reactHooksMap.set(codePathSegment, reactHooks);
           }
           reactHooks.push(node.callee);
-        } 
+        }
         if (node.arguments.some(isHook)) {
           node.arguments.filter(isHook).forEach(hook => {
             const message =

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -528,14 +528,21 @@ export default {
           reactHooks.push(node.callee);
         }
         if (node.arguments.some(isHook)) {
-          const variableDefs = context.getScope().variables.map(variable => variable.defs)
+          const variableDefs = context
+            .getScope()
+            .variables.map(variable => variable.defs);
           node.arguments.filter(isHook).forEach(hook => {
-            const hookDefs = variableDefs.find(defs => defs.some(def => def.name.name === hook.name))
+            const hookDefs = variableDefs.find(defs =>
+              defs.some(def => def.name.name === hook.name),
+            );
             // Prevent flagging variables within the scope starting with `use` prefix that are not functions
-            if (hookDefs && !hookDefs.some(def => !!getFunctionName(def.node))) {
-              return
+            if (
+              hookDefs &&
+              !hookDefs.some(def => !!getFunctionName(def.node))
+            ) {
+              return;
             }
-            
+
             const message =
               `React Hook "${context.getSource(hook)}" cannot be passed ` +
               'as a callback. React Hooks must be called in a ' +

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -530,8 +530,8 @@ export default {
         if (node.arguments.some(isHook)) {
           node.arguments.filter(isHook).forEach(hook => {
             const message =
-              `React Hook "${context.getSource(hook)}" cannot be called ` +
-              'inside a callback. React Hooks must be called in a ' +
+              `React Hook "${context.getSource(hook)}" cannot be passed ` +
+              'as a callback. React Hooks must be called in a ' +
               'React function component or a custom React Hook function.';
             context.report({node: hook, message});
           });


### PR DESCRIPTION
## Summary

Recreating #22044

Rebasing my fork triggered GitHub to close the original PR

> ## Summary
> It seems that it is possible to use react hooks as callback to functions like map, forEach or even custom hooks without getting a lint error. My hunch is that this could be an oversight as it is not allowed to use hooks inside callbacks.

> Usage in the wild: https://twitter.com/erikras/status/1418487174866128897

> ## Test Plan
> I've added a failing test-case for the team to look at and decide on the intended behavior.