### PR TITLE
[DevTools] Add events necessary for click to inspect on RN

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -256,7 +256,7 @@ function initialize(socket: WebSocket) {
 
   store = new Store(bridge, {
     checkBridgeProtocolCompatibility: true,
-    supportsNativeInspection: false,
+    supportsNativeInspection: true,
   });
 
   log('Connected');

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -657,6 +657,10 @@ export default class Agent extends EventEmitter<{|
     this._bridge.send('profilingStatus', this._isProfiling);
   };
 
+  stopInspectingNative = (selected: boolean) => {
+    this._bridge.send('stopInspectingNative', selected);
+  };
+
   storeAsGlobal = ({count, id, path, rendererID}: StoreAsGlobalParams) => {
     const renderer = this._rendererInterfaces[rendererID];
     if (renderer == null) {

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -144,6 +144,8 @@ type PersistedSelection = {|
 export default class Agent extends EventEmitter<{|
   hideNativeHighlight: [],
   showNativeHighlight: [NativeType],
+  startInspectingNative: [],
+  stopInspectingNative: [],
   shutdown: [],
   traceUpdates: [Set<NativeType>],
 |}> {

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -48,6 +48,8 @@ export default function setupHighlighter(
       window.addEventListener('pointerdown', onPointerDown, true);
       window.addEventListener('pointerover', onPointerOver, true);
       window.addEventListener('pointerup', onPointerUp, true);
+    } else {
+      agent.emit('startInspectingNative');
     }
   }
 
@@ -74,6 +76,8 @@ export default function setupHighlighter(
       window.removeEventListener('pointerdown', onPointerDown, true);
       window.removeEventListener('pointerover', onPointerOver, true);
       window.removeEventListener('pointerup', onPointerUp, true);
+    } else {
+      agent.emit('stopInspectingNative');
     }
   }
 


### PR DESCRIPTION
We want to enable the inspector toggle on devtools and allow click to inspect on RN. 
The changes here are necessary to enable the toggle and pass events to RN.

The change is tested locally on RN. Verified events are received on RN and toggle is shown.