### PR TITLE
[DevTools][RN] Return closestInstance in `getInspectorDataForViewAtPoint`

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -217,6 +217,7 @@ if (__DEV__) {
                 pointerY: locationY,
                 frame: {left: pageX, top: pageY, width, height},
                 touchedViewTag: nativeViewTag,
+                closestInstance,
               });
             },
           );

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -150,6 +150,7 @@ export type InspectorData = $ReadOnly<{|
 export type TouchedViewDataAtPoint = $ReadOnly<{|
   pointerY: number,
   touchedViewTag?: number,
+  closestInstance?: Object,
   frame: $ReadOnly<{|
     top: number,
     left: number,


### PR DESCRIPTION
## Context

Currently in fabric mode, selecting an element in the RN inspector doesn't actually select the element in the React DevTools, because DevTools failed to find the tag sent from the [selectNode call in RN inspector.js](https://github.com/facebook/react-native/blob/main/Libraries/Inspector/Inspector.js#L198-L200). I found we need to send the instance directly for selecting element to work in fabric.

## This PR
Returns the closestInstance if it's in fabric mode for devtools
