### PR TITLE
Stub out useMemoCache()

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -175,6 +175,13 @@ function useCacheRefresh(): () => void {
   return () => {};
 }
 
+function useMemoCache(size: number): Array<any> {
+  const hook = nextHook();
+  const value = hook !== null ? hook.memoizedState[0] : new Array(size);
+  hookLog.push({primitive: 'MemoCache', stackError: new Error(), value});
+  return value;
+}
+
 function useLayoutEffect(
   create: () => (() => void) | void,
   inputs: Array<mixed> | void | null,
@@ -334,6 +341,7 @@ const Dispatcher: DispatcherType = {
   getCacheForType,
   readContext,
   useCacheRefresh,
+  useMemoCache,
   useCallback,
   useContext,
   useEffect,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -403,6 +403,7 @@ export type Dispatcher = {|
   ): T,
   useId(): string,
   useCacheRefresh?: () => <T>(?() => T, ?T) => void,
+  useMemoCache?: (size: number) => Array<any>,
 
   unstable_isNewReconciler?: boolean,
 |};

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -78,6 +78,9 @@ export const Dispatcher: DispatcherType = {
   useCacheRefresh(): <T>(?() => T, ?T) => void {
     return unsupportedRefresh;
   },
+  useMemoCache(size: number): Array<any> {
+    return new Array(size);
+  },
 };
 
 function unsupportedHook(): void {

--- a/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
+++ b/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
@@ -46,6 +46,7 @@ export function waitForSuspense<T>(fn: () => T): Promise<T> {
     useMutableSource: unsupported,
     useSyncExternalStore: unsupported,
     useCacheRefresh: unsupported,
+    useMemoCache: unsupported,
   };
   // Not using async/await because we don't compile it.
   return new Promise((resolve, reject) => {

--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -42,6 +42,7 @@ export {
   unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
+  unstable_useMemoCache,
   useId,
   useCallback,
   useContext,

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -35,6 +35,7 @@ export {
   unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
+  unstable_useMemoCache,
   useId,
   useCallback,
   useContext,

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -63,6 +63,7 @@ export {
   unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
+  unstable_useMemoCache,
   useId,
   useCallback,
   useContext,

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -40,6 +40,7 @@ export {
   unstable_getCacheSignal,
   unstable_getCacheForType,
   unstable_useCacheRefresh,
+  unstable_useMemoCache,
   useId,
   useCallback,
   useContext,

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -55,6 +55,7 @@ import {
   useDeferredValue,
   useId,
   useCacheRefresh,
+  useMemoCache,
 } from './ReactHooks';
 import {
   createElementWithValidation,
@@ -126,6 +127,7 @@ export {
   getCacheSignal as unstable_getCacheSignal,
   getCacheForType as unstable_getCacheForType,
   useCacheRefresh as unstable_useCacheRefresh,
+  useMemoCache as unstable_useMemoCache,
   REACT_CACHE_TYPE as unstable_Cache,
   // enableScopeAPI
   REACT_SCOPE_TYPE as unstable_Scope,

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -204,3 +204,9 @@ export function useCacheRefresh(): <T>(?() => T, ?T) => void {
   // $FlowFixMe This is unstable, thus optional
   return dispatcher.useCacheRefresh();
 }
+
+export function useMemoCache(size: number): Array<any> {
+  const dispatcher = resolveDispatcher();
+  // $FlowFixMe This is unstable, thus optional
+  return dispatcher.useMemoCache(size);
+}


### PR DESCRIPTION
## Summary

Stubs out a new hook, `useMemoCache(size: number): Array<any>` which is intended for use only as a compilation target for our experimental build-time auto-memoization feature (see [React without memo](https://www.youtube.com/watch?v=lGEMwh32soc) for background). This hook is _unsafe_ to call manually, ie the API is powerful and allows violating the rules of React, and the user is responsible for ensuring that the usage is safe. The intent is that build-time tools such as our auto-memoization feature will guarantee that transformed code uses the API safely.

## How did you test this change?

yarn test/flow