### PR TITLE
[Flight] Test the node-register hooks in unit tests

### DIFF
--- a/packages/react-server-dom-webpack/node-register.js
+++ b/packages/react-server-dom-webpack/node-register.js
@@ -7,4 +7,4 @@
  * @flow
  */
 
-export * from './src/ReactFlightWebpackNodeRegister';
+module.exports = require('./src/ReactFlightWebpackNodeRegister');

--- a/packages/react-server-dom-webpack/package.json
+++ b/packages/react-server-dom-webpack/package.json
@@ -35,6 +35,7 @@
     "./writer.browser.server": "./writer.browser.server.js",
     "./node-loader": "./esm/react-server-dom-webpack-node-loader.js",
     "./node-register": "./node-register.js",
+    "./src/*": "./src/*",
     "./package.json": "./package.json"
   },
   "main": "index.js",

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -57,7 +57,7 @@ module.exports = function register() {
     },
   };
 
-  (require: any).extensions['.client.js'] = function(module, path) {
+  Module._extensions['.client.js'] = function(module, path) {
     const moduleId = url.pathToFileURL(path).href;
     const moduleReference: {[string]: any} = {
       $$typeof: MODULE_REFERENCE,

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -17,14 +17,9 @@ global.TextDecoder = require('util').TextDecoder;
 // TODO: we can replace this with FlightServer.act().
 global.setImmediate = cb => cb();
 
-let webpackModuleIdx = 0;
-let webpackModules = {};
-let webpackMap = {};
-global.__webpack_require__ = function(id) {
-  return webpackModules[id];
-};
-
 let act;
+let clientExports;
+let webpackMap;
 let Stream;
 let React;
 let ReactDOMClient;
@@ -35,15 +30,17 @@ let Suspense;
 describe('ReactFlightDOM', () => {
   beforeEach(() => {
     jest.resetModules();
-    webpackModules = {};
-    webpackMap = {};
     act = require('jest-react').act;
+    const WebpackMock = require('./utils/WebpackMock');
+    clientExports = WebpackMock.clientExports;
+    webpackMap = WebpackMock.webpackMap;
+
     Stream = require('stream');
     React = require('react');
+    Suspense = React.Suspense;
     ReactDOMClient = require('react-dom/client');
     ReactServerDOMWriter = require('react-server-dom-webpack/writer.node.server');
     ReactServerDOMReader = require('react-server-dom-webpack');
-    Suspense = React.Suspense;
   });
 
   function getTestStream() {
@@ -62,22 +59,6 @@ describe('ReactFlightDOM', () => {
       readable,
       writable,
     };
-  }
-
-  function moduleReference(moduleExport) {
-    const idx = webpackModuleIdx++;
-    webpackModules[idx] = {
-      d: moduleExport,
-    };
-    webpackMap['path/' + idx] = {
-      default: {
-        id: '' + idx,
-        chunks: [],
-        name: 'd',
-      },
-    };
-    const MODULE_TAG = Symbol.for('react.module.reference');
-    return {$$typeof: MODULE_TAG, filepath: 'path/' + idx, name: 'default'};
   }
 
   async function waitForSuspense(fn) {
@@ -345,7 +326,7 @@ describe('ReactFlightDOM', () => {
       return <div>{games}</div>;
     }
 
-    const MyErrorBoundaryClient = moduleReference(MyErrorBoundary);
+    const MyErrorBoundaryClient = clientExports(MyErrorBoundary);
 
     function ProfileContent() {
       return (
@@ -470,7 +451,7 @@ describe('ReactFlightDOM', () => {
       return <input />;
     }
 
-    const InputClient = moduleReference(Input);
+    const InputClient = clientExports(Input);
 
     // Server
 

--- a/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
+++ b/packages/react-server-dom-webpack/src/__tests__/utils/WebpackMock.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const url = require('url');
+const Module = require('module');
+
+let webpackModuleIdx = 0;
+const webpackModules = {};
+const webpackMap = {};
+global.__webpack_require__ = function(id) {
+  return webpackModules[id];
+};
+
+const previousLoader = Module._extensions['.client.js'];
+
+const register = require('react-server-dom-webpack/node-register');
+// Register node loader
+register();
+
+const nodeLoader = Module._extensions['.client.js'];
+
+if (previousLoader === nodeLoader) {
+  throw new Error(
+    'Expected the Node loader to register the .client.js extension',
+  );
+}
+
+Module._extensions['.client.js'] = previousLoader;
+
+exports.webpackMap = webpackMap;
+exports.webpackModules = webpackModules;
+
+exports.clientExports = function clientExports(moduleExports) {
+  const idx = '' + webpackModuleIdx++;
+  webpackModules[idx] = moduleExports;
+  const path = url.pathToFileURL(idx).href;
+  webpackMap[path] = {
+    '': {
+      id: idx,
+      chunks: [],
+      name: '',
+    },
+    '*': {
+      id: idx,
+      chunks: [],
+      name: '*',
+    },
+  };
+  for (const name in moduleExports) {
+    webpackMap[path] = {
+      [name]: {
+        id: idx,
+        chunks: [],
+        name: name,
+      },
+    };
+  }
+  const mod = {exports: {}};
+  nodeLoader(mod, idx);
+  return mod.exports;
+};

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -408,7 +408,8 @@ const bundles = [
   {
     bundleTypes: [NODE_ES2015],
     moduleType: RENDERER_UTILS,
-    entry: 'react-server-dom-webpack/node-register',
+    entry: 'react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js',
+    name: 'react-server-dom-webpack-node-register',
     global: 'ReactFlightWebpackNodeRegister',
     minifyWithProdErrorCodes: false,
     wrapWithModuleBoundaries: false,


### PR DESCRIPTION
We used to just test the runtime and not the loaders that emit client references. This moves some of that to a separate helper for these tests, that extracts the loader from the Node.js CJS loader.

This lets us test a bit more of the real implementation but it's still not testing the Webpack client plugin parts.
