### PR TITLE
Fix typo: supportsMicrotask -> supportsMicrotasks

### DIFF
--- a/packages/react-reconciler/README.md
+++ b/packages/react-reconciler/README.md
@@ -199,7 +199,7 @@ You can proxy this to `clearTimeout` or its equivalent in your environment.
 
 This is a property (not a function) that should be set to something that can never be a valid timeout ID. For example, you can set it to `-1`.
 
-#### `supportsMicrotask`
+#### `supportsMicrotasks`
 
 Set this to true to indicate that your renderer supports `scheduleMicrotask`. We use microtasks as part of our discrete event implementation in React DOM. If you're not sure if your renderer should support this, you probably should. The option to not implement `scheduleMicrotask` exists so that platforms with more control over user events, like React Native, can choose to use a different mechanism.
 #### `scheduleMicrotask(fn)`


### PR DESCRIPTION
Fix a typo in the README because [the implementation](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js#L75) and its method name were different.