### PR TITLE
[DevTools][easy] Fix flow type

### DIFF
--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -150,7 +150,7 @@ export type InspectorData = $ReadOnly<{|
 export type TouchedViewDataAtPoint = $ReadOnly<{|
   pointerY: number,
   touchedViewTag?: number,
-  closestInstance?: Object,
+  closestInstance?: mixed,
   frame: $ReadOnly<{|
     top: number,
     left: number,


### PR DESCRIPTION
The `Object` type added in #25118  caused a flow error when used internally, changing it to `mixed` fix the error.