### PR TITLE
[Flight] Minor error handling fixes

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -312,6 +312,11 @@ export function parseModelString(
       } else {
         const id = parseInt(value.substring(1), 16);
         const chunk = getChunk(response, id);
+        if (chunk._status === PENDING) {
+          throw new Error(
+            "We didn't expect to see a forward reference. This is a bug in the React Server.",
+          );
+        }
         return readChunk(chunk);
       }
     }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
@@ -35,12 +35,18 @@ function startReadingFromStream(
     }
     const buffer: Uint8Array = (value: any);
     processBinaryChunk(response, buffer);
-    return reader.read().then(progress, error);
+    return reader
+      .read()
+      .then(progress)
+      .catch(error);
   }
   function error(e) {
     reportGlobalError(response, e);
   }
-  reader.read().then(progress, error);
+  reader
+    .read()
+    .then(progress)
+    .catch(error);
 }
 
 function createFromReadableStream(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -902,7 +902,7 @@ function abortTask(task: Task, request: Request, errorId: number): void {
   // has a single value referencing the error.
   const ref = serializeByValueID(errorId);
   const processedChunk = processReferenceChunk(request, task.id, ref);
-  request.completedJSONChunks.push(processedChunk);
+  request.completedErrorChunks.push(processedChunk);
 }
 
 function flushCompletedChunks(

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -423,5 +423,6 @@
   "435": "Unexpected Suspense handler tag (%s). This is a bug in React.",
   "436": "Stylesheet resources need a unique representation in the DOM while hydrating and more than one matching DOM Node was found. To fix, ensure you are only rendering one stylesheet link with an href attribute of \"%s\".",
   "437": "the \"precedence\" prop for links to stylesheets expects to receive a string but received something of type \"%s\" instead.",
-  "438": "An unsupported type was passed to use(): %s"
+  "438": "An unsupported type was passed to use(): %s",
+  "439": "We didn't expect to see a forward reference. This is a bug in the React Server."
 }


### PR DESCRIPTION
I noticed that when we error in progress of a web stream, that becomes an unhandled promise. This handles this using the usual error reporting (which might not actually work to propagate the error neither but it gives us a chance).

I also changed it so we serialize references to errors in the error priority queue. It doesn't make sense to emit references to future values at higher pri than the value that they're referencing. This ensures that we don't emit hard forward references to values that don't yet exist. Which can help simplify the client.

Now we have a guarantee that non-lazy values `$123` always reference backwards and not forwards.