### PR TITLE
[react devtools][easy] Fix code highlighting in VSCode

### DIFF
--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -108,8 +108,9 @@ export function getWrappedDisplayName(
   wrapperName: string,
   fallbackName?: string,
 ): string {
+  const displayName = (outerType: any).displayName;
   return (
-    (outerType: any).displayName ||
+    displayName ||
     `${wrapperName}(${getDisplayName(innerType, fallbackName)})`
   );
 }


### PR DESCRIPTION
* Minor change that fixes code highlighting in VSCode in a particular file

## Summary

* See above

## How did you test this change?

:eyes:

In particular, before:
<img width="766" alt="Screen Shot 2022-08-30 at 2 10 04 PM" src="https://user-images.githubusercontent.com/4277077/187511667-d2eefdbb-64c0-49bf-9bc7-55607d276d44.png">


And after:

<img width="867" alt="Screen Shot 2022-08-30 at 2 08 33 PM" src="https://user-images.githubusercontent.com/4277077/187511591-ec2f4b89-1a1a-4ba5-a1b7-cb8539ca7ed2.png">

## But this isn't synced with `getWrappedName` in `getComponentNameFromFiber`

* Turns out, it wasn't synced before this commit, too!