### PR TITLE
[eslint-plugin-react-hooks] Allow standalone "use" for hook

### DIFF
--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -16,7 +16,7 @@
  */
 
 function isHookName(s) {
-  return /^use[A-Z0-9].*$/.test(s);
+  return /^use[A-Z$0-9].*$/.test(s) || s === "use";
 }
 
 /**


### PR DESCRIPTION
## Summary

As a ReScript user, various package & modules have simple name like `Module.use()` (to avoid repetition like `Module.useModule()` or worst (add "something" just to have code accepted by the rule)) or even generated code (eg: `use$1`, generated by rescript-relay). 

## How did you test this change?

I am currently using this code as a patch (using patch-package) and it didn't bring any regression but allow rules-of-hook to be used in a considerable ReScript codebase.
