### PR TITLE
Don't use the Flight terminology in public error messages

### DIFF
--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -26,7 +26,9 @@ export function resetHooksForRequest() {
 function readContext<T>(context: ReactServerContext<T>): T {
   if (__DEV__) {
     if (context.$$typeof !== REACT_SERVER_CONTEXT_TYPE) {
-      console.error('Only ServerContext is supported in Flight');
+      console.error(
+        'Only createServerContext is supported in Server Components.',
+      );
     }
     if (currentCache === null) {
       console.error(


### PR DESCRIPTION
This error message shouldn't even be possible if you're running a compatible environment because you can't even get to createContext if `react` is properly aliased. Unfortunately, that's not the case in any environment outside the prototype yet.