### PR TITLE
failing test demonstrating infinite updates

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -2270,7 +2270,11 @@ function dispatchSetState<S, A>(
   }
 
   const lane = requestUpdateLane(fiber);
-
+  console.log(
+    'dispatchSetState fiber.lanes: %s  update.lane: %s',
+    fiber.lanes,
+    lane,
+  );
   const update: Update<S, A> = {
     lane,
     action,
@@ -2290,6 +2294,7 @@ function dispatchSetState<S, A>(
       // The queue is currently empty, which means we can eagerly compute the
       // next state before entering the render phase. If the new state is the
       // same as the current state, we may be able to bail out entirely.
+      console.log('can possibly avoid rerender');
       const lastRenderedReducer = queue.lastRenderedReducer;
       if (lastRenderedReducer !== null) {
         let prevDispatcher;
@@ -2313,6 +2318,7 @@ function dispatchSetState<S, A>(
             // time the reducer has changed.
             // TODO: Do we still need to entangle transitions in this case?
             enqueueConcurrentHookUpdateAndEagerlyBailout(fiber, queue, update);
+            console.log('state was the same, re-render avoided');
             return;
           }
         } catch (error) {
@@ -2324,6 +2330,7 @@ function dispatchSetState<S, A>(
         }
       }
     }
+    console.log('enqueueing a rerender');
 
     const root = enqueueConcurrentHookUpdate(fiber, queue, update, lane);
     if (root !== null) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -962,6 +962,7 @@ function ensureRootIsScheduled(root: FiberRoot, currentTime: number) {
 // This is the entry point for every concurrent task, i.e. anything that
 // goes through Scheduler.
 function performConcurrentWorkOnRoot(root, didTimeout) {
+  console.log('performConcurrentWorkOnRoot');
   if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
     resetNestedUpdateFlag();
   }
@@ -1103,6 +1104,7 @@ function performConcurrentWorkOnRoot(root, didTimeout) {
       root.finishedWork = finishedWork;
       root.finishedLanes = lanes;
       finishConcurrentRender(root, exitStatus, lanes);
+      console.log('finishConcurrentWorkOnRoot');
     }
   }
 
@@ -1409,6 +1411,7 @@ function markRootSuspended(root, suspendedLanes) {
 // This is the entry point for synchronous tasks that don't go
 // through Scheduler
 function performSyncWorkOnRoot(root) {
+  console.log('performSyncWorkOnRoot');
   if (enableProfilerTimer && enableProfilerNestedUpdatePhase) {
     syncNestedUpdateFlag();
   }
@@ -1473,7 +1476,7 @@ function performSyncWorkOnRoot(root) {
   // Before exiting, make sure there's a callback scheduled for the next
   // pending level.
   ensureRootIsScheduled(root, now());
-
+  console.log('FinishSyncWorkOnRoot', exitStatus);
   return null;
 }
 
@@ -2553,7 +2556,9 @@ function commitRootImpl(
 
   if (__DEV__ && enableStrictEffects) {
     if (!rootDidHavePassiveEffects) {
+      console.log('--- double invoke effects in dev ---');
       commitDoubleInvokeEffectsInDEV(root);
+      console.log('--- double invoke over           ---');
     }
   }
 
@@ -3170,6 +3175,7 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
   parentFiber: Fiber,
   isInStrictMode: boolean,
 ) {
+  console.log('recursivelyTraverseAndDoubleInvokeEffectsInDEV');
   let child = parentFiber.child;
   while (child !== null) {
     doubleInvokeEffectsInDEV(root, child, isInStrictMode);
@@ -3184,6 +3190,15 @@ function doubleInvokeEffectsInDEV(
 ) {
   const isStrictModeFiber = fiber.type === REACT_STRICT_MODE_TYPE;
   const isInStrictMode = parentIsInStrictMode || isStrictModeFiber;
+  console.log(
+    'doubleInvokeEffectsInDEV',
+    isInStrictMode,
+    fiber.flags & PlacementDEV,
+    fiber.tag === OffscreenComponent,
+    fiber.return.tag === SuspenseComponent
+      ? 'This OffscreenComponent is an indirection from a SuspenseBoundary'
+      : '',
+  );
   if (fiber.flags & PlacementDEV || fiber.tag === OffscreenComponent) {
     setCurrentDebugFiberInDEV(fiber);
     if (isInStrictMode) {


### PR DESCRIPTION
This was.... fun?

So in a Next.js project there was an infinite updates issue causing a page to fail and unmount. After narrowing the scope of the problem as much as possible I was able to start to repro in a test case (see ReactDOMHooks-test.js)

There is a confluence of things happening

In StrictMode some effects are refired
In a SuspenseBoundary there is a OffscreenComponent fiber as a child fiber
DoubleInvoke-ing effects in Dev looks for whether there is a PlacementDEV flag or (critically) if the fiber is an OffscreenComponent.

This means that for every descendant of a SuspenseBoundary, you will double-invoke effects even on updates that happened after a Placement (In StrictMode of course)

So what is happening in this contrived test case is

a first layoutEffect is causing an immediate Sync render. there is also a passive effect queued to some non Sync lane.
a second layoutEffect is causing another immediate Sync render however b/c the passive effect is inside an OffscreenComponent it gets cleanedup and re-executed.

This effect has a setState but it cannot bail out of the update because there is pending work already on this fiber (from a previous run of the effect). It takes a few loops around but eventually there is an inifinite loop of setStates causing Sync renders causing setStates that cannot be bailed out, causing Sync renders...

At least I think...

The simple fix is probably to not always doubleinvoke with an OffscreenComponent child. I think that is wrong in the SuspenseBoundary case but maybe it makes sense for regular offscreen. I don't really know though