### PR TITLE
[react devtools] Don't rely on global.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ etc behavior in console-test

### DIFF
--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -810,32 +810,28 @@ export function attach(
   // Patching the console enables DevTools to do a few useful things:
   // * Append component stacks to warnings and error messages
   // * Disable logging during re-renders to inspect hooks (see inspectHooksOfFiber)
-  //
-  // Don't patch in test environments because we don't want to interfere with Jest's own console overrides.
-  if (process.env.NODE_ENV !== 'test') {
-    registerRendererWithConsole(renderer, onErrorOrWarning);
+  registerRendererWithConsole(renderer, onErrorOrWarning);
 
-    // The renderer interface can't read these preferences directly,
-    // because it is stored in localStorage within the context of the extension.
-    // It relies on the extension to pass the preference through via the global.
-    const appendComponentStack =
-      window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ !== false;
-    const breakOnConsoleErrors =
-      window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ === true;
-    const showInlineWarningsAndErrors =
-      window.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ !== false;
-    const hideConsoleLogsInStrictMode =
-      window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ === true;
-    const browserTheme = window.__REACT_DEVTOOLS_BROWSER_THEME__;
+  // The renderer interface can't read these preferences directly,
+  // because it is stored in localStorage within the context of the extension.
+  // It relies on the extension to pass the preference through via the global.
+  const appendComponentStack =
+    window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__ !== false;
+  const breakOnConsoleErrors =
+    window.__REACT_DEVTOOLS_BREAK_ON_CONSOLE_ERRORS__ === true;
+  const showInlineWarningsAndErrors =
+    window.__REACT_DEVTOOLS_SHOW_INLINE_WARNINGS_AND_ERRORS__ !== false;
+  const hideConsoleLogsInStrictMode =
+    window.__REACT_DEVTOOLS_HIDE_CONSOLE_LOGS_IN_STRICT_MODE__ === true;
+  const browserTheme = window.__REACT_DEVTOOLS_BROWSER_THEME__;
 
-    patchConsole({
-      appendComponentStack,
-      breakOnConsoleErrors,
-      showInlineWarningsAndErrors,
-      hideConsoleLogsInStrictMode,
-      browserTheme,
-    });
-  }
+  patchConsole({
+    appendComponentStack,
+    breakOnConsoleErrors,
+    showInlineWarningsAndErrors,
+    hideConsoleLogsInStrictMode,
+    browserTheme,
+  });
 
   const debug = (
     name: string,


### PR DESCRIPTION
## What

* Currently, `patchConsole` is called when react dom is loaded and when an initial component is rendered.
* The parameters that `patchConsole` receives are based on `window.__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__` etc. This is a hack to allow the devtools backend (including `patchConsole`) to know about devtools settings before the devtools frontend connects. The DevTools frontend is the source of truth for these settings.
* This reliance on these globals will be removed soon in favor of injected persistent on-device storage.
* To prepare the way, we can start by changing (most) tests to not rely on these globals

## Notes

* I will land this and the PR that actually removes `__REACT_DEVTOOLS_APPEND_COMPONENT_STACK__` at once.