### PR TITLE
Update to Flow from 0.97 to 0.122

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "0.97",
+    "flow-bin": "^0.122",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/jest-react/src/internalAct.js
+++ b/packages/jest-react/src/internalAct.js
@@ -28,6 +28,8 @@ export function act<T>(scope: () => Thenable<T> | T): Thenable<T> {
       'This version of `act` requires a special mock build of Scheduler.',
     );
   }
+
+  // $FlowFixMe: _isMockFunction doesn't exist on function
   if (setTimeout._isMockFunction !== true) {
     throw Error(
       "This version of `act` requires Jest's timer mocks " +

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -683,6 +683,7 @@ function handleRenderFunctionError(error: any): void {
   // TODO: refactor this if we ever combine the devtools and debug tools packages
   wrapperError.name = 'ReactDebugToolsRenderError';
   // this stage-4 proposal is not supported by all environments yet.
+  // $FlowFixMe Flow doesn't have this type yet.
   wrapperError.cause = error;
   throw wrapperError;
 }

--- a/packages/react-devtools-shared/src/backend/StyleX/utils.js
+++ b/packages/react-devtools-shared/src/backend/StyleX/utils.js
@@ -92,7 +92,9 @@ function getPropertyValueForStyleName(styleName: string): string | null {
     ]: any): CSSStyleSheet);
     // $FlowFixMe Flow doesn't konw about these properties
     const rules = styleSheet.rules || styleSheet.cssRules;
+    // $FlowFixMe `rules` is mixed
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
+      // $FlowFixMe `rules` is mixed
       const rule = rules[ruleIndex];
       // $FlowFixMe Flow doesn't konw about these properties
       const {cssText, selectorText, style} = rule;

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -124,7 +124,7 @@ import type {
 } from 'react-devtools-shared/src/types';
 
 type getDisplayNameForFiberType = (fiber: Fiber) => string | null;
-type getTypeSymbolType = (type: any) => Symbol | number;
+type getTypeSymbolType = (type: any) => symbol | number;
 
 type ReactPriorityLevelsType = {|
   ImmediatePriority: number,
@@ -382,13 +382,14 @@ export function getInternalReactConstants(
   // End of copied code.
   // **********************************************************
 
-  function getTypeSymbol(type: any): Symbol | number {
+  function getTypeSymbol(type: any): symbol | number {
     const symbolOrNumber =
       typeof type === 'object' && type !== null ? type.$$typeof : type;
 
     // $FlowFixMe Flow doesn't know about typeof "symbol"
     return typeof symbolOrNumber === 'symbol'
-      ? symbolOrNumber.toString()
+      ? // $FlowFixMe `toString()` doesn't match the type signature?
+        symbolOrNumber.toString()
       : symbolOrNumber;
   }
 

--- a/packages/react-devtools-shared/src/backend/types.js
+++ b/packages/react-devtools-shared/src/backend/types.js
@@ -84,7 +84,7 @@ export type GetFiberIDForNative = (
 export type FindNativeNodesForFiberID = (id: number) => ?Array<NativeType>;
 
 export type ReactProviderType<T> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   _context: ReactContext<T>,
   ...
 };

--- a/packages/react-devtools-shared/src/devtools/views/Button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Button.js
@@ -28,6 +28,7 @@ export default function Button({
   ...rest
 }: Props) {
   let button = (
+    // $FlowFixMe unsafe spread
     <button
       className={`${styles.Button} ${className}`}
       data-testname={testName}

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/AutoSizeInput.js
@@ -42,6 +42,7 @@ export default function AutoSizeInput({
   const isEmpty = value === '' || value === '""';
 
   return (
+    // $FlowFixMe unsafe rest spread
     <input
       className={[styles.Input, className].join(' ')}
       data-testname={testName}

--- a/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/menu-button.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/menu-button.js
@@ -19,6 +19,7 @@ import useThemeStyles from '../../useThemeStyles';
 const MenuList = ({children, ...props}: {children: React$Node, ...}) => {
   const style = useThemeStyles();
   return (
+    // $FlowFixMe unsafe spread
     <ReachMenuList style={style} {...props}>
       {children}
     </ReachMenuList>

--- a/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/tooltip.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/reach-ui/tooltip.js
@@ -23,6 +23,7 @@ const Tooltip = ({
 }) => {
   const style = useThemeStyles();
   return (
+    // $FlowFixMe unsafe spread
     <ReachTooltip
       className={`${tooltipStyles.Tooltip} ${className}`}
       style={style}

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -396,7 +396,7 @@ export function hydrate(
       parent[last] = undefined;
     } else {
       // Replace the string keys with Symbols so they're non-enumerable.
-      const replaced: {[key: Symbol]: boolean | string, ...} = {};
+      const replaced: {[key: symbol]: boolean | string, ...} = {};
       replaced[meta.inspectable] = !!value.inspectable;
       replaced[meta.inspected] = false;
       replaced[meta.name] = value.name;

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/createGridComponent.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/createGridComponent.js
@@ -613,6 +613,7 @@ export default function createGridComponent({
       } else {
         itemStyleCache[key] = style = {
           position: 'absolute',
+          // $FlowFixMe computed properties are unsupported
           [direction === 'rtl' ? 'right' : 'left']: getColumnOffset(
             this.props,
             columnIndex,

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/createListComponent.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/createListComponent.js
@@ -469,6 +469,7 @@ export default function createListComponent({
 
         itemStyleCache[index] = style = {
           position: 'absolute',
+          // $FlowFixMe computed properties are unsupported
           [direction === 'rtl' ? 'right' : 'left']: isHorizontal ? offset : 0,
           top: !isHorizontal ? offset : 0,
           height: !isHorizontal ? size : '100%',

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -31,6 +31,7 @@ export function registerDevToolsEventLogger(
         let metadata = null;
         if (event.metadata != null) {
           metadata = event.metadata;
+          // $FlowFixMe: metadata is not writable and nullable
           delete event.metadata;
         }
         loggingIFrame.contentWindow.postMessage(
@@ -42,7 +43,8 @@ export function registerDevToolsEventLogger(
               version: process.env.DEVTOOLS_VERSION,
               metadata: metadata !== null ? JSON.stringify(metadata) : '',
               ...(fetchAdditionalContext != null
-                ? await fetchAdditionalContext()
+                ? // $FlowFixMe
+                  await fetchAdditionalContext()
                 : {}),
             },
           },

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -67,8 +67,8 @@ const encodedStringCache: LRUCache<string, Array<number>> = new LRU({
 });
 
 export function alphaSortKeys(
-  a: string | number | Symbol,
-  b: string | number | Symbol,
+  a: string | number | symbol,
+  b: string | number | symbol,
 ): number {
   if (a.toString() > b.toString()) {
     return 1;
@@ -81,7 +81,7 @@ export function alphaSortKeys(
 
 export function getAllEnumerableKeys(
   obj: Object,
-): Set<string | number | Symbol> {
+): Set<string | number | symbol> {
   const keys = new Set();
   let current = obj;
   while (current != null) {

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -166,7 +166,9 @@ let lastMouseEvent;
 function updateMouseMovementPolyfillState(event) {
   if (event !== lastMouseEvent) {
     if (lastMouseEvent && event.type === 'mousemove') {
+      // $FlowFixMe assuming this is a number
       lastMovementX = event.screenX - lastMouseEvent.screenX;
+      // $FlowFixMe assuming this is a number
       lastMovementY = event.screenY - lastMouseEvent.screenY;
     } else {
       lastMovementX = 0;
@@ -367,7 +369,9 @@ function getEventKey(nativeEvent) {
 
     // FireFox implements `key` but returns `MozPrintableKey` for all
     // printable characters (normalized to `Unidentified`), ignore it.
-    const key = normalizeKey[nativeEvent.key] || nativeEvent.key;
+    const key =
+      // $FlowFixMe unable to index with a `mixed` value
+      normalizeKey[nativeEvent.key] || nativeEvent.key;
     if (key !== 'Unidentified') {
       return key;
     }
@@ -375,7 +379,10 @@ function getEventKey(nativeEvent) {
 
   // Browser does not implement `key`, polyfill as much of it as we can.
   if (nativeEvent.type === 'keypress') {
-    const charCode = getEventCharCode(nativeEvent);
+    const charCode = getEventCharCode(
+      // $FlowFixMe unable to narrow to `KeyboardEvent`
+      nativeEvent,
+    );
 
     // The enter-key is technically both printable and non-printable and can
     // thus be captured by `keypress`, no other non-printable key should.
@@ -384,6 +391,7 @@ function getEventKey(nativeEvent) {
   if (nativeEvent.type === 'keydown' || nativeEvent.type === 'keyup') {
     // While user keyboard layout determines the actual meaning of each
     // `keyCode` value, almost all function keys have a universal value.
+    // $FlowFixMe unable to index with a `mixed` value
     return translateToKey[nativeEvent.keyCode] || 'Unidentified';
   }
   return '';
@@ -441,7 +449,10 @@ const KeyboardEventInterface = {
     // KeyPress is deprecated, but its replacement is not yet final and not
     // implemented in any major browser. Only KeyPress has charCode.
     if (event.type === 'keypress') {
-      return getEventCharCode(event);
+      return getEventCharCode(
+        // $FlowFixMe unable to narrow to `KeyboardEvent`
+        event,
+      );
     }
     return 0;
   },
@@ -462,7 +473,10 @@ const KeyboardEventInterface = {
     // `which` is an alias for either `keyCode` or `charCode` depending on the
     // type of the event.
     if (event.type === 'keypress') {
-      return getEventCharCode(event);
+      return getEventCharCode(
+        // $FlowFixMe unable to narrow to `KeyboardEvent`
+        event,
+      );
     }
     if (event.type === 'keydown' || event.type === 'keyup') {
       return event.keyCode;
@@ -538,7 +552,8 @@ const WheelEventInterface = {
       ? event.deltaX
       : // Fallback to `wheelDeltaX` for Webkit and normalize (right is positive).
       'wheelDeltaX' in event
-      ? -event.wheelDeltaX
+      ? // $FlowFixMe assuming this is a number
+        -event.wheelDeltaX
       : 0;
   },
   deltaY(event) {
@@ -546,10 +561,12 @@ const WheelEventInterface = {
       ? event.deltaY
       : // Fallback to `wheelDeltaY` for Webkit and normalize (down is positive).
       'wheelDeltaY' in event
-      ? -event.wheelDeltaY
+      ? // $FlowFixMe assuming this is a number
+        -event.wheelDeltaY
       : // Fallback to `wheelDelta` for IE<9 and normalize (down is positive).
       'wheelDelta' in event
-      ? -event.wheelDelta
+      ? // $FlowFixMe assuming this is a number
+        -event.wheelDelta
       : 0;
   },
   deltaZ: 0,

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -57,10 +57,10 @@ function renderToReadableStream(
       const stream: ReactDOMServerReadableStream = (new ReadableStream(
         {
           type: 'bytes',
-          pull(controller) {
+          pull(controller): ?Promise<void> {
             startFlowing(request, controller);
           },
-          cancel(reason) {
+          cancel(reason): ?Promise<void> {
             abort(request);
           },
         },

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -50,7 +50,7 @@ function prerender(
       const stream = new ReadableStream(
         {
           type: 'bytes',
-          pull(controller) {
+          pull(controller): ?Promise<void> {
             startFlowing(request, controller);
           },
         },

--- a/packages/react-fetch/src/ReactFetchNode.js
+++ b/packages/react-fetch/src/ReactFetchNode.js
@@ -43,6 +43,7 @@ function nodeFetch(
     // TODO: cherry-pick supported user-passed options.
   };
   const nodeImpl = protocol === 'https:' ? https : http;
+  // $FlowFixMe: node flow type has `port` as a number
   const request = nodeImpl.request(nodeOptions, response => {
     // TODO: support redirects.
     onResolve(new Response(response));

--- a/packages/react-native-renderer/src/legacy-events/accumulateInto.js
+++ b/packages/react-native-renderer/src/legacy-events/accumulateInto.js
@@ -40,9 +40,11 @@ function accumulateInto<T>(
   // certain that x is an Array (x could be a string with concat method).
   if (isArray(current)) {
     if (isArray(next)) {
+      // $FlowFixMe `isArray` does not ensure array is mutable
       current.push.apply(current, next);
       return current;
     }
+    // $FlowFixMe `isArray` does not ensure array is mutable
     current.push(next);
     return current;
   }

--- a/packages/react-noop-renderer/src/ReactNoopFlightServer.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightServer.js
@@ -53,7 +53,7 @@ const ReactNoopFlightServer = ReactFlightServer({
   },
   resolveModuleMetaData(
     config: void,
-    reference: {$$typeof: Symbol, value: any},
+    reference: {$$typeof: symbol, value: any},
   ) {
     return saveModule(reference.value);
   },

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -80,6 +80,7 @@ if (__DEV__) {
       );
     }
 
+    // $FlowFixMe unable to verify object is writable
     child._store.validated = true;
 
     const componentName = getComponentNameFromFiber(returnFiber) || 'Component';

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -80,7 +80,7 @@ if (__DEV__) {
       );
     }
 
-    // $FlowFixMe unable to verify object is writable
+    // $FlowFixMe unable to narrow type from mixed to writable object
     child._store.validated = true;
 
     const componentName = getComponentNameFromFiber(returnFiber) || 'Component';

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -80,6 +80,7 @@ if (__DEV__) {
       );
     }
 
+    // $FlowFixMe unable to narrow type from mixed to writable object
     child._store.validated = true;
 
     const componentName = getComponentNameFromFiber(returnFiber) || 'Component';

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -296,6 +296,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         }
       }
     } else {
+      // $FlowFixMe unable to narrow type to RefObject
       ref.current = null;
     }
   }
@@ -1522,6 +1523,7 @@ function commitAttachRef(finishedWork: Fiber) {
         }
       }
 
+      // $FlowFixMe unable to narrow type to the non-function case
       ref.current = instanceToUse;
     }
   }
@@ -1542,6 +1544,7 @@ function commitDetachRef(current: Fiber) {
         currentRef(null);
       }
     } else {
+      // $FlowFixMe unable to narrow type to the non-function case
       currentRef.current = null;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -296,7 +296,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         }
       }
     } else {
-      // $FlowFixMe unable to narrow type to the non-function case
+      // $FlowFixMe unable to narrow type to RefObject
       ref.current = null;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -296,6 +296,7 @@ function safelyDetachRef(current: Fiber, nearestMountedAncestor: Fiber | null) {
         }
       }
     } else {
+      // $FlowFixMe unable to narrow type to the non-function case
       ref.current = null;
     }
   }
@@ -1522,6 +1523,7 @@ function commitAttachRef(finishedWork: Fiber) {
         }
       }
 
+      // $FlowFixMe unable to narrow type to the non-function case
       ref.current = instanceToUse;
     }
   }
@@ -1542,6 +1544,7 @@ function commitDetachRef(current: Fiber) {
         currentRef(null);
       }
     } else {
+      // $FlowFixMe unable to narrow type to the non-function case
       currentRef.current = null;
     }
   }

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -62,7 +62,7 @@ export type FindHostInstancesForRefresh = (
 ) => Set<Instance>;
 
 let resolveFamily: RefreshHandler | null = null;
-// $FlowFixMe Flow got confused by a feature check below.
+// $FlowFixMe Flow gets confused by a WeakSet feature check below.
 let failedBoundaries: WeakSet<Fiber> | null = null;
 
 export const setRefreshHandler = (handler: RefreshHandler | null): void => {

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -62,7 +62,7 @@ export type FindHostInstancesForRefresh = (
 ) => Set<Instance>;
 
 let resolveFamily: RefreshHandler | null = null;
-// $FlowFixMe Flow gets confused by a WeakSet feature check below.
+// $FlowFixMe Flow got confused by a feature check below.
 let failedBoundaries: WeakSet<Fiber> | null = null;
 
 export const setRefreshHandler = (handler: RefreshHandler | null): void => {
@@ -222,6 +222,7 @@ export function markFailedErrorBoundaryForHotReloading(fiber: Fiber) {
       return;
     }
     if (failedBoundaries === null) {
+      // $FlowFixMe Flow got confused by the feature check above.
       failedBoundaries = new WeakSet();
     }
     failedBoundaries.add(fiber);

--- a/packages/react-reconciler/src/ReactFiberHotReloading.old.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.old.js
@@ -222,6 +222,7 @@ export function markFailedErrorBoundaryForHotReloading(fiber: Fiber) {
       return;
     }
     if (failedBoundaries === null) {
+      // $FlowFixMe Flow got confused by the feature check above.
       failedBoundaries = new WeakSet();
     }
     failedBoundaries.add(fiber);

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -39,7 +39,7 @@ if (typeof Symbol === 'function' && Symbol.for) {
   TEXT_TYPE = symbolFor('selector.text');
 }
 
-type Type = Symbol | number;
+type Type = symbol | number;
 
 type ComponentSelector = {|
   $$typeof: Type,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -52,13 +52,13 @@ function renderToReadableStream(
   const stream = new ReadableStream(
     {
       type: 'bytes',
-      start(controller) {
+      start(controller): ?Promise<void> {
         startWork(request);
       },
-      pull(controller) {
+      pull(controller): ?Promise<void> {
         startFlowing(request, controller);
       },
-      cancel(reason) {},
+      cancel(reason): ?Promise<void> {},
     },
     // $FlowFixMe size() methods are not allowed on byte streams.
     {highWaterMark: 0},

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -17,7 +17,7 @@ export type BundlerConfig = WebpackMap;
 
 // eslint-disable-next-line no-unused-vars
 export type ModuleReference<T> = {
-  $$typeof: Symbol,
+  $$typeof: symbol,
   filepath: string,
   name: string,
   async: boolean,

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -25,7 +25,7 @@ import {
 import isArray from 'shared/isArray';
 
 class ClientReferenceDependency extends ModuleDependency {
-  constructor(request) {
+  constructor(request: mixed) {
     super(request);
   }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -81,6 +81,7 @@ export type ReactModel =
   | string
   | boolean
   | number
+  | symbol
   | null
   | Iterable<ReactModel>
   | ReactModelObject;
@@ -197,14 +198,12 @@ function attemptResolveElement(
   if (typeof type === 'function') {
     if (isModuleReference(type)) {
       // This is a reference to a client component.
-      // $FlowFixMe unsure how this return type is supposed to match ReactModel
       return [REACT_ELEMENT_TYPE, type, key, props];
     }
     // This is a server-side component.
     return type(props);
   } else if (typeof type === 'string') {
     // This is a host element. E.g. HTML.
-    // $FlowFixMe unsure how this return type is supposed to match ReactModel
     return [REACT_ELEMENT_TYPE, type, key, props];
   } else if (typeof type === 'symbol') {
     if (type === REACT_FRAGMENT_TYPE) {
@@ -216,12 +215,10 @@ function attemptResolveElement(
     }
     // This might be a built-in React component. We'll let the client decide.
     // Any built-in works as long as its props are serializable.
-    // $FlowFixMe unsure how this return type is supposed to match ReactModel
     return [REACT_ELEMENT_TYPE, type, key, props];
   } else if (type != null && typeof type === 'object') {
     if (isModuleReference(type)) {
       // This is a reference to a client component.
-      // $FlowFixMe unsure how this return type is supposed to match ReactModel
       return [REACT_ELEMENT_TYPE, type, key, props];
     }
     switch (type.$$typeof) {
@@ -254,7 +251,6 @@ function attemptResolveElement(
             );
           }
         }
-        // $FlowFixMe unsure how this return type is supposed to match ReactModel
         return [
           REACT_ELEMENT_TYPE,
           type,
@@ -723,12 +719,17 @@ export function resolveModelToJSON(
     if (existingId !== undefined) {
       return serializeByValueID(existingId);
     }
-    const name = value.description;
+    // $FlowFixMe `description` might be undefined
+    const name: string = value.description;
 
+    // $FlowFixMe `name` might be undefined
     if (Symbol.for(name) !== value) {
       throw new Error(
         'Only global symbols received from Symbol.for(...) can be passed to client components. ' +
-          `The symbol Symbol.for(${value.description}) cannot be found among global symbols. ` +
+          `The symbol Symbol.for(${
+            // $FlowFixMe `description` might be undefined
+            value.description
+          }) cannot be found among global symbols. ` +
           `Remove ${describeKeyForErrorMessage(
             key,
           )} from this object, or avoid the entire object: ${describeObjectForErrorMessage(

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -113,7 +113,7 @@ export type Request = {
   completedModuleChunks: Array<Chunk>,
   completedJSONChunks: Array<Chunk>,
   completedErrorChunks: Array<Chunk>,
-  writtenSymbols: Map<Symbol, number>,
+  writtenSymbols: Map<symbol, number>,
   writtenModules: Map<ModuleKey, number>,
   writtenProviders: Map<string, number>,
   identifierPrefix: string,
@@ -197,12 +197,14 @@ function attemptResolveElement(
   if (typeof type === 'function') {
     if (isModuleReference(type)) {
       // This is a reference to a client component.
+      // $FlowFixMe unsure how this return type is supposed to match ReactModel
       return [REACT_ELEMENT_TYPE, type, key, props];
     }
     // This is a server-side component.
     return type(props);
   } else if (typeof type === 'string') {
     // This is a host element. E.g. HTML.
+    // $FlowFixMe unsure how this return type is supposed to match ReactModel
     return [REACT_ELEMENT_TYPE, type, key, props];
   } else if (typeof type === 'symbol') {
     if (type === REACT_FRAGMENT_TYPE) {
@@ -214,10 +216,12 @@ function attemptResolveElement(
     }
     // This might be a built-in React component. We'll let the client decide.
     // Any built-in works as long as its props are serializable.
+    // $FlowFixMe unsure how this return type is supposed to match ReactModel
     return [REACT_ELEMENT_TYPE, type, key, props];
   } else if (type != null && typeof type === 'object') {
     if (isModuleReference(type)) {
       // This is a reference to a client component.
+      // $FlowFixMe unsure how this return type is supposed to match ReactModel
       return [REACT_ELEMENT_TYPE, type, key, props];
     }
     switch (type.$$typeof) {
@@ -250,6 +254,7 @@ function attemptResolveElement(
             );
           }
         }
+        // $FlowFixMe unsure how this return type is supposed to match ReactModel
         return [
           REACT_ELEMENT_TYPE,
           type,

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -94,7 +94,8 @@ export function processModelChunk(
   id: number,
   model: ReactModel,
 ): Chunk {
-  const json = stringify(model, request.toJSON);
+  // $FlowFixMe: `json` might be `undefined` when model is a symbol.
+  const json: string = stringify(model, request.toJSON);
   const row = serializeRowHeader('J', id) + json + '\n';
   return stringToChunk(row);
 }
@@ -114,7 +115,8 @@ export function processModuleChunk(
   id: number,
   moduleMetaData: ReactModel,
 ): Chunk {
-  const json = stringify(moduleMetaData);
+  // $FlowFixMe: `json` might be `undefined` when moduleMetaData is a symbol.
+  const json: string = stringify(moduleMetaData);
   const row = serializeRowHeader('M', id) + json + '\n';
   return stringToChunk(row);
 }

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -65,7 +65,7 @@ type ReactTestRendererJSON = {|
   type: string,
   props: {[propName: string]: any, ...},
   children: null | Array<ReactTestRendererNode>,
-  $$typeof?: Symbol, // Optional because we add it with defineProperty().
+  $$typeof?: symbol, // Optional because we add it with defineProperty().
 |};
 type ReactTestRendererNode = ReactTestRendererJSON | string;
 

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -137,9 +137,12 @@ function mapIntoArray(
           escapedPrefix +
             // $FlowFixMe Flow incorrectly thinks React.Portal doesn't have a key
             (mappedChild.key && (!child || child.key !== mappedChild.key)
-              ? // $FlowFixMe Flow incorrectly thinks existing element's key can be a number
-                // eslint-disable-next-line react-internal/safe-string-coercion
-                escapeUserProvidedKey('' + mappedChild.key) + '/'
+              ? escapeUserProvidedKey(
+                  // eslint-disable-next-line react-internal/safe-string-coercion
+                  '' +
+                    // $FlowFixMe Flow incorrectly thinks existing element's key can be a number
+                    mappedChild.key,
+                ) + '/'
               : '') +
             childKey,
         );
@@ -190,6 +193,7 @@ function mapIntoArray(
       const iterator = iteratorFn.call(iterableChildren);
       let step;
       let ii = 0;
+      // $FlowFixMe `iteratorFn` might return null according to typing.
       while (!(step = iterator.next()).done) {
         child = step.value;
         nextName = nextNamePrefix + getElementKey(child, ii++);
@@ -222,7 +226,7 @@ function mapIntoArray(
   return subtreeCount;
 }
 
-type MapFunc = (child: ?React$Node) => ?ReactNodeList;
+type MapFunc = (child: ?React$Node, index: number) => ?ReactNodeList;
 
 /**
  * Maps children that are typically specified as `props.children`.

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -43,7 +43,7 @@ type Payload<T> =
   | RejectedPayload;
 
 export type LazyComponent<T, P> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
 };

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -26,6 +26,7 @@ function typeName(value: mixed): string {
       (hasToStringTag && (value: any)[Symbol.toStringTag]) ||
       (value: any).constructor.name ||
       'Object';
+    // $FlowFixMe
     return type;
   }
 }

--- a/packages/shared/ReactServerContextRegistry.js
+++ b/packages/shared/ReactServerContextRegistry.js
@@ -17,6 +17,7 @@ export function getOrCreateServerContext(globalName: string) {
   if (!ContextRegistry[globalName]) {
     ContextRegistry[globalName] = createServerContext(
       globalName,
+      // $FlowFixMe function signature doesn't reflect the symbol value
       REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED,
     );
   }

--- a/packages/shared/ReactSymbols.js
+++ b/packages/shared/ReactSymbols.js
@@ -40,7 +40,7 @@ export const REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED = Symbol.for(
 const MAYBE_ITERATOR_SYMBOL = Symbol.iterator;
 const FAUX_ITERATOR_SYMBOL = '@@iterator';
 
-export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<*> {
+export function getIteratorFn(maybeIterable: ?any): ?() => ?Iterator<any> {
   if (maybeIterable === null || typeof maybeIterable !== 'object') {
     return null;
   }

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -24,7 +24,7 @@ export type ReactNodeList = ReactEmpty | React$Node;
 export type ReactText = string | number;
 
 export type ReactProvider<T> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   type: ReactProviderType<T>,
   key: null | string,
   ref: null,
@@ -37,13 +37,13 @@ export type ReactProvider<T> = {
 };
 
 export type ReactProviderType<T> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   _context: ReactContext<T>,
   ...
 };
 
 export type ReactConsumer<T> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   type: ReactContext<T>,
   key: null | string,
   ref: null,
@@ -55,7 +55,7 @@ export type ReactConsumer<T> = {
 };
 
 export type ReactContext<T> = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   Consumer: ReactContext<T>,
   Provider: ReactProviderType<T>,
   _currentValue: T,
@@ -85,7 +85,7 @@ export type ServerContextJSONValue =
 export type ReactServerContext<T: any> = ReactContext<T>;
 
 export type ReactPortal = {
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
   key: null | string,
   containerInfo: any,
   children: ReactNodeList,
@@ -99,7 +99,7 @@ export type RefObject = {|
 |};
 
 export type ReactScope = {|
-  $$typeof: Symbol | number,
+  $$typeof: symbol | number,
 |};
 
 export type ReactScopeQuery = (

--- a/packages/shared/isValidElementType.js
+++ b/packages/shared/isValidElementType.js
@@ -33,7 +33,7 @@ import {
   enableLegacyHidden,
 } from './ReactFeatureFlags';
 
-const REACT_MODULE_REFERENCE: Symbol = Symbol.for('react.module.reference');
+const REACT_MODULE_REFERENCE: symbol = Symbol.for('react.module.reference');
 
 export default function isValidElementType(type: mixed) {
   if (typeof type === 'string' || typeof type === 'function') {

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -50,4 +50,4 @@ esproposal.optional_chaining=enable
 munge_underscores=false
 
 [version]
-^0.97.0
+^0.122.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7924,10 +7924,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.97:
-  version "0.97.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
-  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
+flow-bin@^0.122:
+  version "0.122.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.122.0.tgz#c723a2b33b1a70bd10204704ae1dc776d5d89d79"
+  integrity sha512-my8N5jgl/A+UVby9E7NDppHdhLgRbWgKbmFZSx2MSYMRh3d9YGnM2MM+wexpUpl0ftY1IM6ZcUwaAhrypLyvlA==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
Lots of things have improved over the last years in Flow. This is an incremental update from 0.97 (April, 2019) to 0.122 (April, 2020).

This version offers some extra options and seemed like a decent incremental stop towards the recent version.

The largest impact seems to be that Flow is now aware of the `symbol` primitive type. Maybe there could be follow-ups to fix the FixMes.

