### PR TITLE
Flow: implicit-inexact-object=error

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -129,10 +129,12 @@ function readRoot<T>(): T {
 }
 
 function createPendingChunk(response: Response): PendingChunk {
+  // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(PENDING, null, response);
 }
 
 function createErrorChunk(response: Response, error: Error): ErroredChunk {
+  // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(ERRORED, error, response);
 }
 
@@ -140,6 +142,7 @@ function createInitializedChunk<T>(
   response: Response,
   value: T,
 ): InitializedChunk<T> {
+  // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(INITIALIZED, value, response);
 }
 
@@ -168,6 +171,7 @@ function createResolvedModelChunk(
   response: Response,
   value: UninitializedModel,
 ): ResolvedModelChunk {
+  // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(RESOLVED_MODEL, value, response);
 }
 
@@ -175,6 +179,7 @@ function createResolvedModuleChunk<T>(
   response: Response,
   value: ModuleReference<T>,
 ): ResolvedModuleChunk<T> {
+  // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(RESOLVED_MODULE, value, response);
 }
 

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -34,7 +34,7 @@ export type JSONValue =
   | null
   | boolean
   | string
-  | {+[key: string]: JSONValue, ...}
+  | {|+[key: string]: JSONValue|}
   | $ReadOnlyArray<JSONValue>;
 
 const PENDING = 0;
@@ -43,41 +43,36 @@ const RESOLVED_MODULE = 2;
 const INITIALIZED = 3;
 const ERRORED = 4;
 
-type PendingChunk = {
+type PendingChunk = {|
   _status: 0,
   _value: null | Array<() => mixed>,
   _response: Response,
   then(resolve: () => mixed): void,
-  ...
-};
-type ResolvedModelChunk = {
+|};
+type ResolvedModelChunk = {|
   _status: 1,
   _value: UninitializedModel,
   _response: Response,
   then(resolve: () => mixed): void,
-  ...
-};
-type ResolvedModuleChunk<T> = {
+|};
+type ResolvedModuleChunk<T> = {|
   _status: 2,
   _value: ModuleReference<T>,
   _response: Response,
   then(resolve: () => mixed): void,
-  ...
-};
-type InitializedChunk<T> = {
+|};
+type InitializedChunk<T> = {|
   _status: 3,
   _value: T,
   _response: Response,
   then(resolve: () => mixed): void,
-  ...
-};
-type ErroredChunk = {
+|};
+type ErroredChunk = {|
   _status: 4,
   _value: Error,
   _response: Response,
   then(resolve: () => mixed): void,
-  ...
-};
+|};
 type SomeChunk<T> =
   | PendingChunk
   | ResolvedModelChunk
@@ -338,7 +333,7 @@ export function parseModelString(
 
 export function parseModelTuple(
   response: Response,
-  value: {+[key: string]: JSONValue, ...} | $ReadOnlyArray<JSONValue>,
+  value: {|+[key: string]: JSONValue|} | $ReadOnlyArray<JSONValue>,
 ): any {
   const tuple: [mixed, mixed, mixed, mixed] = (value: any);
 

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -34,7 +34,7 @@ export type JSONValue =
   | null
   | boolean
   | string
-  | {+[key: string]: JSONValue}
+  | {+[key: string]: JSONValue, ...}
   | $ReadOnlyArray<JSONValue>;
 
 const PENDING = 0;
@@ -48,30 +48,35 @@ type PendingChunk = {
   _value: null | Array<() => mixed>,
   _response: Response,
   then(resolve: () => mixed): void,
+  ...
 };
 type ResolvedModelChunk = {
   _status: 1,
   _value: UninitializedModel,
   _response: Response,
   then(resolve: () => mixed): void,
+  ...
 };
 type ResolvedModuleChunk<T> = {
   _status: 2,
   _value: ModuleReference<T>,
   _response: Response,
   then(resolve: () => mixed): void,
+  ...
 };
 type InitializedChunk<T> = {
   _status: 3,
   _value: T,
   _response: Response,
   then(resolve: () => mixed): void,
+  ...
 };
 type ErroredChunk = {
   _status: 4,
   _value: Error,
   _response: Response,
   then(resolve: () => mixed): void,
+  ...
 };
 type SomeChunk<T> =
   | PendingChunk
@@ -333,7 +338,7 @@ export function parseModelString(
 
 export function parseModelTuple(
   response: Response,
-  value: {+[key: string]: JSONValue} | $ReadOnlyArray<JSONValue>,
+  value: {+[key: string]: JSONValue, ...} | $ReadOnlyArray<JSONValue>,
 ): any {
   const tuple: [mixed, mixed, mixed, mixed] = (value: any);
 

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -10,12 +10,11 @@
 import type {ResponseBase} from './ReactFlightClient';
 import type {StringDecoder} from './ReactFlightClientHostConfig';
 
-export type Response = ResponseBase & {
+export type Response = ResponseBase & {|
   _partialRow: string,
   _fromJSON: (key: string, value: JSONValue) => any,
   _stringDecoder: StringDecoder,
-  ...
-};
+|};
 
 export type UninitializedModel = string;
 

--- a/packages/react-client/src/ReactFlightClientHostConfigStream.js
+++ b/packages/react-client/src/ReactFlightClientHostConfigStream.js
@@ -14,6 +14,7 @@ export type Response = ResponseBase & {
   _partialRow: string,
   _fromJSON: (key: string, value: JSONValue) => any,
   _stringDecoder: StringDecoder,
+  ...
 };
 
 export type UninitializedModel = string;

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -51,11 +51,10 @@ type Dispatch<A> = A => void;
 
 let primitiveStackCache: null | Map<string, Array<any>> = null;
 
-type Hook = {
+type Hook = {|
   memoizedState: any,
   next: Hook | null,
-  ...
-};
+|};
 
 function getPrimitiveStackCache(): Map<string, Array<any>> {
   // This initializes a cache of all primitive hooks so that the top
@@ -372,13 +371,12 @@ const DispatcherProxy = new Proxy(Dispatcher, DispatcherProxyHandler);
 
 // Inspect
 
-export type HookSource = {
+export type HookSource = {|
   lineNumber: number | null,
   columnNumber: number | null,
   fileName: string | null,
   functionName: string | null,
-  ...
-};
+|};
 
 export type HooksNode = {
   id: number | null,

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -54,6 +54,7 @@ let primitiveStackCache: null | Map<string, Array<any>> = null;
 type Hook = {
   memoizedState: any,
   next: Hook | null,
+  ...
 };
 
 function getPrimitiveStackCache(): Map<string, Array<any>> {
@@ -376,6 +377,7 @@ export type HookSource = {
   columnNumber: number | null,
   fileName: string | null,
   functionName: string | null,
+  ...
 };
 
 export type HooksNode = {

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -36,6 +36,7 @@ export type LoggerEvent =
       +event_name: 'select-element',
       +metadata: {
         +source: string,
+        ...
       },
     |}
   | {|
@@ -45,12 +46,14 @@ export type LoggerEvent =
       +event_name: 'profiling-start',
       +metadata: {
         +current_tab: string,
+        ...
       },
     |}
   | {|
       +event_name: 'profiler-tab-changed',
       +metadata: {
         +tabId: string,
+        ...
       },
     |}
   | {|

--- a/packages/react-devtools-shared/src/Logger.js
+++ b/packages/react-devtools-shared/src/Logger.js
@@ -34,27 +34,24 @@ export type LoggerEvent =
     |}
   | {|
       +event_name: 'select-element',
-      +metadata: {
+      +metadata: {|
         +source: string,
-        ...
-      },
+      |},
     |}
   | {|
       +event_name: 'inspect-element-button-clicked',
     |}
   | {|
       +event_name: 'profiling-start',
-      +metadata: {
+      +metadata: {|
         +current_tab: string,
-        ...
-      },
+      |},
     |}
   | {|
       +event_name: 'profiler-tab-changed',
-      +metadata: {
+      +metadata: {|
         +tabId: string,
-        ...
-      },
+      |},
     |}
   | {|
       +event_name: 'settings-changed',

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -151,14 +151,13 @@ export function patch({
   showInlineWarningsAndErrors,
   hideConsoleLogsInStrictMode,
   browserTheme,
-}: {
+}: {|
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
   showInlineWarningsAndErrors: boolean,
   hideConsoleLogsInStrictMode: boolean,
   browserTheme: BrowserTheme,
-  ...
-}): void {
+|}): void {
   // Settings may change after we've patched the console.
   // Using a shared ref allows the patch function to read the latest values.
   consoleSettingsRef.appendComponentStack = appendComponentStack;

--- a/packages/react-devtools-shared/src/backend/console.js
+++ b/packages/react-devtools-shared/src/backend/console.js
@@ -157,6 +157,7 @@ export function patch({
   showInlineWarningsAndErrors: boolean,
   hideConsoleLogsInStrictMode: boolean,
   browserTheme: BrowserTheme,
+  ...
 }): void {
   // Settings may change after we've patched the console.
   // Using a shared ref allows the patch function to read the latest values.

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -79,7 +79,7 @@ import type {
   DisplayDensity,
 } from './devtools/views/Settings/SettingsContext';
 
-export const THEME_STYLES: {[style: Theme | DisplayDensity]: any} = {
+export const THEME_STYLES: {[style: Theme | DisplayDensity]: any, ...} = {
   light: {
     '--color-attribute-name': '#ef6632',
     '--color-attribute-name-not-editable': '#23272f',

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -79,7 +79,7 @@ import type {
   DisplayDensity,
 } from './devtools/views/Settings/SettingsContext';
 
-export const THEME_STYLES: {[style: Theme | DisplayDensity]: any, ...} = {
+export const THEME_STYLES: {|[style: Theme | DisplayDensity]: any|} = {
   light: {
     '--color-attribute-name': '#ef6632',
     '--color-attribute-name-not-editable': '#23272f',

--- a/packages/react-devtools-shared/src/constants.js
+++ b/packages/react-devtools-shared/src/constants.js
@@ -79,7 +79,7 @@ import type {
   DisplayDensity,
 } from './devtools/views/Settings/SettingsContext';
 
-export const THEME_STYLES: {|[style: Theme | DisplayDensity]: any|} = {
+export const THEME_STYLES: {[style: Theme | DisplayDensity]: any, ...} = {
   light: {
     '--color-attribute-name': '#ef6632',
     '--color-attribute-name-not-editable': '#23272f',

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
@@ -22,7 +22,7 @@ export default function useContextMenu({
   data: Object,
   id: string,
   onChange?: OnChangeFn,
-  ref: {current: ElementRef<*> | null, ...},
+  ref: {|current: ElementRef<*> | null|},
 |}) {
   const {showMenu} = useContext<RegistryContextType>(RegistryContext);
 

--- a/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
+++ b/packages/react-devtools-shared/src/devtools/ContextMenu/useContextMenu.js
@@ -22,7 +22,7 @@ export default function useContextMenu({
   data: Object,
   id: string,
   onChange?: OnChangeFn,
-  ref: {current: ElementRef<*> | null},
+  ref: {current: ElementRef<*> | null, ...},
 |}) {
   const {showMenu} = useContext<RegistryContextType>(RegistryContext);
 

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorsAndWarningsTree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementErrorsAndWarningsTree.js
@@ -119,7 +119,7 @@ type TreeProps = {|
   badgeClassName: string,
   actions: React$Node,
   className: string,
-  clearMessages: () => {},
+  clearMessages: () => void,
   entries: Array<[string, number]>,
   isTransitionPending: boolean,
   label: string,

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
@@ -23,10 +23,9 @@ export type TooltipFiberData = {|
   name: string,
 |};
 
-export type Props = {
+export type Props = {|
   fiberData: ChartNode,
-  ...
-};
+|};
 
 export default function HoveredFiberInfo({fiberData}: Props) {
   const {profilerStore} = useContext(StoreContext);

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/HoveredFiberInfo.js
@@ -25,6 +25,7 @@ export type TooltipFiberData = {|
 
 export type Props = {
   fiberData: ChartNode,
+  ...
 };
 
 export default function HoveredFiberInfo({fiberData}: Props) {

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
@@ -86,6 +86,7 @@ type DragState = {
   commitIndex: number,
   left: number,
   sizeIncrement: number,
+  ...
 };
 
 function List({

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SnapshotCommitList.js
@@ -82,12 +82,11 @@ type ListProps = {|
   width: number,
 |};
 
-type DragState = {
+type DragState = {|
   commitIndex: number,
   left: number,
   sizeIncrement: number,
-  ...
-};
+|};
 
 function List({
   commitData,

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -227,6 +227,7 @@ export function installHook(target: any): DevToolsHook | null {
   }: {
     hideConsoleLogsInStrictMode: boolean,
     browserTheme: BrowserTheme,
+    ...
   }) {
     const overrideConsoleMethods = [
       'error',

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -224,11 +224,10 @@ export function installHook(target: any): DevToolsHook | null {
   function patchConsoleForInitialRenderInStrictMode({
     hideConsoleLogsInStrictMode,
     browserTheme,
-  }: {
+  }: {|
     hideConsoleLogsInStrictMode: boolean,
     browserTheme: BrowserTheme,
-    ...
-  }) {
+  |}) {
     const overrideConsoleMethods = [
       'error',
       'group',

--- a/packages/react-devtools-shared/src/hooks/astUtils.js
+++ b/packages/react-devtools-shared/src/hooks/astUtils.js
@@ -22,6 +22,7 @@ export type SourceFileASTWithHookDetails = {
   sourceFileAST: File,
   line: number,
   source: string,
+  ...
 };
 
 export const NO_HOOK_NAME = '<no-hook>';

--- a/packages/react-devtools-shared/src/hooks/astUtils.js
+++ b/packages/react-devtools-shared/src/hooks/astUtils.js
@@ -18,12 +18,11 @@ export type Position = {|
   column: number,
 |};
 
-export type SourceFileASTWithHookDetails = {
+export type SourceFileASTWithHookDetails = {|
   sourceFileAST: File,
   line: number,
   source: string,
-  ...
-};
+|};
 
 export const NO_HOOK_NAME = '<no-hook>';
 

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -168,13 +168,12 @@ export function checkForUpdate({
   element,
   refresh,
   store,
-}: {
+}: {|
   bridge: FrontendBridge,
   element: Element,
   refresh: RefreshFunction,
   store: Store,
-  ...
-}): void {
+|}): void {
   const {id} = element;
   const rendererID = store.getRendererIDForElement(id);
   if (rendererID != null) {

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -173,6 +173,7 @@ export function checkForUpdate({
   element: Element,
   refresh: RefreshFunction,
   store: Store,
+  ...
 }): void {
   const {id} = element;
   const rendererID = store.getRendererIDForElement(id);

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
@@ -19,7 +19,7 @@ type ItemMetadata = {|
   offset: number,
   size: number,
 |};
-type ItemMetadataMap = { [index: number]: ItemMetadata };
+type ItemMetadataMap = { [index: number]: ItemMetadata, ... };
 type InstanceProps = {|
   columnMetadataMap: ItemMetadataMap,
   estimatedColumnWidth: number,

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
@@ -19,7 +19,7 @@ type ItemMetadata = {|
   offset: number,
   size: number,
 |};
-type ItemMetadataMap = { [index: number]: ItemMetadata, ... };
+type ItemMetadataMap = {| [index: number]: ItemMetadata, |};
 type InstanceProps = {|
   columnMetadataMap: ItemMetadataMap,
   estimatedColumnWidth: number,

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeGrid.js
@@ -19,7 +19,7 @@ type ItemMetadata = {|
   offset: number,
   size: number,
 |};
-type ItemMetadataMap = {| [index: number]: ItemMetadata, |};
+type ItemMetadataMap = { [index: number]: ItemMetadata, ... };
 type InstanceProps = {|
   columnMetadataMap: ItemMetadataMap,
   estimatedColumnWidth: number,

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
@@ -18,7 +18,7 @@ type ItemMetadata = {|
   size: number,
 |};
 type InstanceProps = {|
-  itemMetadataMap: { [index: number]: ItemMetadata },
+  itemMetadataMap: { [index: number]: ItemMetadata, ... },
   estimatedItemSize: number,
   lastMeasuredIndex: number,
 |};

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
@@ -18,7 +18,7 @@ type ItemMetadata = {|
   size: number,
 |};
 type InstanceProps = {|
-  itemMetadataMap: { [index: number]: ItemMetadata, ... },
+  itemMetadataMap: {| [index: number]: ItemMetadata,  |},
   estimatedItemSize: number,
   lastMeasuredIndex: number,
 |};

--- a/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
+++ b/packages/react-devtools-shared/src/node_modules/react-window/src/VariableSizeList.js
@@ -18,7 +18,7 @@ type ItemMetadata = {|
   size: number,
 |};
 type InstanceProps = {|
-  itemMetadataMap: {| [index: number]: ItemMetadata,  |},
+  itemMetadataMap: { [index: number]: ItemMetadata, ... },
   estimatedItemSize: number,
   lastMeasuredIndex: number,
 |};

--- a/packages/react-devtools-timeline/src/CanvasPage.js
+++ b/packages/react-devtools-timeline/src/CanvasPage.js
@@ -80,7 +80,7 @@ function CanvasPage({profilerData, viewState}: Props) {
       className={styles.CanvasPage}
       style={{backgroundColor: COLORS.BACKGROUND}}>
       <AutoSizer>
-        {({height, width}: {height: number, width: number}) => (
+        {({height, width}: {height: number, width: number, ...}) => (
           <AutoSizedCanvas
             data={profilerData}
             height={height}

--- a/packages/react-devtools-timeline/src/CanvasPage.js
+++ b/packages/react-devtools-timeline/src/CanvasPage.js
@@ -80,7 +80,7 @@ function CanvasPage({profilerData, viewState}: Props) {
       className={styles.CanvasPage}
       style={{backgroundColor: COLORS.BACKGROUND}}>
       <AutoSizer>
-        {({height, width}: {height: number, width: number, ...}) => (
+        {({height, width}: {|height: number, width: number|}) => (
           <AutoSizedCanvas
             data={profilerData}
             height={height}

--- a/packages/react-devtools-timeline/src/types.js
+++ b/packages/react-devtools-timeline/src/types.js
@@ -17,12 +17,11 @@ export type Return<T> = Return_<*, T>;
 
 // Project types
 
-export type ErrorStackFrame = {
+export type ErrorStackFrame = {|
   fileName: string,
   lineNumber: number,
   columnNumber: number,
-  ...
-};
+|};
 
 export type Milliseconds = number;
 

--- a/packages/react-devtools-timeline/src/types.js
+++ b/packages/react-devtools-timeline/src/types.js
@@ -21,6 +21,7 @@ export type ErrorStackFrame = {
   fileName: string,
   lineNumber: number,
   columnNumber: number,
+  ...
 };
 
 export type Milliseconds = number;

--- a/packages/react-devtools-timeline/src/utils/useSmartTooltip.js
+++ b/packages/react-devtools-timeline/src/utils/useSmartTooltip.js
@@ -16,12 +16,11 @@ export default function useSmartTooltip({
   canvasRef,
   mouseX,
   mouseY,
-}: {
+}: {|
   canvasRef: {|current: HTMLCanvasElement | null|},
   mouseX: number,
   mouseY: number,
-  ...
-}) {
+|}) {
   const ref = useRef<HTMLElement | null>(null);
 
   // HACK: Browser extension reports window.innerHeight of 0,

--- a/packages/react-devtools-timeline/src/utils/useSmartTooltip.js
+++ b/packages/react-devtools-timeline/src/utils/useSmartTooltip.js
@@ -20,6 +20,7 @@ export default function useSmartTooltip({
   canvasRef: {|current: HTMLCanvasElement | null|},
   mouseX: number,
   mouseY: number,
+  ...
 }) {
   const ref = useRef<HTMLElement | null>(null);
 

--- a/packages/react-devtools-timeline/src/view-base/resizable/ResizableView.js
+++ b/packages/react-devtools-timeline/src/view-base/resizable/ResizableView.js
@@ -47,7 +47,7 @@ const HIDDEN_RECT = {
 };
 
 export class ResizableView extends View {
-  _canvasRef: {current: HTMLCanvasElement | null};
+  _canvasRef: {current: HTMLCanvasElement | null, ...};
   _layoutState: LayoutState;
   _mutableViewStateKey: string;
   _resizeBar: ResizeBarView;
@@ -60,7 +60,7 @@ export class ResizableView extends View {
     frame: Rect,
     subview: View,
     viewState: ViewState,
-    canvasRef: {current: HTMLCanvasElement | null},
+    canvasRef: {current: HTMLCanvasElement | null, ...},
     label: string,
   ) {
     super(surface, frame, noopLayout);

--- a/packages/react-devtools-timeline/src/view-base/resizable/ResizableView.js
+++ b/packages/react-devtools-timeline/src/view-base/resizable/ResizableView.js
@@ -47,7 +47,7 @@ const HIDDEN_RECT = {
 };
 
 export class ResizableView extends View {
-  _canvasRef: {current: HTMLCanvasElement | null, ...};
+  _canvasRef: {|current: HTMLCanvasElement | null|};
   _layoutState: LayoutState;
   _mutableViewStateKey: string;
   _resizeBar: ResizeBarView;
@@ -60,7 +60,7 @@ export class ResizableView extends View {
     frame: Rect,
     subview: View,
     viewState: ViewState,
-    canvasRef: {current: HTMLCanvasElement | null, ...},
+    canvasRef: {|current: HTMLCanvasElement | null|},
     label: string,
   ) {
     super(surface, frame, noopLayout);

--- a/packages/react-devtools-timeline/src/view-base/utils/scrollState.js
+++ b/packages/react-devtools-timeline/src/view-base/utils/scrollState.js
@@ -35,13 +35,12 @@ function clampLength({
   minContentLength,
   maxContentLength,
   containerLength,
-}: {
+}: {|
   state: ScrollState,
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
-  ...
-}): ScrollState {
+|}): ScrollState {
   return {
     offset: state.offset,
     length: clamp(
@@ -63,13 +62,12 @@ export function clampState({
   minContentLength,
   maxContentLength,
   containerLength,
-}: {
+}: {|
   state: ScrollState,
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
-  ...
-}): ScrollState {
+|}): ScrollState {
   return clampOffset(
     clampLength({
       state,
@@ -85,12 +83,11 @@ export function translateState({
   state,
   delta,
   containerLength,
-}: {
+}: {|
   state: ScrollState,
   delta: number,
   containerLength: number,
-  ...
-}): ScrollState {
+|}): ScrollState {
   return clampOffset(
     {
       offset: state.offset + delta,
@@ -122,7 +119,7 @@ export function zoomState({
   minContentLength,
   maxContentLength,
   containerLength,
-}: {
+}: {|
   state: ScrollState,
   multiplier: number,
   fixedPoint: number,
@@ -130,8 +127,7 @@ export function zoomState({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
-  ...
-}): ScrollState {
+|}): ScrollState {
   // Length and offset must be computed separately, so that if the length is
   // clamped the offset will still be correct (unless it gets clamped too).
 
@@ -168,7 +164,7 @@ export function moveStateToRange({
   minContentLength,
   maxContentLength,
   containerLength,
-}: {
+}: {|
   state: ScrollState,
   rangeStart: number,
   rangeEnd: number,
@@ -177,8 +173,7 @@ export function moveStateToRange({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
-  ...
-}): ScrollState {
+|}): ScrollState {
   // Length and offset must be computed separately, so that if the length is
   // clamped the offset will still be correct (unless it gets clamped too).
 

--- a/packages/react-devtools-timeline/src/view-base/utils/scrollState.js
+++ b/packages/react-devtools-timeline/src/view-base/utils/scrollState.js
@@ -40,6 +40,7 @@ function clampLength({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
+  ...
 }): ScrollState {
   return {
     offset: state.offset,
@@ -67,6 +68,7 @@ export function clampState({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
+  ...
 }): ScrollState {
   return clampOffset(
     clampLength({
@@ -87,6 +89,7 @@ export function translateState({
   state: ScrollState,
   delta: number,
   containerLength: number,
+  ...
 }): ScrollState {
   return clampOffset(
     {
@@ -127,6 +130,7 @@ export function zoomState({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
+  ...
 }): ScrollState {
   // Length and offset must be computed separately, so that if the length is
   // clamped the offset will still be correct (unless it gets clamped too).
@@ -173,6 +177,7 @@ export function moveStateToRange({
   minContentLength: number,
   maxContentLength: number,
   containerLength: number,
+  ...
 }): ScrollState {
   // Length and offset must be computed separately, so that if the length is
   // clamped the offset will still be correct (unless it gets clamped too).

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -733,7 +733,7 @@ export function isSuspenseInstanceFallback(instance: SuspenseInstance) {
 
 export function getSuspenseInstanceFallbackErrorDetails(
   instance: SuspenseInstance,
-): {digest: ?string, message?: string, stack?: string} {
+): {digest: ?string, message?: string, stack?: string, ...} {
   const dataset =
     instance.nextSibling && ((instance.nextSibling: any): HTMLElement).dataset;
   let digest, message, stack;
@@ -1323,6 +1323,7 @@ export function setFocusIfFocusable(node: Instance): boolean {
 type RectRatio = {
   ratio: number,
   rect: BoundingRect,
+  ...
 };
 
 export function setupIntersectionObserver(

--- a/packages/react-dom/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom/src/client/ReactDOMHostConfig.js
@@ -733,7 +733,7 @@ export function isSuspenseInstanceFallback(instance: SuspenseInstance) {
 
 export function getSuspenseInstanceFallbackErrorDetails(
   instance: SuspenseInstance,
-): {digest: ?string, message?: string, stack?: string, ...} {
+): {|digest: ?string, message?: string, stack?: string|} {
   const dataset =
     instance.nextSibling && ((instance.nextSibling: any): HTMLElement).dataset;
   let digest, message, stack;
@@ -1320,11 +1320,10 @@ export function setFocusIfFocusable(node: Instance): boolean {
   return didFocus;
 }
 
-type RectRatio = {
+type RectRatio = {|
   ratio: number,
   rect: BoundingRect,
-  ...
-};
+|};
 
 export function setupIntersectionObserver(
   targets: Array<Instance>,

--- a/packages/react-dom/src/events/ReactSyntheticEventType.js
+++ b/packages/react-dom/src/events/ReactSyntheticEventType.js
@@ -20,7 +20,7 @@ export type DispatchConfig = {|
   registrationName?: string,
 |};
 
-type BaseSyntheticEvent = {
+type BaseSyntheticEvent = {|
   isPersistent: () => boolean,
   isPropagationStopped: () => boolean,
   _dispatchInstances?: null | Array<Fiber | null> | Fiber,
@@ -31,17 +31,14 @@ type BaseSyntheticEvent = {
   relatedTarget?: mixed,
   type: string,
   currentTarget: null | EventTarget,
-  ...
-};
+|};
 
-export type KnownReactSyntheticEvent = BaseSyntheticEvent & {
+export type KnownReactSyntheticEvent = BaseSyntheticEvent & {|
   _reactName: string,
-  ...
-};
-export type UnknownReactSyntheticEvent = BaseSyntheticEvent & {
+|};
+export type UnknownReactSyntheticEvent = BaseSyntheticEvent & {|
   _reactName: null,
-  ...
-};
+|};
 
 export type ReactSyntheticEvent =
   | KnownReactSyntheticEvent

--- a/packages/react-dom/src/events/ReactSyntheticEventType.js
+++ b/packages/react-dom/src/events/ReactSyntheticEventType.js
@@ -31,13 +31,16 @@ type BaseSyntheticEvent = {
   relatedTarget?: mixed,
   type: string,
   currentTarget: null | EventTarget,
+  ...
 };
 
 export type KnownReactSyntheticEvent = BaseSyntheticEvent & {
   _reactName: string,
+  ...
 };
 export type UnknownReactSyntheticEvent = BaseSyntheticEvent & {
   _reactName: null,
+  ...
 };
 
 export type ReactSyntheticEvent =

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -13,7 +13,8 @@ import assign from 'shared/assign';
 import getEventCharCode from './getEventCharCode';
 
 type EventInterfaceType = {
-  [propName: string]: 0 | ((event: {[propName: string]: mixed}) => mixed),
+  [propName: string]: 0 | ((event: {[propName: string]: mixed, ...}) => mixed),
+  ...,
 };
 
 function functionThatReturnsTrue() {
@@ -44,7 +45,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
     reactName: string | null,
     reactEventType: string,
     targetInst: Fiber,
-    nativeEvent: {[propName: string]: mixed},
+    nativeEvent: {[propName: string]: mixed, ...},
     nativeEventTarget: null | EventTarget,
   ) {
     this._reactName = reactName;

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -12,10 +12,9 @@
 import assign from 'shared/assign';
 import getEventCharCode from './getEventCharCode';
 
-type EventInterfaceType = {
-  [propName: string]: 0 | ((event: {[propName: string]: mixed, ...}) => mixed),
-  ...,
-};
+type EventInterfaceType = {|
+  [propName: string]: 0 | ((event: {|[propName: string]: mixed|}) => mixed),
+|};
 
 function functionThatReturnsTrue() {
   return true;
@@ -45,7 +44,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
     reactName: string | null,
     reactEventType: string,
     targetInst: Fiber,
-    nativeEvent: {[propName: string]: mixed, ...},
+    nativeEvent: {|[propName: string]: mixed|},
     nativeEventTarget: null | EventTarget,
   ) {
     this._reactName = reactName;

--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -12,9 +12,10 @@
 import assign from 'shared/assign';
 import getEventCharCode from './getEventCharCode';
 
-type EventInterfaceType = {|
-  [propName: string]: 0 | ((event: {|[propName: string]: mixed|}) => mixed),
-|};
+type EventInterfaceType = {
+  [propName: string]: 0 | ((event: {[propName: string]: mixed, ...}) => mixed),
+  ...,
+};
 
 function functionThatReturnsTrue() {
   return true;
@@ -44,7 +45,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
     reactName: string | null,
     reactEventType: string,
     targetInst: Fiber,
-    nativeEvent: {|[propName: string]: mixed|},
+    nativeEvent: {[propName: string]: mixed, ...},
     nativeEventTarget: null | EventTarget,
   ) {
     this._reactName = reactName;

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -37,10 +37,9 @@ type Options = {|
 |};
 
 // TODO: Move to sub-classing ReadableStream.
-type ReactDOMServerReadableStream = ReadableStream & {
+type ReactDOMServerReadableStream = ReadableStream & {|
   allReady: Promise<void>,
-  ...
-};
+|};
 
 function renderToReadableStream(
   children: ReactNodeList,

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -39,6 +39,7 @@ type Options = {|
 // TODO: Move to sub-classing ReadableStream.
 type ReactDOMServerReadableStream = ReadableStream & {
   allReady: Promise<void>,
+  ...
 };
 
 function renderToReadableStream(

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -11,10 +11,9 @@ import type {ReactNodeList} from 'shared/ReactTypes';
 
 import {version, renderToStringImpl} from './ReactDOMLegacyServerImpl';
 
-type ServerOptions = {
+type ServerOptions = {|
   identifierPrefix?: string,
-  ...
-};
+|};
 
 function renderToString(
   children: ReactNodeList,

--- a/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerBrowser.js
@@ -13,6 +13,7 @@ import {version, renderToStringImpl} from './ReactDOMLegacyServerImpl';
 
 type ServerOptions = {
   identifierPrefix?: string,
+  ...
 };
 
 function renderToString(

--- a/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
@@ -23,10 +23,9 @@ import {
   createRootFormatContext,
 } from './ReactDOMServerLegacyFormatConfig';
 
-type ServerOptions = {
+type ServerOptions = {|
   identifierPrefix?: string,
-  ...
-};
+|};
 
 function onError() {
   // Non-fatal errors are ignored.

--- a/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerImpl.js
@@ -25,6 +25,7 @@ import {
 
 type ServerOptions = {
   identifierPrefix?: string,
+  ...
 };
 
 function onError() {

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
@@ -15,10 +15,9 @@ import {
   renderToStaticNodeStream,
 } from './ReactDOMLegacyServerNodeStream';
 
-type ServerOptions = {
+type ServerOptions = {|
   identifierPrefix?: string,
-  ...
-};
+|};
 
 function renderToString(
   children: ReactNodeList,

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNode.js
@@ -17,6 +17,7 @@ import {
 
 type ServerOptions = {
   identifierPrefix?: string,
+  ...
 };
 
 function renderToString(

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -25,10 +25,9 @@ import {
 
 import {Readable} from 'stream';
 
-type ServerOptions = {
+type ServerOptions = {|
   identifierPrefix?: string,
-  ...
-};
+|};
 
 class ReactMarkupReadableStream extends Readable {
   request: Request;

--- a/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
+++ b/packages/react-dom/src/server/ReactDOMLegacyServerNodeStream.js
@@ -27,6 +27,7 @@ import {Readable} from 'stream';
 
 type ServerOptions = {
   identifierPrefix?: string,
+  ...
 };
 
 class ReactMarkupReadableStream extends Readable {

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -105,11 +105,10 @@ const scriptRegex = /(<\/|<)(s)(cript)/gi;
 const scriptReplacer = (match, prefix, s, suffix) =>
   `${prefix}${s === 's' ? '\\u0073' : '\\u0053'}${suffix}`;
 
-export type BootstrapScriptDescriptor = {
+export type BootstrapScriptDescriptor = {|
   src: string,
   integrity?: string,
-  ...
-};
+|};
 // Allows us to keep track of what we've already written so we can refer back to it.
 export function createResponseState(
   identifierPrefix: string | void,
@@ -204,11 +203,10 @@ const HTML_COLGROUP_MODE = 7;
 type InsertionMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
 // Lets us keep track of contextual state and pick it back up after suspending.
-export type FormatContext = {
+export type FormatContext = {|
   insertionMode: InsertionMode, // root/svg/html/mathml/table
   selectedValue: null | string | Array<string>, // the selected value(s) inside a <select>, or null outside <select>
-  ...
-};
+|};
 
 function createFormatContext(
   insertionMode: InsertionMode,

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -108,6 +108,7 @@ const scriptReplacer = (match, prefix, s, suffix) =>
 export type BootstrapScriptDescriptor = {
   src: string,
   integrity?: string,
+  ...
 };
 // Allows us to keep track of what we've already written so we can refer back to it.
 export function createResponseState(
@@ -206,6 +207,7 @@ type InsertionMode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 export type FormatContext = {
   insertionMode: InsertionMode, // root/svg/html/mathml/table
   selectedValue: null | string | Array<string>, // the selected value(s) inside a <select>, or null outside <select>
+  ...
 };
 
 function createFormatContext(

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -42,6 +42,7 @@ export type ResponseState = {
   sentClientRenderFunction: boolean,
   // This is an extra field for the legacy renderer
   generateStaticMarkup: boolean,
+  ...
 };
 
 export function createResponseState(

--- a/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerLegacyFormatConfig.js
@@ -28,7 +28,7 @@ import type {
 
 export const isPrimaryRenderer = false;
 
-export type ResponseState = {
+export type ResponseState = {|
   // Keep this in sync with ReactDOMServerFormatConfig
   bootstrapChunks: Array<Chunk | PrecomputedChunk>,
   startInlineScript: PrecomputedChunk,
@@ -42,8 +42,7 @@ export type ResponseState = {
   sentClientRenderFunction: boolean,
   // This is an extra field for the legacy renderer
   generateStaticMarkup: boolean,
-  ...
-};
+|};
 
 export function createResponseState(
   generateStaticMarkup: boolean,

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -128,7 +128,7 @@ function createLstatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
-export function lstat(path: string, options?: {bigint?: boolean, ...}): mixed {
+export function lstat(path: string, options?: {|bigint?: boolean|}): mixed {
   checkPathInDev(path);
   let bigint = false;
   if (options && options.bigint) {
@@ -167,7 +167,7 @@ function createReaddirMap(): Map<
 
 export function readdir(
   path: string,
-  options?: string | {encoding?: string, withFileTypes?: boolean, ...},
+  options?: string | {|encoding?: string, withFileTypes?: boolean|},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -215,13 +215,12 @@ export function readFile(
   path: string,
   options:
     | string
-    | {
+    | {|
         encoding?: string | null,
         // Unsupported:
         flag?: string, // Doesn't make sense except "r"
         signal?: mixed, // We'll have our own signal
-        ...
-      },
+      |},
 ): string | Buffer {
   checkPathInDev(path);
   const map = unstable_getCacheForType(createReadFileMap);
@@ -271,7 +270,7 @@ function createReadlinkMap(): Map<string, Array<string | Record<mixed>>> {
 
 export function readlink(
   path: string,
-  options?: string | {encoding?: string, ...},
+  options?: string | {|encoding?: string|},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -312,7 +311,7 @@ function createRealpathMap(): Map<string, Array<string | Record<mixed>>> {
 
 export function realpath(
   path: string,
-  options?: string | {encoding?: string, ...},
+  options?: string | {|encoding?: string|},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -351,7 +350,7 @@ function createStatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
-export function stat(path: string, options?: {bigint?: boolean, ...}): mixed {
+export function stat(path: string, options?: {|bigint?: boolean|}): mixed {
   checkPathInDev(path);
   let bigint = false;
   if (options && options.bigint) {

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -128,7 +128,7 @@ function createLstatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
-export function lstat(path: string, options?: {bigint?: boolean}): mixed {
+export function lstat(path: string, options?: {bigint?: boolean, ...}): mixed {
   checkPathInDev(path);
   let bigint = false;
   if (options && options.bigint) {
@@ -167,7 +167,7 @@ function createReaddirMap(): Map<
 
 export function readdir(
   path: string,
-  options?: string | {encoding?: string, withFileTypes?: boolean},
+  options?: string | {encoding?: string, withFileTypes?: boolean, ...},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -220,6 +220,7 @@ export function readFile(
         // Unsupported:
         flag?: string, // Doesn't make sense except "r"
         signal?: mixed, // We'll have our own signal
+        ...
       },
 ): string | Buffer {
   checkPathInDev(path);
@@ -270,7 +271,7 @@ function createReadlinkMap(): Map<string, Array<string | Record<mixed>>> {
 
 export function readlink(
   path: string,
-  options?: string | {encoding?: string},
+  options?: string | {encoding?: string, ...},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -311,7 +312,7 @@ function createRealpathMap(): Map<string, Array<string | Record<mixed>>> {
 
 export function realpath(
   path: string,
-  options?: string | {encoding?: string},
+  options?: string | {encoding?: string, ...},
 ): mixed {
   checkPathInDev(path);
   let encoding = 'utf8';
@@ -350,7 +351,7 @@ function createStatMap(): Map<string, Array<boolean | Record<mixed>>> {
   return new Map();
 }
 
-export function stat(path: string, options?: {bigint?: boolean}): mixed {
+export function stat(path: string, options?: {bigint?: boolean, ...}): mixed {
   checkPathInDev(path);
   let bigint = false;
   if (options && options.bigint) {

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -20,6 +20,7 @@ type UseFocusOptions = {
   onFocus?: ?(FocusEvent) => void,
   onFocusChange?: ?(boolean) => void,
   onFocusVisibleChange?: ?(boolean) => void,
+  ...
 };
 
 type UseFocusWithinOptions = {
@@ -30,6 +31,7 @@ type UseFocusWithinOptions = {
   onFocusWithin?: FocusEvent => void,
   onFocusWithinChange?: boolean => void,
   onFocusWithinVisibleChange?: boolean => void,
+  ...
 };
 
 const isMac =
@@ -154,7 +156,7 @@ function useFocusLifecycles() {
 }
 
 export function useFocus(
-  focusTargetRef: {current: null | Node},
+  focusTargetRef: {current: null | Node, ...},
   {
     disabled,
     onBlur,
@@ -164,9 +166,11 @@ export function useFocus(
   }: UseFocusOptions,
 ): void {
   // Setup controlled state for this useFocus hook
-  const stateRef = useRef<null | {isFocused: boolean, isFocusVisible: boolean}>(
-    {isFocused: false, isFocusVisible: false},
-  );
+  const stateRef = useRef<null | {
+    isFocused: boolean,
+    isFocusVisible: boolean,
+    ...
+  }>({isFocused: false, isFocusVisible: false});
   const focusHandle = useEvent('focusin');
   const blurHandle = useEvent('focusout');
   const focusVisibleHandles = useFocusVisibleInputHandles();
@@ -248,7 +252,7 @@ export function useFocus(
 
 export function useFocusWithin<T>(
   focusWithinTargetRef:
-    | {current: null | T}
+    | {current: null | T, ...}
     | ((focusWithinTarget: null | T) => void),
   {
     disabled,
@@ -261,9 +265,11 @@ export function useFocusWithin<T>(
   }: UseFocusWithinOptions,
 ): (focusWithinTarget: null | T) => void {
   // Setup controlled state for this useFocus hook
-  const stateRef = useRef<null | {isFocused: boolean, isFocusVisible: boolean}>(
-    {isFocused: false, isFocusVisible: false},
-  );
+  const stateRef = useRef<null | {
+    isFocused: boolean,
+    isFocusVisible: boolean,
+    ...
+  }>({isFocused: false, isFocusVisible: false});
   const focusHandle = useEvent('focusin');
   const blurHandle = useEvent('focusout');
   const afterBlurHandle = useEvent('afterblur');

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -14,16 +14,15 @@ const {useCallback, useEffect, useLayoutEffect, useRef} = React;
 
 type FocusEvent = SyntheticEvent<EventTarget>;
 
-type UseFocusOptions = {
+type UseFocusOptions = {|
   disabled?: boolean,
   onBlur?: ?(FocusEvent) => void,
   onFocus?: ?(FocusEvent) => void,
   onFocusChange?: ?(boolean) => void,
   onFocusVisibleChange?: ?(boolean) => void,
-  ...
-};
+|};
 
-type UseFocusWithinOptions = {
+type UseFocusWithinOptions = {|
   disabled?: boolean,
   onAfterBlurWithin?: FocusEvent => void,
   onBeforeBlurWithin?: FocusEvent => void,
@@ -31,8 +30,7 @@ type UseFocusWithinOptions = {
   onFocusWithin?: FocusEvent => void,
   onFocusWithinChange?: boolean => void,
   onFocusWithinVisibleChange?: boolean => void,
-  ...
-};
+|};
 
 const isMac =
   typeof window !== 'undefined' && window.navigator != null
@@ -156,7 +154,7 @@ function useFocusLifecycles() {
 }
 
 export function useFocus(
-  focusTargetRef: {current: null | Node, ...},
+  focusTargetRef: {|current: null | Node|},
   {
     disabled,
     onBlur,
@@ -166,11 +164,10 @@ export function useFocus(
   }: UseFocusOptions,
 ): void {
   // Setup controlled state for this useFocus hook
-  const stateRef = useRef<null | {
+  const stateRef = useRef<null | {|
     isFocused: boolean,
     isFocusVisible: boolean,
-    ...
-  }>({isFocused: false, isFocusVisible: false});
+  |}>({isFocused: false, isFocusVisible: false});
   const focusHandle = useEvent('focusin');
   const blurHandle = useEvent('focusout');
   const focusVisibleHandles = useFocusVisibleInputHandles();
@@ -252,7 +249,7 @@ export function useFocus(
 
 export function useFocusWithin<T>(
   focusWithinTargetRef:
-    | {current: null | T, ...}
+    | {|current: null | T|}
     | ((focusWithinTarget: null | T) => void),
   {
     disabled,
@@ -265,11 +262,10 @@ export function useFocusWithin<T>(
   }: UseFocusWithinOptions,
 ): (focusWithinTarget: null | T) => void {
   // Setup controlled state for this useFocus hook
-  const stateRef = useRef<null | {
+  const stateRef = useRef<null | {|
     isFocused: boolean,
     isFocusVisible: boolean,
-    ...
-  }>({isFocused: false, isFocusVisible: false});
+  |}>({isFocused: false, isFocusVisible: false});
   const focusHandle = useEvent('focusin');
   const blurHandle = useEvent('focusout');
   const afterBlurHandle = useEvent('afterblur');

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -255,8 +255,8 @@ class ReactFabricHostComponent {
     const passive = optionsObj.passive || false;
     const signal = null; // TODO: implement signal/AbortSignal
 
-    // $FlowFixMe the old version of Flow doesn't have a good way to define an
-    // empty exact object.
+    /* $FlowFixMe the old version of Flow doesn't have a good way to define an
+     * empty exact object. */
     const eventListeners: InternalEventListeners = this._eventListeners || {};
     if (this._eventListeners == null) {
       this._eventListeners = eventListeners;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -108,14 +108,13 @@ export type EventListenerRemoveOptions = $ReadOnly<{|
 // TODO?: this will be changed in the future to be w3c-compatible and allow "EventListener" objects as well as functions.
 export type EventListener = Function;
 
-type InternalEventListeners = {
+type InternalEventListeners = {|
   [string]: {|
     listener: EventListener,
     options: EventListenerOptions,
     invalidated: boolean,
   |}[],
-  ...,
-};
+|};
 
 // TODO: Remove this conditional once all changes have propagated.
 if (registerEventHandler) {

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -255,6 +255,8 @@ class ReactFabricHostComponent {
     const passive = optionsObj.passive || false;
     const signal = null; // TODO: implement signal/AbortSignal
 
+    // $FlowFixMe the old version of Flow doesn't have a good way to define an
+    // empty exact object.
     const eventListeners: InternalEventListeners = this._eventListeners || {};
     if (this._eventListeners == null) {
       this._eventListeners = eventListeners;

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -114,6 +114,7 @@ type InternalEventListeners = {
     options: EventListenerOptions,
     invalidated: boolean,
   |}[],
+  ...,
 };
 
 // TODO: Remove this conditional once all changes have propagated.

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -74,18 +74,22 @@ export type ViewConfig = $ReadOnly<{
         captured: string,
         bubbled: string,
         skipBubbling?: ?boolean,
+        ...
       }>,
+      ...
     }>,
     ...,
   }>,
   directEventTypes?: $ReadOnly<{
     [eventName: string]: $ReadOnly<{
       registrationName: string,
+      ...
     }>,
     ...,
   }>,
   uiViewClassName: string,
   validAttributes: AttributeConfiguration,
+  ...
 }>;
 
 export type PartialViewConfig = $ReadOnly<{
@@ -93,6 +97,7 @@ export type PartialViewConfig = $ReadOnly<{
   directEventTypes?: $PropertyType<ViewConfig, 'directEventTypes'>,
   uiViewClassName: string,
   validAttributes?: PartialAttributeConfiguration,
+  ...
 }>;
 
 export type NativeMethods = $ReadOnly<{|

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -62,43 +62,38 @@ export type PartialAttributeConfiguration = $ReadOnly<{
   ...
 }>;
 
-export type ViewConfig = $ReadOnly<{
+export type ViewConfig = $ReadOnly<{|
   Commands?: $ReadOnly<{[commandName: string]: number, ...}>,
   Constants?: $ReadOnly<{[name: string]: mixed, ...}>,
   Manager?: string,
   NativeProps?: $ReadOnly<{[propName: string]: string, ...}>,
   baseModuleName?: ?string,
   bubblingEventTypes?: $ReadOnly<{
-    [eventName: string]: $ReadOnly<{
-      phasedRegistrationNames: $ReadOnly<{
+    [eventName: string]: $ReadOnly<{|
+      phasedRegistrationNames: $ReadOnly<{|
         captured: string,
         bubbled: string,
         skipBubbling?: ?boolean,
-        ...
-      }>,
-      ...
-    }>,
+      |}>,
+    |}>,
     ...,
   }>,
   directEventTypes?: $ReadOnly<{
-    [eventName: string]: $ReadOnly<{
+    [eventName: string]: $ReadOnly<{|
       registrationName: string,
-      ...
-    }>,
+    |}>,
     ...,
   }>,
   uiViewClassName: string,
   validAttributes: AttributeConfiguration,
-  ...
-}>;
+|}>;
 
-export type PartialViewConfig = $ReadOnly<{
+export type PartialViewConfig = $ReadOnly<{|
   bubblingEventTypes?: $PropertyType<ViewConfig, 'bubblingEventTypes'>,
   directEventTypes?: $PropertyType<ViewConfig, 'directEventTypes'>,
   uiViewClassName: string,
   validAttributes?: PartialAttributeConfiguration,
-  ...
-}>;
+|}>;
 
 export type NativeMethods = $ReadOnly<{|
   blur(): void,

--- a/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
+++ b/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
@@ -33,4 +33,5 @@ export type LegacyPluginModule<NativeEvent> = {
     container?: null | EventTarget,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
+  ...
 };

--- a/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
+++ b/packages/react-native-renderer/src/legacy-events/PluginModuleType.js
@@ -22,7 +22,7 @@ export type PluginName = string;
 
 export type EventSystemFlags = number;
 
-export type LegacyPluginModule<NativeEvent> = {
+export type LegacyPluginModule<NativeEvent> = {|
   eventTypes: EventTypes,
   extractEvents: (
     topLevelType: TopLevelType,
@@ -33,5 +33,4 @@ export type LegacyPluginModule<NativeEvent> = {
     container?: null | EventTarget,
   ) => ?ReactSyntheticEvent,
   tapMoveThreshold?: number,
-  ...
-};
+|};

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -60,6 +60,7 @@ SUSPENSE_UPDATE_TO_CLIENT_RENDER[0] = SUSPENSE_UPDATE_TO_CLIENT_RENDER_TAG;
 // Per response,
 export type ResponseState = {
   nextSuspenseID: number,
+  ...
 };
 
 // Allows us to keep track of what we've already written so we can refer back to it.

--- a/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
+++ b/packages/react-native-renderer/src/server/ReactNativeServerFormatConfig.js
@@ -58,10 +58,9 @@ const SUSPENSE_UPDATE_TO_CLIENT_RENDER = new Uint8Array(1);
 SUSPENSE_UPDATE_TO_CLIENT_RENDER[0] = SUSPENSE_UPDATE_TO_CLIENT_RENDER_TAG;
 
 // Per response,
-export type ResponseState = {
+export type ResponseState = {|
   nextSuspenseID: number,
-  ...
-};
+|};
 
 // Allows us to keep track of what we've already written so we can refer back to it.
 export function createResponseState(): ResponseState {

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
@@ -36,10 +36,12 @@ import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 export type ConcurrentUpdate = {
   next: ConcurrentUpdate,
   lane: Lane,
+  ...
 };
 
 type ConcurrentQueue = {
   pending: ConcurrentUpdate | null,
+  ...
 };
 
 // If a render is in progress, and we receive an update from a concurrent event,

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
@@ -33,16 +33,14 @@ import {NoFlags, Placement, Hydrating} from './ReactFiberFlags';
 import {HostRoot, OffscreenComponent} from './ReactWorkTags';
 import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
-export type ConcurrentUpdate = {
+export type ConcurrentUpdate = {|
   next: ConcurrentUpdate,
   lane: Lane,
-  ...
-};
+|};
 
-type ConcurrentQueue = {
+type ConcurrentQueue = {|
   pending: ConcurrentUpdate | null,
-  ...
-};
+|};
 
 // If a render is in progress, and we receive an update from a concurrent event,
 // we wait until the current render is over (either finished or interrupted)

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
@@ -36,10 +36,12 @@ import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 export type ConcurrentUpdate = {
   next: ConcurrentUpdate,
   lane: Lane,
+  ...
 };
 
 type ConcurrentQueue = {
   pending: ConcurrentUpdate | null,
+  ...
 };
 
 // If a render is in progress, and we receive an update from a concurrent event,

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
@@ -33,16 +33,14 @@ import {NoFlags, Placement, Hydrating} from './ReactFiberFlags';
 import {HostRoot, OffscreenComponent} from './ReactWorkTags';
 import {OffscreenVisible} from './ReactFiberOffscreenComponent';
 
-export type ConcurrentUpdate = {
+export type ConcurrentUpdate = {|
   next: ConcurrentUpdate,
   lane: Lane,
-  ...
-};
+|};
 
-type ConcurrentQueue = {
+type ConcurrentQueue = {|
   pending: ConcurrentUpdate | null,
-  ...
-};
+|};
 
 // If a render is in progress, and we receive an update from a concurrent event,
 // we wait until the current render is over (either finished or interrupted)

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
@@ -22,6 +22,7 @@ type HiddenContext = {
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
+  ...
 };
 
 // TODO: This isn't being used yet, but it's intended to replace the

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
@@ -17,13 +17,12 @@ import {getRenderLanes, setRenderLanes} from './ReactFiberWorkLoop.new';
 import {NoLanes, mergeLanes} from './ReactFiberLane.new';
 
 // TODO: Remove `renderLanes` context in favor of hidden context
-type HiddenContext = {
+type HiddenContext = {|
   // Represents the lanes that must be included when processing updates in
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
-  ...
-};
+|};
 
 // TODO: This isn't being used yet, but it's intended to replace the
 // InvisibleParentContext that is currently managed by SuspenseContext.

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.new.js
@@ -17,12 +17,13 @@ import {getRenderLanes, setRenderLanes} from './ReactFiberWorkLoop.new';
 import {NoLanes, mergeLanes} from './ReactFiberLane.new';
 
 // TODO: Remove `renderLanes` context in favor of hidden context
-type HiddenContext = {|
+type HiddenContext = {
   // Represents the lanes that must be included when processing updates in
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
-|};
+  ...
+};
 
 // TODO: This isn't being used yet, but it's intended to replace the
 // InvisibleParentContext that is currently managed by SuspenseContext.

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
@@ -22,6 +22,7 @@ type HiddenContext = {
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
+  ...
 };
 
 // TODO: This isn't being used yet, but it's intended to replace the

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
@@ -17,12 +17,13 @@ import {getRenderLanes, setRenderLanes} from './ReactFiberWorkLoop.old';
 import {NoLanes, mergeLanes} from './ReactFiberLane.old';
 
 // TODO: Remove `renderLanes` context in favor of hidden context
-type HiddenContext = {|
+type HiddenContext = {
   // Represents the lanes that must be included when processing updates in
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
-|};
+  ...
+};
 
 // TODO: This isn't being used yet, but it's intended to replace the
 // InvisibleParentContext that is currently managed by SuspenseContext.

--- a/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHiddenContext.old.js
@@ -17,13 +17,12 @@ import {getRenderLanes, setRenderLanes} from './ReactFiberWorkLoop.old';
 import {NoLanes, mergeLanes} from './ReactFiberLane.old';
 
 // TODO: Remove `renderLanes` context in favor of hidden context
-type HiddenContext = {
+type HiddenContext = {|
   // Represents the lanes that must be included when processing updates in
   // order to reveal the hidden content.
   // TODO: Remove `subtreeLanes` context from work loop in favor of this one.
   baseLanes: number,
-  ...
-};
+|};
 
 // TODO: This isn't being used yet, but it's intended to replace the
 // InvisibleParentContext that is currently managed by SuspenseContext.

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1032,11 +1032,10 @@ function rerenderReducer<S, I, A>(
 }
 
 type MutableSourceMemoizedState<Source, Snapshot> = {|
-  refs: {
+  refs: {|
     getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
     setSnapshot: Snapshot => void,
-    ...
-  },
+  |},
   source: MutableSource<any>,
   subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
 |};

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1035,6 +1035,7 @@ type MutableSourceMemoizedState<Source, Snapshot> = {|
   refs: {
     getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
     setSnapshot: Snapshot => void,
+    ...
   },
   source: MutableSource<any>,
   subscribe: MutableSourceSubscribeFn<Source, Snapshot>,

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1032,11 +1032,10 @@ function rerenderReducer<S, I, A>(
 }
 
 type MutableSourceMemoizedState<Source, Snapshot> = {|
-  refs: {
+  refs: {|
     getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
     setSnapshot: Snapshot => void,
-    ...
-  },
+  |},
   source: MutableSource<any>,
   subscribe: MutableSourceSubscribeFn<Source, Snapshot>,
 |};

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1035,6 +1035,7 @@ type MutableSourceMemoizedState<Source, Snapshot> = {|
   refs: {
     getSnapshot: MutableSourceGetSnapshotFn<Source, Snapshot>,
     setSnapshot: Snapshot => void,
+    ...
   },
   source: MutableSource<any>,
   subscribe: MutableSourceSubscribeFn<Source, Snapshot>,

--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -42,6 +42,7 @@ export type RootState = {
   element: any,
   isDehydrated: boolean,
   cache: Cache,
+  ...
 };
 
 function FiberRootNode(

--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -38,12 +38,11 @@ import {initializeUpdateQueue} from './ReactFiberClassUpdateQueue.new';
 import {LegacyRoot, ConcurrentRoot} from './ReactRootTags';
 import {createCache, retainCache} from './ReactFiberCacheComponent.new';
 
-export type RootState = {
+export type RootState = {|
   element: any,
   isDehydrated: boolean,
   cache: Cache,
-  ...
-};
+|};
 
 function FiberRootNode(
   containerInfo,

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -38,12 +38,11 @@ import {initializeUpdateQueue} from './ReactFiberClassUpdateQueue.old';
 import {LegacyRoot, ConcurrentRoot} from './ReactRootTags';
 import {createCache, retainCache} from './ReactFiberCacheComponent.old';
 
-export type RootState = {
+export type RootState = {|
   element: any,
   isDehydrated: boolean,
   cache: Cache,
-  ...
-};
+|};
 
 function FiberRootNode(
   containerInfo,

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -42,6 +42,7 @@ export type RootState = {
   element: any,
   isDehydrated: boolean,
   cache: Cache,
+  ...
 };
 
 function FiberRootNode(

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
@@ -19,7 +19,7 @@ import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack.new';
 import {getWorkInProgressTransitions} from './ReactFiberWorkLoop.new';
 
-export type SuspenseInfo = {name: string | null};
+export type SuspenseInfo = {name: string | null, ...};
 
 export type PendingTransitionCallbacks = {
   transitionStart: Array<Transition> | null,
@@ -27,24 +27,27 @@ export type PendingTransitionCallbacks = {
   transitionComplete: Array<Transition> | null,
   markerProgress: Map<
     string,
-    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>},
+    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>, ...},
   > | null,
   markerIncomplete: Map<
     string,
-    {aborts: Array<TransitionAbort>, transitions: Set<Transition>},
+    {aborts: Array<TransitionAbort>, transitions: Set<Transition>, ...},
   > | null,
   markerComplete: Map<string, Set<Transition>> | null,
+  ...
 };
 
 export type Transition = {
   name: string,
   startTime: number,
+  ...
 };
 
 export type BatchConfigTransition = {
   name?: string,
   startTime?: number,
   _updatedFibers?: Set<Fiber>,
+  ...
 };
 
 // TODO: Is there a way to not include the tag or name here?

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.new.js
@@ -19,36 +19,33 @@ import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack.new';
 import {getWorkInProgressTransitions} from './ReactFiberWorkLoop.new';
 
-export type SuspenseInfo = {name: string | null, ...};
+export type SuspenseInfo = {|name: string | null|};
 
-export type PendingTransitionCallbacks = {
+export type PendingTransitionCallbacks = {|
   transitionStart: Array<Transition> | null,
   transitionProgress: Map<Transition, PendingBoundaries> | null,
   transitionComplete: Array<Transition> | null,
   markerProgress: Map<
     string,
-    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>, ...},
+    {|pendingBoundaries: PendingBoundaries, transitions: Set<Transition>|},
   > | null,
   markerIncomplete: Map<
     string,
-    {aborts: Array<TransitionAbort>, transitions: Set<Transition>, ...},
+    {|aborts: Array<TransitionAbort>, transitions: Set<Transition>|},
   > | null,
   markerComplete: Map<string, Set<Transition>> | null,
-  ...
-};
+|};
 
-export type Transition = {
+export type Transition = {|
   name: string,
   startTime: number,
-  ...
-};
+|};
 
-export type BatchConfigTransition = {
+export type BatchConfigTransition = {|
   name?: string,
   startTime?: number,
   _updatedFibers?: Set<Fiber>,
-  ...
-};
+|};
 
 // TODO: Is there a way to not include the tag or name here?
 export type TracingMarkerInstance = {|

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
@@ -19,36 +19,33 @@ import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack.old';
 import {getWorkInProgressTransitions} from './ReactFiberWorkLoop.old';
 
-export type SuspenseInfo = {name: string | null, ...};
+export type SuspenseInfo = {|name: string | null|};
 
-export type PendingTransitionCallbacks = {
+export type PendingTransitionCallbacks = {|
   transitionStart: Array<Transition> | null,
   transitionProgress: Map<Transition, PendingBoundaries> | null,
   transitionComplete: Array<Transition> | null,
   markerProgress: Map<
     string,
-    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>, ...},
+    {|pendingBoundaries: PendingBoundaries, transitions: Set<Transition>|},
   > | null,
   markerIncomplete: Map<
     string,
-    {aborts: Array<TransitionAbort>, transitions: Set<Transition>, ...},
+    {|aborts: Array<TransitionAbort>, transitions: Set<Transition>|},
   > | null,
   markerComplete: Map<string, Set<Transition>> | null,
-  ...
-};
+|};
 
-export type Transition = {
+export type Transition = {|
   name: string,
   startTime: number,
-  ...
-};
+|};
 
-export type BatchConfigTransition = {
+export type BatchConfigTransition = {|
   name?: string,
   startTime?: number,
   _updatedFibers?: Set<Fiber>,
-  ...
-};
+|};
 
 // TODO: Is there a way to not include the tag or name here?
 export type TracingMarkerInstance = {|

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.old.js
@@ -19,7 +19,7 @@ import {enableTransitionTracing} from 'shared/ReactFeatureFlags';
 import {createCursor, push, pop} from './ReactFiberStack.old';
 import {getWorkInProgressTransitions} from './ReactFiberWorkLoop.old';
 
-export type SuspenseInfo = {name: string | null};
+export type SuspenseInfo = {name: string | null, ...};
 
 export type PendingTransitionCallbacks = {
   transitionStart: Array<Transition> | null,
@@ -27,24 +27,27 @@ export type PendingTransitionCallbacks = {
   transitionComplete: Array<Transition> | null,
   markerProgress: Map<
     string,
-    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>},
+    {pendingBoundaries: PendingBoundaries, transitions: Set<Transition>, ...},
   > | null,
   markerIncomplete: Map<
     string,
-    {aborts: Array<TransitionAbort>, transitions: Set<Transition>},
+    {aborts: Array<TransitionAbort>, transitions: Set<Transition>, ...},
   > | null,
   markerComplete: Map<string, Set<Transition>> | null,
+  ...
 };
 
 export type Transition = {
   name: string,
   startTime: number,
+  ...
 };
 
 export type BatchConfigTransition = {
   name?: string,
   startTime?: number,
   _updatedFibers?: Set<Fiber>,
+  ...
 };
 
 // TODO: Is there a way to not include the tag or name here?

--- a/packages/react-reconciler/src/ReactFiberTreeContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.new.js
@@ -67,6 +67,7 @@ import {Forked, NoFlags} from './ReactFiberFlags';
 export type TreeContext = {
   id: number,
   overflow: string,
+  ...
 };
 
 // TODO: Use the unified fiber stack module instead of this local one?

--- a/packages/react-reconciler/src/ReactFiberTreeContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.new.js
@@ -64,11 +64,10 @@ import {getIsHydrating} from './ReactFiberHydrationContext.new';
 import {clz32} from './clz32';
 import {Forked, NoFlags} from './ReactFiberFlags';
 
-export type TreeContext = {
+export type TreeContext = {|
   id: number,
   overflow: string,
-  ...
-};
+|};
 
 // TODO: Use the unified fiber stack module instead of this local one?
 // Intentionally not using it yet to derisk the initial implementation, because

--- a/packages/react-reconciler/src/ReactFiberTreeContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.old.js
@@ -67,6 +67,7 @@ import {Forked, NoFlags} from './ReactFiberFlags';
 export type TreeContext = {
   id: number,
   overflow: string,
+  ...
 };
 
 // TODO: Use the unified fiber stack module instead of this local one?

--- a/packages/react-reconciler/src/ReactFiberTreeContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.old.js
@@ -64,11 +64,10 @@ import {getIsHydrating} from './ReactFiberHydrationContext.old';
 import {clz32} from './clz32';
 import {Forked, NoFlags} from './ReactFiberFlags';
 
-export type TreeContext = {
+export type TreeContext = {|
   id: number,
   overflow: string,
-  ...
-};
+|};
 
 // TODO: Use the unified fiber stack module instead of this local one?
 // Intentionally not using it yet to derisk the initial implementation, because

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -258,7 +258,7 @@ type BaseFiberRootProperties = {|
 
   onRecoverableError: (
     error: mixed,
-    errorInfo: {digest?: ?string, componentStack?: ?string},
+    errorInfo: {digest?: ?string, componentStack?: ?string, ...},
   ) => void,
 |};
 
@@ -286,7 +286,7 @@ export type TransitionTracingCallbacks = {
     transitionName: string,
     startTime: number,
     currentTime: number,
-    pending: Array<{name: null | string}>,
+    pending: Array<{name: null | string, ...}>,
   ) => void,
   onTransitionIncomplete?: (
     transitionName: string,
@@ -295,6 +295,7 @@ export type TransitionTracingCallbacks = {
       type: string,
       name?: string | null,
       endTime: number,
+      ...
     }>,
   ) => void,
   onTransitionComplete?: (
@@ -307,7 +308,7 @@ export type TransitionTracingCallbacks = {
     marker: string,
     startTime: number,
     currentTime: number,
-    pending: Array<{name: null | string}>,
+    pending: Array<{name: null | string, ...}>,
   ) => void,
   onMarkerIncomplete?: (
     transitionName: string,
@@ -317,6 +318,7 @@ export type TransitionTracingCallbacks = {
       type: string,
       name?: string | null,
       endTime: number,
+      ...
     }>,
   ) => void,
   onMarkerComplete?: (
@@ -325,6 +327,7 @@ export type TransitionTracingCallbacks = {
     startTime: number,
     endTime: number,
   ) => void,
+  ...
 };
 
 // The following fields are only used in transition tracing in Profile builds

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -258,7 +258,7 @@ type BaseFiberRootProperties = {|
 
   onRecoverableError: (
     error: mixed,
-    errorInfo: {digest?: ?string, componentStack?: ?string, ...},
+    errorInfo: {|digest?: ?string, componentStack?: ?string|},
   ) => void,
 |};
 
@@ -280,23 +280,22 @@ type SuspenseCallbackOnlyFiberRootProperties = {|
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
 |};
 
-export type TransitionTracingCallbacks = {
+export type TransitionTracingCallbacks = {|
   onTransitionStart?: (transitionName: string, startTime: number) => void,
   onTransitionProgress?: (
     transitionName: string,
     startTime: number,
     currentTime: number,
-    pending: Array<{name: null | string, ...}>,
+    pending: Array<{|name: null | string|}>,
   ) => void,
   onTransitionIncomplete?: (
     transitionName: string,
     startTime: number,
-    deletions: Array<{
+    deletions: Array<{|
       type: string,
       name?: string | null,
       endTime: number,
-      ...
-    }>,
+    |}>,
   ) => void,
   onTransitionComplete?: (
     transitionName: string,
@@ -308,18 +307,17 @@ export type TransitionTracingCallbacks = {
     marker: string,
     startTime: number,
     currentTime: number,
-    pending: Array<{name: null | string, ...}>,
+    pending: Array<{|name: null | string|}>,
   ) => void,
   onMarkerIncomplete?: (
     transitionName: string,
     marker: string,
     startTime: number,
-    deletions: Array<{
+    deletions: Array<{|
       type: string,
       name?: string | null,
       endTime: number,
-      ...
-    }>,
+    |}>,
   ) => void,
   onMarkerComplete?: (
     transitionName: string,
@@ -327,8 +325,7 @@ export type TransitionTracingCallbacks = {
     startTime: number,
     endTime: number,
   ) => void,
-  ...
-};
+|};
 
 // The following fields are only used in transition tracing in Profile builds
 type TransitionTracingOnlyFiberRootProperties = {|

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -506,14 +506,14 @@ export function onCommitRoot(): void {
 export type IntersectionObserverOptions = Object;
 
 export type ObserveVisibleRectsCallback = (
-  intersections: Array<{ratio: number, rect: BoundingRect, ...}>,
+  intersections: Array<{|ratio: number, rect: BoundingRect|}>,
 ) => void;
 
 export function observeVisibleRects(
   hostRoot: Instance,
   selectors: Array<Selector>,
   callback: (
-    intersections: Array<{ratio: number, rect: BoundingRect, ...}>,
+    intersections: Array<{|ratio: number, rect: BoundingRect|}>,
   ) => void,
   options?: IntersectionObserverOptions,
 ): {|disconnect: () => void|} {

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -506,13 +506,15 @@ export function onCommitRoot(): void {
 export type IntersectionObserverOptions = Object;
 
 export type ObserveVisibleRectsCallback = (
-  intersections: Array<{ratio: number, rect: BoundingRect}>,
+  intersections: Array<{ratio: number, rect: BoundingRect, ...}>,
 ) => void;
 
 export function observeVisibleRects(
   hostRoot: Instance,
   selectors: Array<Selector>,
-  callback: (intersections: Array<{ratio: number, rect: BoundingRect}>) => void,
+  callback: (
+    intersections: Array<{ratio: number, rect: BoundingRect, ...}>,
+  ) => void,
   options?: IntersectionObserverOptions,
 ): {|disconnect: () => void|} {
   if (!supportsTestSelectors) {

--- a/packages/react-server-dom-relay/src/ReactDOMServerFB.js
+++ b/packages/react-server-dom-relay/src/ReactDOMServerFB.js
@@ -26,21 +26,19 @@ import {
   createRootFormatContext,
 } from 'react-server/src/ReactServerFormatConfig';
 
-type Options = {
+type Options = {|
   identifierPrefix?: string,
   bootstrapScriptContent?: string,
   bootstrapScripts: Array<string>,
   bootstrapModules: Array<string>,
   progressiveChunkSize?: number,
   onError: (error: mixed) => void,
-  ...
-};
+|};
 
-opaque type Stream = {
+opaque type Stream = {|
   destination: Destination,
   request: Request,
-  ...
-};
+|};
 
 function renderToStream(children: ReactNodeList, options: Options): Stream {
   const destination = {

--- a/packages/react-server-dom-relay/src/ReactDOMServerFB.js
+++ b/packages/react-server-dom-relay/src/ReactDOMServerFB.js
@@ -33,11 +33,13 @@ type Options = {
   bootstrapModules: Array<string>,
   progressiveChunkSize?: number,
   onError: (error: mixed) => void,
+  ...
 };
 
 opaque type Stream = {
   destination: Destination,
   request: Request,
+  ...
 };
 
 function renderToStream(children: ReactNodeList, options: Options): Stream {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -24,8 +24,10 @@ export {createResponse, close};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'J') {
+    // $FlowFixMe unable to refine on array indices
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {
+    // $FlowFixMe unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'S') {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -15,7 +15,7 @@ export type JSONValue =
   | boolean
   | null
   | {|+[key: string]: JSONValue|}
-  | Array<JSONValue>;
+  | $ReadOnlyArray<JSONValue>;
 
 export type RowEncoding =
   | ['J', number, JSONValue]

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -14,7 +14,7 @@ export type JSONValue =
   | number
   | boolean
   | null
-  | {+[key: string]: JSONValue}
+  | {+[key: string]: JSONValue, ...}
   | Array<JSONValue>;
 
 export type RowEncoding =

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -14,7 +14,7 @@ export type JSONValue =
   | number
   | boolean
   | null
-  | {+[key: string]: JSONValue, ...}
+  | {|+[key: string]: JSONValue|}
   | Array<JSONValue>;
 
 export type RowEncoding =

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -22,6 +22,7 @@ import {
 type Options = {
   onError?: (error: mixed) => void,
   identifierPrefix?: string,
+  ...
 };
 
 function render(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServer.js
@@ -19,11 +19,10 @@ import {
   startFlowing,
 } from 'react-server/src/ReactFlightServer';
 
-type Options = {
+type Options = {|
   onError?: (error: mixed) => void,
   identifierPrefix?: string,
-  ...
-};
+|};
 
 function render(
   model: ReactModel,

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -78,7 +78,7 @@ export function processErrorChunk(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent: {+[key: string]: ReactModel, ...} | $ReadOnlyArray<ReactModel>,
   key: string,
   model: ReactModel,
 ): JSONValue {
@@ -91,7 +91,7 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      const jsonObj: {[key: string]: JSONValue} = {};
+      const jsonObj: {[key: string]: JSONValue, ...} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
           jsonObj[nextKey] = convertModelToJSON(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -91,6 +91,8 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
+      /* $FlowFixMe the old version of Flow doesn't have a good way to define
+       * an empty exact object. */
       const jsonObj: {|[key: string]: JSONValue|} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -78,7 +78,7 @@ export function processErrorChunk(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel, ...} | $ReadOnlyArray<ReactModel>,
+  parent: {|+[key: string]: ReactModel|} | $ReadOnlyArray<ReactModel>,
   key: string,
   model: ReactModel,
 ): JSONValue {
@@ -91,7 +91,7 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      const jsonObj: {[key: string]: JSONValue, ...} = {};
+      const jsonObj: {|[key: string]: JSONValue|} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
           jsonObj[nextKey] = convertModelToJSON(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -115,6 +115,7 @@ export function processModelChunk(
   id: number,
   model: ReactModel,
 ): Chunk {
+  // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
   return ['J', id, json];
 }
@@ -161,6 +162,7 @@ export function flushBuffered(destination: Destination) {}
 export function beginWriting(destination: Destination) {}
 
 export function writeChunk(destination: Destination, chunk: Chunk): void {
+  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
 }
 
@@ -168,6 +170,7 @@ export function writeChunkAndReturn(
   destination: Destination,
   chunk: Chunk,
 ): boolean {
+  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
   return true;
 }

--- a/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
+++ b/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
@@ -7,13 +7,12 @@
  * @flow
  */
 
-export type Destination = {
+export type Destination = {|
   buffer: string,
   done: boolean,
   fatal: boolean,
   error: mixed,
-  ...
-};
+|};
 
 export type PrecomputedChunk = string;
 export type Chunk = string;

--- a/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
+++ b/packages/react-server-dom-relay/src/ReactServerStreamConfigFB.js
@@ -12,6 +12,7 @@ export type Destination = {
   done: boolean,
   fatal: boolean,
   error: mixed,
+  ...
 };
 
 export type PrecomputedChunk = string;

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -12,7 +12,9 @@ import type {Thenable} from 'shared/ReactTypes';
 export type WebpackSSRMap = {
   [clientId: string]: {
     [clientExportName: string]: ModuleMetaData,
+    ...,
   },
+  ...,
 };
 
 export type BundlerConfig = null | WebpackSSRMap;
@@ -22,6 +24,7 @@ export opaque type ModuleMetaData = {
   chunks: Array<string>,
   name: string,
   async: boolean,
+  ...
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -9,23 +9,20 @@
 
 import type {Thenable} from 'shared/ReactTypes';
 
-export type WebpackSSRMap = {
-  [clientId: string]: {
+export type WebpackSSRMap = {|
+  [clientId: string]: {|
     [clientExportName: string]: ModuleMetaData,
-    ...,
-  },
-  ...,
-};
+  |},
+|};
 
 export type BundlerConfig = null | WebpackSSRMap;
 
-export opaque type ModuleMetaData = {
+export opaque type ModuleMetaData = {|
   id: string,
   chunks: Array<string>,
   name: string,
   async: boolean,
-  ...
-};
+|};
 
 // eslint-disable-next-line no-unused-vars
 export opaque type ModuleReference<T> = ModuleMetaData;

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
@@ -19,10 +19,9 @@ import {
   close,
 } from 'react-client/src/ReactFlightClientStream';
 
-export type Options = {
+export type Options = {|
   moduleMap?: BundlerConfig,
-  ...
-};
+|};
 
 function startReadingFromStream(
   response: FlightResponse,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
@@ -21,6 +21,7 @@ import {
 
 export type Options = {
   moduleMap?: BundlerConfig,
+  ...
 };
 
 function startReadingFromStream(

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -23,6 +23,7 @@ type Options = {
   signal?: AbortSignal,
   context?: Array<[string, ServerContextJSONValue]>,
   onError?: (error: mixed) => void,
+  ...
 };
 
 function renderToReadableStream(

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -18,13 +18,12 @@ import {
   abort,
 } from 'react-server/src/ReactFlightServer';
 
-type Options = {
+type Options = {|
   identifierPrefix?: string,
   signal?: AbortSignal,
   context?: Array<[string, ServerContextJSONValue]>,
   onError?: (error: mixed) => void,
-  ...
-};
+|};
 
 function renderToReadableStream(
   model: ReactModel,

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -27,6 +27,7 @@ type Options = {
   onError?: (error: mixed) => void,
   context?: Array<[string, ServerContextJSONValue]>,
   identifierPrefix?: string,
+  ...
 };
 
 type PipeableStream = {|

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -23,12 +23,11 @@ function createDrainHandler(destination, request) {
   return () => startFlowing(request, destination);
 }
 
-type Options = {
+type Options = {|
   onError?: (error: mixed) => void,
   context?: Array<[string, ServerContextJSONValue]>,
   identifierPrefix?: string,
-  ...
-};
+|};
 
 type PipeableStream = {|
   abort(reason: mixed): void,

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -10,7 +10,9 @@
 type WebpackMap = {
   [filepath: string]: {
     [name: string]: ModuleMetaData,
+    ...,
   },
+  ...,
 };
 
 export type BundlerConfig = WebpackMap;
@@ -21,6 +23,7 @@ export type ModuleReference<T> = {
   filepath: string,
   name: string,
   async: boolean,
+  ...
 };
 
 export type ModuleMetaData = {
@@ -28,6 +31,7 @@ export type ModuleMetaData = {
   chunks: Array<string>,
   name: string,
   async: boolean,
+  ...
 };
 
 export type ModuleKey = string;

--- a/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightServerWebpackBundlerConfig.js
@@ -7,32 +7,28 @@
  * @flow
  */
 
-type WebpackMap = {
-  [filepath: string]: {
+type WebpackMap = {|
+  [filepath: string]: {|
     [name: string]: ModuleMetaData,
-    ...,
-  },
-  ...,
-};
+  |},
+|};
 
 export type BundlerConfig = WebpackMap;
 
 // eslint-disable-next-line no-unused-vars
-export type ModuleReference<T> = {
+export type ModuleReference<T> = {|
   $$typeof: symbol,
   filepath: string,
   name: string,
   async: boolean,
-  ...
-};
+|};
 
-export type ModuleMetaData = {
+export type ModuleMetaData = {|
   id: string,
   chunks: Array<string>,
   name: string,
   async: boolean,
-  ...
-};
+|};
 
 export type ModuleKey = string;
 

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -9,40 +9,37 @@
 
 import {acorn} from 'acorn';
 
-type ResolveContext = {
+type ResolveContext = {|
   conditions: Array<string>,
   parentURL: string | void,
-  ...
-};
+|};
 
 type ResolveFunction = (
   string,
   ResolveContext,
   ResolveFunction,
-) => {url: string, ...} | Promise<{url: string, ...}>;
+) => {|url: string|} | Promise<{|url: string|}>;
 
-type GetSourceContext = {
+type GetSourceContext = {|
   format: string,
-  ...
-};
+|};
 
 type GetSourceFunction = (
   string,
   GetSourceContext,
   GetSourceFunction,
-) => Promise<{source: Source, ...}>;
+) => Promise<{|source: Source|}>;
 
-type TransformSourceContext = {
+type TransformSourceContext = {|
   format: string,
   url: string,
-  ...
-};
+|};
 
 type TransformSourceFunction = (
   Source,
   TransformSourceContext,
   TransformSourceFunction,
-) => Promise<{source: Source, ...}>;
+) => Promise<{|source: Source|}>;
 
 type Source = string | ArrayBuffer | Uint8Array;
 
@@ -55,7 +52,7 @@ export async function resolve(
   specifier: string,
   context: ResolveContext,
   defaultResolve: ResolveFunction,
-): Promise<{url: string, ...}> {
+): Promise<{|url: string|}> {
   // We stash this in case we end up needing to resolve export * statements later.
   stashedResolve = defaultResolve;
 
@@ -136,7 +133,7 @@ function addExportNames(names, node) {
 function resolveClientImport(
   specifier: string,
   parentURL: string,
-): {url: string, ...} | Promise<{url: string, ...}> {
+): {|url: string|} | Promise<{|url: string|}> {
   // Resolve an import specifier as if it was loaded by the client. This doesn't use
   // the overrides that this loader does but instead reverts to the default.
   // This resolution algorithm will not necessarily have the same configuration
@@ -154,7 +151,7 @@ function resolveClientImport(
 async function loadClientImport(
   url: string,
   defaultTransformSource: TransformSourceFunction,
-): Promise<{source: Source, ...}> {
+): Promise<{|source: Source|}> {
   if (stashedGetSource === null) {
     throw new Error(
       'Expected getSource to have been called before transformSource',
@@ -228,7 +225,7 @@ export async function transformSource(
   source: Source,
   context: TransformSourceContext,
   defaultTransformSource: TransformSourceFunction,
-): Promise<{source: Source, ...}> {
+): Promise<{|source: Source|}> {
   const transformed = await defaultTransformSource(
     source,
     context,

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -12,34 +12,37 @@ import {acorn} from 'acorn';
 type ResolveContext = {
   conditions: Array<string>,
   parentURL: string | void,
+  ...
 };
 
 type ResolveFunction = (
   string,
   ResolveContext,
   ResolveFunction,
-) => {url: string} | Promise<{url: string}>;
+) => {url: string, ...} | Promise<{url: string, ...}>;
 
 type GetSourceContext = {
   format: string,
+  ...
 };
 
 type GetSourceFunction = (
   string,
   GetSourceContext,
   GetSourceFunction,
-) => Promise<{source: Source}>;
+) => Promise<{source: Source, ...}>;
 
 type TransformSourceContext = {
   format: string,
   url: string,
+  ...
 };
 
 type TransformSourceFunction = (
   Source,
   TransformSourceContext,
   TransformSourceFunction,
-) => Promise<{source: Source}>;
+) => Promise<{source: Source, ...}>;
 
 type Source = string | ArrayBuffer | Uint8Array;
 
@@ -52,7 +55,7 @@ export async function resolve(
   specifier: string,
   context: ResolveContext,
   defaultResolve: ResolveFunction,
-): Promise<{url: string}> {
+): Promise<{url: string, ...}> {
   // We stash this in case we end up needing to resolve export * statements later.
   stashedResolve = defaultResolve;
 
@@ -133,7 +136,7 @@ function addExportNames(names, node) {
 function resolveClientImport(
   specifier: string,
   parentURL: string,
-): {url: string} | Promise<{url: string}> {
+): {url: string, ...} | Promise<{url: string, ...}> {
   // Resolve an import specifier as if it was loaded by the client. This doesn't use
   // the overrides that this loader does but instead reverts to the default.
   // This resolution algorithm will not necessarily have the same configuration
@@ -151,7 +154,7 @@ function resolveClientImport(
 async function loadClientImport(
   url: string,
   defaultTransformSource: TransformSourceFunction,
-): Promise<{source: Source}> {
+): Promise<{source: Source, ...}> {
   if (stashedGetSource === null) {
     throw new Error(
       'Expected getSource to have been called before transformSource',
@@ -225,7 +228,7 @@ export async function transformSource(
   source: Source,
   context: TransformSourceContext,
   defaultTransformSource: TransformSourceFunction,
-): Promise<{source: Source}> {
+): Promise<{source: Source, ...}> {
   const transformed = await defaultTransformSource(
     source,
     context,

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -52,7 +52,7 @@ module.exports = function register() {
             // we should resolve that with a client reference that unwraps the Promise on
             // the client.
             const then = function then(resolve, reject) {
-              const moduleReference: {[string]: any} = {
+              const moduleReference: {[string]: any, ...} = {
                 $$typeof: MODULE_REFERENCE,
                 filepath: target.filepath,
                 name: '*', // Represents the whole object instead of a particular import.
@@ -93,7 +93,7 @@ module.exports = function register() {
 
   Module._extensions['.client.js'] = function(module, path) {
     const moduleId = url.pathToFileURL(path).href;
-    const moduleReference: {[string]: any} = {
+    const moduleReference: {[string]: any, ...} = {
       $$typeof: MODULE_REFERENCE,
       filepath: moduleId,
       name: '*', // Represents the whole object instead of a particular import.

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -52,7 +52,7 @@ module.exports = function register() {
             // we should resolve that with a client reference that unwraps the Promise on
             // the client.
             const then = function then(resolve, reject) {
-              const moduleReference: {|[string]: any|} = {
+              const moduleReference: {[string]: any, ...} = {
                 $$typeof: MODULE_REFERENCE,
                 filepath: target.filepath,
                 name: '*', // Represents the whole object instead of a particular import.
@@ -93,7 +93,7 @@ module.exports = function register() {
 
   Module._extensions['.client.js'] = function(module, path) {
     const moduleId = url.pathToFileURL(path).href;
-    const moduleReference: {|[string]: any|} = {
+    const moduleReference: {[string]: any, ...} = {
       $$typeof: MODULE_REFERENCE,
       filepath: moduleId,
       name: '*', // Represents the whole object instead of a particular import.

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -52,7 +52,7 @@ module.exports = function register() {
             // we should resolve that with a client reference that unwraps the Promise on
             // the client.
             const then = function then(resolve, reject) {
-              const moduleReference: {[string]: any, ...} = {
+              const moduleReference: {|[string]: any|} = {
                 $$typeof: MODULE_REFERENCE,
                 filepath: target.filepath,
                 name: '*', // Represents the whole object instead of a particular import.
@@ -93,7 +93,7 @@ module.exports = function register() {
 
   Module._extensions['.client.js'] = function(module, path) {
     const moduleId = url.pathToFileURL(path).href;
-    const moduleReference: {[string]: any, ...} = {
+    const moduleReference: {|[string]: any|} = {
       $$typeof: MODULE_REFERENCE,
       filepath: moduleId,
       name: '*', // Represents the whole object instead of a particular import.

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -47,6 +47,7 @@ type ClientReferenceSearchPath = {
   recursive?: boolean,
   include: RegExp,
   exclude?: RegExp,
+  ...
 };
 
 type ClientReferencePath = string | ClientReferenceSearchPath;
@@ -56,6 +57,7 @@ type Options = {
   clientReferences?: ClientReferencePath | $ReadOnlyArray<ClientReferencePath>,
   chunkName?: string,
   manifestFilename?: string,
+  ...
 };
 
 const PLUGIN_NAME = 'React Server Plugin';

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -42,23 +42,21 @@ class ClientReferenceDependency extends ModuleDependency {
 const clientImportName = 'react-server-dom-webpack';
 const clientFileName = require.resolve('../');
 
-type ClientReferenceSearchPath = {
+type ClientReferenceSearchPath = {|
   directory: string,
   recursive?: boolean,
   include: RegExp,
   exclude?: RegExp,
-  ...
-};
+|};
 
 type ClientReferencePath = string | ClientReferenceSearchPath;
 
-type Options = {
+type Options = {|
   isServer: boolean,
   clientReferences?: ClientReferencePath | $ReadOnlyArray<ClientReferencePath>,
   chunkName?: string,
   manifestFilename?: string,
-  ...
-};
+|};
 
 const PLUGIN_NAME = 'React Server Plugin';
 

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -24,8 +24,10 @@ export {createResponse, close};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'J') {
+    // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {
+    // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'S') {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -14,7 +14,7 @@ export type JSONValue =
   | number
   | boolean
   | null
-  | {+[key: string]: JSONValue}
+  | {+[key: string]: JSONValue, ...}
   | Array<JSONValue>;
 
 export type RowEncoding =

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -14,7 +14,7 @@ export type JSONValue =
   | number
   | boolean
   | null
-  | {+[key: string]: JSONValue, ...}
+  | {|+[key: string]: JSONValue|}
   | Array<JSONValue>;
 
 export type RowEncoding =

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -88,6 +88,7 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
+      // $FlowFixMe no good way to define an empty exact object
       const jsonObj: {|[key: string]: JSONValue|} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
@@ -110,6 +111,7 @@ export function processModelChunk(
   id: number,
   model: ReactModel,
 ): Chunk {
+  // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
   return ['J', id, json];
 }
@@ -156,6 +158,7 @@ export function flushBuffered(destination: Destination) {}
 export function beginWriting(destination: Destination) {}
 
 export function writeChunk(destination: Destination, chunk: Chunk): void {
+  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
 }
 
@@ -163,6 +166,7 @@ export function writeChunkAndReturn(
   destination: Destination,
   chunk: Chunk,
 ): boolean {
+  // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
   emitRow(destination, chunk);
   return true;
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -75,7 +75,7 @@ export function processErrorChunk(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent: {+[key: string]: ReactModel, ...} | $ReadOnlyArray<ReactModel>,
   key: string,
   model: ReactModel,
 ): JSONValue {
@@ -88,7 +88,7 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      const jsonObj: {[key: string]: JSONValue} = {};
+      const jsonObj: {[key: string]: JSONValue, ...} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
           jsonObj[nextKey] = convertModelToJSON(

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -75,7 +75,7 @@ export function processErrorChunk(
 
 function convertModelToJSON(
   request: Request,
-  parent: {+[key: string]: ReactModel, ...} | $ReadOnlyArray<ReactModel>,
+  parent: {|+[key: string]: ReactModel|} | $ReadOnlyArray<ReactModel>,
   key: string,
   model: ReactModel,
 ): JSONValue {
@@ -88,7 +88,7 @@ function convertModelToJSON(
       }
       return jsonArray;
     } else {
-      const jsonObj: {[key: string]: JSONValue, ...} = {};
+      const jsonObj: {|[key: string]: JSONValue|} = {};
       for (const nextKey in json) {
         if (hasOwnProperty.call(json, nextKey)) {
           jsonObj[nextKey] = convertModelToJSON(

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -103,6 +103,7 @@ function warnNoop(
 type InternalInstance = {
   queue: null | Array<Object>,
   replace: boolean,
+  ...
 };
 
 const classComponentUpdater = {

--- a/packages/react-server/src/ReactFizzClassComponent.js
+++ b/packages/react-server/src/ReactFizzClassComponent.js
@@ -100,11 +100,10 @@ function warnNoop(
   }
 }
 
-type InternalInstance = {
+type InternalInstance = {|
   queue: null | Array<Object>,
   replace: boolean,
-  ...
-};
+|};
 
 const classComponentUpdater = {
   isMounted(inst) {

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -14,24 +14,21 @@ import {
 } from 'shared/ReactComponentStackFrame';
 
 // DEV-only reverse linked list representing the current component stack
-type BuiltInComponentStackNode = {
+type BuiltInComponentStackNode = {|
   tag: 0,
   parent: null | ComponentStackNode,
   type: string,
-  ...
-};
-type FunctionComponentStackNode = {
+|};
+type FunctionComponentStackNode = {|
   tag: 1,
   parent: null | ComponentStackNode,
   type: Function,
-  ...
-};
-type ClassComponentStackNode = {
+|};
+type ClassComponentStackNode = {|
   tag: 2,
   parent: null | ComponentStackNode,
   type: Function,
-  ...
-};
+|};
 export type ComponentStackNode =
   | BuiltInComponentStackNode
   | FunctionComponentStackNode

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -18,16 +18,19 @@ type BuiltInComponentStackNode = {
   tag: 0,
   parent: null | ComponentStackNode,
   type: string,
+  ...
 };
 type FunctionComponentStackNode = {
   tag: 1,
   parent: null | ComponentStackNode,
   type: Function,
+  ...
 };
 type ClassComponentStackNode = {
   tag: 2,
   parent: null | ComponentStackNode,
   type: Function,
+  ...
 };
 export type ComponentStackNode =
   | BuiltInComponentStackNode

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -20,14 +20,13 @@ if (__DEV__) {
 
 // Used to store the parent path of all context overrides in a shared linked list.
 // Forming a reverse tree.
-type ContextNode<T> = {
+type ContextNode<T> = {|
   parent: null | ContextNode<any>,
   depth: number, // Short hand to compute the depth of the tree at this node.
   context: ReactContext<T>,
   parentValue: T,
   value: T,
-  ...
-};
+|};
 
 // The structure of a context snapshot is an implementation of this file.
 // Currently, it's implemented as tracking the current active node.

--- a/packages/react-server/src/ReactFizzNewContext.js
+++ b/packages/react-server/src/ReactFizzNewContext.js
@@ -26,6 +26,7 @@ type ContextNode<T> = {
   context: ReactContext<T>,
   parentValue: T,
   value: T,
+  ...
 };
 
 // The structure of a context snapshot is an implementation of this file.

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -129,6 +129,7 @@ const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 
 type LegacyContext = {
   [key: string]: any,
+  ...,
 };
 
 type SuspenseBoundary = {
@@ -143,6 +144,7 @@ type SuspenseBoundary = {
   completedSegments: Array<Segment>, // completed but not yet flushed segments.
   byteSize: number, // used to determine whether to inline children boundaries.
   fallbackAbortableTasks: Set<Task>, // used to cancel task on the fallback if the boundary completes or gets canceled.
+  ...
 };
 
 export type Task = {
@@ -155,6 +157,7 @@ export type Task = {
   context: ContextSnapshot, // the current new context that this task is executing in
   treeContext: TreeContext, // the current tree context that this task is executing in
   componentStack: null | ComponentStackNode, // DEV-only component stack
+  ...
 };
 
 const PENDING = 0;
@@ -179,6 +182,7 @@ type Segment = {
   // used to discern when text separator boundaries are needed
   lastPushedText: boolean,
   textEmbedded: boolean,
+  ...
 };
 
 const OPEN = 0;
@@ -218,6 +222,7 @@ export opaque type Request = {
   // emit a different response to the stream instead.
   onShellError: (error: mixed) => void,
   onFatalError: (error: mixed) => void,
+  ...
 };
 
 // This is a default heuristic for how to split up the HTML content into progressive

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -127,12 +127,11 @@ import isArray from 'shared/isArray';
 const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 
-type LegacyContext = {
+type LegacyContext = {|
   [key: string]: any,
-  ...,
-};
+|};
 
-type SuspenseBoundary = {
+type SuspenseBoundary = {|
   id: SuspenseBoundaryID,
   rootSegmentID: number,
   errorDigest: ?string, // the error hash if it errors
@@ -144,10 +143,9 @@ type SuspenseBoundary = {
   completedSegments: Array<Segment>, // completed but not yet flushed segments.
   byteSize: number, // used to determine whether to inline children boundaries.
   fallbackAbortableTasks: Set<Task>, // used to cancel task on the fallback if the boundary completes or gets canceled.
-  ...
-};
+|};
 
-export type Task = {
+export type Task = {|
   node: ReactNodeList,
   ping: () => void,
   blockedBoundary: Root | SuspenseBoundary,
@@ -157,8 +155,7 @@ export type Task = {
   context: ContextSnapshot, // the current new context that this task is executing in
   treeContext: TreeContext, // the current tree context that this task is executing in
   componentStack: null | ComponentStackNode, // DEV-only component stack
-  ...
-};
+|};
 
 const PENDING = 0;
 const COMPLETED = 1;
@@ -168,7 +165,7 @@ const ERRORED = 4;
 
 type Root = null;
 
-type Segment = {
+type Segment = {|
   status: 0 | 1 | 2 | 3 | 4,
   parentFlushed: boolean, // typically a segment will be flushed by its parent, except if its parent was already flushed
   id: number, // starts as 0 and is lazily assigned if the parent flushes early
@@ -182,14 +179,13 @@ type Segment = {
   // used to discern when text separator boundaries are needed
   lastPushedText: boolean,
   textEmbedded: boolean,
-  ...
-};
+|};
 
 const OPEN = 0;
 const CLOSING = 1;
 const CLOSED = 2;
 
-export opaque type Request = {
+export opaque type Request = {|
   destination: null | Destination,
   +responseState: ResponseState,
   +progressiveChunkSize: number,
@@ -222,8 +218,7 @@ export opaque type Request = {
   // emit a different response to the stream instead.
   onShellError: (error: mixed) => void,
   onFatalError: (error: mixed) => void,
-  ...
-};
+|};
 
 // This is a default heuristic for how to split up the HTML content into progressive
 // loading. Our goal is to be able to display additional new content about every 500ms.

--- a/packages/react-server/src/ReactFizzTreeContext.js
+++ b/packages/react-server/src/ReactFizzTreeContext.js
@@ -63,6 +63,7 @@
 export type TreeContext = {
   +id: number,
   +overflow: string,
+  ...
 };
 
 export const emptyTreeContext = {

--- a/packages/react-server/src/ReactFizzTreeContext.js
+++ b/packages/react-server/src/ReactFizzTreeContext.js
@@ -60,11 +60,10 @@
 // log2(32) = 5 bits. That means we can lop bits off the end 5 at a time without
 // affecting the final result.
 
-export type TreeContext = {
+export type TreeContext = {|
   +id: number,
   +overflow: string,
-  ...
-};
+|};
 
 export const emptyTreeContext = {
   id: 1,

--- a/packages/react-server/src/ReactFlightNewContext.js
+++ b/packages/react-server/src/ReactFlightNewContext.js
@@ -29,6 +29,7 @@ type ContextNode<T: ServerContextJSONValue> = {
   context: ReactServerContext<T>,
   parentValue: T,
   value: T,
+  ...
 };
 
 // The structure of a context snapshot is an implementation of this file.

--- a/packages/react-server/src/ReactFlightNewContext.js
+++ b/packages/react-server/src/ReactFlightNewContext.js
@@ -23,14 +23,13 @@ if (__DEV__) {
 
 // Used to store the parent path of all context overrides in a shared linked list.
 // Forming a reverse tree.
-type ContextNode<T: ServerContextJSONValue> = {
+type ContextNode<T: ServerContextJSONValue> = {|
   parent: null | ContextNode<any>,
   depth: number, // Short hand to compute the depth of the tree at this node.
   context: ReactServerContext<T>,
   parentValue: T,
   value: T,
-  ...
-};
+|};
 
 // The structure of a context snapshot is an implementation of this file.
 // Currently, it's implemented as tracking the current active node.

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,7 +91,7 @@ export type ReactModel =
   | Iterable<ReactModel>
   | ReactModelObject;
 
-type ReactModelObject = {+[key: string]: ReactModel};
+type ReactModelObject = {+[key: string]: ReactModel, ...};
 
 const PENDING = 0;
 const COMPLETED = 1;
@@ -105,6 +105,7 @@ type Task = {
   ping: () => void,
   context: ContextSnapshot,
   thenableState: ThenableState | null,
+  ...
 };
 
 export type Request = {
@@ -127,6 +128,7 @@ export type Request = {
   identifierCount: number,
   onError: (error: mixed) => void,
   toJSON: (key: string, value: ReactModel) => ReactJSONValue,
+  ...
 };
 
 const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
@@ -324,7 +326,9 @@ function serializeByRefID(id: number): string {
 
 function serializeModuleReference(
   request: Request,
-  parent: {+[key: string | number]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent:
+    | {+[key: string | number]: ReactModel, ...}
+    | $ReadOnlyArray<ReactModel>,
   key: string,
   moduleReference: ModuleReference<any>,
 ): string {
@@ -465,7 +469,7 @@ function describeValueForErrorMessage(value: ReactModel): string {
 
 function describeObjectForErrorMessage(
   objectOrArray:
-    | {+[key: string | number]: ReactModel}
+    | {+[key: string | number]: ReactModel, ...}
     | $ReadOnlyArray<ReactModel>,
   expandedName?: string,
 ): string {
@@ -495,7 +499,7 @@ function describeObjectForErrorMessage(
     return str;
   } else {
     let str = '{';
-    const object: {+[key: string | number]: ReactModel} = objectOrArray;
+    const object: {+[key: string | number]: ReactModel, ...} = objectOrArray;
     const names = Object.keys(object);
     for (let i = 0; i < names.length; i++) {
       if (i > 0) {
@@ -528,7 +532,9 @@ let isInsideContextValue = false;
 
 export function resolveModelToJSON(
   request: Request,
-  parent: {+[key: string | number]: ReactModel} | $ReadOnlyArray<ReactModel>,
+  parent:
+    | {+[key: string | number]: ReactModel, ...}
+    | $ReadOnlyArray<ReactModel>,
   key: string,
   value: ReactModel,
 ): ReactJSONValue {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,7 +91,7 @@ export type ReactModel =
   | Iterable<ReactModel>
   | ReactModelObject;
 
-type ReactModelObject = {+[key: string]: ReactModel, ...};
+type ReactModelObject = {|+[key: string]: ReactModel|};
 
 const PENDING = 0;
 const COMPLETED = 1;
@@ -272,6 +272,7 @@ function attemptResolveElement(
             );
           }
         }
+        // $FlowFixMe issue discovered when updating Flow
         return [
           REACT_ELEMENT_TYPE,
           type,
@@ -698,6 +699,7 @@ export function resolveModelToJSON(
       }
     }
 
+    // $FlowFixMe
     return value;
   }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,24 +91,23 @@ export type ReactModel =
   | Iterable<ReactModel>
   | ReactModelObject;
 
-type ReactModelObject = {+[key: string]: ReactModel, ...};
+type ReactModelObject = {|+[key: string]: ReactModel|};
 
 const PENDING = 0;
 const COMPLETED = 1;
 const ABORTED = 3;
 const ERRORED = 4;
 
-type Task = {
+type Task = {|
   id: number,
   status: 0 | 1 | 3 | 4,
   model: ReactModel,
   ping: () => void,
   context: ContextSnapshot,
   thenableState: ThenableState | null,
-  ...
-};
+|};
 
-export type Request = {
+export type Request = {|
   status: 0 | 1 | 2,
   fatalError: mixed,
   destination: null | Destination,
@@ -128,8 +127,7 @@ export type Request = {
   identifierCount: number,
   onError: (error: mixed) => void,
   toJSON: (key: string, value: ReactModel) => ReactJSONValue,
-  ...
-};
+|};
 
 const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
 
@@ -326,9 +324,7 @@ function serializeByRefID(id: number): string {
 
 function serializeModuleReference(
   request: Request,
-  parent:
-    | {+[key: string | number]: ReactModel, ...}
-    | $ReadOnlyArray<ReactModel>,
+  parent: {|+[key: string | number]: ReactModel|} | $ReadOnlyArray<ReactModel>,
   key: string,
   moduleReference: ModuleReference<any>,
 ): string {
@@ -469,7 +465,7 @@ function describeValueForErrorMessage(value: ReactModel): string {
 
 function describeObjectForErrorMessage(
   objectOrArray:
-    | {+[key: string | number]: ReactModel, ...}
+    | {|+[key: string | number]: ReactModel|}
     | $ReadOnlyArray<ReactModel>,
   expandedName?: string,
 ): string {
@@ -499,7 +495,7 @@ function describeObjectForErrorMessage(
     return str;
   } else {
     let str = '{';
-    const object: {+[key: string | number]: ReactModel, ...} = objectOrArray;
+    const object: {|+[key: string | number]: ReactModel|} = objectOrArray;
     const names = Object.keys(object);
     for (let i = 0; i < names.length; i++) {
       if (i > 0) {
@@ -532,9 +528,7 @@ let isInsideContextValue = false;
 
 export function resolveModelToJSON(
   request: Request,
-  parent:
-    | {+[key: string | number]: ReactModel, ...}
-    | $ReadOnlyArray<ReactModel>,
+  parent: {|+[key: string | number]: ReactModel|} | $ReadOnlyArray<ReactModel>,
   key: string,
   value: ReactModel,
 ): ReactJSONValue {

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -91,7 +91,7 @@ export type ReactModel =
   | Iterable<ReactModel>
   | ReactModelObject;
 
-type ReactModelObject = {|+[key: string]: ReactModel|};
+type ReactModelObject = {+[key: string]: ReactModel, ...};
 
 const PENDING = 0;
 const COMPLETED = 1;
@@ -465,7 +465,7 @@ function describeValueForErrorMessage(value: ReactModel): string {
 
 function describeObjectForErrorMessage(
   objectOrArray:
-    | {|+[key: string | number]: ReactModel|}
+    | {+[key: string | number]: ReactModel, ...}
     | $ReadOnlyArray<ReactModel>,
   expandedName?: string,
 ): string {
@@ -495,7 +495,7 @@ function describeObjectForErrorMessage(
     return str;
   } else {
     let str = '{';
-    const object: {|+[key: string | number]: ReactModel|} = objectOrArray;
+    const object: {+[key: string | number]: ReactModel, ...} = objectOrArray;
     const names = Object.keys(object);
     for (let i = 0; i < names.length; i++) {
       if (i > 0) {
@@ -839,6 +839,7 @@ function emitModuleChunk(
   id: number,
   moduleMetaData: ModuleMetaData,
 ): void {
+  // $FlowFixMe ModuleMetaData is not a ReactModel
   const processedChunk = processModuleChunk(request, id, moduleMetaData);
   request.completedModuleChunks.push(processedChunk);
 }

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -175,6 +175,7 @@ function mapIntoArray(
     if (typeof iteratorFn === 'function') {
       const iterableChildren: Iterable<React$Node> & {
         entries: any,
+        ...
       } = (children: any);
 
       if (__DEV__) {

--- a/packages/react/src/ReactChildren.js
+++ b/packages/react/src/ReactChildren.js
@@ -173,10 +173,9 @@ function mapIntoArray(
   } else {
     const iteratorFn = getIteratorFn(children);
     if (typeof iteratorFn === 'function') {
-      const iterableChildren: Iterable<React$Node> & {
+      const iterableChildren: Iterable<React$Node> & {|
         entries: any,
-        ...
-      } = (children: any);
+      |} = (children: any);
 
       if (__DEV__) {
         // Warn about using Maps as children

--- a/packages/react/src/ReactCurrentBatchConfig.js
+++ b/packages/react/src/ReactCurrentBatchConfig.js
@@ -11,6 +11,7 @@ import type {BatchConfigTransition} from 'react-reconciler/src/ReactFiberTracing
 
 type BatchConfig = {
   transition: BatchConfigTransition | null,
+  ...
 };
 /**
  * Keeps track of the current batch's configuration such as how long an update

--- a/packages/react/src/ReactCurrentBatchConfig.js
+++ b/packages/react/src/ReactCurrentBatchConfig.js
@@ -9,10 +9,9 @@
 
 import type {BatchConfigTransition} from 'react-reconciler/src/ReactFiberTracingMarkerComponent.new';
 
-type BatchConfig = {
+type BatchConfig = {|
   transition: BatchConfigTransition | null,
-  ...
-};
+|};
 /**
  * Keeps track of the current batch's configuration such as how long an update
  * should suspend for if it needs to.

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -19,21 +19,25 @@ const Rejected = 2;
 type UninitializedPayload<T> = {
   _status: -1,
   _result: () => Thenable<{default: T, ...}>,
+  ...
 };
 
 type PendingPayload = {
   _status: 0,
   _result: Wakeable,
+  ...
 };
 
 type ResolvedPayload<T> = {
   _status: 1,
-  _result: {default: T},
+  _result: {default: T, ...},
+  ...
 };
 
 type RejectedPayload = {
   _status: 2,
   _result: mixed,
+  ...
 };
 
 type Payload<T> =
@@ -46,6 +50,7 @@ export type LazyComponent<T, P> = {
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
+  ...
 };
 
 function lazyInitializer<T>(payload: Payload<T>): T {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -16,29 +16,25 @@ const Pending = 0;
 const Resolved = 1;
 const Rejected = 2;
 
-type UninitializedPayload<T> = {
+type UninitializedPayload<T> = {|
   _status: -1,
   _result: () => Thenable<{default: T, ...}>,
-  ...
-};
+|};
 
-type PendingPayload = {
+type PendingPayload = {|
   _status: 0,
   _result: Wakeable,
-  ...
-};
+|};
 
-type ResolvedPayload<T> = {
+type ResolvedPayload<T> = {|
   _status: 1,
-  _result: {default: T, ...},
-  ...
-};
+  _result: {|default: T|},
+|};
 
-type RejectedPayload = {
+type RejectedPayload = {|
   _status: 2,
   _result: mixed,
-  ...
-};
+|};
 
 type Payload<T> =
   | UninitializedPayload<T>
@@ -46,12 +42,11 @@ type Payload<T> =
   | ResolvedPayload<T>
   | RejectedPayload;
 
-export type LazyComponent<T, P> = {
+export type LazyComponent<T, P> = {|
   $$typeof: symbol | number,
   _payload: P,
   _init: (payload: P) => T,
-  ...
-};
+|};
 
 function lazyInitializer<T>(payload: Payload<T>): T {
   if (payload._status === Uninitialized) {

--- a/packages/react/src/ReactLazy.js
+++ b/packages/react/src/ReactLazy.js
@@ -28,7 +28,7 @@ type PendingPayload = {|
 
 type ResolvedPayload<T> = {|
   _status: 1,
-  _result: {|default: T|},
+  _result: {default: T, ...},
 |};
 
 type RejectedPayload = {|

--- a/packages/scheduler/src/forks/SchedulerPostTask.js
+++ b/packages/scheduler/src/forks/SchedulerPostTask.js
@@ -77,7 +77,7 @@ type SchedulerCallback<T> = (
 export function unstable_scheduleCallback<T>(
   priorityLevel: PriorityLevel,
   callback: SchedulerCallback<T>,
-  options?: {delay?: number, ...},
+  options?: {|delay?: number|},
 ): CallbackNode {
   let postTaskPriority;
   switch (priorityLevel) {

--- a/packages/scheduler/src/forks/SchedulerPostTask.js
+++ b/packages/scheduler/src/forks/SchedulerPostTask.js
@@ -77,7 +77,7 @@ type SchedulerCallback<T> = (
 export function unstable_scheduleCallback<T>(
   priorityLevel: PriorityLevel,
   callback: SchedulerCallback<T>,
-  options?: {delay?: number},
+  options?: {delay?: number, ...},
 ): CallbackNode {
   let postTaskPriority;
   switch (priorityLevel) {

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -80,7 +80,7 @@ export type ServerContextJSONValue =
   | number
   | null
   | $ReadOnlyArray<ServerContextJSONValue>
-  | {+[key: string]: ServerContextJSONValue, ...};
+  | {|+[key: string]: ServerContextJSONValue|};
 
 export type ReactServerContext<T: any> = ReactContext<T>;
 
@@ -209,10 +209,9 @@ export type OffscreenMode =
   | 'unstable-defer-without-hiding'
   | 'visible';
 
-export type StartTransitionOptions = {
+export type StartTransitionOptions = {|
   name?: string,
-  ...
-};
+|};
 
 // TODO: Add Context support
 export type Usable<T> = Thenable<T> | ReactContext<T>;

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -80,7 +80,7 @@ export type ServerContextJSONValue =
   | number
   | null
   | $ReadOnlyArray<ServerContextJSONValue>
-  | {+[key: string]: ServerContextJSONValue};
+  | {+[key: string]: ServerContextJSONValue, ...};
 
 export type ReactServerContext<T: any> = ReactContext<T>;
 
@@ -211,6 +211,7 @@ export type OffscreenMode =
 
 export type StartTransitionOptions = {
   name?: string,
+  ...
 };
 
 // TODO: Add Context support

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -37,6 +37,7 @@
 
 [lints]
 untyped-type-import=error
+implicit-inexact-object=error
 
 [options]
 server.max_workers=4

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -77,57 +77,52 @@ declare module 'fs/promises' {
   declare var access: (path: string, mode?: number) => Promise<void>;
   declare var lstat: (
     path: string,
-    options?: ?{bigint?: boolean, ...},
+    options?: ?{|bigint?: boolean|},
   ) => Promise<mixed>;
   declare var readdir: (
     path: string,
     options?:
       | ?string
-      | {
+      | {|
           encoding?: ?string,
           withFileTypes?: ?boolean,
-          ...
-        },
+        |},
   ) => Promise<Buffer>;
   declare var readFile: (
     path: string,
     options?:
       | ?string
-      | {
+      | {|
           encoding?: ?string,
-          ...
-        },
+        |},
   ) => Promise<Buffer>;
   declare var readlink: (
     path: string,
     options?:
       | ?string
-      | {
+      | {|
           encoding?: ?string,
-          ...
-        },
+        |},
   ) => Promise<mixed>;
   declare var realpath: (
     path: string,
     options?:
       | ?string
-      | {
+      | {|
           encoding?: ?string,
-          ...
-        },
+        |},
   ) => Promise<mixed>;
   declare var stat: (
     path: string,
-    options?: ?{bigint?: boolean, ...},
+    options?: ?{|bigint?: boolean|},
   ) => Promise<mixed>;
 }
 declare module 'pg' {
   declare var Pool: (
     options: mixed,
-  ) => {
+  ) => {|
     query: (query: string, values?: Array<mixed>) => void,
-    ...
-  };
+  |};
 }
 
 declare module 'util' {
@@ -152,14 +147,13 @@ declare module 'util' {
     encodeInto(
       buffer: string,
       dest: Uint8Array,
-    ): {read: number, written: number, ...};
+    ): {|read: number, written: number|};
     encoding: string;
   }
 }
 
 declare module 'pg/lib/utils' {
-  declare module.exports: {
+  declare module.exports: {|
     prepareValue(val: any): mixed,
-    ...
-  };
+  |};
 }

--- a/scripts/flow/environment.js
+++ b/scripts/flow/environment.js
@@ -77,7 +77,7 @@ declare module 'fs/promises' {
   declare var access: (path: string, mode?: number) => Promise<void>;
   declare var lstat: (
     path: string,
-    options?: ?{bigint?: boolean},
+    options?: ?{bigint?: boolean, ...},
   ) => Promise<mixed>;
   declare var readdir: (
     path: string,
@@ -86,6 +86,7 @@ declare module 'fs/promises' {
       | {
           encoding?: ?string,
           withFileTypes?: ?boolean,
+          ...
         },
   ) => Promise<Buffer>;
   declare var readFile: (
@@ -94,6 +95,7 @@ declare module 'fs/promises' {
       | ?string
       | {
           encoding?: ?string,
+          ...
         },
   ) => Promise<Buffer>;
   declare var readlink: (
@@ -102,6 +104,7 @@ declare module 'fs/promises' {
       | ?string
       | {
           encoding?: ?string,
+          ...
         },
   ) => Promise<mixed>;
   declare var realpath: (
@@ -110,11 +113,12 @@ declare module 'fs/promises' {
       | ?string
       | {
           encoding?: ?string,
+          ...
         },
   ) => Promise<mixed>;
   declare var stat: (
     path: string,
-    options?: ?{bigint?: boolean},
+    options?: ?{bigint?: boolean, ...},
   ) => Promise<mixed>;
 }
 declare module 'pg' {
@@ -122,6 +126,7 @@ declare module 'pg' {
     options: mixed,
   ) => {
     query: (query: string, values?: Array<mixed>) => void,
+    ...
   };
 }
 
@@ -147,7 +152,7 @@ declare module 'util' {
     encodeInto(
       buffer: string,
       dest: Uint8Array,
-    ): {read: number, written: number};
+    ): {read: number, written: number, ...};
     encoding: string;
   }
 }
@@ -155,5 +160,6 @@ declare module 'util' {
 declare module 'pg/lib/utils' {
   declare module.exports: {
     prepareValue(val: any): mixed,
+    ...
   };
 }

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -26,7 +26,7 @@ type RawEventEmitterEvent = $ReadOnly<{|
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),
   // and a stateNode of the native element/Fiber the event was emitted to.
-  nativeEvent: {[string]: mixed},
+  nativeEvent: {[string]: mixed, ...},
 |}>;
 
 declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface' {

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -26,7 +26,7 @@ type RawEventEmitterEvent = $ReadOnly<{|
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),
   // and a stateNode of the native element/Fiber the event was emitted to.
-  nativeEvent: {[string]: mixed, ...},
+  nativeEvent: {|[string]: mixed|},
 |}>;
 
 declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface' {

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -26,7 +26,7 @@ type RawEventEmitterEvent = $ReadOnly<{|
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),
   // and a stateNode of the native element/Fiber the event was emitted to.
-  nativeEvent: {|[string]: mixed|},
+  nativeEvent: {[string]: mixed, ...},
 |}>;
 
 declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface' {

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -12,7 +12,7 @@ type JSONValue =
   | boolean
   | number
   | null
-  | {+[key: string]: JSONValue, ...}
+  | {|+[key: string]: JSONValue|}
   | $ReadOnlyArray<JSONValue>;
 
 declare module 'JSResourceReference' {

--- a/scripts/flow/react-relay-hooks.js
+++ b/scripts/flow/react-relay-hooks.js
@@ -12,7 +12,7 @@ type JSONValue =
   | boolean
   | number
   | null
-  | {+[key: string]: JSONValue}
+  | {+[key: string]: JSONValue, ...}
   | $ReadOnlyArray<JSONValue>;
 
 declare module 'JSResourceReference' {


### PR DESCRIPTION
Over the last years, the meaning of the Flow type `{ a: number }` has changed from an inexact object (explicitly written as `{ a: number, ... }`) to an exact object (i.e. `{| a: number |}`).

This PR makes these implicitly inexact object explicitly inexact by adding the `...` and configures flow to make the ambiguous type without either `...` or `|` an error. A following step can then change the default to be exact.