### PR TITLE
Test case for potentially undesirable combo of useMemo w setState-in-render

### DIFF
--- a/packages/react-reconciler/src/__tests__/useMemo-invalidation-test.js
+++ b/packages/react-reconciler/src/__tests__/useMemo-invalidation-test.js
@@ -1,0 +1,89 @@
+let React;
+let ReactNoop;
+let act;
+let useState;
+
+describe('possible useMemo invalidation bug', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    React = require('react');
+    ReactNoop = require('react-noop-renderer');
+    act = require('jest-react').act;
+    useState = React.useState;
+  });
+
+  // @gate experimental || www
+  test('caches values whose inputs are unchanged after setstate in render (useMemo)', async () => {
+    let setX;
+    function Component({limit}) {
+      const [x, _setX] = useState(0);
+      setX = _setX;
+
+      // `x` is a controlled state that can't be set higher than the provided `limit`
+      if (x > limit) {
+        setX(limit);
+      }
+
+      // `obj` is an object that captures the value of `x`
+      const obj = React.useMemo(
+        // POSSIBLE BUG: because useMemo tries to reuse the WIP memo value after a setState-in-render,
+        // the previous value is discarded. This means that even though the final render has the same
+        // inputs as the last commit, the memoized value is discarded and recreated, breaking
+        // memoization of all the child components down the tree.
+        //
+        // 1) First render: cache is initialized to {count: 0} with deps of [x=0, limit=10]
+        // 2) Update: cache updated to {count: 10} with deps of [x=10, limit=10]
+        // 3) Second update:
+        // 3a) initially renders and caches {count: 12} with deps of [x=12, limit=10]
+        // 3b) re-renders bc of setstate, caches {count: 10} with deps of [x=10, limit=10]
+        // If this last step started from the `current` fiber's memo cache (from 2, instead of from 3a),
+        // then it would not re-execute and preserve object identity
+        () => {
+          return {count: x};
+        },
+        // Note that `limit` isn't technically a dependency,
+        // it's included here to show that even if we modeled that
+        // `x` can depend on the value of `limit`, it isn't sufficient
+        // to avoid breaking memoization across renders
+        [x, limit],
+      );
+
+      return <Child obj={obj} />;
+    }
+
+    const Child = React.memo(function Child({obj}) {
+      const text = React.useMemo(() => {
+        return {text: `Count ${obj.count}`};
+      }, [obj]);
+      return <Text value={text} />;
+    });
+
+    // Text should only ever re-render if the object identity of `value`
+    // changes.
+    let renderCount = 0;
+    const Text = React.memo(function Text({value}) {
+      renderCount++;
+      return value.text;
+    });
+
+    const root = ReactNoop.createRoot();
+    await act(async () => {
+      root.render(<Component limit={10} />);
+    });
+    expect(root).toMatchRenderedOutput('Count 0');
+    expect(renderCount).toBe(1);
+
+    await act(async () => {
+      setX(10); // set to the limit
+    });
+    expect(root).toMatchRenderedOutput('Count 10');
+    expect(renderCount).toBe(2);
+
+    await act(async () => {
+      setX(12); // exceeds limit, will be reset in setState during render
+    });
+    expect(root).toMatchRenderedOutput('Count 10');
+    expect(renderCount).toBe(2); // should not re-render, since value has not changed
+  });
+});


### PR DESCRIPTION
## Summary

This came out of an offline discussion about `useMemoCache()` (#25143) and whether, after a setState in render, the cache should reset back to that of the current fiber or continue using the wip cache. @acdlite pointed out that `useMemo()` does the equivalent of the latter, ie reusing the wip memo cache, but I realized that this can break memoization of child components in some edge cases (ie, cause child components to rerender/recompute memoized values due to unnecessarily breaking referential equality in the parent).

A render pass that does _not_ contain a setState will always compute useMemo values relative to the current fiber: this means that if the dependencies have not changed, the computed memo value will be the same as the object that was computed and passed to children (and that thefore is present as the dependency value in their useMemo deps arrays):
* Parent renders with input@v0, computes value@v0
* Parent updates with input@v0, _reuses_ value@v0
  * downstream memo caches don't recompute bc their input is the same

However, a render pass that _does_ have a setState will (currently) reuse the work-in-progress useMemo values. Even if the input is reset to its last committed value, dependencies have already been reset:
* Parent renders with input@v0, computes value@v0
* Parent updates with input@v1, computes value@v1 (at this point the value@v0 is lost). SetState resets back to input@v0
* Parent updates with input@v0, _recomputes_ value@v2 (which is structurally equal, but !== to, value@v0
  * oops, downstream memo caches recompute bc their input is accidentally different

The current behavior is in some senses reasonable: a setState in render that happens to reset back to the same state as the last commit seems very unlikely in practice, whereas a setState in render having to redo the same (new) computation again seems likely. However, recomputing a single new value an extra time is less costly than breaking memoization caches for an entire subtree, so it's worth considering.

## How did you test this change?

`yarn test` (the new test is expected to fail)