### PR TITLE
[Flight] Add some test coverage for some error cases

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -317,11 +317,6 @@ export function parseModelString(
       } else {
         const id = parseInt(value.substring(1), 16);
         const chunk = getChunk(response, id);
-        if (chunk._status === PENDING) {
-          throw new Error(
-            "We didn't expect to see a forward reference. This is a bug in the React Server.",
-          );
-        }
         return readChunk(chunk);
       }
     }


### PR DESCRIPTION
This adds some tests for some error cases loading modules.

I mistakenly thought that we didn't have any forward references anymore but there's a case where a module resolution synchronously errors. Typically this would only happen due to a bug in the bundler.

This is a weird edge but I'll probably model synchronous references to async module references as forward references anyway so I'll just remove this error for now.

I couldn't actually figure out how to properly test this using public APIs because the scenario only happens if we manage to read the model referencing the error before the error resolves. Which is race condition in the stream of the client. So this particular test didn't fail before. We could probably do something to yield the stream similar to Scheduler.yield but there's no user code involved here to do that from in predictably the right slot.