### PR TITLE
Flow: fix Fiber typed as any

### DIFF
--- a/packages/react-dom/src/events/SyntheticEvent.js
+++ b/packages/react-dom/src/events/SyntheticEvent.js
@@ -9,6 +9,8 @@
 
 /* eslint valid-typeof: 0 */
 
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+
 import assign from 'shared/assign';
 import getEventCharCode from './getEventCharCode';
 
@@ -44,7 +46,7 @@ function createSyntheticEvent(Interface: EventInterfaceType) {
   function SyntheticBaseEvent(
     reactName: string | null,
     reactEventType: string,
-    targetInst: Fiber,
+    targetInst: Fiber | null,
     nativeEvent: {[propName: string]: mixed, ...},
     nativeEventTarget: null | EventTarget,
   ) {

--- a/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/BeforeInputEventPlugin.js
@@ -12,6 +12,7 @@ import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {AnyNativeEvent} from '../../events/PluginModuleType';
 import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
+import type {ReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 
@@ -228,7 +229,8 @@ function extractCompositionEvent(
 
   const listeners = accumulateTwoPhaseListeners(targetInst, eventType);
   if (listeners.length > 0) {
-    const event = new SyntheticCompositionEvent(
+    // $FlowFixMe[incompatible-type]
+    const event: ReactSyntheticEvent = new SyntheticCompositionEvent(
       eventType,
       domEventName,
       null,
@@ -239,10 +241,12 @@ function extractCompositionEvent(
     if (fallbackData) {
       // Inject data generated from fallback path into the synthetic event.
       // This matches the property of native CompositionEventInterface.
+      // $FlowFixMe[incompatible-use]
       event.data = fallbackData;
     } else {
       const customData = getDataFromCustomEvent(nativeEvent);
       if (customData !== null) {
+        // $FlowFixMe[incompatible-use]
         event.data = customData;
       }
     }
@@ -398,7 +402,8 @@ function extractBeforeInputEvent(
 
   const listeners = accumulateTwoPhaseListeners(targetInst, 'onBeforeInput');
   if (listeners.length > 0) {
-    const event = new SyntheticInputEvent(
+    // $FlowFixMe[incompatible-type]
+    const event: ReactSyntheticEvent = new SyntheticInputEvent(
       'onBeforeInput',
       'beforeinput',
       null,
@@ -406,6 +411,7 @@ function extractBeforeInputEvent(
       nativeEventTarget,
     );
     dispatchQueue.push({event, listeners});
+    // $FlowFixMe[incompatible-use]
     event.data = chars;
   }
 }

--- a/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/ChangeEventPlugin.js
@@ -10,6 +10,8 @@ import type {AnyNativeEvent} from '../PluginModuleType';
 import type {DOMEventName} from '../DOMEventNames';
 import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {ReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {registerTwoPhaseEvent} from '../EventRegistry';
 import {SyntheticEvent} from '../SyntheticEvent';
@@ -57,7 +59,8 @@ function createAndAccumulateChangeEvent(
   enqueueStateRestore(((target: any): Node));
   const listeners = accumulateTwoPhaseListeners(inst, 'onChange');
   if (listeners.length > 0) {
-    const event = new SyntheticEvent(
+    // $FlowFixMe[incompatible-type]
+    const event: ReactSyntheticEvent = new SyntheticEvent(
       'onChange',
       'change',
       null,

--- a/packages/react-dom/src/events/plugins/EnterLeaveEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/EnterLeaveEventPlugin.js
@@ -11,6 +11,8 @@ import type {AnyNativeEvent} from '../PluginModuleType';
 import type {DOMEventName} from '../DOMEventNames';
 import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {KnownReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {registerDirectEvent} from '../EventRegistry';
 import {isReplayingEvent} from '../CurrentReplayingEvent';
@@ -21,7 +23,6 @@ import {
   isContainerMarkedAsRoot,
 } from '../../client/ReactDOMComponentTree';
 import {accumulateEnterLeaveTwoPhaseListeners} from '../DOMPluginEventSystem';
-import type {KnownReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {HostComponent, HostText} from 'react-reconciler/src/ReactWorkTags';
 import {getNearestMountedFiber} from 'react-reconciler/src/ReactFiberTreeReflection';
@@ -133,7 +134,9 @@ function extractEvents(
   const fromNode = from == null ? win : getNodeFromInstance(from);
   const toNode = to == null ? win : getNodeFromInstance(to);
 
-  const leave = new SyntheticEventCtor(
+  // $FlowFixMe[prop-missing]
+  // $FlowFixMe[incompatible-type]
+  const leave: KnownReactSyntheticEvent = new SyntheticEventCtor(
     leaveEventType,
     eventTypePrefix + 'leave',
     from,
@@ -149,6 +152,7 @@ function extractEvents(
   // the first ancestor. Next time, we will ignore the event.
   const nativeTargetInst = getClosestInstanceFromNode((nativeEventTarget: any));
   if (nativeTargetInst === targetInst) {
+    // $FlowFixMe[prop-missing]
     const enterEvent: KnownReactSyntheticEvent = new SyntheticEventCtor(
       enterEventType,
       eventTypePrefix + 'enter',

--- a/packages/react-dom/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SelectEventPlugin.js
@@ -11,6 +11,8 @@ import type {AnyNativeEvent} from '../PluginModuleType';
 import type {DOMEventName} from '../DOMEventNames';
 import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import type {ReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {canUseDOM} from 'shared/ExecutionEnvironment';
 import {SyntheticEvent} from '../../events/SyntheticEvent';
@@ -114,7 +116,8 @@ function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
       'onSelect',
     );
     if (listeners.length > 0) {
-      const event = new SyntheticEvent(
+      // $FlowFixMe[incompatible-type]
+      const event: ReactSyntheticEvent = new SyntheticEvent(
         'onSelect',
         'select',
         null,

--- a/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
+++ b/packages/react-dom/src/events/plugins/SimpleEventPlugin.js
@@ -12,6 +12,7 @@ import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {AnyNativeEvent} from '../../events/PluginModuleType';
 import type {DispatchQueue} from '../DOMPluginEventSystem';
 import type {EventSystemFlags} from '../EventSystemFlags';
+import type {ReactSyntheticEvent} from '../ReactSyntheticEventType';
 
 import {
   SyntheticEvent,
@@ -172,7 +173,8 @@ function extractEvents(
     );
     if (listeners.length > 0) {
       // Intentionally create event lazily.
-      const event = new SyntheticEventCtor(
+      // $FlowFixMe[incompatible-type]
+      const event: ReactSyntheticEvent = new SyntheticEventCtor(
         reactName,
         reactEventType,
         null,
@@ -204,7 +206,8 @@ function extractEvents(
     );
     if (listeners.length > 0) {
       // Intentionally create event lazily.
-      const event = new SyntheticEventCtor(
+      // $FlowFixMe[incompatible-type]
+      const event: ReactSyntheticEvent = new SyntheticEventCtor(
         reactName,
         reactEventType,
         null,

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -11,7 +11,10 @@ import type {AnyNativeEvent} from './legacy-events/PluginModuleType';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {LegacyPluginModule} from './legacy-events/PluginModuleType';
 import type {ReactSyntheticEvent} from './legacy-events/ReactSyntheticEventType';
-import type {TopLevelType} from './legacy-events/TopLevelEventTypes';
+import type {
+  RNTopLevelEventType,
+  TopLevelType,
+} from './legacy-events/TopLevelEventTypes';
 
 import {registrationNameModules} from './legacy-events/EventPluginRegistry';
 import {batchedUpdates} from './legacy-events/ReactGenericBatching';

--- a/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactContext} from 'shared/ReactTypes';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {enableCache} from 'shared/ReactFeatureFlags';
 import {REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';

--- a/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactContext} from 'shared/ReactTypes';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 
 import {enableCache} from 'shared/ReactFeatureFlags';
 import {REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.new.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {
   UpdateQueue as HookQueue,
   Update as HookUpdate,

--- a/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
+++ b/packages/react-reconciler/src/ReactFiberConcurrentUpdates.old.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {
   UpdateQueue as HookQueue,
   Update as HookUpdate,

--- a/packages/react-reconciler/src/ReactFiberLane.new.js
+++ b/packages/react-reconciler/src/ReactFiberLane.new.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Transition} from './ReactFiberTracingMarkerComponent.new';
 import type {ConcurrentUpdate} from './ReactFiberConcurrentUpdates.new';
 

--- a/packages/react-reconciler/src/ReactFiberLane.old.js
+++ b/packages/react-reconciler/src/ReactFiberLane.old.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Transition} from './ReactFiberTracingMarkerComponent.old';
 import type {ConcurrentUpdate} from './ReactFiberConcurrentUpdates.old';
 

--- a/packages/react-reconciler/src/ReactFiberTransition.new.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.new.js
@@ -6,7 +6,7 @@
  *
  * @flow
  */
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.new';
 import type {StackCursor} from './ReactFiberStack.new';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent.new';

--- a/packages/react-reconciler/src/ReactFiberTransition.old.js
+++ b/packages/react-reconciler/src/ReactFiberTransition.old.js
@@ -6,7 +6,7 @@
  *
  * @flow
  */
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {StackCursor} from './ReactFiberStack.old';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent.old';

--- a/packages/react-reconciler/src/ReactFiberTransitionPool.old.js
+++ b/packages/react-reconciler/src/ReactFiberTransitionPool.old.js
@@ -6,7 +6,7 @@
  *
  * @flow
  */
-import type {FiberRoot} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {StackCursor} from './ReactFiberStack.old';
 import type {Cache, SpawnedCachePool} from './ReactFiberCacheComponent.old';

--- a/packages/react-reconciler/src/ReactFiberTreeContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.new.js
@@ -60,6 +60,8 @@
 // log2(32) = 5 bits. That means we can lop bits off the end 5 at a time without
 // affecting the final result.
 
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+
 import {getIsHydrating} from './ReactFiberHydrationContext.new';
 import {clz32} from './clz32';
 import {Forked, NoFlags} from './ReactFiberFlags';

--- a/packages/react-reconciler/src/ReactFiberTreeContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberTreeContext.old.js
@@ -60,6 +60,8 @@
 // log2(32) = 5 bits. That means we can lop bits off the end 5 at a time without
 // affecting the final result.
 
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+
 import {getIsHydrating} from './ReactFiberHydrationContext.old';
 import {clz32} from './clz32';
 import {Forked, NoFlags} from './ReactFiberFlags';

--- a/packages/react-reconciler/src/getComponentNameFromFiber.js
+++ b/packages/react-reconciler/src/getComponentNameFromFiber.js
@@ -8,6 +8,7 @@
  */
 
 import type {ReactContext, ReactProviderType} from 'shared/ReactTypes';
+import type {Fiber} from './ReactInternalTypes';
 
 import {enableLegacyHidden} from 'shared/ReactFeatureFlags';
 

--- a/packages/shared/ReactTypes.js
+++ b/packages/shared/ReactTypes.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+
 export type ReactNode =
   | React$Element<any>
   | ReactPortal

--- a/scripts/flow/react-native-host-hooks.js
+++ b/scripts/flow/react-native-host-hooks.js
@@ -9,16 +9,21 @@
 
 /* eslint-disable */
 
-import type {
-  MeasureOnSuccessCallback,
-  MeasureInWindowOnSuccessCallback,
-  MeasureLayoutOnSuccessCallback,
-  ReactNativeBaseComponentViewConfig,
-  ViewConfigGetter,
-} from 'react-native-renderer/src/ReactNativeTypes';
-import type {RNTopLevelEventType} from 'react-native-renderer/src/legacy-events/TopLevelEventTypes';
-import type {CapturedError} from 'react-reconciler/src/ReactCapturedValue';
-import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+// libdefs cannot actually import. These are supposed to be the types imported
+// from 'react-native-renderer/src/ReactNativeTypes'
+type __MeasureOnSuccessCallback = any;
+type __MeasureInWindowOnSuccessCallback = any;
+type __MeasureLayoutOnSuccessCallback = any;
+type __ReactNativeBaseComponentViewConfig = any;
+type __ViewConfigGetter = any;
+
+// libdefs cannot actually import. This is supposed to be the type imported
+// from 'react-native-renderer/src/legacy-events/TopLevelEventTypes';
+type __RNTopLevelEventType = any;
+
+// libdefs cannot actually import. This is supposed to be the type imported
+// from 'react-reconciler/src/ReactCapturedValue'
+type __CapturedError = any;
 
 type DeepDifferOptions = {+unsafelyIgnoreFunctions?: boolean};
 type RawEventEmitterEvent = $ReadOnly<{
@@ -53,7 +58,7 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
     ...
   };
   declare export var ReactFiberErrorDialog: {
-    showErrorDialog: (error: CapturedError) => boolean,
+    showErrorDialog: (error: __CapturedError) => boolean,
     ...
   };
   declare export var Platform: {OS: string, ...};
@@ -130,8 +135,8 @@ declare module 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface'
     customDirectEventTypes: Object,
     eventTypes: Object,
 
-    register: (name: string, callback: ViewConfigGetter) => string,
-    get: (name: string) => ReactNativeBaseComponentViewConfig,
+    register: (name: string, callback: __ViewConfigGetter) => string,
+    get: (name: string) => __ReactNativeBaseComponentViewConfig,
     ...
   };
   declare export var RawEventEmitter: {
@@ -166,7 +171,7 @@ declare var nativeFabricUIManager: {
   registerEventHandler: (
     callback: (
       eventTarget: null | Object,
-      type: RNTopLevelEventType,
+      type: __RNTopLevelEventType,
       payload: Object,
     ) => void,
   ) => void,
@@ -174,22 +179,22 @@ declare var nativeFabricUIManager: {
   dispatchCommand: (node: Object, command: string, args: Array<any>) => void,
   sendAccessibilityEvent: (node: Object, eventTypeName: string) => void,
 
-  measure: (node: Node, callback: MeasureOnSuccessCallback) => void,
+  measure: (node: Node, callback: __MeasureOnSuccessCallback) => void,
   measureInWindow: (
     node: Node,
-    callback: MeasureInWindowOnSuccessCallback,
+    callback: __MeasureInWindowOnSuccessCallback,
   ) => void,
   measureLayout: (
     node: Node,
     relativeNode: Node,
     onFail: () => void,
-    onSuccess: MeasureLayoutOnSuccessCallback,
+    onSuccess: __MeasureLayoutOnSuccessCallback,
   ) => void,
   findNodeAtPoint: (
     node: Node,
     locationX: number,
     locationY: number,
-    callback: (Fiber) => void,
+    callback: (Object) => void,
   ) => void,
   setIsJSResponder: (
     node: Node,


### PR DESCRIPTION
Flow library definitions cannot actually import the checked code (I think the library definitions are in an earlier step, so cannot be recursive).

Somehow in older versions of flow, it's actually not an error to import in a library definition. The imports there are defining globally available `any` types… This made `Fiber` whereever it wasn't imported explicitly use the globally available `any` type.

Here the globally leaked `any` is fixed by explicitly setting it to any and renaming the type to `__Fiber` in the lib def to avoid this global leak of `Fiber` (I think we still leak the new `__Fiber` name)