### PR TITLE
Flow: upgrade to 0.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.131",
+    "flow-bin": "^0.132",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/react-devtools-inline/src/backend.js
+++ b/packages/react-devtools-inline/src/backend.js
@@ -9,7 +9,7 @@ import setupNativeStyleEditor from 'react-devtools-shared/src/backend/NativeStyl
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {Wall} from 'react-devtools-shared/src/types';
 
-function startActivation(contentWindow: window, bridge: BackendBridge) {
+function startActivation(contentWindow: any, bridge: BackendBridge) {
   const onSavedPreferences = data => {
     // This is the only message we're listening for,
     // so it's safe to cleanup after we've received it.
@@ -55,7 +55,7 @@ function startActivation(contentWindow: window, bridge: BackendBridge) {
   bridge.send('getSavedPreferences');
 }
 
-function finishActivation(contentWindow: window, bridge: BackendBridge) {
+function finishActivation(contentWindow: any, bridge: BackendBridge) {
   const agent = new Agent(bridge);
 
   const hook = contentWindow.__REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -75,7 +75,7 @@ function finishActivation(contentWindow: window, bridge: BackendBridge) {
 }
 
 export function activate(
-  contentWindow: window,
+  contentWindow: any,
   {
     bridge,
   }: {
@@ -89,10 +89,7 @@ export function activate(
   startActivation(contentWindow, bridge);
 }
 
-export function createBridge(
-  contentWindow: window,
-  wall?: Wall,
-): BackendBridge {
+export function createBridge(contentWindow: any, wall?: Wall): BackendBridge {
   const {parent} = contentWindow;
 
   if (wall == null) {
@@ -115,6 +112,6 @@ export function createBridge(
   return (new Bridge(wall): BackendBridge);
 }
 
-export function initialize(contentWindow: window): void {
+export function initialize(contentWindow: any): void {
   installHook(contentWindow);
 }

--- a/packages/react-devtools-inline/src/frontend.js
+++ b/packages/react-devtools-inline/src/frontend.js
@@ -33,10 +33,7 @@ export function createStore(bridge: FrontendBridge, config?: Config): Store {
   });
 }
 
-export function createBridge(
-  contentWindow: window,
-  wall?: Wall,
-): FrontendBridge {
+export function createBridge(contentWindow: any, wall?: Wall): FrontendBridge {
   if (wall == null) {
     wall = {
       listen(fn) {
@@ -58,7 +55,7 @@ export function createBridge(
 }
 
 export function initialize(
-  contentWindow: window,
+  contentWindow: any,
   {
     bridge,
     store,

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -148,8 +148,8 @@ class OverlayTip {
 }
 
 export default class Overlay {
-  window: window;
-  tipBoundsWindow: window;
+  window: any;
+  tipBoundsWindow: any;
   container: HTMLElement;
   tip: OverlayTip;
   rects: Array<OverlayRect>;

--- a/packages/react-devtools-shared/src/hooks/astUtils.js
+++ b/packages/react-devtools-shared/src/hooks/astUtils.js
@@ -8,10 +8,15 @@
  */
 
 import {withSyncPerfMeasurements} from 'react-devtools-shared/src/PerformanceLoggingUtils';
-import traverse, {NodePath, Node} from '@babel/traverse';
-import {File} from '@babel/types';
+import traverse from '@babel/traverse';
 
 import type {HooksNode} from 'react-debug-tools/src/ReactDebugHooks';
+
+// Missing types in @babel/traverse
+type NodePath = any;
+type Node = any;
+// Missing types in @babel/types
+type File = any;
 
 export type Position = {
   line: number,

--- a/packages/react-devtools-shared/src/hooks/generateHookMap.js
+++ b/packages/react-devtools-shared/src/hooks/generateHookMap.js
@@ -9,7 +9,9 @@
 
 import {getHookNamesMappingFromAST} from './astUtils';
 import {encode, decode} from 'sourcemap-codec';
-import {File} from '@babel/types';
+
+// Missing types in @babel/types
+type File = any;
 
 export type HookMap = {
   names: $ReadOnlyArray<string>,

--- a/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.new.js
@@ -18,7 +18,7 @@ import * as Scheduler from 'scheduler';
 
 // In environments without AbortController (e.g. tests)
 // replace it with a lightweight shim that only has the features we use.
-const AbortControllerLocal = enableCache
+const AbortControllerLocal: typeof AbortController = enableCache
   ? typeof AbortController !== 'undefined'
     ? AbortController
     : (function AbortControllerShim() {

--- a/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberCacheComponent.old.js
@@ -18,7 +18,7 @@ import * as Scheduler from 'scheduler';
 
 // In environments without AbortController (e.g. tests)
 // replace it with a lightweight shim that only has the features we use.
-const AbortControllerLocal = enableCache
+const AbortControllerLocal: typeof AbortController = enableCache
   ? typeof AbortController !== 'undefined'
     ? AbortController
     : (function AbortControllerShim() {

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -327,7 +327,7 @@ export default class ReactFlightWebpackPlugin {
             contextModuleFactory.resolveDependencies(
               fs,
               options,
-              (err2: null | Error, deps: Array<ModuleDependency>) => {
+              (err2: null | Error, deps: Array<any /*ModuleDependency*/>) => {
                 if (err2) return cb(err2);
                 const clientRefDeps = deps.map(dep => {
                   // use userRequest instead of request. request always end with undefined which is wrong

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -54,4 +54,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.131.0
+^0.132.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7914,10 +7914,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.131:
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.131.0.tgz#d4228b6070afdf3b2a76acdee77a7f3f8e8f5133"
-  integrity sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==
+flow-bin@^0.132:
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
+  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
This Flow release disallows using implicitly "any" values as types. This impacts `window` used as a type in devtools and some values imported from Babel that don't actually have flow types defined.