### PR TITLE
Show DevTools icons in Edge browser panel

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -472,7 +472,7 @@ function createPanelIfReactLoaded() {
       let needsToSyncElementSelection = false;
 
       chrome.devtools.panels.create(
-        isChrome ? '⚛️ Components' : 'Components',
+        (isChrome || isEdge) ? '⚛️ Components' : 'Components',
         '',
         'panel.html',
         extensionPanel => {
@@ -503,7 +503,7 @@ function createPanelIfReactLoaded() {
       );
 
       chrome.devtools.panels.create(
-        isChrome ? '⚛️ Profiler' : 'Profiler',
+        (isChrome || isEdge) ? '⚛️ Profiler' : 'Profiler',
         '',
         'panel.html',
         extensionPanel => {

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -472,7 +472,7 @@ function createPanelIfReactLoaded() {
       let needsToSyncElementSelection = false;
 
       chrome.devtools.panels.create(
-        (isChrome || isEdge) ? '⚛️ Components' : 'Components',
+        isChrome || isEdge ? '⚛️ Components' : 'Components',
         '',
         'panel.html',
         extensionPanel => {
@@ -503,7 +503,7 @@ function createPanelIfReactLoaded() {
       );
 
       chrome.devtools.panels.create(
-        (isChrome || isEdge) ? '⚛️ Profiler' : 'Profiler',
+        isChrome || isEdge ? '⚛️ Profiler' : 'Profiler',
         '',
         'panel.html',
         extensionPanel => {


### PR DESCRIPTION
Show DevTools icons in Edge browser panel

Bug https://github.com/facebook/react/issues/25228