### PR TITLE
CI: try to make caching more reliable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,45 +49,6 @@ aliases:
       paths:
         - ~/.cache/yarn
 
-  - &prepare_node_modules_cache_key
-    run:
-      name: Preparing node_modules cache key
-      command: yarn workspaces info | head -n -1 > workspace_info.txt
-
-  - &save_node_modules
-    save_cache:
-      name: Save node_modules cache
-      key: v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
-      paths:
-        - node_modules
-        - packages/eslint-plugin-react-hooks/node_modules
-        - packages/react-art/node_modules
-        - packages/react-client/node_modules
-        - packages/react-devtools-core/node_modules
-        - packages/react-devtools-extensions/node_modules
-        - packages/react-devtools-inline/node_modules
-        - packages/react-devtools-shared/node_modules
-        - packages/react-devtools-shell/node_modules
-        - packages/react-devtools-timeline/node_modules
-        - packages/react-devtools/node_modules
-        - packages/react-dom/node_modules
-        - packages/react-interactions/node_modules
-        - packages/react-native-renderer/node_modules
-        - packages/react-reconciler/node_modules
-        - packages/react-server-dom-relay/node_modules
-        - packages/react-server-dom-webpack/node_modules
-        - packages/react-server-native-relay/node_modules
-        - packages/react-server/node_modules
-        - packages/react-test-renderer/node_modules
-        - packages/react/node_modules
-        - packages/scheduler/node_modules
-
-  - &restore_node_modules
-    restore_cache:
-      name: Restore node_modules cache
-      keys:
-        - v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
-
   - &TEST_PARALLELISM 20
 
   - &attach_workspace
@@ -113,12 +74,9 @@ jobs:
       - run:
           name: Nodejs Version
           command: node --version
-      - *prepare_node_modules_cache_key
       - *restore_yarn_cache
-      - *restore_node_modules
       - *yarn_install
       - *save_yarn_cache
-      - *save_node_modules
 
   yarn_lint:
     docker: *docker
@@ -126,8 +84,8 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: node ./scripts/prettier/index
       - run: node ./scripts/tasks/eslint
       - run: ./scripts/circleci/check_license.sh
@@ -141,8 +99,8 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: node ./scripts/tasks/flow-ci
 
   scrape_warning_messages:
@@ -151,8 +109,8 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           command: |
             mkdir -p ./build
@@ -168,8 +126,8 @@ jobs:
     parallelism: 40
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: yarn build-combined
       - persist_to_workspace:
           root: .
@@ -184,8 +142,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Download artifacts for revision
           command: |
@@ -202,8 +160,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Download artifacts for base revision
           command: |
@@ -231,8 +189,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
         # Compress build directory into a single tarball for easy download
       - run: tar -zcvf ./build.tgz ./build
@@ -251,8 +209,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           command: node ./scripts/tasks/danger
 
@@ -263,8 +221,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           environment:
             RELEASE_CHANNEL: experimental
@@ -279,8 +237,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Playwright install deps
           command: |
@@ -302,8 +260,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
       - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
 
@@ -318,8 +276,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Playwright install deps
           command: |
@@ -343,8 +301,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: yarn lint-build
 
   yarn_check_release_dependencies:
@@ -354,8 +312,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: yarn check-release-dependencies
 
 
@@ -365,8 +323,8 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Search build artifacts for unminified errors
           command: |
@@ -382,8 +340,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: yarn test <<parameters.args>> --ci
 
   yarn_test_build:
@@ -397,8 +355,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run: yarn test --build <<parameters.args>> --ci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
@@ -408,8 +366,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
       - *restore_yarn_cache_fixtures_dom
       - *yarn_install_fixtures_dom
       - *save_yarn_cache_fixtures_dom
@@ -427,8 +383,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Run fuzz tests
           command: |
@@ -447,8 +403,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Run publish script
           command: |
@@ -466,8 +422,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
-      - *restore_node_modules
+      - *restore_yarn_cache
+      - *yarn_install
       - run:
           name: Fetch revisions that contain an intentional fork
           # This will fetch each revision listed in the `forked-revisions` file,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,18 +10,62 @@ aliases:
   - &restore_yarn_cache
     restore_cache:
       name: Restore yarn cache
-      key: v2-node-{{ arch }}-{{ checksum "yarn.lock" }}-yarn
+      keys:
+        - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+        - v1-yarn_cache-{{ arch }}-
+        - v1-yarn_cache-
+
+  - &yarn_install
+    run:
+      name: Install dependencies
+      command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+
+  - &save_yarn_cache
+    save_cache:
+      name: Save yarn cache
+      key: v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+      paths:
+        - ~/.cache/yarn
+
+  - &restore_yarn_cache_fixtures_dom
+    restore_cache:
+      name: Restore yarn cache for fixtures/dom
+      keys:
+        - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
+        - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+        - v1-yarn_cache-{{ arch }}-
+        - v1-yarn_cache-
+
+  - &yarn_install_fixtures_dom
+    run:
+      name: Install dependencies in fixtures/dom
+      working_directory: fixtures/dom
+      command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+
+  - &save_yarn_cache_fixtures_dom
+    save_cache:
+      name: Save yarn cache for fixtures/dom
+      key: v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
+      paths:
+        - ~/.cache/yarn
 
   - &prepare_node_modules_cache_key
     run:
       name: Preparing node_modules cache key
       command: yarn workspaces info | head -n -1 > workspace_info.txt
 
+  - &save_node_modules
+    save_cache:
+      name: Save node_modules cache
+      key: v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+      paths:
+        - node_modules
+
   - &restore_node_modules
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}-node-modules
+        - v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
 
   - &TEST_PARALLELISM 20
 
@@ -48,28 +92,12 @@ jobs:
       - run:
           name: Nodejs Version
           command: node --version
+      - *prepare_node_modules_cache_key
       - *restore_yarn_cache
-      - run:
-          name: Install Packages
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
-      - run: yarn workspaces info | head -n -1 > workspace_info.txt
-      - save_cache:
-          # Store the yarn cache globally for all lock files with this same
-          # checksum. This will speed up the setup job for all PRs where the
-          # lockfile is the same.
-          name: Save yarn cache for future installs
-          key: v2-node-{{ arch }}-{{ checksum "yarn.lock" }}-yarn
-          paths:
-            - ~/.cache/yarn
-      - save_cache:
-          # Store node_modules for all jobs in this workflow so that they don't
-          # need to each run a yarn install for each job. This will speed up
-          # all jobs run on this branch with the same lockfile.
-          name: Save node_modules cache
-          # This cache key is per branch, a yarn install in setup is required.
-          key: v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}-node-modules
-          paths:
-            - node_modules
+      - *restore_node_modules
+      - *yarn_install
+      - *save_yarn_cache
+      - *save_node_modules
 
   yarn_lint:
     docker: *docker
@@ -217,9 +245,6 @@ jobs:
       - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
-          name: Install Packages
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
-      - run:
           environment:
             RELEASE_CHANNEL: experimental
           command: ./scripts/circleci/pack_and_store_devtools_artifacts.sh
@@ -235,9 +260,6 @@ jobs:
           at: .
       - *prepare_node_modules_cache_key
       - *restore_node_modules
-      - run:
-          name: Install Packages
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
           name: Playwright install deps
           command: |
@@ -261,9 +283,6 @@ jobs:
           at: .
       - *prepare_node_modules_cache_key
       - *restore_node_modules
-      - run:
-          name: Install nested packages from Yarn cache
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
       - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
 
@@ -280,9 +299,6 @@ jobs:
           at: .
       - *prepare_node_modules_cache_key
       - *restore_node_modules
-      - run:
-          name: Install nested packages from Yarn cache
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
           name: Playwright install deps
           command: |
@@ -362,9 +378,6 @@ jobs:
           at: .
       - *prepare_node_modules_cache_key
       - *restore_node_modules
-      - run:
-          name: Install nested packages from Yarn cache
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run: yarn test --build <<parameters.args>> --ci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
@@ -376,13 +389,15 @@ jobs:
           at: .
       - *prepare_node_modules_cache_key
       - *restore_node_modules
+      - *restore_yarn_cache_fixtures_dom
+      - *yarn_install_fixtures_dom
+      - *save_yarn_cache_fixtures_dom
       - run:
           name: Run DOM fixture tests
           environment:
             RELEASE_CHANNEL: stable
+          working_directory: fixtures/dom
           command: |
-            cd fixtures/dom
-            yarn --frozen-lockfile
             yarn prestart
             yarn test --maxWorkers=2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,27 @@ aliases:
       key: v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
       paths:
         - node_modules
+        - packages/eslint-plugin-react-hooks/node_modules
+        - packages/react-art/node_modules
+        - packages/react-client/node_modules
+        - packages/react-devtools-core/node_modules
+        - packages/react-devtools-extensions/node_modules
+        - packages/react-devtools-inline/node_modules
+        - packages/react-devtools-shared/node_modules
+        - packages/react-devtools-shell/node_modules
+        - packages/react-devtools-timeline/node_modules
+        - packages/react-devtools/node_modules
+        - packages/react-dom/node_modules
+        - packages/react-interactions/node_modules
+        - packages/react-native-renderer/node_modules
+        - packages/react-reconciler/node_modules
+        - packages/react-server-dom-relay/node_modules
+        - packages/react-server-dom-webpack/node_modules
+        - packages/react-server-native-relay/node_modules
+        - packages/react-server/node_modules
+        - packages/react-test-renderer/node_modules
+        - packages/react/node_modules
+        - packages/scheduler/node_modules
 
   - &restore_node_modules
     restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
   - &save_node_modules
     save_cache:
       name: Save node_modules cache
-      key: v2-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+      key: v1-node_modules-{{ arch }}-{{ epoch }}
       paths:
         - node_modules
         - packages/eslint-plugin-react-hooks/node_modules
@@ -86,7 +86,7 @@ aliases:
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v2-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+        - v1-node_modules-{{ arch }}-{{ epoch }}
 
   - &TEST_PARALLELISM 20
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,6 @@ aliases:
       paths:
         - ~/.cache/yarn
 
-  - &prepare_node_modules_cache_key
-    run:
-      name: Preparing node_modules cache key
-      command: yarn workspaces info | head -n -1 > workspace_info.txt
-
   - &save_node_modules
     save_cache:
       name: Save node_modules cache
@@ -113,7 +108,6 @@ jobs:
       - run:
           name: Nodejs Version
           command: node --version
-      - *prepare_node_modules_cache_key
       - *restore_yarn_cache
       - *restore_node_modules
       - *yarn_install
@@ -126,7 +120,6 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: node ./scripts/prettier/index
       - run: node ./scripts/tasks/eslint
@@ -141,7 +134,6 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: node ./scripts/tasks/flow-ci
 
@@ -151,7 +143,6 @@ jobs:
 
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           command: |
@@ -168,7 +159,6 @@ jobs:
     parallelism: 40
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: yarn build-combined
       - persist_to_workspace:
@@ -184,7 +174,6 @@ jobs:
         type: string
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Download artifacts for revision
@@ -202,7 +191,6 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Download artifacts for base revision
@@ -231,7 +219,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
         # Compress build directory into a single tarball for easy download
@@ -251,7 +238,6 @@ jobs:
       - attach_workspace:
           at: .
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           command: node ./scripts/tasks/danger
@@ -263,7 +249,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           environment:
@@ -279,7 +264,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Playwright install deps
@@ -302,7 +286,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
       - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
@@ -318,7 +301,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Playwright install deps
@@ -343,7 +325,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: yarn lint-build
 
@@ -354,7 +335,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: yarn check-release-dependencies
 
@@ -365,7 +345,6 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Search build artifacts for unminified errors
@@ -382,7 +361,6 @@ jobs:
         type: string
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: yarn test <<parameters.args>> --ci
 
@@ -397,7 +375,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run: yarn test --build <<parameters.args>> --ci
 
@@ -408,7 +385,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - *restore_yarn_cache_fixtures_dom
       - *yarn_install_fixtures_dom
@@ -427,7 +403,6 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Run fuzz tests
@@ -447,7 +422,6 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Run publish script
@@ -466,7 +440,6 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *prepare_node_modules_cache_key
       - *restore_node_modules
       - run:
           name: Fetch revisions that contain an intentional fork

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ aliases:
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v1-node_modules-{{ arch }}-{{ epoch }}
+        - v1-node_modules-{{ arch }}-{{ .Revision }}
 
   - &TEST_PARALLELISM 20
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,12 @@ aliases:
       name: Install dependencies
       command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
+  - &yarn_install_retry
+    run:
+      name: Install dependencies (retry)
+      when: on_fail
+      command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+
   - &save_yarn_cache
     save_cache:
       name: Save yarn cache
@@ -39,6 +45,13 @@ aliases:
   - &yarn_install_fixtures_dom
     run:
       name: Install dependencies in fixtures/dom
+      working_directory: fixtures/dom
+      command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+
+  - &yarn_install_fixtures_dom_retry
+    run:
+      name: Install dependencies in fixtures/dom (retry)
+      when: on_fail
       working_directory: fixtures/dom
       command: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
@@ -111,6 +124,7 @@ jobs:
       - *restore_yarn_cache
       - *restore_node_modules
       - *yarn_install
+      - *yarn_install_retry
       - *save_yarn_cache
       - *save_node_modules
 
@@ -388,6 +402,7 @@ jobs:
       - *restore_node_modules
       - *restore_yarn_cache_fixtures_dom
       - *yarn_install_fixtures_dom
+      - *yarn_install_fixtures_dom_retry
       - *save_yarn_cache_fixtures_dom
       - run:
           name: Run DOM fixture tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
   - &save_node_modules
     save_cache:
       name: Save node_modules cache
-      key: v1-node_modules-{{ arch }}-{{ epoch }}
+      key: v1-node_modules-{{ arch }}-{{ .Revision }}
       paths:
         - node_modules
         - packages/eslint-plugin-react-hooks/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,45 @@ aliases:
       paths:
         - ~/.cache/yarn
 
+  - &prepare_node_modules_cache_key
+    run:
+      name: Preparing node_modules cache key
+      command: yarn workspaces info | head -n -1 > workspace_info.txt
+
+  - &save_node_modules
+    save_cache:
+      name: Save node_modules cache
+      key: v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+      paths:
+        - node_modules
+        - packages/eslint-plugin-react-hooks/node_modules
+        - packages/react-art/node_modules
+        - packages/react-client/node_modules
+        - packages/react-devtools-core/node_modules
+        - packages/react-devtools-extensions/node_modules
+        - packages/react-devtools-inline/node_modules
+        - packages/react-devtools-shared/node_modules
+        - packages/react-devtools-shell/node_modules
+        - packages/react-devtools-timeline/node_modules
+        - packages/react-devtools/node_modules
+        - packages/react-dom/node_modules
+        - packages/react-interactions/node_modules
+        - packages/react-native-renderer/node_modules
+        - packages/react-reconciler/node_modules
+        - packages/react-server-dom-relay/node_modules
+        - packages/react-server-dom-webpack/node_modules
+        - packages/react-server-native-relay/node_modules
+        - packages/react-server/node_modules
+        - packages/react-test-renderer/node_modules
+        - packages/react/node_modules
+        - packages/scheduler/node_modules
+
+  - &restore_node_modules
+    restore_cache:
+      name: Restore node_modules cache
+      keys:
+        - v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+
   - &TEST_PARALLELISM 20
 
   - &attach_workspace
@@ -74,9 +113,12 @@ jobs:
       - run:
           name: Nodejs Version
           command: node --version
+      - *prepare_node_modules_cache_key
       - *restore_yarn_cache
+      - *restore_node_modules
       - *yarn_install
       - *save_yarn_cache
+      - *save_node_modules
 
   yarn_lint:
     docker: *docker
@@ -84,8 +126,8 @@ jobs:
 
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: node ./scripts/prettier/index
       - run: node ./scripts/tasks/eslint
       - run: ./scripts/circleci/check_license.sh
@@ -99,8 +141,8 @@ jobs:
 
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: node ./scripts/tasks/flow-ci
 
   scrape_warning_messages:
@@ -109,8 +151,8 @@ jobs:
 
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           command: |
             mkdir -p ./build
@@ -126,8 +168,8 @@ jobs:
     parallelism: 40
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: yarn build-combined
       - persist_to_workspace:
           root: .
@@ -142,8 +184,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Download artifacts for revision
           command: |
@@ -160,8 +202,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Download artifacts for base revision
           command: |
@@ -189,8 +231,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
         # Compress build directory into a single tarball for easy download
       - run: tar -zcvf ./build.tgz ./build
@@ -209,8 +251,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: echo "<< pipeline.git.revision	>>" >> build/COMMIT_SHA
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           command: node ./scripts/tasks/danger
 
@@ -221,8 +263,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           environment:
             RELEASE_CHANNEL: experimental
@@ -237,8 +279,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Playwright install deps
           command: |
@@ -260,8 +302,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >> --replaceBuild
       - run: node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental --reactVersion << parameters.version >> --ci
 
@@ -276,8 +318,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Playwright install deps
           command: |
@@ -301,8 +343,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: yarn lint-build
 
   yarn_check_release_dependencies:
@@ -312,8 +354,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: yarn check-release-dependencies
 
 
@@ -323,8 +365,8 @@ jobs:
     steps:
       - checkout
       - attach_workspace: *attach_workspace
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Search build artifacts for unminified errors
           command: |
@@ -340,8 +382,8 @@ jobs:
         type: string
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: yarn test <<parameters.args>> --ci
 
   yarn_test_build:
@@ -355,8 +397,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run: yarn test --build <<parameters.args>> --ci
 
   RELEASE_CHANNEL_stable_yarn_test_dom_fixtures:
@@ -366,6 +408,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - *restore_yarn_cache_fixtures_dom
       - *yarn_install_fixtures_dom
       - *save_yarn_cache_fixtures_dom
@@ -383,8 +427,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Run fuzz tests
           command: |
@@ -403,8 +447,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Run publish script
           command: |
@@ -422,8 +466,8 @@ jobs:
     environment: *environment
     steps:
       - checkout
-      - *restore_yarn_cache
-      - *yarn_install
+      - *prepare_node_modules_cache_key
+      - *restore_node_modules
       - run:
           name: Fetch revisions that contain an intentional fork
           # This will fetch each revision listed in the `forked-revisions` file,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
   - &save_node_modules
     save_cache:
       name: Save node_modules cache
-      key: v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+      key: v2-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
       paths:
         - node_modules
         - packages/eslint-plugin-react-hooks/node_modules
@@ -86,7 +86,7 @@ aliases:
     restore_cache:
       name: Restore node_modules cache
       keys:
-        - v1-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
+        - v2-node_modules-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "workspace_info.txt" }}
 
   - &TEST_PARALLELISM 20
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ aliases:
   - &save_node_modules
     save_cache:
       name: Save node_modules cache
+      # Cache only for the current revision to prevent cache injections from
+      # malicious PRs.
       key: v1-node_modules-{{ arch }}-{{ .Revision }}
       paths:
         - node_modules


### PR DESCRIPTION
- `~/.yarn/cache` is now restored from an hierarchical cache key, if no precise match is found, we fallback to less precise ones. 
- The yarn install in `fixtures/dom` is also cached. Notably, is utilizes the cache from root, but stores into its more precise key.
- Steps running in root no longer have a `yarn install` and rely on the cache from the setup step.
- Retry `yarn install` once on failure.