### PR TITLE
[Flight] response.readRoot() -> use(response)

### DIFF
--- a/fixtures/flight-browser/index.html
+++ b/fixtures/flight-browser/index.html
@@ -83,7 +83,7 @@
       }
 
       function Shell({ data }) {
-        let model = data.readRoot();
+        let model = React.experimental_use(data);
         return <div>
           <Suspense fallback="...">
             <h1>{model.title}</h1>

--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -6,7 +6,7 @@ import ReactServerDOMReader from 'react-server-dom-webpack';
 let data = ReactServerDOMReader.createFromFetch(fetch('http://localhost:3001'));
 
 function Content() {
-  return data.readRoot();
+  return React.experimental_use(data);
 }
 
 ReactDOM.render(

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -178,7 +178,7 @@ function readChunk<T>(chunk: SomeChunk<T>): T {
 
 export function getRoot<T>(response: Response): Thenable<T> {
   const chunk = getChunk(response, 0);
-  return chunk;
+  return (chunk: any);
 }
 
 function createPendingChunk<T>(response: Response): PendingChunk<T> {

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -147,7 +147,6 @@ Chunk.prototype.then = function<T>(
 export type ResponseBase = {
   _bundlerConfig: BundlerConfig,
   _chunks: Map<number, SomeChunk<any>>,
-  readRoot<T>(): T,
   ...
 };
 
@@ -177,10 +176,9 @@ function readChunk<T>(chunk: SomeChunk<T>): T {
   }
 }
 
-function readRoot<T>(): T {
-  const response: Response = this;
+export function getRoot<T>(response: Response): Thenable<T> {
   const chunk = getChunk(response, 0);
-  return readChunk(chunk);
+  return chunk;
 }
 
 function createPendingChunk<T>(response: Response): PendingChunk<T> {
@@ -541,7 +539,6 @@ export function createResponse(bundlerConfig: BundlerConfig): ResponseBase {
   const response = {
     _bundlerConfig: bundlerConfig,
     _chunks: chunks,
-    readRoot: readRoot,
   };
   return response;
 }

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -137,4 +137,4 @@ export function createResponse(bundlerConfig: BundlerConfig): Response {
   return response;
 }
 
-export {reportGlobalError, close} from './ReactFlightClient';
+export {reportGlobalError, getRoot, close} from './ReactFlightClient';

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -349,6 +349,7 @@ describe('ReactFlight', () => {
     expect(ReactNoop).toMatchRenderedOutput(<div>I am client</div>);
   });
 
+  // @gate enableUseHook
   it('should error if a non-serializable value is passed to a host component', async () => {
     function EventHandlerProp() {
       return (
@@ -405,6 +406,7 @@ describe('ReactFlight', () => {
     });
   });
 
+  // @gate enableUseHook
   it('should trigger the inner most error boundary inside a client component', async () => {
     function ServerComponent() {
       throw new Error('This was thrown in the server component.');

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -11,6 +11,8 @@
 'use strict';
 
 let act;
+let use;
+let startTransition;
 let React;
 let ReactNoop;
 let ReactNoopFlightServer;
@@ -24,6 +26,8 @@ describe('ReactFlight', () => {
     jest.resetModules();
 
     React = require('react');
+    startTransition = React.startTransition;
+    use = React.experimental_use;
     ReactNoop = require('react-noop-renderer');
     ReactNoopFlightServer = require('react-noop-renderer/flight-server');
     ReactNoopFlightClient = require('react-noop-renderer/flight-client');
@@ -79,7 +83,7 @@ describe('ReactFlight', () => {
     };
   }
 
-  it('can render a server component', () => {
+  it('can render a server component', async () => {
     function Bar({text}) {
       return text.toUpperCase();
     }
@@ -95,7 +99,7 @@ describe('ReactFlight', () => {
     const transport = ReactNoopFlightServer.render({
       foo: <Foo />,
     });
-    const model = ReactNoopFlightClient.read(transport);
+    const model = await ReactNoopFlightClient.read(transport);
     expect(model).toEqual({
       foo: {
         bar: (
@@ -109,7 +113,7 @@ describe('ReactFlight', () => {
     });
   });
 
-  it('can render a client component using a module reference and render there', () => {
+  it('can render a client component using a module reference and render there', async () => {
     function UserClient(props) {
       return (
         <span>
@@ -129,8 +133,8 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(model);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       const greeting = rootModel.greeting;
       ReactNoop.render(greeting);
     });
@@ -166,15 +170,15 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput(
@@ -211,8 +215,8 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
@@ -248,15 +252,15 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput(
@@ -293,8 +297,8 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
@@ -331,21 +335,21 @@ describe('ReactFlight', () => {
 
     const transport = ReactNoopFlightServer.render(<ServerComponent />);
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
     await load();
 
-    act(() => {
-      const rootModel = ReactNoopFlightClient.read(transport);
+    await act(async () => {
+      const rootModel = await ReactNoopFlightClient.read(transport);
       ReactNoop.render(rootModel);
     });
     expect(ReactNoop).toMatchRenderedOutput(<div>I am client</div>);
   });
 
-  it('should error if a non-serializable value is passed to a host component', () => {
+  it('should error if a non-serializable value is passed to a host component', async () => {
     function EventHandlerProp() {
       return (
         <div className="foo" onClick={function() {}}>
@@ -375,31 +379,33 @@ describe('ReactFlight', () => {
     const symbol = ReactNoopFlightServer.render(<SymbolProp />, options);
     const refs = ReactNoopFlightServer.render(<RefProp />, options);
 
-    function Client({transport}) {
-      return ReactNoopFlightClient.read(transport);
+    function Client({promise}) {
+      return use(promise);
     }
 
-    act(() => {
-      ReactNoop.render(
-        <>
-          <ErrorBoundary expectedMessage="Event handlers cannot be passed to client component props.">
-            <Client transport={event} />
-          </ErrorBoundary>
-          <ErrorBoundary expectedMessage="Functions cannot be passed directly to client components because they're not serializable.">
-            <Client transport={fn} />
-          </ErrorBoundary>
-          <ErrorBoundary expectedMessage="Only global symbols received from Symbol.for(...) can be passed to client components.">
-            <Client transport={symbol} />
-          </ErrorBoundary>
-          <ErrorBoundary expectedMessage="Refs cannot be used in server components, nor passed to client components.">
-            <Client transport={refs} />
-          </ErrorBoundary>
-        </>,
-      );
+    await act(async () => {
+      startTransition(() => {
+        ReactNoop.render(
+          <>
+            <ErrorBoundary expectedMessage="Event handlers cannot be passed to client component props.">
+              <Client promise={ReactNoopFlightClient.read(event)} />
+            </ErrorBoundary>
+            <ErrorBoundary expectedMessage="Functions cannot be passed directly to client components because they're not serializable.">
+              <Client promise={ReactNoopFlightClient.read(fn)} />
+            </ErrorBoundary>
+            <ErrorBoundary expectedMessage="Only global symbols received from Symbol.for(...) can be passed to client components.">
+              <Client promise={ReactNoopFlightClient.read(symbol)} />
+            </ErrorBoundary>
+            <ErrorBoundary expectedMessage="Refs cannot be used in server components, nor passed to client components.">
+              <Client promise={ReactNoopFlightClient.read(refs)} />
+            </ErrorBoundary>
+          </>,
+        );
+      });
     });
   });
 
-  it('should trigger the inner most error boundary inside a client component', () => {
+  it('should trigger the inner most error boundary inside a client component', async () => {
     function ServerComponent() {
       throw new Error('This was thrown in the server component.');
     }
@@ -433,16 +439,18 @@ describe('ReactFlight', () => {
       },
     });
 
-    function Client({transport}) {
-      return ReactNoopFlightClient.read(transport);
+    function Client({promise}) {
+      return use(promise);
     }
 
-    act(() => {
-      ReactNoop.render(
-        <NoErrorExpected>
-          <Client transport={data} />
-        </NoErrorExpected>,
-      );
+    await act(async () => {
+      startTransition(() => {
+        ReactNoop.render(
+          <NoErrorExpected>
+            <Client promise={ReactNoopFlightClient.read(data)} />
+          </NoErrorExpected>,
+        );
+      });
     });
   });
 
@@ -451,9 +459,7 @@ describe('ReactFlight', () => {
       const transport = ReactNoopFlightServer.render(
         <input value={new Date()} />,
       );
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
-      });
+      ReactNoopFlightClient.read(transport);
     }).toErrorDev(
       'Only plain objects can be passed to client components from server components. ',
       {withoutStack: true},
@@ -463,9 +469,7 @@ describe('ReactFlight', () => {
   it('should warn in DEV if a special object is passed to a host component', () => {
     expect(() => {
       const transport = ReactNoopFlightServer.render(<input value={Math} />);
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
-      });
+      ReactNoopFlightClient.read(transport);
     }).toErrorDev(
       'Only plain objects can be passed to client components from server components. ' +
         'Built-ins like Math are not supported.',
@@ -475,9 +479,7 @@ describe('ReactFlight', () => {
 
   it('should NOT warn in DEV for key getters', () => {
     const transport = ReactNoopFlightServer.render(<div key="a" />);
-    act(() => {
-      ReactNoop.render(ReactNoopFlightClient.read(transport));
-    });
+    ReactNoopFlightClient.read(transport);
   });
 
   it('should warn in DEV if an object with symbols is passed to a host component', () => {
@@ -485,9 +487,7 @@ describe('ReactFlight', () => {
       const transport = ReactNoopFlightServer.render(
         <input value={{[Symbol.iterator]: {}}} />,
       );
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
-      });
+      ReactNoopFlightClient.read(transport);
     }).toErrorDev(
       'Only plain objects can be passed to client components from server components. ' +
         'Objects with symbol properties like Symbol.iterator are not supported.',
@@ -503,9 +503,7 @@ describe('ReactFlight', () => {
       const transport = ReactNoopFlightServer.render(
         <input value={new Foo()} />,
       );
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
-      });
+      ReactNoopFlightClient.read(transport);
     }).toErrorDev(
       'Only plain objects can be passed to client components from server components. ',
       {withoutStack: true},
@@ -518,7 +516,7 @@ describe('ReactFlight', () => {
       return <div prop={id}>{children}</div>;
     }
 
-    it('should support useId', () => {
+    it('should support useId', async () => {
       function App() {
         return (
           <>
@@ -529,8 +527,8 @@ describe('ReactFlight', () => {
       }
 
       const transport = ReactNoopFlightServer.render(<App />);
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+      await act(async () => {
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
       expect(ReactNoop).toMatchRenderedOutput(
         <>
@@ -540,7 +538,7 @@ describe('ReactFlight', () => {
       );
     });
 
-    it('accepts an identifier prefix that prefixes generated ids', () => {
+    it('accepts an identifier prefix that prefixes generated ids', async () => {
       function App() {
         return (
           <>
@@ -553,8 +551,8 @@ describe('ReactFlight', () => {
       const transport = ReactNoopFlightServer.render(<App />, {
         identifierPrefix: 'foo',
       });
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+      await act(async () => {
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
       expect(ReactNoop).toMatchRenderedOutput(
         <>
@@ -591,8 +589,8 @@ describe('ReactFlight', () => {
       const transport = ReactNoopFlightServer.render(<App />);
       expect(Scheduler).toHaveYielded([]);
 
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+      await act(async () => {
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
       expect(Scheduler).toHaveYielded(['ClientDoubler']);
@@ -607,7 +605,7 @@ describe('ReactFlight', () => {
 
   describe('ServerContext', () => {
     // @gate enableServerContext
-    it('supports basic createServerContext usage', () => {
+    it('supports basic createServerContext usage', async () => {
       const ServerContext = React.createServerContext(
         'ServerContext',
         'hello from server',
@@ -618,17 +616,17 @@ describe('ReactFlight', () => {
       }
 
       const transport = ReactNoopFlightServer.render(<Foo />);
-      act(() => {
+      await act(async () => {
         ServerContext._currentRenderer = null;
         ServerContext._currentRenderer2 = null;
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
       expect(ReactNoop).toMatchRenderedOutput(<div>hello from server</div>);
     });
 
     // @gate enableServerContext
-    it('propagates ServerContext providers in flight', () => {
+    it('propagates ServerContext providers in flight', async () => {
       const ServerContext = React.createServerContext(
         'ServerContext',
         'default',
@@ -649,10 +647,10 @@ describe('ReactFlight', () => {
       }
 
       const transport = ReactNoopFlightServer.render(<Foo />);
-      act(() => {
+      await act(async () => {
         ServerContext._currentRenderer = null;
         ServerContext._currentRenderer2 = null;
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
       expect(ReactNoop).toMatchRenderedOutput(<div>hi this is server</div>);
@@ -693,7 +691,7 @@ describe('ReactFlight', () => {
     });
 
     // @gate enableServerContext
-    it('propagates ServerContext and cleansup providers in flight', () => {
+    it('propagates ServerContext and cleansup providers in flight', async () => {
       const ServerContext = React.createServerContext(
         'ServerContext',
         'default',
@@ -724,8 +722,8 @@ describe('ReactFlight', () => {
       }
 
       const transport = ReactNoopFlightServer.render(<Foo />);
-      act(() => {
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+      await act(async () => {
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
       expect(ReactNoop).toMatchRenderedOutput(
@@ -788,10 +786,10 @@ describe('ReactFlight', () => {
 
       expect(Scheduler).toHaveYielded(['rendered']);
 
-      act(() => {
+      await act(async () => {
         ServerContext._currentRenderer = null;
         ServerContext._currentRenderer2 = null;
-        ReactNoop.render(ReactNoopFlightClient.read(transport));
+        ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
       expect(ReactNoop).toMatchRenderedOutput(<div>hi this is server</div>);
@@ -828,10 +826,10 @@ describe('ReactFlight', () => {
 
       expect(Scheduler).toHaveYielded([]);
 
-      act(() => {
+      await act(async () => {
         ServerContext._currentRenderer = null;
         ServerContext._currentRenderer2 = null;
-        const flightModel = ReactNoopFlightClient.read(transport);
+        const flightModel = await ReactNoopFlightClient.read(transport);
         ReactNoop.render(flightModel.foo);
       });
 
@@ -856,8 +854,8 @@ describe('ReactFlight', () => {
         context: [['ServerContext', 'Override']],
       });
 
-      act(() => {
-        const flightModel = ReactNoopFlightClient.read(transport);
+      await act(async () => {
+        const flightModel = await ReactNoopFlightClient.read(transport);
         ReactNoop.render(flightModel);
       });
       expect(ReactNoop).toMatchRenderedOutput(<span>Override</span>);
@@ -937,8 +935,8 @@ describe('ReactFlight', () => {
       act = require('jest-react').act;
       Scheduler = require('scheduler');
 
-      act(() => {
-        const serverModel = ReactNoopFlightClient.read(transport);
+      await act(async () => {
+        const serverModel = await ReactNoopFlightClient.read(transport);
         ReactNoop.render(<ClientApp serverModel={serverModel} />);
       });
 

--- a/packages/react-noop-renderer/src/ReactNoopFlightClient.js
+++ b/packages/react-noop-renderer/src/ReactNoopFlightClient.js
@@ -20,7 +20,7 @@ import ReactFlightClient from 'react-client/flight';
 
 type Source = Array<string>;
 
-const {createResponse, processStringChunk, close} = ReactFlightClient({
+const {createResponse, processStringChunk, getRoot, close} = ReactFlightClient({
   supportsBinaryStreams: false,
   resolveModuleReference(bundlerConfig: null, idx: string) {
     return idx;
@@ -34,13 +34,13 @@ const {createResponse, processStringChunk, close} = ReactFlightClient({
   },
 });
 
-function read<T>(source: Source): T {
+function read<T>(source: Source): Thenable<T> {
   const response = createResponse(source, null);
   for (let i = 0; i < source.length; i++) {
     processStringChunk(response, source[i], 0);
   }
   close(response);
-  return response.readRoot();
+  return getRoot(response);
 }
 
 export {read};

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -18,9 +18,10 @@ import {
   resolveSymbol,
   resolveError,
   close,
+  getRoot,
 } from 'react-client/src/ReactFlightClient';
 
-export {createResponse, close};
+export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'J') {

--- a/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
+++ b/packages/react-server-dom-relay/src/__tests__/ReactFlightDOMRelay-test.internal.js
@@ -31,13 +31,22 @@ describe('ReactFlightDOMRelay', () => {
   });
 
   function readThrough(data) {
-    const response = ReactDOMFlightRelayClient.createResponse(null);
+    const response = ReactDOMFlightRelayClient.createResponse();
     for (let i = 0; i < data.length; i++) {
       const chunk = data[i];
       ReactDOMFlightRelayClient.resolveRow(response, chunk);
     }
     ReactDOMFlightRelayClient.close(response);
-    const model = response.readRoot();
+    const promise = ReactDOMFlightRelayClient.getRoot(response);
+    let model;
+    let error;
+    promise.then(
+      m => (model = m),
+      e => (error = e),
+    );
+    if (error) {
+      throw error;
+    }
     return model;
   }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMClient.js
@@ -7,12 +7,15 @@
  * @flow
  */
 
+import type {Thenable} from 'shared/ReactTypes.js';
+
 import type {Response as FlightResponse} from 'react-client/src/ReactFlightClientStream';
 
 import type {BundlerConfig} from './ReactFlightClientWebpackBundlerConfig';
 
 import {
   createResponse,
+  getRoot,
   reportGlobalError,
   processStringChunk,
   processBinaryChunk,
@@ -49,21 +52,21 @@ function startReadingFromStream(
     .catch(error);
 }
 
-function createFromReadableStream(
+function createFromReadableStream<T>(
   stream: ReadableStream,
   options?: Options,
-): FlightResponse {
+): Thenable<T> {
   const response: FlightResponse = createResponse(
     options && options.moduleMap ? options.moduleMap : null,
   );
   startReadingFromStream(response, stream);
-  return response;
+  return getRoot(response);
 }
 
-function createFromFetch(
+function createFromFetch<T>(
   promiseForResponse: Promise<Response>,
   options?: Options,
-): FlightResponse {
+): Thenable<T> {
   const response: FlightResponse = createResponse(
     options && options.moduleMap ? options.moduleMap : null,
   );
@@ -75,13 +78,13 @@ function createFromFetch(
       reportGlobalError(response, e);
     },
   );
-  return response;
+  return getRoot(response);
 }
 
-function createFromXHR(
+function createFromXHR<T>(
   request: XMLHttpRequest,
   options?: Options,
-): FlightResponse {
+): Thenable<T> {
   const response: FlightResponse = createResponse(
     options && options.moduleMap ? options.moduleMap : null,
   );
@@ -103,7 +106,7 @@ function createFromXHR(
   request.addEventListener('error', error);
   request.addEventListener('abort', error);
   request.addEventListener('timeout', error);
-  return response;
+  return getRoot(response);
 }
 
 export {createFromXHR, createFromFetch, createFromReadableStream};

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -125,6 +125,7 @@ describe('ReactFlightDOM', () => {
     });
   });
 
+  // @gate enableUseHook
   it('should resolve the root', async () => {
     // Model
     function Text({children}) {
@@ -174,6 +175,7 @@ describe('ReactFlightDOM', () => {
     );
   });
 
+  // @gate enableUseHook
   it('should not get confused by $', async () => {
     // Model
     function RootModel() {
@@ -208,6 +210,7 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>$1</p>');
   });
 
+  // @gate enableUseHook
   it('should not get confused by @', async () => {
     // Model
     function RootModel() {
@@ -242,6 +245,7 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>@div</p>');
   });
 
+  // @gate enableUseHook
   it('should unwrap async module references', async () => {
     const AsyncModule = Promise.resolve(function AsyncModule({text}) {
       return 'Async: ' + text;
@@ -282,6 +286,7 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>Async: Module</p>');
   });
 
+  // @gate enableUseHook
   it('should be able to import a name called "then"', async () => {
     const thenExports = {
       then: function then() {
@@ -319,6 +324,7 @@ describe('ReactFlightDOM', () => {
     expect(container.innerHTML).toBe('<p>and then</p>');
   });
 
+  // @gate enableUseHook
   it('should progressively reveal server components', async () => {
     let reportedErrors = [];
 
@@ -506,6 +512,7 @@ describe('ReactFlightDOM', () => {
     expect(reportedErrors).toEqual([]);
   });
 
+  // @gate enableUseHook
   it('should preserve state of client components on refetch', async () => {
     // Client
 
@@ -591,6 +598,7 @@ describe('ReactFlightDOM', () => {
     expect(inputB.value).toBe('goodbye');
   });
 
+  // @gate enableUseHook
   it('should be able to complete after aborting and throw the reason client-side', async () => {
     const reportedErrors = [];
 
@@ -635,6 +643,7 @@ describe('ReactFlightDOM', () => {
     expect(reportedErrors).toEqual(['for reasons']);
   });
 
+  // @gate enableUseHook
   it('should be able to recover from a direct reference erroring client-side', async () => {
     const reportedErrors = [];
 
@@ -680,6 +689,7 @@ describe('ReactFlightDOM', () => {
     expect(reportedErrors).toEqual([]);
   });
 
+  // @gate enableUseHook
   it('should be able to recover from a direct reference erroring client-side async', async () => {
     const reportedErrors = [];
 
@@ -737,6 +747,7 @@ describe('ReactFlightDOM', () => {
     expect(reportedErrors).toEqual([]);
   });
 
+  // @gate enableUseHook
   it('should be able to recover from a direct reference erroring server-side', async () => {
     const reportedErrors = [];
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -18,6 +18,7 @@ global.TextDecoder = require('util').TextDecoder;
 global.setImmediate = cb => cb();
 
 let act;
+let use;
 let clientExports;
 let clientModuleError;
 let webpackMap;
@@ -40,6 +41,7 @@ describe('ReactFlightDOM', () => {
 
     Stream = require('stream');
     React = require('react');
+    use = React.experimental_use;
     Suspense = React.Suspense;
     ReactDOMClient = require('react-dom/client');
     ReactServerDOMWriter = require('react-server-dom-webpack/writer.node.server');
@@ -80,20 +82,6 @@ describe('ReactFlightDOM', () => {
     };
   }
 
-  async function waitForSuspense(fn) {
-    while (true) {
-      try {
-        return fn();
-      } catch (promise) {
-        if (typeof promise.then === 'function') {
-          await promise;
-        } else {
-          throw promise;
-        }
-      }
-    }
-  }
-
   const theInfinitePromise = new Promise(() => {});
   function InfiniteSuspend() {
     throw theInfinitePromise;
@@ -126,16 +114,14 @@ describe('ReactFlightDOM', () => {
     );
     pipe(writable);
     const response = ReactServerDOMReader.createFromReadableStream(readable);
-    await waitForSuspense(() => {
-      const model = response.readRoot();
-      expect(model).toEqual({
-        html: (
-          <div>
-            <span>hello</span>
-            <span>world</span>
-          </div>
-        ),
-      });
+    const model = await response;
+    expect(model).toEqual({
+      html: (
+        <div>
+          <span>hello</span>
+          <span>world</span>
+        </div>
+      ),
     });
   });
 
@@ -160,7 +146,7 @@ describe('ReactFlightDOM', () => {
 
     // View
     function Message({response}) {
-      return <section>{response.readRoot().html}</section>;
+      return <section>{use(response).html}</section>;
     }
     function App({response}) {
       return (
@@ -196,7 +182,7 @@ describe('ReactFlightDOM', () => {
 
     // View
     function Message({response}) {
-      return <p>{response.readRoot().text}</p>;
+      return <p>{use(response).text}</p>;
     }
     function App({response}) {
       return (
@@ -230,7 +216,7 @@ describe('ReactFlightDOM', () => {
 
     // View
     function Message({response}) {
-      return <p>{response.readRoot().text}</p>;
+      return <p>{use(response).text}</p>;
     }
     function App({response}) {
       return (
@@ -266,7 +252,7 @@ describe('ReactFlightDOM', () => {
     });
 
     function Print({response}) {
-      return <p>{response.readRoot()}</p>;
+      return <p>{use(response)}</p>;
     }
 
     function App({response}) {
@@ -304,7 +290,7 @@ describe('ReactFlightDOM', () => {
     };
 
     function Print({response}) {
-      return <p>{response.readRoot()}</p>;
+      return <p>{use(response)}</p>;
     }
 
     function App({response}) {
@@ -432,7 +418,7 @@ describe('ReactFlightDOM', () => {
     };
 
     function ProfilePage({response}) {
-      return response.readRoot().rootContent;
+      return use(response).rootContent;
     }
 
     const {writable, readable} = getTestStream();
@@ -524,7 +510,7 @@ describe('ReactFlightDOM', () => {
     // Client
 
     function Page({response}) {
-      return response.readRoot();
+      return use(response);
     }
 
     function Input() {
@@ -627,7 +613,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOMClient.createRoot(container);
 
     function App({res}) {
-      return res.readRoot();
+      return use(res);
     }
 
     await act(async () => {
@@ -677,7 +663,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOMClient.createRoot(container);
 
     function App({res}) {
-      return res.readRoot();
+      return use(res);
     }
 
     await act(async () => {
@@ -727,7 +713,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOMClient.createRoot(container);
 
     function App({res}) {
-      return res.readRoot();
+      return use(res);
     }
 
     await act(async () => {
@@ -787,7 +773,7 @@ describe('ReactFlightDOM', () => {
     const root = ReactDOMClient.createRoot(container);
 
     function App({res}) {
-      return res.readRoot();
+      return use(res);
     }
 
     await act(async () => {

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -151,6 +151,7 @@ describe('ReactFlightDOMBrowser', () => {
     });
   });
 
+  // @gate enableUseHook
   it('should progressively reveal server components', async () => {
     let reportedErrors = [];
 
@@ -438,6 +439,7 @@ describe('ReactFlightDOMBrowser', () => {
     expect(isDone).toBeTruthy();
   });
 
+  // @gate enableUseHook
   it('should allow an alternative module mapping to be used for SSR', async () => {
     function ClientComponent() {
       return <span>Client Component</span>;
@@ -483,6 +485,7 @@ describe('ReactFlightDOMBrowser', () => {
     expect(result).toEqual('<span>Client Component</span>');
   });
 
+  // @gate enableUseHook
   it('should be able to complete after aborting and throw the reason client-side', async () => {
     const reportedErrors = [];
 

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -43,20 +43,6 @@ describe('ReactFlightDOMBrowser', () => {
     use = React.experimental_use;
   });
 
-  async function waitForSuspense(fn) {
-    while (true) {
-      try {
-        return fn();
-      } catch (promise) {
-        if (typeof promise.then === 'function') {
-          await promise;
-        } else {
-          throw promise;
-        }
-      }
-    }
-  }
-
   async function readResult(stream) {
     const reader = stream.getReader();
     let result = '';
@@ -121,16 +107,14 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMWriter.renderToReadableStream(<App />);
     const response = ReactServerDOMReader.createFromReadableStream(stream);
-    await waitForSuspense(() => {
-      const model = response.readRoot();
-      expect(model).toEqual({
-        html: (
-          <div>
-            <span>hello</span>
-            <span>world</span>
-          </div>
-        ),
-      });
+    const model = await response;
+    expect(model).toEqual({
+      html: (
+        <div>
+          <span>hello</span>
+          <span>world</span>
+        </div>
+      ),
     });
   });
 
@@ -156,16 +140,14 @@ describe('ReactFlightDOMBrowser', () => {
 
     const stream = ReactServerDOMWriter.renderToReadableStream(<App />);
     const response = ReactServerDOMReader.createFromReadableStream(stream);
-    await waitForSuspense(() => {
-      const model = response.readRoot();
-      expect(model).toEqual({
-        html: (
-          <div>
-            <span>hello</span>
-            <span>world</span>
-          </div>
-        ),
-      });
+    const model = await response;
+    expect(model).toEqual({
+      html: (
+        <div>
+          <span>hello</span>
+          <span>world</span>
+        </div>
+      ),
     });
   });
 
@@ -259,7 +241,7 @@ describe('ReactFlightDOMBrowser', () => {
     };
 
     function ProfilePage({response}) {
-      return response.readRoot().rootContent;
+      return use(response).rootContent;
     }
 
     const stream = ReactServerDOMWriter.renderToReadableStream(
@@ -491,7 +473,7 @@ describe('ReactFlightDOMBrowser', () => {
     });
 
     function ClientRoot() {
-      return response.readRoot();
+      return use(response);
     }
 
     const ssrStream = await ReactDOMServer.renderToReadableStream(
@@ -539,7 +521,7 @@ describe('ReactFlightDOMBrowser', () => {
     const root = ReactDOMClient.createRoot(container);
 
     function App({res}) {
-      return res.readRoot();
+      return use(res);
     }
 
     await act(async () => {
@@ -579,7 +561,7 @@ describe('ReactFlightDOMBrowser', () => {
     const response = ReactServerDOMReader.createFromReadableStream(stream);
 
     function Client() {
-      return response.readRoot();
+      return use(response);
     }
 
     const container = document.createElement('div');
@@ -613,7 +595,7 @@ describe('ReactFlightDOMBrowser', () => {
     const response = ReactServerDOMReader.createFromReadableStream(stream);
 
     function Client() {
-      return response.readRoot();
+      return use(response);
     }
 
     const container = document.createElement('div');
@@ -644,7 +626,7 @@ describe('ReactFlightDOMBrowser', () => {
     const response = ReactServerDOMReader.createFromReadableStream(stream);
 
     function Client() {
-      return response.readRoot();
+      return use(response);
     }
 
     const container = document.createElement('div');
@@ -699,7 +681,7 @@ describe('ReactFlightDOMBrowser', () => {
     }
 
     function Client() {
-      return response.readRoot();
+      return use(response);
     }
 
     const container = document.createElement('div');
@@ -733,7 +715,7 @@ describe('ReactFlightDOMBrowser', () => {
     const response = ReactServerDOMReader.createFromReadableStream(stream);
 
     function Client() {
-      return response.readRoot();
+      return use(response);
     }
 
     const container = document.createElement('div');

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -18,9 +18,10 @@ import {
   resolveSymbol,
   resolveError,
   close,
+  getRoot,
 } from 'react-client/src/ReactFlightClient';
 
-export {createResponse, close};
+export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'J') {

--- a/packages/react-server-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
+++ b/packages/react-server-native-relay/src/__tests__/ReactFlightNativeRelay-test.internal.js
@@ -48,7 +48,16 @@ describe('ReactFlightNativeRelay', () => {
       ReactNativeFlightRelayClient.resolveRow(response, chunk);
     }
     ReactNativeFlightRelayClient.close(response);
-    const model = response.readRoot();
+    const promise = ReactNativeFlightRelayClient.getRoot(response);
+    let model;
+    let error;
+    promise.then(
+      m => (model = m),
+      e => (error = e),
+    );
+    if (error) {
+      throw error;
+    }
     return model;
   }
 


### PR DESCRIPTION
Builds on top of https://github.com/facebook/react/pull/25260

This updates the Flight response. Instead of returning an object with readRoot() that throws a Promise, it now returns a Promise that can be passed to `experimental_use(...)` to be unwrapped (or just used as a regular Promise).

This will affect the Relay renderer and the Hydrogen renderers as well.

cc @frandiox @jplhomer @kassens