### PR TITLE
[DevTools][BE] Read username using gh in release script

### DIFF
--- a/scripts/devtools/prepare-release.js
+++ b/scripts/devtools/prepare-release.js
@@ -99,26 +99,43 @@ async function getCommitLog(sha) {
   let shortLog = '';
   let formattedLog = '';
 
+  const hasGh = await hasGithubCLI();
   const rawLog = await execRead(`
     git log --topo-order --pretty=format:'%s' ${sha}...HEAD -- packages/react-devtools*
   `);
-  rawLog.split('\n').forEach(line => {
-    line = line.replace('[DevTools] ', '');
-
+  for (let line of rawLog.split('\n')) {
+    line = line.replace(/^\[[dD]ev[tT]ools\]? /, '');
     const match = line.match(/(.+) \(#([0-9]+)\)/);
     if (match !== null) {
       const title = match[1];
       const pr = match[2];
-
-      formattedLog += `\n* ${title} ([USERNAME](https://github.com/USERNAME) in [#${pr}](${PULL_REQUEST_BASE_URL}${pr}))`;
+      let username;
+      if (hasGh) {
+        const response = await execRead(
+          `gh api /repos/facebook/react/pulls/${pr}`
+        );
+        const {user} = JSON.parse(response);
+        username = `[${user.login}](${user.html_url})`;
+      } else {
+        username = '[USERNAME](https://github.com/USERNAME)';
+      }
+      formattedLog += `\n* ${title} (${username} in [#${pr}](${PULL_REQUEST_BASE_URL}${pr}))`;
       shortLog += `\n* ${title}`;
     } else {
       formattedLog += `\n* ${line}`;
       shortLog += `\n* ${line}`;
     }
-  });
+  }
 
   return [shortLog, formattedLog];
+}
+
+async function hasGithubCLI() {
+  try {
+    await exec('which gh');
+    return true;
+  } catch (_) {}
+  return false;
 }
 
 async function getPreviousCommitSha() {

--- a/scripts/devtools/prepare-release.js
+++ b/scripts/devtools/prepare-release.js
@@ -103,8 +103,9 @@ async function getCommitLog(sha) {
   const rawLog = await execRead(`
     git log --topo-order --pretty=format:'%s' ${sha}...HEAD -- packages/react-devtools*
   `);
-  for (let line of rawLog.split('\n')) {
-    line = line.replace(/^\[[dD]ev[tT]ools\]? /, '');
+  const lines = rawLog.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].replace(/^\[devtools\] */i, '');
     const match = line.match(/(.+) \(#([0-9]+)\)/);
     if (match !== null) {
       const title = match[1];


### PR DESCRIPTION
The script required manually filling github names in the changelog, this PR is to automate this process. 
If `gh` is installed, use github API to fetch PR author.
Also, improves `[DevTools]` tag removal.


Some of generated change log looks like the following:
* log more events + metadata ([mondaychen](https://github.com/mondaychen) in [#24951](https://github.com/facebook/react/pull/24951))
* add simple usage events for internal logging ([mondaychen](https://github.com/mondaychen) in [#24888](https://github.com/facebook/react/pull/24888))


