### PR TITLE
[Flight] Fix Webpack Chunk Loading

### DIFF
--- a/fixtures/flight/src/index.js
+++ b/fixtures/flight/src/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Suspense} from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import ReactServerDOMReader from 'react-server-dom-webpack';
 
 let data = ReactServerDOMReader.createFromFetch(fetch('http://localhost:3001'));
@@ -9,9 +9,8 @@ function Content() {
   return React.experimental_use(data);
 }
 
-ReactDOM.render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <Suspense fallback={<h1>Loading...</h1>}>
     <Content />
-  </Suspense>,
-  document.getElementById('root')
+  </Suspense>
 );

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -55,7 +55,7 @@ export function resolveModuleReference<T>(
 // If they're still pending they're a thenable. This map also exists
 // in Webpack but unfortunately it's not exposed so we have to
 // replicate it in user space. null means that it has already loaded.
-const chunkCache: Map<string, null | Promise<any> | Error> = new Map();
+const chunkCache: Map<string, null | Promise<any>> = new Map();
 const asyncModuleCache: Map<string, Thenable<any>> = new Map();
 
 // Start preloading the modules since we might need them soon.
@@ -72,9 +72,10 @@ export function preloadModule<T>(
       const thenable = __webpack_chunk_load__(chunkId);
       promises.push(thenable);
       const resolve = chunkCache.set.bind(chunkCache, chunkId, null);
-      const reject = chunkCache.set.bind(chunkCache, chunkId);
-      thenable.then(resolve, reject);
+      thenable.then(resolve);
       chunkCache.set(chunkId, thenable);
+    } else if (entry !== null) {
+      promises.push(entry);
     }
   }
   if (moduleData.async) {

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {acorn} from 'acorn';
+import * as acorn from 'acorn';
 
 type ResolveContext = {
   conditions: Array<string>,


### PR DESCRIPTION
We don't have good coverage of this in the unit tests because we're not currently testing the chunk part, just the module init part.

However, I got the fixture working which revealed this issue. We weren't adding the already found but not yet loaded chunks to the list of promises to block on. I realized we also weren't dealing with errors when they rejected. Now it just lets the promise reject to trigger the error.
