### PR TITLE
Grammar. Removed doubles of the word "the".

### DIFF
--- a/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
+++ b/packages/react-devtools-shared/src/__tests__/preprocessData-test.js
@@ -1926,7 +1926,7 @@ describe('Timeline profiler', () => {
   });
 
   // Note the in-memory tests vary slightly (e.g. timestamp values, lane numbers) from the above tests.
-  // That's okay; the important thing is the the lane-to-label matches the subsequent events/measures.
+  // That's okay; the important thing is the lane-to-label matches the subsequent events/measures.
   describe('DevTools hook (in memory)', () => {
     let store;
 

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1983,7 +1983,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
       handleThrow(root, thrownValue);
       if (isTrackingSuspendedThenable()) {
         // If this fiber just suspended, it's possible the data is already
-        // cached. Yield to the the main thread to give it a chance to ping. If
+        // cached. Yield to the main thread to give it a chance to ping. If
         // it does, we can retry immediately without unwinding the stack.
         break;
       }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1983,7 +1983,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
       handleThrow(root, thrownValue);
       if (isTrackingSuspendedThenable()) {
         // If this fiber just suspended, it's possible the data is already
-        // cached. Yield to the the main thread to give it a chance to ping. If
+        // cached. Yield to the main thread to give it a chance to ping. If
         // it does, we can retry immediately without unwinding the stack.
         break;
       }


### PR DESCRIPTION
## Summary

I saw an error in the documentation where the work "the" was repeated twice in a row on a couple of different places, and corrected them.

## How did you test this change?

Not applicable, only comments edited.
