### PR TITLE
Refactor/format code: else block is unnecessary.

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -1201,12 +1201,11 @@ function ChildReconciler(shouldTrackSideEffects) {
       );
       created.return = returnFiber;
       return created;
-    } else {
-      const created = createFiberFromElement(element, returnFiber.mode, lanes);
-      created.ref = coerceRef(returnFiber, currentFirstChild, element);
-      created.return = returnFiber;
-      return created;
     }
+    const created = createFiberFromElement(element, returnFiber.mode, lanes);
+    created.ref = coerceRef(returnFiber, currentFirstChild, element);
+    created.return = returnFiber;
+    return created;
   }
 
   function reconcileSinglePortal(

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -1201,12 +1201,11 @@ function ChildReconciler(shouldTrackSideEffects) {
       );
       created.return = returnFiber;
       return created;
-    } else {
-      const created = createFiberFromElement(element, returnFiber.mode, lanes);
-      created.ref = coerceRef(returnFiber, currentFirstChild, element);
-      created.return = returnFiber;
-      return created;
     }
+    const created = createFiberFromElement(element, returnFiber.mode, lanes);
+    created.ref = coerceRef(returnFiber, currentFirstChild, element);
+    created.return = returnFiber;
+    return created;
   }
 
   function reconcileSinglePortal(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -1898,49 +1898,48 @@ function mountIndeterminateComponent(
       hasContext,
       renderLanes,
     );
-  } else {
-    // Proceed under the assumption that this is a function component
-    workInProgress.tag = FunctionComponent;
-    if (__DEV__) {
-      if (disableLegacyContext && Component.contextTypes) {
-        console.error(
-          '%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with React.useContext() instead.',
-          getComponentNameFromType(Component) || 'Unknown',
-        );
-      }
-
-      if (
-        debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictLegacyMode
-      ) {
-        setIsStrictModeForDevtools(true);
-        try {
-          value = renderWithHooks(
-            null,
-            workInProgress,
-            Component,
-            props,
-            context,
-            renderLanes,
-          );
-          hasId = checkDidRenderIdHook();
-        } finally {
-          setIsStrictModeForDevtools(false);
-        }
-      }
-    }
-
-    if (getIsHydrating() && hasId) {
-      pushMaterializedTreeId(workInProgress);
-    }
-
-    reconcileChildren(null, workInProgress, value, renderLanes);
-    if (__DEV__) {
-      validateFunctionComponentInDev(workInProgress, Component);
-    }
-    return workInProgress.child;
   }
+  // Proceed under the assumption that this is a function component
+  workInProgress.tag = FunctionComponent;
+  if (__DEV__) {
+    if (disableLegacyContext && Component.contextTypes) {
+      console.error(
+        '%s uses the legacy contextTypes API which is no longer supported. ' +
+          'Use React.createContext() with React.useContext() instead.',
+        getComponentNameFromType(Component) || 'Unknown',
+      );
+    }
+
+    if (
+      debugRenderPhaseSideEffectsForStrictMode &&
+      workInProgress.mode & StrictLegacyMode
+    ) {
+      setIsStrictModeForDevtools(true);
+      try {
+        value = renderWithHooks(
+          null,
+          workInProgress,
+          Component,
+          props,
+          context,
+          renderLanes,
+        );
+        hasId = checkDidRenderIdHook();
+      } finally {
+        setIsStrictModeForDevtools(false);
+      }
+    }
+  }
+
+  if (getIsHydrating() && hasId) {
+    pushMaterializedTreeId(workInProgress);
+  }
+
+  reconcileChildren(null, workInProgress, value, renderLanes);
+  if (__DEV__) {
+    validateFunctionComponentInDev(workInProgress, Component);
+  }
+  return workInProgress.child;
 }
 
 function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -1898,49 +1898,48 @@ function mountIndeterminateComponent(
       hasContext,
       renderLanes,
     );
-  } else {
-    // Proceed under the assumption that this is a function component
-    workInProgress.tag = FunctionComponent;
-    if (__DEV__) {
-      if (disableLegacyContext && Component.contextTypes) {
-        console.error(
-          '%s uses the legacy contextTypes API which is no longer supported. ' +
-            'Use React.createContext() with React.useContext() instead.',
-          getComponentNameFromType(Component) || 'Unknown',
-        );
-      }
-
-      if (
-        debugRenderPhaseSideEffectsForStrictMode &&
-        workInProgress.mode & StrictLegacyMode
-      ) {
-        setIsStrictModeForDevtools(true);
-        try {
-          value = renderWithHooks(
-            null,
-            workInProgress,
-            Component,
-            props,
-            context,
-            renderLanes,
-          );
-          hasId = checkDidRenderIdHook();
-        } finally {
-          setIsStrictModeForDevtools(false);
-        }
-      }
-    }
-
-    if (getIsHydrating() && hasId) {
-      pushMaterializedTreeId(workInProgress);
-    }
-
-    reconcileChildren(null, workInProgress, value, renderLanes);
-    if (__DEV__) {
-      validateFunctionComponentInDev(workInProgress, Component);
-    }
-    return workInProgress.child;
   }
+  // Proceed under the assumption that this is a function component
+  workInProgress.tag = FunctionComponent;
+  if (__DEV__) {
+    if (disableLegacyContext && Component.contextTypes) {
+      console.error(
+        '%s uses the legacy contextTypes API which is no longer supported. ' +
+          'Use React.createContext() with React.useContext() instead.',
+        getComponentNameFromType(Component) || 'Unknown',
+      );
+    }
+
+    if (
+      debugRenderPhaseSideEffectsForStrictMode &&
+      workInProgress.mode & StrictLegacyMode
+    ) {
+      setIsStrictModeForDevtools(true);
+      try {
+        value = renderWithHooks(
+          null,
+          workInProgress,
+          Component,
+          props,
+          context,
+          renderLanes,
+        );
+        hasId = checkDidRenderIdHook();
+      } finally {
+        setIsStrictModeForDevtools(false);
+      }
+    }
+  }
+
+  if (getIsHydrating() && hasId) {
+    pushMaterializedTreeId(workInProgress);
+  }
+
+  reconcileChildren(null, workInProgress, value, renderLanes);
+  if (__DEV__) {
+    validateFunctionComponentInDev(workInProgress, Component);
+  }
+  return workInProgress.child;
 }
 
 function validateFunctionComponentInDev(workInProgress: Fiber, Component: any) {


### PR DESCRIPTION
## Summary

Run the code but not need `else`. Because it has been returned ahead in `if`.

> If an if block always executes a return statement, the subsequent else block is unnecessary.

## How did you test this change?

We have been runed all test cases, and not change the logic of code execution