### PR TITLE
[Flight] Implement error digests for Flight runtime and expose errorInfo in getDerivedStateFromError

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -193,7 +193,7 @@ function createBlockedChunk<T>(response: Response): BlockedChunk<T> {
 
 function createErrorChunk<T>(
   response: Response,
-  error: Error,
+  error: ErrorWithDigest,
 ): ErroredChunk<T> {
   // $FlowFixMe Flow doesn't support functions as constructors
   return new Chunk(ERRORED, null, error, response);
@@ -628,7 +628,7 @@ export function resolveSymbol(
   chunks.set(id, createInitializedChunk(response, Symbol.for(name)));
 }
 
-type ErrorWithDigest = Error & {_digest?: string};
+type ErrorWithDigest = Error & {digest?: string};
 export function resolveErrorProd(
   response: Response,
   id: number,
@@ -641,9 +641,13 @@ export function resolveErrorProd(
       'resolveErrorProd should never be called in development mode. Use resolveErrorDev instead. This is a bug in React.',
     );
   }
-  const error = new Error('An error occurred in the Server Components render.');
+  const error = new Error(
+    'An error occurred in the Server Components render. The specific message is omitted in production' +
+      ' builds to avoid leaking sensitive details. A digest property is included on this error instance which' +
+      ' may provide additional details about the nature of the error.',
+  );
   error.stack = '';
-  (error: any)._digest = digest;
+  (error: any).digest = digest;
   const errorWithDigest: ErrorWithDigest = (error: any);
   const chunks = response._chunks;
   const chunk = chunks.get(id);
@@ -674,7 +678,7 @@ export function resolveErrorDev(
       'An error occurred in the Server Components render but no message was provided',
   );
   error.stack = stack;
-  (error: any)._digest = digest;
+  (error: any).digest = digest;
   const errorWithDigest: ErrorWithDigest = (error: any);
   const chunks = response._chunks;
   const chunk = chunks.get(id);

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -16,7 +16,8 @@ import {
   resolveModel,
   resolveProvider,
   resolveSymbol,
-  resolveError,
+  resolveErrorProd,
+  resolveErrorDev,
   createResponse as createResponseBase,
   parseModelString,
   parseModelTuple,
@@ -62,7 +63,17 @@ function processFullRow(response: Response, row: string): void {
     }
     case 'E': {
       const errorInfo = JSON.parse(text);
-      resolveError(response, id, errorInfo.message, errorInfo.stack);
+      if (__DEV__) {
+        resolveErrorDev(
+          response,
+          id,
+          errorInfo.digest,
+          errorInfo.message,
+          errorInfo.stack,
+        );
+      } else {
+        resolveErrorProd(response, id, errorInfo.digest);
+      }
       return;
     }
     default: {

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -49,9 +49,9 @@ describe('ReactFlight', () => {
           expect(this.state.error.message).toContain(
             this.props.expectedMessage,
           );
-          expect(this.state.error._digest).toContain('a dev digest');
+          expect(this.state.error._digest).toBe('a dev digest');
         } else {
-          expect(this.state.error.message).toContain(
+          expect(this.state.error.message).toBe(
             'An error occurred in the Server Components render.',
           );
           expect(this.state.error._digest).toContain(

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -49,14 +49,12 @@ describe('ReactFlight', () => {
           expect(this.state.error.message).toContain(
             this.props.expectedMessage,
           );
-          expect(this.state.error._digest).toBe('a dev digest');
+          expect(this.state.error.digest).toBe('a dev digest');
         } else {
           expect(this.state.error.message).toBe(
             'An error occurred in the Server Components render.',
           );
-          expect(this.state.error._digest).toContain(
-            this.props.expectedMessage,
-          );
+          expect(this.state.error.digest).toContain(this.props.expectedMessage);
         }
       }
       render() {

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -52,7 +52,9 @@ describe('ReactFlight', () => {
           expect(this.state.error.digest).toBe('a dev digest');
         } else {
           expect(this.state.error.message).toBe(
-            'An error occurred in the Server Components render.',
+            'An error occurred in the Server Components render. The specific message is omitted in production' +
+              ' builds to avoid leaking sensitive details. A digest property is included on this error instance which' +
+              ' may provide additional details about the nature of the error.',
           );
           expect(this.state.error.digest).toContain(this.props.expectedMessage);
         }

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -45,7 +45,19 @@ describe('ReactFlight', () => {
       componentDidMount() {
         expect(this.state.hasError).toBe(true);
         expect(this.state.error).toBeTruthy();
-        expect(this.state.error.message).toContain(this.props.expectedMessage);
+        if (__DEV__) {
+          expect(this.state.error.message).toContain(
+            this.props.expectedMessage,
+          );
+          expect(this.state.error._digest).toContain('a dev digest');
+        } else {
+          expect(this.state.error.message).toContain(
+            'An error occurred in the Server Components render.',
+          );
+          expect(this.state.error._digest).toContain(
+            this.props.expectedMessage,
+          );
+        }
       }
       render() {
         if (this.state.hasError) {
@@ -371,8 +383,8 @@ describe('ReactFlight', () => {
     }
 
     const options = {
-      onError() {
-        // ignore
+      onError(x) {
+        return __DEV__ ? 'a dev digest' : `digest("${x.message}")`;
       },
     };
     const event = ReactNoopFlightServer.render(<EventHandlerProp />, options);

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -16,7 +16,8 @@ import {
   resolveModel,
   resolveModule,
   resolveSymbol,
-  resolveError,
+  resolveErrorDev,
+  resolveErrorProd,
   close,
   getRoot,
 } from 'react-client/src/ReactFlightClient';
@@ -34,7 +35,20 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
     resolveSymbol(response, chunk[1], chunk[2]);
   } else {
-    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
-    resolveError(response, chunk[1], chunk[2].message, chunk[2].stack);
+    if (__DEV__) {
+      resolveErrorDev(
+        response,
+        chunk[1],
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].digest,
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].message || '',
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].stack || '',
+      );
+    } else {
+      // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+      resolveErrorPro(response, chunk[1], chunk[2].digest);
+    }
   }
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -48,7 +48,7 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
       );
     } else {
       // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
-      resolveErrorPro(response, chunk[1], chunk[2].digest);
+      resolveErrorProd(response, chunk[1], chunk[2].digest);
     }
   }
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -26,8 +26,9 @@ export type RowEncoding =
       'E',
       number,
       {
-        message: string,
-        stack: string,
+        digest: string,
+        message?: string,
+        stack?: string,
         ...
       },
     ];

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -60,16 +60,48 @@ export function resolveModuleMetaData<T>(
 
 export type Chunk = RowEncoding;
 
-export function processErrorChunk(
+export function processErrorChunkProd(
   request: Request,
   id: number,
-  message: string,
-  stack: string,
+  digest: string,
 ): Chunk {
+  if (__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkProd should never be called while in development mode. Use processErrorChunkDev instead. This is a bug in React.',
+    );
+  }
+
   return [
     'E',
     id,
     {
+      digest,
+    },
+  ];
+}
+
+export function processErrorChunkDev(
+  request: Request,
+  id: number,
+  digest: string,
+  message: string,
+  stack: string,
+): Chunk {
+  if (!__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkDev should never be called while in production mode. Use processErrorChunkProd instead. This is a bug in React.',
+    );
+  }
+
+  return [
+    'E',
+    id,
+    {
+      digest,
       message,
       stack,
     },

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -797,7 +797,7 @@ describe('ReactFlightDOM', () => {
       {
         onError(x) {
           reportedErrors.push(x.message);
-          return `digestOf("${x.message}")`;
+          return __DEV__ ? 'a dev digest' : `digest("${x.message}")`;
         },
       },
     );
@@ -816,10 +816,10 @@ describe('ReactFlightDOM', () => {
       root.render(
         <ErrorBoundary
           fallback={e => (
-            <>
-              <p>{e.message}</p>
-              <p>{e._digest}</p>
-            </>
+            <p>
+              {__DEV__ ? e.message + ' + ' : null}
+              {e._digest}
+            </p>
           )}>
           <Suspense fallback={<p>(loading)</p>}>
             <App res={response} />
@@ -829,12 +829,10 @@ describe('ReactFlightDOM', () => {
     });
     if (__DEV__) {
       expect(container.innerHTML).toBe(
-        '<p>bug in the bundler</p><p>digestOf("bug in the bundler")</p>',
+        '<p>bug in the bundler + a dev digest</p>',
       );
     } else {
-      expect(container.innerHTML).toBe(
-        '<p>An error occurred in the Server Components render.</p><p>digestOf("bug in the bundler")</p>',
-      );
+      expect(container.innerHTML).toBe('<p>digest("bug in the bundler")</p>');
     }
 
     expect(reportedErrors).toEqual(['bug in the bundler']);

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -336,7 +336,7 @@ describe('ReactFlightDOM', () => {
           fallback={e => (
             <p>
               {__DEV__ ? e.message + ' + ' : null}
-              {e._digest}
+              {e.digest}
             </p>
           )}>
           {children}
@@ -642,7 +642,7 @@ describe('ReactFlightDOM', () => {
           fallback={e => (
             <p>
               {__DEV__ ? e.message + ' + ' : null}
-              {e._digest}
+              {e.digest}
             </p>
           )}>
           <Suspense fallback={<p>(loading)</p>}>
@@ -818,7 +818,7 @@ describe('ReactFlightDOM', () => {
           fallback={e => (
             <p>
               {__DEV__ ? e.message + ' + ' : null}
-              {e._digest}
+              {e.digest}
             </p>
           )}>
           <Suspense fallback={<p>(loading)</p>}>

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -183,7 +183,9 @@ describe('ReactFlightDOMBrowser', () => {
     } else {
       errorBoundaryFn = e => {
         expect(e.message).toBe(
-          'An error occurred in the Server Components render.',
+          'An error occurred in the Server Components render. The specific message is omitted in production' +
+            ' builds to avoid leaking sensitive details. A digest property is included on this error instance which' +
+            ' may provide additional details about the nature of the error.',
         );
         return <p>{e.digest}</p>;
       };
@@ -519,7 +521,9 @@ describe('ReactFlightDOMBrowser', () => {
     } else {
       errorBoundaryFn = e => {
         expect(e.message).toBe(
-          'An error occurred in the Server Components render.',
+          'An error occurred in the Server Components render. The specific message is omitted in production' +
+            ' builds to avoid leaking sensitive details. A digest property is included on this error instance which' +
+            ' may provide additional details about the nature of the error.',
         );
         return <p>{e.digest}</p>;
       };

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -309,7 +309,7 @@ describe('ReactFlightDOMBrowser', () => {
       rejectGames(theError);
     });
 
-    let gamesExpectedValue = __DEV__
+    const gamesExpectedValue = __DEV__
       ? '<p>Game over + a dev digest</p>'
       : '<p>digest("Game over")</p>';
 
@@ -550,7 +550,7 @@ describe('ReactFlightDOMBrowser', () => {
       {
         signal: controller.signal,
         onError(x) {
-          let message = typeof x === 'string' ? x : x.message;
+          const message = typeof x === 'string' ? x : x.message;
           reportedErrors.push(x);
           return __DEV__ ? 'a dev digest' : `digest("${message}")`;
         },

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOMBrowser-test.js
@@ -177,7 +177,7 @@ describe('ReactFlightDOMBrowser', () => {
     if (__DEV__) {
       errorBoundaryFn = e => (
         <p>
-          {e.message} + {e._digest}
+          {e.message} + {e.digest}
         </p>
       );
     } else {
@@ -185,7 +185,7 @@ describe('ReactFlightDOMBrowser', () => {
         expect(e.message).toBe(
           'An error occurred in the Server Components render.',
         );
-        return <p>{e._digest}</p>;
+        return <p>{e.digest}</p>;
       };
     }
 
@@ -513,7 +513,7 @@ describe('ReactFlightDOMBrowser', () => {
     if (__DEV__) {
       errorBoundaryFn = e => (
         <p>
-          {e.message} + {e._digest}
+          {e.message} + {e.digest}
         </p>
       );
     } else {
@@ -521,7 +521,7 @@ describe('ReactFlightDOMBrowser', () => {
         expect(e.message).toBe(
           'An error occurred in the Server Components render.',
         );
-        return <p>{e._digest}</p>;
+        return <p>{e.digest}</p>;
       };
     }
 
@@ -720,8 +720,8 @@ describe('ReactFlightDOMBrowser', () => {
       render() {
         if (this.state.error) {
           return __DEV__
-            ? this.state.error.message + ' + ' + this.state.error._digest
-            : this.state.error._digest;
+            ? this.state.error.message + ' + ' + this.state.error.digest
+            : this.state.error.digest;
         }
         return this.props.children;
       }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -16,7 +16,8 @@ import {
   resolveModel,
   resolveModule,
   resolveSymbol,
-  resolveError,
+  resolveErrorDev,
+  resolveErrorProd,
   close,
   getRoot,
 } from 'react-client/src/ReactFlightClient';
@@ -34,7 +35,20 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
     // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
     resolveSymbol(response, chunk[1], chunk[2]);
   } else {
-    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
-    resolveError(response, chunk[1], chunk[2].message, chunk[2].stack);
+    if (__DEV__) {
+      resolveErrorDev(
+        response,
+        chunk[1],
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].digest,
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].message || '',
+        // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+        chunk[2].stack || '',
+      );
+    } else {
+      // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
+      resolveErrorProd(response, chunk[1], chunk[2].digest);
+    }
   }
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -26,8 +26,9 @@ export type RowEncoding =
       'E',
       number,
       {
-        message: string,
-        stack: string,
+        digest: string,
+        message?: string,
+        stack?: string,
         ...
       },
     ];

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -57,16 +57,47 @@ export function resolveModuleMetaData<T>(
 
 export type Chunk = RowEncoding;
 
-export function processErrorChunk(
+export function processErrorChunkProd(
   request: Request,
   id: number,
-  message: string,
-  stack: string,
+  digest: string,
 ): Chunk {
+  if (__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkProd should never be called while in development mode. Use processErrorChunkDev instead. This is a bug in React.',
+    );
+  }
+
   return [
     'E',
     id,
     {
+      digest,
+    },
+  ];
+}
+export function processErrorChunkDev(
+  request: Request,
+  id: number,
+  digest: string,
+  message: string,
+  stack: string,
+): Chunk {
+  if (!__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkDev should never be called while in production mode. Use processErrorChunkProd instead. This is a bug in React.',
+    );
+  }
+
+  return [
+    'E',
+    id,
+    {
+      digest,
       message,
       stack,
     },

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -35,7 +35,8 @@ import {
   processModuleChunk,
   processProviderChunk,
   processSymbolChunk,
-  processErrorChunk,
+  processErrorChunkProd,
+  processErrorChunkDev,
   processReferenceChunk,
   resolveModuleMetaData,
   getModuleKey,
@@ -125,7 +126,7 @@ export type Request = {
   writtenProviders: Map<string, number>,
   identifierPrefix: string,
   identifierCount: number,
-  onError: (error: mixed) => void,
+  onError: (error: mixed) => ?string,
   toJSON: (key: string, value: ReactModel) => ReactJSONValue,
 };
 
@@ -143,7 +144,7 @@ const CLOSED = 2;
 export function createRequest(
   model: ReactModel,
   bundlerConfig: BundlerConfig,
-  onError: void | ((error: mixed) => void),
+  onError: void | ((error: mixed) => ?string),
   context?: Array<[string, ServerContextJSONValue]>,
   identifierPrefix?: string,
 ): Request {
@@ -364,7 +365,13 @@ function serializeModuleReference(
   } catch (x) {
     request.pendingChunks++;
     const errorId = request.nextChunkId++;
-    emitErrorChunk(request, errorId, x);
+    const digest = logRecoverableError(request, x);
+    if (__DEV__) {
+      const {message, stack} = getErrorMessageAndStackDev(x);
+      emitErrorChunkDev(request, errorId, digest, message, stack);
+    } else {
+      emitErrorChunkProd(request, errorId, digest);
+    }
     return serializeByValueID(errorId);
   }
 }
@@ -629,7 +636,13 @@ export function resolveModelToJSON(
         // once it gets rendered.
         request.pendingChunks++;
         const errorId = request.nextChunkId++;
-        emitErrorChunk(request, errorId, x);
+        const digest = logRecoverableError(request, x);
+        if (__DEV__) {
+          const {message, stack} = getErrorMessageAndStackDev(x);
+          emitErrorChunkDev(request, errorId, digest, message, stack);
+        } else {
+          emitErrorChunkProd(request, errorId, digest);
+        }
         return serializeByRefID(errorId);
       }
     }
@@ -797,9 +810,47 @@ export function resolveModelToJSON(
   );
 }
 
-function logRecoverableError(request: Request, error: mixed): void {
+function logRecoverableError(request: Request, error: mixed): string {
   const onError = request.onError;
-  onError(error);
+  const errorDigest = onError(error);
+  if (errorDigest != null && typeof errorDigest !== 'string') {
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      `onError returned something with a type other than "string". onError should return a string and may return null or undefined but must not return anything else. It received something of type "${typeof errorDigest}" instead`,
+    );
+  }
+  return errorDigest || '';
+}
+
+function getErrorMessageAndStackDev(
+  error: mixed,
+): {message: string, stack: string} {
+  if (__DEV__) {
+    let message;
+    let stack = '';
+    try {
+      if (error instanceof Error) {
+        // eslint-disable-next-line react-internal/safe-string-coercion
+        message = String(error.message);
+        // eslint-disable-next-line react-internal/safe-string-coercion
+        stack = String(error.stack);
+      } else {
+        message = 'Error: ' + (error: any);
+      }
+    } catch (x) {
+      message = 'An error occurred but serializing the error message failed.';
+    }
+    return {
+      message,
+      stack,
+    };
+  } else {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'getErrorMessageAndStackDev should never be called from production mode. This is a bug in React.',
+    );
+  }
 }
 
 function fatalError(request: Request, error: mixed): void {
@@ -813,26 +864,29 @@ function fatalError(request: Request, error: mixed): void {
   }
 }
 
-function emitErrorChunk(request: Request, id: number, error: mixed): void {
-  // TODO: We should not leak error messages to the client in prod.
-  // Give this an error code instead and log on the server.
-  // We can serialize the error in DEV as a convenience.
-  let message;
-  let stack = '';
-  try {
-    if (error instanceof Error) {
-      // eslint-disable-next-line react-internal/safe-string-coercion
-      message = String(error.message);
-      // eslint-disable-next-line react-internal/safe-string-coercion
-      stack = String(error.stack);
-    } else {
-      message = 'Error: ' + (error: any);
-    }
-  } catch (x) {
-    message = 'An error occurred but serializing the error message failed.';
-  }
+function emitErrorChunkProd(
+  request: Request,
+  id: number,
+  digest: string,
+): void {
+  const processedChunk = processErrorChunkProd(request, id, digest);
+  request.completedErrorChunks.push(processedChunk);
+}
 
-  const processedChunk = processErrorChunk(request, id, message, stack);
+function emitErrorChunkDev(
+  request: Request,
+  id: number,
+  digest: string,
+  message: string,
+  stack: string,
+): void {
+  const processedChunk = processErrorChunkDev(
+    request,
+    id,
+    digest,
+    message,
+    stack,
+  );
   request.completedErrorChunks.push(processedChunk);
 }
 
@@ -935,9 +989,13 @@ function retryTask(request: Request, task: Task): void {
     } else {
       request.abortableTasks.delete(task);
       task.status = ERRORED;
-      logRecoverableError(request, x);
-      // This errored, we need to serialize this error to the
-      emitErrorChunk(request, task.id, x);
+      const digest = logRecoverableError(request, x);
+      if (__DEV__) {
+        const {message, stack} = getErrorMessageAndStackDev(x);
+        emitErrorChunkDev(request, task.id, digest, message, stack);
+      } else {
+        emitErrorChunkProd(request, task.id, digest);
+      }
     }
   }
 }
@@ -1077,10 +1135,15 @@ export function abort(request: Request, reason: mixed): void {
           ? new Error('The render was aborted by the server without a reason.')
           : reason;
 
-      logRecoverableError(request, error);
+      const digest = logRecoverableError(request, error);
       request.pendingChunks++;
       const errorId = request.nextChunkId++;
-      emitErrorChunk(request, errorId, error);
+      if (__DEV__) {
+        const {message, stack} = getErrorMessageAndStackDev(error);
+        emitErrorChunkDev(request, errorId, digest, message, stack);
+      } else {
+        emitErrorChunkProd(request, errorId, digest);
+      }
       abortableTasks.forEach(task => abortTask(task, request, errorId));
       abortableTasks.clear();
     }

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -78,13 +78,40 @@ function serializeRowHeader(tag: string, id: number) {
   return tag + id.toString(16) + ':';
 }
 
-export function processErrorChunk(
+export function processErrorChunkProd(
   request: Request,
   id: number,
+  digest: string,
+): Chunk {
+  if (__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkProd should never be called while in development mode. Use processErrorChunkDev instead. This is a bug in React.',
+    );
+  }
+
+  const errorInfo: any = {digest};
+  const row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
+  return stringToChunk(row);
+}
+
+export function processErrorChunkDev(
+  request: Request,
+  id: number,
+  digest: string,
   message: string,
   stack: string,
 ): Chunk {
-  const errorInfo = {message, stack};
+  if (!__DEV__) {
+    // These errors should never make it into a build so we don't need to encode them in codes.json
+    // eslint-disable-next-line react-internal/prod-error-codes
+    throw new Error(
+      'processErrorChunkDev should never be called while in production mode. Use processErrorChunkProd instead. This is a bug in React.',
+    );
+  }
+
+  const errorInfo: any = {digest, message, stack};
   const row = serializeRowHeader('E', id) + stringify(errorInfo) + '\n';
   return stringToChunk(row);
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -425,5 +425,6 @@
   "437": "the \"precedence\" prop for links to stylesheets expects to receive a string but received something of type \"%s\" instead.",
   "438": "An unsupported type was passed to use(): %s",
   "439": "We didn't expect to see a forward reference. This is a bug in the React Server.",
-  "440": "An event from useEvent was called during render."
+  "440": "An event from useEvent was called during render.",
+  "441": "An error occurred in the Server Components render."
 }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -426,5 +426,5 @@
   "438": "An unsupported type was passed to use(): %s",
   "439": "We didn't expect to see a forward reference. This is a bug in the React Server.",
   "440": "An event from useEvent was called during render.",
-  "441": "An error occurred in the Server Components render."
+  "441": "An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error."
 }


### PR DESCRIPTION
Similar to Fizz, Flight now supports a return value from the user provided onError option. If a value is returned from onError it will be serialized and provided to the client.

The digest is stashed on the constructed Error on the client as `.digest`