### PR TITLE
Support new `load`/`resolve` API for Node ESM loaders

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -9,6 +9,17 @@
 
 import * as acorn from 'acorn';
 
+type LoadContext = {
+  format: string,
+  importAssertions: {}
+};
+
+type LoadFunction = (
+  string,
+  LoadContext,
+  LoadFunction,
+) => { format: string, source: Source, shortCircuit?: boolean } | Promise<{ format: string, source: Source, shortCircuit?: boolean }>;
+
 type ResolveContext = {
   conditions: Array<string>,
   parentURL: string | void,
@@ -52,8 +63,8 @@ let stashedResolve: null | ResolveFunction = null;
 // Node version 17+
 // 
 
-export async function load(url, context, defaultLoad) {
-  const transformed = await transformed(
+export async function load(url: string, context: LoadContext, defaultLoad: LoadFunction) {
+  const transformed = await defaultLoad(
     url,
     context,
     defaultLoad,

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -74,7 +74,7 @@ export async function load(url: string, context: LoadContext, defaultLoad: LoadF
   );
 
   if (context.format === 'module' && url.endsWith('.client.js')) {
-    const transformedSource = transformed.source;
+    const transformedSource = transformed.source.toString();
     if (typeof transformedSource !== 'string') {
       throw new Error('Expected source to have been transformed to a string.');
     }
@@ -297,7 +297,7 @@ export async function transformSource(
     defaultTransformSource,
   );
   if (context.format === 'module' && context.url.endsWith('.client.js')) {
-    const transformedSource = transformed.source;
+    const transformedSource = transformed.source.toString();
     if (typeof transformedSource !== 'string') {
       throw new Error('Expected source to have been transformed to a string.');
     }

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -70,7 +70,7 @@ export async function load(url: string, context: LoadContext, defaultLoad: LoadF
     defaultLoad,
   );
 
-  if (context.format === 'module' && context.url.endsWith('.client.js')) {
+  if (context.format === 'module' && url.endsWith('.client.js')) {
     const transformedSource = transformed.source;
     if (typeof transformedSource !== 'string') {
       throw new Error('Expected source to have been transformed to a string.');
@@ -80,7 +80,7 @@ export async function load(url: string, context: LoadContext, defaultLoad: LoadF
     await parseExportNamesInto(
       transformedSource,
       names,
-      context.url,
+      url,
       defaultLoad,
     );
 
@@ -94,7 +94,7 @@ export async function load(url: string, context: LoadContext, defaultLoad: LoadF
         newSrc += 'export const ' + name + ' = ';
       }
       newSrc += '{ $$typeof: MODULE_REFERENCE, filepath: ';
-      newSrc += JSON.stringify(context.url);
+      newSrc += JSON.stringify(url);
       newSrc += ', name: ';
       newSrc += JSON.stringify(name);
       newSrc += '};\n';

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -48,6 +48,10 @@ let warnedAboutConditionsFlag = false;
 let stashedGetSource: null | GetSourceFunction = null;
 let stashedResolve: null | ResolveFunction = null;
 
+//
+// Node version 17+
+// 
+
 export async function load(url, context, defaultLoad) {
   const transformed = await transformed(
     url,
@@ -132,6 +136,10 @@ export async function resolve(
   }
   return resolved;
 }
+
+//
+// Node version < 17.
+// 
 
 export async function getSource(
   url: string,


### PR DESCRIPTION
## Summary

As explained [here](https://github.com/facebook/react/issues/25303), the current node loader in [react-server-dom-webpack](https://github.com/facebook/react/tree/main/packages/react-server-dom-webpack) only supports the older ESM loader API and not the new API. This PR adds support for the newer API by implementing the `load` function to replace `getSource` / `transformSource`

## How did you test this change?

I am actually not sure how to test this within the react repo, I've only managed to test it within the context of my own project and it does seem to work. Ideas?