### PR TITLE
Strict mode fix offscreen edge case

### DIFF
--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -17,7 +17,7 @@ import {
   Placement,
   ChildDeletion,
   Forked,
-  PlacementDEV,
+  NeedsDoubleInvokedEffectsDEV,
 } from './ReactFiberFlags';
 import {
   getIteratorFn,
@@ -349,7 +349,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       const oldIndex = current.index;
       if (oldIndex < lastPlacedIndex) {
         // This is a move.
-        newFiber.flags |= Placement | PlacementDEV;
+        newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
         return lastPlacedIndex;
       } else {
         // This item can stay in place.
@@ -357,7 +357,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     } else {
       // This is an insertion.
-      newFiber.flags |= Placement | PlacementDEV;
+      newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
       return lastPlacedIndex;
     }
   }
@@ -366,7 +366,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
     if (shouldTrackSideEffects && newFiber.alternate === null) {
-      newFiber.flags |= Placement | PlacementDEV;
+      newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
     }
     return newFiber;
   }

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -17,7 +17,7 @@ import {
   Placement,
   ChildDeletion,
   Forked,
-  PlacementDEV,
+  NeedsDoubleInvokedEffectsDEV,
 } from './ReactFiberFlags';
 import {
   getIteratorFn,
@@ -349,7 +349,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       const oldIndex = current.index;
       if (oldIndex < lastPlacedIndex) {
         // This is a move.
-        newFiber.flags |= Placement | PlacementDEV;
+        newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
         return lastPlacedIndex;
       } else {
         // This item can stay in place.
@@ -357,7 +357,7 @@ function ChildReconciler(shouldTrackSideEffects) {
       }
     } else {
       // This is an insertion.
-      newFiber.flags |= Placement | PlacementDEV;
+      newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
       return lastPlacedIndex;
     }
   }
@@ -366,7 +366,7 @@ function ChildReconciler(shouldTrackSideEffects) {
     // This is simpler for the single child case. We only need to do a
     // placement for inserting new children.
     if (shouldTrackSideEffects && newFiber.alternate === null) {
-      newFiber.flags |= Placement | PlacementDEV;
+      newFiber.flags |= Placement | NeedsDoubleInvokedEffectsDEV;
     }
     return newFiber;
   }

--- a/packages/react-reconciler/src/ReactFiber.new.js
+++ b/packages/react-reconciler/src/ReactFiber.new.js
@@ -33,7 +33,12 @@ import {
   enableTransitionTracing,
   enableDebugTracing,
 } from 'shared/ReactFeatureFlags';
-import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
+import {
+  NoFlags,
+  Placement,
+  StaticMask,
+  NeedsDoubleInvokedEffectsDEV,
+} from './ReactFiberFlags';
 import {ConcurrentRoot} from './ReactRootTags';
 import {
   IndeterminateComponent,
@@ -300,9 +305,12 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     }
   }
 
-  // Reset all effects except static ones.
+  // Reset all effects except static ones NeedsDoubleInvokedEffectsDEV.
   // Static effects are not specific to a render.
-  workInProgress.flags = current.flags & StaticMask;
+  // NeedsDoubleInvokedEffectsDEV is cleared when component is double invoked
+  // in debugging. It is only used with StrictMode enabled.
+  workInProgress.flags =
+    current.flags & (StaticMask | NeedsDoubleInvokedEffectsDEV);
   workInProgress.childLanes = current.childLanes;
   workInProgress.lanes = current.lanes;
 
@@ -369,7 +377,9 @@ export function resetWorkInProgress(
 
   // Reset the effect flags but keep any Placement tags, since that's something
   // that child fiber is setting, not the reconciliation.
-  workInProgress.flags &= StaticMask | Placement;
+  // NeedsDoubleInvokedEffectsDEV is cleared when component is double invoked
+  // in debugging. It is only used with StrictMode enabled.
+  workInProgress.flags &= StaticMask | Placement | NeedsDoubleInvokedEffectsDEV;
 
   // The effects are no longer valid.
 

--- a/packages/react-reconciler/src/ReactFiber.old.js
+++ b/packages/react-reconciler/src/ReactFiber.old.js
@@ -33,7 +33,12 @@ import {
   enableTransitionTracing,
   enableDebugTracing,
 } from 'shared/ReactFeatureFlags';
-import {NoFlags, Placement, StaticMask} from './ReactFiberFlags';
+import {
+  NoFlags,
+  Placement,
+  StaticMask,
+  NeedsDoubleInvokedEffectsDEV,
+} from './ReactFiberFlags';
 import {ConcurrentRoot} from './ReactRootTags';
 import {
   IndeterminateComponent,
@@ -300,9 +305,12 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     }
   }
 
-  // Reset all effects except static ones.
+  // Reset all effects except static ones NeedsDoubleInvokedEffectsDEV.
   // Static effects are not specific to a render.
-  workInProgress.flags = current.flags & StaticMask;
+  // NeedsDoubleInvokedEffectsDEV is cleared when component is double invoked
+  // in debugging. It is only used with StrictMode enabled.
+  workInProgress.flags =
+    current.flags & (StaticMask | NeedsDoubleInvokedEffectsDEV);
   workInProgress.childLanes = current.childLanes;
   workInProgress.lanes = current.lanes;
 
@@ -369,7 +377,9 @@ export function resetWorkInProgress(
 
   // Reset the effect flags but keep any Placement tags, since that's something
   // that child fiber is setting, not the reconciliation.
-  workInProgress.flags &= StaticMask | Placement;
+  // NeedsDoubleInvokedEffectsDEV is cleared when component is double invoked
+  // in debugging. It is only used with StrictMode enabled.
+  workInProgress.flags &= StaticMask | Placement | NeedsDoubleInvokedEffectsDEV;
 
   // The effects are no longer valid.
 

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -53,8 +53,8 @@ export const RefStatic = /*                    */ 0b000100000000000000000000;
 export const LayoutStatic = /*                 */ 0b001000000000000000000000;
 export const PassiveStatic = /*                */ 0b010000000000000000000000;
 
-// Flag used to identify newly inserted fibers. It isn't reset after commit unlike `Placement`.
-export const PlacementDEV = /*                 */ 0b100000000000000000000000;
+// Flag used to identify fibers that need to have effects double invoked.
+export const NeedsDoubleInvokedEffectsDEV = /* */ 0b100000000000000000000000;
 
 // Groups of flags that are used in the commit phase to skip over trees that
 // don't contain effects, by checking subtreeFlags.


### PR DESCRIPTION
We need to keep track of fibers that have had effects invoked twice.
To achieve this, this commit repurposes flag `PlacementDEV` to
`NeedsDoubleInvokedEffectsDEV`, which is unset by StrictMode.
Previous approach with Offscreen was not enough. When previously visible
Offscreen is hidden, it can have descendants added. Once Offscreen
becomes visible, only newly added components have to have their effects
double invoked. Not the previously existing components.
