### PR TITLE
experimental: Ignore innerText and textContent props on the server

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -648,6 +648,15 @@ describe('ReactDOMServerIntegration', () => {
       const e = await render(<div on="tap:do-something" />);
       expect(e.getAttribute('on')).toEqual('tap:do-something');
     });
+
+    itRenders('no reserved attributes', async render => {
+      const e = await render(<div innerText="1" />);
+      if (ReactFeatureFlags.enableCustomElementPropertySupport) {
+        expect(e.hasAttribute('innerText')).toBe(false);
+      } else {
+        expect(e.hasAttribute('innerText')).toBe(true);
+      }
+    });
   });
 
   // These tests mostly verify the existing behavior.

--- a/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom/src/server/ReactDOMServerFormatConfig.js
@@ -43,6 +43,7 @@ import {
   OVERLOADED_BOOLEAN,
   NUMERIC,
   POSITIVE_NUMERIC,
+  RESERVED,
 } from '../shared/DOMProperty';
 import {isUnitlessNumber} from '../shared/CSSProperty';
 
@@ -454,13 +455,6 @@ function pushAttribute(
       pushStyle(target, responseState, value);
       return;
     }
-    case 'defaultValue':
-    case 'defaultChecked': // These shouldn't be set as attributes on generic HTML elements.
-    case 'innerHTML': // Must use dangerouslySetInnerHTML instead.
-    case 'suppressContentEditableWarning':
-    case 'suppressHydrationWarning':
-      // Ignored. These are built-in to React on the client.
-      return;
   }
   if (
     // shouldIgnoreAttribute
@@ -566,6 +560,9 @@ function pushAttribute(
           );
         }
         break;
+      case RESERVED:
+        // Ignored. These are built-in to React on the client.
+        return;
       default:
         if (propertyInfo.sanitizeURL) {
           if (__DEV__) {


### PR DESCRIPTION
## Summary

`<custom-element innerText="1">Hello, Dave!</custom-element>` currently renders an element with a `innerText` attribute if server rendered (+hydrated) but not if just client rendered: https://codesandbox.io/s/new-reserved-props-are-written-on-server-but-not-client-87lr9z

The server config now uses `propertyInfo.type === RESERVED` instead of duplicating a list of reserved props.
The list of reserved props current explicitly states these props shouldn't be written to the DOM so the expectation is that adding a prop there does exactly that: ensure that the prop is not written to the DOM. But the server has a forked implementation in that regard making the "shared" reserved props list misleading since it's not actually shared.

## How did you test this change?

- [ ] TODO: https://codesandbox.io/s/new-reserved-props-are-written-on-server-but-not-client-87lr9z with build from this PR
- [ ] Added tests
