### PR TITLE
ReactTestInstance to expose toJSON() method for focused snapshots

### DIFF
--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -136,39 +136,35 @@ function toJSON(inst: Instance | TextInstance): ReactTestRendererNode | null {
 function testInstanceToJSON(
   node: ReactTestInstance | string,
 ): Array<ReactTestRendererNode> | ReactTestRendererNode | null {
+  // Text node
   if (typeof node === 'string') {
     return node;
   }
-
   // Host node
   if (typeof node.type === 'string') {
     return toJSON(node._fiber.stateNode);
   }
-
   if (node.children == null || node.children.length === 0) {
     return null;
   }
 
   const renderedChildren = [];
   for (let i = 0; i < node.children.length; i++) {
-    const childrenJSON = testInstanceToJSON(node.children[i]);
-    if (childrenJSON !== null) {
-      if (Array.isArray(childrenJSON)) {
-        renderedChildren.push(...childrenJSON);
+    const childJSON = testInstanceToJSON(node.children[i]);
+    if (childJSON !== null) {
+      if (Array.isArray(childJSON)) {
+        renderedChildren.push(...childJSON);
       } else {
-        renderedChildren.push(childrenJSON);
+        renderedChildren.push(childJSON);
       }
     }
   }
-
   if (renderedChildren.length === 0) {
     return null;
   }
-
   if (renderedChildren.length === 1) {
     return renderedChildren[0];
   }
-
   return renderedChildren;
 }
 

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -411,7 +411,7 @@ class ReactTestInstance {
         const renderedChild = child.toJSON();
         if (Array.isArray(renderedChild)) {
           renderedChildren.push(...renderedChild);
-        } else {
+        } else if (renderedChild != null) {
           renderedChildren.push(renderedChild);
         }
       }

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -391,6 +391,10 @@ class ReactTestInstance {
       options,
     );
   }
+
+  toJSON(): ReactTestRendererNode | null {
+    return toJSON(this._fiber.stateNode);
+  }
 }
 
 function findAll(

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -133,41 +133,6 @@ function toJSON(inst: Instance | TextInstance): ReactTestRendererNode | null {
   }
 }
 
-function testInstanceToJSON(
-  node: ReactTestInstance | string,
-): Array<ReactTestRendererNode> | ReactTestRendererNode | null {
-  // Text node
-  if (typeof node === 'string') {
-    return node;
-  }
-  // Host node
-  if (typeof node.type === 'string') {
-    return toJSON(node._fiber.stateNode);
-  }
-  if (node.children == null || node.children.length === 0) {
-    return null;
-  }
-
-  const renderedChildren = [];
-  for (let i = 0; i < node.children.length; i++) {
-    const childJSON = testInstanceToJSON(node.children[i]);
-    if (childJSON !== null) {
-      if (Array.isArray(childJSON)) {
-        renderedChildren.push(...childJSON);
-      } else {
-        renderedChildren.push(childJSON);
-      }
-    }
-  }
-  if (renderedChildren.length === 0) {
-    return null;
-  }
-  if (renderedChildren.length === 1) {
-    return renderedChildren[0];
-  }
-  return renderedChildren;
-}
-
 function childrenToTree(node) {
   if (!node) {
     return null;
@@ -426,6 +391,39 @@ class ReactTestInstance {
       options,
     );
   }
+
+  toJSON(): Array<ReactTestRendererNode> | ReactTestRendererNode | null {
+    // Host node
+    if (typeof this.type === 'string') {
+      return toJSON(this._fiber.stateNode);
+    }
+
+    if (this.children == null || this.children.length === 0) {
+      return null;
+    }
+
+    const renderedChildren = [];
+    for (let i = 0; i < this.children.length; i++) {
+      const child = this.children[i];
+      if (typeof child === 'string') {
+        renderedChildren.push(child);
+      } else {
+        const renderedChild = child.toJSON();
+        if (Array.isArray(renderedChild)) {
+          renderedChildren.push(...renderedChild);
+        } else {
+          renderedChildren.push(renderedChild);
+        }
+      }
+    }
+    if (renderedChildren.length === 0) {
+      return null;
+    }
+    if (renderedChildren.length === 1) {
+      return renderedChildren[0];
+    }
+    return renderedChildren;
+  }
 }
 
 function findAll(
@@ -669,5 +667,4 @@ export {
   /* eslint-disable-next-line camelcase */
   batchedUpdates as unstable_batchedUpdates,
   act,
-  testInstanceToJSON as toJSON,
 };

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -59,6 +59,7 @@ describe('ReactTestRenderer', () => {
       props: {role: 'link'},
       children: null,
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('renders a top-level empty component', () => {
@@ -67,6 +68,7 @@ describe('ReactTestRenderer', () => {
     }
     const renderer = ReactTestRenderer.create(<Empty />);
     expect(renderer.toJSON()).toEqual(null);
+    expect(renderer.root.toJSON()).toEqual(null);
   });
 
   it('exposes a type flag', () => {
@@ -76,6 +78,7 @@ describe('ReactTestRenderer', () => {
     const renderer = ReactTestRenderer.create(<Link />);
     const object = renderer.toJSON();
     expect(object.$$typeof).toBe(Symbol.for('react.test.json'));
+    expect(renderer.root.toJSON().$$typeof).toBe(Symbol.for('react.test.json'));
 
     // $$typeof should not be enumerable.
     for (const key in object) {
@@ -106,6 +109,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: [{type: 'moo', props: {}, children: null}],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('renders some basics with an update', () => {
@@ -146,6 +150,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: ['7', {type: 'moo', props: {}, children: null}],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     expect(renders).toBe(6);
   });
 
@@ -169,6 +174,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     const mouse = renderer.getInstance();
     mouse.handleMoose();
@@ -177,6 +183,7 @@ describe('ReactTestRenderer', () => {
       children: ['moose'],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('updates types', () => {
@@ -186,6 +193,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     renderer.update(<span>mice</span>);
     expect(renderer.toJSON()).toEqual({
@@ -193,6 +201,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mice'],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('updates children', () => {
@@ -212,6 +221,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['C']},
       ],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     renderer.update(
       <div>
@@ -229,6 +239,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['B']},
       ],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('does the full lifecycle', () => {
@@ -459,6 +470,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['Happy Birthday!'],
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     expect(log).toEqual([
       'Boundary render',
       'Angry render',
@@ -481,24 +493,28 @@ describe('ReactTestRenderer', () => {
       children: ['Hi'],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>{['Hi', 'Bye']}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Hi', 'Bye'],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>Bye</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Bye'],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>{42}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['42'],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(
       <Component>
         <div />
@@ -515,6 +531,7 @@ describe('ReactTestRenderer', () => {
       ],
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('toTree() renders simple components returning host components', () => {
@@ -861,10 +878,13 @@ describe('ReactTestRenderer', () => {
   it('can update text nodes when rendered as root', () => {
     const renderer = ReactTestRenderer.create(['Hello', 'world']);
     expect(renderer.toJSON()).toEqual(['Hello', 'world']);
+    expect(renderer.root.toJSON()).toEqual(['Hello', 'world']);
     renderer.update(42);
     expect(renderer.toJSON()).toEqual('42');
+    // Not able to call `renderer.root.toJSON()` because it is "42" string
     renderer.update([42, 'world']);
     expect(renderer.toJSON()).toEqual(['42', 'world']);
+    expect(renderer.root.toJSON()).toEqual(['42', 'world']);
   });
 
   it('can render and update root fragments', () => {
@@ -875,12 +895,14 @@ describe('ReactTestRenderer', () => {
       <Component key="b">Bye</Component>,
     ]);
     expect(renderer.toJSON()).toEqual(['Hi', 'Bye']);
+    expect(renderer.root.toJSON()).toEqual(['Hi', 'Bye']);
     renderer.update(<div />);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: null,
       props: {},
     });
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update([<div key="a">goodbye</div>, 'world']);
     expect(renderer.toJSON()).toEqual([
       {
@@ -890,6 +912,7 @@ describe('ReactTestRenderer', () => {
       },
       'world',
     ]);
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('supports context providers and consumers', () => {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -16,8 +16,6 @@ const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 const prettyFormat = require('pretty-format');
 
-const {toJSON} = ReactTestRenderer;
-
 // Isolate noop renderer
 jest.resetModules();
 const ReactNoop = require('react-noop-renderer');

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -16,6 +16,8 @@ const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 const prettyFormat = require('pretty-format');
 
+const {toJSON} = ReactTestRenderer;
+
 // Isolate noop renderer
 jest.resetModules();
 const ReactNoop = require('react-noop-renderer');
@@ -59,7 +61,7 @@ describe('ReactTestRenderer', () => {
       props: {role: 'link'},
       children: null,
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('renders a top-level empty component', () => {
@@ -68,7 +70,7 @@ describe('ReactTestRenderer', () => {
     }
     const renderer = ReactTestRenderer.create(<Empty />);
     expect(renderer.toJSON()).toEqual(null);
-    expect(renderer.root.toJSON()).toEqual(null);
+    expect(toJSON(renderer.root)).toEqual(null);
   });
 
   it('exposes a type flag', () => {
@@ -78,7 +80,7 @@ describe('ReactTestRenderer', () => {
     const renderer = ReactTestRenderer.create(<Link />);
     const object = renderer.toJSON();
     expect(object.$$typeof).toBe(Symbol.for('react.test.json'));
-    expect(renderer.root.toJSON().$$typeof).toBe(Symbol.for('react.test.json'));
+    expect(toJSON(renderer.root).$$typeof).toBe(Symbol.for('react.test.json'));
 
     // $$typeof should not be enumerable.
     for (const key in object) {
@@ -109,7 +111,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: [{type: 'moo', props: {}, children: null}],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('renders some basics with an update', () => {
@@ -150,7 +152,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: ['7', {type: 'moo', props: {}, children: null}],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     expect(renders).toBe(6);
   });
 
@@ -174,7 +176,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
 
     const mouse = renderer.getInstance();
     mouse.handleMoose();
@@ -183,7 +185,7 @@ describe('ReactTestRenderer', () => {
       children: ['moose'],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('updates types', () => {
@@ -193,7 +195,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
 
     renderer.update(<span>mice</span>);
     expect(renderer.toJSON()).toEqual({
@@ -201,7 +203,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mice'],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('updates children', () => {
@@ -221,7 +223,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['C']},
       ],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
 
     renderer.update(
       <div>
@@ -239,7 +241,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['B']},
       ],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('does the full lifecycle', () => {
@@ -470,7 +472,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['Happy Birthday!'],
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     expect(log).toEqual([
       'Boundary render',
       'Angry render',
@@ -493,28 +495,28 @@ describe('ReactTestRenderer', () => {
       children: ['Hi'],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     renderer.update(<Component>{['Hi', 'Bye']}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Hi', 'Bye'],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     renderer.update(<Component>Bye</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Bye'],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     renderer.update(<Component>{42}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['42'],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     renderer.update(
       <Component>
         <div />
@@ -531,7 +533,7 @@ describe('ReactTestRenderer', () => {
       ],
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('toTree() renders simple components returning host components', () => {
@@ -878,13 +880,13 @@ describe('ReactTestRenderer', () => {
   it('can update text nodes when rendered as root', () => {
     const renderer = ReactTestRenderer.create(['Hello', 'world']);
     expect(renderer.toJSON()).toEqual(['Hello', 'world']);
-    expect(renderer.root.toJSON()).toEqual(['Hello', 'world']);
+    expect(toJSON(renderer.root)).toEqual(['Hello', 'world']);
     renderer.update(42);
     expect(renderer.toJSON()).toEqual('42');
-    // Not able to call `renderer.root.toJSON()` because it is "42" string
+    // Not able to call `toJSON(renderer.root)` because it is "42" string
     renderer.update([42, 'world']);
     expect(renderer.toJSON()).toEqual(['42', 'world']);
-    expect(renderer.root.toJSON()).toEqual(['42', 'world']);
+    expect(toJSON(renderer.root)).toEqual(['42', 'world']);
   });
 
   it('can render and update root fragments', () => {
@@ -895,14 +897,14 @@ describe('ReactTestRenderer', () => {
       <Component key="b">Bye</Component>,
     ]);
     expect(renderer.toJSON()).toEqual(['Hi', 'Bye']);
-    expect(renderer.root.toJSON()).toEqual(['Hi', 'Bye']);
+    expect(toJSON(renderer.root)).toEqual(['Hi', 'Bye']);
     renderer.update(<div />);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: null,
       props: {},
     });
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
     renderer.update([<div key="a">goodbye</div>, 'world']);
     expect(renderer.toJSON()).toEqual([
       {
@@ -912,7 +914,7 @@ describe('ReactTestRenderer', () => {
       },
       'world',
     ]);
-    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
+    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
   });
 
   it('supports context providers and consumers', () => {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRenderer-test.internal.js
@@ -61,7 +61,7 @@ describe('ReactTestRenderer', () => {
       props: {role: 'link'},
       children: null,
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('renders a top-level empty component', () => {
@@ -70,7 +70,7 @@ describe('ReactTestRenderer', () => {
     }
     const renderer = ReactTestRenderer.create(<Empty />);
     expect(renderer.toJSON()).toEqual(null);
-    expect(toJSON(renderer.root)).toEqual(null);
+    expect(renderer.root.toJSON()).toEqual(null);
   });
 
   it('exposes a type flag', () => {
@@ -80,7 +80,7 @@ describe('ReactTestRenderer', () => {
     const renderer = ReactTestRenderer.create(<Link />);
     const object = renderer.toJSON();
     expect(object.$$typeof).toBe(Symbol.for('react.test.json'));
-    expect(toJSON(renderer.root).$$typeof).toBe(Symbol.for('react.test.json'));
+    expect(renderer.root.toJSON().$$typeof).toBe(Symbol.for('react.test.json'));
 
     // $$typeof should not be enumerable.
     for (const key in object) {
@@ -111,7 +111,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: [{type: 'moo', props: {}, children: null}],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('renders some basics with an update', () => {
@@ -152,7 +152,7 @@ describe('ReactTestRenderer', () => {
       props: {className: 'purple'},
       children: ['7', {type: 'moo', props: {}, children: null}],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     expect(renders).toBe(6);
   });
 
@@ -176,7 +176,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     const mouse = renderer.getInstance();
     mouse.handleMoose();
@@ -185,7 +185,7 @@ describe('ReactTestRenderer', () => {
       children: ['moose'],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('updates types', () => {
@@ -195,7 +195,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mouse'],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     renderer.update(<span>mice</span>);
     expect(renderer.toJSON()).toEqual({
@@ -203,7 +203,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['mice'],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('updates children', () => {
@@ -223,7 +223,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['C']},
       ],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
 
     renderer.update(
       <div>
@@ -241,7 +241,7 @@ describe('ReactTestRenderer', () => {
         {type: 'span', props: {}, children: ['B']},
       ],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('does the full lifecycle', () => {
@@ -472,7 +472,7 @@ describe('ReactTestRenderer', () => {
       props: {},
       children: ['Happy Birthday!'],
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     expect(log).toEqual([
       'Boundary render',
       'Angry render',
@@ -495,28 +495,28 @@ describe('ReactTestRenderer', () => {
       children: ['Hi'],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>{['Hi', 'Bye']}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Hi', 'Bye'],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>Bye</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['Bye'],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(<Component>{42}</Component>);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: ['42'],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update(
       <Component>
         <div />
@@ -533,7 +533,7 @@ describe('ReactTestRenderer', () => {
       ],
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('toTree() renders simple components returning host components', () => {
@@ -880,13 +880,13 @@ describe('ReactTestRenderer', () => {
   it('can update text nodes when rendered as root', () => {
     const renderer = ReactTestRenderer.create(['Hello', 'world']);
     expect(renderer.toJSON()).toEqual(['Hello', 'world']);
-    expect(toJSON(renderer.root)).toEqual(['Hello', 'world']);
+    expect(renderer.root.toJSON()).toEqual(['Hello', 'world']);
     renderer.update(42);
     expect(renderer.toJSON()).toEqual('42');
-    // Not able to call `toJSON(renderer.root)` because it is "42" string
+    // Not able to call `renderer.root.toJSON()` because `root` is a string here
     renderer.update([42, 'world']);
     expect(renderer.toJSON()).toEqual(['42', 'world']);
-    expect(toJSON(renderer.root)).toEqual(['42', 'world']);
+    expect(renderer.root.toJSON()).toEqual(['42', 'world']);
   });
 
   it('can render and update root fragments', () => {
@@ -897,14 +897,14 @@ describe('ReactTestRenderer', () => {
       <Component key="b">Bye</Component>,
     ]);
     expect(renderer.toJSON()).toEqual(['Hi', 'Bye']);
-    expect(toJSON(renderer.root)).toEqual(['Hi', 'Bye']);
+    expect(renderer.root.toJSON()).toEqual(['Hi', 'Bye']);
     renderer.update(<div />);
     expect(renderer.toJSON()).toEqual({
       type: 'div',
       children: null,
       props: {},
     });
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
     renderer.update([<div key="a">goodbye</div>, 'world']);
     expect(renderer.toJSON()).toEqual([
       {
@@ -914,7 +914,7 @@ describe('ReactTestRenderer', () => {
       },
       'world',
     ]);
-    expect(toJSON(renderer.root)).toEqual(renderer.toJSON());
+    expect(renderer.root.toJSON()).toEqual(renderer.toJSON());
   });
 
   it('supports context providers and consumers', () => {

--- a/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactTestRendererTraversal-test.js
@@ -243,4 +243,63 @@ describe('ReactTestRendererTraversal', () => {
       ).root.findAllByType('div').length,
     ).toBe(2);
   });
+
+  it('renders JSON for elements correctly', () => {
+    const render = ReactTestRenderer.create(<Example />);
+
+    expect(render.root.findByProps({foo: 'foo'}).toJSON()).toEqual({
+      type: 'RCTView',
+      props: {foo: 'foo'},
+      children: [
+        {type: 'RCTView', children: null, props: {bar: 'bar'}},
+        {
+          type: 'RCTView',
+          children: null,
+          props: {bar: 'bar', baz: 'baz', itself: 'itself'},
+        },
+        {type: 'RCTView', children: null, props: {}},
+        {type: 'RCTView', children: null, props: {bar: 'bar'}},
+        {type: 'RCTView', children: null, props: {baz: 'baz'}},
+        {type: 'RCTView', children: null, props: {qux: 'qux'}},
+        {type: 'RCTView', children: null, props: {nested: true}},
+        {type: 'RCTView', children: null, props: {nested: true}},
+        {type: 'RCTView', children: null, props: {nested: true}},
+      ],
+    });
+
+    expect(render.root.findByProps({itself: 'itself'}).toJSON()).toEqual({
+      type: 'RCTView',
+      children: null,
+      props: {bar: 'bar', baz: 'baz', itself: 'itself'},
+    });
+
+    expect(render.root.findByType(ExampleSpread).toJSON()).toEqual({
+      type: 'RCTView',
+      children: null,
+      props: {bar: 'bar'},
+    });
+
+    expect(render.root.findByType(ExampleFn).toJSON()).toEqual({
+      type: 'RCTView',
+      children: null,
+      props: {baz: 'baz'},
+    });
+
+    expect(render.root.findByType(ExampleForwardRef).toJSON()).toEqual({
+      type: 'RCTView',
+      children: null,
+      props: {qux: 'qux'},
+    });
+
+    const nullComposites = render.root.findAllByType(ExampleNull);
+    expect(nullComposites[0].toJSON()).toEqual(null);
+    expect(nullComposites[1].toJSON()).toEqual(null);
+
+    const nestedViews = render.root.findAllByProps({nested: true});
+    expect(nestedViews[0].toJSON()).toEqual({
+      type: 'RCTView',
+      children: null,
+      props: {nested: true},
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Allow calling `toJSON` on any `ReactTestInstance` in order to be able to make focused snapshots when writing tests using React Test Renderer or [React Native Testing Library](https://github.com/callstack/react-native-testing-library/).

Currently Test Renderer only exposes parameterless `toJSON()` as a result to `ReactTestRenderer.create()` function call but that function can only output whole component tree, which frequently result in very long snapshots that are hard to work with. 

Additionally, we plan to use this new function to improve implementation of various internal elements from React Native Testing Library, like `getByText` query algorithm, focused `debug()` function, etc.

This PR adds `toJSON()` method to `ReactTestInstance` class, so that users can generate JSON tree for any node. Implementation works by calling internal `toJSON` method if given node is host component, otherwise it recursively calls `toJSON()` on its children and returns collected JSON trees as array.

Resolves #14539

## How did you test this change?

I've added additional assertions to all relevant `ReactTestRenderer-test.internal.js` tests. The new assertions verify that `renderer.root.toJSON()` output is the same as `renderer.toJSON()` output. These tests cover different component tree structures and lifecycle changes.
