### PR TITLE
refactor: removed duplicated words in comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
     'space-before-blocks': ERROR,
     'space-before-function-paren': OFF,
     'valid-typeof': [ERROR, {requireStringLiterals: true}],
-    // Flow fails with with non-string literal keys
+    // Flow fails with non-string literal keys
     'no-useless-computed-key': OFF,
 
     // We apply these settings to files that should run on Node.

--- a/packages/jest-react/src/internalAct.js
+++ b/packages/jest-react/src/internalAct.js
@@ -139,7 +139,7 @@ function flushActWork(resolve, reject) {
   // Once the scheduler queue is empty, run all the timers. The purpose of this
   // is to force any pending fallbacks to commit. The public version of act does
   // this with dev-only React runtime logic, but since our internal act needs to
-  // work work production builds of React, we have to cheat.
+  // work production builds of React, we have to cheat.
   // $FlowFixMe: Flow doesn't know about global Jest object
   jest.runOnlyPendingTimers();
   if (Scheduler.unstable_hasPendingWork()) {

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -225,7 +225,7 @@ function dispatchEventOriginal(
 
   if (allowReplay) {
     if (isDiscreteEventThatRequiresHydration(domEventName)) {
-      // This this to be replayed later once the target is available.
+      // This to be replayed later once the target is available.
       queueDiscreteEvent(
         blockedOn,
         domEventName,


### PR DESCRIPTION
## Summary

Found some more duplicates in the comments. Removed doubles of the words "with", "this", and "work".

## How did you test this change?

Not applicable since only comments were edited, but ran linting just in case.
