### PR TITLE
Example of how StrictMode is not aligned with production

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -3300,9 +3300,9 @@ function doubleInvokeEffectsInDEVIfNecessary(
     // Only consider Offscreen that is visible.
     // TODO (Offscreen) Handle manual mode.
     setCurrentDebugFiberInDEV(fiber);
-    if (isInStrictMode && fiber.flags & Visibility) {
+    if (isInStrictMode && fiber.flags & (Visibility | PlacementDEV)) {
       // Double invoke effects on Offscreen's subtree only
-      // if it is visible and its visibility has changed.
+      // if it is visible and its visibility has changed
 
       // For backwards compatibility, we don't unmount passive effects when a tree suspends.
       // StrictMode needs to align with this.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -62,7 +62,6 @@ import {
   scheduleSyncCallback,
   scheduleLegacySyncCallback,
 } from './ReactFiberSyncTaskQueue.new';
-import {OffscreenPassiveEffectsConnected} from './ReactFiberOffscreenComponent';
 import {
   logCommitStarted,
   logCommitStopped,
@@ -3307,11 +3306,10 @@ function doubleInvokeEffectsInDEVIfNecessary(
 
       // For backwards compatibility, we don't unmount passive effects when a tree suspends.
       // StrictMode needs to align with this.
+      // TODO: Remove special case for Offscreen in Suspense when Relay internal
+      // implementation stops depending on it.
       const includePassiveEffects: boolean =
-        (fiber.stateNode._visibility & OffscreenPassiveEffectsConnected) !==
-          0 &&
-        fiber.return !== null &&
-        fiber.return.tag !== SuspenseComponent;
+        fiber.return !== null && fiber.return.tag !== SuspenseComponent;
       doubleInvokeEffectsOnFiber(root, fiber, includePassiveEffects);
     } else if (fiber.subtreeFlags & PlacementDEV) {
       // Something in the subtree could have been suspended.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -62,6 +62,7 @@ import {
   scheduleSyncCallback,
   scheduleLegacySyncCallback,
 } from './ReactFiberSyncTaskQueue.new';
+import {OffscreenPassiveEffectsConnected} from './ReactFiberOffscreenComponent';
 import {
   logCommitStarted,
   logCommitStopped,
@@ -3252,11 +3253,19 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
 }
 
 // Unconditionally disconnects and connects passive and layout effects.
-function doubleInvokeEffectsOnFiber(root: FiberRoot, fiber: Fiber) {
+function doubleInvokeEffectsOnFiber(
+  root: FiberRoot,
+  fiber: Fiber,
+  includePassiveEffects: boolean,
+) {
   disappearLayoutEffects(fiber);
-  disconnectPassiveEffect(fiber);
+  if (includePassiveEffects) {
+    disconnectPassiveEffect(fiber);
+  }
   reappearLayoutEffects(root, fiber.alternate, fiber, false);
-  reconnectPassiveEffects(root, fiber, NoLanes, null, false);
+  if (includePassiveEffects) {
+    reconnectPassiveEffects(root, fiber, NoLanes, null, false);
+  }
 }
 
 function doubleInvokeEffectsInDEVIfNecessary(
@@ -3273,7 +3282,7 @@ function doubleInvokeEffectsInDEVIfNecessary(
     if (fiber.flags & PlacementDEV) {
       setCurrentDebugFiberInDEV(fiber);
       if (isInStrictMode) {
-        doubleInvokeEffectsOnFiber(root, fiber);
+        doubleInvokeEffectsOnFiber(root, fiber, true);
       }
       resetCurrentDebugFiberInDEV();
     } else {
@@ -3295,7 +3304,15 @@ function doubleInvokeEffectsInDEVIfNecessary(
     if (isInStrictMode && fiber.flags & Visibility) {
       // Double invoke effects on Offscreen's subtree only
       // if it is visible and its visibility has changed.
-      doubleInvokeEffectsOnFiber(root, fiber);
+
+      // For backwards compatibility, we don't unmount passive effects when a tree suspends.
+      // StrictMode needs to align with this.
+      const includePassiveEffects: boolean =
+        (fiber.stateNode._visibility & OffscreenPassiveEffectsConnected) !==
+          0 &&
+        fiber.return !== null &&
+        fiber.return.tag !== SuspenseComponent;
+      doubleInvokeEffectsOnFiber(root, fiber, includePassiveEffects);
     } else if (fiber.subtreeFlags & PlacementDEV) {
       // Something in the subtree could have been suspended.
       // We need to continue traversal and find newly inserted fibers.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -62,6 +62,7 @@ import {
   scheduleSyncCallback,
   scheduleLegacySyncCallback,
 } from './ReactFiberSyncTaskQueue.old';
+import {OffscreenPassiveEffectsConnected} from './ReactFiberOffscreenComponent';
 import {
   logCommitStarted,
   logCommitStopped,
@@ -3252,11 +3253,19 @@ function recursivelyTraverseAndDoubleInvokeEffectsInDEV(
 }
 
 // Unconditionally disconnects and connects passive and layout effects.
-function doubleInvokeEffectsOnFiber(root: FiberRoot, fiber: Fiber) {
+function doubleInvokeEffectsOnFiber(
+  root: FiberRoot,
+  fiber: Fiber,
+  includePassiveEffects: boolean,
+) {
   disappearLayoutEffects(fiber);
-  disconnectPassiveEffect(fiber);
+  if (includePassiveEffects) {
+    disconnectPassiveEffect(fiber);
+  }
   reappearLayoutEffects(root, fiber.alternate, fiber, false);
-  reconnectPassiveEffects(root, fiber, NoLanes, null, false);
+  if (includePassiveEffects) {
+    reconnectPassiveEffects(root, fiber, NoLanes, null, false);
+  }
 }
 
 function doubleInvokeEffectsInDEVIfNecessary(
@@ -3273,7 +3282,7 @@ function doubleInvokeEffectsInDEVIfNecessary(
     if (fiber.flags & PlacementDEV) {
       setCurrentDebugFiberInDEV(fiber);
       if (isInStrictMode) {
-        doubleInvokeEffectsOnFiber(root, fiber);
+        doubleInvokeEffectsOnFiber(root, fiber, true);
       }
       resetCurrentDebugFiberInDEV();
     } else {
@@ -3295,7 +3304,15 @@ function doubleInvokeEffectsInDEVIfNecessary(
     if (isInStrictMode && fiber.flags & Visibility) {
       // Double invoke effects on Offscreen's subtree only
       // if it is visible and its visibility has changed.
-      doubleInvokeEffectsOnFiber(root, fiber);
+
+      // For backwards compatibility, we don't unmount passive effects when a tree suspends.
+      // StrictMode needs to align with this.
+      const includePassiveEffects: boolean =
+        (fiber.stateNode._visibility & OffscreenPassiveEffectsConnected) !==
+          0 &&
+        fiber.return !== null &&
+        fiber.return.tag !== SuspenseComponent;
+      doubleInvokeEffectsOnFiber(root, fiber, includePassiveEffects);
     } else if (fiber.subtreeFlags & PlacementDEV) {
       // Something in the subtree could have been suspended.
       // We need to continue traversal and find newly inserted fibers.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -3300,9 +3300,9 @@ function doubleInvokeEffectsInDEVIfNecessary(
     // Only consider Offscreen that is visible.
     // TODO (Offscreen) Handle manual mode.
     setCurrentDebugFiberInDEV(fiber);
-    if (isInStrictMode && fiber.flags & Visibility) {
+    if (isInStrictMode && fiber.flags & (Visibility | PlacementDEV)) {
       // Double invoke effects on Offscreen's subtree only
-      // if it is visible and its visibility has changed.
+      // if it is visible and its visibility has changed
 
       // For backwards compatibility, we don't unmount passive effects when a tree suspends.
       // StrictMode needs to align with this.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -62,7 +62,6 @@ import {
   scheduleSyncCallback,
   scheduleLegacySyncCallback,
 } from './ReactFiberSyncTaskQueue.old';
-import {OffscreenPassiveEffectsConnected} from './ReactFiberOffscreenComponent';
 import {
   logCommitStarted,
   logCommitStopped,
@@ -3307,11 +3306,10 @@ function doubleInvokeEffectsInDEVIfNecessary(
 
       // For backwards compatibility, we don't unmount passive effects when a tree suspends.
       // StrictMode needs to align with this.
+      // TODO: Remove special case for Offscreen in Suspense when Relay internal
+      // implementation stops depending on it.
       const includePassiveEffects: boolean =
-        (fiber.stateNode._visibility & OffscreenPassiveEffectsConnected) !==
-          0 &&
-        fiber.return !== null &&
-        fiber.return.tag !== SuspenseComponent;
+        fiber.return !== null && fiber.return.tag !== SuspenseComponent;
       doubleInvokeEffectsOnFiber(root, fiber, includePassiveEffects);
     } else if (fiber.subtreeFlags & PlacementDEV) {
       // Something in the subtree could have been suspended.

--- a/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactOffscreenStrictMode-test.js
@@ -203,13 +203,6 @@ describe('ReactOffscreenStrictMode', () => {
       );
     });
 
-    log.push('------------------------------');
-
-    await act(async () => {
-      resolve();
-      shouldSuspend = false;
-    });
-
     expect(log).toEqual([
       'Parent rendered',
       'Parent rendered',
@@ -218,12 +211,15 @@ describe('ReactOffscreenStrictMode', () => {
       'Parent mount',
       'Parent unmount',
       'Parent mount',
-      '------------------------------',
-      'Child rendered',
-      'Child rendered',
-      'Child mount',
-      'Child unmount',
-      'Child mount',
     ]);
+
+    log = [];
+
+    await act(async () => {
+      resolve();
+      shouldSuspend = false;
+    });
+
+    expect(log).toEqual(['Child rendered', 'Child rendered', 'Child mount']);
   });
 });


### PR DESCRIPTION
Without StrictMode, Offscreen in Suspense does not disconnect passive effects when a component is suspended. It disconnects layout effects but for backward compatibility, passive effects are not disconnected. This is for backwards compatibility. Ideally, we want Offscreen even in Suspense to disconnect passive effects.
StrictMode, however, does disconnect passive effects, as well as layout effects. To unblock sync of React, we will make StrictMode backwards compatible as well.

