### PR TITLE
Refactor useEvent

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -665,11 +665,11 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
 
 function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-  const eventStates = updateQueue !== null ? updateQueue.events : null;
-  if (eventStates !== null) {
-    for (let ii = 0; ii < eventStates.length; ii++) {
-      const eventState = eventStates[ii];
-      eventState.event._current = eventState.nextEvent;
+  const eventPayloads = updateQueue !== null ? updateQueue.events : null;
+  if (eventPayloads !== null) {
+    for (let ii = 0; ii < eventPayloads.length; ii++) {
+      const eventPayload = eventPayloads[ii];
+      eventPayload.event._impl = eventPayload.nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -16,7 +16,7 @@ import type {
   UpdatePayload,
 } from './ReactFiberHostConfig';
 import type {Fiber} from './ReactInternalTypes';
-import type {FiberRoot} from './ReactInternalTypes';
+import type {FiberRoot, EventFunctionWrapper} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.new';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.new';
@@ -667,9 +667,13 @@ function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const eventPayloads = updateQueue !== null ? updateQueue.events : null;
   if (eventPayloads !== null) {
-    for (let ii = 0; ii < eventPayloads.length; ii++) {
-      const eventPayload = eventPayloads[ii];
-      eventPayload.event._impl = eventPayload.nextImpl;
+    // FunctionComponentUpdateQueue.events is a flat array of
+    // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
+    // pair.
+    for (let ii = 0; ii < eventPayloads.length; ii += 2) {
+      const event: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
+      const nextImpl = eventPayloads[ii + 1];
+      event._impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -164,7 +164,6 @@ import {
   Layout as HookLayout,
   Insertion as HookInsertion,
   Passive as HookPassive,
-  Snapshot as HookSnapshot,
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork.new';
 import {doesFiberContain} from './ReactFiberTreeReflection';
@@ -416,8 +415,7 @@ function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
     case FunctionComponent: {
       if (enableUseEventHook) {
         if ((flags & Update) !== NoFlags) {
-          // useEvent doesn't need to be cleaned up
-          commitHookEffectListMount(HookSnapshot | HookHasEffect, finishedWork);
+          commitUseEventMount(finishedWork);
         }
       }
       break;
@@ -662,6 +660,17 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
       }
       effect = effect.next;
     } while (effect !== firstEffect);
+  }
+}
+
+function commitUseEventMount(finishedWork: Fiber) {
+  const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
+  const eventStates = updateQueue !== null ? updateQueue.events : null;
+  if (eventStates !== null) {
+    for (let ii = 0; ii < eventStates.length; ii++) {
+      const eventState = eventStates[ii];
+      eventState.event._current = eventState.nextEvent;
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -671,9 +671,9 @@ function commitUseEventMount(finishedWork: Fiber) {
     // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
     // pair.
     for (let ii = 0; ii < eventPayloads.length; ii += 2) {
-      const event: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
+      const eventFn: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
       const nextImpl = eventPayloads[ii + 1];
-      event._impl = nextImpl;
+      eventFn._impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -665,11 +665,11 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
 
 function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
-  const eventStates = updateQueue !== null ? updateQueue.events : null;
-  if (eventStates !== null) {
-    for (let ii = 0; ii < eventStates.length; ii++) {
-      const eventState = eventStates[ii];
-      eventState.event._current = eventState.nextEvent;
+  const eventPayloads = updateQueue !== null ? updateQueue.events : null;
+  if (eventPayloads !== null) {
+    for (let ii = 0; ii < eventPayloads.length; ii++) {
+      const eventPayload = eventPayloads[ii];
+      eventPayload.event._impl = eventPayload.nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -16,7 +16,7 @@ import type {
   UpdatePayload,
 } from './ReactFiberHostConfig';
 import type {Fiber} from './ReactInternalTypes';
-import type {FiberRoot} from './ReactInternalTypes';
+import type {FiberRoot, EventFunctionWrapper} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.old';
@@ -667,9 +667,13 @@ function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const eventPayloads = updateQueue !== null ? updateQueue.events : null;
   if (eventPayloads !== null) {
-    for (let ii = 0; ii < eventPayloads.length; ii++) {
-      const eventPayload = eventPayloads[ii];
-      eventPayload.event._impl = eventPayload.nextImpl;
+    // FunctionComponentUpdateQueue.events is a flat array of
+    // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
+    // pair.
+    for (let ii = 0; ii < eventPayloads.length; ii += 2) {
+      const event: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
+      const nextImpl = eventPayloads[ii + 1];
+      event._impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -164,7 +164,6 @@ import {
   Layout as HookLayout,
   Insertion as HookInsertion,
   Passive as HookPassive,
-  Snapshot as HookSnapshot,
 } from './ReactHookEffectTags';
 import {didWarnAboutReassigningProps} from './ReactFiberBeginWork.old';
 import {doesFiberContain} from './ReactFiberTreeReflection';
@@ -416,8 +415,7 @@ function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
     case FunctionComponent: {
       if (enableUseEventHook) {
         if ((flags & Update) !== NoFlags) {
-          // useEvent doesn't need to be cleaned up
-          commitHookEffectListMount(HookSnapshot | HookHasEffect, finishedWork);
+          commitUseEventMount(finishedWork);
         }
       }
       break;
@@ -662,6 +660,17 @@ function commitHookEffectListMount(flags: HookFlags, finishedWork: Fiber) {
       }
       effect = effect.next;
     } while (effect !== firstEffect);
+  }
+}
+
+function commitUseEventMount(finishedWork: Fiber) {
+  const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
+  const eventStates = updateQueue !== null ? updateQueue.events : null;
+  if (eventStates !== null) {
+    for (let ii = 0; ii < eventStates.length; ii++) {
+      const eventState = eventStates[ii];
+      eventState.event._current = eventState.nextEvent;
+    }
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -671,9 +671,9 @@ function commitUseEventMount(finishedWork: Fiber) {
     // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
     // pair.
     for (let ii = 0; ii < eventPayloads.length; ii += 2) {
-      const event: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
+      const eventFn: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
       const nextImpl = eventPayloads[ii + 1];
-      event._impl = nextImpl;
+      eventFn._impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1898,29 +1898,28 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
   const hook = mountWorkInProgressHook();
-
-  const event: EventFunctionWrapper<Args, Return, F> = function event() {
+  const eventFn: EventFunctionWrapper<Args, Return, F> = function eventFn() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
         "A function wrapped in useEvent can't be called during rendering.",
       );
     }
-    return event._impl.apply(undefined, arguments);
+    return eventFn._impl.apply(undefined, arguments);
   };
-  event._impl = callback;
+  eventFn._impl = callback;
 
-  useEventImpl(event, callback);
-  hook.memoizedState = event;
-  return event;
+  useEventImpl(eventFn, callback);
+  hook.memoizedState = eventFn;
+  return eventFn;
 }
 
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
   const hook = updateWorkInProgressHook();
-  const event = hook.memoizedState;
-  useEventImpl(event, callback);
-  return event;
+  const eventFn = hook.memoizedState;
+  useEventImpl(eventFn, callback);
+  return eventFn;
 }
 
 function mountInsertionEffect(

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -21,6 +21,7 @@ import type {
   Dispatcher,
   HookType,
   MemoCache,
+  EventFunctionWrapper,
 } from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.new';
 import type {HookFlags} from './ReactHookEffectTags';
@@ -181,19 +182,14 @@ type StoreConsistencyCheck<T> = {
   getSnapshot: () => T,
 };
 
-type EventFunctionPayload<T> = {
-  event: EventFunctionWrapper<T>,
-  nextImpl: EventFunction<T>,
+type EventFunctionPayload<Args, Return, F: (...Array<Args>) => Return> = {
+  event: EventFunctionWrapper<Args, Return, F>,
+  nextImpl: F,
 };
-type EventFunctionWrapper<T> = {
-  (): T,
-  _impl: EventFunction<T>,
-};
-type EventFunction<T> = () => T;
 
 export type FunctionComponentUpdateQueue = {
   lastEffect: Effect | null,
-  events: Array<EventFunctionPayload<any>> | null,
+  events: Array<EventFunctionPayload<any, any, any>> | null,
   stores: Array<StoreConsistencyCheck<any>> | null,
   // NOTE: optional, only set when enableUseMemoCacheHook is enabled
   memoCache?: MemoCache | null,
@@ -1883,7 +1879,10 @@ function updateEffect(
   return updateEffectImpl(PassiveEffect, HookPassive, create, deps);
 }
 
-function useEventImpl<T>(event: EventFunction<T>, nextImpl: () => T) {
+function useEventImpl<Args, Return, F: (...Array<Args>) => Return>(
+  event: EventFunctionWrapper<Args, Return, F>,
+  nextImpl: F,
+) {
   const eventPayload = {event, nextImpl};
   currentlyRenderingFiber.flags |= UpdateEffect;
   let componentUpdateQueue: null | FunctionComponentUpdateQueue = (currentlyRenderingFiber.updateQueue: any);
@@ -1901,17 +1900,19 @@ function useEventImpl<T>(event: EventFunction<T>, nextImpl: () => T) {
   }
 }
 
-function mountEvent<T>(callback: () => T): () => T {
+function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): EventFunctionWrapper<Args, Return, F> {
   const hook = mountWorkInProgressHook();
 
-  function event() {
+  const event: EventFunctionWrapper<Args, Return, F> = function event() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
         "A function wrapped in useEvent can't be called during rendering.",
       );
     }
     return event._impl.apply(undefined, arguments);
-  }
+  };
   event._impl = callback;
 
   useEventImpl(event, callback);
@@ -1919,7 +1920,9 @@ function mountEvent<T>(callback: () => T): () => T {
   return event;
 }
 
-function updateEvent<T>(callback: () => T): () => T {
+function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): EventFunctionWrapper<Args, Return, F> {
   const hook = updateWorkInProgressHook();
   const event = hook.memoizedState;
   useEventImpl(event, callback);
@@ -2900,9 +2903,11 @@ if (__DEV__) {
     (HooksDispatcherOnMountInDEV: Dispatcher).useMemoCache = useMemoCache;
   }
   if (enableUseEventHook) {
-    (HooksDispatcherOnMountInDEV: Dispatcher).useEvent = function useEvent<T>(
-      callback: () => T,
-    ): () => T {
+    (HooksDispatcherOnMountInDEV: Dispatcher).useEvent = function useEvent<
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       mountHookTypesDev();
       return mountEvent(callback);
@@ -3058,8 +3063,10 @@ if (__DEV__) {
   }
   if (enableUseEventHook) {
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).useEvent = function useEvent<
-      T,
-    >(callback: () => T): () => T {
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return mountEvent(callback);
@@ -3214,9 +3221,11 @@ if (__DEV__) {
     (HooksDispatcherOnUpdateInDEV: Dispatcher).useMemoCache = useMemoCache;
   }
   if (enableUseEventHook) {
-    (HooksDispatcherOnUpdateInDEV: Dispatcher).useEvent = function useEvent<T>(
-      callback: () => T,
-    ): () => T {
+    (HooksDispatcherOnUpdateInDEV: Dispatcher).useEvent = function useEvent<
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return updateEvent(callback);
@@ -3373,8 +3382,10 @@ if (__DEV__) {
   }
   if (enableUseEventHook) {
     (HooksDispatcherOnRerenderInDEV: Dispatcher).useEvent = function useEvent<
-      T,
-    >(callback: () => T): () => T {
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return updateEvent(callback);
@@ -3557,8 +3568,10 @@ if (__DEV__) {
   }
   if (enableUseEventHook) {
     (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).useEvent = function useEvent<
-      T,
-    >(callback: () => T): () => T {
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       mountHookTypesDev();
@@ -3742,8 +3755,10 @@ if (__DEV__) {
   }
   if (enableUseEventHook) {
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).useEvent = function useEvent<
-      T,
-    >(callback: () => T): () => T {
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();
@@ -3928,8 +3943,10 @@ if (__DEV__) {
   }
   if (enableUseEventHook) {
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).useEvent = function useEvent<
-      T,
-    >(callback: () => T): () => T {
+      Args,
+      Return,
+      F: (...Array<Args>) => Return,
+    >(callback: F): EventFunctionWrapper<Args, Return, F> {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1898,29 +1898,28 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
   const hook = mountWorkInProgressHook();
-
-  const event: EventFunctionWrapper<Args, Return, F> = function event() {
+  const eventFn: EventFunctionWrapper<Args, Return, F> = function eventFn() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
         "A function wrapped in useEvent can't be called during rendering.",
       );
     }
-    return event._impl.apply(undefined, arguments);
+    return eventFn._impl.apply(undefined, arguments);
   };
-  event._impl = callback;
+  eventFn._impl = callback;
 
-  useEventImpl(event, callback);
-  hook.memoizedState = event;
-  return event;
+  useEventImpl(eventFn, callback);
+  hook.memoizedState = eventFn;
+  return eventFn;
 }
 
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
   const hook = updateWorkInProgressHook();
-  const event = hook.memoizedState;
-  useEventImpl(event, callback);
-  return event;
+  const eventFn = hook.memoizedState;
+  useEventImpl(eventFn, callback);
+  return eventFn;
 }
 
 function mountInsertionEffect(

--- a/packages/react-reconciler/src/ReactHookEffectTags.js
+++ b/packages/react-reconciler/src/ReactHookEffectTags.js
@@ -9,13 +9,12 @@
 
 export type HookFlags = number;
 
-export const NoFlags = /*   */ 0b00000;
+export const NoFlags = /*   */ 0b0000;
 
 // Represents whether effect should fire.
-export const HasEffect = /* */ 0b00001;
+export const HasEffect = /* */ 0b0001;
 
 // Represents the phase in which the effect (not the clean-up) fires.
-export const Snapshot = /*  */ 0b00010;
-export const Insertion = /* */ 0b00100;
-export const Layout = /*    */ 0b01000;
-export const Passive = /*   */ 0b10000;
+export const Insertion = /* */ 0b0010;
+export const Layout = /*    */ 0b0100;
+export const Passive = /*   */ 0b1000;

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -286,6 +286,11 @@ type SuspenseCallbackOnlyFiberRootProperties = {
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
 };
 
+export type EventFunctionWrapper<Args, Return, F: (...Array<Args>) => Return> = {
+  (): F,
+  _impl: F,
+};
+
 export type TransitionTracingCallbacks = {
   onTransitionStart?: (transitionName: string, startTime: number) => void,
   onTransitionProgress?: (
@@ -377,7 +382,9 @@ export type Dispatcher = {
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,
   ): void,
-  useEvent?: <T>(callback: () => T) => () => T,
+  useEvent?: <Args, Return, F: (...Array<Args>) => Return>(
+    callback: F,
+  ) => EventFunctionWrapper<Args, Return, F>,
   useInsertionEffect(
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -286,7 +286,13 @@ type SuspenseCallbackOnlyFiberRootProperties = {
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
 };
 
-export type EventFunctionWrapper<Args, Return, F: (...Array<Args>) => Return> = {
+// A wrapper callable object around a useEvent callback that throws if the callback is called during
+// rendering. The _impl property points to the actual implementation.
+export type EventFunctionWrapper<
+  Args,
+  Return,
+  F: (...Array<Args>) => Return,
+> = {
   (): F,
   _impl: F,
 };

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Dispatcher as DispatcherType} from 'react-reconciler/src/ReactInternalTypes';
+import type {Dispatcher as DispatcherType, EventFunctionWrapper} from 'react-reconciler/src/ReactInternalTypes';
 
 import type {
   MutableSource,
@@ -509,7 +509,10 @@ function throwOnUseEventCall() {
   );
 }
 
-export function useEvent<T>(callback: () => T): () => T {
+export function useEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): EventFunctionWrapper<Args, Return, F> {
+  // $FlowIgnore[incompatible-return] useEvent doesn't work in Fizz
   return throwOnUseEventCall;
 }
 

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -7,7 +7,10 @@
  * @flow
  */
 
-import type {Dispatcher as DispatcherType, EventFunctionWrapper} from 'react-reconciler/src/ReactInternalTypes';
+import type {
+  Dispatcher as DispatcherType,
+  EventFunctionWrapper,
+} from 'react-reconciler/src/ReactInternalTypes';
 
 import type {
   MutableSource,


### PR DESCRIPTION
Previously, the useEvent implementation made use of effect infra under the hood. This was a lot of extra overhead for functionality we didn't use (events have no deps, and no clean up functions). This PR refactors the implementation to instead use a queue to ensure that the callback is stable across renders.

Additionally, the function signature was updated to infer the callback's argument types and return value. While this doesn't affect anything internal it more accurately describes what's being passed.