### PR TITLE
Fix before before

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
     'space-before-blocks': ERROR,
     'space-before-function-paren': OFF,
     'valid-typeof': [ERROR, {requireStringLiterals: true}],
-    // Flow fails with with non-string literal keys
+    // Flow fails with non-string literal keys
     'no-useless-computed-key': OFF,
 
     // We apply these settings to files that should run on Node.

--- a/packages/jest-react/src/internalAct.js
+++ b/packages/jest-react/src/internalAct.js
@@ -139,7 +139,7 @@ function flushActWork(resolve, reject) {
   // Once the scheduler queue is empty, run all the timers. The purpose of this
   // is to force any pending fallbacks to commit. The public version of act does
   // this with dev-only React runtime logic, but since our internal act needs to
-  // work work production builds of React, we have to cheat.
+  // work production builds of React, we have to cheat.
   // $FlowFixMe: Flow doesn't know about global Jest object
   jest.runOnlyPendingTimers();
   if (Scheduler.unstable_hasPendingWork()) {

--- a/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/inspectedElement-test.js
@@ -889,7 +889,7 @@ describe('InspectedElement', () => {
     `);
   });
 
-  it('should support objects with with inherited keys', async () => {
+  it('should support objects with inherited keys', async () => {
     const Example = () => null;
 
     const base = Object.create(Object.prototype, {

--- a/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
+++ b/packages/react-devtools-shared/src/__tests__/legacy/inspectElement-test.js
@@ -478,7 +478,7 @@ describe('InspectedElementContext', () => {
   });
 
   // @reactVersion >= 16.0
-  it('should support objects with with inherited keys', async () => {
+  it('should support objects with inherited keys', async () => {
     const Example = () => null;
 
     const base = Object.create(Object.prototype, {

--- a/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMAttribute-test.js
@@ -106,7 +106,7 @@ describe('ReactDOM unknown attribute', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'Warning: The provided `unknown` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMComponent-test.js
@@ -272,7 +272,7 @@ describe('ReactDOMComponent', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'Warning: The provided `fontSize` CSS property is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 

--- a/packages/react-dom/src/__tests__/ReactDOMInput-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInput-test.js
@@ -564,7 +564,7 @@ describe('ReactDOMInput', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'Form field values (value, checked, defaultValue, or defaultChecked props) must be ' +
-        'strings, not TemporalLike. This value must be coerced to a string before before using it here.',
+        'strings, not TemporalLike. This value must be coerced to a string before using it here.',
     );
   });
 
@@ -588,7 +588,7 @@ describe('ReactDOMInput', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'Form field values (value, checked, defaultValue, or defaultChecked props) must be ' +
-        'strings, not TemporalLike. This value must be coerced to a string before before using it here.',
+        'strings, not TemporalLike. This value must be coerced to a string before using it here.',
     );
   });
 
@@ -612,7 +612,7 @@ describe('ReactDOMInput', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'Form field values (value, checked, defaultValue, or defaultChecked props) must be ' +
-        'strings, not TemporalLike. This value must be coerced to a string before before using it here.',
+        'strings, not TemporalLike. This value must be coerced to a string before using it here.',
     );
   });
 
@@ -636,7 +636,7 @@ describe('ReactDOMInput', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'Form field values (value, checked, defaultValue, or defaultChecked props) must be ' +
-        'strings, not TemporalLike. This value must be coerced to a string before before using it here.',
+        'strings, not TemporalLike. This value must be coerced to a string before using it here.',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSelect-test.js
@@ -1047,7 +1047,7 @@ describe('ReactDOMSelect', () => {
       ).toErrorDev(
         'Form field values (value, checked, defaultValue, or defaultChecked props)' +
           ' must be strings, not TemporalLike. ' +
-          'This value must be coerced to a string before before using it here.',
+          'This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1067,7 +1067,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1087,7 +1087,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1113,7 +1113,7 @@ describe('ReactDOMSelect', () => {
       ).toErrorDev(
         'Form field values (value, checked, defaultValue, or defaultChecked props)' +
           ' must be strings, not TemporalLike. ' +
-          'This value must be coerced to a string before before using it here.',
+          'This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1140,7 +1140,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1167,7 +1167,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1186,7 +1186,7 @@ describe('ReactDOMSelect', () => {
       ).toErrorDev(
         'Form field values (value, checked, defaultValue, or defaultChecked props)' +
           ' must be strings, not TemporalLike. ' +
-          'This value must be coerced to a string before before using it here.',
+          'This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1206,7 +1206,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1226,7 +1226,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1252,7 +1252,7 @@ describe('ReactDOMSelect', () => {
       ).toErrorDev(
         'Form field values (value, checked, defaultValue, or defaultChecked props)' +
           ' must be strings, not TemporalLike. ' +
-          'This value must be coerced to a string before before using it here.',
+          'This value must be coerced to a string before using it here.',
       );
     });
 
@@ -1279,7 +1279,7 @@ describe('ReactDOMSelect', () => {
         expect(test).toThrowError(new TypeError('prod message')),
       ).toErrorDev(
         'The provided `value` attribute is an unsupported type TemporalLike.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
       );
     });
   });

--- a/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMTextarea-test.js
@@ -245,7 +245,7 @@ describe('ReactDOMTextarea', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'Form field values (value, checked, defaultValue, or defaultChecked props) must be ' +
-        'strings, not TemporalLike. This value must be coerced to a string before before using it here.',
+        'strings, not TemporalLike. This value must be coerced to a string before using it here.',
     );
   });
 

--- a/packages/react-dom/src/__tests__/ReactIdentity-test.js
+++ b/packages/react-dom/src/__tests__/ReactIdentity-test.js
@@ -287,7 +287,7 @@ describe('ReactIdentity', () => {
       expect(test).toThrowError(new TypeError('prod message')),
     ).toErrorDev(
       'The provided key is an unsupported type TemporalLike.' +
-        ' This value must be coerced to a string before before using it here.',
+        ' This value must be coerced to a string before using it here.',
       {withoutStack: true},
     );
   });

--- a/packages/react-dom/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom/src/events/ReactDOMEventListener.js
@@ -225,7 +225,7 @@ function dispatchEventOriginal(
 
   if (allowReplay) {
     if (isDiscreteEventThatRequiresHydration(domEventName)) {
-      // This this to be replayed later once the target is available.
+      // This to be replayed later once the target is available.
       queueDiscreteEvent(
         blockedOn,
         domEventName,

--- a/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
+++ b/packages/react-test-renderer/src/__tests__/ReactShallowRendererHooks-test.js
@@ -356,7 +356,7 @@ describe('ReactShallowRenderer with hooks', () => {
     );
   });
 
-  it('should work with with forwardRef + any hook', () => {
+  it('should work with forwardRef + any hook', () => {
     const SomeComponent = React.forwardRef((props, ref) => {
       const randomNumberRef = React.useRef({number: Math.random()});
 

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -78,7 +78,7 @@ export function checkAttributeStringCoercion(
     if (willCoercionThrow(value)) {
       console.error(
         'The provided `%s` attribute is an unsupported type %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         attributeName,
         typeName(value),
       );
@@ -92,7 +92,7 @@ export function checkKeyStringCoercion(value: mixed): void | string {
     if (willCoercionThrow(value)) {
       console.error(
         'The provided key is an unsupported type %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         typeName(value),
       );
       return testStringCoercion(value); // throw (to help callers find troubleshooting comments)
@@ -108,7 +108,7 @@ export function checkPropStringCoercion(
     if (willCoercionThrow(value)) {
       console.error(
         'The provided `%s` prop is an unsupported type %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         propName,
         typeName(value),
       );
@@ -125,7 +125,7 @@ export function checkCSSPropertyStringCoercion(
     if (willCoercionThrow(value)) {
       console.error(
         'The provided `%s` CSS property is an unsupported type %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         propName,
         typeName(value),
       );
@@ -139,7 +139,7 @@ export function checkHtmlStringCoercion(value: mixed): void | string {
     if (willCoercionThrow(value)) {
       console.error(
         'The provided HTML markup uses a value of unsupported type %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         typeName(value),
       );
       return testStringCoercion(value); // throw (to help callers find troubleshooting comments)
@@ -153,7 +153,7 @@ export function checkFormFieldValueStringCoercion(value: mixed): void | string {
       console.error(
         'Form field values (value, checked, defaultValue, or defaultChecked props)' +
           ' must be strings, not %s.' +
-          ' This value must be coerced to a string before before using it here.',
+          ' This value must be coerced to a string before using it here.',
         typeName(value),
       );
       return testStringCoercion(value); // throw (to help callers find troubleshooting comments)


### PR DESCRIPTION
## Summary

Found more duplicate words. Removed doubles of the word "before".

## How did you test this change?

Since the words were removed from tests I tried running the tests to make sure they weren't broken, and they passed without issue.
