### PR TITLE
Flow: enable well_formed_exports for shared

### DIFF
--- a/packages/react/src/ReactServerContextRegistry.js
+++ b/packages/react/src/ReactServerContextRegistry.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import type {ReactServerContext} from 'shared/ReactTypes';
 
 export const ContextRegistry: {

--- a/packages/shared/ReactErrorUtils.js
+++ b/packages/shared/ReactErrorUtils.js
@@ -109,7 +109,7 @@ export function hasCaughtError(): boolean {
   return hasError;
 }
 
-export function clearCaughtError() {
+export function clearCaughtError(): mixed {
   if (hasError) {
     const error = caughtError;
     hasError = false;

--- a/packages/shared/ReactServerContextRegistry.js
+++ b/packages/shared/ReactServerContextRegistry.js
@@ -7,13 +7,17 @@
  * @flow
  */
 
+import type {ReactServerContext} from 'shared/ReactTypes';
+
 import {REACT_SERVER_CONTEXT_DEFAULT_VALUE_NOT_LOADED} from 'shared/ReactSymbols';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {createServerContext} from 'react';
 
 const ContextRegistry = ReactSharedInternals.ContextRegistry;
 
-export function getOrCreateServerContext(globalName: string) {
+export function getOrCreateServerContext(
+  globalName: string,
+): ReactServerContext<any> {
   if (!ContextRegistry[globalName]) {
     ContextRegistry[globalName] = createServerContext(
       globalName,

--- a/packages/shared/enqueueTask.js
+++ b/packages/shared/enqueueTask.js
@@ -10,7 +10,7 @@
 let didWarnAboutMessageChannel = false;
 let enqueueTaskImpl = null;
 
-export default function enqueueTask(task: () => void) {
+export default function enqueueTask(task: () => void): void {
   if (enqueueTaskImpl === null) {
     try {
       // read require off the module object to get around the bundlers.

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -7,26 +7,25 @@
  * @flow
  */
 
-function invokeGuardedCallbackProd<A, B, C, D, E, F, Context>(
+function invokeGuardedCallbackProd<Args: Array<mixed>, Context>(
   name: string | null,
-  func: (a: A, b: B, c: C, d: D, e: E, f: F) => mixed,
+  func: (...Args) => mixed,
   context: Context,
-  a: A,
-  b: B,
-  c: C,
-  d: D,
-  e: E,
-  f: F,
-) {
+): void {
   const funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
+    // $FlowFixMe[incompatible-call] Flow doesn't understand the arguments splicing.
     func.apply(context, funcArgs);
   } catch (error) {
     this.onError(error);
   }
 }
 
-let invokeGuardedCallbackImpl = invokeGuardedCallbackProd;
+let invokeGuardedCallbackImpl: <Args: Array<mixed>, Context>(
+  name: string | null,
+  func: (...Args) => mixed,
+  context: Context,
+) => void = invokeGuardedCallbackProd;
 
 if (__DEV__) {
   // In DEV mode, we swap out invokeGuardedCallback for a special version
@@ -59,24 +58,9 @@ if (__DEV__) {
     const fakeNode = document.createElement('react');
 
     invokeGuardedCallbackImpl = function invokeGuardedCallbackDev<
-      A,
-      B,
-      C,
-      D,
-      E,
-      F,
+      Args: Array<mixed>,
       Context,
-    >(
-      name: string | null,
-      func: (a: A, b: B, c: C, d: D, e: E, f: F) => mixed,
-      context: Context,
-      a: A,
-      b: B,
-      c: C,
-      d: D,
-      e: E,
-      f: F,
-    ) {
+    >(name: string | null, func: (...Args) => mixed, context: Context): void {
       // If document doesn't exist we know for sure we will crash in this method
       // when we call document.createEvent(). However this can cause confusing
       // errors: https://github.com/facebook/create-react-app/issues/3482
@@ -142,6 +126,7 @@ if (__DEV__) {
       function callCallback() {
         didCall = true;
         restoreAfterDispatch();
+        // $FlowFixMe[incompatible-call] Flow doesn't understand the arguments splicing.
         func.apply(context, funcArgs);
         didError = false;
       }

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -82,7 +82,7 @@ well_formed_exports.includes=<PROJECT_ROOT>/packages/react-server-native-relay
 well_formed_exports.includes=<PROJECT_ROOT>/packages/react-suspense-test-utils
 ; well_formed_exports.includes=<PROJECT_ROOT>/packages/react-test-renderer
 well_formed_exports.includes=<PROJECT_ROOT>/packages/scheduler
-; well_formed_exports.includes=<PROJECT_ROOT>/packages/shared
+well_formed_exports.includes=<PROJECT_ROOT>/packages/shared
 well_formed_exports.includes=<PROJECT_ROOT>/packages/use-subscription
 well_formed_exports.includes=<PROJECT_ROOT>/packages/use-sync-external-store
 


### PR DESCRIPTION
Related PRs:
- #25361
- #25362
- #25363

---

Not too much going on here.

One simplification was to use Flows typing for rest arguments instead of many generics.