### PR TITLE
Flow: remove max_workers setting

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -39,7 +39,7 @@
 untyped-type-import=error
 
 [options]
-server.max_workers=4
+%CI_MAX_WORKERS%
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 esproposal.optional_chaining=enable

--- a/scripts/flow/createFlowConfigs.js
+++ b/scripts/flow/createFlowConfigs.js
@@ -46,6 +46,11 @@ function writeConfig(renderer, rendererInfo, isServerSupported) {
 
   const config = configTemplate
     .replace(
+      '%CI_MAX_WORKERS%\n',
+      // On CI, we seem to need to limit workers.
+      process.env.CI ? 'server.max_workers=4\n' : '',
+    )
+    .replace(
       '%REACT_RENDERER_FLOW_OPTIONS%',
       `
 module.name_mapper='ReactFiberHostConfig$$' -> 'forks/ReactFiberHostConfig.${renderer}'


### PR DESCRIPTION
This was added back in #17880 to make CI pass for an unrelated change.

This limits the max worker setting to CI environments as removing the setting completely still seems to break on CircleCI.
