### PR TITLE
Refactor: more word doubles removed

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMEventPropagation-test.js
@@ -1932,7 +1932,7 @@ describe('ReactDOMEventListener', () => {
     // Since the element is created by the inner React, the bubbling
     // stops at the inner parent and never reaches the outer React.
     // In the future, we might consider not bubbling these events
-    // at all, in in which case inner parent also wouldn't be logged.
+    // at all, in which case inner parent also wouldn't be logged.
     expect(log).toEqual(unindent`
       - outer parent capture
       -- outer capture
@@ -2096,7 +2096,7 @@ describe('ReactDOMEventListener', () => {
     // Since the element is created by the inner React, the bubbling
     // stops at the inner parent and never reaches the outer React.
     // In the future, we might consider not bubbling these events
-    // at all, in in which case inner parent also wouldn't be logged.
+    // at all, in which case inner parent also wouldn't be logged.
     expect(log).toEqual(unindent`
       - outer parent capture
       -- outer capture

--- a/packages/shared/CheckStringCoercion.js
+++ b/packages/shared/CheckStringCoercion.js
@@ -8,7 +8,7 @@
  */
 
 /*
- * The `'' + value` pattern (used in in perf-sensitive code) throws for Symbol
+ * The `'' + value` pattern (used in perf-sensitive code) throws for Symbol
  * and Temporal.* types. See https://github.com/facebook/react/pull/22064.
  *
  * The functions in this module will throw an easier-to-understand,

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -126,7 +126,7 @@ export const enableUseEventHook = __EXPERIMENTAL__;
 // Chopping Block
 //
 // Planned feature deprecations and breaking changes. Sorted roughly in order of
-// when we we plan to enable them.
+// when we plan to enable them.
 // -----------------------------------------------------------------------------
 
 // This flag enables Strict Effects by default. We're not turning this on until

--- a/scripts/rollup/validate/index.js
+++ b/scripts/rollup/validate/index.js
@@ -23,7 +23,7 @@ function getFormat(filepath) {
     if (filepath.includes('shims')) {
       // We don't currently lint these shims. We rely on the downstream Facebook
       // repo to transform them.
-      // TODO: Should we we lint them?
+      // TODO: Should we lint them?
       return null;
     }
     return 'rn';


### PR DESCRIPTION
## Summary

Found more duplicate words in comments. Removed doubles of the words "we" and "in".

## How did you test this change?

Not applicable, since I only edited comments.
