### PR TITLE
CI: update CircleCI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 aliases:
   - &docker
-    - image: cimg/openjdk:17.0.0-node
+    - image: cimg/openjdk:18.0-node
 
   - &environment
     TZ: /usr/share/zoneinfo/America/Los_Angeles
@@ -121,7 +121,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Nodejs Version
+          name: NodeJS Version
           command: node --version
       - *restore_yarn_cache
       - *restore_node_modules


### PR DESCRIPTION
This updates to an image that's using node 16.16.0 and java 18.0.2.

| Package | Old    | New
| ------ | ------- | ---
| git    | 2.32.0  | 2.37.1
| gradle | 7.2     | 7.5.1
| java   | 17      | 18.0.2
| maven  | 3.8.2   | 3.8.6
| node   | 14.17.6 | 16.16.0
| ubuntu | 20.04.2 LTS |  20.04.4 LTS
| yarn   | 1.22.5 |  1.22.5

Let's see if this works…
