### PR TITLE
Fix failing tests in latest 16.x and 18.x Node versions

### DIFF
--- a/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
+++ b/packages/react-dom/src/__tests__/ReactTestUtilsAct-test.js
@@ -503,16 +503,15 @@ function runActTests(label, render, unmount, rerender) {
       // @gate __DEV__
       it('warns if you try to interleave multiple act calls', async () => {
         spyOnDevAndProd(console, 'error');
-        // let's try to cheat and spin off a 'thread' with an act call
-        (async () => {
-          await act(async () => {
-            await sleep(50);
-          });
-        })();
 
-        await act(async () => {
-          await sleep(100);
-        });
+        await Promise.all([
+          act(async () => {
+            await sleep(50);
+          }),
+          act(async () => {
+            await sleep(100);
+          }),
+        ]);
 
         await sleep(150);
         if (__DEV__) {


### PR DESCRIPTION


## Summary

Fixes full test matrix when using latest Node versions. 

Unblocks https://github.com/facebook/react/pull/25374

https://github.com/facebook/react/pull/25348 is still blocked: https://app.circleci.com/pipelines/github/facebook/react/32861/workflows/e0e04ca7-b376-44dc-8fa3-0ccf76b64035/jobs/554401

## How did you test this change?

- Ran this with 14.20.1, 16.17.1, and 18.10.0 in https://github.com/facebook/react/pull/25377
