### PR TITLE
Flow upgrade to 0.176

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.175.0",
+    "flow-bin": "^0.176.0",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/react-devtools-shared/src/hooks/SourceMapConsumer.js
+++ b/packages/react-devtools-shared/src/hooks/SourceMapConsumer.js
@@ -242,6 +242,7 @@ function IndexedSourceMapConsumer(sourceMapJSON: IndexSourceMap) {
 
     if (section.sourceMapConsumer === null) {
       // Lazily parse the section only when it's needed.
+      // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
       section.sourceMapConsumer = new SourceMapConsumer(section.map);
     }
 

--- a/packages/react-devtools-shared/src/inspectedElementCache.js
+++ b/packages/react-devtools-shared/src/inspectedElementCache.js
@@ -128,7 +128,10 @@ export function inspectElement(
       path,
       rendererID: ((rendererID: any): number),
     }).then(
-      ([inspectedElement: InspectedElementFrontend]) => {
+      ([inspectedElement]: [
+        InspectedElementFrontend,
+        InspectedElementResponseType,
+      ]) => {
         const resolvedRecord = ((newRecord: any): ResolvedRecord<InspectedElementFrontend>);
         resolvedRecord.status = Resolved;
         resolvedRecord.value = inspectedElement;
@@ -183,9 +186,9 @@ export function checkForUpdate({
       path: null,
       rendererID: ((rendererID: any): number),
     }).then(
-      ([
-        inspectedElement: InspectedElementFrontend,
-        responseType: InspectedElementResponseType,
+      ([inspectedElement, responseType]: [
+        InspectedElementFrontend,
+        InspectedElementResponseType,
       ]) => {
         if (responseType === 'full-data') {
           startTransition(() => {

--- a/packages/react-dom-bindings/src/shared/DOMProperty.js
+++ b/packages/react-dom-bindings/src/shared/DOMProperty.js
@@ -260,6 +260,7 @@ if (enableCustomElementPropertySupport) {
 }
 
 reservedProps.forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     RESERVED,
@@ -279,6 +280,7 @@ reservedProps.forEach(name => {
   ['htmlFor', 'for'],
   ['httpEquiv', 'http-equiv'],
 ].forEach(([name, attributeName]) => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     STRING,
@@ -294,6 +296,7 @@ reservedProps.forEach(name => {
 // In React, we let users pass `true` and `false` even though technically
 // these aren't boolean attributes (they are coerced to strings).
 ['contentEditable', 'draggable', 'spellCheck', 'value'].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     BOOLEANISH_STRING,
@@ -315,6 +318,7 @@ reservedProps.forEach(name => {
   'focusable',
   'preserveAlpha',
 ].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     BOOLEANISH_STRING,
@@ -355,6 +359,7 @@ reservedProps.forEach(name => {
   // Microdata
   'itemScope',
 ].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     BOOLEAN,
@@ -380,6 +385,7 @@ reservedProps.forEach(name => {
   // you'll need to set attributeName to name.toLowerCase()
   // instead in the assignment below.
 ].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     BOOLEAN,
@@ -401,6 +407,7 @@ reservedProps.forEach(name => {
   // you'll need to set attributeName to name.toLowerCase()
   // instead in the assignment below.
 ].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     OVERLOADED_BOOLEAN,
@@ -423,6 +430,7 @@ reservedProps.forEach(name => {
   // you'll need to set attributeName to name.toLowerCase()
   // instead in the assignment below.
 ].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     POSITIVE_NUMERIC,
@@ -436,6 +444,7 @@ reservedProps.forEach(name => {
 
 // These are HTML attributes that must be numbers.
 ['rowSpan', 'start'].forEach(name => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     NUMERIC,
@@ -535,6 +544,7 @@ const capitalize = token => token[1].toUpperCase();
   // instead in the assignment below.
 ].forEach(attributeName => {
   const name = attributeName.replace(CAMELIZE, capitalize);
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     STRING,
@@ -560,6 +570,7 @@ const capitalize = token => token[1].toUpperCase();
   // instead in the assignment below.
 ].forEach(attributeName => {
   const name = attributeName.replace(CAMELIZE, capitalize);
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     STRING,
@@ -582,6 +593,7 @@ const capitalize = token => token[1].toUpperCase();
   // instead in the assignment below.
 ].forEach(attributeName => {
   const name = attributeName.replace(CAMELIZE, capitalize);
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[name] = new PropertyInfoRecord(
     name,
     STRING,
@@ -597,6 +609,7 @@ const capitalize = token => token[1].toUpperCase();
 // The attribute name is case-sensitive in SVG so we can't just use
 // the React name like we do for attributes that exist only in HTML.
 ['tabIndex', 'crossOrigin'].forEach(attributeName => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[attributeName] = new PropertyInfoRecord(
     attributeName,
     STRING,
@@ -611,6 +624,7 @@ const capitalize = token => token[1].toUpperCase();
 // These attributes accept URLs. These must not allow javascript: URLS.
 // These will also need to accept Trusted Types object in the future.
 const xlinkHref = 'xlinkHref';
+// $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
 properties[xlinkHref] = new PropertyInfoRecord(
   'xlinkHref',
   STRING,
@@ -622,6 +636,7 @@ properties[xlinkHref] = new PropertyInfoRecord(
 );
 
 ['src', 'href', 'action', 'formAction'].forEach(attributeName => {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   properties[attributeName] = new PropertyInfoRecord(
     attributeName,
     STRING,

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -248,6 +248,7 @@ export function createRoot(
       : container;
   listenToAllSupportedEvents(rootContainerElement);
 
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   return new ReactDOMRoot(root);
 }
 
@@ -340,6 +341,7 @@ export function hydrateRoot(
     }
   }
 
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   return new ReactDOMHydrationRoot(root);
 }
 

--- a/packages/react-fetch/src/ReactFetchBrowser.js
+++ b/packages/react-fetch/src/ReactFetchBrowser.js
@@ -163,6 +163,7 @@ export function fetch(url: string, options: mixed): Object {
   if (nativeResponse._reactResponse) {
     return nativeResponse._reactResponse;
   } else {
+    // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
     return (nativeResponse._reactResponse = new Response(nativeResponse));
   }
 }

--- a/packages/react-fetch/src/ReactFetchNode.js
+++ b/packages/react-fetch/src/ReactFetchNode.js
@@ -46,6 +46,7 @@ function nodeFetch(
   // $FlowFixMe: node flow type has `port` as a number
   const request = nodeImpl.request(nodeOptions, response => {
     // TODO: support redirects.
+    // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
     onResolve(new Response(response));
   });
   request.on('error', error => {

--- a/packages/react-pg/src/ReactPostgres.js
+++ b/packages/react-pg/src/ReactPostgres.js
@@ -67,6 +67,7 @@ function readRecordValue(record: Record) {
 }
 
 export function Pool(options: mixed) {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   this.pool = new PostgresPool(options);
   // Unique function per instance because it's used for cache identity.
   this.createRecordMap = function() {

--- a/packages/react-reconciler/src/ReactFiberRoot.new.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.new.js
@@ -144,6 +144,7 @@ export function createFiberRoot(
   onRecoverableError: null | ((error: mixed) => void),
   transitionCallbacks: null | TransitionTracingCallbacks,
 ): FiberRoot {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   const root: FiberRoot = (new FiberRootNode(
     containerInfo,
     tag,

--- a/packages/react-reconciler/src/ReactFiberRoot.old.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.old.js
@@ -144,6 +144,7 @@ export function createFiberRoot(
   onRecoverableError: null | ((error: mixed) => void),
   transitionCallbacks: null | TransitionTracingCallbacks,
 ): FiberRoot {
+  // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   const root: FiberRoot = (new FiberRootNode(
     containerInfo,
     tag,

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -48,4 +48,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.175.0
+^0.176.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7912,10 +7912,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.175.0:
-  version "0.175.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.175.1.tgz#72237070ba4f293f9e04113481e18929c1de50df"
-  integrity sha512-zMCP0BPa9BrfBSR7QTcyT/XBwzUbyLdNG0eXvBuNxfHCbMRkUzSceRoOaEZIw+R+GH0UHjVfUvPJ30hXxz1Nfw==
+flow-bin@^0.176.0:
+  version "0.176.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.176.3.tgz#d32de04e044ab474afe543b9fd245608bb6a6ac8"
+  integrity sha512-lbNqgjr2GlGLAEVp5+dhG4LdnFE7ekbvVNifAdlvTx58/nE8GrCOMiUwEQy4dLnfL2NIRMk2dbEVTrugeQJ3mA==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This upgrade deprecated calling `new` on functions which introduced
the majority of breakages and I suppressed those.