### PR TITLE
Flow upgrade to 0.143

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.142.0",
+    "flow-bin": "^0.143.0",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerBrowser.js
@@ -57,10 +57,10 @@ function renderToReadableStream(
       const stream: ReactDOMServerReadableStream = (new ReadableStream(
         {
           type: 'bytes',
-          pull(controller): ?Promise<void> {
+          pull: (controller): ?Promise<void> => {
             startFlowing(request, controller);
           },
-          cancel(reason): ?Promise<void> {
+          cancel: (reason): ?Promise<void> => {
             abort(request);
           },
         },

--- a/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticBrowser.js
@@ -50,7 +50,7 @@ function prerender(
       const stream = new ReadableStream(
         {
           type: 'bytes',
-          pull(controller): ?Promise<void> {
+          pull: (controller): ?Promise<void> => {
             startFlowing(request, controller);
           },
         },

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -20,11 +20,11 @@ type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
 
 const ReactStrictModeWarnings = {
-  recordUnsafeLifecycleWarnings(fiber: Fiber, instance: any): void {},
-  flushPendingUnsafeLifecycleWarnings(): void {},
-  recordLegacyContextWarning(fiber: Fiber, instance: any): void {},
-  flushLegacyContextWarning(): void {},
-  discardPendingWarnings(): void {},
+  recordUnsafeLifecycleWarnings: (fiber: Fiber, instance: any): void => {},
+  flushPendingUnsafeLifecycleWarnings: (): void => {},
+  recordLegacyContextWarning: (fiber: Fiber, instance: any): void => {},
+  flushLegacyContextWarning: (): void => {},
+  discardPendingWarnings: (): void => {},
 };
 
 if (__DEV__) {

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -20,11 +20,11 @@ type FiberArray = Array<Fiber>;
 type FiberToFiberComponentsMap = Map<Fiber, FiberArray>;
 
 const ReactStrictModeWarnings = {
-  recordUnsafeLifecycleWarnings(fiber: Fiber, instance: any): void {},
-  flushPendingUnsafeLifecycleWarnings(): void {},
-  recordLegacyContextWarning(fiber: Fiber, instance: any): void {},
-  flushLegacyContextWarning(): void {},
-  discardPendingWarnings(): void {},
+  recordUnsafeLifecycleWarnings: (fiber: Fiber, instance: any): void => {},
+  flushPendingUnsafeLifecycleWarnings: (): void => {},
+  recordLegacyContextWarning: (fiber: Fiber, instance: any): void => {},
+  flushLegacyContextWarning: (): void => {},
+  discardPendingWarnings: (): void => {},
 };
 
 if (__DEV__) {

--- a/packages/react-refresh/src/ReactFreshRuntime.js
+++ b/packages/react-refresh/src/ReactFreshRuntime.js
@@ -460,20 +460,18 @@ export function injectIntoGlobalHook(globalObject: any): void {
       globalObject.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook = {
         renderers: new Map(),
         supportsFiber: true,
-        inject(injected) {
-          return nextID++;
-        },
-        onScheduleFiberRoot(
+        inject: injected => nextID++,
+        onScheduleFiberRoot: (
           id: number,
           root: FiberRoot,
           children: ReactNodeList,
-        ) {},
-        onCommitFiberRoot(
+        ) => {},
+        onCommitFiberRoot: (
           id: number,
           root: FiberRoot,
           maybePriorityLevel: mixed,
           didError: boolean,
-        ) {},
+        ) => {},
         onCommitFiberUnmount() {},
       };
     }

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerBrowser.js
@@ -52,13 +52,13 @@ function renderToReadableStream(
   const stream = new ReadableStream(
     {
       type: 'bytes',
-      start(controller): ?Promise<void> {
+      start: (controller): ?Promise<void> => {
         startWork(request);
       },
-      pull(controller): ?Promise<void> {
+      pull: (controller): ?Promise<void> => {
         startFlowing(request, controller);
       },
-      cancel(reason): ?Promise<void> {},
+      cancel: (reason): ?Promise<void> => {},
     },
     // $FlowFixMe size() methods are not allowed on byte streams.
     {highWaterMark: 0},

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -45,11 +45,9 @@ esproposal.class_instance_fields=enable
 esproposal.optional_chaining=enable
 exact_by_default=true
 munge_underscores=false
-types_first=true
-well_formed_exports=true
 
 # Substituted by createFlowConfig.js:
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.142.0
+^0.143.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,10 +7911,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.142.0:
-  version "0.142.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.142.0.tgz#b46b69de1123cf7c5a50917402968e07291df054"
-  integrity sha512-YgiapK/wrJjcgSgOWfoncbZ4vZrZWdHs+p7V9duI9zo4ehW2nM/VRrpSaWoZ+CWu3t+duGyAvupJvC6MM2l07w==
+flow-bin@^0.143.0:
+  version "0.143.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.143.1.tgz#2ff825dfd85e84531b0ae780842cb1c2a9743cd2"
+  integrity sha512-6S6bgZ/pghBzEUELXkwFH/bsHT+GBMo8ftHDYs0SSJ+1e6NRdFfqxcYhaTvAK8zteSfQLZBIoec6G4WPPp4qQg==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This was a large upgrade that removed "classic mode" and made "types first" the only option.
Most of the needed changes have been done in previous PRs, this just fixes up the last few instances.