### PR TITLE
Flow upgrade to 0.146

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.145.0",
+    "flow-bin": "^0.146.0",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/react-devtools-core/src/editor.js
+++ b/packages/react-devtools-core/src/editor.js
@@ -186,6 +186,7 @@ export function launchEditor(
     childProcess = spawn(editor, args, {stdio: 'inherit'});
   }
   childProcess.on('error', function() {});
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   childProcess.on('exit', function(errorCode) {
     childProcess = null;
   });

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -350,7 +350,9 @@ export function createProfilingHooks({
           );
         }
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentReactComponentMeasure.duration =
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           getRelativeTime() - currentReactComponentMeasure.timestamp;
         currentReactComponentMeasure = null;
       }
@@ -393,7 +395,9 @@ export function createProfilingHooks({
           );
         }
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentReactComponentMeasure.duration =
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           getRelativeTime() - currentReactComponentMeasure.timestamp;
         currentReactComponentMeasure = null;
       }
@@ -438,7 +442,9 @@ export function createProfilingHooks({
           );
         }
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentReactComponentMeasure.duration =
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           getRelativeTime() - currentReactComponentMeasure.timestamp;
         currentReactComponentMeasure = null;
       }
@@ -481,7 +487,9 @@ export function createProfilingHooks({
           );
         }
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentReactComponentMeasure.duration =
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           getRelativeTime() - currentReactComponentMeasure.timestamp;
         currentReactComponentMeasure = null;
       }
@@ -526,7 +534,9 @@ export function createProfilingHooks({
           );
         }
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentReactComponentMeasure.duration =
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           getRelativeTime() - currentReactComponentMeasure.timestamp;
         currentReactComponentMeasure = null;
       }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -1310,6 +1310,7 @@ export function attach(
           const id = getFiberIDThrows(fiber);
           const contexts = getContextsForFiber(fiber);
           if (contexts !== null) {
+            // $FlowFixMe[incompatible-use] found when upgrading Flow
             idToContextsMap.set(id, contexts);
           }
         }
@@ -1380,8 +1381,10 @@ export function attach(
   function getContextChangedKeys(fiber: Fiber): null | boolean | Array<string> {
     if (idToContextsMap !== null) {
       const id = getFiberIDThrows(fiber);
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const prevContexts = idToContextsMap.has(id)
-        ? idToContextsMap.get(id)
+        ? // $FlowFixMe[incompatible-use] found when upgrading Flow
+          idToContextsMap.get(id)
         : null;
       const nextContexts = getContextsForFiber(fiber);
 
@@ -2636,7 +2639,9 @@ export function attach(
         const {effectDuration, passiveEffectDuration} = getEffectDurations(
           root,
         );
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentCommitProfilingMetadata.effectDuration = effectDuration;
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentCommitProfilingMetadata.passiveEffectDuration = passiveEffectDuration;
       }
     }
@@ -3702,6 +3707,7 @@ export function attach(
       id,
       responseID: requestID,
       type: 'full-data',
+      // $FlowFixMe[incompatible-return] found when upgrading Flow
       value: cleanedInspectedElement,
     };
   }
@@ -4276,6 +4282,7 @@ export function attach(
     ) {
       // Is this the next Fiber we should select? Let's compare the frames.
       const actualFrame = getPathFrame(fiber);
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const expectedFrame = trackedPath[trackedPathMatchDepth + 1];
       if (expectedFrame === undefined) {
         throw new Error('Expected to see a frame at the next depth.');
@@ -4289,6 +4296,7 @@ export function attach(
         trackedPathMatchFiber = fiber;
         trackedPathMatchDepth++;
         // Are we out of frames to match?
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (trackedPathMatchDepth === trackedPath.length - 1) {
           // There's nothing that can possibly match afterwards.
           // Don't check the children.
@@ -4443,6 +4451,7 @@ export function attach(
     }
     return {
       id: getFiberIDThrows(fiber),
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       isFullMatch: trackedPathMatchDepth === trackedPath.length - 1,
     };
   }

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
@@ -45,6 +45,7 @@ const resource: Resource<
   (element: Element) => {
     const request = inProgressRequests.get(element);
     if (request != null) {
+      // $FlowFixMe[incompatible-call] found when upgrading Flow
       return request.promise;
     }
 
@@ -53,6 +54,7 @@ const resource: Resource<
       resolveFn = resolve;
     });
 
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     inProgressRequests.set(element, {promise, resolveFn});
 
     return promise;

--- a/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
+++ b/packages/react-devtools-shared/src/hooks/parseHookNames/parseSourceAndMetadata.js
@@ -186,6 +186,7 @@ function findHookNames(
     }
 
     const key = getHookSourceLocationKey(hookSource);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     map.set(key, name);
   });
 

--- a/packages/react-devtools-shared/src/inspectedElementMutableSource.js
+++ b/packages/react-devtools-shared/src/inspectedElementMutableSource.js
@@ -137,6 +137,7 @@ export function inspectElement({
 
         // A path has been hydrated.
         // Merge it with the latest copy we have locally and resolve with the merged value.
+        // $FlowFixMe[incompatible-type] found when upgrading Flow
         inspectedElement = inspectedElementCache.get(id) || null;
         if (inspectedElement !== null) {
           // Clone element
@@ -150,6 +151,7 @@ export function inspectElement({
             hydrateHelper(value, ((path: any): Path)),
           );
 
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           inspectedElementCache.set(id, inspectedElement);
 
           return [inspectedElement, type];

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -40,13 +40,16 @@ app.on('ready', function() {
   }
 
   // https://stackoverflow.com/questions/32402327/
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.webContents.on('new-window', function(event, url) {
     event.preventDefault();
     require('electron').shell.openExternal(url);
   });
 
   // and load the index.html of the app.
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.loadURL('file://' + __dirname + '/app.html'); // eslint-disable-line no-path-concat
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.webContents.executeJavaScript(
     // We use this so that RN can keep relative JSX __source filenames
     // but "click to open in editor" still works. js1 passes project roots
@@ -55,6 +58,7 @@ app.on('ready', function() {
   );
 
   // Emitted when the window is closed.
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.on('closed', function() {
     mainWindow = null;
   });

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -241,6 +241,7 @@ function preinit(href: string, options: PreinitOptions) {
             options,
           );
           resource = createStyleResource(
+            // $FlowFixMe[incompatible-call] found when upgrading Flow
             currentDocument,
             href,
             precedence,
@@ -347,6 +348,7 @@ export function getResource(
             } else {
               const resourceProps = stylePropsFromRawProps(styleRawProps);
               resource = createStyleResource(
+                // $FlowFixMe[incompatible-call] found when upgrading Flow
                 currentDocument,
                 href,
                 precedence,
@@ -382,6 +384,7 @@ export function getResource(
             } else {
               const resourceProps = preloadPropsFromRawProps(preloadRawProps);
               resource = createPreloadResource(
+                // $FlowFixMe[incompatible-call] found when upgrading Flow
                 currentDocument,
                 href,
                 resourceProps,

--- a/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
@@ -227,6 +227,7 @@ function extractCompositionEvent(
     }
   }
 
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const listeners = accumulateTwoPhaseListeners(targetInst, eventType);
   if (listeners.length > 0) {
     // $FlowFixMe[incompatible-type]

--- a/packages/react-dom-bindings/src/events/plugins/EnterLeaveEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/EnterLeaveEventPlugin.js
@@ -104,6 +104,7 @@ function extractEvents(
       const nearestMounted = getNearestMountedFiber(to);
       if (
         to !== nearestMounted ||
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         (to.tag !== HostComponent && to.tag !== HostText)
       ) {
         to = null;

--- a/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
@@ -144,6 +144,7 @@ function preload(href: string, options: PreloadOptions) {
     options !== null
   ) {
     const as = options.as;
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     let resource = currentResources.preloadsMap.get(href);
     if (resource) {
       if (__DEV__) {
@@ -159,12 +160,14 @@ function preload(href: string, options: PreloadOptions) {
       }
     } else {
       resource = createPreloadResource(
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         currentResources,
         href,
         as,
         preloadPropsFromPreloadOptions(href, as, options),
       );
     }
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     captureExplicitPreloadResourceDependency(currentResources, resource);
   }
 }
@@ -199,6 +202,7 @@ function preinit(href: string, options: PreinitOptions) {
       case 'style': {
         const precedence = options.precedence || 'default';
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         let resource = currentResources.stylesMap.get(href);
         if (resource) {
           if (__DEV__) {
@@ -216,6 +220,7 @@ function preinit(href: string, options: PreinitOptions) {
             options,
           );
           resource = createStyleResource(
+            // $FlowFixMe[incompatible-call] found when upgrading Flow
             currentResources,
             href,
             precedence,
@@ -224,6 +229,7 @@ function preinit(href: string, options: PreinitOptions) {
         }
 
         // Do not associate preinit style resources with any specific boundary regardless of where it is called
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         captureStyleResourceDependency(currentResources, null, resource);
 
         return;
@@ -459,9 +465,11 @@ export function resourcesFromLink(props: Props): boolean {
         if (__DEV__) {
           validateLinkPropsForStyleResource(props);
         }
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         let preloadResource = currentResources.preloadsMap.get(href);
         if (!preloadResource) {
           preloadResource = createPreloadResource(
+            // $FlowFixMe[incompatible-call] found when upgrading Flow
             currentResources,
             href,
             'style',
@@ -472,6 +480,7 @@ export function resourcesFromLink(props: Props): boolean {
           }
         }
         captureImplicitPreloadResourceDependency(
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           currentResources,
           preloadResource,
         );
@@ -492,6 +501,7 @@ export function resourcesFromLink(props: Props): boolean {
         } else {
           const resourceProps = stylePropsFromRawProps(href, precedence, props);
           resource = createStyleResource(
+            // $FlowFixMe[incompatible-call] found when upgrading Flow
             currentResources,
             href,
             precedence,
@@ -499,7 +509,9 @@ export function resourcesFromLink(props: Props): boolean {
           );
         }
         captureStyleResourceDependency(
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           currentResources,
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentResources.boundaryResources,
           resource,
         );
@@ -519,6 +531,7 @@ export function resourcesFromLink(props: Props): boolean {
           if (__DEV__) {
             validateLinkPropsForPreloadResource(props);
           }
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           let resource = currentResources.preloadsMap.get(href);
           if (resource) {
             if (__DEV__) {
@@ -534,12 +547,14 @@ export function resourcesFromLink(props: Props): boolean {
             }
           } else {
             resource = createPreloadResource(
+              // $FlowFixMe[incompatible-call] found when upgrading Flow
               currentResources,
               href,
               as,
               preloadPropsFromRawProps(href, as, props),
             );
           }
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           captureExplicitPreloadResourceDependency(currentResources, resource);
           return true;
         }

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -121,6 +121,7 @@ export function access(path: string, mode?: number): void {
     record = createRecordFromThenable(thenable);
     accessCache.push(mode, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   readRecord(record); // No return value.
 }
 
@@ -154,6 +155,7 @@ export function lstat(path: string, options?: {bigint?: boolean}): mixed {
     record = createRecordFromThenable(thenable);
     lstatCache.push(bigint, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const stats = readRecord(record).value;
   return stats;
 }
@@ -203,6 +205,7 @@ export function readdir(
     record = createRecordFromThenable(thenable);
     readdirCache.push(encoding, withFileTypes, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const files = readRecord(record).value;
   return files;
 }
@@ -301,6 +304,7 @@ export function readlink(
     record = createRecordFromThenable(thenable);
     readlinkCache.push(encoding, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const linkString = readRecord(record).value;
   return linkString;
 }
@@ -342,6 +346,7 @@ export function realpath(
     record = createRecordFromThenable(thenable);
     realpathCache.push(encoding, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const resolvedPath = readRecord(record).value;
   return resolvedPath;
 }
@@ -376,6 +381,7 @@ export function stat(path: string, options?: {bigint?: boolean}): mixed {
     record = createRecordFromThenable(thenable);
     statCache.push(bigint, record);
   }
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   const stats = readRecord(record).value;
   return stats;
 }

--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -98,6 +98,7 @@ function restoreDeletedValuesInNestedArray(
             : nextProp;
         updatePayload[propKey] = nextValue;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       removedKeys[propKey] = false;
       removedKeyCount--;
     }
@@ -356,7 +357,8 @@ function diffProperties(
       if (shouldUpdate) {
         const nextValue =
           typeof attributeConfig.process === 'function'
-            ? attributeConfig.process(nextProp)
+            ? // $FlowFixMe[incompatible-use] found when upgrading Flow
+              attributeConfig.process(nextProp)
             : nextProp;
         (updatePayload || (updatePayload = {}))[propKey] = nextValue;
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -350,6 +350,7 @@ function commitBeforeMutationEffects_begin() {
     // Let's skip the whole loop if it's off.
     if (enableCreateEventHandleAPI) {
       // TODO: Should wrap this in flags check, too, as optimization
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const deletions = fiber.deletions;
       if (deletions !== null) {
         for (let i = 0; i < deletions.length; i++) {
@@ -359,8 +360,10 @@ function commitBeforeMutationEffects_begin() {
       }
     }
 
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const child = fiber.child;
     if (
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       (fiber.subtreeFlags & BeforeMutationMask) !== NoFlags &&
       child !== null
     ) {
@@ -405,6 +408,7 @@ function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
       if (
         finishedWork.tag === SuspenseComponent &&
         isSuspenseBoundaryBeingHidden(current, finishedWork) &&
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         doesFiberContain(finishedWork, focusedInstanceHandle)
       ) {
         shouldFireAfterActiveInstanceBlur = true;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -350,6 +350,7 @@ function commitBeforeMutationEffects_begin() {
     // Let's skip the whole loop if it's off.
     if (enableCreateEventHandleAPI) {
       // TODO: Should wrap this in flags check, too, as optimization
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const deletions = fiber.deletions;
       if (deletions !== null) {
         for (let i = 0; i < deletions.length; i++) {
@@ -359,8 +360,10 @@ function commitBeforeMutationEffects_begin() {
       }
     }
 
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const child = fiber.child;
     if (
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       (fiber.subtreeFlags & BeforeMutationMask) !== NoFlags &&
       child !== null
     ) {
@@ -405,6 +408,7 @@ function commitBeforeMutationEffectsOnFiber(finishedWork: Fiber) {
       if (
         finishedWork.tag === SuspenseComponent &&
         isSuspenseBoundaryBeingHidden(current, finishedWork) &&
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         doesFiberContain(finishedWork, focusedInstanceHandle)
       ) {
         shouldFireAfterActiveInstanceBlur = true;

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -191,6 +191,7 @@ export function isCompatibleFamilyForHotReloading(
       // then we would risk falsely saying two separate memo(Foo)
       // calls are equivalent because they wrap the same Foo function.
       const prevFamily = resolveFamily(prevType);
+      // $FlowFixMe[not-a-function] found when upgrading Flow
       if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
         return true;
       }

--- a/packages/react-reconciler/src/ReactFiberHotReloading.old.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.old.js
@@ -191,6 +191,7 @@ export function isCompatibleFamilyForHotReloading(
       // then we would risk falsely saying two separate memo(Foo)
       // calls are equivalent because they wrap the same Foo function.
       const prevFamily = resolveFamily(prevType);
+      // $FlowFixMe[not-a-function] found when upgrading Flow
       if (prevFamily !== undefined && prevFamily === resolveFamily(nextType)) {
         return true;
       }

--- a/packages/react-reconciler/src/ReactFiberSyncTaskQueue.new.js
+++ b/packages/react-reconciler/src/ReactFiberSyncTaskQueue.new.js
@@ -60,7 +60,9 @@ export function flushSyncCallbacks(): null {
       // TODO: Is this necessary anymore? The only user code that runs in this
       // queue is in the render or commit phases.
       setCurrentUpdatePriority(DiscreteEventPriority);
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       for (; i < queue.length; i++) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         let callback = queue[i];
         do {
           callback = callback(isSync);

--- a/packages/react-reconciler/src/ReactFiberSyncTaskQueue.old.js
+++ b/packages/react-reconciler/src/ReactFiberSyncTaskQueue.old.js
@@ -60,7 +60,9 @@ export function flushSyncCallbacks(): null {
       // TODO: Is this necessary anymore? The only user code that runs in this
       // queue is in the render or commit phases.
       setCurrentUpdatePriority(DiscreteEventPriority);
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       for (; i < queue.length; i++) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         let callback = queue[i];
         do {
           callback = callback(isSync);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -415,6 +415,7 @@ export function addMarkerProgressCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerProgress === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerProgress = new Map();
     }
 
@@ -443,6 +444,7 @@ export function addMarkerIncompleteCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerIncomplete === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerIncomplete = new Map();
     }
 
@@ -470,6 +472,7 @@ export function addMarkerCompleteCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerComplete === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerComplete = new Map();
     }
 
@@ -497,6 +500,7 @@ export function addTransitionProgressCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.transitionProgress === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.transitionProgress = new Map();
     }
 
@@ -1670,7 +1674,8 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   if (workInProgress !== null) {
     let interruptedWork = workInProgressIsSuspended
       ? workInProgress
-      : workInProgress.return;
+      : // $FlowFixMe[incompatible-use] found when upgrading Flow
+        workInProgress.return;
     while (interruptedWork !== null) {
       const current = interruptedWork.alternate;
       unwindInterruptedWork(
@@ -3052,10 +3057,12 @@ export function attachPingListener(
       pingCache.set(wakeable, threadIDs);
     }
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   if (!threadIDs.has(lanes)) {
     workInProgressRootDidAttachPingListener = true;
 
     // Memoize using the thread ID to prevent redundant listeners.
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     threadIDs.add(lanes);
     const ping = pingSuspendedRoot.bind(null, root, wakeable, lanes);
     if (enableUpdaterTracking) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -415,6 +415,7 @@ export function addMarkerProgressCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerProgress === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerProgress = new Map();
     }
 
@@ -443,6 +444,7 @@ export function addMarkerIncompleteCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerIncomplete === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerIncomplete = new Map();
     }
 
@@ -470,6 +472,7 @@ export function addMarkerCompleteCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.markerComplete === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.markerComplete = new Map();
     }
 
@@ -497,6 +500,7 @@ export function addTransitionProgressCallbackToPendingTransition(
     }
 
     if (currentPendingTransitionCallbacks.transitionProgress === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPendingTransitionCallbacks.transitionProgress = new Map();
     }
 
@@ -1670,7 +1674,8 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   if (workInProgress !== null) {
     let interruptedWork = workInProgressIsSuspended
       ? workInProgress
-      : workInProgress.return;
+      : // $FlowFixMe[incompatible-use] found when upgrading Flow
+        workInProgress.return;
     while (interruptedWork !== null) {
       const current = interruptedWork.alternate;
       unwindInterruptedWork(
@@ -3052,10 +3057,12 @@ export function attachPingListener(
       pingCache.set(wakeable, threadIDs);
     }
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   if (!threadIDs.has(lanes)) {
     workInProgressRootDidAttachPingListener = true;
 
     // Memoize using the thread ID to prevent redundant listeners.
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     threadIDs.add(lanes);
     const ping = pingSuspendedRoot.bind(null, root, wakeable, lanes);
     if (enableUpdaterTracking) {

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -159,7 +159,9 @@ export default class ReactFlightWebpackPlugin {
             clientFileNameFound = true;
 
             if (resolvedClientReferences) {
+              // $FlowFixMe[incompatible-use] found when upgrading Flow
               for (let i = 0; i < resolvedClientReferences.length; i++) {
+                // $FlowFixMe[incompatible-use] found when upgrading Flow
                 const dep = resolvedClientReferences[i];
 
                 const chunkName = _this.chunkName

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -182,6 +182,7 @@ function createWorkInProgressHook(): Hook {
     if (workInProgressHook.next === null) {
       isReRender = false;
       // Append to the end of the list
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       workInProgressHook = workInProgressHook.next = createHook();
     } else {
       // There's already a work-in-progress. Reuse it.
@@ -339,7 +340,9 @@ export function useReducer<S, I, A>(
       // Render phase updates are stored in a map of queue -> linked list
       const firstRenderPhaseUpdate = renderPhaseUpdates.get(queue);
       if (firstRenderPhaseUpdate !== undefined) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         renderPhaseUpdates.delete(queue);
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         let newState = workInProgressHook.memoizedState;
         let update = firstRenderPhaseUpdate;
         do {
@@ -357,11 +360,13 @@ export function useReducer<S, I, A>(
           update = update.next;
         } while (update !== null);
 
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         workInProgressHook.memoizedState = newState;
 
         return [newState, dispatch];
       }
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     return [workInProgressHook.memoizedState, dispatch];
   } else {
     if (__DEV__) {
@@ -381,7 +386,9 @@ export function useReducer<S, I, A>(
     if (__DEV__) {
       isInHookUserCodeInDev = false;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     workInProgressHook.memoizedState = initialState;
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const queue: UpdateQueue<A> = (workInProgressHook.queue = {
       last: null,
       dispatch: null,
@@ -391,6 +398,7 @@ export function useReducer<S, I, A>(
       currentlyRenderingComponent,
       queue,
     ): any));
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     return [workInProgressHook.memoizedState, dispatch];
   }
 }
@@ -420,6 +428,7 @@ function useMemo<T>(nextCreate: () => T, deps: Array<mixed> | void | null): T {
   if (__DEV__) {
     isInHookUserCodeInDev = false;
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   workInProgressHook.memoizedState = [nextValue, nextDeps];
   return nextValue;
 }
@@ -483,6 +492,7 @@ function dispatchAction<A>(
     }
     const firstRenderPhaseUpdate = renderPhaseUpdates.get(queue);
     if (firstRenderPhaseUpdate === undefined) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       renderPhaseUpdates.set(queue, update);
     } else {
       // Append the update to the end of the list.

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -83,6 +83,7 @@ export const Dispatcher: DispatcherType = {
     if (entry === undefined) {
       entry = resourceType();
       // TODO: Warn if undefined?
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentCache.set(resourceType, entry);
     }
     return entry;

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -73,6 +73,7 @@ function writeStringChunk(destination: Destination, stringChunk: string) {
   if (read < stringChunk.length) {
     writeToDestination(destination, (currentView: any));
     currentView = new Uint8Array(VIEW_SIZE);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     writtenBytes = textEncoder.encodeInto(stringChunk.slice(read), currentView)
       .written;
   }

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -593,6 +593,7 @@ function create(
         } else {
           // However, we give you the root if there's more than one root child.
           // We could make this the behavior for all cases but it would be a breaking change.
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           return wrapFiber(root.current);
         }
       },

--- a/packages/react/src/ReactStartTransition.js
+++ b/packages/react/src/ReactStartTransition.js
@@ -20,6 +20,7 @@ export function startTransition(
   const currentTransition = ReactCurrentBatchConfig.transition;
 
   if (__DEV__) {
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     ReactCurrentBatchConfig.transition._updatedFibers = new Set();
   }
 

--- a/packages/scheduler/src/SchedulerProfiling.js
+++ b/packages/scheduler/src/SchedulerProfiling.js
@@ -47,6 +47,7 @@ function logEvent(entries) {
         return;
       }
       const newEventLog = new Int32Array(eventLogSize * 4);
+      // $FlowFixMe[incompatible-call] found when upgrading Flow
       newEventLog.set(eventLog);
       eventLogBuffer = newEventLog.buffer;
       eventLog = newEventLog;

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -183,7 +183,9 @@ function flushWork(hasTimeRemaining, initialTime) {
       } catch (error) {
         if (currentTask !== null) {
           const currentTime = getCurrentTime();
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskErrored(currentTask, currentTime);
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentTask.isQueued = false;
         }
         throw error;
@@ -218,12 +220,17 @@ function workLoop(hasTimeRemaining, initialTime) {
       // This currentTask hasn't expired, and we've reached the deadline.
       break;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const callback = currentTask.callback;
     if (typeof callback === 'function') {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentTask.callback = null;
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPriorityLevel = currentTask.priorityLevel;
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
       if (enableProfiling) {
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         markTaskRun(currentTask, currentTime);
       }
       const continuationCallback = callback(didUserCallbackTimeout);
@@ -231,15 +238,19 @@ function workLoop(hasTimeRemaining, initialTime) {
       if (typeof continuationCallback === 'function') {
         // If a continuation is returned, immediately yield to the main thread
         // regardless of how much time is left in the current time slice.
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentTask.callback = continuationCallback;
         if (enableProfiling) {
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskYield(currentTask, currentTime);
         }
         advanceTimers(currentTime);
         return true;
       } else {
         if (enableProfiling) {
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskCompleted(currentTask, currentTime);
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentTask.isQueued = false;
         }
         if (currentTask === peek(taskQueue)) {
@@ -564,6 +575,7 @@ const performWorkUntilDeadline = () => {
     // `hasMoreWork` will remain true, and we'll continue the work loop.
     let hasMoreWork = true;
     try {
+      // $FlowFixMe[not-a-function] found when upgrading Flow
       hasMoreWork = scheduledHostCallback(hasTimeRemaining, currentTime);
     } finally {
       if (hasMoreWork) {

--- a/packages/scheduler/src/forks/SchedulerMock.js
+++ b/packages/scheduler/src/forks/SchedulerMock.js
@@ -169,7 +169,9 @@ function flushWork(hasTimeRemaining: boolean, initialTime: number) {
       } catch (error) {
         if (currentTask !== null) {
           const currentTime = getCurrentTime();
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskErrored(currentTask, currentTime);
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentTask.isQueued = false;
         }
         throw error;
@@ -204,12 +206,17 @@ function workLoop(hasTimeRemaining, initialTime: number): boolean {
       // This currentTask hasn't expired, and we've reached the deadline.
       break;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const callback = currentTask.callback;
     if (typeof callback === 'function') {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentTask.callback = null;
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       currentPriorityLevel = currentTask.priorityLevel;
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       const didUserCallbackTimeout = currentTask.expirationTime <= currentTime;
       if (enableProfiling) {
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         markTaskRun(currentTask, currentTime);
       }
       const continuationCallback = callback(didUserCallbackTimeout);
@@ -217,8 +224,10 @@ function workLoop(hasTimeRemaining, initialTime: number): boolean {
       if (typeof continuationCallback === 'function') {
         // If a continuation is returned, immediately yield to the main thread
         // regardless of how much time is left in the current time slice.
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         currentTask.callback = continuationCallback;
         if (enableProfiling) {
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskYield(currentTask, currentTime);
         }
         advanceTimers(currentTime);
@@ -233,7 +242,9 @@ function workLoop(hasTimeRemaining, initialTime: number): boolean {
         }
       } else {
         if (enableProfiling) {
+          // $FlowFixMe[incompatible-call] found when upgrading Flow
           markTaskCompleted(currentTask, currentTime);
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentTask.isQueued = false;
         }
         if (currentTask === peek(taskQueue)) {
@@ -509,6 +520,7 @@ function unstable_flushNumberOfYields(count: number): void {
     try {
       let hasMoreWork = true;
       do {
+        // $FlowFixMe[not-a-function] found when upgrading Flow
         hasMoreWork = cb(true, currentMockTime);
       } while (hasMoreWork && !didStop);
       if (!hasMoreWork) {
@@ -534,6 +546,7 @@ function unstable_flushUntilNextPaint(): false {
     try {
       let hasMoreWork = true;
       do {
+        // $FlowFixMe[not-a-function] found when upgrading Flow
         hasMoreWork = cb(true, currentMockTime);
       } while (hasMoreWork && !didStop);
       if (!hasMoreWork) {
@@ -580,6 +593,7 @@ function unstable_flushAllWithoutAsserting(): boolean {
     try {
       let hasMoreWork = true;
       do {
+        // $FlowFixMe[not-a-function] found when upgrading Flow
         hasMoreWork = cb(true, currentMockTime);
       } while (hasMoreWork);
       if (!hasMoreWork) {

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -50,4 +50,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.145.0
+^0.146.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7911,10 +7911,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.145.0:
-  version "0.145.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.145.0.tgz#922f7c3568caaa5eb64621ec536deb56b24d1795"
-  integrity sha512-+9fi9BMxRBtSWC1x0hWggWTb8Vih+AC7wyvLAX5wR1m6u2lF2HLtixXqy2GX8bWgaynSEJR5lmPxYYC4wMI8cA==
+flow-bin@^0.146.0:
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.146.0.tgz#fafa002663a0e13bf3c08c3972dd93d68289ccc6"
+  integrity sha512-TP8eCwltqc7fo6ad5klgsrZ2veZIK2qM1vHf1A/cnXTStPh8hLAz1cOXmlQIFZR/7fjSMI39TS3CgF6M/HUhAw==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #25410
* #25409
* #25408

This upgrade made more expressions invalidate refinements. In some
places this lead to a large number of suppressions that I automatically
suppressed and should be followed up on when the code is touched.
I think most of them might require either manual annotations or moving
a value into a const to allow refinement.