### PR TITLE
Flow upgrade to 0.153

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.152.0",
+    "flow-bin": "^0.153.0",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/jest-react/src/internalAct.js
+++ b/packages/jest-react/src/internalAct.js
@@ -72,6 +72,7 @@ export function act<T>(scope: () => Thenable<T> | T): Thenable<T> {
     if (
       typeof result === 'object' &&
       result !== null &&
+      // $FlowFixMe[method-unbinding]
       typeof result.then === 'function'
     ) {
       const thenableResult: Thenable<T> = (result: any);

--- a/packages/react-cache/src/ReactCacheOld.js
+++ b/packages/react-cache/src/ReactCacheOld.js
@@ -13,7 +13,9 @@ import * as React from 'react';
 
 import {createLRU} from './LRU';
 
-type Suspender = {then(resolve: () => mixed, reject: () => mixed): mixed, ...};
+interface Suspender {
+  then(resolve: () => mixed, reject: () => mixed): mixed;
+}
 
 type PendingResult = {
   status: 0,
@@ -120,6 +122,7 @@ function accessResult<I, K, V>(
     );
     const newResult: PendingResult = {
       status: Pending,
+      // $FlowFixMe[method-unbinding]
       value: thenable,
     };
     // $FlowFixMe[escaped-generic] discovered when updating Flow

--- a/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
+++ b/packages/react-devtools-shared/src/PerformanceLoggingUtils.js
@@ -11,10 +11,13 @@ import {__PERFORMANCE_PROFILE__} from './constants';
 
 const supportsUserTiming =
   typeof performance !== 'undefined' &&
+  // $FlowFixMe[method-unbinding]
   typeof performance.mark === 'function' &&
+  // $FlowFixMe[method-unbinding]
   typeof performance.clearMarks === 'function';
 
 const supportsPerformanceNow =
+  // $FlowFixMe[method-unbinding]
   typeof performance !== 'undefined' && typeof performance.now === 'function';
 
 function mark(markName: string): void {

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -44,7 +44,9 @@ let performanceTarget: Performance | null = null;
 // If performance exists and supports the subset of the User Timing API that we require.
 let supportsUserTiming =
   typeof performance !== 'undefined' &&
+  // $FlowFixMe[method-unbinding]
   typeof performance.mark === 'function' &&
+  // $FlowFixMe[method-unbinding]
   typeof performance.clearMarks === 'function';
 
 let supportsUserTimingV3 = false;
@@ -76,6 +78,7 @@ if (supportsUserTimingV3) {
 
 // Some environments (e.g. React Native / Hermes) don't support the performance API yet.
 const getCurrentTime =
+  // $FlowFixMe[method-unbinding]
   typeof performance === 'object' && typeof performance.now === 'function'
     ? () => performance.now()
     : () => Date.now();

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -151,6 +151,7 @@ function getFiberFlags(fiber: Fiber): number {
 
 // Some environments (e.g. React Native / Hermes) don't support the performance API yet.
 const getCurrentTime =
+  // $FlowFixMe[method-unbinding]
   typeof performance === 'object' && typeof performance.now === 'function'
     ? () => performance.now()
     : () => Date.now();

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/index.js
@@ -115,6 +115,7 @@ export default function setupHighlighter(
 
     if (nodes != null && nodes[0] != null) {
       const node = nodes[0];
+      // $FlowFixMe[method-unbinding]
       if (scrollIntoView && typeof node.scrollIntoView === 'function') {
         // If the node isn't visible show it before highlighting it.
         // We may want to reconsider this; it might be a little disruptive.

--- a/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
+++ b/packages/react-devtools-shared/src/backend/views/TraceUpdates/index.js
@@ -26,6 +26,7 @@ const REMEASUREMENT_AFTER_DURATION = 250;
 
 // Some environments (e.g. React Native / Hermes) don't support the performance API yet.
 const getCurrentTime =
+  // $FlowFixMe[method-unbinding]
   typeof performance === 'object' && typeof performance.now === 'function'
     ? () => performance.now()
     : () => Date.now();

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -7,15 +7,14 @@
  * @flow
  */
 
-export type Rect = {
-  bottom: number,
-  height: number,
-  left: number,
-  right: number,
-  top: number,
-  width: number,
-  ...
-};
+export interface Rect {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}
 
 // Get the window object for the document that a node belongs to,
 // or return null if it cannot be found (node not attached to DOM,

--- a/packages/react-devtools-shared/src/devtools/cache.js
+++ b/packages/react-devtools-shared/src/devtools/cache.js
@@ -26,7 +26,9 @@ import {createContext} from 'react';
 
 export type {Thenable};
 
-type Suspender = {then(resolve: () => mixed, reject: () => mixed): mixed, ...};
+interface Suspender {
+  then(resolve: () => mixed, reject: () => mixed): mixed;
+}
 
 type PendingResult = {
   status: 0,
@@ -124,6 +126,7 @@ function accessResult<Input, Key, Value>(
     );
     const newResult: PendingResult = {
       status: Pending,
+      // $FlowFixMe[method-unbinding]
       value: thenable,
     };
     entriesForResource.set(key, newResult);

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -33,6 +33,7 @@ import type {Element} from 'react-devtools-shared/src/devtools/views/Components/
 import type {Element as ReactElement} from 'react';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 
+// $FlowFixMe[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 type Type = 'props' | 'state' | 'context' | 'hooks';

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarSelectedFiberInfo.js
@@ -67,6 +67,7 @@ export default function SidebarSelectedFiberInfo(_: Props): React.Node {
     const selectedElement = selectedListItemRef.current;
     if (
       selectedElement !== null &&
+      // $FlowFixMe[method-unbinding]
       typeof selectedElement.scrollIntoView === 'function'
     ) {
       selectedElement.scrollIntoView({block: 'nearest', inline: 'nearest'});

--- a/packages/react-devtools-shared/src/devtools/views/utils.js
+++ b/packages/react-devtools-shared/src/devtools/views/utils.js
@@ -14,6 +14,7 @@ import isArray from 'react-devtools-shared/src/isArray';
 
 import type {HooksTree} from 'react-debug-tools/src/ReactDebugHooks';
 
+// $FlowFixMe[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export function alphaSortEntries(

--- a/packages/react-devtools-shared/src/hook.js
+++ b/packages/react-devtools-shared/src/hook.js
@@ -61,6 +61,7 @@ export function installHook(target: any): DevToolsHook | null {
         // it happens *outside* of the renderer injection. See `checkDCE` below.
       }
 
+      // $FlowFixMe[method-unbinding]
       const toString = Function.prototype.toString;
       if (renderer.Mount && renderer.Mount._renderNewRootComponent) {
         // React DOM Stack
@@ -147,6 +148,7 @@ export function installHook(target: any): DevToolsHook | null {
     // This runs for production versions of React.
     // Needs to be super safe.
     try {
+      // $FlowFixMe[method-unbinding]
       const toString = Function.prototype.toString;
       const code = toString.call(fn);
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -56,6 +56,7 @@ import isArray from './isArray';
 import type {ComponentFilter, ElementType} from './types';
 import type {LRUCache} from 'react-devtools-shared/src/types';
 
+// $FlowFixMe[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const cachedDisplayNames: WeakMap<Function, string> = new WeakMap();
@@ -598,6 +599,7 @@ export function getDataType(data: Object): DataType {
       } else if (data.constructor && data.constructor.name === 'RegExp') {
         return 'regexp';
       } else {
+        // $FlowFixMe[method-unbinding]
         const toStringValue = Object.prototype.toString.call(data);
         if (toStringValue === '[object Date]') {
           return 'date';
@@ -612,6 +614,7 @@ export function getDataType(data: Object): DataType {
       return 'symbol';
     case 'undefined':
       if (
+        // $FlowFixMe[method-unbinding]
         Object.prototype.toString.call(data) === '[object HTMLAllCollection]'
       ) {
         return 'html_all_collection';

--- a/packages/react-devtools-timeline/src/import-worker/preprocessData.js
+++ b/packages/react-devtools-timeline/src/import-worker/preprocessData.js
@@ -968,8 +968,11 @@ function preprocessFlamechart(rawData: TimelineEvent[]): Flamechart {
   const profile = parsedData.profiles[0]; // TODO: Choose the main CPU thread only
 
   const speedscopeFlamechart = new SpeedscopeFlamechart({
+    // $FlowFixMe[method-unbinding]
     getTotalWeight: profile.getTotalWeight.bind(profile),
+    // $FlowFixMe[method-unbinding]
     forEachCall: profile.forEachCall.bind(profile),
+    // $FlowFixMe[method-unbinding]
     formatValue: profile.formatValue.bind(profile),
     getColorBucketForFrame: () => 0,
   });

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -455,6 +455,7 @@ export function createElement(
     if (namespaceURI === HTML_NAMESPACE) {
       if (
         !isCustomComponentTag &&
+        // $FlowFixMe[method-unbinding]
         Object.prototype.toString.call(domElement) ===
           '[object HTMLUnknownElement]' &&
         !hasOwnProperty.call(warnedUnknownTags, type)

--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -61,14 +61,17 @@ export function precacheFiberNode(
 }
 
 export function markContainerAsRoot(hostRoot: Fiber, node: Container): void {
+  // $FlowFixMe[prop-missing]
   node[internalContainerInstanceKey] = hostRoot;
 }
 
 export function unmarkContainerAsRoot(node: Container): void {
+  // $FlowFixMe[prop-missing]
   node[internalContainerInstanceKey] = null;
 }
 
 export function isContainerMarkedAsRoot(node: Container): boolean {
+  // $FlowFixMe[prop-missing]
   return !!node[internalContainerInstanceKey];
 }
 
@@ -132,6 +135,7 @@ export function getClosestInstanceFromNode(targetNode: Node): null | Fiber {
           // have had an internalInstanceKey on it.
           // Let's get the fiber associated with the SuspenseComponent
           // as the deepest instance.
+          // $FlowFixMe[prop-missing]
           const targetSuspenseInst = suspenseInstance[internalInstanceKey];
           if (targetSuspenseInst) {
             return targetSuspenseInst;

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -117,12 +117,14 @@ export type EventTargetChildElement = {
   ...
 };
 export type Container =
-  | (Element & {_reactRootContainer?: FiberRoot, ...})
-  | (Document & {_reactRootContainer?: FiberRoot, ...})
-  | (DocumentFragment & {_reactRootContainer?: FiberRoot, ...});
+  | interface extends Element {_reactRootContainer?: FiberRoot}
+  | interface extends Document {_reactRootContainer?: FiberRoot}
+  | interface extends DocumentFragment {_reactRootContainer?: FiberRoot};
 export type Instance = Element;
 export type TextInstance = Text;
-export type SuspenseInstance = Comment & {_reactRetry?: () => void, ...};
+export interface SuspenseInstance extends Comment {
+  _reactRetry?: () => void;
+}
 export type HydratableInstance = Instance | TextInstance | SuspenseInstance;
 export type PublicInstance = Element | Text;
 type HostContextDev = {
@@ -644,6 +646,7 @@ export function hideInstance(instance: Instance): void {
   // pass host context to this method?
   instance = ((instance: any): HTMLElement);
   const style = instance.style;
+  // $FlowFixMe[method-unbinding]
   if (typeof style.setProperty === 'function') {
     style.setProperty('display', 'none', 'important');
   } else {
@@ -679,6 +682,7 @@ export function clearContainer(container: Container): void {
     ((container: any): Element).textContent = '';
   } else if (container.nodeType === DOCUMENT_NODE) {
     if (container.documentElement) {
+      // $FlowFixMe[incompatible-call]
       container.removeChild(container.documentElement);
     }
   }
@@ -1267,6 +1271,7 @@ export function setFocusIfFocusable(node: Instance): boolean {
   const element = ((node: any): HTMLElement);
   try {
     element.addEventListener('focus', handleFocus);
+    // $FlowFixMe[method-unbinding]
     (element.focus || HTMLElement.prototype.focus).call(element);
   } finally {
     element.removeEventListener('focus', handleFocus);
@@ -1349,11 +1354,13 @@ export const supportsResources = true;
 export {isHostResourceType};
 function isHostResourceInstance(instance: Instance | Container): boolean {
   if (instance.nodeType === ELEMENT_NODE) {
+    // $FlowFixMe[prop-missing] Flow doesn't understand `nodeType` test.
     switch (instance.tagName.toLowerCase()) {
       case 'link': {
         const rel = ((instance: any): HTMLLinkElement).rel;
         return (
           rel === 'preload' ||
+          // $FlowFixMe[prop-missing] Flow doesn't understand `nodeType` test.
           (rel === 'stylesheet' && instance.hasAttribute('data-rprec'))
         );
       }

--- a/packages/react-dom-bindings/src/client/ReactDOMSelect.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMSelect.js
@@ -73,11 +73,7 @@ function updateOptions(
   propValue: any,
   setDefaultSelected: boolean,
 ) {
-  type IndexableHTMLOptionsCollection = HTMLOptionsCollection & {
-    [key: number]: HTMLOptionElement,
-    ...,
-  };
-  const options: IndexableHTMLOptionsCollection = node.options;
+  const options: HTMLOptionsCollection = node.options;
 
   if (multiple) {
     const selectedValues = (propValue: Array<string>);

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -14,8 +14,9 @@ type ValueTracker = {
   setValue(value: string): void,
   stopTracking(): void,
 };
-type WrapperState = {_valueTracker?: ?ValueTracker, ...};
-type ElementWithValueTracker = HTMLInputElement & WrapperState;
+interface ElementWithValueTracker extends HTMLInputElement {
+  _valueTracker?: ?ValueTracker;
+}
 
 function isCheckable(elem: HTMLInputElement) {
   const type = elem.type;

--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -761,7 +761,7 @@ export function accumulateSinglePhaseListeners(
     // current instance fiber. In which case, we should clear all existing
     // listeners.
     if (enableCreateEventHandleAPI && nativeEvent.type === 'beforeblur') {
-      // $FlowFixMe: internal field
+      // $FlowFixMe[prop-missing] internal field
       const detachedInterceptFiber = nativeEvent._detachedInterceptFiber;
       if (
         detachedInterceptFiber !== null &&

--- a/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMLegacyServerStreamConfig.js
@@ -7,11 +7,10 @@
  * @flow
  */
 
-export type Destination = {
-  push(chunk: string | null): boolean,
-  destroy(error: Error): mixed,
-  ...
-};
+export interface Destination {
+  push(chunk: string | null): boolean;
+  destroy(error: Error): mixed;
+}
 
 export type PrecomputedChunk = string;
 export type Chunk = string;

--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -145,6 +145,7 @@ function legacyCreateRootFromDOMContainer(
 
     const rootContainerElement =
       container.nodeType === COMMENT_NODE ? container.parentNode : container;
+    // $FlowFixMe[incompatible-call]
     listenToAllSupportedEvents(rootContainerElement);
 
     flushSync();
@@ -179,6 +180,7 @@ function legacyCreateRootFromDOMContainer(
 
     const rootContainerElement =
       container.nodeType === COMMENT_NODE ? container.parentNode : container;
+    // $FlowFixMe[incompatible-call]
     listenToAllSupportedEvents(rootContainerElement);
 
     // Initial mount should not be batched.
@@ -435,6 +437,8 @@ export function unmountComponentAtNode(container: Container): boolean {
       const isContainerReactRoot =
         container.nodeType === ELEMENT_NODE &&
         isValidContainerLegacy(container.parentNode) &&
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[incompatible-use]
         !!container.parentNode._reactRootContainer;
 
       if (hasNonRootReactChild) {

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -115,6 +115,7 @@ export function dispatchEvent(
     // Note that extracted events are *not* emitted,
     // only events that have a 1:1 mapping with a native event, at least for now.
     const event = {eventName: topLevelType, nativeEvent};
+    // $FlowFixMe[class-object-subtyping] found when upgrading Flow
     RawEventEmitter.emit(topLevelType, event);
     RawEventEmitter.emit('*', event);
 

--- a/packages/react-native-renderer/src/ReactFabricHostConfig.js
+++ b/packages/react-native-renderer/src/ReactFabricHostConfig.js
@@ -316,6 +316,7 @@ class ReactFabricHostComponent {
 }
 
 // eslint-disable-next-line no-unused-expressions
+// $FlowFixMe[class-object-subtyping] found when upgrading Flow
 (ReactFabricHostComponent.prototype: $ReadOnly<{...NativeMethods, ...}>);
 
 export * from 'react-reconciler/src/ReactFiberHostConfigWithNoMutation';

--- a/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberHostComponent.js
@@ -127,6 +127,7 @@ class ReactNativeFiberHostComponent {
 }
 
 // eslint-disable-next-line no-unused-expressions
+// $FlowFixMe[class-object-subtyping] found when upgrading Flow
 (ReactNativeFiberHostComponent.prototype: $ReadOnly<{...NativeMethods, ...}>);
 
 export default ReactNativeFiberHostComponent;

--- a/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
+++ b/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
@@ -219,6 +219,7 @@ export function injectEventPluginOrder(
   }
 
   // Clone the ordering so it cannot be dynamically mutated.
+  // $FlowFixMe[method-unbinding] found when upgrading Flow
   eventPluginOrder = Array.prototype.slice.call(injectedEventPluginOrder);
   recomputePluginOrdering();
 }

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -228,6 +228,7 @@ function coerceRef(
 }
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
+  // $FlowFixMe[method-unbinding]
   const childString = Object.prototype.toString.call(newChild);
 
   throw new Error(

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -228,6 +228,7 @@ function coerceRef(
 }
 
 function throwOnInvalidObjectType(returnFiber: Fiber, newChild: Object) {
+  // $FlowFixMe[method-unbinding]
   const childString = Object.prototype.toString.call(newChild);
 
   throw new Error(

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2336,6 +2336,7 @@ function getRetryCache(finishedWork) {
       const instance: OffscreenInstance = finishedWork.stateNode;
       let retryCache = instance._retryCache;
       if (retryCache === null) {
+        // $FlowFixMe[incompatible-type]
         retryCache = instance._retryCache = new PossiblyWeakSet();
       }
       return retryCache;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2336,6 +2336,7 @@ function getRetryCache(finishedWork) {
       const instance: OffscreenInstance = finishedWork.stateNode;
       let retryCache = instance._retryCache;
       if (retryCache === null) {
+        // $FlowFixMe[incompatible-type]
         retryCache = instance._retryCache = new PossiblyWeakSet();
       }
       return retryCache;

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -768,6 +768,8 @@ if (enableUseMemoCacheHook) {
 
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
+    // $FlowFixMe[method-unbinding]
+    // $FlowFixMe[prop-missing]
     if (typeof usable.then === 'function') {
       // This is a thenable.
       const thenable: Thenable<T> = (usable: any);

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -768,6 +768,8 @@ if (enableUseMemoCacheHook) {
 
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
+    // $FlowFixMe[method-unbinding]
+    // $FlowFixMe[prop-missing]
     if (typeof usable.then === 'function') {
       // This is a thenable.
       const thenable: Thenable<T> = (usable: any);

--- a/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
+++ b/packages/react-reconciler/src/ReactFiberOffscreenComponent.js
@@ -51,5 +51,6 @@ export type OffscreenInstance = {
   _visibility: OffscreenVisibility,
   _pendingMarkers: Set<TracingMarkerInstance> | null,
   _transitions: Set<Transition> | null,
+  // $FlowFixMe[incompatible-type-arg] found when upgrading Flow
   _retryCache: WeakSet<Wakeable> | Set<Wakeable> | null,
 };

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1213,6 +1213,7 @@ export function queueRecoverableErrors(errors: Array<CapturedValue<mixed>>) {
   if (workInProgressRootRecoverableErrors === null) {
     workInProgressRootRecoverableErrors = errors;
   } else {
+    // $FlowFixMe[method-unbinding]
     workInProgressRootRecoverableErrors.push.apply(
       workInProgressRootRecoverableErrors,
       errors,
@@ -3169,6 +3170,7 @@ export function resolveRetryWakeable(boundaryFiber: Fiber, wakeable: Wakeable) {
       break;
     case OffscreenComponent: {
       const instance: OffscreenInstance = boundaryFiber.stateNode;
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       retryCache = instance._retryCache;
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1213,6 +1213,7 @@ export function queueRecoverableErrors(errors: Array<CapturedValue<mixed>>) {
   if (workInProgressRootRecoverableErrors === null) {
     workInProgressRootRecoverableErrors = errors;
   } else {
+    // $FlowFixMe[method-unbinding]
     workInProgressRootRecoverableErrors.push.apply(
       workInProgressRootRecoverableErrors,
       errors,
@@ -3169,6 +3170,7 @@ export function resolveRetryWakeable(boundaryFiber: Fiber, wakeable: Wakeable) {
       break;
     case OffscreenComponent: {
       const instance: OffscreenInstance = boundaryFiber.stateNode;
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       retryCache = instance._retryCache;
       break;
     }

--- a/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightClientWebpackBundlerConfig.js
@@ -74,6 +74,7 @@ export function preloadModule<T>(
     if (entry === undefined) {
       const thenable = __webpack_chunk_load__(chunkId);
       promises.push(thenable);
+      // $FlowFixMe[method-unbinding]
       const resolve = chunkCache.set.bind(chunkCache, chunkId, null);
       thenable.then(resolve, ignoreReject);
       chunkCache.set(chunkId, thenable);

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -59,6 +59,7 @@ module.exports = function register() {
                 async: true,
               };
               return Promise.resolve(
+                // $FlowFixMe[incompatible-call] found when upgrading Flow
                 resolve(new Proxy(moduleReference, proxyHandlers)),
               );
             };

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -351,6 +351,7 @@ export default class ReactFlightWebpackPlugin {
         if (err) return callback(err);
         const flat = [];
         for (let i = 0; i < result.length; i++) {
+          // $FlowFixMe[method-unbinding]
           flat.push.apply(flat, result[i]);
         }
         callback(null, flat);

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -589,6 +589,8 @@ function useId(): string {
 
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
+    // $FlowFixMe[method-unbinding]
+    // $FlowFixMe[prop-missing]
     if (typeof usable.then === 'function') {
       // This is a thenable.
       const thenable: Thenable<T> = (usable: any);

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1455,6 +1455,7 @@ function renderNodeDestructiveImpl(
       }
     }
 
+    // $FlowFixMe[method-unbinding]
     const childString = Object.prototype.toString.call(node);
 
     throw new Error(

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -145,6 +145,8 @@ function useId(): string {
 
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
+    // $FlowFixMe[method-unbinding]
+    // $FlowFixMe[prop-missing]
     if (typeof usable.then === 'function') {
       // This is a thenable.
       const thenable: Thenable<T> = (usable: any);

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -435,6 +435,7 @@ function isSimpleObject(object): boolean {
 }
 
 function objectName(object): string {
+  // $FlowFixMe[method-unbinding]
   const name = Object.prototype.toString.call(object);
   return name.replace(/^\[object (.*)\]$/, function(m, p0) {
     return p0;
@@ -494,6 +495,7 @@ function describeObjectForErrorMessage(
         typeof value === 'object' &&
         value !== null
       ) {
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         str += describeObjectForErrorMessage(value);
       } else {
         str += describeValueForErrorMessage(value);
@@ -521,6 +523,7 @@ function describeObjectForErrorMessage(
         typeof value === 'object' &&
         value !== null
       ) {
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         str += describeObjectForErrorMessage(value);
       } else {
         str += describeValueForErrorMessage(value);

--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -115,6 +115,7 @@ export function stringToPrecomputedChunk(content: string): PrecomputedChunk {
 }
 
 export function closeWithError(destination: Destination, error: mixed): void {
+  // $FlowFixMe[method-unbinding]
   if (typeof destination.error === 'function') {
     // $FlowFixMe: This is an Error object or the destination accepts other types.
     destination.error(error);

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -10,10 +10,9 @@
 import type {Writable} from 'stream';
 import {TextEncoder} from 'util';
 
-type MightBeFlushable = {
-  flush?: () => void,
-  ...
-};
+interface MightBeFlushable {
+  flush?: () => void;
+}
 
 export type Destination = Writable & MightBeFlushable;
 

--- a/packages/react/src/ReactAct.js
+++ b/packages/react/src/ReactAct.js
@@ -60,6 +60,7 @@ export function act<T>(callback: () => T | Thenable<T>): Thenable<T> {
     if (
       result !== null &&
       typeof result === 'object' &&
+      // $FlowFixMe[method-unbinding]
       typeof result.then === 'function'
     ) {
       const thenableResult: Thenable<T> = (result: any);

--- a/packages/scheduler/src/forks/Scheduler.js
+++ b/packages/scheduler/src/forks/Scheduler.js
@@ -58,6 +58,7 @@ type Task = {
 
 let getCurrentTime: () => number | DOMHighResTimeStamp;
 const hasPerformanceNow =
+  // $FlowFixMe[method-unbinding]
   typeof performance === 'object' && typeof performance.now === 'function';
 
 if (hasPerformanceNow) {

--- a/packages/shared/hasOwnProperty.js
+++ b/packages/shared/hasOwnProperty.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+// $FlowFixMe[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export default hasOwnProperty;

--- a/packages/shared/invokeGuardedCallbackImpl.js
+++ b/packages/shared/invokeGuardedCallbackImpl.js
@@ -12,6 +12,7 @@ function invokeGuardedCallbackProd<Args: Array<mixed>, Context>(
   func: (...Args) => mixed,
   context: Context,
 ): void {
+  // $FlowFixMe[method-unbinding]
   const funcArgs = Array.prototype.slice.call(arguments, 3);
   try {
     // $FlowFixMe[incompatible-call] Flow doesn't understand the arguments splicing.
@@ -53,6 +54,7 @@ if (__DEV__) {
     typeof window !== 'undefined' &&
     typeof window.dispatchEvent === 'function' &&
     typeof document !== 'undefined' &&
+    // $FlowFixMe[method-unbinding]
     typeof document.createEvent === 'function'
   ) {
     const fakeNode = document.createElement('react');
@@ -122,6 +124,7 @@ if (__DEV__) {
       // Create an event handler for our fake event. We will synchronously
       // dispatch our fake event using `dispatchEvent`. Inside the handler, we
       // call the user-provided callback.
+      // $FlowFixMe[method-unbinding]
       const funcArgs = Array.prototype.slice.call(arguments, 3);
       function callCallback() {
         didCall = true;

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -47,4 +47,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.152.0
+^0.153.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7912,10 +7912,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.152.0:
-  version "0.152.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.152.0.tgz#6980d0cd58f59e9aefd580b11109a1d56eba46b1"
-  integrity sha512-b4ijbZIQovcx5l/T7VnwyBPIikj60A2qk7hKqQKVWiuftQMrUmC5ct2/0SuVvheX6ZbPdZfeyw2EHO1/n3eAmw==
+flow-bin@^0.153.0:
+  version "0.153.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.153.0.tgz#44d941acaf5ef977fa26d1b4b5dc3cf56b68eefc"
+  integrity sha512-sxP9nfXnoyCUT6hjAO+zDyHLO3dZcWg0h+4HttHs/5wg/2oAkTDwmsWbj095IQsEmwTicq2TfqWq5QRuLxynlQ==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #25414
* #25413
* __->__ #25412
* #25411

- method unbinding is no longer supported in Flow for soundness, this added a bunch of suppressions
- Flow now prevents objects to be supertypes of interfaces/classes