### PR TITLE
Flow: inference_mode=constrain_writes

### DIFF
--- a/packages/react-cache/src/LRU.js
+++ b/packages/react-cache/src/LRU.js
@@ -57,7 +57,7 @@ export function createLRU<T>(limit: number): LRU<T> {
     // Delete entries from the cache, starting from the end of the list.
     if (first !== null) {
       const resolvedFirst: Entry<T> = (first: any);
-      let last = resolvedFirst.previous;
+      let last: null | Entry<T> = resolvedFirst.previous;
       while (size > targetSize && last !== null) {
         const onDelete = last.onDelete;
         const previous = last.previous;

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -217,7 +217,7 @@ function useImperativeHandle<T>(
   // and if there is a ref callback it might not store it but if it does we
   // have no way of knowing where. So let's only enable introspection of the
   // ref itself if it is using the object form.
-  let instance = undefined;
+  let instance: ?T = undefined;
   if (ref !== null && typeof ref === 'object') {
     instance = ref.current;
   }
@@ -716,6 +716,7 @@ export function inspectHooks<Props>(
   } finally {
     readHookLog = hookLog;
     hookLog = [];
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     currentDispatcher.current = previousDispatcher;
   }
   const rootStack = ErrorStackParser.parse(ancestorStackError);
@@ -723,7 +724,7 @@ export function inspectHooks<Props>(
 }
 
 function setupContexts(contextMap: Map<ReactContext<any>, any>, fiber: Fiber) {
-  let current = fiber;
+  let current: null | Fiber = fiber;
   while (current) {
     if (current.tag === ContextProvider) {
       const providerType: ReactProviderType<any> = current.type;

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -146,6 +146,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
         }
       },
     );
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     bridge.addListener(
       'updateComponentFilters',
       (componentFilters: Array<ComponentFilter>) => {
@@ -165,10 +166,12 @@ export function connectToDevTools(options: ?ConnectOptions) {
     // Ideally the backend would save the filters itself, but RN doesn't provide a sync storage solution.
     // So for now we just fall back to using the default filters...
     if (window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ == null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       bridge.send('overrideComponentFilters', savedComponentFilters);
     }
 
     // TODO (npm-packages) Warn if "isBackendStorageAPISupported"
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     const agent = new Agent(bridge);
     agent.addListener('shutdown', () => {
       // If we received 'shutdown' from `agent`, we assume the `bridge` is already shutting down,
@@ -181,6 +184,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
     // Setup React Native style editor if the environment supports it.
     if (resolveRNStyle != null || hook.resolveRNStyle != null) {
       setupNativeStyleEditor(
+        // $FlowFixMe[incompatible-call] found when upgrading Flow
         bridge,
         agent,
         ((resolveRNStyle || hook.resolveRNStyle: any): ResolveNativeStyle),

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -256,6 +256,7 @@ function initialize(socket: WebSocket) {
     socket.close();
   });
 
+  // $FlowFixMe[incompatible-call] found when upgrading Flow
   store = new Store(bridge, {
     checkBridgeProtocolCompatibility: true,
     supportsNativeInspection: true,

--- a/packages/react-devtools-shared/src/backend/DevToolsFiberComponentStack.js
+++ b/packages/react-devtools-shared/src/backend/DevToolsFiberComponentStack.js
@@ -84,9 +84,10 @@ export function getStackByFiberInDevAndProd(
 ): string {
   try {
     let info = '';
-    let node = workInProgress;
+    let node: Fiber = workInProgress;
     do {
       info += describeFiber(workTagMap, node, currentDispatcherRef);
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.return;
     } while (node);
     return info;

--- a/packages/react-devtools-shared/src/backend/legacy/renderer.js
+++ b/packages/react-devtools-shared/src/backend/legacy/renderer.js
@@ -248,6 +248,7 @@ export function attach(
           parentIDStack.pop();
           return result;
         } catch (err) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           parentIDStack = [];
           throw err;
         } finally {
@@ -284,6 +285,7 @@ export function attach(
           parentIDStack.pop();
           return result;
         } catch (err) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           parentIDStack = [];
           throw err;
         } finally {
@@ -320,6 +322,7 @@ export function attach(
           parentIDStack.pop();
           return result;
         } catch (err) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           parentIDStack = [];
           throw err;
         } finally {
@@ -351,6 +354,7 @@ export function attach(
 
           return result;
         } catch (err) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           parentIDStack = [];
           throw err;
         } finally {

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -799,7 +799,7 @@ export function createProfilingHooks({
 
   function getParentFibers(fiber: Fiber): Array<Fiber> {
     const parents = [];
-    let parent = fiber;
+    let parent: null | Fiber = fiber;
     while (parent !== null) {
       parents.push(parent);
       parent = parent.return;
@@ -824,6 +824,7 @@ export function createProfilingHooks({
             warning: null,
           };
           currentFiberStacks.set(event, getParentFibers(fiber));
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           currentTimelineData.schedulingEvents.push(event);
         }
       }

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2269,7 +2269,7 @@ export function attach(
 
     // This is a naive implementation that shallowly recourses children.
     // We might want to revisit this if it proves to be too inefficient.
-    let child = childSet;
+    let child: null | Fiber = childSet;
     while (child !== null) {
       findReorderedChildrenRecursively(child, nextChildren);
       child = child.sibling;
@@ -2846,11 +2846,11 @@ export function attach(
   // https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberTreeReflection.js
   function getNearestMountedFiber(fiber: Fiber): null | Fiber {
     let node = fiber;
-    let nearestMounted = fiber;
+    let nearestMounted: null | Fiber = fiber;
     if (!fiber.alternate) {
       // If there is no alternate, this might be a new tree that isn't inserted
       // yet. If it is, then it will have a pending insertion effect on it.
-      let nextNode = node;
+      let nextNode: Fiber = node;
       do {
         node = nextNode;
         if ((node.flags & (Placement | Hydrating)) !== NoFlags) {
@@ -2859,6 +2859,7 @@ export function attach(
           // if that one is still mounted.
           nearestMounted = node.return;
         }
+        // $FlowFixMe[incompatible-type] we bail out when we get a null
         nextNode = node.return;
       } while (nextNode);
     } else {
@@ -3097,7 +3098,7 @@ export function attach(
     const owners: Array<SerializedElement> = [fiberToSerializedElement(fiber)];
 
     if (_debugOwner) {
-      let owner = _debugOwner;
+      let owner: null | Fiber = _debugOwner;
       while (owner !== null) {
         owners.unshift(fiberToSerializedElement(owner));
         owner = owner._debugOwner || null;
@@ -3256,7 +3257,7 @@ export function attach(
     let owners = null;
     if (_debugOwner) {
       owners = [];
-      let owner = _debugOwner;
+      let owner: null | Fiber = _debugOwner;
       while (owner !== null) {
         owners.push(fiberToSerializedElement(owner));
         owner = owner._debugOwner || null;
@@ -3687,18 +3688,22 @@ export function attach(
     // This will enable us to send patches without re-inspecting if hydrated paths are requested.
     // (Reducing how often we shallow-render is a better DX for function components that use hooks.)
     const cleanedInspectedElement = {...mostRecentlyInspectedElement};
+    // $FlowFixMe[prop-missing] found when upgrading Flow
     cleanedInspectedElement.context = cleanForBridge(
       cleanedInspectedElement.context,
       createIsPathAllowed('context', null),
     );
+    // $FlowFixMe[prop-missing] found when upgrading Flow
     cleanedInspectedElement.hooks = cleanForBridge(
       cleanedInspectedElement.hooks,
       createIsPathAllowed('hooks', 'hooks'),
     );
+    // $FlowFixMe[prop-missing] found when upgrading Flow
     cleanedInspectedElement.props = cleanForBridge(
       cleanedInspectedElement.props,
       createIsPathAllowed('props', null),
     );
+    // $FlowFixMe[prop-missing] found when upgrading Flow
     cleanedInspectedElement.state = cleanForBridge(
       cleanedInspectedElement.state,
       createIsPathAllowed('state', null),
@@ -3709,6 +3714,7 @@ export function attach(
       responseID: requestID,
       type: 'full-data',
       // $FlowFixMe[incompatible-return] found when upgrading Flow
+      // $FlowFixMe[prop-missing] found when upgrading Flow
       value: cleanedInspectedElement,
     };
   }
@@ -4420,13 +4426,15 @@ export function attach(
   // The return path will contain Fibers that are "invisible" to the store
   // because their keys and indexes are important to restoring the selection.
   function getPathForElement(id: number): Array<PathFrame> | null {
-    let fiber = idToArbitraryFiberMap.get(id);
+    let fiber: ?Fiber = idToArbitraryFiberMap.get(id);
     if (fiber == null) {
       return null;
     }
     const keyPath = [];
     while (fiber !== null) {
+      // $FlowFixMe[incompatible-call] found when upgrading Flow
       keyPath.push(getPathFrame(fiber));
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       fiber = fiber.return;
     }
     keyPath.reverse();
@@ -4443,7 +4451,7 @@ export function attach(
       return null;
     }
     // Find the closest Fiber store is aware of.
-    let fiber = trackedPathMatchFiber;
+    let fiber: null | Fiber = trackedPathMatchFiber;
     while (fiber !== null && shouldFilterFiber(fiber)) {
       fiber = fiber.return;
     }

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -282,7 +282,7 @@ function findTipPos(dims, bounds, tipSize) {
   const tipWidth = Math.max(tipSize.width, 60);
   const margin = 5;
 
-  let top;
+  let top: number | string;
   if (dims.top + dims.height + tipHeight <= bounds.top + bounds.height) {
     if (dims.top + dims.height < bounds.top + 0) {
       top = bounds.top + margin;
@@ -299,7 +299,7 @@ function findTipPos(dims, bounds, tipSize) {
     top = bounds.top + bounds.height - tipHeight - margin;
   }
 
-  let left = dims.left + margin;
+  let left: number | string = dims.left + margin;
   if (dims.left < bounds.left) {
     left = bounds.left + margin;
   }

--- a/packages/react-devtools-shared/src/backend/views/utils.js
+++ b/packages/react-devtools-shared/src/backend/views/utils.js
@@ -84,7 +84,7 @@ export function getNestedBoundingClientRect(
   const ownerIframe = getOwnerIframe(node);
   if (ownerIframe && ownerIframe !== boundaryWindow) {
     const rects = [node.getBoundingClientRect()];
-    let currentIframe = ownerIframe;
+    let currentIframe: null | HTMLElement = ownerIframe;
     let onlyOneMore = false;
     while (currentIframe) {
       const rect = getBoundingClientRectWithBorderOffset(currentIframe);

--- a/packages/react-devtools-shared/src/devtools/cache.js
+++ b/packages/react-devtools-shared/src/devtools/cache.js
@@ -88,7 +88,7 @@ const resourceConfigs: Map<Resource<any, any, any>, Config> = new Map();
 function getEntriesForResource(
   resource: any,
 ): Map<any, any> | WeakMap<any, any> {
-  let entriesForResource = ((entries.get(resource): any): Map<any, any>);
+  let entriesForResource: Map<any, any> | WeakMap<any, any> = ((entries.get(resource): any): Map<any, any>);
   if (entriesForResource === undefined) {
     const config = resourceConfigs.get(resource);
     entriesForResource =

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -763,7 +763,7 @@ export default class Store extends EventEmitter<{
 
           const weightDelta = 1 - element.weight;
 
-          let parentElement = ((this._idToElement.get(
+          let parentElement: void | Element = ((this._idToElement.get(
             element.parentID,
           ): any): Element);
           while (parentElement != null) {
@@ -789,7 +789,7 @@ export default class Store extends EventEmitter<{
               : currentElement.weight;
             const weightDelta = newWeight - oldWeight;
 
-            let parentElement = ((this._idToElement.get(
+            let parentElement: void | Element = ((this._idToElement.get(
               currentElement.parentID,
             ): any): Element);
             while (parentElement != null) {
@@ -806,7 +806,9 @@ export default class Store extends EventEmitter<{
 
           currentElement =
             currentElement.parentID !== 0
+              // $FlowFixMe[incompatible-type] found when upgrading Flow
               ? this.getElementByID(currentElement.parentID)
+              // $FlowFixMe[incompatible-type] found when upgrading Flow
               : null;
         }
       }

--- a/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NativeStyleEditor/context.js
@@ -66,7 +66,9 @@ const resource: Resource<
       return request.promise;
     }
 
-    let resolveFn = ((null: any): ResolveFn);
+    let resolveFn: 
+  | ResolveFn
+  | ((result: Promise<StyleAndLayoutFrontend> | StyleAndLayoutFrontend) => void) = ((null: any): ResolveFn);
     const promise = new Promise(resolve => {
       resolveFn = resolve;
     });

--- a/packages/react-devtools-shared/src/devtools/views/Components/NewKeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NewKeyValue.js
@@ -57,7 +57,7 @@ export default function NewKeyValue({
     const {id} = inspectedElement;
     const rendererID = store.getRendererIDForElement(id);
     if (rendererID !== null) {
-      let basePath = newPath;
+      let basePath: Array<string | number> = newPath;
       if (hookID != null) {
         basePath = parseHookPathForEdit(basePath);
       }

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersListContext.js
@@ -49,7 +49,11 @@ const resource: Resource<
       return request.promise;
     }
 
-    let resolveFn = ((null: any): ResolveFn);
+    let resolveFn: 
+  | ResolveFn
+  | ((
+    result: Promise<Array<SerializedElement>> | Array<SerializedElement>
+  ) => void) = ((null: any): ResolveFn);
     const promise = new Promise(resolve => {
       resolveFn = resolve;
     });

--- a/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/SelectedTreeHighlight.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import * as React from 'react';
+import type { Element } from './types';import * as React from 'react';
 import {useContext, useMemo} from 'react';
 import {TreeStateContext} from './TreeContext';
 import {SettingsContext} from '../Settings/SettingsContext';
@@ -53,7 +53,7 @@ export default function SelectedTreeHighlight(_: {}): React.Node {
         }
 
         let stopIndex = null;
-        let current = element;
+        let current: null | Element = element;
         while (current !== null) {
           if (current.isCollapsed || current.children.length === 0) {
             // We've found the last/deepest descendant.

--- a/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/TreeContext.js
@@ -294,7 +294,7 @@ function reduceTreeState(store: Store, state: State, action: Action): State {
           ) {
             const leafElement = store.getElementByID(ownerSubtreeLeafElementID);
             if (leafElement !== null) {
-              let currentElement = leafElement;
+              let currentElement: null | Element = leafElement;
               while (currentElement !== null) {
                 if (currentElement.ownerID === selectedElementID) {
                   selectedElementIndex = store.getIndexOfElementID(

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Tooltip.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Tooltip.js
@@ -57,8 +57,8 @@ const TOOLTIP_OFFSET = 5;
 // Method used to find the position of the tooltip based on current mouse position
 function getTooltipPosition(element, mousePosition) {
   const {height, mouseX, mouseY, width} = mousePosition;
-  let top = 0;
-  let left = 0;
+  let top: number | string = 0;
+  let left: number | string = 0;
 
   if (mouseY + TOOLTIP_OFFSET + element.offsetHeight >= height) {
     if (mouseY - TOOLTIP_OFFSET - element.offsetHeight > 0) {

--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -238,7 +238,7 @@ export function useModalDismissSignal(
     // Delay until after the current call stack is empty,
     // in case this effect is being run while an event is currently bubbling.
     // In that case, we don't want to listen to the pre-existing event.
-    let timeoutID = setTimeout(() => {
+    let timeoutID: null | TimeoutID = setTimeout(() => {
       timeoutID = null;
 
       // It's important to listen to the ownerDocument to support the browser extension.

--- a/packages/react-devtools-shared/src/dynamicImportCache.js
+++ b/packages/react-devtools-shared/src/dynamicImportCache.js
@@ -136,7 +136,7 @@ export function loadModule(moduleLoaderFunction: ModuleLoaderFunction): Module {
     );
 
     // Eventually timeout and stop trying to load the module.
-    let timeoutID = setTimeout(function onTimeout() {
+    let timeoutID: null | TimeoutID = setTimeout(function onTimeout() {
       if (__DEBUG__) {
         console.log(
           `[dynamicImportCache] loadModule("${moduleLoaderFunction.name}") onTimeout()`,

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -13,7 +13,7 @@ import {registerEventLogger} from 'react-devtools-shared/src/Logger';
 import {enableLogger} from 'react-devtools-feature-flags';
 
 let loggingIFrame = null;
-let missedEvents = [];
+let missedEvents: Array<LoggerEvent> = [];
 
 type LoggerContext = {
   page_url: ?string,

--- a/packages/react-devtools-timeline/src/view-base/useCanvasInteraction.js
+++ b/packages/react-devtools-timeline/src/view-base/useCanvasInteraction.js
@@ -125,6 +125,7 @@ export function useCanvasInteraction(
     }
 
     function localToCanvasCoordinates(localCoordinates: Point): Point {
+      // $FlowFixMe[incompatible-call] found when upgrading Flow
       const canvasRect = cacheFirstGetCanvasBoundingRect(canvas);
       return {
         x: localCoordinates.x - canvasRect.left,

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -595,7 +595,7 @@ function createPreloadResource(
   const limitedEscapedHref = escapeSelectorAttributeValueInsideDoubleQuotes(
     href,
   );
-  let element = ownerDocument.querySelector(
+  let element: null | Instance | HTMLElement = ownerDocument.querySelector(
     `link[rel="preload"][href="${limitedEscapedHref}"]`,
   );
   if (!element) {

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -593,7 +593,7 @@ export function clearSuspenseBoundary(
   parentInstance: Instance,
   suspenseInstance: SuspenseInstance,
 ): void {
-  let node = suspenseInstance;
+  let node: Node = suspenseInstance;
   // Delete all nodes within this suspense boundary.
   // There might be nested nodes so we need to keep track of how
   // deep we are and only break out when we're back on top.
@@ -620,6 +620,7 @@ export function clearSuspenseBoundary(
         depth++;
       }
     }
+    // $FlowFixMe[incompatible-type] we bail out when we get a null
     node = nextNode;
   } while (node);
   // TODO: Warn, we didn't find the end comment boundary.

--- a/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
+++ b/packages/react-dom-bindings/src/events/DOMPluginEventSystem.js
@@ -427,7 +427,7 @@ function addTrappedEventListener(
   );
   // If passive option is not supported, then the event will be
   // active and not passive.
-  let isPassiveListener = undefined;
+  let isPassiveListener: void | boolean = undefined;
   if (passiveBrowserEventsSupported) {
     // Browsers introduced an intervention, making these events
     // passive by default on document. React doesn't bind them
@@ -578,7 +578,7 @@ export function dispatchEventForPluginEventSystem(
       // root boundaries that match that of our current "rootContainer".
       // If we find that "rootContainer", we find the parent fiber
       // sub-tree for that root and make that our ancestor instance.
-      let node = targetInst;
+      let node: null | Fiber = targetInst;
 
       mainLoop: while (true) {
         if (node === null) {
@@ -823,6 +823,7 @@ function getParent(inst: Fiber | null): Fiber | null {
     return null;
   }
   do {
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     inst = inst.return;
     // TODO: If this is a HostRoot we might want to bail out.
     // That is depending on if we want nested subtrees (layers) to bubble
@@ -841,14 +842,14 @@ function getParent(inst: Fiber | null): Fiber | null {
  * different trees.
  */
 function getLowestCommonAncestor(instA: Fiber, instB: Fiber): Fiber | null {
-  let nodeA = instA;
-  let nodeB = instB;
+  let nodeA: null | Fiber = instA;
+  let nodeB: null | Fiber = instB;
   let depthA = 0;
-  for (let tempA = nodeA; tempA; tempA = getParent(tempA)) {
+  for (let tempA: null | Fiber = nodeA; tempA; tempA = getParent(tempA)) {
     depthA++;
   }
   let depthB = 0;
-  for (let tempB = nodeB; tempB; tempB = getParent(tempB)) {
+  for (let tempB: null | Fiber = nodeB; tempB; tempB = getParent(tempB)) {
     depthB++;
   }
 
@@ -886,7 +887,7 @@ function accumulateEnterLeaveListenersForEvent(
   const registrationName = event._reactName;
   const listeners: Array<DispatchListener> = [];
 
-  let instance = target;
+  let instance: null | Fiber = target;
   while (instance !== null) {
     if (instance === common) {
       break;

--- a/packages/react-fs/src/ReactFilesystem.js
+++ b/packages/react-fs/src/ReactFilesystem.js
@@ -153,6 +153,7 @@ export function lstat(path: string, options?: {bigint?: boolean}): mixed {
   if (!record) {
     const thenable = fs.lstat(path, {bigint});
     record = createRecordFromThenable(thenable);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     lstatCache.push(bigint, record);
   }
   // $FlowFixMe[incompatible-call] found when upgrading Flow
@@ -203,6 +204,7 @@ export function readdir(
   if (!record) {
     const thenable = fs.readdir(path, {encoding, withFileTypes});
     record = createRecordFromThenable(thenable);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     readdirCache.push(encoding, withFileTypes, record);
   }
   // $FlowFixMe[incompatible-call] found when upgrading Flow
@@ -302,6 +304,7 @@ export function readlink(
   if (!record) {
     const thenable = fs.readlink(path, {encoding});
     record = createRecordFromThenable(thenable);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     readlinkCache.push(encoding, record);
   }
   // $FlowFixMe[incompatible-call] found when upgrading Flow
@@ -344,6 +347,7 @@ export function realpath(
   if (!record) {
     const thenable = fs.realpath(path, {encoding});
     record = createRecordFromThenable(thenable);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     realpathCache.push(encoding, record);
   }
   // $FlowFixMe[incompatible-call] found when upgrading Flow
@@ -379,6 +383,7 @@ export function stat(path: string, options?: {bigint?: boolean}): mixed {
   if (!record) {
     const thenable = fs.stat(path, {bigint});
     record = createRecordFromThenable(thenable);
+    // $FlowFixMe[incompatible-call] found when upgrading Flow
     statCache.push(bigint, record);
   }
   // $FlowFixMe[incompatible-call] found when upgrading Flow

--- a/packages/react-native-renderer/src/ReactNativeAttributePayload.js
+++ b/packages/react-native-renderer/src/ReactNativeAttributePayload.js
@@ -64,6 +64,7 @@ function restoreDeletedValuesInNestedArray(
   } else if (node && removedKeyCount > 0) {
     const obj = node;
     for (const propKey in removedKeys) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       if (!removedKeys[propKey]) {
         continue;
       }
@@ -78,9 +79,11 @@ function restoreDeletedValuesInNestedArray(
       }
 
       if (typeof nextProp === 'function') {
+        // $FlowFixMe[incompatible-type] found when upgrading Flow
         nextProp = true;
       }
       if (typeof nextProp === 'undefined') {
+        // $FlowFixMe[incompatible-type] found when upgrading Flow
         nextProp = null;
       }
 

--- a/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
+++ b/packages/react-native-renderer/src/legacy-events/EventPluginRegistry.js
@@ -42,6 +42,7 @@ function recomputePluginOrdering(): void {
   }
   for (const pluginName in namesToPlugins) {
     const pluginModule = namesToPlugins[pluginName];
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     const pluginIndex = eventPluginOrder.indexOf(pluginName);
 
     if (pluginIndex <= -1) {

--- a/packages/react-pg/src/ReactPostgres.js
+++ b/packages/react-pg/src/ReactPostgres.js
@@ -82,7 +82,7 @@ Pool.prototype.query = function(query: string, values?: Array<mixed>) {
   const outerMap = unstable_getCacheForType(this.createRecordMap);
 
   let innerMap: NestedMap = outerMap;
-  let key = query;
+  let key: mixed = query;
   if (values != null) {
     // If we have parameters, each becomes as a nesting layer for Maps.
     // We want to find (or create as needed) the innermost Map, and return that.

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -319,7 +319,7 @@ function createChildReconciler(shouldTrackSideEffects): ChildReconciler {
     // instead.
     const existingChildren: Map<string | number, Fiber> = new Map();
 
-    let existingChild = currentFirstChild;
+    let existingChild: null | Fiber = currentFirstChild;
     while (existingChild !== null) {
       if (existingChild.key !== null) {
         existingChildren.set(existingChild.key, existingChild);

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -319,7 +319,7 @@ function createChildReconciler(shouldTrackSideEffects): ChildReconciler {
     // instead.
     const existingChildren: Map<string | number, Fiber> = new Map();
 
-    let existingChild = currentFirstChild;
+    let existingChild: null | Fiber = currentFirstChild;
     while (existingChild !== null) {
       if (existingChild.key !== null) {
         existingChildren.set(existingChild.key, existingChild);

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -592,6 +592,7 @@ function updateSimpleMemoComponent(
         try {
           outerMemoType = init(payload);
         } catch (x) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           outerMemoType = null;
         }
         // Inner propTypes will be validated in the function component path.
@@ -2990,12 +2991,15 @@ function propagateSuspenseContextChange(
     if (node === workInProgress) {
       return;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     while (node.sibling === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       if (node.return === null || node.return === workInProgress) {
         return;
       }
       node = node.return;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     node.sibling.return = node.return;
     node = node.sibling;
   }
@@ -3596,13 +3600,16 @@ function remountFiber(
         // eslint-disable-next-line react-internal/prod-error-codes
         throw new Error('Expected parent to have a child.');
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (prevSibling.sibling !== oldWorkInProgress) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         prevSibling = prevSibling.sibling;
         if (prevSibling === null) {
           // eslint-disable-next-line react-internal/prod-error-codes
           throw new Error('Expected to find the previous sibling.');
         }
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       prevSibling.sibling = newWorkInProgress;
     }
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -592,6 +592,7 @@ function updateSimpleMemoComponent(
         try {
           outerMemoType = init(payload);
         } catch (x) {
+          // $FlowFixMe[incompatible-type] found when upgrading Flow
           outerMemoType = null;
         }
         // Inner propTypes will be validated in the function component path.
@@ -2990,12 +2991,15 @@ function propagateSuspenseContextChange(
     if (node === workInProgress) {
       return;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     while (node.sibling === null) {
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       if (node.return === null || node.return === workInProgress) {
         return;
       }
       node = node.return;
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     node.sibling.return = node.return;
     node = node.sibling;
   }
@@ -3596,13 +3600,16 @@ function remountFiber(
         // eslint-disable-next-line react-internal/prod-error-codes
         throw new Error('Expected parent to have a child.');
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (prevSibling.sibling !== oldWorkInProgress) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         prevSibling = prevSibling.sibling;
         if (prevSibling === null) {
           // eslint-disable-next-line react-internal/prod-error-codes
           throw new Error('Expected to find the previous sibling.');
         }
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       prevSibling.sibling = newWorkInProgress;
     }
 

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.new.js
@@ -325,7 +325,7 @@ export function enqueueCapturedUpdate<State>(
       const firstBaseUpdate = queue.firstBaseUpdate;
       if (firstBaseUpdate !== null) {
         // Loop through the updates and clone them.
-        let update = firstBaseUpdate;
+        let update: Update<State> = firstBaseUpdate;
         do {
           const clone: Update<State> = {
             eventTime: update.eventTime,
@@ -345,6 +345,7 @@ export function enqueueCapturedUpdate<State>(
             newLast.next = clone;
             newLast = clone;
           }
+          // $FlowFixMe[incompatible-type] we bail out when we get a null
           update = update.next;
         } while (update !== null);
 
@@ -534,7 +535,7 @@ export function processUpdateQueue<State>(
     let newFirstBaseUpdate = null;
     let newLastBaseUpdate = null;
 
-    let update = firstBaseUpdate;
+    let update: Update<State> = firstBaseUpdate;
     do {
       // TODO: Don't need this field anymore
       const updateEventTime = update.eventTime;
@@ -620,6 +621,7 @@ export function processUpdateQueue<State>(
           }
         }
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       update = update.next;
       if (update === null) {
         pendingQueue = queue.shared.pending;

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.old.js
@@ -325,7 +325,7 @@ export function enqueueCapturedUpdate<State>(
       const firstBaseUpdate = queue.firstBaseUpdate;
       if (firstBaseUpdate !== null) {
         // Loop through the updates and clone them.
-        let update = firstBaseUpdate;
+        let update: Update<State> = firstBaseUpdate;
         do {
           const clone: Update<State> = {
             eventTime: update.eventTime,
@@ -345,6 +345,7 @@ export function enqueueCapturedUpdate<State>(
             newLast.next = clone;
             newLast = clone;
           }
+          // $FlowFixMe[incompatible-type] we bail out when we get a null
           update = update.next;
         } while (update !== null);
 
@@ -534,7 +535,7 @@ export function processUpdateQueue<State>(
     let newFirstBaseUpdate = null;
     let newLastBaseUpdate = null;
 
-    let update = firstBaseUpdate;
+    let update: Update<State> = firstBaseUpdate;
     do {
       // TODO: Don't need this field anymore
       const updateEventTime = update.eventTime;
@@ -620,6 +621,7 @@ export function processUpdateQueue<State>(
           }
         }
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       update = update.next;
       if (update === null) {
         pendingQueue = queue.shared.pending;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1316,7 +1316,7 @@ function abortParentMarkerTransitionsForDeletedFiber(
   if (enableTransitionTracing) {
     // Find all pending markers that are waiting on child suspense boundaries in the
     // aborted subtree and cancels them
-    let fiber = abortedFiber;
+    let fiber: null | Fiber = abortedFiber;
     while (fiber !== null) {
       switch (fiber.tag) {
         case TracingMarkerComponent:
@@ -1785,6 +1785,7 @@ function getHostSibling(fiber: Fiber): ?Instance {
         // last sibling.
         return null;
       }
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       node = node.return;
     }
     node.sibling.return = node.return;
@@ -1951,7 +1952,7 @@ function commitDeletionEffects(
     // TODO: Instead of searching up the fiber return path on every deletion, we
     // can track the nearest host component on the JS stack as we traverse the
     // tree during the commit phase. This would make insertions faster, too.
-    let parent = returnFiber;
+    let parent: null | Fiber = returnFiber;
     findParent: while (parent !== null) {
       switch (parent.tag) {
         case HostComponent: {
@@ -2332,7 +2333,10 @@ function getRetryCache(finishedWork) {
     }
     case OffscreenComponent: {
       const instance: OffscreenInstance = finishedWork.stateNode;
-      let retryCache = instance._retryCache;
+      // $FlowFixMe[incompatible-type-arg] found when upgrading Flow
+      let retryCache: null | Set<Wakeable> | WeakSet<Wakeable> =
+        // $FlowFixMe[incompatible-type] found when upgrading Flow
+        instance._retryCache;
       if (retryCache === null) {
         // $FlowFixMe[incompatible-type]
         retryCache = instance._retryCache = new PossiblyWeakSet();
@@ -3818,7 +3822,9 @@ function detachAlternateSiblings(parentFiber: Fiber) {
       if (detachedChild !== null) {
         previousFiber.child = null;
         do {
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           const detachedSibling = detachedChild.sibling;
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           detachedChild.sibling = null;
           detachedChild = detachedSibling;
         } while (detachedChild !== null);

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1316,7 +1316,7 @@ function abortParentMarkerTransitionsForDeletedFiber(
   if (enableTransitionTracing) {
     // Find all pending markers that are waiting on child suspense boundaries in the
     // aborted subtree and cancels them
-    let fiber = abortedFiber;
+    let fiber: null | Fiber = abortedFiber;
     while (fiber !== null) {
       switch (fiber.tag) {
         case TracingMarkerComponent:
@@ -1785,6 +1785,7 @@ function getHostSibling(fiber: Fiber): ?Instance {
         // last sibling.
         return null;
       }
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       node = node.return;
     }
     node.sibling.return = node.return;
@@ -1951,7 +1952,7 @@ function commitDeletionEffects(
     // TODO: Instead of searching up the fiber return path on every deletion, we
     // can track the nearest host component on the JS stack as we traverse the
     // tree during the commit phase. This would make insertions faster, too.
-    let parent = returnFiber;
+    let parent: null | Fiber = returnFiber;
     findParent: while (parent !== null) {
       switch (parent.tag) {
         case HostComponent: {
@@ -2332,7 +2333,10 @@ function getRetryCache(finishedWork) {
     }
     case OffscreenComponent: {
       const instance: OffscreenInstance = finishedWork.stateNode;
-      let retryCache = instance._retryCache;
+      // $FlowFixMe[incompatible-type-arg] found when upgrading Flow
+      let retryCache: null | Set<Wakeable> | WeakSet<Wakeable> =
+        // $FlowFixMe[incompatible-type] found when upgrading Flow
+        instance._retryCache;
       if (retryCache === null) {
         // $FlowFixMe[incompatible-type]
         retryCache = instance._retryCache = new PossiblyWeakSet();
@@ -3818,7 +3822,9 @@ function detachAlternateSiblings(parentFiber: Fiber) {
       if (detachedChild !== null) {
         previousFiber.child = null;
         do {
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           const detachedSibling = detachedChild.sibling;
+          // $FlowFixMe[incompatible-use] found when upgrading Flow
           detachedChild.sibling = null;
           detachedChild = detachedSibling;
         } while (detachedChild !== null);

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.new.js
@@ -239,12 +239,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }
@@ -359,12 +362,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }
@@ -424,12 +430,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.old.js
@@ -239,12 +239,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }
@@ -359,12 +362,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }
@@ -424,12 +430,15 @@ if (supportsMutation) {
       if (node === workInProgress) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       while (node.sibling === null) {
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         if (node.return === null || node.return === workInProgress) {
           return;
         }
         node = node.return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       node.sibling.return = node.return;
       node = node.sibling;
     }

--- a/packages/react-reconciler/src/ReactFiberComponentStack.js
+++ b/packages/react-reconciler/src/ReactFiberComponentStack.js
@@ -60,9 +60,10 @@ function describeFiber(fiber: Fiber): string {
 export function getStackByFiberInDevAndProd(workInProgress: Fiber): string {
   try {
     let info = '';
-    let node = workInProgress;
+    let node: Fiber = workInProgress;
     do {
       info += describeFiber(node);
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.return;
     } while (node);
     return info;

--- a/packages/react-reconciler/src/ReactFiberContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberContext.new.js
@@ -303,7 +303,7 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
       );
     }
 
-    let node = fiber;
+    let node: Fiber = fiber;
     do {
       switch (node.tag) {
         case HostRoot:
@@ -316,6 +316,7 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
           break;
         }
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.return;
     } while (node !== null);
 

--- a/packages/react-reconciler/src/ReactFiberContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberContext.old.js
@@ -303,7 +303,7 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
       );
     }
 
-    let node = fiber;
+    let node: Fiber = fiber;
     do {
       switch (node.tag) {
         case HostRoot:
@@ -316,6 +316,7 @@ function findCurrentUnmaskedContext(fiber: Fiber): Object {
           break;
         }
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.return;
     } while (node !== null);
 

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -387,7 +387,9 @@ function areHookInputsEqual(
       );
     }
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     if (is(nextDeps[i], prevDeps[i])) {
       continue;
     }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -387,7 +387,9 @@ function areHookInputsEqual(
       );
     }
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     if (is(nextDeps[i], prevDeps[i])) {
       continue;
     }

--- a/packages/react-reconciler/src/ReactFiberHotReloading.new.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.new.js
@@ -303,6 +303,7 @@ function scheduleFibersWithFamiliesRecursively(
     if (failedBoundaries !== null) {
       if (
         failedBoundaries.has(fiber) ||
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         (alternate !== null && failedBoundaries.has(alternate))
       ) {
         needsRemount = true;

--- a/packages/react-reconciler/src/ReactFiberHotReloading.old.js
+++ b/packages/react-reconciler/src/ReactFiberHotReloading.old.js
@@ -303,6 +303,7 @@ function scheduleFibersWithFamiliesRecursively(
     if (failedBoundaries !== null) {
       if (
         failedBoundaries.has(fiber) ||
+        // $FlowFixMe[incompatible-use] found when upgrading Flow
         (alternate !== null && failedBoundaries.has(alternate))
       ) {
         needsRemount = true;

--- a/packages/react-reconciler/src/ReactFiberNewContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.new.js
@@ -525,7 +525,7 @@ function propagateParentContextChanges(
   // Collect all the parent providers that changed. Since this is usually small
   // number, we use an Array instead of Set.
   let contexts = null;
-  let parent = workInProgress;
+  let parent: null | Fiber = workInProgress;
   let isInsidePropagationBailout = false;
   while (parent !== null) {
     if (!isInsidePropagationBailout) {

--- a/packages/react-reconciler/src/ReactFiberNewContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.old.js
@@ -525,7 +525,7 @@ function propagateParentContextChanges(
   // Collect all the parent providers that changed. Since this is usually small
   // number, we use an Array instead of Set.
   let contexts = null;
-  let parent = workInProgress;
+  let parent: null | Fiber = workInProgress;
   let isInsidePropagationBailout = false;
   while (parent !== null) {
     if (!isInsidePropagationBailout) {

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -525,7 +525,7 @@ export function findHostInstanceWithNoPortals(
   return hostFiber.stateNode;
 }
 
-let shouldErrorImpl = fiber => null;
+let shouldErrorImpl: Fiber => ?boolean = fiber => null;
 
 export function shouldError(fiber: Fiber): ?boolean {
   return shouldErrorImpl(fiber);

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -525,7 +525,7 @@ export function findHostInstanceWithNoPortals(
   return hostFiber.stateNode;
 }
 
-let shouldErrorImpl = fiber => null;
+let shouldErrorImpl: Fiber => ?boolean = fiber => null;
 
 export function shouldError(fiber: Fiber): ?boolean {
   return shouldErrorImpl(fiber);

--- a/packages/react-reconciler/src/ReactFiberScope.new.js
+++ b/packages/react-reconciler/src/ReactFiberScope.new.js
@@ -86,7 +86,7 @@ function collectScopedNodesFromChildren(
   fn: ReactScopeQuery,
   scopedNodes: Array<any>,
 ): void {
-  let child = startingChild;
+  let child: null | Fiber = startingChild;
   while (child !== null) {
     collectScopedNodes(child, fn, scopedNodes);
     child = child.sibling;
@@ -97,7 +97,7 @@ function collectFirstScopedNodeFromChildren(
   startingChild: Fiber,
   fn: ReactScopeQuery,
 ): Object | null {
-  let child = startingChild;
+  let child: null | Fiber = startingChild;
   while (child !== null) {
     const scopedNode = collectFirstScopedNode(child, fn);
     if (scopedNode !== null) {

--- a/packages/react-reconciler/src/ReactFiberScope.old.js
+++ b/packages/react-reconciler/src/ReactFiberScope.old.js
@@ -86,7 +86,7 @@ function collectScopedNodesFromChildren(
   fn: ReactScopeQuery,
   scopedNodes: Array<any>,
 ): void {
-  let child = startingChild;
+  let child: null | Fiber = startingChild;
   while (child !== null) {
     collectScopedNodes(child, fn, scopedNodes);
     child = child.sibling;
@@ -97,7 +97,7 @@ function collectFirstScopedNodeFromChildren(
   startingChild: Fiber,
   fn: ReactScopeQuery,
 ): Object | null {
-  let child = startingChild;
+  let child: null | Fiber = startingChild;
   while (child !== null) {
     const scopedNode = collectFirstScopedNode(child, fn);
     if (scopedNode !== null) {

--- a/packages/react-reconciler/src/ReactFiberSyncTaskQueue.new.js
+++ b/packages/react-reconciler/src/ReactFiberSyncTaskQueue.new.js
@@ -63,8 +63,9 @@ export function flushSyncCallbacks(): null {
       // $FlowFixMe[incompatible-use] found when upgrading Flow
       for (; i < queue.length; i++) {
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        let callback = queue[i];
+        let callback: SchedulerCallback = queue[i];
         do {
+          // $FlowFixMe[incompatible-type] we bail out when we get a null
           callback = callback(isSync);
         } while (callback !== null);
       }

--- a/packages/react-reconciler/src/ReactFiberSyncTaskQueue.old.js
+++ b/packages/react-reconciler/src/ReactFiberSyncTaskQueue.old.js
@@ -63,8 +63,9 @@ export function flushSyncCallbacks(): null {
       // $FlowFixMe[incompatible-use] found when upgrading Flow
       for (; i < queue.length; i++) {
         // $FlowFixMe[incompatible-use] found when upgrading Flow
-        let callback = queue[i];
+        let callback: SchedulerCallback = queue[i];
         do {
+          // $FlowFixMe[incompatible-type] we bail out when we get a null
           callback = callback(isSync);
         } while (callback !== null);
       }

--- a/packages/react-reconciler/src/ReactFiberThrow.new.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.new.js
@@ -488,7 +488,7 @@ function throwException(
   // We didn't find a boundary that could handle this type of exception. Start
   // over and traverse parent path again, this time treating the exception
   // as an error.
-  let workInProgress = returnFiber;
+  let workInProgress: Fiber = returnFiber;
   do {
     switch (workInProgress.tag) {
       case HostRoot: {
@@ -528,6 +528,7 @@ function throwException(
       default:
         break;
     }
+    // $FlowFixMe[incompatible-type] we bail out when we get a null
     workInProgress = workInProgress.return;
   } while (workInProgress !== null);
 }

--- a/packages/react-reconciler/src/ReactFiberThrow.old.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.old.js
@@ -488,7 +488,7 @@ function throwException(
   // We didn't find a boundary that could handle this type of exception. Start
   // over and traverse parent path again, this time treating the exception
   // as an error.
-  let workInProgress = returnFiber;
+  let workInProgress: Fiber = returnFiber;
   do {
     switch (workInProgress.tag) {
       case HostRoot: {
@@ -528,6 +528,7 @@ function throwException(
       default:
         break;
     }
+    // $FlowFixMe[incompatible-type] we bail out when we get a null
     workInProgress = workInProgress.return;
   } while (workInProgress !== null);
 }

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -30,11 +30,11 @@ const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 export function getNearestMountedFiber(fiber: Fiber): null | Fiber {
   let node = fiber;
-  let nearestMounted = fiber;
+  let nearestMounted: null | Fiber = fiber;
   if (!fiber.alternate) {
     // If there is no alternate, this might be a new tree that isn't inserted
     // yet. If it is, then it will have a pending insertion effect on it.
-    let nextNode = node;
+    let nextNode: Fiber = node;
     do {
       node = nextNode;
       if ((node.flags & (Placement | Hydrating)) !== NoFlags) {
@@ -43,6 +43,7 @@ export function getNearestMountedFiber(fiber: Fiber): null | Fiber {
         // if that one is still mounted.
         nearestMounted = node.return;
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       nextNode = node.return;
     } while (nextNode);
   } else {
@@ -339,7 +340,7 @@ export function doesFiberContain(
   parentFiber: Fiber,
   childFiber: Fiber,
 ): boolean {
-  let node = childFiber;
+  let node: null | Fiber = childFiber;
   const parentFiberAlternate = parentFiber.alternate;
   while (node !== null) {
     if (node === parentFiber || node === parentFiberAlternate) {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -742,7 +742,7 @@ export function scheduleUpdateOnFiber(
         root === rootCommittingMutationOrLayoutEffects
       ) {
         if (fiber.mode & ProfileMode) {
-          let current = fiber;
+          let current: null | Fiber = fiber;
           while (current !== null) {
             if (current.tag === Profiler) {
               const {id, onNestedUpdateScheduled} = current.memoizedProps;
@@ -2195,7 +2195,7 @@ function resumeSuspendedUnitOfWork(
 function completeUnitOfWork(unitOfWork: Fiber): void {
   // Attempt to complete the current unit of work, then move to the next
   // sibling. If there are no more siblings, return to the parent fiber.
-  let completedWork = unitOfWork;
+  let completedWork: Fiber = unitOfWork;
   do {
     // The current, flushed, state of this fiber is the alternate. Ideally
     // nothing should rely on this, but relying on it here means that we don't
@@ -2281,6 +2281,7 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
       return;
     }
     // Otherwise, return to the parent
+    // $FlowFixMe[incompatible-type] we bail out when we get a null
     completedWork = returnFiber;
     // Update the next thing we're working on in case something throws.
     workInProgress = completedWork;
@@ -3388,7 +3389,7 @@ function invokeEffectsInDev(
   fiberFlags: Flags,
   invokeEffectFn: (fiber: Fiber) => void,
 ) {
-  let current = firstChild;
+  let current: null | Fiber = firstChild;
   let subtreeRoot = null;
   while (current != null) {
     const primarySubtreeFlag = current.subtreeFlags & fiberFlags;
@@ -3445,6 +3446,7 @@ export function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber: Fiber) {
       if (didWarnStateUpdateForNotYetMountedComponent.has(componentName)) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       didWarnStateUpdateForNotYetMountedComponent.add(componentName);
     } else {
       didWarnStateUpdateForNotYetMountedComponent = new Set([componentName]);

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -742,7 +742,7 @@ export function scheduleUpdateOnFiber(
         root === rootCommittingMutationOrLayoutEffects
       ) {
         if (fiber.mode & ProfileMode) {
-          let current = fiber;
+          let current: null | Fiber = fiber;
           while (current !== null) {
             if (current.tag === Profiler) {
               const {id, onNestedUpdateScheduled} = current.memoizedProps;
@@ -2195,7 +2195,7 @@ function resumeSuspendedUnitOfWork(
 function completeUnitOfWork(unitOfWork: Fiber): void {
   // Attempt to complete the current unit of work, then move to the next
   // sibling. If there are no more siblings, return to the parent fiber.
-  let completedWork = unitOfWork;
+  let completedWork: Fiber = unitOfWork;
   do {
     // The current, flushed, state of this fiber is the alternate. Ideally
     // nothing should rely on this, but relying on it here means that we don't
@@ -2281,6 +2281,7 @@ function completeUnitOfWork(unitOfWork: Fiber): void {
       return;
     }
     // Otherwise, return to the parent
+    // $FlowFixMe[incompatible-type] we bail out when we get a null
     completedWork = returnFiber;
     // Update the next thing we're working on in case something throws.
     workInProgress = completedWork;
@@ -3388,7 +3389,7 @@ function invokeEffectsInDev(
   fiberFlags: Flags,
   invokeEffectFn: (fiber: Fiber) => void,
 ) {
-  let current = firstChild;
+  let current: null | Fiber = firstChild;
   let subtreeRoot = null;
   while (current != null) {
     const primarySubtreeFlag = current.subtreeFlags & fiberFlags;
@@ -3445,6 +3446,7 @@ export function warnAboutUpdateOnNotYetMountedFiberInDEV(fiber: Fiber) {
       if (didWarnStateUpdateForNotYetMountedComponent.has(componentName)) {
         return;
       }
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
       didWarnStateUpdateForNotYetMountedComponent.add(componentName);
     } else {
       didWarnStateUpdateForNotYetMountedComponent = new Set([componentName]);

--- a/packages/react-reconciler/src/ReactPostPaintCallback.js
+++ b/packages/react-reconciler/src/ReactPostPaintCallback.js
@@ -9,7 +9,7 @@
 import {requestPostPaintCallback} from './ReactFiberHostConfig';
 
 let postPaintCallbackScheduled = false;
-let callbacks = [];
+let callbacks: Array<any | ((endTime: number) => void)> = [];
 
 export function schedulePostPaintCallback(callback: (endTime: number) => void) {
   callbacks.push(callback);

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -31,7 +31,7 @@ if (__DEV__) {
   const findStrictRoot = (fiber: Fiber): Fiber | null => {
     let maybeStrictRoot = null;
 
-    let node = fiber;
+    let node: null | Fiber = fiber;
     while (node !== null) {
       if (node.mode & StrictLegacyMode) {
         maybeStrictRoot = node;

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -31,7 +31,7 @@ if (__DEV__) {
   const findStrictRoot = (fiber: Fiber): Fiber | null => {
     let maybeStrictRoot = null;
 
-    let node = fiber;
+    let node: null | Fiber = fiber;
     while (node !== null) {
       if (node.mode & StrictLegacyMode) {
         maybeStrictRoot = node;

--- a/packages/react-reconciler/src/ReactTestSelectors.js
+++ b/packages/react-reconciler/src/ReactTestSelectors.js
@@ -28,11 +28,11 @@ import {
   supportsTestSelectors,
 } from './ReactFiberHostConfig';
 
-let COMPONENT_TYPE = 0b000;
-let HAS_PSEUDO_CLASS_TYPE = 0b001;
-let ROLE_TYPE = 0b010;
-let TEST_NAME_TYPE = 0b011;
-let TEXT_TYPE = 0b100;
+let COMPONENT_TYPE: symbol | number = 0b000;
+let HAS_PSEUDO_CLASS_TYPE: symbol | number = 0b001;
+let ROLE_TYPE: symbol | number = 0b010;
+let TEST_NAME_TYPE: symbol | number = 0b011;
+let TEXT_TYPE: symbol | number = 0b100;
 
 if (typeof Symbol === 'function' && Symbol.for) {
   const symbolFor = Symbol.for;

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -88,6 +88,7 @@ export default class ReactFlightWebpackPlugin {
     ) {
       this.clientReferences = [(options.clientReferences: $FlowFixMe)];
     } else {
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       this.clientReferences = options.clientReferences;
     }
     if (typeof options.chunkName === 'string') {

--- a/packages/react-server/src/ReactFizzComponentStack.js
+++ b/packages/react-server/src/ReactFizzComponentStack.js
@@ -39,7 +39,7 @@ export function getStackByComponentStackNode(
 ): string {
   try {
     let info = '';
-    let node = componentStack;
+    let node: ComponentStackNode = componentStack;
     do {
       switch (node.tag) {
         case 0:
@@ -52,6 +52,7 @@ export function getStackByComponentStackNode(
           info += describeClassComponentFrame(node.type, null, null);
           break;
       }
+      // $FlowFixMe[incompatible-type] we bail out when we get a null
       node = node.parent;
     } while (node);
     return info;

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -147,7 +147,9 @@ function areHookInputsEqual(
       );
     }
   }
+  // $FlowFixMe[incompatible-use] found when upgrading Flow
   for (let i = 0; i < prevDeps.length && i < nextDeps.length; i++) {
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     if (is(nextDeps[i], prevDeps[i])) {
       continue;
     }
@@ -344,7 +346,7 @@ export function useReducer<S, I, A>(
         renderPhaseUpdates.delete(queue);
         // $FlowFixMe[incompatible-use] found when upgrading Flow
         let newState = workInProgressHook.memoizedState;
-        let update = firstRenderPhaseUpdate;
+        let update: Update<any> = firstRenderPhaseUpdate;
         do {
           // Process this render phase update. We don't have to check the
           // priority because it will always be the same as the current
@@ -357,6 +359,7 @@ export function useReducer<S, I, A>(
           if (__DEV__) {
             isInHookUserCodeInDev = false;
           }
+          // $FlowFixMe[incompatible-type] we bail out when we get a null
           update = update.next;
         } while (update !== null);
 
@@ -442,6 +445,7 @@ function useRef<T>(initialValue: T): {current: T} {
     if (__DEV__) {
       Object.seal(ref);
     }
+    // $FlowFixMe[incompatible-use] found when upgrading Flow
     workInProgressHook.memoizedState = ref;
     return ref;
   } else {

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -468,6 +468,7 @@ function create(
   let concurrentUpdatesByDefault = null;
   if (typeof options === 'object' && options !== null) {
     if (typeof options.createNodeMock === 'function') {
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       createNodeMock = options.createNodeMock;
     }
     if (options.unstable_isConcurrent === true) {
@@ -561,6 +562,7 @@ function create(
         return;
       }
       updateContainer(null, root, null, null);
+      // $FlowFixMe[incompatible-type] found when upgrading Flow
       container = null;
       root = null;
     },

--- a/packages/react/src/ReactAct.js
+++ b/packages/react/src/ReactAct.js
@@ -207,6 +207,7 @@ function flushActQueue(queue) {
         for (; i < queue.length; i++) {
           let callback = queue[i];
           do {
+            // $FlowFixMe[incompatible-type] found when upgrading Flow
             callback = callback(true);
           } while (callback !== null);
         }

--- a/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
@@ -43,7 +43,7 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
     // copies of the hook/component.
     let hasMemo = false;
     let memoizedSnapshot;
-    let memoizedSelection;
+    let memoizedSelection: Selection;
     const memoizedSelector = nextSnapshot => {
       if (!hasMemo) {
         // The first time the hook is called, there is no memoized result.

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -43,7 +43,6 @@ untyped-type-import=error
 %CI_MAX_WORKERS%
 exact_by_default=true
 munge_underscores=false
-inference_mode=classic
 
 # Substituted by createFlowConfig.js:
 %REACT_RENDERER_FLOW_OPTIONS%


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #25423
* __->__ #25422

This mode is going to be the new default in Flow going forward.
There was an unfortuante large number of suppressions in this update.

More on the changes can be found in this [Flow blog post](https://medium.com/flow-type/new-flow-language-rule-constrained-writes-4c70e375d190).

Added some of the required annotations using the provided codemod:

```sh
node_modules/.bin/flow codemod annotate-declarations --write .
```