### PR TITLE
react-hooks: Rules of Hooks now considers component/hook declarations inside JSX attributes

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -505,6 +505,28 @@ const tests = {
         }
       `,
     },
+    {
+      // because
+      // const useNamed = async () => useQuery();
+      // <Foo useData={useNamed} />;
+      // would also be valid
+      code: normalizeIndent`
+        function useQuery() {
+          return React.useState(null);
+        }
+        function App() {
+          const useNamed = async () => useQuery();
+
+          return (
+            <div className="App">
+              <Foo useData={async () => useQuery()} />
+              <Foo useData={useNamed} />
+              <Foo {...useHooks()} />
+            </div>
+          );
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -479,6 +479,32 @@ const tests = {
         }
       `,
     },
+    {
+      // Nested component declarations are bad but should be covered by other ESLint rules
+      code: normalizeIndent`
+        function App() {
+          return createElement(Child, {
+            Component: () => {
+              const [myState, setMyState] = useState(null);
+            },
+          });
+        }
+      `,
+    },
+    {
+      // Nested component declarations are bad but should be covered by other ESLint rules
+      code: normalizeIndent`
+        function JSXApp() {
+          return (
+            <Child
+              Component={() => {
+                const [myState, setMyState] = useState(null);
+              }}
+            />
+          );
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1041,6 +1067,38 @@ const tests = {
         (class {i() { useState(); }});
       `,
       errors: [classError('useState')],
+    },
+    {
+      // Nested component declarations are bad but should be covered by other ESLint rules
+      code: normalizeIndent`
+        function App() {
+          return createElement(Child, {
+            Component: () => {
+              if (flag) {
+                const [myState, setMyState] = useState(null);
+              }
+            },
+          });
+        }
+      `,
+      errors: [conditionalError('useState')],
+    },
+    {
+      // Nested component declarations are bad but should be covered by other ESLint rules
+      code: normalizeIndent`
+        function App() {
+          return (
+            <Child
+              Component={({ flag }) => {
+                if (flag) {
+                  const [myState, setMyState] = useState(null);
+                }
+              }}
+            />
+          );
+        }
+      `,
+      errors: [conditionalError('useState')],
     },
   ],
 };

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -28,7 +28,7 @@ function isHookName(s) {
  */
 
 function isHook(node) {
-  if (node.type === 'Identifier') {
+  if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
     return isHookName(node.name);
   } else if (
     node.type === 'MemberExpression' &&

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -49,7 +49,10 @@ function isHook(node) {
  */
 
 function isComponentName(node) {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  return (
+    (node.type === 'Identifier' || node.type === 'JSXIdentifier') &&
+    /^[A-Z]/.test(node.name)
+  );
 }
 
 function isReactFunction(node, functionName) {
@@ -678,6 +681,15 @@ function getFunctionName(node) {
       //
       // class {useHook = () => {}}
       // class {useHook() {}}
+    } else if (
+      node.parent.type === 'JSXExpressionContainer' &&
+      node.parent.parent.type === 'JSXAttribute' &&
+      node.parent.parent.name.type === 'JSXIdentifier'
+    ) {
+      // <Component Child={() => {}} />
+      // is actually
+      // createElement(Component, { Child: () => {}})
+      return node.parent.parent.name;
     } else if (
       node.parent.type === 'AssignmentPattern' &&
       node.parent.right === node &&


### PR DESCRIPTION
## Summary

Noticed during work in https://github.com/facebook/react/pull/25360.
Closes https://github.com/facebook/react/issues/23230

Currently, the below code will trigger rules of hooks with "hooks can only be called at the top level" despite the hook being called in something that looks like a component.
```jsx
function JSXApp() {
  return (
    <Child
      Component={() => {
        const [myState, setMyState] = useState(null);
      }}
    />
  );
}
```

The above code is equivalent to the code below where we already apply Rules of Hooks
```js
function App() {
  return createElement(Child, {
    Component: () => {
      const [myState, setMyState] = useState(null);
    },
  });
}
```

It's kind of neat to not apply rules of hook the components in JSX attributes since this can prevent declaration of nested components. But the error message wouldn't make sense and it would also flag component declarations in JSX elements that are not created during render.

The idea is to release this and https://github.com/facebook/react/pull/25360 together (though https://github.com/facebook/react/pull/25360 would need some rework if this PR is merged to also consider JSXAttributes). 

## How did you test this change?

- [x] Added tests
- [x] https://github.com/mui/material-ui/
- [x] Klarna monorepo