### PR TITLE
[react devtools] Device storage support

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -14,6 +14,11 @@ import {initBackend} from 'react-devtools-shared/src/backend';
 import {__DEBUG__} from 'react-devtools-shared/src/constants';
 import setupNativeStyleEditor from 'react-devtools-shared/src/backend/NativeStyleEditor/setupNativeStyleEditor';
 import {getDefaultComponentFilters} from 'react-devtools-shared/src/utils';
+import {
+  initializeUsingCachedSettings,
+  cacheConsolePatchSettings,
+  type DevToolsSettingsManager,
+} from './cachedSettings';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
 import type {ComponentFilter} from 'react-devtools-shared/src/types';
@@ -29,6 +34,7 @@ type ConnectOptions = {
   retryConnectionDelay?: number,
   isAppActive?: () => boolean,
   websocket?: ?WebSocket,
+  devToolsSettingsManager: ?DevToolsSettingsManager,
   ...
 };
 
@@ -63,6 +69,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
     resolveRNStyle = null,
     retryConnectionDelay = 2000,
     isAppActive = () => true,
+    devToolsSettingsManager,
   } = options || {};
 
   const protocol = useHttps ? 'wss' : 'ws';
@@ -75,6 +82,16 @@ export function connectToDevTools(options: ?ConnectOptions) {
         () => connectToDevTools(options),
         retryConnectionDelay,
       );
+    }
+  }
+
+  if (devToolsSettingsManager != null) {
+    try {
+      initializeUsingCachedSettings(devToolsSettingsManager);
+    } catch (e) {
+      // If we call a method on devToolsSettingsManager that throws, or if
+      // is invalid data read out, don't throw and don't interrupt initialization
+      console.error(e);
     }
   }
 
@@ -156,6 +173,15 @@ export function connectToDevTools(options: ?ConnectOptions) {
         savedComponentFilters = componentFilters;
       },
     );
+
+    if (devToolsSettingsManager != null && bridge != null) {
+      bridge.addListener('updateConsolePatchSettings', consolePatchSettings =>
+        cacheConsolePatchSettings(
+          devToolsSettingsManager,
+          consolePatchSettings,
+        ),
+      );
+    }
 
     // The renderer interface doesn't read saved component filters directly,
     // because they are generally stored in localStorage within the context of the extension.

--- a/packages/react-devtools-core/src/cachedSettings.js
+++ b/packages/react-devtools-core/src/cachedSettings.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {
+  type ConsolePatchSettings,
+  writeConsolePatchSettingsToWindow,
+} from 'react-devtools-shared/src/backend/console';
+import {castBool, castBrowserTheme} from 'react-devtools-shared/src/utils';
+
+// Note: all keys should be optional in this type, because users can use newer
+// versions of React DevTools with older versions of React Native, and the object
+// provided by React Native may not include all of this type's fields.
+export type DevToolsSettingsManager = {
+  getConsolePatchSettings: ?() => string,
+  setConsolePatchSettings: ?(key: string) => void,
+};
+
+export function initializeUsingCachedSettings(
+  devToolsSettingsManager: DevToolsSettingsManager,
+) {
+  initializeConsolePatchSettings(devToolsSettingsManager);
+}
+
+function initializeConsolePatchSettings(
+  devToolsSettingsManager: DevToolsSettingsManager,
+) {
+  if (devToolsSettingsManager.getConsolePatchSettings == null) {
+    return;
+  }
+  const consolePatchSettingsString = devToolsSettingsManager.getConsolePatchSettings();
+  if (consolePatchSettingsString == null) {
+    return;
+  }
+  const parsedConsolePatchSettings = parseConsolePatchSettings(
+    consolePatchSettingsString,
+  );
+  if (parsedConsolePatchSettings == null) {
+    return;
+  }
+  writeConsolePatchSettingsToWindow(parsedConsolePatchSettings);
+}
+
+function parseConsolePatchSettings(
+  consolePatchSettingsString: string,
+): ?ConsolePatchSettings {
+  const parsedValue = JSON.parse(consolePatchSettingsString ?? '{}');
+  const {
+    appendComponentStack,
+    breakOnConsoleErrors,
+    showInlineWarningsAndErrors,
+    hideConsoleLogsInStrictMode,
+    browserTheme,
+  } = parsedValue;
+  return {
+    appendComponentStack: castBool(appendComponentStack) ?? true,
+    breakOnConsoleErrors: castBool(breakOnConsoleErrors) ?? false,
+    showInlineWarningsAndErrors: castBool(showInlineWarningsAndErrors) ?? true,
+    hideConsoleLogsInStrictMode: castBool(hideConsoleLogsInStrictMode) ?? false,
+    browserTheme: castBrowserTheme(browserTheme) ?? 'dark',
+  };
+}
+
+export function cacheConsolePatchSettings(
+  devToolsSettingsManager: DevToolsSettingsManager,
+  value: ConsolePatchSettings,
+): void {
+  if (devToolsSettingsManager.setConsolePatchSettings == null) {
+    return;
+  }
+  devToolsSettingsManager.setConsolePatchSettings(JSON.stringify(value));
+}

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -25,7 +25,7 @@ import {
   initialize as setupTraceUpdates,
   toggleEnabled as setTraceUpdatesEnabled,
 } from './views/TraceUpdates';
-import {patch as patchConsole} from './console';
+import {patch as patchConsole, type ConsolePatchSettings} from './console';
 import {currentBridgeProtocol} from 'react-devtools-shared/src/bridge';
 
 import type {BackendBridge} from 'react-devtools-shared/src/bridge';
@@ -712,11 +712,11 @@ export default class Agent extends EventEmitter<{
     showInlineWarningsAndErrors,
     hideConsoleLogsInStrictMode,
     browserTheme,
-  }) => {
-    // If the frontend preference has change,
-    // or in the case of React Native- if the backend is just finding out the preference-
+  }: ConsolePatchSettings) => {
+    // If the frontend preferences have changed,
+    // or in the case of React Native- if the backend is just finding out the preferences-
     // then reinstall the console overrides.
-    // It's safe to call these methods multiple times, so we don't need to worry about that.
+    // It's safe to call `patchConsole` multiple times.
     patchConsole({
       appendComponentStack,
       breakOnConsoleErrors,

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -17,7 +17,7 @@ import type {
   RendererID,
 } from 'react-devtools-shared/src/backend/types';
 import type {StyleAndLayout as StyleAndLayoutPayload} from 'react-devtools-shared/src/backend/NativeStyleEditor/types';
-import type {BrowserTheme} from 'react-devtools-shared/src/devtools/views/DevTools';
+import type {ConsolePatchSettings} from 'react-devtools-shared/src/backend/console';
 
 const BATCH_DURATION = 100;
 
@@ -171,14 +171,6 @@ type NativeStyleEditor_SetValueParams = {
   value: string,
 };
 
-type UpdateConsolePatchSettingsParams = {
-  appendComponentStack: boolean,
-  breakOnConsoleErrors: boolean,
-  showInlineWarningsAndErrors: boolean,
-  hideConsoleLogsInStrictMode: boolean,
-  browserTheme: BrowserTheme,
-};
-
 type SavedPreferencesParams = {
   appendComponentStack: boolean,
   breakOnConsoleErrors: boolean,
@@ -247,7 +239,7 @@ type FrontendEvents = {
   stopProfiling: [],
   storeAsGlobal: [StoreAsGlobalParams],
   updateComponentFilters: [Array<ComponentFilter>],
-  updateConsolePatchSettings: [UpdateConsolePatchSettingsParams],
+  updateConsolePatchSettings: [ConsolePatchSettings],
   viewAttributeSource: [ViewAttributeSourceParams],
   viewElementSource: [ElementAndRendererID],
 

--- a/packages/react-devtools-shared/src/utils.js
+++ b/packages/react-devtools-shared/src/utils.js
@@ -55,6 +55,7 @@ import isArray from './isArray';
 
 import type {ComponentFilter, ElementType} from './types';
 import type {LRUCache} from 'react-devtools-shared/src/types';
+import type {BrowserTheme} from 'react-devtools-shared/src/devtools/views/DevTools';
 
 // $FlowFixMe[method-unbinding]
 const hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -350,6 +351,18 @@ function parseBool(s: ?string): ?boolean {
   }
   if (s === 'false') {
     return false;
+  }
+}
+
+export function castBool(v: any): ?boolean {
+  if (v === true || v === false) {
+    return v;
+  }
+}
+
+export function castBrowserTheme(v: any): ?BrowserTheme {
+  if (v === 'light' || v === 'dark' || v === 'auto') {
+    return v;
   }
 }
 


### PR DESCRIPTION
# Summary
* This PR adds support for persisting certain settings to device storage, allowing e.g. RN apps to properly patch the console when restarted.
  * The device storage APIs have signature `getValue(string)` and `setValue(string, string)`, and are thin wrappers around the `Library/Settings` turbomodule.
* Pass device storage getters/setters from RN to DevTools' `connectToDevtools`. The setters are then used to populate values on `window`. Later, the console is patched using these values.
* If we receive a notification from DevTools that the console patching fields have been updated, we write values back to local storage.
* See https://github.com/facebook/react-native/pull/34903

# How did you test this change?
Manual testing, `yarn run test-build-devtools`, `yarn run prettier`, `yarn run flow dom`

## Manual testing setup:

### React DevTools Frontend
* Get the DevTools frontend in flipper:
  * `nvm install -g react-devtools-core`, then replace that package with a symlink to the local package
  * enable "use globally installed devtools" in flipper
* yarn run start in react-devtools, etc. as well

### React DevTools Backend
* `yarn run build:backend` in react-devtools-core, then copy-paste that file to the expo app's node_modules directory

### React Native
* A local version of React Native can be patched in by modifying an expo app's package.json, as in `"react-native": "rbalicki2/react-native#branch-name"`

# Versioning safety
* There are three versioned modules to worry about: react native, the devtools frontend and the devtools backend.
* The react devtools backend checks for whether a `cachedSettingsStore` is passed from react native. If not (e.g. if React Native is outdated), then no behavior changes.
* The devtools backend reads the patched console values from the cached settings store. However, if nothing has been stored, for example because the frontend is outdated or has never synced its settings, then behavior doesn't change.
* The devtools frontend sends no new messages. However, if it did send a new message (e.g. "store this value at this key"), and the backend was outdated, that message would be silently ignored.
