### PR TITLE
[useEvent] Non-stable function identity

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -15,11 +15,7 @@ import type {
   ChildSet,
   UpdatePayload,
 } from './ReactFiberHostConfig';
-import type {
-  Fiber,
-  FiberRoot,
-  EventFunctionWrapper,
-} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.new';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.new';
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.new';
@@ -689,13 +685,9 @@ function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const eventPayloads = updateQueue !== null ? updateQueue.events : null;
   if (eventPayloads !== null) {
-    // FunctionComponentUpdateQueue.events is a flat array of
-    // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
-    // pair.
-    for (let ii = 0; ii < eventPayloads.length; ii += 2) {
-      const eventFn: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
-      const nextImpl = eventPayloads[ii + 1];
-      eventFn._impl = nextImpl;
+    for (let ii = 0; ii < eventPayloads.length; ii++) {
+      const {ref, nextImpl} = eventPayloads[ii];
+      ref.impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -15,11 +15,7 @@ import type {
   ChildSet,
   UpdatePayload,
 } from './ReactFiberHostConfig';
-import type {
-  Fiber,
-  FiberRoot,
-  EventFunctionWrapper,
-} from './ReactInternalTypes';
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
 import type {Lanes} from './ReactFiberLane.old';
 import type {SuspenseState} from './ReactFiberSuspenseComponent.old';
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.old';
@@ -689,13 +685,9 @@ function commitUseEventMount(finishedWork: Fiber) {
   const updateQueue: FunctionComponentUpdateQueue | null = (finishedWork.updateQueue: any);
   const eventPayloads = updateQueue !== null ? updateQueue.events : null;
   if (eventPayloads !== null) {
-    // FunctionComponentUpdateQueue.events is a flat array of
-    // [EventFunctionWrapper, EventFunction, ...], so increment by 2 each iteration to find the next
-    // pair.
-    for (let ii = 0; ii < eventPayloads.length; ii += 2) {
-      const eventFn: EventFunctionWrapper<any, any, any> = eventPayloads[ii];
-      const nextImpl = eventPayloads[ii + 1];
-      eventFn._impl = nextImpl;
+    for (let ii = 0; ii < eventPayloads.length; ii++) {
+      const {ref, nextImpl} = eventPayloads[ii];
+      ref.impl = nextImpl;
     }
   }
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1928,10 +1928,9 @@ function useEventImpl<Args, Return, F: (...Array<Args>) => Return>(
   }
 }
 
-function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
+function wrapEventFunction<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const hook = mountWorkInProgressHook();
   const eventFn: EventFunctionWrapper<Args, Return, F> = function eventFn() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
@@ -1942,17 +1941,21 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
     return eventFn._impl.apply(undefined, arguments);
   };
   eventFn._impl = callback;
+  return eventFn;
+}
 
+function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): EventFunctionWrapper<Args, Return, F> {
+  const eventFn = wrapEventFunction(callback);
   useEventImpl(eventFn, callback);
-  hook.memoizedState = eventFn;
   return eventFn;
 }
 
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const hook = updateWorkInProgressHook();
-  const eventFn = hook.memoizedState;
+  const eventFn = wrapEventFunction(callback);
   useEventImpl(eventFn, callback);
   return eventFn;
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1947,7 +1947,9 @@ function wrapEventFunction<Args, Return, F: (...Array<Args>) => Return>(
 function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
+  const hook = mountWorkInProgressHook();
   const eventFn = wrapEventFunction(callback);
+  hook.memoizedState = eventFn;
   useEventImpl(eventFn, callback);
   return eventFn;
 }
@@ -1955,9 +1957,11 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const eventFn = wrapEventFunction(callback);
+  const hook = updateWorkInProgressHook();
+  const eventFn = hook.memoizedState;
   useEventImpl(eventFn, callback);
-  return eventFn;
+  // Always return a new function
+  return wrapEventFunction(callback);
 }
 
 function mountInsertionEffect(

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1950,7 +1950,6 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   const hook = mountWorkInProgressHook();
   const eventFn = wrapEventFunction(callback);
   hook.memoizedState = eventFn;
-  useEventImpl(eventFn, callback);
   return eventFn;
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1928,10 +1928,9 @@ function useEventImpl<Args, Return, F: (...Array<Args>) => Return>(
   }
 }
 
-function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
+function wrapEventFunction<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const hook = mountWorkInProgressHook();
   const eventFn: EventFunctionWrapper<Args, Return, F> = function eventFn() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
@@ -1942,17 +1941,21 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
     return eventFn._impl.apply(undefined, arguments);
   };
   eventFn._impl = callback;
+  return eventFn;
+}
 
+function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
+  callback: F,
+): EventFunctionWrapper<Args, Return, F> {
+  const eventFn = wrapEventFunction(callback);
   useEventImpl(eventFn, callback);
-  hook.memoizedState = eventFn;
   return eventFn;
 }
 
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const hook = updateWorkInProgressHook();
-  const eventFn = hook.memoizedState;
+  const eventFn = wrapEventFunction(callback);
   useEventImpl(eventFn, callback);
   return eventFn;
 }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1947,7 +1947,9 @@ function wrapEventFunction<Args, Return, F: (...Array<Args>) => Return>(
 function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
+  const hook = mountWorkInProgressHook();
   const eventFn = wrapEventFunction(callback);
+  hook.memoizedState = eventFn;
   useEventImpl(eventFn, callback);
   return eventFn;
 }
@@ -1955,9 +1957,11 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
 ): EventFunctionWrapper<Args, Return, F> {
-  const eventFn = wrapEventFunction(callback);
+  const hook = updateWorkInProgressHook();
+  const eventFn = hook.memoizedState;
   useEventImpl(eventFn, callback);
-  return eventFn;
+  // Always return a new function
+  return wrapEventFunction(callback);
 }
 
 function mountInsertionEffect(

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1950,7 +1950,6 @@ function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   const hook = mountWorkInProgressHook();
   const eventFn = wrapEventFunction(callback);
   hook.memoizedState = eventFn;
-  useEventImpl(eventFn, callback);
   return eventFn;
 }
 

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -22,7 +22,6 @@ import type {
   Dispatcher,
   HookType,
   MemoCache,
-  EventFunctionWrapper,
 } from './ReactInternalTypes';
 import type {Lanes, Lane} from './ReactFiberLane.old';
 import type {HookFlags} from './ReactHookEffectTags';
@@ -189,9 +188,17 @@ type StoreConsistencyCheck<T> = {
   getSnapshot: () => T,
 };
 
+type EventFunctionPayload<Args, Return, F: (...Array<Args>) => Return> = {
+  ref: {
+    eventFn: F,
+    impl: F,
+  },
+  nextImpl: F,
+};
+
 export type FunctionComponentUpdateQueue = {
   lastEffect: Effect | null,
-  events: Array<() => mixed> | null,
+  events: Array<EventFunctionPayload<any, any, any>> | null,
   stores: Array<StoreConsistencyCheck<any>> | null,
   // NOTE: optional, only set when enableUseMemoCacheHook is enabled
   memoCache?: MemoCache | null,
@@ -1909,58 +1916,56 @@ function updateEffect(
 }
 
 function useEventImpl<Args, Return, F: (...Array<Args>) => Return>(
-  event: EventFunctionWrapper<Args, Return, F>,
-  nextImpl: F,
+  payload: EventFunctionPayload<Args, Return, F>,
 ) {
   currentlyRenderingFiber.flags |= UpdateEffect;
   let componentUpdateQueue: null | FunctionComponentUpdateQueue = (currentlyRenderingFiber.updateQueue: any);
   if (componentUpdateQueue === null) {
     componentUpdateQueue = createFunctionComponentUpdateQueue();
     currentlyRenderingFiber.updateQueue = (componentUpdateQueue: any);
-    componentUpdateQueue.events = [event, nextImpl];
+    componentUpdateQueue.events = [payload];
   } else {
     const events = componentUpdateQueue.events;
     if (events === null) {
-      componentUpdateQueue.events = [event, nextImpl];
+      componentUpdateQueue.events = [payload];
     } else {
-      events.push(event, nextImpl);
+      events.push(payload);
     }
   }
 }
 
-function wrapEventFunction<Args, Return, F: (...Array<Args>) => Return>(
+function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
-): EventFunctionWrapper<Args, Return, F> {
-  const eventFn: EventFunctionWrapper<Args, Return, F> = function eventFn() {
+): F {
+  const hook = mountWorkInProgressHook();
+  const ref = {impl: callback};
+  hook.memoizedState = ref;
+  // $FlowIgnore[incompatible-return]
+  return function eventFn() {
     if (isInvalidExecutionContextForEventFunction()) {
       throw new Error(
         "A function wrapped in useEvent can't be called during rendering.",
       );
     }
-    // $FlowFixMe[prop-missing] found when upgrading Flow
-    return eventFn._impl.apply(undefined, arguments);
+    return ref.impl.apply(undefined, arguments);
   };
-  eventFn._impl = callback;
-  return eventFn;
-}
-
-function mountEvent<Args, Return, F: (...Array<Args>) => Return>(
-  callback: F,
-): EventFunctionWrapper<Args, Return, F> {
-  const hook = mountWorkInProgressHook();
-  const eventFn = wrapEventFunction(callback);
-  hook.memoizedState = eventFn;
-  return eventFn;
 }
 
 function updateEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
-): EventFunctionWrapper<Args, Return, F> {
+): F {
   const hook = updateWorkInProgressHook();
-  const eventFn = hook.memoizedState;
-  useEventImpl(eventFn, callback);
-  // Always return a new function
-  return wrapEventFunction(callback);
+  const ref = hook.memoizedState;
+  useEventImpl({ref, nextImpl: callback});
+  // $FlowIgnore[incompatible-return]
+  return function eventFn() {
+    if (isInvalidExecutionContextForEventFunction()) {
+      throw new Error(
+        "A function wrapped in useEvent can't be called during rendering.",
+      );
+    }
+    return ref.impl.apply(undefined, arguments);
+  };
 }
 
 function mountInsertionEffect(
@@ -2922,7 +2927,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       mountHookTypesDev();
       return mountEvent(callback);
@@ -3079,7 +3084,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return mountEvent(callback);
@@ -3236,7 +3241,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return updateEvent(callback);
@@ -3394,7 +3399,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       updateHookTypesDev();
       return updateEvent(callback);
@@ -3578,7 +3583,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       mountHookTypesDev();
@@ -3763,7 +3768,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();
@@ -3949,7 +3954,7 @@ if (__DEV__) {
       Args,
       Return,
       F: (...Array<Args>) => Return,
-    >(callback: F): EventFunctionWrapper<Args, Return, F> {
+    >(callback: F): F {
       currentHookNameInDev = 'useEvent';
       warnInvalidHookAccess();
       updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -290,17 +290,6 @@ type SuspenseCallbackOnlyFiberRootProperties = {
   hydrationCallbacks: null | SuspenseHydrationCallbacks,
 };
 
-// A wrapper callable object around a useEvent callback that throws if the callback is called during
-// rendering. The _impl property points to the actual implementation.
-export type EventFunctionWrapper<
-  Args,
-  Return,
-  F: (...Array<Args>) => Return,
-> = {
-  (): F,
-  _impl: F,
-};
-
 export type TransitionTracingCallbacks = {
   onTransitionStart?: (transitionName: string, startTime: number) => void,
   onTransitionProgress?: (
@@ -390,9 +379,7 @@ export type Dispatcher = {
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,
   ): void,
-  useEvent?: <Args, Return, F: (...Array<Args>) => Return>(
-    callback: F,
-  ) => EventFunctionWrapper<Args, Return, F>,
+  useEvent?: <Args, Return, F: (...Array<Args>) => Return>(callback: F) => F,
   useInsertionEffect(
     create: () => (() => void) | void,
     deps: Array<mixed> | void | null,

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -7,10 +7,7 @@
  * @flow
  */
 
-import type {
-  Dispatcher,
-  EventFunctionWrapper,
-} from 'react-reconciler/src/ReactInternalTypes';
+import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
 
 import type {
   MutableSource,
@@ -522,7 +519,8 @@ function throwOnUseEventCall() {
 
 export function useEvent<Args, Return, F: (...Array<Args>) => Return>(
   callback: F,
-): EventFunctionWrapper<Args, Return, F> {
+): F {
+  // $FlowIgnore[incompatible-return]
   return throwOnUseEventCall;
 }
 


### PR DESCRIPTION
Since useEvent shouldn't go in the dependency list of whatever is consuming it (which is enforced by the fact that useEvent functions are always locally created and never passed by reference), its identity doesn't matter. Effectively, this PR is a runtime assertion that you can't rely on the return value of useEvent to be stable.

PR to ExhaustiveDeps to properly lint for this: #25512
