### PR TITLE
Split Cache into its own Dispatcher

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -101,10 +101,6 @@ function nextHook(): null | Hook {
   return hook;
 }
 
-function getCacheForType<T>(resourceType: () => T): T {
-  throw new Error('Not implemented.');
-}
-
 function readContext<T>(context: ReactContext<T>): T {
   // For now we don't expose readContext usage in the hooks debugging info.
   return context._currentValue;
@@ -331,7 +327,6 @@ function useId(): string {
 }
 
 const Dispatcher: DispatcherType = {
-  getCacheForType,
   readContext,
   useCacheRefresh,
   useCallback,

--- a/packages/react-reconciler/src/ReactFiberCache.new.js
+++ b/packages/react-reconciler/src/ReactFiberCache.new.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CacheDispatcher} from './ReactInternalTypes';
+import type {Cache} from './ReactFiberCacheComponent.new';
+
+import {enableCache} from 'shared/ReactFeatureFlags';
+import {readContext} from './ReactFiberNewContext.new';
+import {CacheContext} from './ReactFiberCacheComponent.new';
+
+function getCacheSignal(): AbortSignal {
+  if (!enableCache) {
+    throw new Error('Not implemented.');
+  }
+  const cache: Cache = readContext(CacheContext);
+  return cache.controller.signal;
+}
+
+function getCacheForType<T>(resourceType: () => T): T {
+  if (!enableCache) {
+    throw new Error('Not implemented.');
+  }
+  const cache: Cache = readContext(CacheContext);
+  let cacheForType: T | void = (cache.data.get(resourceType): any);
+  if (cacheForType === undefined) {
+    cacheForType = resourceType();
+    cache.data.set(resourceType, cacheForType);
+  }
+  return cacheForType;
+}
+
+export const DefaultCacheDispatcher: CacheDispatcher = {
+  getCacheSignal,
+  getCacheForType,
+};

--- a/packages/react-reconciler/src/ReactFiberCache.old.js
+++ b/packages/react-reconciler/src/ReactFiberCache.old.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CacheDispatcher} from './ReactInternalTypes';
+import type {Cache} from './ReactFiberCacheComponent.old';
+
+import {enableCache} from 'shared/ReactFeatureFlags';
+import {readContext} from './ReactFiberNewContext.old';
+import {CacheContext} from './ReactFiberCacheComponent.old';
+
+function getCacheSignal(): AbortSignal {
+  if (!enableCache) {
+    throw new Error('Not implemented.');
+  }
+  const cache: Cache = readContext(CacheContext);
+  return cache.controller.signal;
+}
+
+function getCacheForType<T>(resourceType: () => T): T {
+  if (!enableCache) {
+    throw new Error('Not implemented.');
+  }
+  const cache: Cache = readContext(CacheContext);
+  let cacheForType: T | void = (cache.data.get(resourceType): any);
+  if (cacheForType === undefined) {
+    cacheForType = resourceType();
+    cache.data.set(resourceType, cacheForType);
+  }
+  return cacheForType;
+}
+
+export const DefaultCacheDispatcher: CacheDispatcher = {
+  getCacheSignal,
+  getCacheForType,
+};

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -26,7 +26,6 @@ import type {
 import type {Lanes, Lane} from './ReactFiberLane.new';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {FiberRoot} from './ReactInternalTypes';
-import type {Cache} from './ReactFiberCacheComponent.new';
 import type {Flags} from './ReactFiberFlags';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -122,7 +121,7 @@ import {
 } from './ReactMutableSource.new';
 import {logStateUpdateScheduled} from './DebugTracing';
 import {markStateUpdateScheduled} from './ReactFiberDevToolsHook.new';
-import {createCache, CacheContext} from './ReactFiberCacheComponent.new';
+import {createCache} from './ReactFiberCacheComponent.new';
 import {
   createUpdate as createLegacyQueueUpdate,
   enqueueUpdate as enqueueLegacyQueueUpdate,
@@ -2600,27 +2599,6 @@ function markUpdateInDevTools<A>(fiber, lane, action: A) {
   }
 }
 
-function getCacheSignal(): AbortSignal {
-  if (!enableCache) {
-    throw new Error('Not implemented.');
-  }
-  const cache: Cache = readContext(CacheContext);
-  return cache.controller.signal;
-}
-
-function getCacheForType<T>(resourceType: () => T): T {
-  if (!enableCache) {
-    throw new Error('Not implemented.');
-  }
-  const cache: Cache = readContext(CacheContext);
-  let cacheForType: T | void = (cache.data.get(resourceType): any);
-  if (cacheForType === undefined) {
-    cacheForType = resourceType();
-    cache.data.set(resourceType, cacheForType);
-  }
-  return cacheForType;
-}
-
 export const ContextOnlyDispatcher: Dispatcher = {
   readContext,
 
@@ -2644,8 +2622,6 @@ export const ContextOnlyDispatcher: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (ContextOnlyDispatcher: Dispatcher).getCacheSignal = getCacheSignal;
-  (ContextOnlyDispatcher: Dispatcher).getCacheForType = getCacheForType;
   (ContextOnlyDispatcher: Dispatcher).useCacheRefresh = throwInvalidHookError;
 }
 if (enableUseHook) {
@@ -2681,8 +2657,6 @@ const HooksDispatcherOnMount: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnMount: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnMount: Dispatcher).getCacheForType = getCacheForType;
   // $FlowFixMe[escaped-generic] discovered when updating Flow
   (HooksDispatcherOnMount: Dispatcher).useCacheRefresh = mountRefresh;
 }
@@ -2718,8 +2692,6 @@ const HooksDispatcherOnUpdate: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnUpdate: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnUpdate: Dispatcher).getCacheForType = getCacheForType;
   (HooksDispatcherOnUpdate: Dispatcher).useCacheRefresh = updateRefresh;
 }
 if (enableUseMemoCacheHook) {
@@ -2755,8 +2727,6 @@ const HooksDispatcherOnRerender: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnRerender: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnRerender: Dispatcher).getCacheForType = getCacheForType;
   (HooksDispatcherOnRerender: Dispatcher).useCacheRefresh = updateRefresh;
 }
 if (enableUseHook) {
@@ -2935,8 +2905,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnMountInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnMountInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnMountInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       mountHookTypesDev();
@@ -3094,8 +3062,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3253,8 +3219,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnUpdateInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnUpdateInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnUpdateInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3413,8 +3377,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnRerenderInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnRerenderInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnRerenderInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3589,8 +3551,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       mountHookTypesDev();
@@ -3776,8 +3736,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3964,8 +3922,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -26,7 +26,6 @@ import type {
 import type {Lanes, Lane} from './ReactFiberLane.old';
 import type {HookFlags} from './ReactHookEffectTags';
 import type {FiberRoot} from './ReactInternalTypes';
-import type {Cache} from './ReactFiberCacheComponent.old';
 import type {Flags} from './ReactFiberFlags';
 
 import ReactSharedInternals from 'shared/ReactSharedInternals';
@@ -122,7 +121,7 @@ import {
 } from './ReactMutableSource.old';
 import {logStateUpdateScheduled} from './DebugTracing';
 import {markStateUpdateScheduled} from './ReactFiberDevToolsHook.old';
-import {createCache, CacheContext} from './ReactFiberCacheComponent.old';
+import {createCache} from './ReactFiberCacheComponent.old';
 import {
   createUpdate as createLegacyQueueUpdate,
   enqueueUpdate as enqueueLegacyQueueUpdate,
@@ -2600,27 +2599,6 @@ function markUpdateInDevTools<A>(fiber, lane, action: A) {
   }
 }
 
-function getCacheSignal(): AbortSignal {
-  if (!enableCache) {
-    throw new Error('Not implemented.');
-  }
-  const cache: Cache = readContext(CacheContext);
-  return cache.controller.signal;
-}
-
-function getCacheForType<T>(resourceType: () => T): T {
-  if (!enableCache) {
-    throw new Error('Not implemented.');
-  }
-  const cache: Cache = readContext(CacheContext);
-  let cacheForType: T | void = (cache.data.get(resourceType): any);
-  if (cacheForType === undefined) {
-    cacheForType = resourceType();
-    cache.data.set(resourceType, cacheForType);
-  }
-  return cacheForType;
-}
-
 export const ContextOnlyDispatcher: Dispatcher = {
   readContext,
 
@@ -2644,8 +2622,6 @@ export const ContextOnlyDispatcher: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (ContextOnlyDispatcher: Dispatcher).getCacheSignal = getCacheSignal;
-  (ContextOnlyDispatcher: Dispatcher).getCacheForType = getCacheForType;
   (ContextOnlyDispatcher: Dispatcher).useCacheRefresh = throwInvalidHookError;
 }
 if (enableUseHook) {
@@ -2681,8 +2657,6 @@ const HooksDispatcherOnMount: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnMount: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnMount: Dispatcher).getCacheForType = getCacheForType;
   // $FlowFixMe[escaped-generic] discovered when updating Flow
   (HooksDispatcherOnMount: Dispatcher).useCacheRefresh = mountRefresh;
 }
@@ -2718,8 +2692,6 @@ const HooksDispatcherOnUpdate: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnUpdate: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnUpdate: Dispatcher).getCacheForType = getCacheForType;
   (HooksDispatcherOnUpdate: Dispatcher).useCacheRefresh = updateRefresh;
 }
 if (enableUseMemoCacheHook) {
@@ -2755,8 +2727,6 @@ const HooksDispatcherOnRerender: Dispatcher = {
   unstable_isNewReconciler: enableNewReconciler,
 };
 if (enableCache) {
-  (HooksDispatcherOnRerender: Dispatcher).getCacheSignal = getCacheSignal;
-  (HooksDispatcherOnRerender: Dispatcher).getCacheForType = getCacheForType;
   (HooksDispatcherOnRerender: Dispatcher).useCacheRefresh = updateRefresh;
 }
 if (enableUseHook) {
@@ -2935,8 +2905,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnMountInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnMountInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnMountInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       mountHookTypesDev();
@@ -3094,8 +3062,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnMountWithHookTypesInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3253,8 +3219,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnUpdateInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnUpdateInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnUpdateInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3413,8 +3377,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (HooksDispatcherOnRerenderInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (HooksDispatcherOnRerenderInDEV: Dispatcher).getCacheForType = getCacheForType;
     (HooksDispatcherOnRerenderInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3589,8 +3551,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnMountInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       mountHookTypesDev();
@@ -3776,8 +3736,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnUpdateInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();
@@ -3964,8 +3922,6 @@ if (__DEV__) {
     unstable_isNewReconciler: enableNewReconciler,
   };
   if (enableCache) {
-    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).getCacheSignal = getCacheSignal;
-    (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).getCacheForType = getCacheForType;
     (InvalidNestedHooksDispatcherOnRerenderInDEV: Dispatcher).useCacheRefresh = function useCacheRefresh() {
       currentHookNameInDev = 'useCacheRefresh';
       updateHookTypesDev();

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -207,6 +207,7 @@ import {
   ContextOnlyDispatcher,
   getIsUpdatingOpaqueValueInRenderPhaseInDEV,
 } from './ReactFiberHooks.new';
+import {DefaultCacheDispatcher} from './ReactFiberCache.new';
 import {
   createCapturedValueAtFiber,
   type CapturedValue,
@@ -279,6 +280,7 @@ const PossiblyWeakMap = typeof WeakMap === 'function' ? WeakMap : Map;
 
 const {
   ReactCurrentDispatcher,
+  ReactCurrentCache,
   ReactCurrentOwner,
   ReactCurrentBatchConfig,
   ReactCurrentActQueue,
@@ -1790,6 +1792,22 @@ function popDispatcher(prevDispatcher) {
   ReactCurrentDispatcher.current = prevDispatcher;
 }
 
+function pushCacheDispatcher() {
+  if (enableCache) {
+    const prevCacheDispatcher = ReactCurrentCache.current;
+    ReactCurrentCache.current = DefaultCacheDispatcher;
+    return prevCacheDispatcher;
+  } else {
+    return null;
+  }
+}
+
+function popCacheDispatcher(prevCacheDispatcher) {
+  if (enableCache) {
+    ReactCurrentCache.current = prevCacheDispatcher;
+  }
+}
+
 export function markCommitTimeOfFallback() {
   globalMostRecentFallbackTime = now();
 }
@@ -1857,6 +1875,7 @@ function renderRootSync(root: FiberRoot, lanes: Lanes) {
   const prevExecutionContext = executionContext;
   executionContext |= RenderContext;
   const prevDispatcher = pushDispatcher(root.containerInfo);
+  const prevCacheDispatcher = pushCacheDispatcher();
 
   // If the root or lanes have changed, throw out the existing stack
   // and prepare a fresh one. Otherwise we'll continue where we left off.
@@ -1903,6 +1922,7 @@ function renderRootSync(root: FiberRoot, lanes: Lanes) {
 
   executionContext = prevExecutionContext;
   popDispatcher(prevDispatcher);
+  popCacheDispatcher(prevCacheDispatcher);
 
   if (workInProgress !== null) {
     // This is a sync render, so we should have finished the whole tree.
@@ -1957,6 +1977,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
   const prevExecutionContext = executionContext;
   executionContext |= RenderContext;
   const prevDispatcher = pushDispatcher(root.containerInfo);
+  const prevCacheDispatcher = pushCacheDispatcher();
 
   // If the root or lanes have changed, throw out the existing stack
   // and prepare a fresh one. Otherwise we'll continue where we left off.
@@ -2009,6 +2030,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
   resetContextDependencies();
 
   popDispatcher(prevDispatcher);
+  popCacheDispatcher(prevCacheDispatcher);
   executionContext = prevExecutionContext;
 
   if (__DEV__) {

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -377,8 +377,6 @@ type Dispatch<A> = A => void;
 
 export type Dispatcher = {
   use?: <T>(Usable<T>) => T,
-  getCacheSignal?: () => AbortSignal,
-  getCacheForType?: <T>(resourceType: () => T) => T,
   readContext<T>(context: ReactContext<T>): T,
   useState<S>(initialState: (() => S) | S): [S, Dispatch<BasicStateAction<S>>],
   useReducer<S, I, A>(
@@ -431,4 +429,9 @@ export type Dispatcher = {
   useMemoCache?: (size: number) => Array<any>,
 
   unstable_isNewReconciler?: boolean,
+};
+
+export type CacheDispatcher = {
+  getCacheSignal: () => AbortSignal,
+  getCacheForType: <T>(resourceType: () => T) => T,
 };

--- a/packages/react-server/src/ReactFizzCache.js
+++ b/packages/react-server/src/ReactFizzCache.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
+
+function getCacheSignal(): AbortSignal {
+  throw new Error('Not implemented.');
+}
+
+function getCacheForType<T>(resourceType: () => T): T {
+  throw new Error('Not implemented.');
+}
+
+export const DefaultCacheDispatcher: CacheDispatcher = {
+  getCacheSignal,
+  getCacheForType,
+};

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -8,7 +8,7 @@
  */
 
 import type {
-  Dispatcher as DispatcherType,
+  Dispatcher,
   EventFunctionWrapper,
 } from 'react-reconciler/src/ReactInternalTypes';
 
@@ -272,14 +272,6 @@ export function resetHooksState(): void {
   numberOfReRenders = 0;
   renderPhaseUpdates = null;
   workInProgressHook = null;
-}
-
-function getCacheSignal(): AbortSignal {
-  throw new Error('Not implemented.');
-}
-
-function getCacheForType<T>(resourceType: () => T): T {
-  throw new Error('Not implemented.');
 }
 
 function readContext<T>(context: ReactContext<T>): T {
@@ -679,7 +671,7 @@ function useMemoCache(size: number): Array<any> {
 
 function noop(): void {}
 
-export const Dispatcher: DispatcherType = {
+export const HooksDispatcher: Dispatcher = {
   readContext,
   useContext,
   useMemo,
@@ -704,18 +696,16 @@ export const Dispatcher: DispatcherType = {
 };
 
 if (enableCache) {
-  Dispatcher.getCacheSignal = getCacheSignal;
-  Dispatcher.getCacheForType = getCacheForType;
-  Dispatcher.useCacheRefresh = useCacheRefresh;
+  HooksDispatcher.useCacheRefresh = useCacheRefresh;
 }
 if (enableUseEventHook) {
-  Dispatcher.useEvent = useEvent;
+  HooksDispatcher.useEvent = useEvent;
 }
 if (enableUseMemoCacheHook) {
-  Dispatcher.useMemoCache = useMemoCache;
+  HooksDispatcher.useMemoCache = useMemoCache;
 }
 if (enableUseHook) {
-  Dispatcher.use = use;
+  HooksDispatcher.use = use;
 }
 
 export let currentResponseState: null | ResponseState = (null: any);

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -274,9 +274,11 @@ export function resetHooksState(): void {
   workInProgressHook = null;
 }
 
+function getCacheSignal(): AbortSignal {
+  throw new Error('Not implemented.');
+}
+
 function getCacheForType<T>(resourceType: () => T): T {
-  // TODO: This should silently mark this as client rendered since it's not necessarily
-  // considered an error. It needs to work for things like Flight though.
   throw new Error('Not implemented.');
 }
 
@@ -702,6 +704,7 @@ export const Dispatcher: DispatcherType = {
 };
 
 if (enableCache) {
+  Dispatcher.getCacheSignal = getCacheSignal;
   Dispatcher.getCacheForType = getCacheForType;
   Dispatcher.useCacheRefresh = useCacheRefresh;
 }

--- a/packages/react-server/src/ReactFlightCache.js
+++ b/packages/react-server/src/ReactFlightCache.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
+
+export const DefaultCacheDispatcher: CacheDispatcher = {
+  getCacheSignal(): AbortSignal {
+    throw new Error('Not implemented.');
+  },
+  getCacheForType<T>(resourceType: () => T): T {
+    if (!currentCache) {
+      throw new Error('Reading the cache is only supported while rendering.');
+    }
+
+    let entry: T | void = (currentCache.get(resourceType): any);
+    if (entry === undefined) {
+      entry = resourceType();
+      // TODO: Warn if undefined?
+      // $FlowFixMe[incompatible-use] found when upgrading Flow
+      currentCache.set(resourceType, entry);
+    }
+    return entry;
+  },
+};
+
+let currentCache: Map<Function, mixed> | null = null;
+
+export function setCurrentCache(
+  cache: Map<Function, mixed> | null,
+): Map<Function, mixed> | null {
+  currentCache = cache;
+  return currentCache;
+}
+
+export function getCurrentCache(): Map<Function, mixed> | null {
+  return currentCache;
+}

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Dispatcher as DispatcherType} from 'react-reconciler/src/ReactInternalTypes';
+import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
 import type {Request} from './ReactFlightServer';
 import type {ReactServerContext, Thenable, Usable} from 'shared/ReactTypes';
 import type {ThenableState} from './ReactFlightWakeable';
@@ -52,7 +52,7 @@ function readContext<T>(context: ReactServerContext<T>): T {
         'Only createServerContext is supported in Server Components.',
       );
     }
-    if (currentCache === null) {
+    if (currentRequest === null) {
       console.error(
         'Context can only be read while React is rendering. ' +
           'In classes, you can read it in the render method or getDerivedStateFromProps. ' +
@@ -64,7 +64,7 @@ function readContext<T>(context: ReactServerContext<T>): T {
   return readContextImpl(context);
 }
 
-export const Dispatcher: DispatcherType = {
+export const HooksDispatcher: Dispatcher = {
   useMemo<T>(nextCreate: () => T): T {
     return nextCreate();
   },
@@ -74,23 +74,6 @@ export const Dispatcher: DispatcherType = {
   useDebugValue(): void {},
   useDeferredValue: (unsupportedHook: any),
   useTransition: (unsupportedHook: any),
-  getCacheSignal(): AbortSignal {
-    throw new Error('Not implemented.');
-  },
-  getCacheForType<T>(resourceType: () => T): T {
-    if (!currentCache) {
-      throw new Error('Reading the cache is only supported while rendering.');
-    }
-
-    let entry: T | void = (currentCache.get(resourceType): any);
-    if (entry === undefined) {
-      entry = resourceType();
-      // TODO: Warn if undefined?
-      // $FlowFixMe[incompatible-use] found when upgrading Flow
-      currentCache.set(resourceType, entry);
-    }
-    return entry;
-  },
   readContext,
   useContext: readContext,
   useReducer: (unsupportedHook: any),
@@ -117,24 +100,9 @@ function unsupportedHook(): void {
 }
 
 function unsupportedRefresh(): void {
-  if (!currentCache) {
-    throw new Error(
-      'Refreshing the cache is not supported in Server Components.',
-    );
-  }
-}
-
-let currentCache: Map<Function, mixed> | null = null;
-
-export function setCurrentCache(
-  cache: Map<Function, mixed> | null,
-): Map<Function, mixed> | null {
-  currentCache = cache;
-  return currentCache;
-}
-
-export function getCurrentCache(): Map<Function, mixed> | null {
-  return currentCache;
+  throw new Error(
+    'Refreshing the cache is not supported in Server Components.',
+  );
 }
 
 function useId(): string {

--- a/packages/react-server/src/ReactFlightHooks.js
+++ b/packages/react-server/src/ReactFlightHooks.js
@@ -74,6 +74,9 @@ export const Dispatcher: DispatcherType = {
   useDebugValue(): void {},
   useDeferredValue: (unsupportedHook: any),
   useTransition: (unsupportedHook: any),
+  getCacheSignal(): AbortSignal {
+    throw new Error('Not implemented.');
+  },
   getCacheForType<T>(resourceType: () => T): T {
     if (!currentCache) {
       throw new Error('Reading the cache is only supported while rendering.');

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -44,14 +44,17 @@ import {
 } from './ReactFlightServerConfig';
 
 import {
-  Dispatcher,
-  getCurrentCache,
+  HooksDispatcher,
   prepareToUseHooksForRequest,
   prepareToUseHooksForComponent,
   getThenableStateAfterSuspending,
   resetHooksForRequest,
-  setCurrentCache,
 } from './ReactFlightHooks';
+import {
+  DefaultCacheDispatcher,
+  getCurrentCache,
+  setCurrentCache,
+} from './ReactFlightCache';
 import {
   pushProvider,
   popProvider,
@@ -131,6 +134,7 @@ export type Request = {
 };
 
 const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+const ReactCurrentCache = ReactSharedInternals.ReactCurrentCache;
 
 function defaultErrorHandler(error: mixed) {
   console['error'](error);
@@ -1002,8 +1006,10 @@ function retryTask(request: Request, task: Task): void {
 
 function performWork(request: Request): void {
   const prevDispatcher = ReactCurrentDispatcher.current;
+  const prevCacheDispatcher = ReactCurrentCache.current;
   const prevCache = getCurrentCache();
-  ReactCurrentDispatcher.current = Dispatcher;
+  ReactCurrentDispatcher.current = HooksDispatcher;
+  ReactCurrentCache.current = DefaultCacheDispatcher;
   setCurrentCache(request.cache);
   prepareToUseHooksForRequest(request);
 
@@ -1022,6 +1028,7 @@ function performWork(request: Request): void {
     fatalError(request, error);
   } finally {
     ReactCurrentDispatcher.current = prevDispatcher;
+    ReactCurrentCache.current = prevCacheDispatcher;
     setCurrentCache(prevCache);
     resetHooksForRequest();
   }

--- a/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
+++ b/packages/react-suspense-test-utils/src/ReactSuspenseTestUtils.js
@@ -7,10 +7,10 @@
  * @flow
  */
 
-import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
+import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 
-const ReactCurrentDispatcher = ReactSharedInternals.ReactCurrentDispatcher;
+const ReactCurrentCache = ReactSharedInternals.ReactCurrentCache;
 
 function unsupported() {
   throw new Error('This feature is not supported by ReactSuspenseTestUtils.');
@@ -18,7 +18,8 @@ function unsupported() {
 
 export function waitForSuspense<T>(fn: () => T): Promise<T> {
   const cache: Map<Function, mixed> = new Map();
-  const testDispatcher: Dispatcher = {
+  const testDispatcher: CacheDispatcher = {
+    getCacheSignal: unsupported,
     getCacheForType<R>(resourceType: () => R): R {
       let entry: R | void = (cache.get(resourceType): any);
       if (entry === undefined) {
@@ -28,31 +29,12 @@ export function waitForSuspense<T>(fn: () => T): Promise<T> {
       }
       return entry;
     },
-    readContext: unsupported,
-    useContext: unsupported,
-    useMemo: unsupported,
-    useReducer: unsupported,
-    useRef: unsupported,
-    useState: unsupported,
-    useInsertionEffect: unsupported,
-    useLayoutEffect: unsupported,
-    useCallback: unsupported,
-    useImperativeHandle: unsupported,
-    useEffect: unsupported,
-    useDebugValue: unsupported,
-    useDeferredValue: unsupported,
-    useTransition: unsupported,
-    useId: unsupported,
-    useMutableSource: unsupported,
-    useSyncExternalStore: unsupported,
-    useCacheRefresh: unsupported,
-    useMemoCache: unsupported,
   };
   // Not using async/await because we don't compile it.
   return new Promise((resolve, reject) => {
     function retry() {
-      const prevDispatcher = ReactCurrentDispatcher.current;
-      ReactCurrentDispatcher.current = testDispatcher;
+      const prevDispatcher = ReactCurrentCache.current;
+      ReactCurrentCache.current = testDispatcher;
       try {
         const result = fn();
         resolve(result);
@@ -63,7 +45,7 @@ export function waitForSuspense<T>(fn: () => T): Promise<T> {
           reject(thrownValue);
         }
       } finally {
-        ReactCurrentDispatcher.current = prevDispatcher;
+        ReactCurrentCache.current = prevDispatcher;
       }
     }
     retry();

--- a/packages/react/src/ReactCurrentCache.js
+++ b/packages/react/src/ReactCurrentCache.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {CacheDispatcher} from 'react-reconciler/src/ReactInternalTypes';
+
+/**
+ * Keeps track of the current Cache dispatcher.
+ */
+const ReactCurrentCache = {
+  current: (null: null | CacheDispatcher),
+};
+
+export default ReactCurrentCache;

--- a/packages/react/src/ReactCurrentDispatcher.js
+++ b/packages/react/src/ReactCurrentDispatcher.js
@@ -13,10 +13,6 @@ import type {Dispatcher} from 'react-reconciler/src/ReactInternalTypes';
  * Keeps track of the current dispatcher.
  */
 const ReactCurrentDispatcher = {
-  /**
-   * @internal
-   * @type {ReactComponent}
-   */
   current: (null: null | Dispatcher),
 };
 

--- a/packages/react/src/ReactSharedInternals.js
+++ b/packages/react/src/ReactSharedInternals.js
@@ -6,6 +6,7 @@
  */
 
 import ReactCurrentDispatcher from './ReactCurrentDispatcher';
+import ReactCurrentCache from './ReactCurrentCache';
 import ReactCurrentBatchConfig from './ReactCurrentBatchConfig';
 import ReactCurrentActQueue from './ReactCurrentActQueue';
 import ReactCurrentOwner from './ReactCurrentOwner';
@@ -15,6 +16,7 @@ import {ContextRegistry} from './ReactServerContextRegistry';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
+  ReactCurrentCache,
   ReactCurrentBatchConfig,
   ReactCurrentOwner,
 };

--- a/packages/react/src/forks/ReactCurrentDispatcher.www.js
+++ b/packages/react/src/forks/ReactCurrentDispatcher.www.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-export default require('ReactCurrentDispatcher');

--- a/packages/react/src/forks/ReactCurrentOwner.www.js
+++ b/packages/react/src/forks/ReactCurrentOwner.www.js
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-export default require('ReactCurrentOwner');

--- a/packages/react/src/forks/ReactSharedInternals.umd.js
+++ b/packages/react/src/forks/ReactSharedInternals.umd.js
@@ -7,6 +7,7 @@
 
 import * as Scheduler from 'scheduler';
 import ReactCurrentDispatcher from '../ReactCurrentDispatcher';
+import ReactCurrentCache from '../ReactCurrentCache';
 import ReactCurrentActQueue from '../ReactCurrentActQueue';
 import ReactCurrentOwner from '../ReactCurrentOwner';
 import ReactDebugCurrentFrame from '../ReactDebugCurrentFrame';
@@ -16,6 +17,7 @@ import {ContextRegistry} from '../ReactServerContextRegistry';
 
 const ReactSharedInternals = {
   ReactCurrentDispatcher,
+  ReactCurrentCache,
   ReactCurrentOwner,
   ReactCurrentBatchConfig,
 

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -439,5 +439,6 @@
   "451": "resolveSingletonInstance was called with an element type that is not supported. This is a bug in React.",
   "452": "React expected an <html> element (document.documentElement) to exist in the Document but one was not found. React never removes the documentElement for any Document it renders into so the cause is likely in some other script running on this page.",
   "453": "React expected a <head> element (document.head) to exist in the Document but one was not found. React never removes the head for any Document it renders into so the cause is likely in some other script running on this page.",
-  "454": "React expected a <body> element (document.body) to exist in the Document but one was not found. React never removes the body for any Document it renders into so the cause is likely in some other script running on this page."
+  "454": "React expected a <body> element (document.body) to exist in the Document but one was not found. React never removes the body for any Document it renders into so the cause is likely in some other script running on this page.",
+  "455": "This CacheSignal was requested outside React which means that it is immediately aborted."
 }

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -208,32 +208,6 @@ const forks = Object.freeze({
     }
   },
 
-  // In FB bundles, we preserve an inline require to ReactCurrentOwner.
-  // See the explanation in FB version of ReactCurrentOwner in www:
-  './packages/react/src/ReactCurrentOwner.js': (bundleType, entry) => {
-    switch (bundleType) {
-      case FB_WWW_DEV:
-      case FB_WWW_PROD:
-      case FB_WWW_PROFILING:
-        return './packages/react/src/forks/ReactCurrentOwner.www.js';
-      default:
-        return null;
-    }
-  },
-
-  // Similarly, we preserve an inline require to ReactCurrentDispatcher.
-  // See the explanation in FB version of ReactCurrentDispatcher in www:
-  './packages/react/src/ReactCurrentDispatcher.js': (bundleType, entry) => {
-    switch (bundleType) {
-      case FB_WWW_DEV:
-      case FB_WWW_PROD:
-      case FB_WWW_PROFILING:
-        return './packages/react/src/forks/ReactCurrentDispatcher.www.js';
-      default:
-        return null;
-    }
-  },
-
   './packages/react/src/ReactSharedInternals.js': (bundleType, entry) => {
     switch (bundleType) {
       case UMD_DEV:


### PR DESCRIPTION
These are not Hooks and have their own lifetimes that extend beyond React rendering so they'll get their own dispatcher.