### PR TITLE
Add Jest entry file for external-server-runtime

### DIFF
--- a/packages/react-dom/unstable_server-external-runtime.js
+++ b/packages/react-dom/unstable_server-external-runtime.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from 'react-dom/src/server/ReactDOMServerExternalRuntime';


### PR DESCRIPTION
Follow-up to #25482.

This file is created during build, but we need an entry point for local development, too.