### PR TITLE
Fix download-build script

### DIFF
--- a/scripts/release/shared-commands/get-build-id-for-commit.js
+++ b/scripts/release/shared-commands/get-build-id-for-commit.js
@@ -19,7 +19,7 @@ async function getBuildIdForCommit(sha, allowBrokenCI = false) {
   const retryLimit = Date.now() + RETRY_TIMEOUT;
   retry: while (true) {
     const statusesResponse = await fetch(
-      `https://api.github.com/repos/facebook/react/commits/${sha}/status`
+      `https://api.github.com/repos/facebook/react/commits/${sha}/status?per_page=100`
     );
 
     if (!statusesResponse.ok) {


### PR DESCRIPTION
The download-build script works by scraping the CircleCI job number from the GitHub status API. Yes, I know this is super hacky but last I checked this was the least bad of not a lot of options. Because the response is paginated, sometimes the status for the build job exceeds the page size.

This increases the page size to 100 so this is less likely to happen.

It'd be great to find a better way to download the artifacts. I don't love how brittle this solution is. I think switching to the GitHub Checks API might be worth trying, but last I looked into it, it has other flaws.