### PR TITLE
move resource acquisition to mutation phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1089,19 +1089,6 @@ function commitLayoutEffectOnFiber(
           committedLanes,
         );
 
-        if (flags & Update) {
-          const newResource = finishedWork.memoizedState;
-          if (current !== null) {
-            const currentResource = current.memoizedState;
-            if (currentResource !== newResource) {
-              releaseResource(currentResource);
-            }
-          }
-          finishedWork.stateNode = newResource
-            ? acquireResource(newResource)
-            : null;
-        }
-
         if (flags & Ref) {
           safelyAttachRef(finishedWork, finishedWork.return);
         }
@@ -2616,6 +2603,19 @@ function commitMutationEffectsOnFiber(
           if (current !== null) {
             safelyDetachRef(current, current.return);
           }
+        }
+
+        if (flags & Update) {
+          const newResource = finishedWork.memoizedState;
+          if (current !== null) {
+            const currentResource = current.memoizedState;
+            if (currentResource !== newResource) {
+              releaseResource(currentResource);
+            }
+          }
+          finishedWork.stateNode = newResource
+            ? acquireResource(newResource)
+            : null;
         }
         return;
       }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -1089,19 +1089,6 @@ function commitLayoutEffectOnFiber(
           committedLanes,
         );
 
-        if (flags & Update) {
-          const newResource = finishedWork.memoizedState;
-          if (current !== null) {
-            const currentResource = current.memoizedState;
-            if (currentResource !== newResource) {
-              releaseResource(currentResource);
-            }
-          }
-          finishedWork.stateNode = newResource
-            ? acquireResource(newResource)
-            : null;
-        }
-
         if (flags & Ref) {
           safelyAttachRef(finishedWork, finishedWork.return);
         }
@@ -2616,6 +2603,19 @@ function commitMutationEffectsOnFiber(
           if (current !== null) {
             safelyDetachRef(current, current.return);
           }
+        }
+
+        if (flags & Update) {
+          const newResource = finishedWork.memoizedState;
+          if (current !== null) {
+            const currentResource = current.memoizedState;
+            if (currentResource !== newResource) {
+              releaseResource(currentResource);
+            }
+          }
+          finishedWork.stateNode = newResource
+            ? acquireResource(newResource)
+            : null;
         }
         return;
       }


### PR DESCRIPTION
We initially put the acquisition in layout because we could not guarantee there would be a head mounted during mutation. Now that Singletons have landed we can do this. This does however mean that float is now dependent on singletons and so we can't have enableFloat without also having enableHostSingletons. If there is a way we've encoded these dependent flags in the past let me know and I'll update the PR.