### PR TITLE
Let ReactDOM initialize in RSC

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMInReactServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMInReactServer-test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+describe('ReactDOMInReactServer', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('react', () => require('react/react.shared-subset'));
+  });
+
+  // @gate experimental && !www
+  it('can require react-dom', () => {
+    // In RSC this will be aliased.
+    require('react');
+    require('react-dom');
+  });
+});

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -82,7 +82,9 @@ const fakeInternalInstance = {};
 
 // React.Component uses a shared frozen object by default.
 // We'll use it to determine whether we need to initialize legacy refs.
-export const emptyRefsObject: $FlowFixMe = new React.Component().refs;
+export const emptyRefsObject: $FlowFixMe = React.Component
+  ? new React.Component().refs
+  : {};
 
 let didWarnAboutStateAssignmentForComponent;
 let didWarnAboutUninitializedState;

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -82,7 +82,9 @@ const fakeInternalInstance = {};
 
 // React.Component uses a shared frozen object by default.
 // We'll use it to determine whether we need to initialize legacy refs.
-export const emptyRefsObject: $FlowFixMe = new React.Component().refs;
+export const emptyRefsObject: $FlowFixMe = React.Component
+  ? new React.Component().refs
+  : {};
 
 let didWarnAboutStateAssignmentForComponent;
 let didWarnAboutUninitializedState;

--- a/packages/react/react.shared-subset.js
+++ b/packages/react/react.shared-subset.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export * from './src/ReactSharedSubset';

--- a/scripts/jest/setupHostConfigs.js
+++ b/scripts/jest/setupHostConfigs.js
@@ -50,6 +50,14 @@ jest.mock('react', () => {
   return jest.requireActual(resolvedEntryPoint);
 });
 
+jest.mock('react/react.shared-subset', () => {
+  const resolvedEntryPoint = resolveEntryFork(
+    require.resolve('react/src/ReactSharedSubset'),
+    global.__WWW__
+  );
+  return jest.requireActual(resolvedEntryPoint);
+});
+
 jest.mock('react-reconciler/src/ReactFiberReconciler', () => {
   return jest.requireActual(
     __VARIANT__


### PR DESCRIPTION
With the `react-dom/server-rendering-stub` you can import `react-dom` in RSC so that you can call `preload` and `preinit` but if you don't alias it, then requiring it breaks because we React.Component which doesn't exist in the react subset.