### PR TITLE
[Float] support title tags as Resources

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -7,11 +7,7 @@
  * @flow
  */
 
-import type {
-  FloatRoot,
-  StyleResource,
-  ScriptResource,
-} from './ReactDOMFloatClient';
+import type {FloatRoot, RootResources} from './ReactDOMFloatClient';
 import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
 import type {ReactScopeInstance} from 'shared/ReactTypes';
 import type {
@@ -53,6 +49,7 @@ const internalEventHandlersKey = '__reactEvents$' + randomKey;
 const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
 const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
 const internalRootNodeResourcesKey = '__reactResources$' + randomKey;
+const internalResourceMarker = '__reactMarker$' + randomKey;
 
 export function detachDeletedInstance(node: Instance): void {
   // TODO: This function is only called on host components. I don't think all of
@@ -282,15 +279,22 @@ export function doesTargetHaveEventHandle(
   return eventHandles.has(eventHandle);
 }
 
-export function getResourcesFromRoot(
-  root: FloatRoot,
-): {styles: Map<string, StyleResource>, scripts: Map<string, ScriptResource>} {
+export function getResourcesFromRoot(root: FloatRoot): RootResources {
   let resources = (root: any)[internalRootNodeResourcesKey];
   if (!resources) {
     resources = (root: any)[internalRootNodeResourcesKey] = {
       styles: new Map(),
       scripts: new Map(),
+      head: new Map(),
     };
   }
   return resources;
+}
+
+export function isMarkedResource(node: Node): boolean {
+  return !!(node: any)[internalResourceMarker];
+}
+
+export function markNodeAsResource(node: Node) {
+  (node: any)[internalResourceMarker] = true;
 }

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -25,6 +25,7 @@ import {
   getInstanceFromNode as getInstanceFromNodeDOMTree,
   isContainerMarkedAsRoot,
   detachDeletedInstance,
+  isMarkedResource,
 } from './ReactDOMComponentTree';
 export {detachDeletedInstance};
 import {hasRole} from './DOMAccessibilityRoles';
@@ -58,6 +59,7 @@ import {
   TEXT_NODE,
   COMMENT_NODE,
   DOCUMENT_NODE,
+  DOCUMENT_TYPE_NODE,
   DOCUMENT_FRAGMENT_NODE,
 } from '../shared/HTMLNodeType';
 import dangerousStyleValue from '../shared/dangerousStyleValue';
@@ -711,50 +713,15 @@ export function unhideTextInstance(
 
 export function clearContainer(container: Container): void {
   if (enableHostSingletons) {
-    // We have refined the container to Element type
     const nodeType = container.nodeType;
     if (nodeType === DOCUMENT_NODE || nodeType === ELEMENT_NODE) {
       switch (container.nodeName) {
         case '#document':
         case 'HTML':
         case 'HEAD':
-        case 'BODY': {
-          let node = container.firstChild;
-          while (node) {
-            const nextNode = node.nextSibling;
-            const nodeName = node.nodeName;
-            switch (nodeName) {
-              case 'HTML':
-              case 'HEAD':
-              case 'BODY': {
-                clearContainer((node: any));
-                // If these singleton instances had previously been rendered with React they
-                // may still hold on to references to the previous fiber tree. We detatch them
-                // prospectiveyl to reset them to a baseline starting state since we cannot create
-                // new instances.
-                detachDeletedInstance((node: any));
-                break;
-              }
-              case 'STYLE': {
-                break;
-              }
-              case 'LINK': {
-                if (
-                  ((node: any): HTMLLinkElement).rel.toLowerCase() ===
-                  'stylesheet'
-                ) {
-                  break;
-                }
-              }
-              // eslint-disable-next-line no-fallthrough
-              default: {
-                container.removeChild(node);
-              }
-            }
-            node = nextNode;
-          }
+        case 'BODY':
+          clearContainerChildren(container);
           return;
-        }
         default: {
           container.textContent = '';
         }
@@ -773,6 +740,43 @@ export function clearContainer(container: Container): void {
       }
     }
   }
+}
+
+function clearContainerChildren(container: Node) {
+  let node;
+  let nextNode: ?Node = container.firstChild;
+  while (nextNode) {
+    node = nextNode;
+    nextNode = nextNode.nextSibling;
+    switch (node.nodeName) {
+      case 'HTML':
+      case 'HEAD':
+      case 'BODY': {
+        const element: Element = (node: any);
+        clearContainerChildren(element);
+        // If these singleton instances had previously been rendered with React they
+        // may still hold on to references to the previous fiber tree. We detatch them
+        // prospectively to reset them to a baseline starting state since we cannot create
+        // new instances.
+        detachDeletedInstance(element);
+        continue;
+      }
+      case 'STYLE': {
+        continue;
+      }
+      case 'LINK': {
+        if (((node: any): HTMLLinkElement).rel.toLowerCase() === 'stylesheet') {
+          continue;
+        }
+      }
+    }
+    if (node.nodeType === DOCUMENT_TYPE_NODE || isMarkedResource(node)) {
+      // we retain document nodes and resources
+    } else {
+      container.removeChild(node);
+    }
+  }
+  return;
 }
 
 // Making this so we can eventually move all of the instance caching to the commit phase.
@@ -923,6 +927,7 @@ function getNextHydratable(node) {
             }
             break;
           }
+          case 'TITLE':
           case 'HTML':
           case 'HEAD':
           case 'BODY': {
@@ -947,6 +952,9 @@ function getNextHydratable(node) {
               continue;
             }
             break;
+          }
+          case 'TITLE': {
+            continue;
           }
           case 'STYLE': {
             const styleEl: HTMLStyleElement = (element: any);
@@ -1666,9 +1674,10 @@ export function clearSingleton(instance: Instance): void {
   while (node) {
     const nextNode = node.nextSibling;
     const nodeName = node.nodeName;
-    if (getInstanceFromNodeDOMTree(node)) {
+    if (getInstanceFromNodeDOMTree(node) || isMarkedResource(node)) {
       // retain nodes owned by React
     } else if (
+      nodeName === 'TITLE' ||
       nodeName === 'HEAD' ||
       nodeName === 'BODY' ||
       nodeName === 'STYLE' ||

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -745,6 +745,9 @@ export function clearContainer(container: Container): void {
 function clearContainerChildren(container: Node) {
   let node;
   let nextNode: ?Node = container.firstChild;
+  if (nextNode && nextNode.nodeType === DOCUMENT_TYPE_NODE) {
+    nextNode = nextNode.nextSibling;
+  }
   while (nextNode) {
     node = nextNode;
     nextNode = nextNode.nextSibling;
@@ -770,11 +773,7 @@ function clearContainerChildren(container: Node) {
         }
       }
     }
-    if (node.nodeType === DOCUMENT_TYPE_NODE || isMarkedResource(node)) {
-      // we retain document nodes and resources
-    } else {
-      container.removeChild(node);
-    }
+    container.removeChild(node);
   }
   return;
 }
@@ -1674,10 +1673,8 @@ export function clearSingleton(instance: Instance): void {
   while (node) {
     const nextNode = node.nextSibling;
     const nodeName = node.nodeName;
-    if (getInstanceFromNodeDOMTree(node) || isMarkedResource(node)) {
-      // retain nodes owned by React
-    } else if (
-      nodeName === 'TITLE' ||
+    if (
+      isMarkedResource(node) ||
       nodeName === 'HEAD' ||
       nodeName === 'BODY' ||
       nodeName === 'STYLE' ||

--- a/packages/react-dom-bindings/src/shared/HTMLNodeType.js
+++ b/packages/react-dom-bindings/src/shared/HTMLNodeType.js
@@ -15,4 +15,5 @@ export const ELEMENT_NODE = 1;
 export const TEXT_NODE = 3;
 export const COMMENT_NODE = 8;
 export const DOCUMENT_NODE = 9;
+export const DOCUMENT_TYPE_NODE = 10;
 export const DOCUMENT_FRAGMENT_NODE = 11;

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -249,7 +249,14 @@ describe('ReactDOMFloat', () => {
         </html>
       </>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    try {
+      expect(Scheduler).toFlushWithoutYielding();
+    } catch (e) {
+      // for DOMExceptions that happen when expecting this test to fail we need
+      // to clear the scheduler first otherwise the expected failure will fail
+      expect(Scheduler).toFlushWithoutYielding();
+      throw e;
+    }
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -236,6 +236,32 @@ describe('ReactDOMFloat', () => {
   }
 
   // @gate enableFloat
+  it('can render resources before singletons', async () => {
+    const root = ReactDOMClient.createRoot(document);
+    root.render(
+      <>
+        <title>foo</title>
+        <html>
+          <head>
+            <link rel="foo" href="foo" />
+          </head>
+          <body>hello world</body>
+        </html>
+      </>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>foo</title>
+          <link rel="foo" href="foo" />
+        </head>
+        <body>hello world</body>
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
   it('can acquire a resource after releasing it in the same commit', async () => {
     const root = ReactDOMClient.createRoot(container);
     root.render(
@@ -1208,7 +1234,6 @@ describe('ReactDOMFloat', () => {
         <html>
           <head>
             <link rel="stylesheet" href="aresource" data-precedence="foo" />
-            <link rel="preload" href="aresource" as="style" />
           </head>
           <body>
             <div>hello world</div>
@@ -1372,7 +1397,6 @@ describe('ReactDOMFloat', () => {
         <html>
           <head>
             <link rel="stylesheet" href="foo" data-precedence="foo" />
-            <link rel="preload" href="foo" as="style" />
           </head>
           <body>hello world</body>
         </html>,
@@ -1425,7 +1449,6 @@ describe('ReactDOMFloat', () => {
             <link rel="stylesheet" href="foo" data-precedence="foo" />
             <link rel="stylesheet" href="bar" data-precedence="bar" />
             <link rel="stylesheet" href="qux" data-precedence="qux" />
-            <link rel="preload" href="qux" as="style" />
           </head>
           <body>client</body>
         </html>,
@@ -1503,8 +1526,6 @@ describe('ReactDOMFloat', () => {
           <head>
             <link rel="stylesheet" href="foo" data-precedence="foo" />
             <link rel="stylesheet" href="bar" data-precedence="bar" />
-            <link rel="preload" href="foo" as="style" />
-            <link rel="preload" href="bar" as="style" />
           </head>
           <body>hello</body>
         </html>,
@@ -1530,8 +1551,6 @@ describe('ReactDOMFloat', () => {
             <link rel="stylesheet" href="foo" data-precedence="foo" />
             <link rel="stylesheet" href="bar" data-precedence="bar" />
             <link rel="stylesheet" href="baz" data-precedence="baz" />
-            <link rel="preload" href="foo" as="style" />
-            <link rel="preload" href="bar" as="style" />
             <link rel="preload" href="baz" as="style" />
           </head>
           <body>hello</body>

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -236,6 +236,47 @@ describe('ReactDOMFloat', () => {
   }
 
   // @gate enableFloat
+  it('can acquire a resource after releasing it in the same commit', async () => {
+    const root = ReactDOMClient.createRoot(container);
+    root.render(
+      <>
+        <title>foo</title>
+      </>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>foo</title>
+        </head>
+        <body>
+          <div id="container" />
+        </body>
+      </html>,
+    );
+
+    // title is keyed off children so this second resource should match the first one
+    root.render(
+      <>
+        {null}
+        <title data-new="new">foo</title>
+      </>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    // we don't see the attribute because the resource is the same and was not reconstructed
+    expect(getMeaningfulChildren(document)).toEqual(
+      <html>
+        <head>
+          <title>foo</title>
+        </head>
+        <body>
+          <div id="container" />
+        </body>
+      </html>,
+    );
+  });
+
+  // @gate enableFloat
   it('errors if the document does not contain a head when inserting a resource', async () => {
     document.head.parentNode.removeChild(document.head);
     const root = ReactDOMClient.createRoot(document);

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -155,8 +155,8 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html>
         <head lang="es" data-foo="foo">
-          <title>Hello</title>
           <title>Hola</title>
+          <title>Hello</title>
         </head>
         <body />
       </html>,
@@ -241,8 +241,8 @@ describe('ReactDOM HostSingleton', () => {
           <link rel="preload" href="resource" as="style" />
           <link rel="preload" href="3rdparty" as="style" />
           <link rel="preload" href="3rdparty2" as="style" />
-          <link rel="stylesheet" href="resource" />
           <title>a server title</title>
+          <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
         </head>
@@ -287,10 +287,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
+          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -326,10 +326,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
+          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <title>a client title</title>
           <meta />
         </head>
         <body data-client-baz="baz">
@@ -365,10 +365,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
+          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -401,10 +401,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
+          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <title>a client title</title>
         </head>
         <body>
           <style>
@@ -472,19 +472,15 @@ describe('ReactDOM HostSingleton', () => {
       expect(Scheduler).toFlushWithoutYielding();
     }).toErrorDev(
       [
-        `Warning: Expected server HTML to contain a matching <title> in <head>.
-    in title (at **)
-    in head (at **)
+        `Warning: Expected server HTML to contain a matching <div> in <body>.
+    in div (at **)
+    in body (at **)
     in html (at **)`,
         `Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>.`,
       ],
       {withoutStack: 1},
     );
     expect(hydrationErrors).toEqual([
-      [
-        'Hydration failed because the initial UI does not match what was rendered on the server.',
-        'at title',
-      ],
       [
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'at div',
@@ -502,10 +498,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
+          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -768,9 +764,9 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html>
         <head>
+          <title>something new</title>
           <link rel="stylesheet" href="headbefore" />
           <link rel="stylesheet" href="headafter" />
-          <title>something new</title>
         </head>
         <body>
           <link rel="stylesheet" href="bodybefore" />
@@ -804,9 +800,9 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html>
         <head>
+          <title>something new</title>
           <link rel="stylesheet" href="before" />
           <link rel="stylesheet" href="after" />
-          <title>something new</title>
         </head>
         <body />
       </html>,

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -975,4 +975,37 @@ describe('ReactDOM HostSingleton', () => {
       </html>,
     );
   });
+
+  // @gate enableHostSingletons
+  it('allows for hydrating without a head', async () => {
+    await actIntoEmptyDocument(() => {
+      const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+        <html>
+          <body>foo</body>
+        </html>,
+      );
+      pipe(writable);
+    });
+
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>foo</body>
+      </html>,
+    );
+
+    ReactDOMClient.hydrateRoot(
+      document,
+      <html>
+        <body>foo</body>
+      </html>,
+    );
+    expect(Scheduler).toFlushWithoutYielding();
+    expect(getVisibleChildren(document)).toEqual(
+      <html>
+        <head />
+        <body>foo</body>
+      </html>,
+    );
+  });
 });

--- a/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
+++ b/packages/react-dom/src/__tests__/ReactRenderDocument-test.js
@@ -253,10 +253,21 @@ describe('rendering React components at document', () => {
         }
       }
 
-      // getTestDocument() has an extra <meta> that we didn't render.
-      expect(() =>
-        ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
-      ).toErrorDev('Did not expect server HTML to contain a <meta> in <head>.');
+      if (gate(flags => flags.enableFloat)) {
+        // with float the title no longer is a hydration mismatch so we get an error on the body mismatch
+        expect(() =>
+          ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
+        ).toErrorDev(
+          'Expected server HTML to contain a matching text node for "Hello world" in <body>',
+        );
+      } else {
+        // getTestDocument() has an extra <meta> that we didn't render.
+        expect(() =>
+          ReactDOM.hydrate(<Component text="Hello world" />, testDocument),
+        ).toErrorDev(
+          'Did not expect server HTML to contain a <meta> in <head>.',
+        );
+      }
       expect(testDocument.body.innerHTML).toBe('Hello world');
     });
 

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -1599,13 +1599,13 @@ function updateHostResource(current, workInProgress, renderLanes) {
     workInProgress.pendingProps,
     currentProps,
   );
-  reconcileChildren(
-    current,
-    workInProgress,
-    workInProgress.pendingProps.children,
-    renderLanes,
-  );
-  return workInProgress.child;
+  // Resources never have reconciler managed children. It is possible for
+  // the host implementation of getResource to consider children in the
+  // resource construction but they will otherwise be discarded. In practice
+  // this precludes all but the simplest children and Host specific warnings
+  // should be implemented to warn when children are passsed when otherwise not
+  // expected
+  return null;
 }
 
 function updateHostSingleton(

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -1599,13 +1599,13 @@ function updateHostResource(current, workInProgress, renderLanes) {
     workInProgress.pendingProps,
     currentProps,
   );
-  reconcileChildren(
-    current,
-    workInProgress,
-    workInProgress.pendingProps.children,
-    renderLanes,
-  );
-  return workInProgress.child;
+  // Resources never have reconciler managed children. It is possible for
+  // the host implementation of getResource to consider children in the
+  // resource construction but they will otherwise be discarded. In practice
+  // this precludes all but the simplest children and Host specific warnings
+  // should be implemented to warn when children are passsed when otherwise not
+  // expected
+  return null;
 }
 
 function updateHostSingleton(


### PR DESCRIPTION
Adds a category of Resources of type `head` which will be used to track the tags that go into the <head>

Currently only implements for `<title>`.

titles are keyed off their textContent so each time the title changes a new resource will be created. Currently insertion is done by prepending in the <head>. The argument here is that the newest title should "win" if there are multiple rendered. This also helps when a navigation or update causes a server rendered title to hang around but it is not the most recent one.