### PR TITLE
[useEvent] Lint for presence of useEvent functions in dependency lists

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7663,7 +7663,7 @@ if (__EXPERIMENTAL__) {
       errors: [
         {
           message:
-            'Functions wrapped in `useEvent` must not be included in the dependency array. ' +
+            'Functions returned from `useEvent` must not be included in the dependency array. ' +
             'Remove `onStuff` from the list.',
           suggestions: [
             {

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7663,9 +7663,8 @@ if (__EXPERIMENTAL__) {
       errors: [
         {
           message:
-            '`useEvent` functions always return a new identity for every render. This means that ' +
-            'it should not be included in dependency lists, as it would cause the callback to be ' +
-            'run on every render. You can safely remove this.',
+            'Functions wrapped in `useEvent` must not be included in the dependency array. ' +
+            'Remove `onStuff` from the list.',
           suggestions: [
             {
               desc: 'Remove the dependency `onStuff`',

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -7635,15 +7635,54 @@ if (__EXPERIMENTAL__) {
     ...tests.valid,
     {
       code: normalizeIndent`
-      function MyComponent({ theme }) {
-        const onStuff = useEvent(() => {
-          showNotification(theme);
-        });
-        useEffect(() => {
-          onStuff();
-        }, []);
-      }
-    `,
+        function MyComponent({ theme }) {
+          const onStuff = useEvent(() => {
+            showNotification(theme);
+          });
+          useEffect(() => {
+            onStuff();
+          }, []);
+        }
+      `,
+    },
+  ];
+
+  tests.invalid = [
+    ...tests.invalid,
+    {
+      code: normalizeIndent`
+        function MyComponent({ theme }) {
+          const onStuff = useEvent(() => {
+            showNotification(theme);
+          });
+          useEffect(() => {
+            onStuff();
+          }, [onStuff]);
+        }
+      `,
+      errors: [
+        {
+          message:
+            '`useEvent` functions always return a new identity for every render. This means that ' +
+            'it should not be included in dependency lists, as it would cause the callback to be ' +
+            'run on every render. You can safely remove this.',
+          suggestions: [
+            {
+              desc: 'Remove the dependency `onStuff`',
+              output: normalizeIndent`
+                function MyComponent({ theme }) {
+                  const onStuff = useEvent(() => {
+                    showNotification(theme);
+                  });
+                  useEffect(() => {
+                    onStuff();
+                  }, []);
+                }
+              `,
+            },
+          ],
+        },
+      ],
     },
   ];
 }

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -74,6 +74,7 @@ export default {
     const stateVariables = new WeakSet();
     const stableKnownValueCache = new WeakMap();
     const functionWithoutCapturedValueCache = new WeakMap();
+    const useEventVariables = new WeakSet();
     function memoizeWithWeakMap(fn, map) {
       return function(arg) {
         if (map.has(arg)) {
@@ -226,7 +227,12 @@ export default {
           // useRef() return value is stable.
           return true;
         } else if (isUseEventIdentifier(callee) && id.type === 'Identifier') {
-          // useEvent() return value is stable.
+          for (const ref of resolved.references) {
+            if (ref !== id) {
+              useEventVariables.add(ref.identifier);
+            }
+          }
+          // useEvent() return value is always unstable.
           return true;
         } else if (name === 'useState' || name === 'useReducer') {
           // Only consider second value in initializing tuple stable.
@@ -638,6 +644,25 @@ export default {
                 'correct dependencies.',
             });
             return;
+          }
+          if (useEventVariables.has(declaredDependencyNode)) {
+            reportProblem({
+              node: declaredDependencyNode,
+              message:
+                '`useEvent` functions always return a new identity for every render. This means ' +
+                'that it should not be included in dependency lists, as it would cause the ' +
+                'callback to be run on every render. You can safely remove this.',
+              suggest: [
+                {
+                  desc: `Remove the dependency \`${context.getSource(
+                    declaredDependencyNode,
+                  )}\``,
+                  fix(fixer) {
+                    return fixer.removeRange(declaredDependencyNode.range);
+                  },
+                },
+              ],
+            });
           }
           // Try to normalize the declared dependency. If we can't then an error
           // will be thrown. We will catch that error and report an error.

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -649,9 +649,10 @@ export default {
             reportProblem({
               node: declaredDependencyNode,
               message:
-                '`useEvent` functions always return a new identity for every render. This means ' +
-                'that it should not be included in dependency lists, as it would cause the ' +
-                'callback to be run on every render. You can safely remove this.',
+                'Functions wrapped in `useEvent` must not be included in the dependency array. ' +
+                `Remove \`${context.getSource(
+                  declaredDependencyNode,
+                )}\` from the list.`,
               suggest: [
                 {
                   desc: `Remove the dependency \`${context.getSource(

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -649,7 +649,7 @@ export default {
             reportProblem({
               node: declaredDependencyNode,
               message:
-                'Functions wrapped in `useEvent` must not be included in the dependency array. ' +
+                'Functions returned from `useEvent` must not be included in the dependency array. ' +
                 `Remove \`${context.getSource(
                   declaredDependencyNode,
                 )}\` from the list.`,


### PR DESCRIPTION
With #25473, the identity of useEvent's return value is no longer stable across renders. Previously, the ExhaustiveDeps lint rule would only allow the omission of the useEvent function, but you could still add it as a dependency.

This PR updates the ExhaustiveDeps rule to explicitly check for the presence of useEvent functions in dependency lists, and emits a warning and suggestion/autofixer for removing the dependency.