### PR TITLE
[Float] support meta tags as Resources

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -286,6 +286,7 @@ export function getResourcesFromRoot(root: FloatRoot): RootResources {
       styles: new Map(),
       scripts: new Map(),
       head: new Map(),
+      lastStructuredMeta: new Map(),
     };
   }
   return resources;

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -122,7 +122,7 @@ type Resource = StyleResource | ScriptResource | PreloadResource | HeadResource;
 export type RootResources = {
   styles: Map<string, StyleResource>,
   scripts: Map<string, ScriptResource>,
-  head: Map<string, HeadResource | TitleResource | MetaResource>,
+  head: Map<string, HeadResource>,
 };
 
 // Brief on purpose due to insertion by script when streaming late boundaries

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -444,10 +444,18 @@ export function getResource(
         matcher = 'meta[charset]';
       } else if (typeof content === 'string') {
         if (typeof httpEquiv === 'string') {
-          matcher = `meta[http-equiv="${httpEquiv}"][content="${content}"]`;
+          matcher = `meta[http-equiv="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            httpEquiv,
+          )}"][content="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            content,
+          )}"]`;
         } else if (typeof property === 'string') {
           propertyString = property;
-          matcher = `meta[property="${property}"][content="${content}"]`;
+          matcher = `meta[property="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            property,
+          )}"][content="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            content,
+          )}"]`;
 
           const parentPropertyPath = property
             .split(':')
@@ -460,9 +468,17 @@ export function getResource(
             matcher = parentResource.matcher + matcher;
           }
         } else if (typeof name === 'string') {
-          matcher = `meta[name="${name}"][content="${content}"]`;
+          matcher = `meta[name="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            name,
+          )}"][content="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            content,
+          )}"]`;
         } else if (typeof itemProp === 'string') {
-          matcher = `meta[itemprop="${itemProp}"][content="${content}"]`;
+          matcher = `meta[itemprop="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            itemProp,
+          )}"][content="${escapeSelectorAttributeValueInsideDoubleQuotes(
+            content,
+          )}"]`;
         }
       }
       if (matcher) {

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -714,13 +714,14 @@ export function unhideTextInstance(
 export function clearContainer(container: Container): void {
   if (enableHostSingletons) {
     const nodeType = container.nodeType;
-    if (nodeType === DOCUMENT_NODE || nodeType === ELEMENT_NODE) {
+    if (nodeType === DOCUMENT_NODE) {
+      clearContainerSparingly(container);
+    } else if (nodeType === ELEMENT_NODE) {
       switch (container.nodeName) {
-        case '#document':
         case 'HTML':
         case 'HEAD':
         case 'BODY':
-          clearContainerChildren(container);
+          clearContainerSparingly(container);
           return;
         default: {
           container.textContent = '';
@@ -742,7 +743,7 @@ export function clearContainer(container: Container): void {
   }
 }
 
-function clearContainerChildren(container: Node) {
+function clearContainerSparingly(container: Node) {
   let node;
   let nextNode: ?Node = container.firstChild;
   if (nextNode && nextNode.nodeType === DOCUMENT_TYPE_NODE) {
@@ -756,7 +757,7 @@ function clearContainerChildren(container: Node) {
       case 'HEAD':
       case 'BODY': {
         const element: Element = (node: any);
-        clearContainerChildren(element);
+        clearContainerSparingly(element);
         // If these singleton instances had previously been rendered with React they
         // may still hold on to references to the previous fiber tree. We detatch them
         // prospectively to reset them to a baseline starting state since we cannot create

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -2406,15 +2406,12 @@ export function writeInitialResources(
 
   headResources.forEach(r => {
     switch (r.type) {
-      case 'head':
       case 'title': {
-        if (r.instanceType === 'title') {
-          pushStartTitleImpl(target, r.props, responseState);
-          if (typeof r.props.children === 'string') {
-            target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
-          }
-          pushEndInstance(target, target, 'title', r.props);
+        pushStartTitleImpl(target, r.props, responseState);
+        if (typeof r.props.children === 'string') {
+          target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
         }
+        pushEndInstance(target, target, 'title', r.props);
         break;
       }
       case 'meta': {
@@ -2498,15 +2495,12 @@ export function writeImmediateResources(
 
   headResources.forEach(r => {
     switch (r.type) {
-      case 'head':
       case 'title': {
-        if (r.instanceType === 'title') {
-          pushStartTitleImpl(target, r.props, responseState);
-          if (typeof r.props.children === 'string') {
-            target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
-          }
-          pushEndInstance(target, target, 'title', r.props);
+        pushStartTitleImpl(target, r.props, responseState);
+        if (typeof r.props.children === 'string') {
+          target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
         }
+        pushEndInstance(target, target, 'title', r.props);
         break;
       }
       case 'meta': {

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -1150,6 +1150,26 @@ function pushStartTextArea(
   return null;
 }
 
+function pushMeta(
+  target: Array<Chunk | PrecomputedChunk>,
+  props: Object,
+  responseState: ResponseState,
+  textEmbedded: boolean,
+): ReactNodeList {
+  if (enableFloat && resourcesFromElement('meta', props)) {
+    if (textEmbedded) {
+      // This link follows text but we aren't writing a tag. while not as efficient as possible we need
+      // to be safe and assume text will follow by inserting a textSeparator
+      target.push(textSeparator);
+    }
+    // We have converted this link exclusively to a resource and no longer
+    // need to emit it
+    return null;
+  }
+
+  return pushSelfClosing(target, props, 'meta', responseState);
+}
+
 function pushLink(
   target: Array<Chunk | PrecomputedChunk>,
   props: Object,
@@ -1688,6 +1708,8 @@ export function pushStartInstance(
       return pushLink(target, props, responseState, textEmbedded);
     case 'script':
       return pushStartScript(target, props, responseState, textEmbedded);
+    case 'meta':
+      return pushMeta(target, props, responseState, textEmbedded);
     // Newline eating tags
     case 'listing':
     case 'pre': {
@@ -1702,7 +1724,6 @@ export function pushStartInstance(
     case 'hr':
     case 'img':
     case 'keygen':
-    case 'meta':
     case 'param':
     case 'source':
     case 'track':
@@ -2318,6 +2339,7 @@ export function writeInitialResources(
   const target = [];
 
   const {
+    charset,
     fontPreloads,
     precedences,
     usedStylePreloads,
@@ -2327,6 +2349,12 @@ export function writeInitialResources(
     explicitScriptPreloads,
     headResources,
   } = resources;
+
+  if (charset) {
+    pushSelfClosing(target, charset.props, 'meta', responseState);
+    charset.flushed = true;
+    resources.charset = null;
+  }
 
   fontPreloads.forEach(r => {
     // font preload Resources should not already be flushed so we elide this check
@@ -2377,12 +2405,22 @@ export function writeInitialResources(
   explicitScriptPreloads.clear();
 
   headResources.forEach(r => {
-    if (r.instanceType === 'title') {
-      pushStartTitleImpl(target, r.props, responseState);
-      if (typeof r.props.children === 'string') {
-        target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
+    switch (r.type) {
+      case 'head':
+      case 'title': {
+        if (r.instanceType === 'title') {
+          pushStartTitleImpl(target, r.props, responseState);
+          if (typeof r.props.children === 'string') {
+            target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
+          }
+          pushEndInstance(target, target, 'title', r.props);
+        }
+        break;
       }
-      pushEndInstance(target, target, 'title', r.props);
+      case 'meta': {
+        pushSelfClosing(target, r.props, 'meta', responseState);
+        break;
+      }
     }
     r.flushed = true;
   });
@@ -2414,6 +2452,7 @@ export function writeImmediateResources(
   const target = [];
 
   const {
+    charset,
     fontPreloads,
     usedStylePreloads,
     scripts,
@@ -2422,6 +2461,12 @@ export function writeImmediateResources(
     explicitScriptPreloads,
     headResources,
   } = resources;
+
+  if (charset) {
+    pushSelfClosing(target, charset.props, 'meta', responseState);
+    charset.flushed = true;
+    resources.charset = null;
+  }
 
   fontPreloads.forEach(r => {
     // font preload Resources should not already be flushed so we elide this check
@@ -2452,12 +2497,22 @@ export function writeImmediateResources(
   explicitScriptPreloads.clear();
 
   headResources.forEach(r => {
-    if (r.instanceType === 'title') {
-      pushStartTitle(target, r.props, responseState);
-      if (typeof r.props.children === 'string') {
-        target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
+    switch (r.type) {
+      case 'head':
+      case 'title': {
+        if (r.instanceType === 'title') {
+          pushStartTitleImpl(target, r.props, responseState);
+          if (typeof r.props.children === 'string') {
+            target.push(escapeTextForBrowser(stringToChunk(r.props.children)));
+          }
+          pushEndInstance(target, target, 'title', r.props);
+        }
+        break;
       }
-      pushEndInstance(target, target, 'title', r.props);
+      case 'meta': {
+        pushSelfClosing(target, r.props, 'meta', responseState);
+        break;
+      }
     }
     r.flushed = true;
   });

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -942,6 +942,98 @@ describe('ReactDOMFloat', () => {
 
   describe('head resources', () => {
     // @gate enableFloat
+    it('can hydrate the right instances for deeply nested structured metas', async () => {
+      await actIntoEmptyDocument(() => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+          <>
+            <html>
+              <head />
+              <body>
+                <div>hello world</div>
+              </body>
+            </html>
+            <meta property="og:foo" content="one" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+            <meta property="og:foo" content="two" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+          </>,
+        );
+        pipe(writable);
+      });
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:foo" content="one" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+            <meta property="og:foo" content="two" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      const root = ReactDOMClient.hydrateRoot(
+        document,
+        <>
+          <html>
+            <head />
+            <body>
+              <div>hello world</div>
+            </body>
+          </html>
+          <meta property="og:foo" content="one" />
+          <meta property="og:foo:bar" content="bar" />
+          <meta property="og:foo:bar:baz" content="baz" />
+          <meta property="og:foo" content="two" />
+          <meta property="og:foo:bar" content="bar" />
+          <meta property="og:foo:bar:baz" content="baz" />
+        </>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:foo" content="one" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+            <meta property="og:foo" content="two" />
+            <meta property="og:foo:bar" content="bar" />
+            <meta property="og:foo:bar:baz" content="baz" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <>
+          <html>
+            <head />
+            <body>
+              <div>hello world</div>
+            </body>
+          </html>
+        </>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head />
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+    });
+
+    // @gate enableFloat
     it('can insert meta tags in the expected location', async () => {
       await actIntoEmptyDocument(() => {
         const {pipe} = ReactDOMFizzServer.renderToPipeableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -942,6 +942,321 @@ describe('ReactDOMFloat', () => {
 
   describe('head resources', () => {
     // @gate enableFloat
+    it('can insert meta tags in the expected location', async () => {
+      await actIntoEmptyDocument(() => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+          <>
+            <html>
+              <head />
+              <body>
+                <div>hello world</div>
+              </body>
+            </html>
+            <meta charSet="utf-8" />
+            <meta name="google-site-verification" content="somehash1" />
+            <meta name="google-site-verification" content="somehash2" />
+            <meta
+              name="description"
+              property="og:description"
+              content="my site"
+            />
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta httpEquiv="refresh" content="dont actually" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta itemProp="someprop" content="somevalue" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:description:foo" content="foo" />
+          </>,
+        );
+        pipe(writable);
+      });
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <meta name="google-site-verification" content="somehash1" />
+            <meta name="google-site-verification" content="somehash2" />
+            <meta
+              name="description"
+              property="og:description"
+              content="my site"
+            />
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta http-equiv="refresh" content="dont actually" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta itemprop="someprop" content="somevalue" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:description:foo" content="foo" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      const root = ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <head>
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <meta name="google-site-verification" content="somehash1" />
+            <meta name="google-site-verification" content="somehash2" />
+            <meta
+              name="description"
+              property="og:description"
+              content="my site"
+            />
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta http-equiv="refresh" content="dont actually" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta itemprop="someprop" content="somevalue" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:description:foo" content="foo" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <html>
+          <head>
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:description" content="my site" />
+            <meta
+              itemProp="description bar"
+              property="og:description:bar"
+              content="bar"
+            />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <meta name="google-site-verification" content="somehash1" />
+            <meta name="google-site-verification" content="somehash2" />
+            <meta
+              name="description"
+              property="og:description"
+              content="my site"
+            />
+            <meta
+              itemprop="description bar"
+              property="og:description:bar"
+              content="bar"
+            />
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta http-equiv="refresh" content="dont actually" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta itemprop="someprop" content="somevalue" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:description:foo" content="foo" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+    });
+
+    // @gate enableFloat
+    it('can render meta tags with og properties with structured data', async () => {
+      await actIntoEmptyDocument(() => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+          <>
+            <html>
+              <head />
+              <body>
+                <div>hello world</div>
+              </body>
+            </html>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+          </>,
+        );
+        pipe(writable);
+      });
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      const root = ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <head />
+          <body>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <html>
+          <head />
+          <body>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <html>
+          <head />
+          <body>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image:foo" content="foo" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:foo" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <html>
+          <head />
+          <body>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:width:bar" content="bar" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image:foo" content="foo" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <meta property="og:image" content="foo" />
+            <meta property="og:image:foo" content="foo" />
+            <meta property="og:image:height" content="100" />
+            <meta property="og:image:width" content="100" />
+            <meta property="og:image:width:bar" content="bar" />
+            <meta property="og:image" content="bar" />
+            <meta property="og:image:height" content="100" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+    });
+
+    // @gate enableFloat
     it('can render meta tags as resources', async () => {
       await actIntoEmptyDocument(() => {
         const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
@@ -998,107 +1313,6 @@ describe('ReactDOMFloat', () => {
             <meta http-equiv="content-security-policy" content="foo" />
             <meta itemprop="description" content="desc" />
             <meta property="description" content="desc2" />
-          </head>
-          <body>
-            <div>hello world</div>
-          </body>
-        </html>,
-      );
-    });
-
-    // @gate enableFloat
-    it('dedupes metas along charset (static), httpEquiv, name, itemprop, and property attributes', async () => {
-      await actIntoEmptyDocument(() => {
-        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
-          <html>
-            <head>
-              <meta charSet="utf-8" />
-              <meta charSet="utf-16" />
-
-              <meta httpEquiv="content-security-policy" content="foo" />
-              <meta httpEquiv="content-security-policy" content="bar" />
-              <meta httpEquiv="refresh" content="foo" />
-
-              <meta name="robots" content="foo" />
-              <meta name="robots" content="bar" />
-              <meta name="googlebot" content="foo" />
-
-              <meta itemProp="description" content="foo" />
-              <meta itemProp="description" content="bar" />
-              <meta itemProp="desc" content="foo" />
-
-              <meta property="og:title" content="foo" />
-              <meta property="og:title" content="bar" />
-              <meta property="og:description" content="foo" />
-            </head>
-            <body>
-              <div>hello world</div>
-            </body>
-          </html>,
-        );
-        pipe(writable);
-      });
-      expect(getMeaningfulChildren(document)).toEqual(
-        <html>
-          <head>
-            <meta charset="utf-8" />
-
-            <meta http-equiv="content-security-policy" content="foo" />
-            <meta http-equiv="refresh" content="foo" />
-
-            <meta name="robots" content="foo" />
-            <meta name="googlebot" content="foo" />
-
-            <meta itemprop="description" content="foo" />
-            <meta itemprop="desc" content="foo" />
-
-            <meta property="og:title" content="foo" />
-            <meta property="og:description" content="foo" />
-          </head>
-          <body>
-            <div>hello world</div>
-          </body>
-        </html>,
-      );
-
-      ReactDOMClient.hydrateRoot(
-        document,
-        <html>
-          <head>
-            <meta charSet="utf-16" />
-
-            <meta httpEquiv="content-security-policy" content="bar" />
-
-            <meta name="robots" content="bar" />
-
-            <meta itemProp="description" content="bar" />
-
-            <meta property="og:title" content="bar" />
-          </head>
-          <body>
-            <div>hello world</div>
-          </body>
-        </html>,
-      );
-      expect(Scheduler).toFlushWithoutYielding();
-      // charSet is inert on the client
-      // The other resources are placed where their keymatched instances are found and replace them
-      expect(getMeaningfulChildren(document)).toEqual(
-        <html>
-          <head>
-            <meta charset="utf-8" />
-
-            <meta http-equiv="content-security-policy" content="bar" />
-            <meta http-equiv="refresh" content="foo" />
-
-            <meta name="robots" content="bar" />
-            <meta name="googlebot" content="foo" />
-
-            <meta itemprop="description" content="bar" />
-            <meta itemprop="desc" content="foo" />
-
-            <meta property="og:title" content="bar" />
-            <meta property="og:description" content="foo" />
           </head>
           <body>
             <div>hello world</div>

--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -497,9 +497,9 @@ describe('ReactDOMServerIntegration', () => {
       itRenders(
         'badly cased aliased HTML attribute with a warning',
         async render => {
-          const e = await render(<meta httpequiv="refresh" />, 1);
-          expect(e.hasAttribute('http-equiv')).toBe(false);
-          expect(e.getAttribute('httpequiv')).toBe('refresh');
+          const e = await render(<form acceptcharset="utf-8" />, 1);
+          expect(e.hasAttribute('accept-charset')).toBe(false);
+          expect(e.getAttribute('acceptcharset')).toBe('utf-8');
         },
       );
 

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -287,10 +287,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
-          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
+          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -326,11 +326,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
-          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
-          <meta />
+          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -365,10 +364,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
-          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
+          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -401,10 +400,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
-          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
+          <title>a client title</title>
         </head>
         <body>
           <style>
@@ -498,10 +497,10 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html data-client-foo="foo">
         <head>
-          <title>a client title</title>
           <link rel="stylesheet" href="resource" />
           <link rel="stylesheet" href="3rdparty" />
           <link rel="stylesheet" href="3rdparty2" />
+          <title>a client title</title>
         </head>
         <body data-client-baz="baz">
           <style>
@@ -764,9 +763,9 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html>
         <head>
-          <title>something new</title>
           <link rel="stylesheet" href="headbefore" />
           <link rel="stylesheet" href="headafter" />
+          <title>something new</title>
         </head>
         <body>
           <link rel="stylesheet" href="bodybefore" />
@@ -800,9 +799,9 @@ describe('ReactDOM HostSingleton', () => {
     expect(getVisibleChildren(document)).toEqual(
       <html>
         <head>
-          <title>something new</title>
           <link rel="stylesheet" href="before" />
           <link rel="stylesheet" href="after" />
+          <title>something new</title>
         </head>
         <body />
       </html>,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -2057,7 +2057,9 @@ function commitDeletionEffectsOnFiber(
           nearestMountedAncestor,
           deletedFiber,
         );
-        releaseResource(deletedFiber.memoizedState);
+        if (deletedFiber.memoizedState) {
+          releaseResource(deletedFiber.memoizedState);
+        }
         return;
       }
     }

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -2057,7 +2057,9 @@ function commitDeletionEffectsOnFiber(
           nearestMountedAncestor,
           deletedFiber,
         );
-        releaseResource(deletedFiber.memoizedState);
+        if (deletedFiber.memoizedState) {
+          releaseResource(deletedFiber.memoizedState);
+        }
         return;
       }
     }

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -441,5 +441,6 @@
   "453": "React expected a <head> element (document.head) to exist in the Document but one was not found. React never removes the head for any Document it renders into so the cause is likely in some other script running on this page.",
   "454": "React expected a <body> element (document.body) to exist in the Document but one was not found. React never removes the body for any Document it renders into so the cause is likely in some other script running on this page.",
   "455": "This CacheSignal was requested outside React which means that it is immediately aborted.",
-  "456": "Calling Offscreen.detach before instance handle has been set."
+  "456": "Calling Offscreen.detach before instance handle has been set.",
+  "457": "acquireHeadResource encountered a resource type it did not expect: \"%s\". This is a bug in React."
 }


### PR DESCRIPTION
Stacked on #25508

This PR adds meta tags as a resource type.

metas are classified in the following priority

1. charset
2. http-equiv
3. property
4. name
5. itemprop

when using property, there is special logic for og type properties where a `property="og:image:height"` following a `property="og:image"` will inherit the key of the previous tag. this relies on timing effects to stay consistent so when mounting new metas it is important that if structured properties are being used all members of a structure mount together. This is similarly true for arrays where the implicit sequential order defines the array structure. if you need an array you need to mount all array members in the same pass.