### PR TITLE
[Float] support all links as Resources

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
@@ -89,8 +89,20 @@ type MetaResource = {
   flushed: boolean,
 };
 
+type LinkProps = {
+  href: string,
+  rel: string,
+  [string]: mixed,
+};
+type LinkResource = {
+  type: 'link',
+  props: LinkProps,
+
+  flushed: boolean,
+};
+
 export type Resource = PreloadResource | StyleResource | ScriptResource;
-export type HeadResource = TitleResource | MetaResource;
+export type HeadResource = TitleResource | MetaResource | LinkResource;
 
 export type Resources = {
   // Request local cache
@@ -101,6 +113,7 @@ export type Resources = {
 
   // Flushing queues for Resource dependencies
   charset: null | MetaResource,
+  preconnects: Set<LinkResource>,
   fontPreloads: Set<PreloadResource>,
   // usedImagePreloads: Set<PreloadResource>,
   precedences: Map<string, Set<StyleResource>>,
@@ -131,6 +144,7 @@ export function createResources(): Resources {
 
     // cleared on flush
     charset: null,
+    preconnects: new Set(),
     fontPreloads: new Set(),
     // usedImagePreloads: new Set(),
     precedences: new Map(),
@@ -697,10 +711,11 @@ export function resourcesFromLink(props: Props): boolean {
   const resources = currentResources;
 
   const {rel, href} = props;
-  if (!href || typeof href !== 'string') {
+  if (!href || typeof href !== 'string' || !rel || typeof rel !== 'string') {
     return false;
   }
 
+  let key = '';
   switch (rel) {
     case 'stylesheet': {
       const {onLoad, onError, precedence, disabled} = props;
@@ -813,10 +828,37 @@ export function resourcesFromLink(props: Props): boolean {
           return true;
         }
       }
-      return false;
+      break;
     }
   }
-  return false;
+  if (props.onLoad || props.onError) {
+    return false;
+  }
+
+  const sizes = typeof props.sizes === 'string' ? props.sizes : '';
+  const media = typeof props.media === 'string' ? props.media : '';
+  key =
+    'rel:' + rel + '::href:' + href + '::sizes:' + sizes + '::media:' + media;
+  let resource = resources.headsMap.get(key);
+  if (!resource) {
+    resource = {
+      type: 'link',
+      props: Object.assign({}, props),
+      flushed: false,
+    };
+    resources.headsMap.set(key, resource);
+    switch (rel) {
+      case 'preconnect':
+      case 'prefetch-dns': {
+        resources.preconnects.add(resource);
+        break;
+      }
+      default: {
+        resources.headResources.add(resource);
+      }
+    }
+  }
+  return true;
 }
 
 // Construct a resource from link props.

--- a/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
@@ -849,7 +849,7 @@ export function resourcesFromLink(props: Props): boolean {
     resources.headsMap.set(key, resource);
     switch (rel) {
       case 'preconnect':
-      case 'prefetch-dns': {
+      case 'dns-prefetch': {
         resources.preconnects.add(resource);
         break;
       }

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -2340,6 +2340,7 @@ export function writeInitialResources(
 
   const {
     charset,
+    preconnects,
     fontPreloads,
     precedences,
     usedStylePreloads,
@@ -2355,6 +2356,13 @@ export function writeInitialResources(
     charset.flushed = true;
     resources.charset = null;
   }
+
+  preconnects.forEach(r => {
+    // font preload Resources should not already be flushed so we elide this check
+    pushLinkImpl(target, r.props, responseState);
+    r.flushed = true;
+  });
+  preconnects.clear();
 
   fontPreloads.forEach(r => {
     // font preload Resources should not already be flushed so we elide this check
@@ -2418,6 +2426,10 @@ export function writeInitialResources(
         pushSelfClosing(target, r.props, 'meta', responseState);
         break;
       }
+      case 'link': {
+        pushLinkImpl(target, r.props, responseState);
+        break;
+      }
     }
     r.flushed = true;
   });
@@ -2450,6 +2462,7 @@ export function writeImmediateResources(
 
   const {
     charset,
+    preconnects,
     fontPreloads,
     usedStylePreloads,
     scripts,
@@ -2464,6 +2477,13 @@ export function writeImmediateResources(
     charset.flushed = true;
     resources.charset = null;
   }
+
+  preconnects.forEach(r => {
+    // font preload Resources should not already be flushed so we elide this check
+    pushLinkImpl(target, r.props, responseState);
+    r.flushed = true;
+  });
+  preconnects.clear();
 
   fontPreloads.forEach(r => {
     // font preload Resources should not already be flushed so we elide this check
@@ -2505,6 +2525,10 @@ export function writeImmediateResources(
       }
       case 'meta': {
         pushSelfClosing(target, r.props, 'meta', responseState);
+        break;
+      }
+      case 'link': {
+        pushLinkImpl(target, r.props, responseState);
         break;
       }
     }

--- a/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
+++ b/packages/react-dom-bindings/src/shared/ReactDOMResourceValidation.js
@@ -11,7 +11,7 @@ import hasOwnProperty from 'shared/hasOwnProperty';
 
 type Props = {[string]: mixed};
 
-export function validateUnmatchedLinkResourceProps(
+export function warnOnMissingHrefAndRel(
   pendingProps: Props,
   currentProps: ?Props,
 ) {
@@ -24,34 +24,52 @@ export function validateUnmatchedLinkResourceProps(
       const originalRelStatement = getValueDescriptorExpectingEnumForWarning(
         currentProps.rel,
       );
-      const pendingRelStatement = getValueDescriptorExpectingEnumForWarning(
+      const pendingRel = getValueDescriptorExpectingEnumForWarning(
         pendingProps.rel,
       );
-      const pendingHrefStatement =
-        typeof pendingProps.href === 'string'
-          ? ` and the updated href is "${pendingProps.href}"`
-          : '';
-      console.error(
-        'A <link> previously rendered as a %s but was updated with a rel type that is not' +
-          ' valid for a Resource type. Generally Resources are not expected to ever have updated' +
-          ' props however in some limited circumstances it can be valid when changing the href.' +
-          ' When React encounters props that invalidate the Resource it is the same as not rendering' +
-          ' a Resource at all. valid rel types for Resources are "stylesheet" and "preload". The previous' +
-          ' rel for this instance was %s. The updated rel is %s%s.',
-        originalResourceName,
-        originalRelStatement,
-        pendingRelStatement,
-        pendingHrefStatement,
+      const pendingHref = getValueDescriptorExpectingEnumForWarning(
+        pendingProps.href,
       );
+      if (typeof pendingProps.rel !== 'string') {
+        console.error(
+          'A <link> previously rendered as a %s with rel "%s" but was updated with an invalid rel: %s. When a link' +
+            ' does not have a valid rel prop it is not represented in the DOM. If this is intentional, instead' +
+            ' do not render the <link> anymore.',
+          originalResourceName,
+          originalRelStatement,
+          pendingRel,
+        );
+      } else if (typeof pendingProps.href !== 'string') {
+        console.error(
+          'A <link> previously rendered as a %s but was updated with an invalid href prop: %s. When a link' +
+            ' does not have a valid href prop it is not represented in the DOM. If this is intentional, instead' +
+            ' do not render the <link> anymore.',
+          originalResourceName,
+          pendingHref,
+        );
+      }
     } else {
-      const pendingRelStatement = getValueDescriptorExpectingEnumForWarning(
+      const pendingRel = getValueDescriptorExpectingEnumForWarning(
         pendingProps.rel,
       );
-      console.error(
-        'A <link> is rendering as a Resource but has an invalid rel property. The rel encountered is %s.' +
-          ' This is a bug in React.',
-        pendingRelStatement,
+      const pendingHref = getValueDescriptorExpectingEnumForWarning(
+        pendingProps.href,
       );
+      if (typeof pendingProps.rel !== 'string') {
+        console.error(
+          'A <link> is rendering with an invalid rel: %s. When a link' +
+            ' does not have a valid rel prop it is not represented in the DOM. If this is intentional, instead' +
+            ' do not render the <link> anymore.',
+          pendingRel,
+        );
+      } else if (typeof pendingProps.href !== 'string') {
+        console.error(
+          'A <link> is rendering with an invalid href: %s. When a link' +
+            ' does not have a valid href prop it is not represented in the DOM. If this is intentional, instead' +
+            ' do not render the <link> anymore.',
+          pendingHref,
+        );
+      }
     }
   }
 }

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -955,7 +955,7 @@ describe('ReactDOMFloat', () => {
             <link rel="preload" href="bar" as="style" />
             <link rel="stylesheet" href="bar" precedence="default" />
             <link rel="preconnect" href="bar" />
-            <link rel="prefetch-dns" href="bar" />
+            <link rel="dns-prefetch" href="bar" />
             <link rel="icon" href="bar" />
             <link rel="icon" href="bar" sizes="1x1" />
             <link rel="icon" href="bar" media="foo" />
@@ -965,7 +965,7 @@ describe('ReactDOMFloat', () => {
         );
         pipe(writable);
       });
-      // "preconnect" and "prefetch-dns" get hoisted to the front.
+      // "preconnect" and "dns-prefetch" get hoisted to the front.
       // All other generic links (not styles, or typed preloads)
       // get emitted after styles and other higher priority Resources
       // Sizes and Media are part of generic link keys
@@ -973,7 +973,7 @@ describe('ReactDOMFloat', () => {
         <html>
           <head>
             <link rel="preconnect" href="bar" />
-            <link rel="prefetch-dns" href="bar" />
+            <link rel="dns-prefetch" href="bar" />
             <link rel="stylesheet" href="bar" data-precedence="default" />
             <link rel="foo" href="bar" />
             <link rel="preload" href="bar" />
@@ -1001,7 +1001,7 @@ describe('ReactDOMFloat', () => {
           <link rel="preload" href="bar" as="style" />
           <link rel="stylesheet" href="bar" precedence="default" />
           <link rel="preconnect" href="bar" />
-          <link rel="prefetch-dns" href="bar" />
+          <link rel="dns-prefetch" href="bar" />
           <link rel="icon" href="bar" />
           <link rel="icon" href="bar" sizes="1x1" />
           <link rel="icon" href="bar" media="foo" />
@@ -1014,7 +1014,7 @@ describe('ReactDOMFloat', () => {
         <html>
           <head>
             <link rel="preconnect" href="bar" />
-            <link rel="prefetch-dns" href="bar" />
+            <link rel="dns-prefetch" href="bar" />
             <link rel="stylesheet" href="bar" data-precedence="default" />
             <link rel="foo" href="bar" />
             <link rel="preload" href="bar" />

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -389,29 +389,29 @@ describe('ReactDOMFloat', () => {
       root.render(
         <div>
           <link rel="stylesheet" href="foo" precedence="foo" />
+          <link rel="stylesheet" href="bar" precedence="foo" />
         </div>,
       );
       expect(Scheduler).toFlushWithoutYielding();
       root.render(
         <div>
-          <link rel="author" href="bar" />
+          <link rel={() => {}} href="bar" />
+          <link rel="foo" href={() => {}} />
         </div>,
       );
       expect(() => {
         expect(Scheduler).toFlushWithoutYielding();
-      }).toErrorDev(
-        'Warning: A <link> previously rendered as a Resource with href "foo" but was updated with a rel type that is not' +
-          ' valid for a Resource type. Generally Resources are not expected to ever have updated' +
-          ' props however in some limited circumstances it can be valid when changing the href.' +
-          ' When React encounters props that invalidate the Resource it is the same as not rendering' +
-          ' a Resource at all. valid rel types for Resources are "stylesheet" and "preload". The previous' +
-          ' rel for this instance was "stylesheet". The updated rel is "author" and the updated href is "bar".',
-      );
+      }).toErrorDev([
+        'Warning: A <link> previously rendered as a Resource with href "foo" with rel ""stylesheet"" but was updated with an invalid rel: something with type "function". When a link does not have a valid rel prop it is not represented in the DOM. If this is intentional, instead do not render the <link> anymore.',
+        'Warning: A <link> previously rendered as a Resource with href "bar" but was updated with an invalid href prop: something with type "function". When a link does not have a valid href prop it is not represented in the DOM. If this is intentional, instead do not render the <link> anymore.',
+      ]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
             <link rel="stylesheet" href="foo" data-precedence="foo" />
+            <link rel="stylesheet" href="bar" data-precedence="foo" />
             <link rel="preload" as="style" href="foo" />
+            <link rel="preload" as="style" href="bar" />
           </head>
           <body>
             <div id="container">
@@ -941,6 +941,170 @@ describe('ReactDOMFloat', () => {
   });
 
   describe('head resources', () => {
+    // @gate enableFloat
+    it('supports preconnects, prefetc-dns, and arbitrary other link types', async () => {
+      await actIntoEmptyDocument(() => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+          <html>
+            <head />
+            <body>
+              <div>hello world</div>
+            </body>
+            <link rel="foo" href="bar" />
+            <link rel="preload" href="bar" />
+            <link rel="preload" href="bar" as="style" />
+            <link rel="stylesheet" href="bar" precedence="default" />
+            <link rel="preconnect" href="bar" />
+            <link rel="prefetch-dns" href="bar" />
+            <link rel="icon" href="bar" />
+            <link rel="icon" href="bar" sizes="1x1" />
+            <link rel="icon" href="bar" media="foo" />
+            <link rel="shortcut icon" href="bar" />
+            <link rel="apple-touch-icon" href="bar" />
+          </html>,
+        );
+        pipe(writable);
+      });
+      // "preconnect" and "prefetch-dns" get hoisted to the front.
+      // All other generic links (not styles, or typed preloads)
+      // get emitted after styles and other higher priority Resources
+      // Sizes and Media are part of generic link keys
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="preconnect" href="bar" />
+            <link rel="prefetch-dns" href="bar" />
+            <link rel="stylesheet" href="bar" data-precedence="default" />
+            <link rel="foo" href="bar" />
+            <link rel="preload" href="bar" />
+            <link rel="icon" href="bar" />
+            <link rel="icon" href="bar" sizes="1x1" />
+            <link rel="icon" href="bar" media="foo" />
+            <link rel="shortcut icon" href="bar" />
+            <link rel="apple-touch-icon" href="bar" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      const root = ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <head />
+          <body>
+            <div>hello world</div>
+          </body>
+          <link rel="foo" href="bar" />
+          <link rel="preload" href="bar" />
+          <link rel="preload" href="bar" as="style" />
+          <link rel="stylesheet" href="bar" precedence="default" />
+          <link rel="preconnect" href="bar" />
+          <link rel="prefetch-dns" href="bar" />
+          <link rel="icon" href="bar" />
+          <link rel="icon" href="bar" sizes="1x1" />
+          <link rel="icon" href="bar" media="foo" />
+          <link rel="shortcut icon" href="bar" />
+          <link rel="apple-touch-icon" href="bar" />
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="preconnect" href="bar" />
+            <link rel="prefetch-dns" href="bar" />
+            <link rel="stylesheet" href="bar" data-precedence="default" />
+            <link rel="foo" href="bar" />
+            <link rel="preload" href="bar" />
+            <link rel="icon" href="bar" />
+            <link rel="icon" href="bar" sizes="1x1" />
+            <link rel="icon" href="bar" media="foo" />
+            <link rel="shortcut icon" href="bar" />
+            <link rel="apple-touch-icon" href="bar" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      root.render(
+        <html>
+          <head />
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="stylesheet" href="bar" data-precedence="default" />
+            <link rel="preload" href="bar" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+    });
+    // @gate enableFloat
+    it('can render icons and apple-touch-icons as resources', async () => {
+      await actIntoEmptyDocument(() => {
+        const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+          <>
+            <html>
+              <head />
+              <body>
+                <link rel="icon" href="foo" />
+                <div>hello world</div>
+              </body>
+            </html>
+            <link rel="apple-touch-icon" href="foo" />
+          </>,
+        );
+        pipe(writable);
+      });
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="icon" href="foo" />
+            <link rel="apple-touch-icon" href="foo" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+
+      ReactDOMClient.hydrateRoot(
+        document,
+        <html>
+          <link rel="apple-touch-icon" href="foo" />
+          <head />
+          <body>
+            <link rel="icon" href="foo" />
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+      expect(Scheduler).toFlushWithoutYielding();
+      expect(getMeaningfulChildren(document)).toEqual(
+        <html>
+          <head>
+            <link rel="icon" href="foo" />
+            <link rel="apple-touch-icon" href="foo" />
+          </head>
+          <body>
+            <div>hello world</div>
+          </body>
+        </html>,
+      );
+    });
+
     // @gate enableFloat
     it('can hydrate the right instances for deeply nested structured metas', async () => {
       await actIntoEmptyDocument(() => {


### PR DESCRIPTION
stacked on https://github.com/facebook/react/pull/25514

This PR adds support for any type of Link as long as it has a string rel and href and does not include an onLoad or onError property.

The semantics for generic link resources matches other head resources, they will be inserted and removed as their ref counts go positive and back to zero.

Keys are based on rel, href, sizes, and media.

on the server preconnect and prefetch-dns are privileged and will emit near the start of the stream.