### PR TITLE
Unify promise switch statements

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -102,6 +102,7 @@ import {
   requestEventTime,
   markSkippedUpdateLanes,
   isInvalidExecutionContextForEventFunction,
+  getSuspendedThenableState,
 } from './ReactFiberWorkLoop.new';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
@@ -134,6 +135,7 @@ import {
 import {getTreeId} from './ReactFiberTreeContext.new';
 import {now} from './Scheduler';
 import {
+  prepareThenableState,
   trackUsedThenable,
   getPreviouslyUsedThenableAtIndex,
 } from './ReactFiberThenable.new';
@@ -465,6 +467,9 @@ export function renderWithHooks<Props, SecondArg>(
         : HooksDispatcherOnUpdate;
   }
 
+  // If this is a replay, restore the thenable state from the previous attempt.
+  const prevThenableState = getSuspendedThenableState();
+  prepareThenableState(prevThenableState);
   let children = Component(props, secondArg);
 
   // Check if there was a render phase update
@@ -506,6 +511,7 @@ export function renderWithHooks<Props, SecondArg>(
         ? HooksDispatcherOnRerenderInDEV
         : HooksDispatcherOnRerender;
 
+      prepareThenableState(prevThenableState);
       children = Component(props, secondArg);
     } while (didScheduleRenderPhaseUpdateDuringThisPass);
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -137,7 +137,6 @@ import {now} from './Scheduler';
 import {
   prepareThenableState,
   trackUsedThenable,
-  getPreviouslyUsedThenableAtIndex,
 } from './ReactFiberThenable.new';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
@@ -776,8 +775,6 @@ if (enableUseMemoCacheHook) {
   };
 }
 
-function noop(): void {}
-
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
     // $FlowFixMe[method-unbinding]
@@ -788,59 +785,7 @@ function use<T>(usable: Usable<T>): T {
       // Track the position of the thenable within this fiber.
       const index = thenableIndexCounter;
       thenableIndexCounter += 1;
-
-      // TODO: Unify this switch statement with the one in trackUsedThenable.
-      switch (thenable.status) {
-        case 'fulfilled': {
-          const fulfilledValue: T = thenable.value;
-          return fulfilledValue;
-        }
-        case 'rejected': {
-          const rejectedError = thenable.reason;
-          throw rejectedError;
-        }
-        default: {
-          const prevThenableAtIndex: Thenable<T> | null = getPreviouslyUsedThenableAtIndex(
-            index,
-          );
-          if (prevThenableAtIndex !== null) {
-            if (thenable !== prevThenableAtIndex) {
-              // Avoid an unhandled rejection errors for the Promises that we'll
-              // intentionally ignore.
-              thenable.then(noop, noop);
-            }
-            switch (prevThenableAtIndex.status) {
-              case 'fulfilled': {
-                const fulfilledValue: T = prevThenableAtIndex.value;
-                return fulfilledValue;
-              }
-              case 'rejected': {
-                const rejectedError: mixed = prevThenableAtIndex.reason;
-                throw rejectedError;
-              }
-              default: {
-                // The thenable still hasn't resolved. Suspend with the same
-                // thenable as last time to avoid redundant listeners.
-                throw prevThenableAtIndex;
-              }
-            }
-          } else {
-            // This is the first time something has been used at this index.
-            // Stash the thenable at the current index so we can reuse it during
-            // the next attempt.
-            trackUsedThenable(thenable, index);
-
-            // Suspend.
-            // TODO: Throwing here is an implementation detail that allows us to
-            // unwind the call stack. But we shouldn't allow it to leak into
-            // userspace. Throw an opaque placeholder value instead of the
-            // actual thenable. If it doesn't get captured by the work loop, log
-            // a warning, because that means something in userspace must have
-            // caught it.
-            throw thenable;
-          }
-        }
-      }
+      return trackUsedThenable(thenable, index);
     } else if (
       usable.$$typeof === REACT_CONTEXT_TYPE ||
       usable.$$typeof === REACT_SERVER_CONTEXT_TYPE

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -102,6 +102,7 @@ import {
   requestEventTime,
   markSkippedUpdateLanes,
   isInvalidExecutionContextForEventFunction,
+  getSuspendedThenableState,
 } from './ReactFiberWorkLoop.old';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
@@ -134,6 +135,7 @@ import {
 import {getTreeId} from './ReactFiberTreeContext.old';
 import {now} from './Scheduler';
 import {
+  prepareThenableState,
   trackUsedThenable,
   getPreviouslyUsedThenableAtIndex,
 } from './ReactFiberThenable.old';
@@ -465,6 +467,9 @@ export function renderWithHooks<Props, SecondArg>(
         : HooksDispatcherOnUpdate;
   }
 
+  // If this is a replay, restore the thenable state from the previous attempt.
+  const prevThenableState = getSuspendedThenableState();
+  prepareThenableState(prevThenableState);
   let children = Component(props, secondArg);
 
   // Check if there was a render phase update
@@ -506,6 +511,7 @@ export function renderWithHooks<Props, SecondArg>(
         ? HooksDispatcherOnRerenderInDEV
         : HooksDispatcherOnRerender;
 
+      prepareThenableState(prevThenableState);
       children = Component(props, secondArg);
     } while (didScheduleRenderPhaseUpdateDuringThisPass);
   }

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -137,7 +137,6 @@ import {now} from './Scheduler';
 import {
   prepareThenableState,
   trackUsedThenable,
-  getPreviouslyUsedThenableAtIndex,
 } from './ReactFiberThenable.old';
 
 const {ReactCurrentDispatcher, ReactCurrentBatchConfig} = ReactSharedInternals;
@@ -776,8 +775,6 @@ if (enableUseMemoCacheHook) {
   };
 }
 
-function noop(): void {}
-
 function use<T>(usable: Usable<T>): T {
   if (usable !== null && typeof usable === 'object') {
     // $FlowFixMe[method-unbinding]
@@ -788,59 +785,7 @@ function use<T>(usable: Usable<T>): T {
       // Track the position of the thenable within this fiber.
       const index = thenableIndexCounter;
       thenableIndexCounter += 1;
-
-      // TODO: Unify this switch statement with the one in trackUsedThenable.
-      switch (thenable.status) {
-        case 'fulfilled': {
-          const fulfilledValue: T = thenable.value;
-          return fulfilledValue;
-        }
-        case 'rejected': {
-          const rejectedError = thenable.reason;
-          throw rejectedError;
-        }
-        default: {
-          const prevThenableAtIndex: Thenable<T> | null = getPreviouslyUsedThenableAtIndex(
-            index,
-          );
-          if (prevThenableAtIndex !== null) {
-            if (thenable !== prevThenableAtIndex) {
-              // Avoid an unhandled rejection errors for the Promises that we'll
-              // intentionally ignore.
-              thenable.then(noop, noop);
-            }
-            switch (prevThenableAtIndex.status) {
-              case 'fulfilled': {
-                const fulfilledValue: T = prevThenableAtIndex.value;
-                return fulfilledValue;
-              }
-              case 'rejected': {
-                const rejectedError: mixed = prevThenableAtIndex.reason;
-                throw rejectedError;
-              }
-              default: {
-                // The thenable still hasn't resolved. Suspend with the same
-                // thenable as last time to avoid redundant listeners.
-                throw prevThenableAtIndex;
-              }
-            }
-          } else {
-            // This is the first time something has been used at this index.
-            // Stash the thenable at the current index so we can reuse it during
-            // the next attempt.
-            trackUsedThenable(thenable, index);
-
-            // Suspend.
-            // TODO: Throwing here is an implementation detail that allows us to
-            // unwind the call stack. But we shouldn't allow it to leak into
-            // userspace. Throw an opaque placeholder value instead of the
-            // actual thenable. If it doesn't get captured by the work loop, log
-            // a warning, because that means something in userspace must have
-            // caught it.
-            throw thenable;
-          }
-        }
-      }
+      return trackUsedThenable(thenable, index);
     } else if (
       usable.$$typeof === REACT_CONTEXT_TYPE ||
       usable.$$typeof === REACT_SERVER_CONTEXT_TYPE

--- a/packages/react-reconciler/src/ReactFiberThenable.new.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.new.js
@@ -17,8 +17,7 @@ import type {
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 const {ReactCurrentActQueue} = ReactSharedInternals;
 
-// TODO: Sparse arrays are bad for performance.
-export opaque type ThenableState = Array<Thenable<any> | void>;
+export opaque type ThenableState = Array<Thenable<any>>;
 
 let thenableState: ThenableState | null = null;
 
@@ -62,7 +61,9 @@ export function isThenableStateResolved(thenables: ThenableState): boolean {
   return true;
 }
 
-export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
+function noop(): void {}
+
+export function trackUsedThenable<T>(thenable: Thenable<T>, index: number): T {
   if (__DEV__ && ReactCurrentActQueue.current !== null) {
     ReactCurrentActQueue.didUsePromise = true;
   }
@@ -70,7 +71,20 @@ export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
   if (thenableState === null) {
     thenableState = [thenable];
   } else {
-    thenableState[index] = thenable;
+    const previous = thenableState[index];
+    if (previous === undefined) {
+      thenableState.push(thenable);
+    } else {
+      if (previous !== thenable) {
+        // Reuse the previous thenable, and drop the new one. We can assume
+        // they represent the same value, because components are idempotent.
+
+        // Avoid an unhandled rejection errors for the Promises that we'll
+        // intentionally ignore.
+        thenable.then(noop, noop);
+        thenable = previous;
+      }
+    }
   }
 
   // We use an expando to track the status and result of a thenable so that we
@@ -80,52 +94,48 @@ export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
   // If the thenable doesn't have a status, set it to "pending" and attach
   // a listener that will update its status and result when it resolves.
   switch (thenable.status) {
-    case 'fulfilled':
-    case 'rejected':
-      // A thenable that already resolved shouldn't have been thrown, so this is
-      // unexpected. Suggests a mistake in a userspace data library. Don't track
-      // this thenable, because if we keep trying it will likely infinite loop
-      // without ever resolving.
-      // TODO: Log a warning?
-      break;
+    case 'fulfilled': {
+      const fulfilledValue: T = thenable.value;
+      return fulfilledValue;
+    }
+    case 'rejected': {
+      const rejectedError = thenable.reason;
+      throw rejectedError;
+    }
     default: {
       if (typeof thenable.status === 'string') {
         // Only instrument the thenable if the status if not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
-        break;
+      } else {
+        const pendingThenable: PendingThenable<mixed> = (thenable: any);
+        pendingThenable.status = 'pending';
+        pendingThenable.then(
+          fulfilledValue => {
+            if (thenable.status === 'pending') {
+              const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
+              fulfilledThenable.status = 'fulfilled';
+              fulfilledThenable.value = fulfilledValue;
+            }
+          },
+          (error: mixed) => {
+            if (thenable.status === 'pending') {
+              const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
+              rejectedThenable.status = 'rejected';
+              rejectedThenable.reason = error;
+            }
+          },
+        );
       }
-      const pendingThenable: PendingThenable<mixed> = (thenable: any);
-      pendingThenable.status = 'pending';
-      pendingThenable.then(
-        fulfilledValue => {
-          if (thenable.status === 'pending') {
-            const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
-            fulfilledThenable.status = 'fulfilled';
-            fulfilledThenable.value = fulfilledValue;
-          }
-        },
-        (error: mixed) => {
-          if (thenable.status === 'pending') {
-            const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
-            rejectedThenable.status = 'rejected';
-            rejectedThenable.reason = error;
-          }
-        },
-      );
-      break;
-    }
-  }
-}
 
-export function getPreviouslyUsedThenableAtIndex<T>(
-  index: number,
-): Thenable<T> | null {
-  if (thenableState !== null) {
-    const thenable = thenableState[index];
-    if (thenable !== undefined) {
-      return thenable;
+      // Suspend.
+      // TODO: Throwing here is an implementation detail that allows us to
+      // unwind the call stack. But we shouldn't allow it to leak into
+      // userspace. Throw an opaque placeholder value instead of the
+      // actual thenable. If it doesn't get captured by the work loop, log
+      // a warning, because that means something in userspace must have
+      // caught it.
+      throw thenable;
     }
   }
-  return null;
 }

--- a/packages/react-reconciler/src/ReactFiberThenable.old.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.old.js
@@ -17,8 +17,7 @@ import type {
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 const {ReactCurrentActQueue} = ReactSharedInternals;
 
-// TODO: Sparse arrays are bad for performance.
-export opaque type ThenableState = Array<Thenable<any> | void>;
+export opaque type ThenableState = Array<Thenable<any>>;
 
 let thenableState: ThenableState | null = null;
 
@@ -62,7 +61,9 @@ export function isThenableStateResolved(thenables: ThenableState): boolean {
   return true;
 }
 
-export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
+function noop(): void {}
+
+export function trackUsedThenable<T>(thenable: Thenable<T>, index: number): T {
   if (__DEV__ && ReactCurrentActQueue.current !== null) {
     ReactCurrentActQueue.didUsePromise = true;
   }
@@ -70,7 +71,20 @@ export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
   if (thenableState === null) {
     thenableState = [thenable];
   } else {
-    thenableState[index] = thenable;
+    const previous = thenableState[index];
+    if (previous === undefined) {
+      thenableState.push(thenable);
+    } else {
+      if (previous !== thenable) {
+        // Reuse the previous thenable, and drop the new one. We can assume
+        // they represent the same value, because components are idempotent.
+
+        // Avoid an unhandled rejection errors for the Promises that we'll
+        // intentionally ignore.
+        thenable.then(noop, noop);
+        thenable = previous;
+      }
+    }
   }
 
   // We use an expando to track the status and result of a thenable so that we
@@ -80,52 +94,48 @@ export function trackUsedThenable<T>(thenable: Thenable<T>, index: number) {
   // If the thenable doesn't have a status, set it to "pending" and attach
   // a listener that will update its status and result when it resolves.
   switch (thenable.status) {
-    case 'fulfilled':
-    case 'rejected':
-      // A thenable that already resolved shouldn't have been thrown, so this is
-      // unexpected. Suggests a mistake in a userspace data library. Don't track
-      // this thenable, because if we keep trying it will likely infinite loop
-      // without ever resolving.
-      // TODO: Log a warning?
-      break;
+    case 'fulfilled': {
+      const fulfilledValue: T = thenable.value;
+      return fulfilledValue;
+    }
+    case 'rejected': {
+      const rejectedError = thenable.reason;
+      throw rejectedError;
+    }
     default: {
       if (typeof thenable.status === 'string') {
         // Only instrument the thenable if the status if not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
-        break;
+      } else {
+        const pendingThenable: PendingThenable<mixed> = (thenable: any);
+        pendingThenable.status = 'pending';
+        pendingThenable.then(
+          fulfilledValue => {
+            if (thenable.status === 'pending') {
+              const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
+              fulfilledThenable.status = 'fulfilled';
+              fulfilledThenable.value = fulfilledValue;
+            }
+          },
+          (error: mixed) => {
+            if (thenable.status === 'pending') {
+              const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
+              rejectedThenable.status = 'rejected';
+              rejectedThenable.reason = error;
+            }
+          },
+        );
       }
-      const pendingThenable: PendingThenable<mixed> = (thenable: any);
-      pendingThenable.status = 'pending';
-      pendingThenable.then(
-        fulfilledValue => {
-          if (thenable.status === 'pending') {
-            const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
-            fulfilledThenable.status = 'fulfilled';
-            fulfilledThenable.value = fulfilledValue;
-          }
-        },
-        (error: mixed) => {
-          if (thenable.status === 'pending') {
-            const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
-            rejectedThenable.status = 'rejected';
-            rejectedThenable.reason = error;
-          }
-        },
-      );
-      break;
-    }
-  }
-}
 
-export function getPreviouslyUsedThenableAtIndex<T>(
-  index: number,
-): Thenable<T> | null {
-  if (thenableState !== null) {
-    const thenable = thenableState[index];
-    if (thenable !== undefined) {
-      return thenable;
+      // Suspend.
+      // TODO: Throwing here is an implementation detail that allows us to
+      // unwind the call stack. But we shouldn't allow it to leak into
+      // userspace. Throw an opaque placeholder value instead of the
+      // actual thenable. If it doesn't get captured by the work loop, log
+      // a warning, because that means something in userspace must have
+      // caught it.
+      throw thenable;
     }
   }
-  return null;
 }

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -22,6 +22,7 @@ import type {
   TransitionAbort,
 } from './ReactFiberTracingMarkerComponent.old';
 import type {OffscreenInstance} from './ReactFiberOffscreenComponent';
+import type {ThenableState} from './ReactFiberThenable.old';
 
 import {
   warnAboutDeprecatedLifecycles,
@@ -265,10 +266,8 @@ import {
 } from './ReactFiberAct.old';
 import {processTransitionCallbacks} from './ReactFiberTracingMarkerComponent.old';
 import {
-  resetWakeableStateAfterEachAttempt,
-  resetThenableStateOnCompletion,
-  suspendedThenableDidResolve,
-  isTrackingSuspendedThenable,
+  getThenableStateAfterSuspending,
+  isThenableStateResolved,
 } from './ReactFiberThenable.old';
 import {schedulePostPaintCallback} from './ReactPostPaintCallback';
 
@@ -315,6 +314,7 @@ let workInProgressRootRenderLanes: Lanes = NoLanes;
 // immediately instead of unwinding the stack.
 let workInProgressIsSuspended: boolean = false;
 let workInProgressThrownValue: mixed = null;
+let workInProgressSuspendedThenableState: ThenableState | null = null;
 
 // Whether a ping listener was attached during this render. This is slightly
 // different that whether something suspended, because we don't add multiple
@@ -1686,8 +1686,6 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
       );
       interruptedWork = interruptedWork.return;
     }
-    resetWakeableStateAfterEachAttempt();
-    resetThenableStateOnCompletion();
   }
   workInProgressRoot = root;
   const rootWorkInProgress = createWorkInProgress(root.current, null);
@@ -1695,6 +1693,7 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   workInProgressRootRenderLanes = renderLanes = lanes;
   workInProgressIsSuspended = false;
   workInProgressThrownValue = null;
+  workInProgressSuspendedThenableState = null;
   workInProgressRootDidAttachPingListener = false;
   workInProgressRootExitStatus = RootInProgress;
   workInProgressRootFatalError = null;
@@ -1729,6 +1728,7 @@ function handleThrow(root, thrownValue): void {
   // as suspending the execution of the work loop.
   workInProgressIsSuspended = true;
   workInProgressThrownValue = thrownValue;
+  workInProgressSuspendedThenableState = getThenableStateAfterSuspending();
 
   const erroredWork = workInProgress;
   if (erroredWork === null) {
@@ -2014,7 +2014,7 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
       break;
     } catch (thrownValue) {
       handleThrow(root, thrownValue);
-      if (isTrackingSuspendedThenable()) {
+      if (workInProgressSuspendedThenableState !== null) {
         // If this fiber just suspended, it's possible the data is already
         // cached. Yield to the main thread to give it a chance to ping. If
         // it does, we can retry immediately without unwinding the stack.
@@ -2117,13 +2117,14 @@ function resumeSuspendedUnitOfWork(
   // instead of unwinding the stack. It's a separate function to keep the
   // additional logic out of the work loop's hot path.
 
-  const wasPinged = suspendedThenableDidResolve();
-  resetWakeableStateAfterEachAttempt();
+  const wasPinged =
+    workInProgressSuspendedThenableState !== null &&
+    isThenableStateResolved(workInProgressSuspendedThenableState);
 
   if (!wasPinged) {
     // The thenable wasn't pinged. Return to the normal work loop. This will
     // unwind the stack, and potentially result in showing a fallback.
-    resetThenableStateOnCompletion();
+    workInProgressSuspendedThenableState = null;
 
     const returnFiber = unitOfWork.return;
     if (returnFiber === null || workInProgressRoot === null) {
@@ -2188,7 +2189,7 @@ function resumeSuspendedUnitOfWork(
   // The begin phase finished successfully without suspending. Reset the state
   // used to track the fiber while it was suspended. Then return to the normal
   // work loop.
-  resetThenableStateOnCompletion();
+  workInProgressSuspendedThenableState = null;
 
   resetCurrentDebugFiberInDEV();
   unitOfWork.memoizedProps = unitOfWork.pendingProps;
@@ -2200,6 +2201,10 @@ function resumeSuspendedUnitOfWork(
   }
 
   ReactCurrentOwner.current = null;
+}
+
+export function getSuspendedThenableState(): ThenableState | null {
+  return workInProgressSuspendedThenableState;
 }
 
 function completeUnitOfWork(unitOfWork: Fiber): void {

--- a/packages/react-server/src/ReactFizzThenable.js
+++ b/packages/react-server/src/ReactFizzThenable.js
@@ -20,8 +20,7 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
-// TODO: Sparse arrays are bad for performance.
-export opaque type ThenableState = Array<Thenable<any> | void>;
+export opaque type ThenableState = Array<Thenable<any>>;
 
 export function createThenableState(): ThenableState {
   // The ThenableState is created the first time a component suspends. If it
@@ -29,12 +28,27 @@ export function createThenableState(): ThenableState {
   return [];
 }
 
+function noop(): void {}
+
 export function trackUsedThenable<T>(
   thenableState: ThenableState,
   thenable: Thenable<T>,
   index: number,
-) {
-  thenableState[index] = thenable;
+): T {
+  const previous = thenableState[index];
+  if (previous === undefined) {
+    thenableState.push(thenable);
+  } else {
+    if (previous !== thenable) {
+      // Reuse the previous thenable, and drop the new one. We can assume
+      // they represent the same value, because components are idempotent.
+
+      // Avoid an unhandled rejection errors for the Promises that we'll
+      // intentionally ignore.
+      thenable.then(noop, noop);
+      thenable = previous;
+    }
+  }
 
   // We use an expando to track the status and result of a thenable so that we
   // can synchronously unwrap the value. Think of this as an extension of the
@@ -43,53 +57,48 @@ export function trackUsedThenable<T>(
   // If the thenable doesn't have a status, set it to "pending" and attach
   // a listener that will update its status and result when it resolves.
   switch (thenable.status) {
-    case 'fulfilled':
-    case 'rejected':
-      // A thenable that already resolved shouldn't have been thrown, so this is
-      // unexpected. Suggests a mistake in a userspace data library. Don't track
-      // this thenable, because if we keep trying it will likely infinite loop
-      // without ever resolving.
-      // TODO: Log a warning?
-      break;
+    case 'fulfilled': {
+      const fulfilledValue: T = thenable.value;
+      return fulfilledValue;
+    }
+    case 'rejected': {
+      const rejectedError = thenable.reason;
+      throw rejectedError;
+    }
     default: {
       if (typeof thenable.status === 'string') {
         // Only instrument the thenable if the status if not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
-        break;
+      } else {
+        const pendingThenable: PendingThenable<mixed> = (thenable: any);
+        pendingThenable.status = 'pending';
+        pendingThenable.then(
+          fulfilledValue => {
+            if (thenable.status === 'pending') {
+              const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
+              fulfilledThenable.status = 'fulfilled';
+              fulfilledThenable.value = fulfilledValue;
+            }
+          },
+          (error: mixed) => {
+            if (thenable.status === 'pending') {
+              const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
+              rejectedThenable.status = 'rejected';
+              rejectedThenable.reason = error;
+            }
+          },
+        );
       }
-      const pendingThenable: PendingThenable<mixed> = (thenable: any);
-      pendingThenable.status = 'pending';
-      pendingThenable.then(
-        fulfilledValue => {
-          if (thenable.status === 'pending') {
-            const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
-            fulfilledThenable.status = 'fulfilled';
-            fulfilledThenable.value = fulfilledValue;
-          }
-        },
-        (error: mixed) => {
-          if (thenable.status === 'pending') {
-            const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
-            rejectedThenable.status = 'rejected';
-            rejectedThenable.reason = error;
-          }
-        },
-      );
-      break;
-    }
-  }
-}
 
-export function getPreviouslyUsedThenableAtIndex<T>(
-  thenableState: ThenableState | null,
-  index: number,
-): Thenable<T> | null {
-  if (thenableState !== null) {
-    const thenable = thenableState[index];
-    if (thenable !== undefined) {
-      return thenable;
+      // Suspend.
+      // TODO: Throwing here is an implementation detail that allows us to
+      // unwind the call stack. But we shouldn't allow it to leak into
+      // userspace. Throw an opaque placeholder value instead of the
+      // actual thenable. If it doesn't get captured by the work loop, log
+      // a warning, because that means something in userspace must have
+      // caught it.
+      throw thenable;
     }
   }
-  return null;
 }

--- a/packages/react-server/src/ReactFlightThenable.js
+++ b/packages/react-server/src/ReactFlightThenable.js
@@ -14,7 +14,6 @@
 // instead of "Wakeable". Or some other more appropriate name.
 
 import type {
-  Wakeable,
   Thenable,
   PendingThenable,
   FulfilledThenable,
@@ -30,14 +29,12 @@ export function createThenableState(): ThenableState {
   return [];
 }
 
-// TODO: Unify this with trackSuspendedThenable. It needs to support not only
-// `use`, but async components, too.
-export function trackSuspendedWakeable(wakeable: Wakeable) {
-  // If this wakeable isn't already a thenable, turn it into one now. Then,
-  // when we resume the work loop, we can check if its status is
-  // still pending.
-  // TODO: Get rid of the Wakeable type? It's superseded by UntrackedThenable.
-  const thenable: Thenable<mixed> = (wakeable: any);
+export function trackUsedThenable<T>(
+  thenableState: ThenableState,
+  thenable: Thenable<T>,
+  index: number,
+) {
+  thenableState[index] = thenable;
 
   // We use an expando to track the status and result of a thenable so that we
   // can synchronously unwrap the value. Think of this as an extension of the
@@ -82,20 +79,6 @@ export function trackSuspendedWakeable(wakeable: Wakeable) {
       break;
     }
   }
-}
-
-export function trackUsedThenable<T>(
-  thenableState: ThenableState,
-  thenable: Thenable<T>,
-  index: number,
-) {
-  // This is only a separate function from trackSuspendedWakeable for symmetry
-  // with Fiber.
-  // TODO: Disallow throwing a thenable directly. It must go through `use` (or
-  // some equivalent for internal Suspense implementations). We can't do this in
-  // Fiber yet because it's a breaking change but we can do it in Server
-  // Components because Server Components aren't released yet.
-  thenableState[index] = thenable;
 }
 
 export function getPreviouslyUsedThenableAtIndex<T>(

--- a/packages/react-server/src/ReactFlightThenable.js
+++ b/packages/react-server/src/ReactFlightThenable.js
@@ -20,8 +20,7 @@ import type {
   RejectedThenable,
 } from 'shared/ReactTypes';
 
-// TODO: Sparse arrays are bad for performance.
-export opaque type ThenableState = Array<Thenable<any> | void>;
+export opaque type ThenableState = Array<Thenable<any>>;
 
 export function createThenableState(): ThenableState {
   // The ThenableState is created the first time a component suspends. If it
@@ -29,12 +28,27 @@ export function createThenableState(): ThenableState {
   return [];
 }
 
+function noop(): void {}
+
 export function trackUsedThenable<T>(
   thenableState: ThenableState,
   thenable: Thenable<T>,
   index: number,
-) {
-  thenableState[index] = thenable;
+): T {
+  const previous = thenableState[index];
+  if (previous === undefined) {
+    thenableState.push(thenable);
+  } else {
+    if (previous !== thenable) {
+      // Reuse the previous thenable, and drop the new one. We can assume
+      // they represent the same value, because components are idempotent.
+
+      // Avoid an unhandled rejection errors for the Promises that we'll
+      // intentionally ignore.
+      thenable.then(noop, noop);
+      thenable = previous;
+    }
+  }
 
   // We use an expando to track the status and result of a thenable so that we
   // can synchronously unwrap the value. Think of this as an extension of the
@@ -43,53 +57,48 @@ export function trackUsedThenable<T>(
   // If the thenable doesn't have a status, set it to "pending" and attach
   // a listener that will update its status and result when it resolves.
   switch (thenable.status) {
-    case 'fulfilled':
-    case 'rejected':
-      // A thenable that already resolved shouldn't have been thrown, so this is
-      // unexpected. Suggests a mistake in a userspace data library. Don't track
-      // this thenable, because if we keep trying it will likely infinite loop
-      // without ever resolving.
-      // TODO: Log a warning?
-      break;
+    case 'fulfilled': {
+      const fulfilledValue: T = thenable.value;
+      return fulfilledValue;
+    }
+    case 'rejected': {
+      const rejectedError = thenable.reason;
+      throw rejectedError;
+    }
     default: {
       if (typeof thenable.status === 'string') {
         // Only instrument the thenable if the status if not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
-        break;
+      } else {
+        const pendingThenable: PendingThenable<mixed> = (thenable: any);
+        pendingThenable.status = 'pending';
+        pendingThenable.then(
+          fulfilledValue => {
+            if (thenable.status === 'pending') {
+              const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
+              fulfilledThenable.status = 'fulfilled';
+              fulfilledThenable.value = fulfilledValue;
+            }
+          },
+          (error: mixed) => {
+            if (thenable.status === 'pending') {
+              const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
+              rejectedThenable.status = 'rejected';
+              rejectedThenable.reason = error;
+            }
+          },
+        );
       }
-      const pendingThenable: PendingThenable<mixed> = (thenable: any);
-      pendingThenable.status = 'pending';
-      pendingThenable.then(
-        fulfilledValue => {
-          if (thenable.status === 'pending') {
-            const fulfilledThenable: FulfilledThenable<mixed> = (thenable: any);
-            fulfilledThenable.status = 'fulfilled';
-            fulfilledThenable.value = fulfilledValue;
-          }
-        },
-        (error: mixed) => {
-          if (thenable.status === 'pending') {
-            const rejectedThenable: RejectedThenable<mixed> = (thenable: any);
-            rejectedThenable.status = 'rejected';
-            rejectedThenable.reason = error;
-          }
-        },
-      );
-      break;
-    }
-  }
-}
 
-export function getPreviouslyUsedThenableAtIndex<T>(
-  thenableState: ThenableState | null,
-  index: number,
-): Thenable<T> | null {
-  if (thenableState !== null) {
-    const thenable = thenableState[index];
-    if (thenable !== undefined) {
-      return thenable;
+      // Suspend.
+      // TODO: Throwing here is an implementation detail that allows us to
+      // unwind the call stack. But we shouldn't allow it to leak into
+      // userspace. Throw an opaque placeholder value instead of the
+      // actual thenable. If it doesn't get captured by the work loop, log
+      // a warning, because that means something in userspace must have
+      // caught it.
+      throw thenable;
     }
   }
-  return null;
 }


### PR DESCRIPTION
## Based on #25538 

There are two different switch statements that we use to unwrap a `use`-ed promise, but there really only needs to be one. This was a factoring artifact that arose because I implemented the yieldy `status` instrumentation thing before I implemented `use` (for promises that are thrown directly during render, which is the old Suspense pattern that will be superseded by `use`).