### PR TITLE
Revert fetch instrumentation to only RSC

### DIFF
--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -71,9 +71,6 @@ import ReactSharedInternals from './ReactSharedInternals';
 import {startTransition} from './ReactStartTransition';
 import {act} from './ReactAct';
 
-// Patch fetch
-import './ReactFetch';
-
 // TODO: Move this branching into the other module instead and just re-export.
 const createElement: any = __DEV__
   ? createElementWithValidation

--- a/packages/react/src/ReactSharedSubset.experimental.js
+++ b/packages/react/src/ReactSharedSubset.experimental.js
@@ -7,6 +7,9 @@
  * @flow
  */
 
+// Patch fetch
+import './ReactFetch';
+
 export {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
   Children,

--- a/packages/react/src/__tests__/ReactFetch-test.js
+++ b/packages/react/src/__tests__/ReactFetch-test.js
@@ -41,6 +41,9 @@ describe('ReactFetch', () => {
     fetchCount = 0;
     global.fetch = fetchMock;
 
+    if (gate(flags => flags.experimental && !flags.www)) {
+      jest.mock('react', () => require('react/react.shared-subset'));
+    }
     React = require('react');
     ReactServerDOMServer = require('react-server-dom-webpack/server.browser');
     ReactServerDOMClient = require('react-server-dom-webpack/client');


### PR DESCRIPTION
Revert fetch instrumentation so that it only affects RSC by applying it only in the react-server condition of "react".

This helps make the rollout a little smoother because these affects existing libraries that fetch during client components, and then gets forever cached. We need to implement the GC first.

I haven't fully implemented the SSR part anyway.

The main problem that we discovered is that `"react"` and `"react/react.shared-subset"` have separate dispatchers in an environment that runs both Fizz and Flight. That's intentional and sometimes a feature. However, in this case it means that we instrument fetch twice and when you run Flight inside Fizz, that fetch goes into both caches when it's supposed to only see the inner one. I'm not sure how to solve that atm.