### PR TITLE
[Tiny] Fixed incorrect import in `react-server-dom-webpack`

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
@@ -40,7 +40,7 @@ class ClientReferenceDependency extends ModuleDependency {
 // without the client runtime so it's the first time in the loading sequence
 // you might want them.
 const clientImportName = 'react-server-dom-webpack/client';
-const clientFileName = require.resolve('../');
+const clientFileName = require.resolve('../client');
 
 type ClientReferenceSearchPath = {
   directory: string,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

In https://github.com/facebook/react/pull/25504, `react-server-dom-webpack/` was deprecated in favor of `react-server-dom-webpack/client`, but a remaining import wasn't adjusted accordingly.

As a result, the remaining conditions within the file are no longer firing appropriately, which I ran into while playing around with a fork of [server-components-demo](https://github.com/reactjs/server-components-demo).

The `index.js` file now contains a [placeholder](https://github.com/facebook/react/blob/main/packages/react-server-dom-webpack/index.js) and the actual logic of the client now sits in `/client`.

## How did you test this change?

I replaced `require.resolve('../')` with `require.resolve('../client')` in the `react-server-dom-webpack` package in `node_modules` and confirmed that the output of the build looked good again.