### PR TITLE
Fork ReactDOMSharedInternals for www

### DIFF
--- a/packages/shared/forks/ReactDOMSharedInternals.www.js
+++ b/packages/shared/forks/ReactDOMSharedInternals.www.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// $FlowIgnore[cannot-resolve-module] provided by www
+const ReactDOM = require('ReactDOMComet');
+
+const ReactDOMSharedInternals =
+  ReactDOM.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+export default ReactDOMSharedInternals;

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -70,6 +70,14 @@ const forks = Object.freeze({
     if (entry === 'react-dom' || entry === 'react-dom/server-rendering-stub') {
       return './packages/react-dom/src/ReactDOMSharedInternals.js';
     }
+    switch (bundleType) {
+      case FB_WWW_DEV:
+      case FB_WWW_PROD:
+      case FB_WWW_PROFILING:
+        return './packages/shared/forks/ReactDOMSharedInternals.www.js';
+      default:
+        break;
+    }
     if (
       !entry.startsWith('react-dom/') &&
       dependencies.indexOf('react-dom') === -1


### PR DESCRIPTION
I'm not sure if there's a better way to do this, but internally we have some restrictions so we need to add an indirection.