### PR TITLE
[Float] fix coordination of resource identity and hydration

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -1465,9 +1465,9 @@ export function isHostResourceType(type: string, props: Props): boolean {
       }
       return (async: any) && typeof src === 'string' && !onLoad && !onError;
     }
+    case 'noscript':
     case 'template':
-    case 'style':
-    case 'noscript': {
+    case 'style': {
       if (__DEV__) {
         if (resourceFormOnly) {
           console.error(

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -802,7 +802,15 @@ export const supportsHydration = true;
 // inserted without breaking hydration
 export function isHydratable(type: string, props: Props): boolean {
   if (enableFloat) {
-    if (type === 'script') {
+    if (type === 'link') {
+      if (
+        (props: any).rel === 'stylesheet' &&
+        typeof (props: any).precedence !== 'string'
+      ) {
+        return true;
+      }
+      return false;
+    } else if (type === 'script') {
       const {async, onLoad, onError} = (props: any);
       return !(async && (onLoad || onError));
     }
@@ -902,16 +910,25 @@ function getNextHydratable(node) {
       if (nodeType === ELEMENT_NODE) {
         const element: Element = (node: any);
         switch (element.tagName) {
+          case 'TITLE':
+          case 'META':
+          case 'BASE':
+          case 'HTML':
+          case 'HEAD':
+          case 'BODY': {
+            continue;
+          }
           case 'LINK': {
             const linkEl: HTMLLinkElement = (element: any);
-            const rel = linkEl.rel;
+            // All links that are server rendered are resources except
+            // stylesheets that do not have a precedence
             if (
-              rel === 'preload' ||
-              (rel === 'stylesheet' && linkEl.hasAttribute('data-precedence'))
+              linkEl.rel === 'stylesheet' &&
+              !linkEl.hasAttribute('data-precedence')
             ) {
-              continue;
+              break;
             }
-            break;
+            continue;
           }
           case 'STYLE': {
             const styleEl: HTMLStyleElement = (element: any);
@@ -927,12 +944,6 @@ function getNextHydratable(node) {
             }
             break;
           }
-          case 'TITLE':
-          case 'HTML':
-          case 'HEAD':
-          case 'BODY': {
-            continue;
-          }
         }
         break;
       } else if (nodeType === TEXT_NODE) {
@@ -942,18 +953,21 @@ function getNextHydratable(node) {
       if (nodeType === ELEMENT_NODE) {
         const element: Element = (node: any);
         switch (element.tagName) {
+          case 'TITLE':
+          case 'META':
+          case 'BASE': {
+            continue;
+          }
           case 'LINK': {
             const linkEl: HTMLLinkElement = (element: any);
-            const rel = linkEl.rel;
+            // All links that are server rendered are resources except
+            // stylesheets that do not have a precedence
             if (
-              rel === 'preload' ||
-              (rel === 'stylesheet' && linkEl.hasAttribute('data-precedence'))
+              linkEl.rel === 'stylesheet' &&
+              !linkEl.hasAttribute('data-precedence')
             ) {
-              continue;
+              break;
             }
-            break;
-          }
-          case 'TITLE': {
             continue;
           }
           case 'STYLE': {

--- a/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
@@ -863,7 +863,7 @@ export function resourcesFromLink(props: Props): boolean {
     }
   }
   if (props.onLoad || props.onError) {
-    return false;
+    return true;
   }
 
   const sizes = typeof props.sizes === 'string' ? props.sizes : '';


### PR DESCRIPTION
there are a few bugs where dom representations from SSR aren't identified as Resources when they should be.

There are 3 semantics

Resource -> hoist to head, deduping, etc...
hydratable Component -> SSR'd and hydrated in place
non-hydratable Component -> never SSR'd, never hydrated, always inserted on the client

this last category is small
(non stylesheet) links with onLoad and/or onError
async scripts with onLoad and/or onError

The reason we have this distinction for now is we need every SSR'd async script to be assumable to be a Resource. we don't currently encode onLoad on the server and so we couldn't otherwise tell if an async script is a Resource or is an async script with an onLoad which would not be a resource. To avoid this ambiguity we never emit the scripts in SSR and assume they need to be inserted on the client.

We can explore changes to these semantics in the future or possibly encode some identifier when we want to opt out of resource semantics but still SSR the link or script.