### PR TITLE
Add errorInfo argument to onError in Fizz

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -369,7 +369,6 @@ describe('ReactDOMFizzServer', () => {
       );
     }
 
-    let fatalError;
     const errors = [];
     const stacks = [];
     try {
@@ -380,9 +379,6 @@ describe('ReactDOMFizzServer', () => {
             if (errInfo && errInfo.componentStack) {
               stacks.push(normalizeCodeLocInfo(errInfo.componentStack));
             }
-          },
-          onShellError(err) {
-            fatalError = err;
           },
         });
         pipe(writable);

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -443,5 +443,7 @@
   "455": "This CacheSignal was requested outside React which means that it is immediately aborted.",
   "456": "Calling Offscreen.detach before instance handle has been set.",
   "457": "acquireHeadResource encountered a resource type it did not expect: \"%s\". This is a bug in React.",
-  "458": "Currently React only supports one RSC renderer at a time."
+  "458": "Currently React only supports one RSC renderer at a time.",
+  "459": "logRecoverableErrorDev was called in production mode. This is a bug in React.",
+  "460": "logRecoverableErrorProd was called in development mode. This is a bug in React."
 }


### PR DESCRIPTION
Fizz currently accepts an onError callback which is provided any errors thrown during rendering. However previously the component stack was generated and sent to the client after logging the error so if you relied upon server logs to see where an error ocurred it was hard to make sense of it.

This change adds errorInfo as an optional second argument to onError. In dev, it will be passed a componentStack if one exists. in Prod the argument will be omitted because we do not generate component stacks in prod yet.