### PR TITLE
Fix useSyncExternalStore dropped update when state is dispatched in render phase

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1510,7 +1510,7 @@ function updateSyncExternalStore<T>(
       }
     }
   }
-  const prevSnapshot = hook.memoizedState;
+  const prevSnapshot = (currentHook || hook).memoizedState;
   const snapshotChanged = !is(prevSnapshot, nextSnapshot);
   if (snapshotChanged) {
     hook.memoizedState = nextSnapshot;

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1510,7 +1510,7 @@ function updateSyncExternalStore<T>(
       }
     }
   }
-  const prevSnapshot = hook.memoizedState;
+  const prevSnapshot = (currentHook || hook).memoizedState;
   const snapshotChanged = !is(prevSnapshot, nextSnapshot);
   if (snapshotChanged) {
     hook.memoizedState = nextSnapshot;


### PR DESCRIPTION
## Summary

Fix #25565

In `updateSyncExternalStore`, If state is dispatched during render phase, then work in progress `hook` will hold already updated memoized state in the second pass, defeating previous value comparison. As a consequence, the effect updating internal store value with next value will not be scheduled.

This breaks re-rendering when store is set back to it's mounting value.

Using `currentHook` instead (when defined) fixes that issue.

## How did you test this change?

See included test