### PR TITLE
Flow: first batch of function annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.190.0",
+    "flow-bin": "^0.190.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",
     "google-closure-compiler": "^20200517.0.0",

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -465,7 +465,7 @@ function createModelResolver<T>(
 }
 
 function createModelReject<T>(chunk: SomeChunk<T>) {
-  return error => triggerErrorOnChunk(chunk, error);
+  return (error: mixed) => triggerErrorOnChunk(chunk, error);
 }
 
 export function parseModelString(

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -350,7 +350,7 @@ const Dispatcher: DispatcherType = {
 // create a proxy to throw a custom error
 // in case future versions of React adds more hooks
 const DispatcherProxyHandler = {
-  get(target, prop) {
+  get(target: DispatcherType, prop: string) {
     if (target.hasOwnProperty(prop)) {
       return target[prop];
     }
@@ -404,7 +404,7 @@ export type HooksTree = Array<HooksNode>;
 
 let mostLikelyAncestorIndex = 0;
 
-function findSharedIndex(hookStack, rootStack, rootIndex) {
+function findSharedIndex(hookStack, rootStack, rootIndex: number) {
   const source = rootStack[rootIndex].source;
   hookSearch: for (let i = 0; i < hookStack.length; i++) {
     if (hookStack[i].source === source) {
@@ -460,7 +460,7 @@ function isReactWrapper(functionName, primitiveName) {
   );
 }
 
-function findPrimitiveIndex(hookStack, hook) {
+function findPrimitiveIndex(hookStack, hook: HookLogEntry) {
   const stackCache = getPrimitiveStackCache();
   const primitiveStack = stackCache.get(hook.primitive);
   if (primitiveStack === undefined) {
@@ -488,7 +488,7 @@ function findPrimitiveIndex(hookStack, hook) {
   return -1;
 }
 
-function parseTrimmedStack(rootStack, hook) {
+function parseTrimmedStack(rootStack, hook: HookLogEntry) {
   // Get the stack trace between the primitive hook function and
   // the root function call. I.e. the stack frames of custom hooks.
   const hookStack = ErrorStackParser.parse(hook.stackError);
@@ -521,7 +521,7 @@ function parseCustomHookName(functionName: void | string): string {
 
 function buildTree(
   rootStack,
-  readHookLog,
+  readHookLog: Array<HookLogEntry>,
   includeHooksSource: boolean,
 ): HooksTree {
   const rootChildren = [];

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -276,7 +276,7 @@ export function connectToDevTools(options: ?ConnectOptions) {
     scheduleRetry();
   }
 
-  function handleMessage(event) {
+  function handleMessage(event: MessageEvent) {
     let data;
     try {
       if (typeof event.data === 'string') {

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -42,7 +42,7 @@ import type {ComponentFilter} from '../types';
 import {isSynchronousXHRSupported} from './utils';
 import type {BrowserTheme} from 'react-devtools-shared/src/devtools/views/DevTools';
 
-const debug = (methodName, ...args) => {
+const debug = (methodName: string, ...args: Array<string>) => {
   if (__DEBUG__) {
     console.log(
       `%cAgent %c${methodName}`,

--- a/packages/react-devtools-shared/src/backend/profilingHooks.js
+++ b/packages/react-devtools-shared/src/backend/profilingHooks.js
@@ -204,7 +204,7 @@ export function createProfilingHooks({
     }
   }
 
-  function markAndClear(markName) {
+  function markAndClear(markName: string) {
     // This method won't be called unless these functions are defined, so we can skip the extra typeof check.
     ((performanceTarget: any): Performance).mark(markName);
     ((performanceTarget: any): Performance).clearMarks(markName);

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -2647,7 +2647,7 @@ export function attach(
     }
   }
 
-  function handleCommitFiberRoot(root, priorityLevel) {
+  function handleCommitFiberRoot(root: any, priorityLevel: void | number) {
     const current = root.current;
     const alternate = current.alternate;
 
@@ -2808,18 +2808,18 @@ export function attach(
     }
   }
 
-  function getDisplayNameForFiberID(id) {
+  function getDisplayNameForFiberID(id: number) {
     const fiber = idToArbitraryFiberMap.get(id);
     return fiber != null ? getDisplayNameForFiber(((fiber: any): Fiber)) : null;
   }
 
-  function getFiberForNative(hostInstance) {
+  function getFiberForNative(hostInstance: NativeType) {
     return renderer.findFiberByHostInstance(hostInstance);
   }
 
   function getFiberIDForNative(
-    hostInstance,
-    findNearestUnfilteredAncestor = false,
+    hostInstance: NativeType,
+    findNearestUnfilteredAncestor: boolean = false,
   ) {
     let fiber = renderer.findFiberByHostInstance(hostInstance);
     if (fiber != null) {
@@ -2835,7 +2835,7 @@ export function attach(
 
   // This function is copied from React and should be kept in sync:
   // https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberTreeReflection.js
-  function assertIsMounted(fiber) {
+  function assertIsMounted(fiber: Fiber) {
     if (getNearestMountedFiber(fiber) !== fiber) {
       throw new Error('Unable to find node on an unmounted component.');
     }
@@ -3715,7 +3715,7 @@ export function attach(
     };
   }
 
-  function logElementToConsole(id) {
+  function logElementToConsole(id: number) {
     const result = isMostRecentlyInspectedElementCurrent(id)
       ? mostRecentlyInspectedElement
       : inspectElementRaw(id);
@@ -4188,7 +4188,7 @@ export function attach(
     return status;
   }
 
-  function overrideError(id, forceError) {
+  function overrideError(id: number, forceError: boolean) {
     if (
       typeof setErrorHandler !== 'function' ||
       typeof scheduleUpdate !== 'function'
@@ -4222,7 +4222,7 @@ export function attach(
     return maybeID !== null && forceFallbackForSuspenseIDs.has(maybeID);
   }
 
-  function overrideSuspense(id, forceFallback) {
+  function overrideSuspense(id: number, forceFallback: boolean) {
     if (
       typeof setSuspenseHandler !== 'function' ||
       typeof scheduleUpdate !== 'function'
@@ -4320,7 +4320,9 @@ export function attach(
     return true;
   }
 
-  function updateTrackedPathStateAfterMount(mightSiblingsBeOnTrackedPath) {
+  function updateTrackedPathStateAfterMount(
+    mightSiblingsBeOnTrackedPath: boolean,
+  ) {
     // updateTrackedPathStateBeforeMount() told us whether to match siblings.
     // Now that we're entering siblings, let's use that information.
     mightBeOnTrackedPath = mightSiblingsBeOnTrackedPath;

--- a/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
+++ b/packages/react-devtools-shared/src/backend/views/Highlighter/Overlay.js
@@ -277,7 +277,11 @@ export default class Overlay {
   }
 }
 
-function findTipPos(dims, bounds, tipSize) {
+function findTipPos(
+  dims: Box,
+  bounds: Box,
+  tipSize: {height: number, width: number},
+) {
   const tipHeight = Math.max(tipSize.height, 20);
   const tipWidth = Math.max(tipSize.width, 60);
   const margin = 5;
@@ -314,7 +318,7 @@ function findTipPos(dims, bounds, tipSize) {
   };
 }
 
-function boxWrap(dims, what, node) {
+function boxWrap(dims, what: string, node: HTMLElement) {
   assign(node.style, {
     borderTopWidth: dims[what + 'Top'] + 'px',
     borderLeftWidth: dims[what + 'Left'] + 'px',

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -46,7 +46,7 @@ import type {
 } from 'react-devtools-shared/src/bridge';
 import UnsupportedBridgeOperationError from 'react-devtools-shared/src/UnsupportedBridgeOperationError';
 
-const debug = (methodName, ...args) => {
+const debug = (methodName: string, ...args: Array<string>) => {
   if (__DEBUG__) {
     console.log(
       `%cStore %c${methodName}`,
@@ -1146,7 +1146,7 @@ export default class Store extends EventEmitter<{
             debug(`Remove root ${id}`);
           }
 
-          const recursivelyDeleteElements = elementID => {
+          const recursivelyDeleteElements = (elementID: number) => {
             const element = this._idToElement.get(elementID);
             this._idToElement.delete(elementID);
             if (element) {
@@ -1431,7 +1431,7 @@ export default class Store extends EventEmitter<{
   // but the downstream errors they cause will be reported as bugs.
   // For example, https://github.com/facebook/react/issues/21402
   // Emitting an error event allows the ErrorBoundary to show the original error.
-  _throwAndEmitError(error: Error) {
+  _throwAndEmitError(error: Error): empty {
     this.emit('error', error);
 
     // Throwing is still valuable for local development

--- a/packages/react-devtools-shared/src/devtools/views/Components/ComponentSearchInput.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/ComponentSearchInput.js
@@ -19,7 +19,8 @@ export default function ComponentSearchInput(props: Props): React.Node {
   const {searchIndex, searchResults, searchText} = useContext(TreeStateContext);
   const dispatch = useContext(TreeDispatcherContext);
 
-  const search = text => dispatch({type: 'SET_SEARCH_TEXT', payload: text});
+  const search = (text: string) =>
+    dispatch({type: 'SET_SEARCH_TEXT', payload: text});
   const goToNextResult = () => dispatch({type: 'GO_TO_NEXT_SEARCH_RESULT'});
   const goToPreviousResult = () =>
     dispatch({type: 'GO_TO_PREVIOUS_SEARCH_RESULT'});

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspenseToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementSuspenseToggle.js
@@ -39,7 +39,7 @@ export default function InspectedElementSuspenseToggle({
 
   const isSuspended = state !== null;
 
-  const toggleSuspense = (path, value) => {
+  const toggleSuspense = (path, value: boolean) => {
     const rendererID = store.getRendererIDForElement(id);
     if (rendererID !== null) {
       bridge.send('overrideSuspense', {

--- a/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/KeyValue.js
@@ -173,7 +173,10 @@ export default function KeyValue({
     }
   };
 
-  const renamePath = (oldPath, newPath) => {
+  const renamePath = (
+    oldPath: Array<string | number>,
+    newPath: Array<string | number>,
+  ) => {
     if (newPath[newPath.length - 1] === '') {
       // Deleting the key suggests an intent to delete the whole path.
       if (canDeletePaths) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/NewKeyValue.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/NewKeyValue.js
@@ -46,7 +46,7 @@ export default function NewKeyValue({
     setNewPropName(newPath[newPath.length - 1]);
   };
 
-  const overrideNewEntryValue = (newPath, value) => {
+  const overrideNewEntryValue = (newPath: Array<string | number>, value) => {
     if (!newPropName) {
       return;
     }

--- a/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/OwnersStack.js
@@ -56,7 +56,7 @@ type State = {
   selectedIndex: number,
 };
 
-function dialogReducer(state, action) {
+function dialogReducer(state: State, action: Action) {
   switch (action.type) {
     case 'UPDATE_OWNER_ID':
       const selectedIndex = action.owners.findIndex(

--- a/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/Tree.js
@@ -101,7 +101,7 @@ export default function Tree(props: Props): React.Node {
   // Picking an element in the inspector should put focus into the tree.
   // This ensures that keyboard navigation works right after picking a node.
   useEffect(() => {
-    function handleStopInspectingNative(didSelectNode) {
+    function handleStopInspectingNative(didSelectNode: boolean) {
       if (didSelectNode && focusTargetRef.current !== null) {
         focusTargetRef.current.focus();
         logEvent({

--- a/packages/react-devtools-shared/src/devtools/views/ModalDialog.js
+++ b/packages/react-devtools-shared/src/devtools/views/ModalDialog.js
@@ -61,7 +61,7 @@ const ModalDialogContext: ReactContext<ModalDialogContextType> = createContext<M
 );
 ModalDialogContext.displayName = 'ModalDialogContext';
 
-function dialogReducer(state, action) {
+function dialogReducer(state: State, action: Action) {
   switch (action.type) {
     case 'HIDE':
       return {

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/CommitTreeBuilder.js
@@ -28,7 +28,7 @@ import type {
   ProfilingDataForRootFrontend,
 } from 'react-devtools-shared/src/devtools/views/Profiler/types';
 
-const debug = (methodName, ...args) => {
+const debug = (methodName: string, ...args: Array<string>) => {
   if (__DEBUG__) {
     console.log(
       `%cCommitTreeBuilder %c${methodName}`,

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/SidebarEventInfo.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {Stack} from '../../utils';
 import type {SchedulingEvent} from 'react-devtools-timeline/src/types';
 
 import * as React from 'react';
@@ -35,7 +36,7 @@ function SchedulingEventInfo({eventInfo}: SchedulingEventProps) {
   const {componentName, timestamp} = eventInfo;
   const componentStack = eventInfo.componentStack || null;
 
-  const viewSource = source => {
+  const viewSource = (source: ?Stack) => {
     if (viewUrlSourceFunction != null && source != null) {
       viewUrlSourceFunction(...source);
     }

--- a/packages/react-devtools-shared/src/devtools/views/hooks.js
+++ b/packages/react-devtools-shared/src/devtools/views/hooks.js
@@ -43,7 +43,10 @@ type UseEditableValueState = {
   parsedValue: any,
 };
 
-function useEditableValueReducer(state, action) {
+function useEditableValueReducer(
+  state: UseEditableValueState,
+  action: UseEditableValueAction,
+) {
   switch (action.type) {
     case 'RESET':
       return {

--- a/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
+++ b/packages/react-devtools-shared/src/registerDevToolsEventLogger.js
@@ -56,7 +56,7 @@ export function registerDevToolsEventLogger(
     }
   }
 
-  function handleLoggingIFrameLoaded(iframe) {
+  function handleLoggingIFrameLoaded(iframe: HTMLIFrameElement) {
     if (loggingIFrame != null) {
       return;
     }

--- a/packages/react-devtools-shell/src/app/DeeplyNestedComponents/index.js
+++ b/packages/react-devtools-shell/src/app/DeeplyNestedComponents/index.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import {Fragment} from 'react';
 
-function wrapWithHoc(Component, index) {
+function wrapWithHoc(Component, index: number) {
   function HOC() {
     return <Component />;
   }
@@ -22,7 +22,7 @@ function wrapWithHoc(Component, index) {
   return HOC;
 }
 
-function wrapWithNested(Component, times) {
+function wrapWithNested(Component, times: number) {
   for (let i = 0; i < times; i++) {
     Component = wrapWithHoc(Component, i);
   }

--- a/packages/react-devtools-shell/src/app/ElementTypes/index.js
+++ b/packages/react-devtools-shell/src/app/ElementTypes/index.js
@@ -25,7 +25,7 @@ const Context = createContext('abc');
 Context.displayName = 'ExampleContext';
 
 class ClassComponent extends Component<any> {
-  render() {
+  render(): null {
     return null;
   }
 }

--- a/packages/react-devtools-shell/src/app/ErrorBoundaries/index.js
+++ b/packages/react-devtools-shell/src/app/ErrorBoundaries/index.js
@@ -11,9 +11,9 @@ import * as React from 'react';
 import {Fragment} from 'react';
 
 class ErrorBoundary extends React.Component {
-  state = {hasError: false};
+  state: {hasError: boolean} = {hasError: false};
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError(error): {hasError: boolean} {
     return {hasError: true};
   }
 

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomHooks.js
@@ -127,7 +127,7 @@ export default function CustomHooks(): React.Node {
 }
 
 // Below copied from https://usehooks.com/
-function useDebounce(value, delay) {
+function useDebounce(value: number, delay: number) {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState(value);
 

--- a/packages/react-devtools-shell/src/app/InspectableElements/CustomObject.js
+++ b/packages/react-devtools-shell/src/app/InspectableElements/CustomObject.js
@@ -11,7 +11,7 @@ import * as React from 'react';
 
 class Custom {
   _number = 42;
-  get number() {
+  get number(): number {
     return this._number;
   }
 }

--- a/packages/react-devtools-shell/src/app/SuspenseTree/index.js
+++ b/packages/react-devtools-shell/src/app/SuspenseTree/index.js
@@ -51,7 +51,7 @@ function PrimaryFallbackTest({initialSuspend}) {
   );
 }
 
-function useTestSequence(label, T1, T2) {
+function useTestSequence(label: string, T1, T2) {
   const [step, setStep] = useState(0);
   const next = (
     <button onClick={() => setStep(s => (s + 1) % allSteps.length)}>

--- a/packages/react-devtools-shell/src/app/devtools.js
+++ b/packages/react-devtools-shell/src/app/devtools.js
@@ -81,7 +81,7 @@ inject('dist/app-index.js', () => {
   });
 });
 
-function inject(sourcePath, callback) {
+function inject(sourcePath: string, callback: () => void) {
   const script = contentDocument.createElement('script');
   script.onload = callback;
   script.src = sourcePath;

--- a/packages/react-devtools-timeline/src/EventTooltip.js
+++ b/packages/react-devtools-timeline/src/EventTooltip.js
@@ -15,11 +15,12 @@ import type {
   ReactComponentMeasure,
   ReactEventInfo,
   ReactMeasure,
-  TimelineData,
+  ReactMeasureType,
   SchedulingEvent,
   Snapshot,
   SuspenseEvent,
   ThrownError,
+  TimelineData,
   UserTimingMark,
 } from './types';
 
@@ -45,7 +46,7 @@ type Props = {
   width: number,
 };
 
-function getReactMeasureLabel(type): string | null {
+function getReactMeasureLabel(type: ReactMeasureType): string | null {
   switch (type) {
     case 'commit':
       return 'react commit';

--- a/packages/react-devtools-timeline/src/TimelineSearchInput.js
+++ b/packages/react-devtools-timeline/src/TimelineSearchInput.js
@@ -26,7 +26,8 @@ export default function TimelineSearchInput(props: Props): React.Node {
     return null;
   }
 
-  const search = text => dispatch({type: 'SET_SEARCH_TEXT', payload: text});
+  const search = (text: string) =>
+    dispatch({type: 'SET_SEARCH_TEXT', payload: text});
   const goToNextResult = () => dispatch({type: 'GO_TO_NEXT_SEARCH_RESULT'});
   const goToPreviousResult = () =>
     dispatch({type: 'GO_TO_PREVIOUS_SEARCH_RESULT'});

--- a/packages/react-devtools-timeline/src/content-views/ReactMeasuresView.js
+++ b/packages/react-devtools-timeline/src/content-views/ReactMeasuresView.js
@@ -95,7 +95,7 @@ export class ReactMeasuresView extends View {
     scaleFactor: number,
     showGroupHighlight: boolean,
     showHoverHighlight: boolean,
-  ) {
+  ): void {
     const {frame, visibleArea} = this;
     const {timestamp, type, duration} = measure;
 
@@ -202,7 +202,7 @@ export class ReactMeasuresView extends View {
     }
   }
 
-  draw(context: CanvasRenderingContext2D) {
+  draw(context: CanvasRenderingContext2D): void {
     const {
       frame,
       _hoveredMeasure,

--- a/packages/react-devtools-timeline/src/view-base/Surface.js
+++ b/packages/react-devtools-timeline/src/view-base/Surface.js
@@ -22,7 +22,11 @@ export type ViewRefs = {
 };
 
 // hidpi canvas: https://www.html5rocks.com/en/tutorials/canvas/hidpi/
-function configureRetinaCanvas(canvas, height, width) {
+function configureRetinaCanvas(
+  canvas: HTMLCanvasElement,
+  height: number,
+  width: number,
+) {
   canvas.width = width * DPR;
   canvas.height = height * DPR;
   canvas.style.width = `${width}px`;

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -115,7 +115,7 @@ if (__DEV__) {
     webview: true,
   };
 
-  validatePropertiesInDevelopment = function(type, props) {
+  validatePropertiesInDevelopment = function(type: string, props) {
     validateARIAProperties(type, props);
     validateInputProperties(type, props);
     validateUnknownProperties(type, props, {
@@ -172,7 +172,7 @@ if (__DEV__) {
     console.error('Extra attributes from the server: %s', names);
   };
 
-  warnForInvalidEventListener = function(registrationName, listener) {
+  warnForInvalidEventListener = function(registrationName: string, listener) {
     if (listener === false) {
       console.error(
         'Expected `%s` listener to be a function, instead got `false`.\n\n' +

--- a/packages/react-dom-bindings/src/client/inputValueTracking.js
+++ b/packages/react-dom-bindings/src/client/inputValueTracking.js
@@ -101,7 +101,7 @@ function trackValueOnNode(node: any): ?ValueTracker {
     getValue() {
       return currentValue;
     },
-    setValue(value) {
+    setValue(value: string) {
       if (__DEV__) {
         checkFormFieldValueStringCoercion(value);
       }

--- a/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventListener.js
@@ -112,10 +112,10 @@ export function createEventListenerWrapperWithPriority(
 }
 
 function dispatchDiscreteEvent(
-  domEventName,
-  eventSystemFlags,
-  container,
-  nativeEvent,
+  domEventName: DOMEventName,
+  eventSystemFlags: EventSystemFlags,
+  container: EventTarget,
+  nativeEvent: AnyNativeEvent,
 ) {
   const previousPriority = getCurrentUpdatePriority();
   const prevTransition = ReactCurrentBatchConfig.transition;
@@ -130,10 +130,10 @@ function dispatchDiscreteEvent(
 }
 
 function dispatchContinuousEvent(
-  domEventName,
-  eventSystemFlags,
-  container,
-  nativeEvent,
+  domEventName: DOMEventName,
+  eventSystemFlags: EventSystemFlags,
+  container: EventTarget,
+  nativeEvent: AnyNativeEvent,
 ) {
   const previousPriority = getCurrentUpdatePriority();
   const prevTransition = ReactCurrentBatchConfig.transition;

--- a/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
+++ b/packages/react-dom-bindings/src/events/ReactDOMEventReplaying.js
@@ -619,7 +619,7 @@ export function retryIfBlockedOn(
   if (queuedMouse !== null) {
     scheduleCallbackIfUnblocked(queuedMouse, unblocked);
   }
-  const unblock = queuedEvent =>
+  const unblock = (queuedEvent: QueuedReplayableEvent) =>
     scheduleCallbackIfUnblocked(queuedEvent, unblocked);
   queuedPointers.forEach(unblock);
   queuedPointerCaptures.forEach(unblock);

--- a/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/BeforeInputEventPlugin.js
@@ -192,11 +192,11 @@ let isComposing = false;
  * @return {?object} A SyntheticCompositionEvent.
  */
 function extractCompositionEvent(
-  dispatchQueue,
-  domEventName,
-  targetInst,
-  nativeEvent,
-  nativeEventTarget,
+  dispatchQueue: DispatchQueue,
+  domEventName: DOMEventName,
+  targetInst: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+  nativeEventTarget: null | EventTarget,
 ) {
   let eventType;
   let fallbackData;
@@ -379,11 +379,11 @@ function getFallbackBeforeInputChars(
  * @return {?object} A SyntheticInputEvent.
  */
 function extractBeforeInputEvent(
-  dispatchQueue,
-  domEventName,
-  targetInst,
-  nativeEvent,
-  nativeEventTarget,
+  dispatchQueue: DispatchQueue,
+  domEventName: DOMEventName,
+  targetInst: null | Fiber,
+  nativeEvent: AnyNativeEvent,
+  nativeEventTarget: null | EventTarget,
 ) {
   let chars;
 

--- a/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/ChangeEventPlugin.js
@@ -52,7 +52,7 @@ function registerEvents() {
 function createAndAccumulateChangeEvent(
   dispatchQueue,
   inst,
-  nativeEvent,
+  nativeEvent: AnyNativeEvent,
   target,
 ) {
   // Flag this event loop as needing state restore.
@@ -109,7 +109,7 @@ function manualDispatchChangeEvent(nativeEvent) {
   batchedUpdates(runEventInBatch, dispatchQueue);
 }
 
-function runEventInBatch(dispatchQueue) {
+function runEventInBatch(dispatchQueue: DispatchQueue) {
   processDispatchQueue(dispatchQueue, 0);
 }
 
@@ -120,7 +120,10 @@ function getInstIfValueChanged(targetInst: Object) {
   }
 }
 
-function getTargetInstForChangeEvent(domEventName: DOMEventName, targetInst) {
+function getTargetInstForChangeEvent(
+  domEventName: DOMEventName,
+  targetInst: null | Fiber,
+) {
   if (domEventName === 'change') {
     return targetInst;
   }
@@ -178,7 +181,7 @@ function handlePropertyChange(nativeEvent) {
 function handleEventsForInputEventPolyfill(
   domEventName: DOMEventName,
   target,
-  targetInst,
+  targetInst: null | Fiber,
 ) {
   if (domEventName === 'focusin') {
     // In IE9, propertychange fires for most input events but is buggy and
@@ -201,7 +204,7 @@ function handleEventsForInputEventPolyfill(
 // For IE8 and IE9.
 function getTargetInstForInputEventPolyfill(
   domEventName: DOMEventName,
-  targetInst,
+  targetInst: null | Fiber,
 ) {
   if (
     domEventName === 'selectionchange' ||
@@ -237,7 +240,10 @@ function shouldUseClickEvent(elem) {
   );
 }
 
-function getTargetInstForClickEvent(domEventName: DOMEventName, targetInst) {
+function getTargetInstForClickEvent(
+  domEventName: DOMEventName,
+  targetInst: null | Fiber,
+) {
   if (domEventName === 'click') {
     return getInstIfValueChanged(targetInst);
   }
@@ -245,7 +251,7 @@ function getTargetInstForClickEvent(domEventName: DOMEventName, targetInst) {
 
 function getTargetInstForInputOrChangeEvent(
   domEventName: DOMEventName,
-  targetInst,
+  targetInst: null | Fiber,
 ) {
   if (domEventName === 'input' || domEventName === 'change') {
     return getInstIfValueChanged(targetInst);

--- a/packages/react-dom-bindings/src/events/plugins/SelectEventPlugin.js
+++ b/packages/react-dom-bindings/src/events/plugins/SelectEventPlugin.js
@@ -91,7 +91,11 @@ function getEventTargetDocument(eventTarget: any) {
  * @param {object} nativeEventTarget
  * @return {?SyntheticEvent}
  */
-function constructSelectEvent(dispatchQueue, nativeEvent, nativeEventTarget) {
+function constructSelectEvent(
+  dispatchQueue: DispatchQueue,
+  nativeEvent: AnyNativeEvent,
+  nativeEventTarget: null | EventTarget,
+) {
   // Ensure we have the right element, and that the user is not dragging a
   // selection (this matches native `select` event behavior). In HTML5, select
   // fires only on input and textarea thus if there's no focused element we

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -138,14 +138,14 @@ const endAsyncScript = stringToPrecomputedChunk('" async=""></script>');
  * While untrusted script content should be made safe before using this api it will
  * ensure that the script cannot be early terminated or never terminated state
  */
-function escapeBootstrapScriptContent(scriptText) {
+function escapeBootstrapScriptContent(scriptText: string) {
   if (__DEV__) {
     checkHtmlStringCoercion(scriptText);
   }
   return ('' + scriptText).replace(scriptRegex, scriptReplacer);
 }
 const scriptRegex = /(<\/|<)(s)(cript)/gi;
-const scriptReplacer = (match, prefix, s, suffix) =>
+const scriptReplacer = (match: string, prefix, s, suffix) =>
   `${prefix}${s === 's' ? '\\u0073' : '\\u0053'}${suffix}`;
 
 export type BootstrapScriptDescriptor = {
@@ -757,7 +757,7 @@ let didWarnInvalidOptionChildren = false;
 let didWarnInvalidOptionInnerHTML = false;
 let didWarnSelectedSetOnOption = false;
 
-function checkSelectProp(props, propName) {
+function checkSelectProp(props, propName: string) {
   if (__DEV__) {
     const value = props[propName];
     if (value != null) {

--- a/packages/react-dom-bindings/src/shared/DOMProperty.js
+++ b/packages/react-dom-bindings/src/shared/DOMProperty.js
@@ -456,7 +456,7 @@ reservedProps.forEach(name => {
 });
 
 const CAMELIZE = /[\-\:]([a-z])/g;
-const capitalize = token => token[1].toUpperCase();
+const capitalize = (token: string) => token[1].toUpperCase();
 
 // This is a list of all SVG attributes that need special casing, namespacing,
 // or boolean value assignment. Regular attributes that just accept strings

--- a/packages/react-dom/src/server/ReactDOMFizzServerNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzServerNode.js
@@ -10,6 +10,7 @@
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {Writable} from 'stream';
 import type {BootstrapScriptDescriptor} from 'react-dom-bindings/src/server/ReactDOMServerFormatConfig';
+import type {Request} from 'react-server/src/ReactFizzServer';
 import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
 
 import ReactVersion from 'shared/ReactVersion';
@@ -26,11 +27,11 @@ import {
   createRootFormatContext,
 } from 'react-dom-bindings/src/server/ReactDOMServerFormatConfig';
 
-function createDrainHandler(destination: Destination, request) {
+function createDrainHandler(destination: Destination, request: Request) {
   return () => startFlowing(request, destination);
 }
 
-function createAbortHandler(request, reason) {
+function createAbortHandler(request: Request, reason: string) {
   // eslint-disable-next-line react-internal/prod-error-codes
   return () => abort(request, new Error(reason));
 }

--- a/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
+++ b/packages/react-dom/src/server/ReactDOMFizzStaticNode.js
@@ -42,7 +42,7 @@ type StaticResult = {
   prelude: Readable,
 };
 
-function createFakeWritable(readable): Writable {
+function createFakeWritable(readable: stream$Readable): Writable {
   // The current host config expects a Writable so we create
   // a fake writable for now to push into the Readable.
   return ({

--- a/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
+++ b/packages/react-interactions/events/src/dom/create-event-handle/Focus.js
@@ -97,7 +97,7 @@ function handleGlobalFocusVisibleEvent(
 
 function handleFocusVisibleTargetEvents(
   event: SyntheticEvent<EventTarget>,
-  callback,
+  callback: (isFocusVisible: boolean) => void,
 ): void {
   if (event.type === 'keydown') {
     const {nativeEvent} = (event: any);
@@ -127,7 +127,7 @@ function isRelatedTargetWithin(
 function setFocusVisibleListeners(
   focusVisibleHandles,
   focusTarget: EventTarget,
-  callback,
+  callback: (isFocusVisible: boolean) => void,
 ) {
   focusVisibleHandles.forEach(focusVisibleHandle => {
     focusVisibleHandle.setListener(focusTarget, event =>

--- a/packages/react-reconciler/src/ReactChildFiber.new.js
+++ b/packages/react-reconciler/src/ReactChildFiber.new.js
@@ -276,7 +276,9 @@ type ChildReconciler = (
 // to be able to optimize each path individually by branching early. This needs
 // a compiler or we can do it manually. Helpers that don't need this branching
 // live outside of this function.
-function createChildReconciler(shouldTrackSideEffects): ChildReconciler {
+function createChildReconciler(
+  shouldTrackSideEffects: boolean,
+): ChildReconciler {
   function deleteChild(returnFiber: Fiber, childToDelete: Fiber): void {
     if (!shouldTrackSideEffects) {
       // Noop.

--- a/packages/react-reconciler/src/ReactChildFiber.old.js
+++ b/packages/react-reconciler/src/ReactChildFiber.old.js
@@ -276,7 +276,9 @@ type ChildReconciler = (
 // to be able to optimize each path individually by branching early. This needs
 // a compiler or we can do it manually. Helpers that don't need this branching
 // live outside of this function.
-function createChildReconciler(shouldTrackSideEffects): ChildReconciler {
+function createChildReconciler(
+  shouldTrackSideEffects: boolean,
+): ChildReconciler {
   function deleteChild(returnFiber: Fiber, childToDelete: Fiber): void {
     if (!shouldTrackSideEffects) {
       // Noop.

--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -1079,11 +1079,11 @@ function markRef(current: Fiber | null, workInProgress: Fiber) {
 }
 
 function updateFunctionComponent(
-  current,
-  workInProgress,
+  current: null | Fiber,
+  workInProgress: Fiber,
   Component,
   nextProps: any,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   if (__DEV__) {
     if (workInProgress.type !== workInProgress.elementType) {
@@ -1390,7 +1390,7 @@ function finishClassComponent(
   return workInProgress.child;
 }
 
-function pushHostRootContext(workInProgress) {
+function pushHostRootContext(workInProgress: Fiber) {
   const root = (workInProgress.stateNode: FiberRoot);
   if (root.pendingContext) {
     pushTopLevelContextObject(
@@ -1405,7 +1405,11 @@ function pushHostRootContext(workInProgress) {
   pushHostContainer(workInProgress, root.containerInfo);
 }
 
-function updateHostRoot(current, workInProgress, renderLanes) {
+function updateHostRoot(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   pushHostRootContext(workInProgress);
 
   if (current === null) {
@@ -1590,7 +1594,11 @@ function updateHostComponent(
   return workInProgress.child;
 }
 
-function updateHostResource(current, workInProgress, renderLanes) {
+function updateHostResource(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   pushHostContext(workInProgress);
   markRef(current, workInProgress);
   const currentProps = current === null ? null : current.memoizedProps;
@@ -1638,7 +1646,7 @@ function updateHostSingleton(
   return workInProgress.child;
 }
 
-function updateHostText(current, workInProgress) {
+function updateHostText(current: null | Fiber, workInProgress: Fiber) {
   if (current === null) {
     tryToClaimNextHydratableInstance(workInProgress);
   }
@@ -1648,10 +1656,10 @@ function updateHostText(current, workInProgress) {
 }
 
 function mountLazyComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   elementType,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -1757,11 +1765,11 @@ function mountLazyComponent(
 }
 
 function mountIncompleteClassComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   Component,
   nextProps,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -1796,10 +1804,10 @@ function mountIncompleteClassComponent(
 }
 
 function mountIndeterminateComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   Component,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -2156,12 +2164,16 @@ function shouldRemainOnFallback(
   );
 }
 
-function getRemainingWorkInPrimaryTree(current: Fiber, renderLanes) {
+function getRemainingWorkInPrimaryTree(current: Fiber, renderLanes: Lanes) {
   // TODO: Should not remove render lanes that were pinged during this render
   return removeLanes(current.childLanes, renderLanes);
 }
 
-function updateSuspenseComponent(current, workInProgress, renderLanes) {
+function updateSuspenseComponent(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   const nextProps = workInProgress.pendingProps;
 
   // This is used by DevTools to force a boundary to suspend.
@@ -2408,9 +2420,9 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
 }
 
 function mountSuspensePrimaryChildren(
-  workInProgress,
+  workInProgress: Fiber,
   primaryChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const primaryChildProps: OffscreenProps = {
@@ -2428,10 +2440,10 @@ function mountSuspensePrimaryChildren(
 }
 
 function mountSuspenseFallbackChildren(
-  workInProgress,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const progressedPrimaryFragment: Fiber | null = workInProgress.child;
@@ -2511,10 +2523,10 @@ function updateWorkInProgressOffscreenFiber(
 }
 
 function updateSuspensePrimaryChildren(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const currentPrimaryChildFragment: Fiber = (current.child: any);
   const currentFallbackChildFragment: Fiber | null =
@@ -2548,11 +2560,11 @@ function updateSuspensePrimaryChildren(
 }
 
 function updateSuspenseFallbackChildren(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const currentPrimaryChildFragment: Fiber = (current.child: any);
@@ -2673,11 +2685,11 @@ function retrySuspenseComponentWithoutHydrating(
 }
 
 function mountSuspenseFallbackAfterRetryWithoutHydrating(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const fiberMode = workInProgress.mode;
   const primaryChildProps: OffscreenProps = {
@@ -3531,7 +3543,11 @@ function updateContextConsumer(
   return workInProgress.child;
 }
 
-function updateScopeComponent(current, workInProgress, renderLanes) {
+function updateScopeComponent(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   const nextProps = workInProgress.pendingProps;
   const nextChildren = nextProps.children;
 
@@ -3547,7 +3563,10 @@ export function checkIfWorkInProgressReceivedUpdate(): boolean {
   return didReceiveUpdate;
 }
 
-function resetSuspendedCurrentOnMountInLegacyMode(current, workInProgress) {
+function resetSuspendedCurrentOnMountInLegacyMode(
+  current: null | Fiber,
+  workInProgress: Fiber,
+) {
   if ((workInProgress.mode & ConcurrentMode) === NoMode) {
     if (current !== null) {
       // A lazy component only mounts if it suspended inside a non-

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -1079,11 +1079,11 @@ function markRef(current: Fiber | null, workInProgress: Fiber) {
 }
 
 function updateFunctionComponent(
-  current,
-  workInProgress,
+  current: null | Fiber,
+  workInProgress: Fiber,
   Component,
   nextProps: any,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   if (__DEV__) {
     if (workInProgress.type !== workInProgress.elementType) {
@@ -1390,7 +1390,7 @@ function finishClassComponent(
   return workInProgress.child;
 }
 
-function pushHostRootContext(workInProgress) {
+function pushHostRootContext(workInProgress: Fiber) {
   const root = (workInProgress.stateNode: FiberRoot);
   if (root.pendingContext) {
     pushTopLevelContextObject(
@@ -1405,7 +1405,11 @@ function pushHostRootContext(workInProgress) {
   pushHostContainer(workInProgress, root.containerInfo);
 }
 
-function updateHostRoot(current, workInProgress, renderLanes) {
+function updateHostRoot(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   pushHostRootContext(workInProgress);
 
   if (current === null) {
@@ -1590,7 +1594,11 @@ function updateHostComponent(
   return workInProgress.child;
 }
 
-function updateHostResource(current, workInProgress, renderLanes) {
+function updateHostResource(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   pushHostContext(workInProgress);
   markRef(current, workInProgress);
   const currentProps = current === null ? null : current.memoizedProps;
@@ -1638,7 +1646,7 @@ function updateHostSingleton(
   return workInProgress.child;
 }
 
-function updateHostText(current, workInProgress) {
+function updateHostText(current: null | Fiber, workInProgress: Fiber) {
   if (current === null) {
     tryToClaimNextHydratableInstance(workInProgress);
   }
@@ -1648,10 +1656,10 @@ function updateHostText(current, workInProgress) {
 }
 
 function mountLazyComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   elementType,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -1757,11 +1765,11 @@ function mountLazyComponent(
 }
 
 function mountIncompleteClassComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   Component,
   nextProps,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -1796,10 +1804,10 @@ function mountIncompleteClassComponent(
 }
 
 function mountIndeterminateComponent(
-  _current,
-  workInProgress,
+  _current: null | Fiber,
+  workInProgress: Fiber,
   Component,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   resetSuspendedCurrentOnMountInLegacyMode(_current, workInProgress);
 
@@ -2156,12 +2164,16 @@ function shouldRemainOnFallback(
   );
 }
 
-function getRemainingWorkInPrimaryTree(current: Fiber, renderLanes) {
+function getRemainingWorkInPrimaryTree(current: Fiber, renderLanes: Lanes) {
   // TODO: Should not remove render lanes that were pinged during this render
   return removeLanes(current.childLanes, renderLanes);
 }
 
-function updateSuspenseComponent(current, workInProgress, renderLanes) {
+function updateSuspenseComponent(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   const nextProps = workInProgress.pendingProps;
 
   // This is used by DevTools to force a boundary to suspend.
@@ -2408,9 +2420,9 @@ function updateSuspenseComponent(current, workInProgress, renderLanes) {
 }
 
 function mountSuspensePrimaryChildren(
-  workInProgress,
+  workInProgress: Fiber,
   primaryChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const primaryChildProps: OffscreenProps = {
@@ -2428,10 +2440,10 @@ function mountSuspensePrimaryChildren(
 }
 
 function mountSuspenseFallbackChildren(
-  workInProgress,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const progressedPrimaryFragment: Fiber | null = workInProgress.child;
@@ -2511,10 +2523,10 @@ function updateWorkInProgressOffscreenFiber(
 }
 
 function updateSuspensePrimaryChildren(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const currentPrimaryChildFragment: Fiber = (current.child: any);
   const currentFallbackChildFragment: Fiber | null =
@@ -2548,11 +2560,11 @@ function updateSuspensePrimaryChildren(
 }
 
 function updateSuspenseFallbackChildren(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const mode = workInProgress.mode;
   const currentPrimaryChildFragment: Fiber = (current.child: any);
@@ -2673,11 +2685,11 @@ function retrySuspenseComponentWithoutHydrating(
 }
 
 function mountSuspenseFallbackAfterRetryWithoutHydrating(
-  current,
-  workInProgress,
+  current: Fiber,
+  workInProgress: Fiber,
   primaryChildren,
   fallbackChildren,
-  renderLanes,
+  renderLanes: Lanes,
 ) {
   const fiberMode = workInProgress.mode;
   const primaryChildProps: OffscreenProps = {
@@ -3531,7 +3543,11 @@ function updateContextConsumer(
   return workInProgress.child;
 }
 
-function updateScopeComponent(current, workInProgress, renderLanes) {
+function updateScopeComponent(
+  current: null | Fiber,
+  workInProgress: Fiber,
+  renderLanes: Lanes,
+) {
   const nextProps = workInProgress.pendingProps;
   const nextChildren = nextProps.children;
 
@@ -3547,7 +3563,10 @@ export function checkIfWorkInProgressReceivedUpdate(): boolean {
   return didReceiveUpdate;
 }
 
-function resetSuspendedCurrentOnMountInLegacyMode(current, workInProgress) {
+function resetSuspendedCurrentOnMountInLegacyMode(
+  current: null | Fiber,
+  workInProgress: Fiber,
+) {
   if ((workInProgress.mode & ConcurrentMode) === NoMode) {
     if (current !== null) {
       // A lazy component only mounts if it suspended inside a non-

--- a/packages/react-reconciler/src/ReactFiberClassComponent.new.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.new.js
@@ -306,7 +306,7 @@ const classComponentUpdater = {
 };
 
 function checkShouldComponentUpdate(
-  workInProgress,
+  workInProgress: Fiber,
   ctor,
   oldProps,
   newProps,
@@ -767,7 +767,7 @@ function constructClassInstance(
   return instance;
 }
 
-function callComponentWillMount(workInProgress, instance) {
+function callComponentWillMount(workInProgress: Fiber, instance) {
   const oldState = instance.state;
 
   if (typeof instance.componentWillMount === 'function') {
@@ -791,7 +791,7 @@ function callComponentWillMount(workInProgress, instance) {
 }
 
 function callComponentWillReceiveProps(
-  workInProgress,
+  workInProgress: Fiber,
   instance,
   newProps,
   nextContext,

--- a/packages/react-reconciler/src/ReactFiberClassComponent.old.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.old.js
@@ -306,7 +306,7 @@ const classComponentUpdater = {
 };
 
 function checkShouldComponentUpdate(
-  workInProgress,
+  workInProgress: Fiber,
   ctor,
   oldProps,
   newProps,
@@ -767,7 +767,7 @@ function constructClassInstance(
   return instance;
 }
 
-function callComponentWillMount(workInProgress, instance) {
+function callComponentWillMount(workInProgress: Fiber, instance) {
   const oldState = instance.state;
 
   if (typeof instance.componentWillMount === 'function') {
@@ -791,7 +791,7 @@ function callComponentWillMount(workInProgress, instance) {
 }
 
 function callComponentWillReceiveProps(
-  workInProgress,
+  workInProgress: Fiber,
   instance,
   newProps,
   nextContext,

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -247,7 +247,7 @@ export function reportUncaughtErrorInDEV(error: mixed) {
   }
 }
 
-const callComponentWillUnmountWithTimer = function(current, instance) {
+const callComponentWillUnmountWithTimer = function(current: Fiber, instance) {
   instance.props = current.memoizedProps;
   instance.state = current.memoizedState;
   if (shouldProfile(current)) {
@@ -1470,7 +1470,7 @@ function commitTransitionProgress(offscreenFiber: Fiber) {
   }
 }
 
-function hideOrUnhideAllChildren(finishedWork, isHidden) {
+function hideOrUnhideAllChildren(finishedWork: Fiber, isHidden: boolean) {
   // Only hide or unhide the top-most host nodes.
   let hostSubtreeRoot = null;
 
@@ -2024,9 +2024,9 @@ function commitDeletionEffects(
 }
 
 function recursivelyTraverseDeletionEffects(
-  finishedRoot,
-  nearestMountedAncestor,
-  parent,
+  finishedRoot: FiberRoot,
+  nearestMountedAncestor: Fiber,
+  parent: Fiber,
 ) {
   // TODO: Use a static flag to skip trees that don't have unmount effects
   let child = parent.child;
@@ -2380,7 +2380,7 @@ function commitSuspenseHydrationCallbacks(
   }
 }
 
-function getRetryCache(finishedWork) {
+function getRetryCache(finishedWork: Fiber) {
   // TODO: Unify the interface for the retry cache so we don't have to switch
   // on the tag like this.
   switch (finishedWork.tag) {
@@ -3990,7 +3990,7 @@ function detachAlternateSiblings(parentFiber: Fiber) {
 
 function commitHookPassiveUnmountEffects(
   finishedWork: Fiber,
-  nearestMountedAncestor,
+  nearestMountedAncestor: null | Fiber,
   hookFlags: HookFlags,
 ) {
   if (shouldProfile(finishedWork)) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.old.js
@@ -247,7 +247,7 @@ export function reportUncaughtErrorInDEV(error: mixed) {
   }
 }
 
-const callComponentWillUnmountWithTimer = function(current, instance) {
+const callComponentWillUnmountWithTimer = function(current: Fiber, instance) {
   instance.props = current.memoizedProps;
   instance.state = current.memoizedState;
   if (shouldProfile(current)) {
@@ -1470,7 +1470,7 @@ function commitTransitionProgress(offscreenFiber: Fiber) {
   }
 }
 
-function hideOrUnhideAllChildren(finishedWork, isHidden) {
+function hideOrUnhideAllChildren(finishedWork: Fiber, isHidden: boolean) {
   // Only hide or unhide the top-most host nodes.
   let hostSubtreeRoot = null;
 
@@ -2024,9 +2024,9 @@ function commitDeletionEffects(
 }
 
 function recursivelyTraverseDeletionEffects(
-  finishedRoot,
-  nearestMountedAncestor,
-  parent,
+  finishedRoot: FiberRoot,
+  nearestMountedAncestor: Fiber,
+  parent: Fiber,
 ) {
   // TODO: Use a static flag to skip trees that don't have unmount effects
   let child = parent.child;
@@ -2380,7 +2380,7 @@ function commitSuspenseHydrationCallbacks(
   }
 }
 
-function getRetryCache(finishedWork) {
+function getRetryCache(finishedWork: Fiber) {
   // TODO: Unify the interface for the retry cache so we don't have to switch
   // on the tag like this.
   switch (finishedWork.tag) {
@@ -3990,7 +3990,7 @@ function detachAlternateSiblings(parentFiber: Fiber) {
 
 function commitHookPassiveUnmountEffects(
   finishedWork: Fiber,
-  nearestMountedAncestor,
+  nearestMountedAncestor: null | Fiber,
   hookFlags: HookFlags,
 ) {
   if (shouldProfile(finishedWork)) {

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -1606,7 +1606,7 @@ function updateStoreInstance<T>(
   }
 }
 
-function subscribeToStore<T>(fiber, inst: StoreInstance<T>, subscribe) {
+function subscribeToStore<T>(fiber: Fiber, inst: StoreInstance<T>, subscribe) {
   const handleStoreChange = () => {
     // The store changed. Check if the snapshot changed since the last time we
     // read from the store.
@@ -1630,7 +1630,7 @@ function checkIfSnapshotChanged<T>(inst: StoreInstance<T>): boolean {
   }
 }
 
-function forceStoreRerender(fiber) {
+function forceStoreRerender(fiber: Fiber) {
   const root = enqueueConcurrentRenderForLane(fiber, SyncLane);
   if (root !== null) {
     scheduleUpdateOnFiber(root, fiber, SyncLane, NoTimestamp);
@@ -2188,7 +2188,11 @@ function updateDeferredValueImpl<T>(hook: Hook, prevValue: T, value: T): T {
   }
 }
 
-function startTransition(setPending, callback, options) {
+function startTransition(
+  setPending: Dispatch<BasicStateAction<boolean>>,
+  callback: () => void,
+  options: void | StartTransitionOptions,
+) {
   const previousPriority = getCurrentUpdatePriority();
   setCurrentUpdatePriority(
     higherEventPriority(previousPriority, ContinuousEventPriority),
@@ -2557,7 +2561,7 @@ function entangleTransitionUpdate<S, A>(
   }
 }
 
-function markUpdateInDevTools<A>(fiber, lane, action: A) {
+function markUpdateInDevTools<A>(fiber: Fiber, lane: Lane, action: A) {
   if (__DEV__) {
     if (enableDebugTracing) {
       if (fiber.mode & DebugTracingMode) {

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -1606,7 +1606,7 @@ function updateStoreInstance<T>(
   }
 }
 
-function subscribeToStore<T>(fiber, inst: StoreInstance<T>, subscribe) {
+function subscribeToStore<T>(fiber: Fiber, inst: StoreInstance<T>, subscribe) {
   const handleStoreChange = () => {
     // The store changed. Check if the snapshot changed since the last time we
     // read from the store.
@@ -1630,7 +1630,7 @@ function checkIfSnapshotChanged<T>(inst: StoreInstance<T>): boolean {
   }
 }
 
-function forceStoreRerender(fiber) {
+function forceStoreRerender(fiber: Fiber) {
   const root = enqueueConcurrentRenderForLane(fiber, SyncLane);
   if (root !== null) {
     scheduleUpdateOnFiber(root, fiber, SyncLane, NoTimestamp);
@@ -2188,7 +2188,11 @@ function updateDeferredValueImpl<T>(hook: Hook, prevValue: T, value: T): T {
   }
 }
 
-function startTransition(setPending, callback, options) {
+function startTransition(
+  setPending: Dispatch<BasicStateAction<boolean>>,
+  callback: () => void,
+  options: void | StartTransitionOptions,
+) {
   const previousPriority = getCurrentUpdatePriority();
   setCurrentUpdatePriority(
     higherEventPriority(previousPriority, ContinuousEventPriority),
@@ -2557,7 +2561,7 @@ function entangleTransitionUpdate<S, A>(
   }
 }
 
-function markUpdateInDevTools<A>(fiber, lane, action: A) {
+function markUpdateInDevTools<A>(fiber: Fiber, lane: Lane, action: A) {
   if (__DEV__) {
     if (enableDebugTracing) {
       if (fiber.mode & DebugTracingMode) {

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.new.js
@@ -341,7 +341,10 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   warnNonhydratedInstance(returnFiber, fiber);
 }
 
-function tryHydrate(fiber, nextInstance) {
+function tryHydrate(
+  fiber: Fiber,
+  nextInstance: SuspenseInstance | HydratableInstance | Element | Text,
+) {
   switch (fiber.tag) {
     // HostSingleton is intentionally omitted. the hydration pathway for singletons is non-fallible
     // you can find it inlined in claimHydratableSingleton

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.old.js
@@ -341,7 +341,10 @@ function insertNonHydratedInstance(returnFiber: Fiber, fiber: Fiber) {
   warnNonhydratedInstance(returnFiber, fiber);
 }
 
-function tryHydrate(fiber, nextInstance) {
+function tryHydrate(
+  fiber: Fiber,
+  nextInstance: SuspenseInstance | HydratableInstance | Element | Text,
+) {
   switch (fiber.tag) {
     // HostSingleton is intentionally omitted. the hydration pathway for singletons is non-fallible
     // you can find it inlined in claimHydratableSingleton

--- a/packages/react-reconciler/src/ReactFiberReconciler.new.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.new.js
@@ -533,7 +533,7 @@ export function shouldError(fiber: Fiber): ?boolean {
   return shouldErrorImpl(fiber);
 }
 
-let shouldSuspendImpl = fiber => false;
+let shouldSuspendImpl = (fiber: Fiber) => false;
 
 export function shouldSuspend(fiber: Fiber): boolean {
   return shouldSuspendImpl(fiber);

--- a/packages/react-reconciler/src/ReactFiberReconciler.old.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.old.js
@@ -533,7 +533,7 @@ export function shouldError(fiber: Fiber): ?boolean {
   return shouldErrorImpl(fiber);
 }
 
-let shouldSuspendImpl = fiber => false;
+let shouldSuspendImpl = (fiber: Fiber) => false;
 
 export function shouldSuspend(fiber: Fiber): boolean {
   return shouldSuspendImpl(fiber);

--- a/packages/react-reconciler/src/ReactFiberTreeReflection.js
+++ b/packages/react-reconciler/src/ReactFiberTreeReflection.js
@@ -117,7 +117,7 @@ export function isMounted(component: React$Component<any, any>): boolean {
   return getNearestMountedFiber(fiber) === fiber;
 }
 
-function assertIsMounted(fiber) {
+function assertIsMounted(fiber: Fiber) {
   if (getNearestMountedFiber(fiber) !== fiber) {
     throw new Error('Unable to find node on an unmounted component.');
   }

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.new.js
@@ -42,7 +42,7 @@ if (__DEV__) {
     return maybeStrictRoot;
   };
 
-  const setToSortedString = set => {
+  const setToSortedString = (set: $ReadOnlySet<string>) => {
     const array = [];
     set.forEach(value => {
       array.push(value);

--- a/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
+++ b/packages/react-reconciler/src/ReactStrictModeWarnings.old.js
@@ -42,7 +42,7 @@ if (__DEV__) {
     return maybeStrictRoot;
   };
 
-  const setToSortedString = set => {
+  const setToSortedString = (set: $ReadOnlySet<string>) => {
     const array = [];
     set.forEach(value => {
       array.push(value);

--- a/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightDOMServerNode.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ReactModel} from 'react-server/src/ReactFlightServer';
+import type {ReactModel, Request} from 'react-server/src/ReactFlightServer';
 import type {Destination} from 'react-server/src/ReactServerStreamConfigNode';
 import type {BundlerConfig} from './ReactFlightServerWebpackBundlerConfig';
 import type {Writable} from 'stream';
@@ -20,7 +20,7 @@ import {
   abort,
 } from 'react-server/src/ReactFlightServer';
 
-function createDrainHandler(destination: Destination, request) {
+function createDrainHandler(destination: Destination, request: Request) {
   return () => startFlowing(request, destination);
 }
 

--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js
@@ -100,7 +100,7 @@ export async function getSource(
   return defaultGetSource(url, context, defaultGetSource);
 }
 
-function addExportNames(names, node) {
+function addExportNames(names: Array<string>, node) {
   switch (node.type) {
     case 'Identifier':
       names.push(node.name);
@@ -174,7 +174,7 @@ async function parseExportNamesInto(
   transformedSource: string,
   names: Array<string>,
   parentURL: string,
-  defaultTransformSource,
+  defaultTransformSource: TransformSourceFunction,
 ): Promise<void> {
   const {body} = acorn.parse(transformedSource, {
     ecmaVersion: '2019',

--- a/packages/react-server/src/ReactFizzServer.js
+++ b/packages/react-server/src/ReactFizzServer.js
@@ -1503,7 +1503,7 @@ function renderNodeDestructiveImpl(
   }
 }
 
-function renderChildrenArray(request, task, children) {
+function renderChildrenArray(request: Request, task: Task, children) {
   const totalChildren = children.length;
   for (let i = 0; i < totalChildren; i++) {
     const prevTreeContext = task.treeContext;
@@ -2000,7 +2000,7 @@ function flushSubtree(
 
 function flushSegment(
   request: Request,
-  destination,
+  destination: Destination,
   segment: Segment,
 ): boolean {
   const boundary = segment.boundary;

--- a/packages/react/src/ReactContext.js
+++ b/packages/react/src/ReactContext.js
@@ -9,7 +9,7 @@
 
 import {REACT_PROVIDER_TYPE, REACT_CONTEXT_TYPE} from 'shared/ReactSymbols';
 
-import type {ReactContext} from 'shared/ReactTypes';
+import type {ReactProviderType, ReactContext} from 'shared/ReactTypes';
 
 export function createContext<T>(defaultValue: T): ReactContext<T> {
   // TODO: Second argument used to be an optional `calculateChangedBits`
@@ -66,7 +66,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
           }
           return context.Provider;
         },
-        set(_Provider) {
+        set(_Provider: ReactProviderType<T>) {
           context.Provider = _Provider;
         },
       },
@@ -74,7 +74,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
         get() {
           return context._currentValue;
         },
-        set(_currentValue) {
+        set(_currentValue: T) {
           context._currentValue = _currentValue;
         },
       },
@@ -82,7 +82,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
         get() {
           return context._currentValue2;
         },
-        set(_currentValue2) {
+        set(_currentValue2: T) {
           context._currentValue2 = _currentValue2;
         },
       },
@@ -90,7 +90,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
         get() {
           return context._threadCount;
         },
-        set(_threadCount) {
+        set(_threadCount: number) {
           context._threadCount = _threadCount;
         },
       },
@@ -110,7 +110,7 @@ export function createContext<T>(defaultValue: T): ReactContext<T> {
         get() {
           return context.displayName;
         },
-        set(displayName) {
+        set(displayName: void | string) {
           if (!hasWarnedAboutDisplayNameOnConsumer) {
             console.warn(
               'Setting `displayName` on Context.Consumer has no effect. ' +

--- a/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
+++ b/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
@@ -44,7 +44,7 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
     let hasMemo = false;
     let memoizedSnapshot;
     let memoizedSelection: Selection;
-    const memoizedSelector = nextSnapshot => {
+    const memoizedSelector = (nextSnapshot: Snapshot) => {
       if (!hasMemo) {
         // The first time the hook is called, there is no memoized result.
         hasMemo = true;

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -49,4 +49,4 @@ enforce_local_inference_annotations=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.190.0
+^0.190.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -7917,10 +7917,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.190.0:
-  version "0.190.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.190.0.tgz#cfc50e1474facf8150232a6c498fe66a6bb75969"
-  integrity sha512-Qo3bvN3cmGFXsq63ZxcHFZXQDvgx84fCuq8cXuKk5xbvuebBGwMqS+ku/rH+gEkciRrcTYrXqoSzb9b6ShcoJg==
+flow-bin@^0.190.1:
+  version "0.190.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.190.1.tgz#59ccbc9aaa2515fe32acc66117a05e7ef6a11061"
+  integrity sha512-5c9/6eEkMTTfdNuK2WwssrKfsUXKMUXlZVJZnrlWiqJpDSVc70/Smwyi9sXict9k/oq0f+Mo5wVH0d7peBYREg==
 
 fluent-syntax@0.13.0:
   version "0.13.0"


### PR DESCRIPTION
The next version of Flow requires type annotation on all function arguments and some other places.

This adds the types from the automatic codemod provided by flow that didn't repeat large literal objects or similar thing that might need a bit more manual review.

Also include a minor bump to the Flow version from 0.190.0 to 0.190.1.