### PR TITLE
Add `scale` as a unitless property

### DIFF
--- a/packages/react-dom-bindings/src/shared/CSSProperty.js
+++ b/packages/react-dom-bindings/src/shared/CSSProperty.js
@@ -40,6 +40,7 @@ export const isUnitlessNumber = {
   opacity: true,
   order: true,
   orphans: true,
+  scale: true,
   tabSize: true,
   widows: true,
   zIndex: true,


### PR DESCRIPTION
## Summary

CSS has a new property called `scale` (`scale: 2` is a shorthand for `transform: scale(2)`).

In vanilla JavaScript, we can do the following:

```js
document.querySelector('div').scale = 2;
```

which will make the `<div>` twice as big. So in JavaScript, it is possible to pass a plain number.
However, in React, the following does not work currently:


```js
<div style={{scale: 2}}>
```

because `scale` is not in the list of unitless properties. This PR adds `scale` to the list.


## How did you test this change?

I built `react` and `react-dom` from source and copied it into the node_modules of my project and verified that now `<div style={{scale: 2}}>` does indeed work whereas before it did not.