### PR TITLE
Reuse hooks when replaying a suspended component 

### DIFF
--- a/packages/react-reconciler/src/ReactFiberBeginWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.new.js
@@ -38,7 +38,6 @@ import type {
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.new';
 import type {RootState} from './ReactFiberRoot.new';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.new';
-import type {ThenableState} from './ReactFiberThenable.new';
 
 import checkPropTypes from 'shared/checkPropTypes';
 import {
@@ -1167,7 +1166,6 @@ export function replayFunctionComponent(
   workInProgress: Fiber,
   nextProps: any,
   Component: any,
-  prevThenableState: ThenableState,
   renderLanes: Lanes,
 ): Fiber | null {
   // This function is used to replay a component that previously suspended,
@@ -1190,7 +1188,6 @@ export function replayFunctionComponent(
     Component,
     nextProps,
     context,
-    prevThenableState,
   );
   const hasId = checkDidRenderIdHook();
   if (enableSchedulingProfiler) {

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -38,6 +38,8 @@ import type {
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.old';
 import type {RootState} from './ReactFiberRoot.old';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
+import type {ThenableState} from './ReactFiberThenable.old';
+
 import checkPropTypes from 'shared/checkPropTypes';
 import {
   markComponentRenderStarted,
@@ -203,6 +205,7 @@ import {
   renderWithHooks,
   checkDidRenderIdHook,
   bailoutHooks,
+  replaySuspendedComponentWithHooks,
 } from './ReactFiberHooks.old';
 import {stopProfilerTimerIfRunning} from './ReactProfilerTimer.old';
 import {
@@ -1140,6 +1143,56 @@ function updateFunctionComponent(
     );
     hasId = checkDidRenderIdHook();
   }
+  if (enableSchedulingProfiler) {
+    markComponentRenderStopped();
+  }
+
+  if (current !== null && !didReceiveUpdate) {
+    bailoutHooks(current, workInProgress, renderLanes);
+    return bailoutOnAlreadyFinishedWork(current, workInProgress, renderLanes);
+  }
+
+  if (getIsHydrating() && hasId) {
+    pushMaterializedTreeId(workInProgress);
+  }
+
+  // React DevTools reads this flag.
+  workInProgress.flags |= PerformedWork;
+  reconcileChildren(current, workInProgress, nextChildren, renderLanes);
+  return workInProgress.child;
+}
+
+export function replayFunctionComponent(
+  current: Fiber | null,
+  workInProgress: Fiber,
+  nextProps: any,
+  Component: any,
+  prevThenableState: ThenableState,
+  renderLanes: Lanes,
+): Fiber | null {
+  // This function is used to replay a component that previously suspended,
+  // after its data resolves. It's a simplified version of
+  // updateFunctionComponent that reuses the hooks from the previous attempt.
+
+  let context;
+  if (!disableLegacyContext) {
+    const unmaskedContext = getUnmaskedContext(workInProgress, Component, true);
+    context = getMaskedContext(workInProgress, unmaskedContext);
+  }
+
+  prepareToReadContext(workInProgress, renderLanes);
+  if (enableSchedulingProfiler) {
+    markComponentRenderStarted(workInProgress);
+  }
+  const nextChildren = replaySuspendedComponentWithHooks(
+    current,
+    workInProgress,
+    Component,
+    nextProps,
+    context,
+    prevThenableState,
+  );
+  const hasId = checkDidRenderIdHook();
   if (enableSchedulingProfiler) {
     markComponentRenderStopped();
   }

--- a/packages/react-reconciler/src/ReactFiberBeginWork.old.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.old.js
@@ -38,7 +38,6 @@ import type {
 import type {UpdateQueue} from './ReactFiberClassUpdateQueue.old';
 import type {RootState} from './ReactFiberRoot.old';
 import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent.old';
-import type {ThenableState} from './ReactFiberThenable.old';
 
 import checkPropTypes from 'shared/checkPropTypes';
 import {
@@ -1167,7 +1166,6 @@ export function replayFunctionComponent(
   workInProgress: Fiber,
   nextProps: any,
   Component: any,
-  prevThenableState: ThenableState,
   renderLanes: Lanes,
 ): Fiber | null {
   // This function is used to replay a component that previously suspended,
@@ -1190,7 +1188,6 @@ export function replayFunctionComponent(
     Component,
     nextProps,
     context,
-    prevThenableState,
   );
   const hasId = checkDidRenderIdHook();
   if (enableSchedulingProfiler) {

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -839,7 +839,24 @@ function updateWorkInProgressHook(): Hook {
     // Clone from the current hook.
 
     if (nextCurrentHook === null) {
-      throw new Error('Rendered more hooks than during the previous render.');
+      const currentFiber = currentlyRenderingFiber.alternate;
+      if (currentFiber === null) {
+        // This is the initial render. This branch is reached when the component
+        // suspends, resumes, then renders an additional hook.
+        const newHook: Hook = {
+          memoizedState: null,
+
+          baseState: null,
+          baseQueue: null,
+          queue: null,
+
+          next: null,
+        };
+        nextCurrentHook = newHook;
+      } else {
+        // This is an update. We should always have a current hook.
+        throw new Error('Rendered more hooks than during the previous render.');
+      }
     }
 
     currentHook = nextCurrentHook;

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -732,10 +732,19 @@ export function bailoutHooks(
 }
 
 export function resetHooksAfterThrow(): void {
+  // This is called immediaetly after a throw. It shouldn't reset the entire
+  // module state, because the work loop might decide to replay the component
+  // again without rewinding.
+  //
+  // It should only reset things like the current dispatcher, to prevent hooks
+  // from being called outside of a component.
+
   // We can assume the previous dispatcher is always this one, since we set it
   // at the beginning of the render phase and there's no re-entrance.
   ReactCurrentDispatcher.current = ContextOnlyDispatcher;
+}
 
+export function resetHooksOnUnwind(): void {
   if (didScheduleRenderPhaseUpdate) {
     // There were render phase updates. These are only valid for this render
     // phase, which we are now aborting. Remove the updates from the queues so

--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -105,7 +105,6 @@ import {
   requestEventTime,
   markSkippedUpdateLanes,
   isInvalidExecutionContextForEventFunction,
-  getSuspendedThenableState,
 } from './ReactFiberWorkLoop.new';
 
 import getComponentNameFromFiber from 'react-reconciler/src/getComponentNameFromFiber';
@@ -141,9 +140,9 @@ import {
 import {getTreeId} from './ReactFiberTreeContext.new';
 import {now} from './Scheduler';
 import {
-  prepareThenableState,
   trackUsedThenable,
   checkIfUseWrappedInTryCatch,
+  createThenableState,
 } from './ReactFiberThenable.new';
 import type {ThenableState} from './ReactFiberThenable.new';
 
@@ -247,6 +246,7 @@ let shouldDoubleInvokeUserFnsInHooksDEV: boolean = false;
 let localIdCounter: number = 0;
 // Counts number of `use`-d thenables
 let thenableIndexCounter: number = 0;
+let thenableState: ThenableState | null = null;
 
 // Used for ids that are generated completely client-side (i.e. not during
 // hydration). This counter is global, so client ids are not stable across
@@ -449,6 +449,7 @@ export function renderWithHooks<Props, SecondArg>(
   // didScheduleRenderPhaseUpdate = false;
   // localIdCounter = 0;
   // thenableIndexCounter = 0;
+  // thenableState = null;
 
   // TODO Warn if no hooks are used at all during mount, then some are used during update.
   // Currently we will identify the update render as a mount because memoizedState === null.
@@ -476,10 +477,6 @@ export function renderWithHooks<Props, SecondArg>(
         ? HooksDispatcherOnMount
         : HooksDispatcherOnUpdate;
   }
-
-  // If this is a replay, restore the thenable state from the previous attempt.
-  const prevThenableState = getSuspendedThenableState();
-  prepareThenableState(prevThenableState);
 
   // In Strict Mode, during development, user functions are double invoked to
   // help detect side effects. The logic for how this is implemented for in
@@ -525,7 +522,6 @@ export function renderWithHooks<Props, SecondArg>(
       Component,
       props,
       secondArg,
-      prevThenableState,
     );
   }
 
@@ -538,7 +534,6 @@ export function renderWithHooks<Props, SecondArg>(
         Component,
         props,
         secondArg,
-        prevThenableState,
       );
     } finally {
       setIsStrictModeForDevtools(false);
@@ -600,7 +595,9 @@ function finishRenderingHooks(current: Fiber | null, workInProgress: Fiber) {
   didScheduleRenderPhaseUpdate = false;
   // This is reset by checkDidRenderIdHook
   // localIdCounter = 0;
+
   thenableIndexCounter = 0;
+  thenableState = null;
 
   if (didRenderTooFewHooks) {
     throw new Error(
@@ -652,7 +649,6 @@ export function replaySuspendedComponentWithHooks<Props, SecondArg>(
   Component: (p: Props, arg: SecondArg) => any,
   props: Props,
   secondArg: SecondArg,
-  prevThenableState: ThenableState | null,
 ): any {
   // This function is used to replay a component that previously suspended,
   // after its data resolves.
@@ -676,7 +672,6 @@ export function replaySuspendedComponentWithHooks<Props, SecondArg>(
     Component,
     props,
     secondArg,
-    prevThenableState,
   );
   finishRenderingHooks(current, workInProgress);
   return children;
@@ -687,7 +682,6 @@ function renderWithHooksAgain<Props, SecondArg>(
   Component: (p: Props, arg: SecondArg) => any,
   props: Props,
   secondArg: SecondArg,
-  prevThenableState: ThenableState | null,
 ) {
   // This is used to perform another render pass. It's used when setState is
   // called during render, and for double invoking components in Strict Mode
@@ -735,7 +729,6 @@ function renderWithHooksAgain<Props, SecondArg>(
       ? HooksDispatcherOnRerenderInDEV
       : HooksDispatcherOnRerender;
 
-    prepareThenableState(prevThenableState);
     children = Component(props, secondArg);
   } while (didScheduleRenderPhaseUpdateDuringThisPass);
   return children;
@@ -821,6 +814,7 @@ export function resetHooksOnUnwind(): void {
   didScheduleRenderPhaseUpdateDuringThisPass = false;
   localIdCounter = 0;
   thenableIndexCounter = 0;
+  thenableState = null;
 }
 
 function mountWorkInProgressHook(): Hook {
@@ -954,7 +948,11 @@ function use<T>(usable: Usable<T>): T {
       // Track the position of the thenable within this fiber.
       const index = thenableIndexCounter;
       thenableIndexCounter += 1;
-      return trackUsedThenable(thenable, index);
+
+      if (thenableState === null) {
+        thenableState = createThenableState();
+      }
+      return trackUsedThenable(thenableState, thenable, index);
     } else if (
       usable.$$typeof === REACT_CONTEXT_TYPE ||
       usable.$$typeof === REACT_SERVER_CONTEXT_TYPE

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -839,7 +839,24 @@ function updateWorkInProgressHook(): Hook {
     // Clone from the current hook.
 
     if (nextCurrentHook === null) {
-      throw new Error('Rendered more hooks than during the previous render.');
+      const currentFiber = currentlyRenderingFiber.alternate;
+      if (currentFiber === null) {
+        // This is the initial render. This branch is reached when the component
+        // suspends, resumes, then renders an additional hook.
+        const newHook: Hook = {
+          memoizedState: null,
+
+          baseState: null,
+          baseQueue: null,
+          queue: null,
+
+          next: null,
+        };
+        nextCurrentHook = newHook;
+      } else {
+        // This is an update. We should always have a current hook.
+        throw new Error('Rendered more hooks than during the previous render.');
+      }
     }
 
     currentHook = nextCurrentHook;

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -732,10 +732,19 @@ export function bailoutHooks(
 }
 
 export function resetHooksAfterThrow(): void {
+  // This is called immediaetly after a throw. It shouldn't reset the entire
+  // module state, because the work loop might decide to replay the component
+  // again without rewinding.
+  //
+  // It should only reset things like the current dispatcher, to prevent hooks
+  // from being called outside of a component.
+
   // We can assume the previous dispatcher is always this one, since we set it
   // at the beginning of the render phase and there's no re-entrance.
   ReactCurrentDispatcher.current = ContextOnlyDispatcher;
+}
 
+export function resetHooksOnUnwind(): void {
   if (didScheduleRenderPhaseUpdate) {
     // There were render phase updates. These are only valid for this render
     // phase, which we are now aborting. Remove the updates from the queues so

--- a/packages/react-reconciler/src/ReactFiberThenable.new.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.new.js
@@ -54,13 +54,9 @@ export function getThenableStateAfterSuspending(): ThenableState | null {
   return state;
 }
 
-export function isThenableStateResolved(thenables: ThenableState): boolean {
-  const lastThenable = thenables[thenables.length - 1];
-  if (lastThenable !== undefined) {
-    const status = lastThenable.status;
-    return status === 'fulfilled' || status === 'rejected';
-  }
-  return true;
+export function isThenableResolved(thenable: Thenable<mixed>): boolean {
+  const status = thenable.status;
+  return status === 'fulfilled' || status === 'rejected';
 }
 
 function noop(): void {}

--- a/packages/react-reconciler/src/ReactFiberThenable.old.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.old.js
@@ -54,13 +54,9 @@ export function getThenableStateAfterSuspending(): ThenableState | null {
   return state;
 }
 
-export function isThenableStateResolved(thenables: ThenableState): boolean {
-  const lastThenable = thenables[thenables.length - 1];
-  if (lastThenable !== undefined) {
-    const status = lastThenable.status;
-    return status === 'fulfilled' || status === 'rejected';
-  }
-  return true;
+export function isThenableResolved(thenable: Thenable<mixed>): boolean {
+  const status = thenable.status;
+  return status === 'fulfilled' || status === 'rejected';
 }
 
 function noop(): void {}

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -25,7 +25,6 @@ import type {
   TransitionAbort,
 } from './ReactFiberTracingMarkerComponent.new';
 import type {OffscreenInstance} from './ReactFiberOffscreenComponent';
-import type {ThenableState} from './ReactFiberThenable.new';
 
 import {
   warnAboutDeprecatedLifecycles,
@@ -275,7 +274,6 @@ import {processTransitionCallbacks} from './ReactFiberTracingMarkerComponent.new
 import {
   SuspenseException,
   getSuspendedThenable,
-  getThenableStateAfterSuspending,
   isThenableResolved,
 } from './ReactFiberThenable.new';
 import {schedulePostPaintCallback} from './ReactPostPaintCallback';
@@ -322,13 +320,14 @@ let workInProgress: Fiber | null = null;
 // The lanes we're rendering
 let workInProgressRootRenderLanes: Lanes = NoLanes;
 
-opaque type SuspendedReason = 0 | 1 | 2 | 3 | 4 | 5;
+opaque type SuspendedReason = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 const NotSuspended: SuspendedReason = 0;
 const SuspendedOnError: SuspendedReason = 1;
 const SuspendedOnData: SuspendedReason = 2;
 const SuspendedOnImmediate: SuspendedReason = 3;
-const SuspendedAndReadyToUnwind: SuspendedReason = 4;
-const SuspendedOnHydration: SuspendedReason = 5;
+const SuspendedOnDeprecatedThrowPromise: SuspendedReason = 4;
+const SuspendedAndReadyToUnwind: SuspendedReason = 5;
+const SuspendedOnHydration: SuspendedReason = 6;
 
 // When this is true, the work-in-progress fiber just suspended (or errored) and
 // we've yet to unwind the stack. In some cases, we may yield to the main thread
@@ -336,7 +335,6 @@ const SuspendedOnHydration: SuspendedReason = 5;
 // immediately instead of unwinding the stack.
 let workInProgressSuspendedReason: SuspendedReason = NotSuspended;
 let workInProgressThrownValue: mixed = null;
-let workInProgressSuspendedThenableState: ThenableState | null = null;
 
 // Whether a ping listener was attached during this render. This is slightly
 // different that whether something suspended, because we don't add multiple
@@ -1749,7 +1747,6 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   workInProgressRootRenderLanes = renderLanes = lanes;
   workInProgressSuspendedReason = NotSuspended;
   workInProgressThrownValue = null;
-  workInProgressSuspendedThenableState = null;
   workInProgressRootDidAttachPingListener = false;
   workInProgressRootExitStatus = RootInProgress;
   workInProgressRootFatalError = null;
@@ -1802,7 +1799,6 @@ function handleThrow(root, thrownValue): void {
     // API for suspending. This implementation detail can change later, once we
     // deprecate the old API in favor of `use`.
     thrownValue = getSuspendedThenable();
-    workInProgressSuspendedThenableState = getThenableStateAfterSuspending();
     workInProgressSuspendedReason = shouldAttemptToSuspendUntilDataResolves()
       ? SuspendedOnData
       : SuspendedOnImmediate;
@@ -1816,13 +1812,9 @@ function handleThrow(root, thrownValue): void {
     //
     // We could name this something more general but as of now it's the only
     // case where we think this should happen.
-    workInProgressSuspendedThenableState = null;
     workInProgressSuspendedReason = SuspendedOnHydration;
   } else {
-    // This is a regular error. If something earlier in the component already
-    // suspended, we must clear the thenable state to unblock the work loop.
-    workInProgressSuspendedThenableState = null;
-
+    // This is a regular error.
     const isWakeable =
       thrownValue !== null &&
       typeof thrownValue === 'object' &&
@@ -1832,7 +1824,7 @@ function handleThrow(root, thrownValue): void {
     workInProgressSuspendedReason = isWakeable
       ? // A wakeable object was thrown by a legacy Suspense implementation.
         // This has slightly different behavior than suspending with `use`.
-        SuspendedAndReadyToUnwind
+        SuspendedOnDeprecatedThrowPromise
       : // This is a regular error. If something earlier in the component already
         // suspended, we must clear the thenable state to unblock the work loop.
         SuspendedOnError;
@@ -2205,17 +2197,13 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
           }
           case SuspendedOnData: {
             const thenable: Thenable<mixed> = (thrownValue: any);
-            if (workInProgressSuspendedThenableState !== null) {
-              const thenableState = workInProgressSuspendedThenableState;
-              if (isThenableResolved(thenable)) {
-                // The data resolved. Try rendering the component again.
-                workInProgressSuspendedReason = NotSuspended;
-                workInProgressThrownValue = null;
-                replaySuspendedUnitOfWork(unitOfWork, thenable, thenableState);
-                break;
-              }
+            if (isThenableResolved(thenable)) {
+              // The data resolved. Try rendering the component again.
+              workInProgressSuspendedReason = NotSuspended;
+              workInProgressThrownValue = null;
+              replaySuspendedUnitOfWork(unitOfWork);
+              break;
             }
-
             // The work loop is suspended on data. We should wait for it to
             // resolve before continuing to render.
             const onResolution = () => {
@@ -2231,6 +2219,31 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             workInProgressSuspendedReason = SuspendedAndReadyToUnwind;
             break outer;
           }
+          case SuspendedAndReadyToUnwind: {
+            const thenable: Thenable<mixed> = (thrownValue: any);
+            if (isThenableResolved(thenable)) {
+              // The data resolved. Try rendering the component again.
+              workInProgressSuspendedReason = NotSuspended;
+              workInProgressThrownValue = null;
+              replaySuspendedUnitOfWork(unitOfWork);
+            } else {
+              // Otherwise, unwind then continue with the normal work loop.
+              workInProgressSuspendedReason = NotSuspended;
+              workInProgressThrownValue = null;
+              unwindSuspendedUnitOfWork(unitOfWork, thrownValue);
+            }
+            break;
+          }
+          case SuspendedOnDeprecatedThrowPromise: {
+            // Suspended by an old implementation that uses the `throw promise`
+            // pattern. The newer replaying behavior can cause subtle issues
+            // like infinite ping loops. So we maintain the old behavior and
+            // always unwind.
+            workInProgressSuspendedReason = NotSuspended;
+            workInProgressThrownValue = null;
+            unwindSuspendedUnitOfWork(unitOfWork, thrownValue);
+            break;
+          }
           case SuspendedOnHydration: {
             // Selective hydration. An update flowed into a dehydrated tree.
             // Interrupt the current render so the work loop can switch to the
@@ -2240,27 +2253,9 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             break outer;
           }
           default: {
-            if (workInProgressSuspendedThenableState !== null) {
-              const thenableState = workInProgressSuspendedThenableState;
-              const thenable: Thenable<mixed> = (thrownValue: any);
-              if (isThenableResolved(thenable)) {
-                // The data resolved. Try rendering the component again.
-                workInProgressSuspendedReason = NotSuspended;
-                workInProgressThrownValue = null;
-                replaySuspendedUnitOfWork(
-                  unitOfWork,
-                  thrownValue,
-                  thenableState,
-                );
-                break;
-              }
-            }
-
-            // Otherwise, unwind then continue with the normal work loop.
-            workInProgressSuspendedReason = NotSuspended;
-            workInProgressThrownValue = null;
-            unwindSuspendedUnitOfWork(unitOfWork, thrownValue);
-            break;
+            throw new Error(
+              'Unexpected SuspendedReason. This is a bug in React.',
+            );
           }
         }
       }
@@ -2344,11 +2339,7 @@ function performUnitOfWork(unitOfWork: Fiber): void {
   ReactCurrentOwner.current = null;
 }
 
-function replaySuspendedUnitOfWork(
-  unitOfWork: Fiber,
-  thrownValue: mixed,
-  thenableState: ThenableState,
-): void {
+function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
   // This is a fork of performUnitOfWork specifcally for replaying a fiber that
   // just suspended.
   //
@@ -2387,7 +2378,6 @@ function replaySuspendedUnitOfWork(
         unitOfWork,
         resolvedProps,
         Component,
-        thenableState,
         workInProgressRootRenderLanes,
       );
       break;
@@ -2400,7 +2390,6 @@ function replaySuspendedUnitOfWork(
         unitOfWork,
         nextProps,
         Component,
-        thenableState,
         workInProgressRootRenderLanes,
       );
       break;
@@ -2427,10 +2416,8 @@ function replaySuspendedUnitOfWork(
     stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
   }
 
-  // The begin phase finished successfully without suspending. Reset the state
-  // used to track the fiber while it was suspended. Then return to the normal
-  // work loop.
-  workInProgressSuspendedThenableState = null;
+  // The begin phase finished successfully without suspending. Return to the
+  // normal work loop.
 
   resetCurrentDebugFiberInDEV();
   unitOfWork.memoizedProps = unitOfWork.pendingProps;
@@ -2450,7 +2437,6 @@ function unwindSuspendedUnitOfWork(unitOfWork: Fiber, thrownValue: mixed) {
   //
   // Return to the normal work loop. This will unwind the stack, and potentially
   // result in showing a fallback.
-  workInProgressSuspendedThenableState = null;
   resetSuspendedWorkLoopOnUnwind();
 
   const returnFiber = unitOfWork.return;
@@ -2492,10 +2478,6 @@ function unwindSuspendedUnitOfWork(unitOfWork: Fiber, thrownValue: mixed) {
 
   // Return to the normal work loop.
   completeUnitOfWork(unitOfWork);
-}
-
-export function getSuspendedThenableState(): ThenableState | null {
-  return workInProgressSuspendedThenableState;
 }
 
 function completeUnitOfWork(unitOfWork: Fiber): void {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -210,6 +210,7 @@ import {enqueueUpdate} from './ReactFiberClassUpdateQueue.new';
 import {resetContextDependencies} from './ReactFiberNewContext.new';
 import {
   resetHooksAfterThrow,
+  resetHooksOnUnwind,
   ContextOnlyDispatcher,
 } from './ReactFiberHooks.new';
 import {DefaultCacheDispatcher} from './ReactFiberCache.new';
@@ -1719,10 +1720,17 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   }
 
   if (workInProgress !== null) {
-    let interruptedWork =
-      workInProgressSuspendedReason === NotSuspended
-        ? workInProgress.return
-        : workInProgress;
+    let interruptedWork;
+    if (workInProgressSuspendedReason === NotSuspended) {
+      // Normal case. Work-in-progress hasn't started yet. Unwind all
+      // its parents.
+      interruptedWork = workInProgress.return;
+    } else {
+      // Work-in-progress is in suspended state. Reset the work loop and unwind
+      // both the suspended fiber and all its parents.
+      resetSuspendedWorkLoopOnUnwind();
+      interruptedWork = workInProgress;
+    }
     while (interruptedWork !== null) {
       const current = interruptedWork.alternate;
       unwindInterruptedWork(
@@ -1759,13 +1767,30 @@ function prepareFreshStack(root: FiberRoot, lanes: Lanes): Fiber {
   return rootWorkInProgress;
 }
 
-function handleThrow(root, thrownValue): void {
+function resetSuspendedWorkLoopOnUnwind() {
   // Reset module-level state that was set during the render phase.
   resetContextDependencies();
+  resetHooksOnUnwind();
+}
+
+function handleThrow(root, thrownValue): void {
+  // A component threw an exception. Usually this is because it suspended, but
+  // it also includes regular program errors.
+  //
+  // We're either going to unwind the stack to show a Suspense or error
+  // boundary, or we're going to replay the component again. Like after a
+  // promise resolves.
+  //
+  // Until we decide whether we're going to unwind or replay, we should preserve
+  // the current state of the work loop without resetting anything.
+  //
+  // If we do decide to unwind the stack, module-level variables will be reset
+  // in resetSuspendedWorkLoopOnUnwind.
+
+  // These should be reset immediately because they're only supposed to be set
+  // when React is executing user code.
   resetHooksAfterThrow();
   resetCurrentDebugFiberInDEV();
-  // TODO: I found and added this missing line while investigating a
-  // separate issue. Write a regression test using string refs.
   ReactCurrentOwner.current = null;
 
   if (thrownValue === SuspenseException) {
@@ -2317,6 +2342,7 @@ function replaySuspendedUnitOfWork(
   // Instead of unwinding the stack and potentially showing a fallback, unwind
   // only the last stack frame, reset the fiber, and try rendering it again.
   const current = unitOfWork.alternate;
+  resetSuspendedWorkLoopOnUnwind();
   unwindInterruptedWork(current, unitOfWork, workInProgressRootRenderLanes);
   unitOfWork = workInProgress = resetWorkInProgress(unitOfWork, renderLanes);
 
@@ -2355,6 +2381,7 @@ function unwindSuspendedUnitOfWork(unitOfWork: Fiber, thrownValue: mixed) {
   // Return to the normal work loop. This will unwind the stack, and potentially
   // result in showing a fallback.
   workInProgressSuspendedThenableState = null;
+  resetSuspendedWorkLoopOnUnwind();
 
   const returnFiber = unitOfWork.return;
   if (returnFiber === null || workInProgressRoot === null) {
@@ -3707,14 +3734,11 @@ if (__DEV__ && replayFailedUnitOfWorkWithInvokeGuardedCallback) {
         throw originalError;
       }
 
-      // Keep this code in sync with handleThrow; any changes here must have
-      // corresponding changes there.
-      resetContextDependencies();
-      resetHooksAfterThrow();
       // Don't reset current debug fiber, since we're about to work on the
       // same fiber again.
 
       // Unwind the failed stack frame
+      resetSuspendedWorkLoopOnUnwind();
       unwindInterruptedWork(current, unitOfWork, workInProgressRootRenderLanes);
 
       // Restore the original properties of the fiber.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -276,7 +276,7 @@ import {
   SuspenseException,
   getSuspendedThenable,
   getThenableStateAfterSuspending,
-  isThenableStateResolved,
+  isThenableResolved,
 } from './ReactFiberThenable.new';
 import {schedulePostPaintCallback} from './ReactPostPaintCallback';
 import {
@@ -2204,24 +2204,20 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             break;
           }
           case SuspendedOnData: {
+            const thenable: Thenable<mixed> = (thrownValue: any);
             if (workInProgressSuspendedThenableState !== null) {
               const thenableState = workInProgressSuspendedThenableState;
-              if (isThenableStateResolved(thenableState)) {
+              if (isThenableResolved(thenable)) {
                 // The data resolved. Try rendering the component again.
                 workInProgressSuspendedReason = NotSuspended;
                 workInProgressThrownValue = null;
-                replaySuspendedUnitOfWork(
-                  unitOfWork,
-                  thrownValue,
-                  thenableState,
-                );
+                replaySuspendedUnitOfWork(unitOfWork, thenable, thenableState);
                 break;
               }
             }
 
             // The work loop is suspended on data. We should wait for it to
             // resolve before continuing to render.
-            const thenable: Thenable<mixed> = (workInProgressThrownValue: any);
             const onResolution = () => {
               ensureRootIsScheduled(root, now());
             };
@@ -2246,7 +2242,8 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
           default: {
             if (workInProgressSuspendedThenableState !== null) {
               const thenableState = workInProgressSuspendedThenableState;
-              if (isThenableStateResolved(thenableState)) {
+              const thenable: Thenable<mixed> = (thrownValue: any);
+              if (isThenableResolved(thenable)) {
                 // The data resolved. Try rendering the component again.
                 workInProgressSuspendedReason = NotSuspended;
                 workInProgressThrownValue = null;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -276,7 +276,7 @@ import {
   SuspenseException,
   getSuspendedThenable,
   getThenableStateAfterSuspending,
-  isThenableStateResolved,
+  isThenableResolved,
 } from './ReactFiberThenable.old';
 import {schedulePostPaintCallback} from './ReactPostPaintCallback';
 import {
@@ -2204,24 +2204,20 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
             break;
           }
           case SuspendedOnData: {
+            const thenable: Thenable<mixed> = (thrownValue: any);
             if (workInProgressSuspendedThenableState !== null) {
               const thenableState = workInProgressSuspendedThenableState;
-              if (isThenableStateResolved(thenableState)) {
+              if (isThenableResolved(thenable)) {
                 // The data resolved. Try rendering the component again.
                 workInProgressSuspendedReason = NotSuspended;
                 workInProgressThrownValue = null;
-                replaySuspendedUnitOfWork(
-                  unitOfWork,
-                  thrownValue,
-                  thenableState,
-                );
+                replaySuspendedUnitOfWork(unitOfWork, thenable, thenableState);
                 break;
               }
             }
 
             // The work loop is suspended on data. We should wait for it to
             // resolve before continuing to render.
-            const thenable: Thenable<mixed> = (workInProgressThrownValue: any);
             const onResolution = () => {
               ensureRootIsScheduled(root, now());
             };
@@ -2246,7 +2242,8 @@ function renderRootConcurrent(root: FiberRoot, lanes: Lanes) {
           default: {
             if (workInProgressSuspendedThenableState !== null) {
               const thenableState = workInProgressSuspendedThenableState;
-              if (isThenableStateResolved(thenableState)) {
+              const thenable: Thenable<mixed> = (thrownValue: any);
+              if (isThenableResolved(thenable)) {
                 // The data resolved. Try rendering the component again.
                 workInProgressSuspendedReason = NotSuspended;
                 workInProgressThrownValue = null;

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -181,6 +181,7 @@ import {requestCurrentTransition, NoTransition} from './ReactFiberTransition';
 import {
   SelectiveHydrationException,
   beginWork as originalBeginWork,
+  replayFunctionComponent,
 } from './ReactFiberBeginWork.old';
 import {completeWork} from './ReactFiberCompleteWork.old';
 import {unwindWork, unwindInterruptedWork} from './ReactFiberUnwindWork.old';
@@ -282,6 +283,7 @@ import {
   getSuspenseHandler,
   isBadSuspenseFallback,
 } from './ReactFiberSuspenseContext.old';
+import {resolveDefaultProps} from './ReactFiberLazyComponent.old';
 
 const ceil = Math.ceil;
 
@@ -2353,22 +2355,79 @@ function replaySuspendedUnitOfWork(
   // This is a fork of performUnitOfWork specifcally for replaying a fiber that
   // just suspended.
   //
-  // Instead of unwinding the stack and potentially showing a fallback, unwind
-  // only the last stack frame, reset the fiber, and try rendering it again.
   const current = unitOfWork.alternate;
-  resetSuspendedWorkLoopOnUnwind();
-  unwindInterruptedWork(current, unitOfWork, workInProgressRootRenderLanes);
-  unitOfWork = workInProgress = resetWorkInProgress(unitOfWork, renderLanes);
-
   setCurrentDebugFiberInDEV(unitOfWork);
 
   let next;
-  if (enableProfilerTimer && (unitOfWork.mode & ProfileMode) !== NoMode) {
+  setCurrentDebugFiberInDEV(unitOfWork);
+  const isProfilingMode =
+    enableProfilerTimer && (unitOfWork.mode & ProfileMode) !== NoMode;
+  if (isProfilingMode) {
     startProfilerTimer(unitOfWork);
-    next = beginWork(current, unitOfWork, renderLanes);
+  }
+  switch (unitOfWork.tag) {
+    case IndeterminateComponent: {
+      // Because it suspended with `use`, we can assume it's a
+      // function component.
+      unitOfWork.tag = FunctionComponent;
+      // Fallthrough to the next branch.
+    }
+    // eslint-disable-next-line no-fallthrough
+    case FunctionComponent:
+    case ForwardRef: {
+      // Resolve `defaultProps`. This logic is copied from `beginWork`.
+      // TODO: Consider moving this switch statement into that module. Also,
+      // could maybe use this as an opportunity to say `use` doesn't work with
+      // `defaultProps` :)
+      const Component = unitOfWork.type;
+      const unresolvedProps = unitOfWork.pendingProps;
+      const resolvedProps =
+        unitOfWork.elementType === Component
+          ? unresolvedProps
+          : resolveDefaultProps(Component, unresolvedProps);
+      next = replayFunctionComponent(
+        current,
+        unitOfWork,
+        resolvedProps,
+        Component,
+        thenableState,
+        workInProgressRootRenderLanes,
+      );
+      break;
+    }
+    case SimpleMemoComponent: {
+      const Component = unitOfWork.type;
+      const nextProps = unitOfWork.pendingProps;
+      next = replayFunctionComponent(
+        current,
+        unitOfWork,
+        nextProps,
+        Component,
+        thenableState,
+        workInProgressRootRenderLanes,
+      );
+      break;
+    }
+    default: {
+      if (__DEV__) {
+        console.error(
+          'Unexpected type of work: %s, Currently only function ' +
+            'components are replayed after suspending. This is a bug in React.',
+          unitOfWork.tag,
+        );
+      }
+      resetSuspendedWorkLoopOnUnwind();
+      unwindInterruptedWork(current, unitOfWork, workInProgressRootRenderLanes);
+      unitOfWork = workInProgress = resetWorkInProgress(
+        unitOfWork,
+        renderLanes,
+      );
+      next = beginWork(current, unitOfWork, renderLanes);
+      break;
+    }
+  }
+  if (isProfilingMode) {
     stopProfilerTimerIfRunningAndRecordDelta(unitOfWork, true);
-  } else {
-    next = beginWork(current, unitOfWork, renderLanes);
   }
 
   // The begin phase finished successfully without suspending. Reset the state

--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1071,7 +1071,9 @@ describe('ReactHooks', () => {
     expect(() => {
       expect(() => {
         ReactTestRenderer.create(<App />);
-      }).toThrow('Rendered more hooks than during the previous render.');
+      }).toThrow(
+        'Should have a queue. This is likely a bug in React. Please file an issue.',
+      );
     }).toErrorDev([
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -446,5 +446,6 @@
   "458": "Currently React only supports one RSC renderer at a time.",
   "459": "Expected a suspended thenable. This is a bug in React. Please file an issue.",
   "460": "Suspense Exception: This is not a real error! It's an implementation detail of `use` to interrupt the current render. You must either rethrow it immediately, or move the `use` call outside of the `try/catch` block. Capturing without rethrowing will lead to unexpected behavior.\n\nTo handle async errors, wrap your component in an error boundary, or call the promise's `.catch` method and pass the result to `use`",
-  "461": "This is not a real error. It's an implementation detail of React's selective hydration feature. If this leaks into userspace, it's a bug in React. Please file an issue."
+  "461": "This is not a real error. It's an implementation detail of React's selective hydration feature. If this leaks into userspace, it's a bug in React. Please file an issue.",
+  "462": "Unexpected SuspendedReason. This is a bug in React."
 }


### PR DESCRIPTION
## Based on #25632

When a component suspends, under some conditions, we can wait for the data to resolve and replay the component without unwinding the stack or showing a fallback in the interim. When we do this, we reuse the promises that were unwrapped during the previous attempts, so that if they aren't memoized, the result can still be used.

We should do the same for all hooks. That way, if you _do_ memoize an async function call with useMemo, it won't be called again during the replay. This effectively gives you a local version of the functionality provided by `cache`, using the normal memoization patterns that have long existed in React.