### PR TITLE
Refactor: replace argument with rest parameter

### DIFF
--- a/packages/react/src/ReactElement.js
+++ b/packages/react/src/ReactElement.js
@@ -359,7 +359,7 @@ export function jsxDEV(type, config, maybeKey, source, self) {
  * Create and return a new ReactElement of the given type.
  * See https://reactjs.org/docs/react-api.html#createelement
  */
-export function createElement(type, config, children) {
+export function createElement(type, config, ...children) {
   let propName;
 
   // Reserved names are extracted
@@ -400,14 +400,10 @@ export function createElement(type, config, children) {
 
   // Children can be more than one argument, and those are transferred onto
   // the newly allocated props object.
-  const childrenLength = arguments.length - 2;
-  if (childrenLength === 1) {
-    props.children = children;
-  } else if (childrenLength > 1) {
-    const childArray = Array(childrenLength);
-    for (let i = 0; i < childrenLength; i++) {
-      childArray[i] = arguments[i + 2];
-    }
+  if (children.length === 1) {
+    props.children = children[0];
+  } else if (children.length > 1) {
+    const childArray = [...children];
     if (__DEV__) {
       if (Object.freeze) {
         Object.freeze(childArray);


### PR DESCRIPTION
## Summary
The createElement function still **use Argument** to get children, which is not recommended, not good-looking, and myabe with performance issues(see https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments) **compared with rest parameter of ES6**.
So, I just replace Argument with rest parameter.
## How did you test this change?
**Firstly, I checked out the code of two version after build.**

The code before changed is:
```
export function createElement(type, config, children) {
...
  const childrenLength = arguments.length - 2;
  if (childrenLength === 1) {
    props.children = children;
  } else if (childrenLength > 1) {
    const childArray = Array(childrenLength);
    for (let i = 0; i < childrenLength; i++) {
      childArray[i] = arguments[i + 2];
    }
...
```
the operation of Argument looks complicated, after my changed it will look like this:
```
export function createElement(type, config, ...children) {
...
  if (children.length === 1) {
    props.children = children[0];
  } else if (children.length > 1) {
    const childArray = [...children];
...
```
which will look like this **after run yarn build**:
```
function createElement(type, config, children) {
...
  for (var _len = arguments.length, children = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
    children[_key - 2] = arguments[_key];
  }

  if (children.length === 1) {
    props.children = children[0];
  } else if (children.length > 1) {
    var childArray = [].concat(children);
...
```
same effect, but new code is more good-looking and brief.

**Secondly, I use yarn link to test the change in a new project with create-react-app。**
I delete codes of App.js, and add a explicit jsx creating by react.createElement(since After v17, jsx will not use createElement to babel default):
![微信图片_20221103155412](https://user-images.githubusercontent.com/75530249/199671031-a8f43879-11ba-4879-a652-1096305a6624.png)
it works:
![微信图片_20221103155757](https://user-images.githubusercontent.com/75530249/199671161-73bf3e1f-4786-4515-a62e-0a116de17b91.png)

