### PR TITLE
Remove check in renderDidSuspendDelayIfPossible

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.new.js
@@ -1926,13 +1926,7 @@ export function renderDidSuspend(): void {
 }
 
 export function renderDidSuspendDelayIfPossible(): void {
-  if (
-    workInProgressRootExitStatus === RootInProgress ||
-    workInProgressRootExitStatus === RootSuspended ||
-    workInProgressRootExitStatus === RootErrored
-  ) {
-    workInProgressRootExitStatus = RootSuspendedWithDelay;
-  }
+  workInProgressRootExitStatus = RootSuspendedWithDelay;
 
   // Check if there are updates that we skipped tree that might have unblocked
   // this render.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.old.js
@@ -1926,13 +1926,7 @@ export function renderDidSuspend(): void {
 }
 
 export function renderDidSuspendDelayIfPossible(): void {
-  if (
-    workInProgressRootExitStatus === RootInProgress ||
-    workInProgressRootExitStatus === RootSuspended ||
-    workInProgressRootExitStatus === RootErrored
-  ) {
-    workInProgressRootExitStatus = RootSuspendedWithDelay;
-  }
+  workInProgressRootExitStatus = RootSuspendedWithDelay;
 
   // Check if there are updates that we skipped tree that might have unblocked
   // this render.


### PR DESCRIPTION
I don't think we need this anymore. It was added originally because RootSuspended would take priority over RootSuspendedWithDelay. But we've since changed it: any "bad" fallback state is permitted to block a "good" fallback state.

The other status flags that this check used to account for are RootDidNotComplete and RootFatalErrored:

- RootFatalErrored is like an invariant violation, it means something went really wrong already and we can't recover from it
- RootCompleted and RootDidNotComplete are only set at the very end of the work loop, there's no way for renderDidSuspendDelayIfPossible to sneak in after that (at least none that I can think of — it's only called from the render phase)

So I think we can just delete this.

It's entirely possible there's some scenario I haven't considered, though, which is why I'm submitting this change as its own PR. To preserve the ability to bisect to it later.