### PR TITLE
Failing test for ignored `suppressHydrationWarning` using `hydrateRoot`

### DIFF
--- a/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
+++ b/packages/react-dom/src/__tests__/utils/ReactDOMServerIntegrationTestUtils.js
@@ -384,5 +384,7 @@ module.exports = function(initModules) {
     clientRenderOnServerString,
     renderIntoDom,
     streamRender,
+    ReactDOMServer,
+    ReactDOM,
   };
 };


### PR DESCRIPTION
Failing test for https://github.com/facebook/react/issues/25627

The question is whether we should  duplicate all `hydrate` tests to also test with `hydrateRoot` or "just" replace `hydrate` with `hydrateRoot`. And then check where `hydrateRoot` should behave differently than `hydrate`.

Looked through the React 18 WG and couldn't find mention of changed behavior for `suppressHydrationWarning`. https://github.com/facebook/react/issues/24270 makes it sound like `suppressHydrationWarning` should behave the same.