### PR TITLE
[DevTools] Support for Reload and Profile in React Native

### DIFF
--- a/packages/react-devtools-core/src/cachedSettings.js
+++ b/packages/react-devtools-core/src/cachedSettings.js
@@ -12,19 +12,30 @@ import {
   writeConsolePatchSettingsToWindow,
 } from 'react-devtools-shared/src/backend/console';
 import {castBool, castBrowserTheme} from 'react-devtools-shared/src/utils';
+import {sessionStorageSetItem} from 'react-devtools-shared/src/storage';
+import {
+  SESSION_STORAGE_RELOAD_AND_PROFILE_KEY,
+  SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY,
+} from 'react-devtools-shared/src/constants';
+import {setShouldInitiallyProfile} from 'react-devtools-shared/src/backend/agent';
 
 // Note: all keys should be optional in this type, because users can use newer
 // versions of React DevTools with older versions of React Native, and the object
 // provided by React Native may not include all of this type's fields.
 export type DevToolsSettingsManager = {
   getConsolePatchSettings: ?() => string,
-  setConsolePatchSettings: ?(key: string) => void,
+  setConsolePatchSettings: ?(settings: string) => void,
+
+  getProfilingSettings: ?() => string,
+  setProfilingSettings: ?(settings: string) => void,
+  reload: ?() => void,
 };
 
 export function initializeUsingCachedSettings(
   devToolsSettingsManager: DevToolsSettingsManager,
 ) {
   initializeConsolePatchSettings(devToolsSettingsManager);
+  initializeProfilingSettings(devToolsSettingsManager);
 }
 
 function initializeConsolePatchSettings(
@@ -74,4 +85,50 @@ export function cacheConsolePatchSettings(
     return;
   }
   devToolsSettingsManager.setConsolePatchSettings(JSON.stringify(value));
+}
+
+type ProfilingSettings = {
+  isReloadingAndProfiling: boolean,
+};
+
+function initializeProfilingSettings(
+  devToolsSettingsManager: DevToolsSettingsManager,
+): void {
+  if (devToolsSettingsManager.getProfilingSettings == null) {
+    return;
+  }
+
+  const profilingDataString = devToolsSettingsManager.getProfilingSettings();
+  const profilingData = parseProfilingSettings(profilingDataString);
+
+  if (profilingData.isReloadingAndProfiling) {
+    // For whatever reason, sessionStorage changes are not synchronously picked up in Agent
+    setShouldInitiallyProfile(true);
+    sessionStorageSetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY, true);
+    sessionStorageSetItem(SESSION_STORAGE_RECORD_CHANGE_DESCRIPTIONS_KEY, true);
+
+    cacheProfilingSettings(devToolsSettingsManager, {
+      isReloadingAndProfiling: false,
+    });
+  }
+}
+
+function parseProfilingSettings(
+  profilingDataString: string,
+): ProfilingSettings {
+  const parsedValue = JSON.parse(profilingDataString ?? '{}');
+  return {
+    isReloadingAndProfiling:
+      castBool(parsedValue.isReloadingAndProfiling) ?? false,
+  };
+}
+
+export function cacheProfilingSettings(
+  devToolsSettingsManager: DevToolsSettingsManager,
+  value: ProfilingSettings,
+): void {
+  if (devToolsSettingsManager.setProfilingSettings == null) {
+    return;
+  }
+  devToolsSettingsManager.setProfilingSettings(JSON.stringify(value));
 }

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -81,22 +81,6 @@ module.exports = {
       'process.env.LIGHT_MODE_DIMMED_ERROR_COLOR': `"${LIGHT_MODE_DIMMED_ERROR_COLOR}"`,
       'process.env.LIGHT_MODE_DIMMED_LOG_COLOR': `"${LIGHT_MODE_DIMMED_LOG_COLOR}"`,
     }),
-    {
-      apply: compiler => {
-        compiler.hooks.afterEmit.tap('AfterEmitPlugin', compilation => {
-          require('child_process').exec(
-            `
-            cp ~/react/packages/react-devtools-core/dist/backend.js ~/fbsource/xplat/js/public/node_modules/react-devtools-core/dist/
-          `,
-            (err, stdout, stderr) => {
-              if (stdout) process.stdout.write(stdout);
-              if (stderr) process.stderr.write(stderr);
-              console.log('DONe');
-            },
-          );
-        });
-      },
-    },
   ],
   optimization: {
     minimize: false,

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -81,6 +81,22 @@ module.exports = {
       'process.env.LIGHT_MODE_DIMMED_ERROR_COLOR': `"${LIGHT_MODE_DIMMED_ERROR_COLOR}"`,
       'process.env.LIGHT_MODE_DIMMED_LOG_COLOR': `"${LIGHT_MODE_DIMMED_LOG_COLOR}"`,
     }),
+    {
+      apply: compiler => {
+        compiler.hooks.afterEmit.tap('AfterEmitPlugin', compilation => {
+          require('child_process').exec(
+            `
+            cp ~/react/packages/react-devtools-core/dist/backend.js ~/fbsource/xplat/js/public/node_modules/react-devtools-core/dist/
+          `,
+            (err, stdout, stderr) => {
+              if (stdout) process.stdout.write(stdout);
+              if (stderr) process.stderr.write(stderr);
+              console.log('DONe');
+            },
+          );
+        });
+      },
+    },
   ],
   optimization: {
     minimize: false,

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -141,6 +141,11 @@ type PersistedSelection = {
   path: Array<PathFrame>,
 };
 
+let shouldInitiallyProfile = false;
+export const setShouldInitiallyProfile = (newShouldInitiallyProfile: bool): void => {
+  shouldInitiallyProfile = newShouldInitiallyProfile;
+};
+
 export default class Agent extends EventEmitter<{
   hideNativeHighlight: [],
   showNativeHighlight: [NativeType],
@@ -161,7 +166,10 @@ export default class Agent extends EventEmitter<{
     super();
 
     if (
-      sessionStorageGetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY) === 'true'
+      sessionStorageGetItem(SESSION_STORAGE_RELOAD_AND_PROFILE_KEY) ===
+        'true' ||
+      // sessionStorage is not synchronous in React Native, so we must rely on setShouldInitiallyProfile being called
+      shouldInitiallyProfile
     ) {
       this._recordChangeDescriptions =
         sessionStorageGetItem(

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -142,7 +142,9 @@ type PersistedSelection = {
 };
 
 let shouldInitiallyProfile = false;
-export const setShouldInitiallyProfile = (newShouldInitiallyProfile: bool): void => {
+export const setShouldInitiallyProfile = (
+  newShouldInitiallyProfile: boolean,
+): void => {
   shouldInitiallyProfile = newShouldInitiallyProfile;
 };
 

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -179,6 +179,7 @@ type SavedPreferencesParams = {
   hideConsoleLogsInStrictMode: boolean,
 };
 
+// Events emitted by the back-end and received by the front-end
 export type BackendEvents = {
   backendVersion: [string],
   bridgeProtocol: [BridgeProtocol],
@@ -194,6 +195,7 @@ export type BackendEvents = {
   profilingData: [ProfilingDataBackend],
   profilingStatus: [boolean],
   reloadAppForProfiling: [],
+  reloadAndProfileOverride: [],
   selectFiber: [number],
   shutdown: [],
   stopInspectingNative: [boolean],
@@ -208,6 +210,7 @@ export type BackendEvents = {
   NativeStyleEditor_styleAndLayout: [StyleAndLayoutPayload],
 };
 
+// Events emitted by the front-end and received by the back-end
 type FrontendEvents = {
   clearErrorsAndWarnings: [{rendererID: RendererID}],
   clearErrorsForFiberID: [ElementAndRendererID],

--- a/packages/react-devtools-shared/src/devtools/ProfilerStore.js
+++ b/packages/react-devtools-shared/src/devtools/ProfilerStore.js
@@ -190,6 +190,8 @@ export default class ProfilerStore extends EventEmitter<{
     // Wait for onProfilingStatus() to confirm the status has changed.
     // This ensures the frontend and backend are in sync wrt which commits were profiled.
     // We do this to avoid mismatches on e.g. CommitTreeBuilder that would cause errors.
+    //
+    // Instead, wait for the message 'profilingStatus'
   }
 
   stopProfiling(): void {
@@ -199,6 +201,8 @@ export default class ProfilerStore extends EventEmitter<{
     // Wait for onProfilingStatus() to confirm the status has changed.
     // This ensures the frontend and backend are in sync wrt which commits were profiled.
     // We do this to avoid mismatches on e.g. CommitTreeBuilder that would cause errors.
+    //
+    // Instead, wait for the message 'profilingStatus'
   }
 
   _takeProfilingSnapshotRecursive: (

--- a/packages/react-devtools-shared/src/devtools/store.js
+++ b/packages/react-devtools-shared/src/devtools/store.js
@@ -170,12 +170,14 @@ export default class Store extends EventEmitter<{
   // Renderer ID is needed to support inspection fiber props, state, and hooks.
   _rootIDToRendererID: Map<number, number> = new Map();
 
-  // These options may be initially set by a confiugraiton option when constructing the Store.
+  // These options may be initially set by a configuration option when constructing the Store.
   _supportsNativeInspection: boolean = true;
   _supportsProfiling: boolean = false;
   _supportsReloadAndProfile: boolean = false;
   _supportsTimeline: boolean = false;
   _supportsTraceUpdates: boolean = false;
+
+  _supportsReactNativeReloadAndProfile: boolean = false; // React Native sets this option if it supports reload and profile
 
   // These options default to false but may be updated as roots are added and removed.
   _rootSupportsBasicProfiling: boolean = false;
@@ -255,6 +257,9 @@ export default class Store extends EventEmitter<{
       'unsupportedRendererVersion',
       this.onBridgeUnsupportedRendererVersion,
     );
+    bridge.addListener('reloadAndProfileOverride', () => {
+      this._supportsReactNativeReloadAndProfile = true;
+    });
 
     this._profilerStore = new ProfilerStore(bridge, this, isProfiling);
 
@@ -448,7 +453,7 @@ export default class Store extends EventEmitter<{
   // This build of DevTools supports the legacy profiler.
   // This is a static flag, controled by the Store config.
   get supportsProfiling(): boolean {
-    return this._supportsProfiling;
+    return this._supportsProfiling || this._supportsReactNativeReloadAndProfile;
   }
 
   get supportsReloadAndProfile(): boolean {
@@ -456,9 +461,10 @@ export default class Store extends EventEmitter<{
     // And if so, can the backend use the localStorage API and sync XHR?
     // All of these are currently required for the reload-and-profile feature to work.
     return (
-      this._supportsReloadAndProfile &&
-      this._isBackendStorageAPISupported &&
-      this._isSynchronousXHRSupported
+      (this._supportsReloadAndProfile &&
+        this._isBackendStorageAPISupported &&
+        this._isSynchronousXHRSupported) ||
+      this._supportsReactNativeReloadAndProfile
     );
   }
 

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/Profiler.js
@@ -119,8 +119,8 @@ function Profiler(_: {}) {
       <div className={styles.Profiler}>
         <div className={styles.LeftColumn}>
           <div className={styles.Toolbar}>
-            <RecordToggle disabled={!supportsProfiling} />
-            <ReloadAndProfileButton disabled={!supportsProfiling} />
+            <RecordToggle />
+            <ReloadAndProfileButton />
             <ClearProfilingDataButton />
             <ProfilingImportExportButtons />
             <div className={styles.VRule} />

--- a/packages/react-devtools-shared/src/devtools/views/Profiler/RecordToggle.js
+++ b/packages/react-devtools-shared/src/devtools/views/Profiler/RecordToggle.js
@@ -12,20 +12,21 @@ import {useContext} from 'react';
 import Button from '../Button';
 import ButtonIcon from '../ButtonIcon';
 import {ProfilerContext} from './ProfilerContext';
+import {StoreContext} from '../context';
 
 import styles from './RecordToggle.css';
 
-export type Props = {
-  disabled?: boolean,
-};
+type Props = {};
 
-export default function RecordToggle({disabled}: Props): React.Node {
+export default function RecordToggle(_: Props): React.Node {
   const {isProfiling, startProfiling, stopProfiling} = useContext(
     ProfilerContext,
   );
 
+  const {supportsProfiling} = useContext(StoreContext);
+
   let className = styles.InactiveRecordToggle;
-  if (disabled) {
+  if (!supportsProfiling) {
     className = styles.DisabledRecordToggle;
   } else if (isProfiling) {
     className = styles.ActiveRecordToggle;
@@ -34,7 +35,7 @@ export default function RecordToggle({disabled}: Props): React.Node {
   return (
     <Button
       className={className}
-      disabled={disabled}
+      disabled={!supportsProfiling}
       onClick={isProfiling ? stopProfiling : startProfiling}
       testName="ProfilerToggleButton"
       title={isProfiling ? 'Stop profiling' : 'Start profiling'}>


### PR DESCRIPTION
## Summary

> Temporarily, ignore changes to two files (I will remove them when landing): `ReactDebugHooks.js` and `webpack.backend.js`

* Support reload and profile in React Native.
* Add fields to `cachedSettings` that allow DevTools to reload the app, setProfilingSettings, and getProfilingSettings
* Add a reloadAndProfile listener which: stores the fact that we're reloading and profiling and reloads the app
* On startup, if we are reloading and profiling, clear the reloading and profiling setting and start profiling.
* In order to actually start profiling, we set a field on an `initialProfileRef` object, because using `sessionStorageSetItem` is apparently not synchronous in React Native.
* The existing logic for determining whether we support reload and profile is a bit low level, so rather than dealing with refactoring that, I added a field `reloadAndProfileOverride` that the devtools backend sets. It would be ideal to refactor the Profiler context + store context + Profiler Store, but that thing is a mess with many sources of truth and I don't want to tackle that now.

## Known failure

* Occasionally, if the renderer is not setup correctly (????), one gets a ` ERROR  [Error: Could not find ID for Fiber "render()"]` error in Metro. This prevents profiling from starting (or something.)
* It is visible to the user, though, and (usually) restarting the app fixes things.

## How did you test this change?

* Manual testing with iOS + flipper/standalone.
* Will manually test with Android before landing, but the React Native changes for Android aren't done yet.