### PR TITLE
Fork updateSyncExternalStore impl in update and rerender

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -4122,7 +4122,11 @@ if (__DEV__) {
       currentHookNameInDev = 'useSyncExternalStore';
       warnInvalidHookAccess();
       updateHookTypesDev();
-      return updateSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+      return rerenderSyncExternalStore(
+        subscribe,
+        getSnapshot,
+        getServerSnapshot,
+      );
     },
     useId(): string {
       currentHookNameInDev = 'useId';


### PR DESCRIPTION


## Summary

Follow-up to https://github.com/facebook/react/pull/25578.

Applied the same pattern as used in  `useDeferredValue` implementations.

## How did you test this change?

- [x] `yarn test`
- [x] CI
