### PR TITLE
Fix: incorrect window.event check

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -382,7 +382,7 @@ export function createTextInstance(
 
 export function getCurrentEventPriority(): EventPriority {
   const currentEvent = window.event;
-  if (currentEvent === undefined) {
+  if (currentEvent === undefined || currentEvent === null) {
     return DefaultEventPriority;
   }
   return getEventPriority(currentEvent.type);


### PR DESCRIPTION
## Summary

The value of `window.event` in some cases can take the value `null`, which violates the logic of the code.

### Issues:
- #24778
- #25664

## How did you test this change?

Standard, recommended testing.