### PR TITLE
Test for double invoke effect of useLayoutEffect

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMRoot-test.js
@@ -119,6 +119,21 @@ describe('ReactDOMRoot', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it('double invokes useLayoutEffect in __DEV__', () => {
+    const callback = jest.fn();
+    const root = ReactDOMClient.createRoot(container, {
+      unstable_strictMode: true,
+    });
+    function Component() {
+      useLayoutEffect(callback);
+      return null;
+    }
+    act(() => {
+      root.render(<Component />);
+    });
+    expect(callback).toHaveBeenCalledTimes(__DEV__ ? 2 : 1);
+  });
+
   it('unmounts children', () => {
     const root = ReactDOMClient.createRoot(container);
     root.render(<div>Hi</div>);


### PR DESCRIPTION
This behavior has changed with 987292815c68be0fd5916d1f9b0d6c983e2db7ce. This seems like an unintentional bug fix to me, but wanted to add a test to make sure it's intentional.