### PR TITLE
Fixes #11369 adds support for valueAsDate attribute to input type='date' elements

### DIFF
--- a/fixtures/attribute-behavior/src/attributes.js
+++ b/fixtures/attribute-behavior/src/attributes.js
@@ -2096,6 +2096,12 @@ const attributes = [
     type: 'number',
     extraProps: {onChange() {}},
   },
+  {
+    name: 'valueAsDate',
+    tagName: 'input',
+    type: 'date',
+    extraProps: {onChange() {}},
+  },
   {name: 'value', tagName: 'textarea', extraProps: {onChange() {}}},
   {
     name: 'value',

--- a/packages/react-dom/src/shared/possibleStandardNames.js
+++ b/packages/react-dom/src/shared/possibleStandardNames.js
@@ -156,6 +156,7 @@ const possibleStandardNames = {
   type: 'type',
   usemap: 'useMap',
   value: 'value',
+  valueasdate, 'valueAsDate', 
   width: 'width',
   wmode: 'wmode',
   wrap: 'wrap',


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

`valueAsDate` is an attribute unique to `<input type="date">` that allows one to set the value of the input to a `Date` object and have the input interpret that value instead of trying to convert the date object to a localized string and risking converting improperly when passing dates to `value`.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

This was tested manually only so far. This is my first attempt to create a PR for mainline React. Of course I should add unit tests but still learning how to do so. This could be considered at the time of this writing a first draft.

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
