### PR TITLE
[Fix] properly track `useId` use in StrictMode in development

### DIFF
--- a/packages/react-reconciler/src/ReactFiberHooks.new.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.new.js
@@ -697,7 +697,6 @@ function renderWithHooksAgain<Props, SecondArg>(
   let children;
   do {
     didScheduleRenderPhaseUpdateDuringThisPass = false;
-    localIdCounter = 0;
     thenableIndexCounter = 0;
 
     if (numberOfReRenders >= RE_RENDER_LIMIT) {

--- a/packages/react-reconciler/src/ReactFiberHooks.old.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.old.js
@@ -697,7 +697,6 @@ function renderWithHooksAgain<Props, SecondArg>(
   let children;
   do {
     didScheduleRenderPhaseUpdateDuringThisPass = false;
-    localIdCounter = 0;
     thenableIndexCounter = 0;
 
     if (numberOfReRenders >= RE_RENDER_LIMIT) {


### PR DESCRIPTION
In `<StrictMode>` in dev hooks are run twice on each render.

For `useId` the re-render pass uses the `updateId` implementation rather than `mountId`. In the update path we don't increment the local id counter. This causes the render to look like no id was used which changes the tree context and leads to a different set of IDs being generated for subsequent calls to `useId` in the subtree.

This was discovered here: https://github.com/vercel/next.js/issues/43033

It was causing a hydration error because the ID generation no longer matched between server and client. When strict mode is off this does not happen because the hooks are only run once during hydration and it properly sees that the component did generate an ID.

The fix is to not reset the localIdCounter in `renderWithHooksAgain`. It gets reset anyway once the `renderWithHooks` is complete and since we do not re-mount the ID in the `...Again` pass we should retain the state from the initial pass.