### PR TITLE
chore: add cache for eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ chrome-user-data
 .vscode
 *.swp
 *.swo
+.eslintcache
 
 packages/react-devtools-core/dist
 packages/react-devtools-extensions/chrome/build

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "build-for-devtools-dev": "yarn build-for-devtools --type=NODE_DEV",
     "build-for-devtools-prod": "yarn build-for-devtools --type=NODE_PROD",
     "linc": "node ./scripts/tasks/linc.js",
-    "lint": "node ./scripts/tasks/eslint.js",
+    "lint": "node ./scripts/tasks/eslint.js --cache",
     "lint-build": "node ./scripts/rollup/validate/index.js",
     "extract-errors": "node scripts/error-codes/extract-errors.js",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json && node ./scripts/flow/createFlowConfigs.js && node ./scripts/yarn/downloadReactIsForPrettyFormat.js",


### PR DESCRIPTION
Store the info about processed files in order to only operate on the changed ones. The cache is stored in .eslintcache by default. Enabling this option can dramatically improve ESLint’s running time by ensuring that only changed files are linted.

**eslint cache can greatly reduce CI times**