### PR TITLE
useEffect and useLayoutEffect with Create/Update/Delete

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -172,8 +172,11 @@ function useCacheRefresh(): () => void {
 }
 
 function useLayoutEffect(
-  create: () => (() => void) | void,
-  inputs: Array<mixed> | void | null,
+  create: (() => {}) | (() => void) | void,
+  identity: Array<mixed> | void | null,
+  update: (({}) => void) | void,
+  updateDeps: Array<mixed> | void,
+  destroy: (({}) => void) | void,
 ): void {
   nextHook();
   hookLog.push({
@@ -196,8 +199,11 @@ function useInsertionEffect(
 }
 
 function useEffect(
-  create: () => (() => void) | void,
-  inputs: Array<mixed> | void | null,
+  create: (() => {}) | (() => void) | void,
+  identity: Array<mixed> | void | null,
+  update: (({}) => void) | void,
+  updateDeps: Array<mixed> | void,
+  destroy: (({}) => void) | void,
 ): void {
   nextHook();
   hookLog.push({primitive: 'Effect', stackError: new Error(), value: create});

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2060,7 +2060,8 @@ function updateEffectImpl(
       isIdentitySame = areHookInputsEqual(nextIdentityArray, prevIdentityArray);
 
       if (nextDeps !== null) {
-        const prevDeps = prevEffect.updateDeps != null ? prevEffect.updateDeps : null;
+        const prevDeps =
+          prevEffect.updateDeps != null ? prevEffect.updateDeps : null;
         if (isIdentitySame && areHookInputsEqual(nextDeps, prevDeps)) {
           hook.memoizedState = pushEffect(
             hookFlags,

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -376,8 +376,11 @@ export type Dispatcher = {
   useContext<T>(context: ReactContext<T>): T,
   useRef<T>(initialValue: T): {current: T},
   useEffect(
-    create: () => (() => void) | void,
-    deps: Array<mixed> | void | null,
+    create: (() => {}) | (() => void) | void,
+    identity: Array<mixed> | void | null,
+    update: (({}) => void) | void,
+    updateDeps: Array<mixed> | void,
+    destroy: (({}) => void) | void,
   ): void,
   useEffectEvent?: <Args, Return, F: (...Array<Args>) => Return>(
     callback: F,
@@ -387,8 +390,11 @@ export type Dispatcher = {
     deps: Array<mixed> | void | null,
   ): void,
   useLayoutEffect(
-    create: () => (() => void) | void,
-    deps: Array<mixed> | void | null,
+    create: (() => {}) | (() => void) | void,
+    identity: Array<mixed> | void | null,
+    update: (({}) => void) | void,
+    updateDeps: Array<mixed> | void,
+    destroy: (({}) => void) | void,
   ): void,
   useCallback<T>(callback: T, deps: Array<mixed> | void | null): T,
   useMemo<T>(nextCreate: () => T, deps: Array<mixed> | void | null): T,

--- a/packages/react-server/src/ReactFizzHooks.js
+++ b/packages/react-server/src/ReactFizzHooks.js
@@ -441,8 +441,11 @@ function useRef<T>(initialValue: T): {current: T} {
 }
 
 export function useLayoutEffect(
-  create: () => (() => void) | void,
-  inputs: Array<mixed> | void | null,
+  create: (() => {}) | (() => void) | void,
+  deps: Array<mixed> | void | null,
+  update: (({}) => void) | void,
+  dependencies: Array<mixed> | void,
+  destroy: (({}) => void) | void,
 ) {
   if (__DEV__) {
     currentHookNameInDev = 'useLayoutEffect';

--- a/packages/react/src/ReactHooks.js
+++ b/packages/react/src/ReactHooks.js
@@ -123,7 +123,7 @@ export function useEffect(
   deps: Array<mixed> | void | null,
 ): void {
   const dispatcher = resolveDispatcher();
-  return dispatcher.useEffect(create, deps);
+  return dispatcher.useEffect(...arguments);
 }
 
 export function useInsertionEffect(
@@ -139,7 +139,7 @@ export function useLayoutEffect(
   deps: Array<mixed> | void | null,
 ): void {
   const dispatcher = resolveDispatcher();
-  return dispatcher.useLayoutEffect(create, deps);
+  return dispatcher.useLayoutEffect(...arguments);
 }
 
 export function useCallback<T>(


### PR DESCRIPTION
Adds extension to useEffect and useLayoutEffect.
```js
useEffect(
  () => new Instance(id, options), // Create
  [id], // Dependency array for destroy/create. Or in other terms, identity array. In case identity changes, resource is destroyed and new one is created.
  (self) => self.setOptions(options), // Update
  [options], // Dependency array for updates.
  (self) => self.destroy() // Clean up
);
```
The extension makes it easier to write following pattern
```js
let ref = useRef(null);

useEffect(() => {
  ref.current = new Instance(id, options);
  return () => {
    ref.current.destroy();
    ref.current = null;
  };
  // Breaks exhaustive-deps lint rule.
}, [id]);

useEffect(() => {
  // Depending on implementation of `Resource`, need to prevent first call to `setOptions`.
  ref.current.setOptions(options);
}, [options]);

```

Left to do:
- [ ] useInsertionEffect does not have the extension.
- [ ] The error handling is not in place. We need to check return value of clean up and update functions. 
- [ ] Linting for dependency arrays.
- [ ] The extended version of effects does not have Flow type.
- [ ] Gate behind a feature flag.