### PR TITLE
📖 Small Fix - react-dom Tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -13,6 +13,7 @@ module.exports = {
     ],
     ['@babel/plugin-transform-template-literals', {loose: true}],
     '@babel/plugin-transform-literals',
+    '@babel/plugin-transform-classes',
     '@babel/plugin-transform-arrow-functions',
     '@babel/plugin-transform-block-scoped-functions',
     '@babel/plugin-transform-object-super',


### PR DESCRIPTION
## Summary

Node 18
Tests in React-DOM were failing with this: 
```
 FAIL  packages/react-dom/src/__tests__/ReactDOMInput-test.js
  ● Test suite failed to run

    SyntaxError: /Users/---/react/packages/react-dom/src/__tests__/ReactDOMInput-test.js: It's not possible to compile spread arguments in `super()` without compiling classes.
    Please add '@babel/plugin-transform-classes' to your Babel configuration. (This is an error on an internal node. Probably an internal error.)

      87 |         plugins.push(...getDevToolsPlugins(filePath));
      88 |       }
    > 89 |       return babel.transform(
         |                    ^
      90 |         src,
      91 |         Object.assign(
      92 |           {filename: path.relative(process.cwd(), filePath)},
```

I've added the '@babel/plugin-transform-classes' - which was already in package.json, just unused in babel config. Tests now succeed.

## How did you test this change?

For react-dom tests: 
- yarn test
- yarn test --prod

Output: 
```
Test Suites: 2 skipped, 109 passed, 109 of 111 total
Tests:       68 skipped, 3341 passed, 3409 total
Snapshots:   38 passed, 38 total
Time:        175.61 s
Ran all test suites matching /packages\/react-dom\/src\/__tests__\//i.
✨  Done in 177.70s.
```