### PR TITLE
Bug: Add null check for SharePoint IE11 compatibility in react-dom-binding getCurrentEventPriority

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -382,7 +382,7 @@ export function createTextInstance(
 
 export function getCurrentEventPriority(): EventPriority {
   const currentEvent = window.event;
-  if (currentEvent === undefined) {
+  if (currentEvent === undefined || currentEvent === null) {
     return DefaultEventPriority;
   }
   return getEventPriority(currentEvent.type);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn debug-test --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary
I came across a bug when making use of `useState` and `useReducer` in a clients react app when running it on a SharePoint 2013 on-prem site in IE11, which the client has listed as a compulsory supported browser for the web app.

The bug also exists on more modern versions of SharePoint on-prem, i.e. 2019.

I debugged and found that the `getCurrentEventPriority` function in react-dom-binding makes a check on the `window.event` object which according to MDN Web Docs:

> Outside the context of an event handler, the value is always undefined.

However, in IE11 it seems to always be `null` specifically for SharePoint sites. So I've added a null-check in extension of the undefined-check.

I haven't been able to find any other workaround.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
