### PR TITLE
Initial implementation of the Tracing Hooks API

### DIFF
--- a/packages/react-dom/src/client/ReactDOMLegacy.js
+++ b/packages/react-dom/src/client/ReactDOMLegacy.js
@@ -139,6 +139,7 @@ function legacyCreateRootFromDOMContainer(
       noopOnRecoverableError,
       // TODO(luna) Support hydration later
       null,
+      null, // tracingHooks
     );
     container._reactRootContainer = root;
     markContainerAsRoot(root.current, container);
@@ -174,6 +175,7 @@ function legacyCreateRootFromDOMContainer(
       '', // identifierPrefix
       noopOnRecoverableError, // onRecoverableError
       null, // transitionCallbacks
+      null, // tracingHooks
     );
     container._reactRootContainer = root;
     markContainerAsRoot(root.current, container);

--- a/packages/react-dom/src/client/ReactDOMRoot.js
+++ b/packages/react-dom/src/client/ReactDOMRoot.js
@@ -11,6 +11,7 @@ import type {MutableSource, ReactNodeList} from 'shared/ReactTypes';
 import type {
   FiberRoot,
   TransitionTracingCallbacks,
+  TracingHooks,
 } from 'react-reconciler/src/ReactInternalTypes';
 
 import ReactDOMSharedInternals from '../ReactDOMSharedInternals';
@@ -36,6 +37,7 @@ export type CreateRootOptions = {
   unstable_strictMode?: boolean,
   unstable_concurrentUpdatesByDefault?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  unstable_tracingHooks?: TracingHooks,
   identifierPrefix?: string,
   onRecoverableError?: (error: mixed) => void,
   ...
@@ -50,6 +52,7 @@ export type HydrateRootOptions = {
   unstable_strictMode?: boolean,
   unstable_concurrentUpdatesByDefault?: boolean,
   unstable_transitionCallbacks?: TransitionTracingCallbacks,
+  unstable_tracingHooks?: TracingHooks,
   identifierPrefix?: string,
   onRecoverableError?: (error: mixed) => void,
   ...
@@ -190,6 +193,7 @@ export function createRoot(
   let identifierPrefix = '';
   let onRecoverableError = defaultOnRecoverableError;
   let transitionCallbacks = null;
+  let tracingHooks = null;
 
   if (options !== null && options !== undefined) {
     if (__DEV__) {
@@ -231,6 +235,9 @@ export function createRoot(
     if (options.unstable_transitionCallbacks !== undefined) {
       transitionCallbacks = options.unstable_transitionCallbacks;
     }
+    if (options.unstable_tracingHooks !== undefined) {
+      tracingHooks = options.unstable_tracingHooks;
+    }
   }
 
   const root = createContainer(
@@ -242,6 +249,7 @@ export function createRoot(
     identifierPrefix,
     onRecoverableError,
     transitionCallbacks,
+    tracingHooks,
   );
   markContainerAsRoot(root.current, container);
 
@@ -301,6 +309,7 @@ export function hydrateRoot(
   let identifierPrefix = '';
   let onRecoverableError = defaultOnRecoverableError;
   let transitionCallbacks = null;
+  let tracingHooks = null;
   if (options !== null && options !== undefined) {
     if (options.unstable_strictMode === true) {
       isStrictMode = true;
@@ -320,6 +329,9 @@ export function hydrateRoot(
     if (options.unstable_transitionCallbacks !== undefined) {
       transitionCallbacks = options.unstable_transitionCallbacks;
     }
+    if (options.unstable_tracingHooks !== undefined) {
+      tracingHooks = options.unstable_tracingHooks;
+    }
   }
 
   const root = createHydrationContainer(
@@ -333,6 +345,7 @@ export function hydrateRoot(
     identifierPrefix,
     onRecoverableError,
     transitionCallbacks,
+    tracingHooks,
   );
   markContainerAsRoot(root.current, container);
   if (enableFloat) {

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -10,6 +10,7 @@
 import type {HostComponent} from './ReactNativeTypes';
 import type {ReactPortal, ReactNodeList} from 'shared/ReactTypes';
 import type {ElementRef, Element, ElementType} from 'react';
+import type {TracingHooks} from 'react-reconciler/src/ReactInternalTypes';
 
 import './ReactFabricInjection';
 
@@ -212,6 +213,7 @@ function render(
   containerTag: number,
   callback: ?() => void,
   concurrentRoot: ?boolean,
+  tracingHooks: ?TracingHooks,
 ): ?ElementRef<ElementType> {
   let root = roots.get(containerTag);
 
@@ -227,6 +229,7 @@ function render(
       '',
       onRecoverableError,
       null,
+      tracingHooks != null ? tracingHooks : null,
     );
     roots.set(containerTag, root);
   }

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -223,6 +223,7 @@ function render(
       '',
       onRecoverableError,
       null,
+      null,
     );
     roots.set(containerTag, root);
   }

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -192,6 +192,33 @@ export type ReactNativeType = {
   ...
 };
 
+export type TracingHooks = {
+  onCommitStarted?: () => void,
+  onCommitStopped?: () => void,
+  onComponentRenderStarted?: (componentName: ?string) => void,
+  onComponentRenderStopped?: () => void,
+  onComponentPassiveEffectMountStarted?: (componentName: ?string) => void,
+  onComponentPassiveEffectMountStopped?: () => void,
+  onComponentPassiveEffectUnmountStarted?: (componentName: ?string) => void,
+  onComponentPassiveEffectUnmountStopped?: () => void,
+  onComponentLayoutEffectMountStarted?: (componentName: ?string) => void,
+  onComponentLayoutEffectMountStopped?: () => void,
+  onComponentLayoutEffectUnmountStarted?: (componentName: ?string) => void,
+  onComponentLayoutEffectUnmountStopped?: () => void,
+  onComponentErrored?: (thrownValue: mixed) => void,
+  onComponentSuspended?: () => void,
+  onLayoutEffectsStarted?: () => void,
+  onLayoutEffectsStopped?: () => void,
+  onPassiveEffectsStarted?: () => void,
+  onPassiveEffectsStopped?: () => void,
+  onRenderStarted?: () => void,
+  onRenderYielded?: () => void,
+  onRenderStopped?: () => void,
+  onRenderScheduled?: () => void,
+  onForceUpdateScheduled?: (componentName: ?string) => void,
+  onStateUpdateScheduled?: (componentName: ?string) => void,
+};
+
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
@@ -213,6 +240,7 @@ export type ReactFabricType = {
     containerTag: number,
     callback: ?() => void,
     concurrentRoot: ?boolean,
+    tracingHooks: ?TracingHooks,
   ): ?ElementRef<ElementType>,
   unmountComponentAtNode(containerTag: number): void,
   ...

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -41,10 +41,14 @@ import type {TracingMarkerInstance} from './ReactFiberTracingMarkerComponent';
 
 import checkPropTypes from 'shared/checkPropTypes';
 import {
-  markComponentRenderStarted,
-  markComponentRenderStopped,
+  markComponentRenderStarted as markComponentRenderStartedInDevTools,
+  markComponentRenderStopped as markComponentRenderStoppedInDevTools,
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
+import {
+  markComponentRenderStarted as markComponentRenderStartedInTracingHooks,
+  markComponentRenderStopped as markComponentRenderStoppedInTracingHooks,
+} from './ReactFiberTracingHook';
 import {
   IndeterminateComponent,
   FunctionComponent,
@@ -103,6 +107,7 @@ import {
   enableLazyContextPropagation,
   enableSchedulingProfiler,
   enableTransitionTracing,
+  enableTracingHooks,
   enableLegacyHidden,
   enableCPUSuspense,
   enableUseMutableSource,
@@ -406,7 +411,13 @@ function updateForwardRef(
   let hasId;
   prepareToReadContext(workInProgress, renderLanes);
   if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
+    markComponentRenderStartedInDevTools(workInProgress);
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStartedInTracingHooks(
+      getWorkInProgressRoot(),
+      workInProgress,
+    );
   }
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
@@ -433,7 +444,10 @@ function updateForwardRef(
     hasId = checkDidRenderIdHook();
   }
   if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
+    markComponentRenderStoppedInDevTools();
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
   }
 
   if (current !== null && !didReceiveUpdate) {
@@ -1108,7 +1122,13 @@ function updateFunctionComponent(
   let hasId;
   prepareToReadContext(workInProgress, renderLanes);
   if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
+    markComponentRenderStartedInDevTools(workInProgress);
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStartedInTracingHooks(
+      getWorkInProgressRoot(),
+      workInProgress,
+    );
   }
   if (__DEV__) {
     ReactCurrentOwner.current = workInProgress;
@@ -1135,7 +1155,10 @@ function updateFunctionComponent(
     hasId = checkDidRenderIdHook();
   }
   if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
+    markComponentRenderStoppedInDevTools();
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
   }
 
   if (current !== null && !didReceiveUpdate) {
@@ -1172,7 +1195,13 @@ export function replayFunctionComponent(
 
   prepareToReadContext(workInProgress, renderLanes);
   if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
+    markComponentRenderStartedInDevTools(workInProgress);
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStartedInTracingHooks(
+      getWorkInProgressRoot(),
+      workInProgress,
+    );
   }
   const nextChildren = replaySuspendedComponentWithHooks(
     current,
@@ -1183,7 +1212,10 @@ export function replayFunctionComponent(
   );
   const hasId = checkDidRenderIdHook();
   if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
+    markComponentRenderStoppedInDevTools();
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
   }
 
   if (current !== null && !didReceiveUpdate) {
@@ -1362,7 +1394,13 @@ function finishClassComponent(
     }
   } else {
     if (enableSchedulingProfiler) {
-      markComponentRenderStarted(workInProgress);
+      markComponentRenderStartedInDevTools(workInProgress);
+    }
+    if (enableTracingHooks) {
+      markComponentRenderStartedInTracingHooks(
+        getWorkInProgressRoot(),
+        workInProgress,
+      );
     }
     if (__DEV__) {
       setIsRendering(true);
@@ -1383,7 +1421,10 @@ function finishClassComponent(
       nextChildren = instance.render();
     }
     if (enableSchedulingProfiler) {
-      markComponentRenderStopped();
+      markComponentRenderStoppedInDevTools();
+    }
+    if (enableTracingHooks) {
+      markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
     }
   }
 
@@ -1845,7 +1886,13 @@ function mountIndeterminateComponent(
   let hasId;
 
   if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
+    markComponentRenderStartedInDevTools(workInProgress);
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStartedInTracingHooks(
+      getWorkInProgressRoot(),
+      workInProgress,
+    );
   }
   if (__DEV__) {
     if (
@@ -1893,7 +1940,10 @@ function mountIndeterminateComponent(
     hasId = checkDidRenderIdHook();
   }
   if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
+    markComponentRenderStoppedInDevTools();
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
   }
 
   // React DevTools reads this flag.
@@ -3508,7 +3558,13 @@ function updateContextConsumer(
   prepareToReadContext(workInProgress, renderLanes);
   const newValue = readContext(context);
   if (enableSchedulingProfiler) {
-    markComponentRenderStarted(workInProgress);
+    markComponentRenderStartedInDevTools(workInProgress);
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStartedInTracingHooks(
+      getWorkInProgressRoot(),
+      workInProgress,
+    );
   }
   let newChildren;
   if (__DEV__) {
@@ -3520,7 +3576,10 @@ function updateContextConsumer(
     newChildren = render(newValue);
   }
   if (enableSchedulingProfiler) {
-    markComponentRenderStopped();
+    markComponentRenderStoppedInDevTools();
+  }
+  if (enableTracingHooks) {
+    markComponentRenderStoppedInTracingHooks(getWorkInProgressRoot());
   }
 
   // React DevTools reads this flag.

--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -23,6 +23,7 @@ import {
   disableLegacyContext,
   enableDebugTracing,
   enableSchedulingProfiler,
+  enableTracingHooks,
   warnAboutDeprecatedLifecycles,
   enableLazyContextPropagation,
 } from 'shared/ReactFeatureFlags';
@@ -72,10 +73,14 @@ import {
 } from './ReactFiberWorkLoop';
 import {logForceUpdateScheduled, logStateUpdateScheduled} from './DebugTracing';
 import {
-  markForceUpdateScheduled,
-  markStateUpdateScheduled,
+  markForceUpdateScheduled as markForceUpdateScheduledInDevTools,
+  markStateUpdateScheduled as markStateUpdateScheduledInDevTools,
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
+import {
+  markForceUpdateScheduled as markForceUpdateScheduledInTracingHooks,
+  markStateUpdateScheduled as markStateUpdateScheduledInTracingHooks,
+} from './ReactFiberTracingHook';
 
 const fakeInternalInstance = {};
 
@@ -224,7 +229,10 @@ const classComponentUpdater = {
     }
 
     if (enableSchedulingProfiler) {
-      markStateUpdateScheduled(fiber, lane);
+      markStateUpdateScheduledInDevTools(fiber, lane);
+    }
+    if (enableTracingHooks) {
+      markStateUpdateScheduledInTracingHooks(root, fiber);
     }
   },
   enqueueReplaceState(inst, payload, callback) {
@@ -259,7 +267,10 @@ const classComponentUpdater = {
     }
 
     if (enableSchedulingProfiler) {
-      markStateUpdateScheduled(fiber, lane);
+      markStateUpdateScheduledInDevTools(fiber, lane);
+    }
+    if (enableTracingHooks) {
+      markStateUpdateScheduledInTracingHooks(root, fiber);
     }
   },
   enqueueForceUpdate(inst, callback) {
@@ -293,7 +304,10 @@ const classComponentUpdater = {
     }
 
     if (enableSchedulingProfiler) {
-      markForceUpdateScheduled(fiber, lane);
+      markForceUpdateScheduledInDevTools(fiber, lane);
+    }
+    if (enableTracingHooks) {
+      markForceUpdateScheduledInTracingHooks(root, fiber);
     }
   },
 };

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -31,6 +31,7 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 import {
   enableDebugTracing,
   enableSchedulingProfiler,
+  enableTracingHooks,
   enableCache,
   enableUseRefAccessWarning,
   enableLazyContextPropagation,
@@ -122,9 +123,10 @@ import {
 } from './ReactMutableSource';
 import {logStateUpdateScheduled} from './DebugTracing';
 import {
-  markStateUpdateScheduled,
+  markStateUpdateScheduled as markStateUpdateScheduledInDevTools,
   setIsStrictModeForDevtools,
 } from './ReactFiberDevToolsHook';
+import {markStateUpdateScheduled as markStateUpdateScheduledInTracingHooks} from './ReactFiberTracingHook';
 import {createCache} from './ReactFiberCacheComponent';
 import {
   createUpdate as createLegacyQueueUpdate,
@@ -2747,7 +2749,10 @@ function markUpdateInDevTools<A>(fiber, lane, action: A): void {
   }
 
   if (enableSchedulingProfiler) {
-    markStateUpdateScheduled(fiber, lane);
+    markStateUpdateScheduledInDevTools(fiber, lane);
+  }
+  if (enableTracingHooks) {
+    markStateUpdateScheduledInTracingHooks(getWorkInProgressRoot(), fiber);
   }
 }
 

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -12,6 +12,7 @@ import type {
   FiberRoot,
   SuspenseHydrationCallbacks,
   TransitionTracingCallbacks,
+  TracingHooks,
 } from './ReactInternalTypes';
 import type {RootTag} from './ReactRootTags';
 import type {
@@ -254,6 +255,7 @@ export function createContainer(
   identifierPrefix: string,
   onRecoverableError: (error: mixed) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
+  tracingHooks: null | TracingHooks,
 ): OpaqueRoot {
   const hydrate = false;
   const initialChildren = null;
@@ -268,6 +270,7 @@ export function createContainer(
     identifierPrefix,
     onRecoverableError,
     transitionCallbacks,
+    tracingHooks,
   );
 }
 
@@ -283,6 +286,7 @@ export function createHydrationContainer(
   identifierPrefix: string,
   onRecoverableError: (error: mixed) => void,
   transitionCallbacks: null | TransitionTracingCallbacks,
+  tracingHooks: null | TracingHooks,
 ): OpaqueRoot {
   const hydrate = true;
   const root = createFiberRoot(
@@ -296,6 +300,7 @@ export function createHydrationContainer(
     identifierPrefix,
     onRecoverableError,
     transitionCallbacks,
+    tracingHooks,
   );
 
   // TODO: Move this to FiberRoot constructor

--- a/packages/react-reconciler/src/ReactFiberRoot.js
+++ b/packages/react-reconciler/src/ReactFiberRoot.js
@@ -10,6 +10,7 @@
 import type {ReactNodeList} from 'shared/ReactTypes';
 import type {
   FiberRoot,
+  TracingHooks,
   SuspenseHydrationCallbacks,
   TransitionTracingCallbacks,
 } from './ReactInternalTypes';
@@ -33,6 +34,7 @@ import {
   enableProfilerTimer,
   enableUpdaterTracking,
   enableTransitionTracing,
+  enableTracingHooks,
 } from 'shared/ReactFeatureFlags';
 import {initializeUpdateQueue} from './ReactFiberClassUpdateQueue';
 import {LegacyRoot, ConcurrentRoot} from './ReactRootTags';
@@ -143,6 +145,7 @@ export function createFiberRoot(
   identifierPrefix: string,
   onRecoverableError: null | ((error: mixed) => void),
   transitionCallbacks: null | TransitionTracingCallbacks,
+  tracingHooks: null | TracingHooks,
 ): FiberRoot {
   // $FlowFixMe[invalid-constructor] Flow no longer supports calling new on functions
   const root: FiberRoot = (new FiberRootNode(
@@ -158,6 +161,10 @@ export function createFiberRoot(
 
   if (enableTransitionTracing) {
     root.transitionCallbacks = transitionCallbacks;
+  }
+
+  if (enableTracingHooks) {
+    root.tracingHooks = tracingHooks;
   }
 
   // Cyclic construction. This cheats the type system right now because

--- a/packages/react-reconciler/src/ReactFiberTracingHook.js
+++ b/packages/react-reconciler/src/ReactFiberTracingHook.js
@@ -1,0 +1,346 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Fiber, FiberRoot} from './ReactInternalTypes';
+
+import {enableTracingHooks} from 'shared/ReactFeatureFlags';
+import getComponentNameFromFiber from './getComponentNameFromFiber';
+
+export function markCommitStarted(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onCommitStarted === 'function'
+    ) {
+      root.tracingHooks.onCommitStarted();
+    }
+  }
+}
+
+export function markCommitStopped(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onCommitStopped === 'function'
+    ) {
+      root.tracingHooks.onCommitStopped();
+    }
+  }
+}
+
+export function markComponentRenderStarted(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onComponentRenderStarted =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentRenderStarted === 'function'
+        ? root.tracingHooks.onComponentRenderStarted
+        : null;
+    if (onComponentRenderStarted != null) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onComponentRenderStarted(componentName);
+    }
+  }
+}
+
+export function markComponentRenderStopped(root: ?FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentRenderStopped === 'function'
+    ) {
+      root.tracingHooks.onComponentRenderStopped();
+    }
+  }
+}
+
+export function markComponentPassiveEffectMountStarted(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onComponentPassiveEffectMountStarted =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentPassiveEffectMountStarted ===
+        'function'
+        ? root.tracingHooks.onComponentPassiveEffectMountStarted
+        : null;
+    if (onComponentPassiveEffectMountStarted != null) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onComponentPassiveEffectMountStarted(componentName);
+    }
+  }
+}
+
+export function markComponentPassiveEffectMountStopped(root: ?FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentPassiveEffectMountStopped ===
+        'function'
+    ) {
+      root.tracingHooks.onComponentPassiveEffectMountStopped();
+    }
+  }
+}
+
+export function markComponentPassiveEffectUnmountStarted(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onComponentPassiveEffectUnmountStarted =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentPassiveEffectUnmountStarted ===
+        'function'
+        ? root.tracingHooks.onComponentPassiveEffectUnmountStarted
+        : null;
+    if (onComponentPassiveEffectUnmountStarted) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onComponentPassiveEffectUnmountStarted(componentName);
+    }
+  }
+}
+
+export function markComponentPassiveEffectUnmountStopped(
+  root: ?FiberRoot,
+): void {
+  if (enableTracingHooks) {
+    if (
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentPassiveEffectUnmountStopped ===
+        'function'
+    ) {
+      root.tracingHooks.onComponentPassiveEffectUnmountStopped();
+    }
+  }
+}
+
+export function markComponentLayoutEffectMountStarted(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onComponentLayoutEffectMountStarted =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentLayoutEffectMountStarted ===
+        'function'
+        ? root.tracingHooks.onComponentLayoutEffectMountStarted
+        : null;
+    if (onComponentLayoutEffectMountStarted) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onComponentLayoutEffectMountStarted(componentName);
+    }
+  }
+}
+
+export function markComponentLayoutEffectMountStopped(root: ?FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentLayoutEffectMountStopped ===
+        'function'
+    ) {
+      root.tracingHooks.onComponentLayoutEffectMountStopped();
+    }
+  }
+}
+
+export function markComponentLayoutEffectUnmountStarted(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onComponentLayoutEffectUnmountStarted =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentLayoutEffectUnmountStarted ===
+        'function'
+        ? root.tracingHooks.onComponentLayoutEffectUnmountStarted
+        : null;
+    if (onComponentLayoutEffectUnmountStarted) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onComponentLayoutEffectUnmountStarted(componentName);
+    }
+  }
+}
+
+export function markComponentLayoutEffectUnmountStopped(
+  root: ?FiberRoot,
+): void {
+  if (enableTracingHooks) {
+    if (
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentLayoutEffectUnmountStopped ===
+        'function'
+    ) {
+      root.tracingHooks.onComponentLayoutEffectUnmountStopped();
+    }
+  }
+}
+
+export function markComponentErrored(
+  root: FiberRoot,
+  thrownValue: mixed,
+): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentErrored === 'function'
+    ) {
+      root.tracingHooks.onComponentErrored(thrownValue);
+    }
+  }
+}
+
+export function markComponentSuspended(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onComponentSuspended === 'function'
+    ) {
+      root.tracingHooks.onComponentSuspended();
+    }
+  }
+}
+
+export function markLayoutEffectsStarted(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onLayoutEffectsStarted === 'function'
+    ) {
+      root.tracingHooks.onLayoutEffectsStarted();
+    }
+  }
+}
+
+export function markLayoutEffectsStopped(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onLayoutEffectsStopped === 'function'
+    ) {
+      root.tracingHooks.onLayoutEffectsStopped();
+    }
+  }
+}
+
+export function markPassiveEffectsStarted(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onPassiveEffectsStarted === 'function'
+    ) {
+      root.tracingHooks.onPassiveEffectsStarted();
+    }
+  }
+}
+
+export function markPassiveEffectsStopped(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onPassiveEffectsStopped === 'function'
+    ) {
+      root.tracingHooks.onPassiveEffectsStopped();
+    }
+  }
+}
+
+export function markRenderStarted(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onRenderStarted === 'function'
+    ) {
+      root.tracingHooks.onRenderStarted();
+    }
+  }
+}
+
+export function markRenderYielded(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onRenderYielded === 'function'
+    ) {
+      root.tracingHooks.onRenderYielded();
+    }
+  }
+}
+
+export function markRenderStopped(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onRenderStopped === 'function'
+    ) {
+      root.tracingHooks.onRenderStopped();
+    }
+  }
+}
+
+export function markRenderScheduled(root: FiberRoot): void {
+  if (enableTracingHooks) {
+    if (
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onRenderScheduled === 'function'
+    ) {
+      root.tracingHooks.onRenderScheduled();
+    }
+  }
+}
+
+export function markForceUpdateScheduled(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onForceUpdateScheduled =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onForceUpdateScheduled === 'function'
+        ? root.tracingHooks.onForceUpdateScheduled
+        : null;
+    if (onForceUpdateScheduled) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onForceUpdateScheduled(componentName);
+    }
+  }
+}
+
+export function markStateUpdateScheduled(
+  root: ?FiberRoot,
+  workInProgress: Fiber,
+): void {
+  if (enableTracingHooks) {
+    const onStateUpdateScheduled =
+      root &&
+      root.tracingHooks != null &&
+      typeof root.tracingHooks.onStateUpdateScheduled === 'function'
+        ? root.tracingHooks.onStateUpdateScheduled
+        : null;
+    if (onStateUpdateScheduled) {
+      const componentName = getComponentNameFromFiber(workInProgress);
+      onStateUpdateScheduled(componentName);
+    }
+  }
+}

--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -350,6 +350,38 @@ type TransitionTracingOnlyFiberRootProperties = {
   incompleteTransitions: Map<Transition, TracingMarkerInstance>,
 };
 
+export type TracingHooks = {
+  onCommitStarted?: () => void,
+  onCommitStopped?: () => void,
+  onComponentRenderStarted?: (componentName: ?string) => void,
+  onComponentRenderStopped?: () => void,
+  onComponentPassiveEffectMountStarted?: (componentName: ?string) => void,
+  onComponentPassiveEffectMountStopped?: () => void,
+  onComponentPassiveEffectUnmountStarted?: (componentName: ?string) => void,
+  onComponentPassiveEffectUnmountStopped?: () => void,
+  onComponentLayoutEffectMountStarted?: (componentName: ?string) => void,
+  onComponentLayoutEffectMountStopped?: () => void,
+  onComponentLayoutEffectUnmountStarted?: (componentName: ?string) => void,
+  onComponentLayoutEffectUnmountStopped?: () => void,
+  onComponentErrored?: (thrownValue: mixed) => void,
+  onComponentSuspended?: () => void,
+  onLayoutEffectsStarted?: () => void,
+  onLayoutEffectsStopped?: () => void,
+  onPassiveEffectsStarted?: () => void,
+  onPassiveEffectsStopped?: () => void,
+  onRenderStarted?: () => void,
+  onRenderYielded?: () => void,
+  onRenderStopped?: () => void,
+  onRenderScheduled?: () => void,
+  onForceUpdateScheduled?: (componentName: ?string) => void,
+  onStateUpdateScheduled?: (componentName: ?string) => void,
+};
+
+// The following fields are only used when tracing hooks are enabled.
+type TracingHooksOnlyFiberRootProperties = {
+  tracingHooks: null | TracingHooks,
+};
+
 // Exported FiberRoot type includes all properties,
 // To avoid requiring potentially error-prone :any casts throughout the project.
 // The types are defined separately within this file to ensure they stay in sync.
@@ -358,6 +390,7 @@ export type FiberRoot = {
   ...SuspenseCallbackOnlyFiberRootProperties,
   ...UpdaterTrackingOnlyFiberRootProperties,
   ...TransitionTracingOnlyFiberRootProperties,
+  ...TracingHooksOnlyFiberRootProperties,
   ...
 };
 

--- a/packages/react-test-renderer/src/ReactTestRenderer.js
+++ b/packages/react-test-renderer/src/ReactTestRenderer.js
@@ -504,6 +504,7 @@ function create(
     '',
     onRecoverableError,
     null,
+    null,
   );
 
   if (root == null) {

--- a/packages/shared/ReactFeatureFlags.js
+++ b/packages/shared/ReactFeatureFlags.js
@@ -267,3 +267,5 @@ export const consoleManagedByDevToolsDuringStrictMode = true;
 // components will encounter in production, especially when used With <Offscreen />.
 // TODO: clean up legacy <StrictMode /> once tests pass WWW.
 export const useModernStrictMode = false;
+
+export const enableTracingHooks = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb-dynamic.js
@@ -21,6 +21,7 @@ import typeof * as DynamicFlagsType from 'ReactNativeInternalFeatureFlags';
 // update the test configuration.
 
 export const enableUseRefAccessWarning = __VARIANT__;
+export const enableTracingHooks = __VARIANT__;
 
 // Flow magic to verify the exports of this file match the original version.
 ((((null: any): ExportsType): DynamicFlagsType): ExportsType);

--- a/packages/shared/forks/ReactFeatureFlags.native-fb.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-fb.js
@@ -17,7 +17,7 @@ import * as dynamicFlags from 'ReactNativeInternalFeatureFlags';
 
 // We destructure each value before re-exporting to avoid a dynamic look-up on
 // the exports object every time a flag is read.
-export const {enableUseRefAccessWarning} = dynamicFlags;
+export const {enableUseRefAccessWarning, enableTracingHooks} = dynamicFlags;
 
 // The rest of the flags are static for better dead code elimination.
 export const enableDebugTracing = false;

--- a/packages/shared/forks/ReactFeatureFlags.native-oss.js
+++ b/packages/shared/forks/ReactFeatureFlags.native-oss.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.native-oss';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableTracingHooks = false;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = __DEV__;
 export const warnAboutDeprecatedLifecycles = true;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableTracingHooks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.native.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.test-renderer';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableTracingHooks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.test-renderer.www.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.test-renderer.www';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableTracingHooks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.testing.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.testing';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = __PROFILE__;
+export const enableTracingHooks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = __PROFILE__;

--- a/packages/shared/forks/ReactFeatureFlags.testing.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.testing.www.js
@@ -13,6 +13,7 @@ import typeof * as ExportsType from './ReactFeatureFlags.testing.www';
 export const debugRenderPhaseSideEffectsForStrictMode = false;
 export const enableDebugTracing = false;
 export const enableSchedulingProfiler = false;
+export const enableTracingHooks = false;
 export const warnAboutDeprecatedLifecycles = true;
 export const replayFailedUnitOfWorkWithInvokeGuardedCallback = false;
 export const enableProfilerTimer = false;

--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -35,6 +35,7 @@ export const enableTransitionTracing = __VARIANT__;
 export const enableDebugTracing = __EXPERIMENTAL__;
 
 export const enableSchedulingProfiler = __VARIANT__;
+export const enableTracingHooks = false;
 
 // This only has an effect in the new reconciler. But also, the new reconciler
 // is only enabled when __VARIANT__ is true. So this is set to the opposite of

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -60,6 +60,8 @@ export const enableHostSingletons = true;
 export const enableSchedulingProfiler: boolean =
   __PROFILE__ && dynamicFeatureFlags.enableSchedulingProfiler;
 
+export const enableTracingHooks = false;
+
 // Note: we'll want to remove this when we to userland implementation.
 // For now, we'll turn it on for everyone because it's *already* on for everyone in practice.
 // At least this will let us stop shipping <Profiler> implementation to all users.

--- a/scripts/flow/xplat.js
+++ b/scripts/flow/xplat.js
@@ -9,4 +9,5 @@
 
 declare module 'ReactNativeInternalFeatureFlags' {
   declare export var enableUseRefAccessWarning: boolean;
+  declare export var enableTracingHooks: boolean;
 }


### PR DESCRIPTION
# Initial implementation of the Tracing Hooks API

## Summary

This PR creates a new API to inject hooks in React to log low-level events into application/system tracing tools in different platforms.

***Note**: the implementation of this version of the API was relatively simple, so I thought it would be clearer if I shared this proposal together with a potential implementation.*

### Motivation

Many of the platforms that React targets provide tooling for application or system-wide tracing, like Perfetto/Systrace on Android, OSSignposter/Instruments on iOS and the User Timing API on Web. These tools provide very detailed information about what different sub-systems are doing, which is very useful to analyze, monitor, test and optimize performance. Unfortunately, we don’t get this level of detail about the JavaScript thread or what React is doing.

React DevTools is a good tool for product engineers to analyze the performance of their React applications, but it has certain limitations that can be overcome by other types of tooling:

1. It’s a UI tool that needs to be used manually (no automation provided).
2. It doesn’t integrate information from other relevant systems/data sources (e.g.: network, CPU usage across threads, etc.).

The goal of this API is to provide an extension point in React so infrastructure engineers can build integrations with these tools.

### Alternatives considered

There are currently 2 public APIs for tracing/profiling in React, but they target different use cases and have important limitations for the use cases described in this proposal.

In the case of the [**Profiler API (Component)**](https://reactjs.org/docs/profiler.html):

1. It does not support real time reporting. All the data is collected by React and reported together when the work is complete. This doesn’t integrate well with most tracing systems (except for the User Timing API).
2. It doesn’t provide granular information about the work done at the component level or about the work done for different types of effects. Only timing for a specific subtree.

In the case of the new **Transition Tracing API** (which is still work-in-progress):

1. Like the React Profiler API, it does not report data in real time.
2. It only targets work done in the context of a transition, so we lose coverage for high priority updates and legacy application not using transitions.
3. The timing information it provides is, like in the case of the Profiler API, very high level.

We have also tried using the hook provided by React for DevTools (via `__REACT_DEVTOOLS_GLOBAL_HOOK__`), which provides all the features that we need but it’s a private API and also leaks internals from React (e.g.: provides fibers instead of component names). This is an example of that integration: https://gist.github.com/rubennorte/ffd3c301850e6e1746335e550910b851

This PR implements an equivalent to that API through a public interface. This integration would be equivalent to the previous one, but using that public API: https://gist.github.com/rubennorte/5d0d687d5fef5e08ee0ae8979e54ad3a

### Performance/size considerations

This API is fully gated behind a build-time flag, so it doesn’t have any impact for the platforms/build flavors where it’s not explicitly enabled.

When enabled, but no used, I expect a negligible overhead in runtime performance and a small impact on bundle size (1-2%). When used, the overhead from React should be negligible so all the overhead will come from the work that the injected hooks do. This API is meant to integrate with existing tracing tools that are already designed to have a very small overhead, so we expect this to continue being the case here.

For comparison, we tested the Devtools-based implementation of this feature, which has a significantly higher overhead than this new API, in production with real users, and we observed a very small impact on performance compared to the non-instrumented version.

### Addressing other potential concerns

* Doesn’t this expose too many implementation details from React?
    * All the hooks defined in this proposal reference semantics from React that are familiar for all developers (rendering components, suspending/erroring in a component, mounting/unmounting effects/layout effects, committing, etc.) and are very unlikely to change in the foreseeable future.
* Is this going to be hard to maintain?
    * The hooks aligned very well with those in React Devtools so can usually be refactored together. They also signal very specific lifecycle points in React that we probably want to fully understand after refactors all well, so moving the code to the right place is likely going to be easy.
* How are developers going to understand the data that this hook exposes?
    * This is actually a good point, and I think we need better documentation in React in general explaining how these things work in the framework so people can make better decisions for performance. This is already providing value for people and has a small learning curve, so it’s probably worth exploring this independently of whether better documentation about performance in React is available or not.
* I think this might make sense for React Native but maybe not for Web.
    * That might be a legit argument and we can test this in React Native first to validate the API before we roll it out in more platforms.

## How did you test this change?

When we get this PR in a “mergable” state, I’ll add exhaustive unit tests for the new features.

At Meta, we’ve been using the DevTools-based implementation (https://gist.github.com/rubennorte/ffd3c301850e6e1746335e550910b851) for some time and has been extremely useful to analyze performance in React Native, especially for the optimization of complex products with very ambitious performance goals and the rollout of new features like Concurrent Root and pre-rendering.

This is an example of how that integration looks like:

<img width="1935" alt="Screen Shot 2022-12-09 at 17 16 17" src="https://user-images.githubusercontent.com/117921/206763629-97be1e0b-50e4-4b31-9bee-0015e6e8ae43.png">
<img width="1037" alt="Screen Shot 2022-12-09 at 17 17 23" src="https://user-images.githubusercontent.com/117921/206763637-eb4b3b79-18c1-4070-a4e6-149dafd9ca50.png">

As you can see, we can see what React is doing together with the work that Fabric is doing in the background thread (layout) and in the main thread. This is also a small subset of everything displayed on that trace (like specific events that we can use to align the timeline, screenshots/video, etc.).

I’ve also tested this implementation, doing a manual sync of the React code to React Native and migrating the Devtools-based implementation to this public API. The results are very similar (with better coverage for component names, as we now use the React version that understand all types of components).


