### PR TITLE
Platform function refactoring 🔨 

### DIFF
--- a/packages/dom-event-testing-library/domEnvironment.js
+++ b/packages/dom-event-testing-library/domEnvironment.js
@@ -43,25 +43,19 @@ export function setPointerEvent(bool) {
 const platformGetter = jest.spyOn(global.navigator, 'platform', 'get');
 
 export const platform = {
-  clear() {
-    platformGetter.mockClear();
-  },
-  get() {
-    return global.navigator.platform === 'MacIntel' ? 'mac' : 'windows';
-  },
-  set(name: 'mac' | 'windows') {
+  clear: () => platformGetter.mockClear(),
+  get: () => global.navigator.platform === 'MacIntel' ? 'mac' : 'windows',
+  set: (name: 'mac' | 'windows') => {
     switch (name) {
-      case 'mac': {
+      case 'mac':
         platformGetter.mockReturnValue('MacIntel');
         break;
-      }
-      case 'windows': {
+      case 'windows':
         platformGetter.mockReturnValue('Win32');
         break;
-      }
-      default: {
+      default:
         break;
-      }
     }
   },
 };
+


### PR DESCRIPTION
I did the same using a shorter construct in the set() function Also, I thought that if a function has no return value, there would be no need to use the return statement ⚒️ 