### PR TITLE
[DiffTrain] Use original commit message

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -146,7 +146,10 @@ jobs:
       - name: Commit changes to branch
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Build for ${{ github.sha }}
+          commit_message: |
+            ${{ github.event.head_commit.message }}
+
+            DiffTrain build for `${{ github.sha }}`
           branch: builds/facebook-www
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com


### PR DESCRIPTION
Instead of the current commit message (which just shows "Build for
<sha>", re-use the commit message from the origin commit instead.