### PR TITLE
[DiffTrain] Strip @license from files

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -99,6 +99,12 @@ jobs:
             } else {
               process.exitCode = 1;
             }
+      - name: Strip @license from eslint plugin and react-refresh
+        run: |
+          sed -i -e 's/ @license React*//' \
+            build/oss-stable/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js
+          sed -i -e 's/ @license React*//' \
+            build/oss-stable/react-refresh/cjs/react-refresh-babel.development.js
       - name: Move relevant files into compiled
         run: |
           mkdir -p ./compiled

--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -102,8 +102,7 @@ jobs:
       - name: Strip @license from eslint plugin and react-refresh
         run: |
           sed -i -e 's/ @license React*//' \
-            build/oss-stable/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js
-          sed -i -e 's/ @license React*//' \
+            build/oss-stable/eslint-plugin-react-hooks/cjs/eslint-plugin-react-hooks.development.js \
             build/oss-stable/react-refresh/cjs/react-refresh-babel.development.js
       - name: Move relevant files into compiled
         run: |


### PR DESCRIPTION
We need to remove this for some internal tests. This was previously in our upgrade script so adding it back here for parity.

Test plan: files were updated correctly [[1]](https://github.com/facebook/react/commit/1704bbb8268345bf7aa405101313b3639e03e221#diff-80b968e05ce2ceeff6e17c938dc722aff2c1c660f8ef402e6664bc5b2cafa5fbL2) [[2]](https://github.com/facebook/react/commit/1704bbb8268345bf7aa405101313b3639e03e221#diff-6ecd07a61c8e0e28793dace3f9f62751e4808de9c2965aa1ddeb0157f3c9b4ecL2)