### PR TITLE
[DiffTrain] Add REVISION and REVISION_TRANSFORM to output

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -129,6 +129,10 @@ jobs:
             ./compiled/babel-plugin-react-refresh/index.js
 
           ls -R ./compiled
+      - name: Add REVISION files
+        run: |
+          echo ${{ github.sha }} >> ./compiled/facebook-www/REVISION
+          cp ./compiled/facebook-www/REVISION ./compiled/facebook-www/REVISION_TRANSFORMS
       - uses: actions/upload-artifact@v3
         with:
           name: compiled


### PR DESCRIPTION
We use these for the sync script, so to preserve option value let's continue adding these files so the script can still be used for arbitrary commits.