### PR TITLE
[react-www] remove forked bundle

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -46,7 +46,6 @@ const CRITICAL_ARTIFACT_PATHS = new Set([
   'oss-experimental/react-dom/cjs/react-dom.production.min.js',
   'facebook-www/ReactDOM-prod.classic.js',
   'facebook-www/ReactDOM-prod.modern.js',
-  'facebook-www/ReactDOMForked-prod.classic.js',
 ]);
 
 const kilobyteFormatter = new Intl.NumberFormat('en', {

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -163,17 +163,6 @@ const bundles = [
     externals: ['react'],
   },
 
-  /******* React DOM - www - Uses forked reconciler *******/
-  {
-    moduleType: RENDERER,
-    bundleTypes: [FB_WWW_DEV, FB_WWW_PROD, FB_WWW_PROFILING],
-    entry: 'react-dom',
-    global: 'ReactDOMForked',
-    minifyWithProdErrorCodes: true,
-    wrapWithModuleBoundaries: true,
-    externals: ['react'],
-  },
-
   /******* Test Utils *******/
   {
     moduleType: RENDERER_UTILS,


### PR DESCRIPTION
The `enableNewReconciler` was gone with 420f0b7fa1fcc609fc7b438c4599d0f76fab4bc0, this removes the bundle config.
