### PR TITLE
fix tests for when float is off

### DIFF
--- a/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMFloatServer.js
@@ -202,7 +202,7 @@ export function setCurrentlyRenderingBoundaryResourcesTarget(
   resources.boundaryResources = boundaryResources;
 }
 
-export const ReactDOMServerDispatcher = {
+export const ReactDOMServerFloatDispatcher = {
   preload,
   preinit,
 };

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -97,6 +97,7 @@ export function prepareToRender(resources: Resources): mixed {
   prepareToRenderResources(resources);
 
   const previousHostDispatcher = ReactDOMCurrentDispatcher.current;
+  ReactDOMCurrentDispatcher.current = ReactDOMServerDispatcher;
   return previousHostDispatcher;
 }
 

--- a/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
+++ b/packages/react-dom-bindings/src/server/ReactDOMServerFormatConfig.js
@@ -69,7 +69,7 @@ import {
   resourcesFromElement,
   resourcesFromLink,
   resourcesFromScript,
-  ReactDOMServerDispatcher,
+  ReactDOMServerFloatDispatcher,
 } from './ReactDOMFloatServer';
 export {
   createResources,
@@ -89,11 +89,14 @@ import {
 import ReactDOMSharedInternals from 'shared/ReactDOMSharedInternals';
 const ReactDOMCurrentDispatcher = ReactDOMSharedInternals.Dispatcher;
 
+const ReactDOMServerDispatcher = enableFloat
+  ? ReactDOMServerFloatDispatcher
+  : {};
+
 export function prepareToRender(resources: Resources): mixed {
   prepareToRenderResources(resources);
 
   const previousHostDispatcher = ReactDOMCurrentDispatcher.current;
-  ReactDOMCurrentDispatcher.current = ReactDOMServerDispatcher;
   return previousHostDispatcher;
 }
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -608,6 +608,7 @@ describe('ReactDOMFloat', () => {
     ]);
   });
 
+  // @gate enableFloat
   it('dedupes if the external runtime is explicitly loaded using preinit', async () => {
     const unstable_externalRuntimeSrc = 'src-of-external-runtime';
     function App() {
@@ -5681,7 +5682,6 @@ describe('ReactDOMFloat', () => {
       );
     });
 
-    // @gate enableFloat
     it('should not treat title descendants of svg into resources', async () => {
       await actIntoEmptyDocument(() => {
         const {pipe} = renderToPipeableStream(

--- a/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMSingletonComponents-test.js
@@ -116,7 +116,7 @@ describe('ReactDOM HostSingleton', () => {
       : children;
   }
 
-  // @gate enableHostSingletons
+  // @gate enableHostSingletons && enableFloat
   it('warns if you render the same singleton twice at the same time', async () => {
     const root = ReactDOMClient.createRoot(document);
     root.render(
@@ -201,7 +201,7 @@ describe('ReactDOM HostSingleton', () => {
     );
   });
 
-  // @gate enableHostSingletons
+  // @gate enableHostSingletons && enableFloat
   it('renders into html, head, and body persistently so the node identities never change and extraneous styles are retained', async () => {
     gate(flags => {
       if (flags.enableHostSingletons !== true) {


### PR DESCRIPTION
Some tests fail when float is off but when singletons are on. This PR makes some adjustments

1. 2 singleton tests assert float semantics so will fail.
2. the float dispatcher was being set on the server even when float was off. while the float calls didn't do anything warnings were still generated. Instead we provide an empty object for the dispatcher if float is off. Longer term the dispatcher should move to formatconfig and just reference the float methods if the flag is on
3. some external fizz runtime tests did not gate against float but should have