### PR TITLE
[DiffTrain] Add github url for the commit to the commit message

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -158,7 +158,8 @@ jobs:
           commit_message: |
             ${{ github.event.head_commit.message }}
 
-            DiffTrain build for `${{ github.sha }}`
+            DiffTrain build for [${{ github.sha }}](https://github.com/facebook/react/commit/${{ github.sha }})
+            [View git log for this commit](https://github.com/facebook/react/commits/${{ github.sha }})
           branch: builds/facebook-www
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com


### PR DESCRIPTION
Currently we just append the ref for the commit, let's make it clickable for easier debugging in syncs.