### PR TITLE
[DiffTrain] Only generate one REVISION file

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -129,10 +129,9 @@ jobs:
             ./compiled/babel-plugin-react-refresh/index.js
 
           ls -R ./compiled
-      - name: Add REVISION files
+      - name: Add REVISION file
         run: |
           echo ${{ github.sha }} >> ./compiled/facebook-www/REVISION
-          cp ./compiled/facebook-www/REVISION ./compiled/facebook-www/REVISION_TRANSFORMS
       - uses: actions/upload-artifact@v3
         with:
           name: compiled


### PR DESCRIPTION
Since we're always syncing everything now, only one of these is needed.
I'll open an internal diff to update the sync script after this one is
synced.