### PR TITLE
Remove vestigial Suspense batching logic

### DIFF
--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1300,16 +1300,6 @@ function finishConcurrentRender(root, exitStatus, lanes) {
             // There's additional work on this root.
             break;
           }
-          const suspendedLanes = root.suspendedLanes;
-          if (!isSubsetOfLanes(suspendedLanes, lanes)) {
-            // We should prefer to render the fallback of at the last
-            // suspended level. Ping the last suspended level to try
-            // rendering it again.
-            // FIXME: What if the suspended lanes are Idle? Should not restart.
-            const eventTime = requestEventTime();
-            markRootPinged(root, suspendedLanes, eventTime);
-            break;
-          }
 
           // The render is suspended, it hasn't timed out, and there's no
           // lower priority work to do. Instead of committing the fallback


### PR DESCRIPTION
This code was originally added in the old ExpirationTime implementation of Suspense. The idea is that if multiple updates suspend inside the same Suspense boundary, and both of them resolve, we should render both results in the same batch, to reduce jank.

This was an incomplete idea, though. We later discovered a stronger requirement — once we show a fallback, we cannot fill in that fallback without completing _all_ the updates that were previously skipped over. Otherwise you get tearing. This was fixed by #18411, then we discovered additional related flaws that were addressed in #24685. See  those PR descriptions for additional context.

So I believe this older code is no longer necessary.