### PR TITLE
Upgrade to Flow 0.196.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.191.0",
+    "flow-bin": "^0.192.0",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.194.0",
+    "flow-bin": "^0.195.0",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.190.0",
+    "flow-bin": "^0.191.0",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.192.0",
+    "flow-bin": "^0.193.0",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.195.0",
+    "flow-bin": "^0.196.3",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-react-internal": "link:./scripts/eslint-rules",
     "fbjs-scripts": "1.2.0",
     "filesize": "^6.0.1",
-    "flow-bin": "^0.193.0",
+    "flow-bin": "^0.194.0",
     "flow-remove-types": "^2.196.1",
     "glob": "^7.1.6",
     "glob-stream": "^6.1.0",

--- a/packages/react-devtools-shared/src/backend/renderer.js
+++ b/packages/react-devtools-shared/src/backend/renderer.js
@@ -3271,6 +3271,7 @@ export function attach(
       for (const method in console) {
         try {
           originalConsoleMethods[method] = console[method];
+          // $FlowFixMe[prop-missing]
           console[method] = () => {};
         } catch (error) {}
       }
@@ -3285,6 +3286,7 @@ export function attach(
         // Restore original console functionality.
         for (const method in originalConsoleMethods) {
           try {
+            // $FlowFixMe[prop-missing]
             console[method] = originalConsoleMethods[method];
           } catch (error) {}
         }

--- a/packages/react-devtools-shared/src/hydration.js
+++ b/packages/react-devtools-shared/src/hydration.js
@@ -248,6 +248,7 @@ export function dehydrate(
         // Other types (e.g. typed arrays, Sets) will not spread correctly.
         Array.from(data).forEach(
           (item, i) =>
+            // $FlowFixMe[prop-missing] Unserializable doesn't have an index signature
             (unserializableValue[i] = dehydrate(
               item,
               cleaned,

--- a/packages/react-devtools-shell/src/app/console.js
+++ b/packages/react-devtools-shell/src/app/console.js
@@ -11,6 +11,7 @@ function ignoreStrings(
   methodName: string,
   stringsToIgnore: Array<string>,
 ): void {
+  // $FlowFixMe[prop-missing] index access only allowed for objects with index keys
   console[methodName] = (...args) => {
     const maybeString = args[0];
     if (typeof maybeString === 'string') {

--- a/packages/react-reconciler/src/ReactFiberAct.js
+++ b/packages/react-reconciler/src/ReactFiberAct.js
@@ -23,9 +23,10 @@ export function isLegacyActEnvironment(fiber: Fiber): boolean {
     // to false.
 
     const isReactActEnvironmentGlobal =
-      // $FlowFixMe – Flow doesn't know about IS_REACT_ACT_ENVIRONMENT global
+      // $FlowFixMe[cannot-resolve-name] Flow doesn't know about IS_REACT_ACT_ENVIRONMENT global
       typeof IS_REACT_ACT_ENVIRONMENT !== 'undefined'
-        ? IS_REACT_ACT_ENVIRONMENT
+        ? // $FlowFixMe[cannot-resolve-name]
+          IS_REACT_ACT_ENVIRONMENT
         : undefined;
 
     // $FlowFixMe - Flow doesn't know about jest
@@ -40,8 +41,10 @@ export function isLegacyActEnvironment(fiber: Fiber): boolean {
 export function isConcurrentActEnvironment(): void | boolean {
   if (__DEV__) {
     const isReactActEnvironmentGlobal =
+      // $FlowFixMe[cannot-resolve-name] Flow doesn't know about IS_REACT_ACT_ENVIRONMENT global
       typeof IS_REACT_ACT_ENVIRONMENT !== 'undefined'
-        ? IS_REACT_ACT_ENVIRONMENT
+        ? // $FlowFixMe[cannot-resolve-name]
+          IS_REACT_ACT_ENVIRONMENT
         : undefined;
 
     if (!isReactActEnvironmentGlobal && ReactCurrentActQueue.current !== null) {

--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -67,7 +67,7 @@ export const MountPassiveDev = /*              */ 0b100000000000000000000000000;
 // Groups of flags that are used in the commit phase to skip over trees that
 // don't contain effects, by checking subtreeFlags.
 
-export const BeforeMutationMask =
+export const BeforeMutationMask: number =
   // TODO: Remove Update flag from before mutation phase by re-landing Visibility
   // flag logic (see #20043)
   Update |

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -48,4 +48,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.194.0
+^0.195.0

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -48,4 +48,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.192.0
+^0.193.0

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -48,4 +48,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.193.0
+^0.194.0

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -43,11 +43,10 @@ untyped-type-import=error
 %CI_MAX_WORKERS%
 exact_by_default=true
 munge_underscores=false
-enforce_local_inference_annotations=true
 exact_empty_objects=true
 
 # Substituted by createFlowConfig.js:
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.190.0
+^0.191.0

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -48,4 +48,4 @@ munge_underscores=false
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.195.0
+^0.196.3

--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -43,10 +43,9 @@ untyped-type-import=error
 %CI_MAX_WORKERS%
 exact_by_default=true
 munge_underscores=false
-exact_empty_objects=true
 
 # Substituted by createFlowConfig.js:
 %REACT_RENDERER_FLOW_OPTIONS%
 
 [version]
-^0.191.0
+^0.192.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.194.0:
-  version "0.194.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.194.0.tgz#5c55d8fb4c10b3a434100a88e986109743afcbb8"
-  integrity sha512-gJ54JmNXkl9ga3vt2Lx9tFQCuIid1+161dWGdr0bJ/CKW8tVCWxApE/j/1eZo31uVAUNVCY5UTs2gnnAm1hVkQ==
+flow-bin@^0.195.0:
+  version "0.195.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.2.tgz#373b3e0a8bc3a8e5df510365419fd7d3904e6a5a"
+  integrity sha512-GKwUBzIjpiJEspa0xPMlqz+8z25qg9Xx2SJFHwYrvMlR7JhSHTMoP4zEpwnY8qmBEH8NE+sw5rA/jRLJoEJeCg==
 
 flow-parser@^0.196.1:
   version "0.196.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.191.0:
-  version "0.191.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.191.0.tgz#9324c9498584b60575fd8d77a2897ee4f384443b"
-  integrity sha512-IhaDGoOtRDdGUJLjm7KQlHK8BAzOVJmpx+CIR6bCju4pF7zon2v7WNrds5706WZqDE3rD2c8cM4GdhDnIFYXtg==
+flow-bin@^0.192.0:
+  version "0.192.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.192.0.tgz#a1d75fb955b3980b23cff43577044c52f5d95d33"
+  integrity sha512-RlHhXn9m1IRTB5yKhnLGgLWq9z4qJ76slum/DXvmTlrAUPaVcmU/IsTHiY4JpjqK7nFz4oyrnU/YES8xDVBoZg==
 
 flow-parser@^0.196.1:
   version "0.196.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.190.0:
-  version "0.190.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.190.0.tgz#cfc50e1474facf8150232a6c498fe66a6bb75969"
-  integrity sha512-Qo3bvN3cmGFXsq63ZxcHFZXQDvgx84fCuq8cXuKk5xbvuebBGwMqS+ku/rH+gEkciRrcTYrXqoSzb9b6ShcoJg==
+flow-bin@^0.191.0:
+  version "0.191.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.191.0.tgz#9324c9498584b60575fd8d77a2897ee4f384443b"
+  integrity sha512-IhaDGoOtRDdGUJLjm7KQlHK8BAzOVJmpx+CIR6bCju4pF7zon2v7WNrds5706WZqDE3rD2c8cM4GdhDnIFYXtg==
 
 flow-parser@^0.196.1:
   version "0.196.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.192.0:
-  version "0.192.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.192.0.tgz#a1d75fb955b3980b23cff43577044c52f5d95d33"
-  integrity sha512-RlHhXn9m1IRTB5yKhnLGgLWq9z4qJ76slum/DXvmTlrAUPaVcmU/IsTHiY4JpjqK7nFz4oyrnU/YES8xDVBoZg==
+flow-bin@^0.193.0:
+  version "0.193.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.193.0.tgz#250df37ec2d209dbf6dbec654e06d9e48da72ccb"
+  integrity sha512-DREsJfNcU94P3rfh8TrydflQTKI5u8INzqCzi/R7iG2fBo+QKiEdNiv9NRlt4cRmOEsVvQ+5ed2U+u/68M8a6Q==
 
 flow-parser@^0.196.1:
   version "0.196.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.195.0:
-  version "0.195.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.195.2.tgz#373b3e0a8bc3a8e5df510365419fd7d3904e6a5a"
-  integrity sha512-GKwUBzIjpiJEspa0xPMlqz+8z25qg9Xx2SJFHwYrvMlR7JhSHTMoP4zEpwnY8qmBEH8NE+sw5rA/jRLJoEJeCg==
+flow-bin@^0.196.3:
+  version "0.196.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.196.3.tgz#b6df48986a2629f2c6a26fb79d73fc07c8056af0"
+  integrity sha512-pmvjlksi1CvkSnDHpcfhDFj/KC3hwSgE2OpzvugW57dfgqfHzqX1UfZIcScGWM5AmP/IeOsQCW383k3zIbEnrA==
 
 flow-parser@^0.196.1:
   version "0.196.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,10 +7915,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-flow-bin@^0.193.0:
-  version "0.193.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.193.0.tgz#250df37ec2d209dbf6dbec654e06d9e48da72ccb"
-  integrity sha512-DREsJfNcU94P3rfh8TrydflQTKI5u8INzqCzi/R7iG2fBo+QKiEdNiv9NRlt4cRmOEsVvQ+5ed2U+u/68M8a6Q==
+flow-bin@^0.194.0:
+  version "0.194.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.194.0.tgz#5c55d8fb4c10b3a434100a88e986109743afcbb8"
+  integrity sha512-gJ54JmNXkl9ga3vt2Lx9tFQCuIid1+161dWGdr0bJ/CKW8tVCWxApE/j/1eZo31uVAUNVCY5UTs2gnnAm1hVkQ==
 
 flow-parser@^0.196.1:
   version "0.196.1"


### PR DESCRIPTION
After the previous changes these upgrade are easy.

- removes config options that were removed
- object index access now requires an indexer key in the type, this cause a handful of errors that were fixed
- undefined keys error in all places, this needed a few extra suppressions for repeated undefined identifiers.

Flow's [CHANGELOG.md](https://github.com/facebook/flow/blob/main/Changelog.md).