### PR TITLE
Rejct toWarnDev if given callback throws

### DIFF
--- a/scripts/jest/matchers/toWarnDev.js
+++ b/scripts/jest/matchers/toWarnDev.js
@@ -270,15 +270,20 @@ const createMatcherFor = (consoleMethod, matcherName) =>
           // Once `act(async () => {}).then(() => {}).then(() => {})` works
           // we can just return `result.then(onFinally, error => ...)`
           returnPromise = new Promise((resolve, reject) => {
-            result.then(
-              () => {
-                resolve(onFinally());
-              },
-              error => {
-                caughtError = error;
-                return resolve(onFinally());
-              }
-            );
+            result
+              .then(
+                () => {
+                  resolve(onFinally());
+                },
+                error => {
+                  caughtError = error;
+                  return resolve(onFinally());
+                }
+              )
+              // In case onFinally throws we need to reject from this matcher
+              .catch(error => {
+                reject(error);
+              });
           });
         }
       } catch (error) {


### PR DESCRIPTION


## Summary

Should unblock https://github.com/facebook/react/pull/25970
If the callback for `toWarnDev` was `async` and threw, we didn't ultimately reject the await Promise from the matcher. This resulted in tests failing even though the failure was expected due to a test gate.

## How did you test this change?

- [x] tested in https://github.com/facebook/react/pull/25970 with `yarn test --r=stable --env=development packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js --watch`
- [x] `yarn test`
- [x] CI 
