### PR TITLE
Remove the code that judge children are null

### DIFF
--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -728,9 +728,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function getChildrenAsJSX(root) {
     const children = childToJSX(getChildren(root), null);
-    if (children === null) {
-      return null;
-    }
+
     if (isArray(children)) {
       return {
         $$typeof: REACT_ELEMENT_TYPE,
@@ -747,9 +745,7 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function getPendingChildrenAsJSX(root) {
     const children = childToJSX(getChildren(root), null);
-    if (children === null) {
-      return null;
-    }
+ 
     if (isArray(children)) {
       return {
         $$typeof: REACT_ELEMENT_TYPE,

--- a/packages/react-noop-renderer/src/createReactNoop.js
+++ b/packages/react-noop-renderer/src/createReactNoop.js
@@ -728,7 +728,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function getChildrenAsJSX(root) {
     const children = childToJSX(getChildren(root), null);
-
     if (isArray(children)) {
       return {
         $$typeof: REACT_ELEMENT_TYPE,
@@ -745,7 +744,6 @@ function createReactNoop(reconciler: Function, useMutation: boolean) {
 
   function getPendingChildrenAsJSX(root) {
     const children = childToJSX(getChildren(root), null);
- 
     if (isArray(children)) {
       return {
         $$typeof: REACT_ELEMENT_TYPE,


### PR DESCRIPTION
When I learned to react, I found this code. 
I don't think it involves performance issues, so it is redundant.
Looking forward to your suggestions.