### PR TITLE
[DevTools] improve error handling in extension

### DIFF
--- a/packages/react-devtools-extensions/src/background.js
+++ b/packages/react-devtools-extensions/src/background.js
@@ -77,7 +77,7 @@ function doublePipe(one, two, tabId) {
   function lOne(message) {
     try {
       two.postMessage(message);
-    } catch(e) {
+    } catch (e) {
       if (__DEV__) {
         console.log(`Broken pipe ${tabId}: `, e);
       }


### PR DESCRIPTION
## Summary

This is to fix some edge cases I recently observed when developing and using the extension:
- When you reload the page, there's a chance that a port (most likely the devtools one) is not properly unloaded. In this case, the React DevTools will stop working unless you create a new tab.
- For unknown reasons, Chrome sometimes spins up two service worker processes. In this case, an error will be thrown "duplicate ID when registering content script" and sometimes interrupt the execution of the rest of service worker.

This is an attempt to make the logic more robust 
- Automatically shutting down the double pipe if the message fails, and allowing the runtime to rebuild the double pipe.
- Log the error message so Chrome believes we've handled it and will not interrupt the execution.

This also seems to be helpful in fixing #25806. 