### PR TITLE
Revert "Hold host functions in var"

### DIFF
--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -44,11 +44,6 @@ import {LegacyRoot, ConcurrentRoot} from 'react-reconciler/src/ReactRootTags';
 import ReactSharedInternals from 'shared/ReactSharedInternals';
 import getComponentNameFromType from 'shared/getComponentNameFromType';
 
-const {
-  dispatchCommand: fabricDispatchCommand,
-  sendAccessibilityEvent: fabricSendAccessibilityEvent,
-} = nativeFabricUIManager;
-
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
 function findHostInstance_DEPRECATED<TElementType: ElementType>(
@@ -173,7 +168,7 @@ function dispatchCommand(handle: any, command: string, args: Array<any>) {
   if (handle._internalInstanceHandle != null) {
     const {stateNode} = handle._internalInstanceHandle;
     if (stateNode != null) {
-      fabricDispatchCommand(stateNode.node, command, args);
+      nativeFabricUIManager.dispatchCommand(stateNode.node, command, args);
     }
   } else {
     UIManager.dispatchViewManagerCommand(handle._nativeTag, command, args);
@@ -194,7 +189,7 @@ function sendAccessibilityEvent(handle: any, eventType: string) {
   if (handle._internalInstanceHandle != null) {
     const {stateNode} = handle._internalInstanceHandle;
     if (stateNode != null) {
-      fabricSendAccessibilityEvent(stateNode.node, eventType);
+      nativeFabricUIManager.sendAccessibilityEvent(stateNode.node, eventType);
     }
   } else {
     legacySendAccessibilityEvent(handle._nativeTag, eventType);

--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -10,8 +10,6 @@
 // Module provided by RN:
 import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
 
-const {setIsJSResponder} = nativeFabricUIManager;
-
 const ReactFabricGlobalResponderHandler = {
   onChange: function(from: any, to: any, blockNativeResponder: boolean) {
     const fromOrTo = from || to;
@@ -23,7 +21,7 @@ const ReactFabricGlobalResponderHandler = {
     if (isFabric) {
       if (from) {
         // equivalent to clearJSResponder
-        setIsJSResponder(
+        nativeFabricUIManager.setIsJSResponder(
           from.stateNode.node,
           false,
           blockNativeResponder || false,
@@ -32,7 +30,7 @@ const ReactFabricGlobalResponderHandler = {
 
       if (to) {
         // equivalent to setJSResponder
-        setIsJSResponder(
+        nativeFabricUIManager.setIsJSResponder(
           to.stateNode.node,
           true,
           blockNativeResponder || false,

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -26,8 +26,6 @@ if (__DEV__) {
   Object.freeze(emptyObject);
 }
 
-const {measure, findNodeAtPoint} = nativeFabricUIManager;
-
 let createHierarchy;
 let getHostNode;
 let getHostProps;
@@ -56,7 +54,7 @@ if (__DEV__ || enableGetInspectorDataForInstanceInProduction) {
               hostFiber.stateNode.node;
 
             if (shadowNode) {
-              measure(shadowNode, callback);
+              nativeFabricUIManager.measure(shadowNode, callback);
             } else {
               return UIManager.measure(
                 getHostNode(fiber, findNodeHandle),
@@ -202,7 +200,7 @@ if (__DEV__) {
 
     if (inspectedView._internalInstanceHandle != null) {
       // For Fabric we can look up the instance handle directly and measure it.
-      findNodeAtPoint(
+      nativeFabricUIManager.findNodeAtPoint(
         inspectedView._internalInstanceHandle.stateNode.node,
         locationX,
         locationY,
@@ -222,7 +220,7 @@ if (__DEV__) {
           const nativeViewTag =
             internalInstanceHandle.stateNode.canonical._nativeTag;
 
-          measure(
+          nativeFabricUIManager.measure(
             internalInstanceHandle.stateNode.node,
             (x, y, width, height, pageX, pageY) => {
               const inspectorData = getInspectorDataForInstance(

--- a/packages/react-native-renderer/src/ReactNativeRenderer.js
+++ b/packages/react-native-renderer/src/ReactNativeRenderer.js
@@ -49,11 +49,6 @@ import getComponentNameFromType from 'shared/getComponentNameFromType';
 
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 
-const {
-  sendAccessibilityEvent: fabricSendAccessibilityEvent,
-  dispatchCommand: fabricDispatchCommand,
-} = nativeFabricUIManager;
-
 function findHostInstance_DEPRECATED(
   componentOrHandle: any,
 ): ?React$ElementRef<HostComponent<mixed>> {
@@ -170,7 +165,7 @@ function dispatchCommand(handle: any, command: string, args: Array<any>) {
   if (handle._internalInstanceHandle != null) {
     const {stateNode} = handle._internalInstanceHandle;
     if (stateNode != null) {
-      fabricDispatchCommand(stateNode.node, command, args);
+      nativeFabricUIManager.dispatchCommand(stateNode.node, command, args);
     }
   } else {
     UIManager.dispatchViewManagerCommand(handle._nativeTag, command, args);
@@ -191,7 +186,7 @@ function sendAccessibilityEvent(handle: any, eventType: string) {
   if (handle._internalInstanceHandle != null) {
     const {stateNode} = handle._internalInstanceHandle;
     if (stateNode != null) {
-      fabricSendAccessibilityEvent(stateNode.node, eventType);
+      nativeFabricUIManager.sendAccessibilityEvent(stateNode.node, eventType);
     }
   } else {
     legacySendAccessibilityEvent(handle._nativeTag, eventType);

--- a/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeError-test.internal.js
@@ -28,8 +28,6 @@ describe('ReactNativeError', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
-
     React = require('react');
     ReactNative = require('react-native-renderer');
     createReactNativeComponentClass = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')

--- a/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeEvents-test.internal.js
@@ -63,8 +63,6 @@ const fakeRequireNativeComponent = (uiViewClassName, validAttributes) => {
 beforeEach(() => {
   jest.resetModules();
 
-  require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
-
   PropTypes = require('prop-types');
   RCTEventEmitter = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
     .RCTEventEmitter;

--- a/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/ReactNativeMount-test.internal.js
@@ -30,8 +30,6 @@ describe('ReactNative', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
-
     React = require('react');
     StrictMode = React.StrictMode;
     ReactNative = require('react-native-renderer');

--- a/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
+++ b/packages/react-native-renderer/src/__tests__/createReactNativeComponentClass-test.internal.js
@@ -18,8 +18,6 @@ describe('createReactNativeComponentClass', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    require('react-native/Libraries/ReactPrivate/InitializeNativeFabricUIManager');
-
     createReactNativeComponentClass = require('react-native/Libraries/ReactPrivate/ReactNativePrivateInterface')
       .ReactNativeViewConfigRegistry.register;
     React = require('react');


### PR DESCRIPTION
Revert https://github.com/facebook/react/commit/353c30252. The commit breaks old React Native where `nativeFabricUIManager` is undefined. I need to add unit test for this to make sure it doesn't happen in the future and create a mechanism to deal with undefined `nativeFabricUIManager`.
This is to unblock React sync to React Native.
