### PR TITLE
Refactor Flight Encoding

### DIFF
--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -501,6 +501,9 @@ export function parseModelString(
         // When passed into React, we'll know how to suspend on this.
         return createLazyChunkWrapper(chunk);
       }
+      case 'S': {
+        return Symbol.for(value.substring(2));
+      }
       default: {
         // We assume that anything else is a reference ID.
         const id = parseInt(value.substring(1), 16);
@@ -629,17 +632,6 @@ export function resolveModule(
       resolveModuleChunk(chunk, moduleReference);
     }
   }
-}
-
-export function resolveSymbol(
-  response: Response,
-  id: number,
-  name: string,
-): void {
-  const chunks = response._chunks;
-  // We assume that we'll always emit the symbol before anything references it
-  // to save a few bytes.
-  chunks.set(id, createInitializedChunk(response, Symbol.for(name)));
 }
 
 type ErrorWithDigest = Error & {digest?: string};

--- a/packages/react-client/src/ReactFlightClient.js
+++ b/packages/react-client/src/ReactFlightClient.js
@@ -201,14 +201,6 @@ function createErrorChunk<T>(
   return new Chunk(ERRORED, null, error, response);
 }
 
-function createInitializedChunk<T>(
-  response: Response,
-  value: T,
-): InitializedChunk<T> {
-  // $FlowFixMe Flow doesn't support functions as constructors
-  return new Chunk(INITIALIZED, value, null, response);
-}
-
 function wakeChunk<T>(listeners: Array<(T) => mixed>, value: T): void {
   for (let i = 0; i < listeners.length; i++) {
     const listener = listeners[i];
@@ -504,6 +496,9 @@ export function parseModelString(
       case 'S': {
         return Symbol.for(value.substring(2));
       }
+      case 'P': {
+        return getOrCreateServerContext(value.substring(2)).Provider;
+      }
       default: {
         // We assume that anything else is a reference ID.
         const id = parseInt(value.substring(1), 16);
@@ -572,21 +567,6 @@ export function resolveModel(
   } else {
     resolveModelChunk(chunk, model);
   }
-}
-
-export function resolveProvider(
-  response: Response,
-  id: number,
-  contextName: string,
-): void {
-  const chunks = response._chunks;
-  chunks.set(
-    id,
-    createInitializedChunk(
-      response,
-      getOrCreateServerContext(contextName).Provider,
-    ),
-  );
 }
 
 export function resolveModule(

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -44,7 +44,7 @@ function processFullRow(response: Response, row: string): void {
   // switch (tag) {
   // }
   switch (tag) {
-    case 'M': {
+    case 'I': {
       resolveModule(response, id, row.substring(colon + 2));
       return;
     }

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -14,7 +14,6 @@ import type {BundlerConfig} from './ReactFlightClientHostConfig';
 import {
   resolveModule,
   resolveModel,
-  resolveProvider,
   resolveErrorProd,
   resolveErrorDev,
   createResponse as createResponseBase,
@@ -45,10 +44,6 @@ function processFullRow(response: Response, row: string): void {
   switch (tag) {
     case 'I': {
       resolveModule(response, id, row.substring(colon + 2));
-      return;
-    }
-    case 'P': {
-      resolveProvider(response, id, row.substring(colon + 2));
       return;
     }
     case 'E': {

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -43,26 +43,21 @@ function processFullRow(response: Response, row: string): void {
   // parsing the row as text.
   // switch (tag) {
   // }
-  const text = row.substring(colon + 2);
   switch (tag) {
-    case 'J': {
-      resolveModel(response, id, text);
-      return;
-    }
     case 'M': {
-      resolveModule(response, id, text);
+      resolveModule(response, id, row.substring(colon + 2));
       return;
     }
     case 'P': {
-      resolveProvider(response, id, text);
+      resolveProvider(response, id, row.substring(colon + 2));
       return;
     }
     case 'S': {
-      resolveSymbol(response, id, JSON.parse(text));
+      resolveSymbol(response, id, JSON.parse(row.substring(colon + 2)));
       return;
     }
     case 'E': {
-      const errorInfo = JSON.parse(text);
+      const errorInfo = JSON.parse(row.substring(colon + 2));
       if (__DEV__) {
         resolveErrorDev(
           response,
@@ -77,9 +72,9 @@ function processFullRow(response: Response, row: string): void {
       return;
     }
     default: {
-      throw new Error(
-        "Error parsing the data. It's probably an error code or network corruption.",
-      );
+      // We assume anything else is JSON.
+      resolveModel(response, id, row.substring(colon + 1));
+      return;
     }
   }
 }

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -36,14 +36,14 @@ function processFullRow(response: Response, row: string): void {
   if (row === '') {
     return;
   }
-  const tag = row[0];
+  const colon = row.indexOf(':', 0);
+  const id = parseInt(row.substring(0, colon), 16);
+  const tag = row[colon + 1];
   // When tags that are not text are added, check them here before
   // parsing the row as text.
   // switch (tag) {
   // }
-  const colon = row.indexOf(':', 1);
-  const id = parseInt(row.substring(1, colon), 16);
-  const text = row.substring(colon + 1);
+  const text = row.substring(colon + 2);
   switch (tag) {
     case 'J': {
       resolveModel(response, id, text);

--- a/packages/react-client/src/ReactFlightClientStream.js
+++ b/packages/react-client/src/ReactFlightClientStream.js
@@ -15,7 +15,6 @@ import {
   resolveModule,
   resolveModel,
   resolveProvider,
-  resolveSymbol,
   resolveErrorProd,
   resolveErrorDev,
   createResponse as createResponseBase,
@@ -50,10 +49,6 @@ function processFullRow(response: Response, row: string): void {
     }
     case 'P': {
       resolveProvider(response, id, row.substring(colon + 2));
-      return;
-    }
-    case 'S': {
-      resolveSymbol(response, id, JSON.parse(row.substring(colon + 2)));
       return;
     }
     case 'E': {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -25,7 +25,7 @@ import {
 export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
-  if (chunk[0] === 'J') {
+  if (chunk[0] === 'O') {
     // $FlowFixMe unable to refine on array indices
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -15,7 +15,6 @@ import {
   createResponse,
   resolveModel,
   resolveModule,
-  resolveSymbol,
   resolveErrorDev,
   resolveErrorProd,
   close,
@@ -31,9 +30,6 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
   } else if (chunk[0] === 'I') {
     // $FlowFixMe unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);
-  } else if (chunk[0] === 'S') {
-    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
-    resolveSymbol(response, chunk[1], chunk[2]);
   } else {
     if (__DEV__) {
       resolveErrorDev(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayClient.js
@@ -28,7 +28,7 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe unable to refine on array indices
     resolveModel(response, chunk[1], chunk[2]);
-  } else if (chunk[0] === 'M') {
+  } else if (chunk[0] === 'I') {
     // $FlowFixMe unable to refine on array indices
     resolveModule(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'S') {

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -19,7 +19,7 @@ export type JSONValue =
 
 export type RowEncoding =
   | ['O', number, JSONValue]
-  | ['M', number, ModuleMetaData]
+  | ['I', number, ModuleMetaData]
   | ['P', number, string]
   | ['S', number, string]
   | [

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayProtocol.js
@@ -18,7 +18,7 @@ export type JSONValue =
   | $ReadOnlyArray<JSONValue>;
 
 export type RowEncoding =
-  | ['J', number, JSONValue]
+  | ['O', number, JSONValue]
   | ['M', number, ModuleMetaData]
   | ['P', number, string]
   | ['S', number, string]

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -179,14 +179,6 @@ export function processProviderChunk(
   return ['P', id, contextName];
 }
 
-export function processSymbolChunk(
-  request: Request,
-  id: number,
-  name: string,
-): Chunk {
-  return ['S', id, name];
-}
-
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -151,7 +151,7 @@ export function processModelChunk(
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
-  return ['J', id, json];
+  return ['O', id, json];
 }
 
 export function processReferenceChunk(
@@ -159,7 +159,7 @@ export function processReferenceChunk(
   id: number,
   reference: string,
 ): Chunk {
-  return ['J', id, reference];
+  return ['O', id, reference];
 }
 
 export function processModuleChunk(

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -171,14 +171,6 @@ export function processModuleChunk(
   return ['I', id, moduleMetaData];
 }
 
-export function processProviderChunk(
-  request: Request,
-  id: number,
-  contextName: string,
-): Chunk {
-  return ['P', id, contextName];
-}
-
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
+++ b/packages/react-server-dom-relay/src/ReactFlightDOMRelayServerHostConfig.js
@@ -168,7 +168,7 @@ export function processModuleChunk(
   moduleMetaData: ModuleMetaData,
 ): Chunk {
   // The moduleMetaData is already a JSON serializable value.
-  return ['M', id, moduleMetaData];
+  return ['I', id, moduleMetaData];
 }
 
 export function processProviderChunk(

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -28,7 +28,7 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
   if (chunk[0] === 'O') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModel(response, chunk[1], chunk[2]);
-  } else if (chunk[0] === 'M') {
+  } else if (chunk[0] === 'I') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'S') {

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -15,7 +15,6 @@ import {
   createResponse,
   resolveModel,
   resolveModule,
-  resolveSymbol,
   resolveErrorDev,
   resolveErrorProd,
   close,
@@ -31,9 +30,6 @@ export function resolveRow(response: Response, chunk: RowEncoding): void {
   } else if (chunk[0] === 'I') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModule(response, chunk[1], chunk[2]);
-  } else if (chunk[0] === 'S') {
-    // $FlowFixMe: Flow doesn't support disjoint unions on tuples.
-    resolveSymbol(response, chunk[1], chunk[2]);
   } else {
     if (__DEV__) {
       resolveErrorDev(

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayClient.js
@@ -25,7 +25,7 @@ import {
 export {createResponse, close, getRoot};
 
 export function resolveRow(response: Response, chunk: RowEncoding): void {
-  if (chunk[0] === 'J') {
+  if (chunk[0] === 'O') {
     // $FlowFixMe `Chunk` doesn't flow into `JSONValue` because of the `E` row type.
     resolveModel(response, chunk[1], chunk[2]);
   } else if (chunk[0] === 'M') {

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -19,7 +19,7 @@ export type JSONValue =
 
 export type RowEncoding =
   | ['O', number, JSONValue]
-  | ['M', number, ModuleMetaData]
+  | ['I', number, ModuleMetaData]
   | ['P', number, string]
   | ['S', number, string]
   | [

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayProtocol.js
@@ -18,7 +18,7 @@ export type JSONValue =
   | Array<JSONValue>;
 
 export type RowEncoding =
-  | ['J', number, JSONValue]
+  | ['O', number, JSONValue]
   | ['M', number, ModuleMetaData]
   | ['P', number, string]
   | ['S', number, string]

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -146,7 +146,7 @@ export function processModelChunk(
 ): Chunk {
   // $FlowFixMe no good way to define an empty exact object
   const json = convertModelToJSON(request, {}, '', model);
-  return ['J', id, json];
+  return ['O', id, json];
 }
 
 export function processReferenceChunk(
@@ -154,7 +154,7 @@ export function processReferenceChunk(
   id: number,
   reference: string,
 ): Chunk {
-  return ['J', id, reference];
+  return ['O', id, reference];
 }
 
 export function processModuleChunk(

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -163,7 +163,7 @@ export function processModuleChunk(
   moduleMetaData: ModuleMetaData,
 ): Chunk {
   // The moduleMetaData is already a JSON serializable value.
-  return ['M', id, moduleMetaData];
+  return ['I', id, moduleMetaData];
 }
 
 export function processProviderChunk(

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -166,14 +166,6 @@ export function processModuleChunk(
   return ['I', id, moduleMetaData];
 }
 
-export function processProviderChunk(
-  request: Request,
-  id: number,
-  contextName: string,
-): Chunk {
-  return ['P', id, contextName];
-}
-
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
+++ b/packages/react-server-native-relay/src/ReactFlightNativeRelayServerHostConfig.js
@@ -174,14 +174,6 @@ export function processProviderChunk(
   return ['P', id, contextName];
 }
 
-export function processSymbolChunk(
-  request: Request,
-  id: number,
-  name: string,
-): Chunk {
-  return ['S', id, name];
-}
-
 export function scheduleWork(callback: () => void) {
   callback();
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -417,7 +417,7 @@ function serializeByValueID(id: number): string {
 }
 
 function serializeByRefID(id: number): string {
-  return '@' + id.toString(16);
+  return '$L' + id.toString(16);
 }
 
 function serializeClientReference(
@@ -473,7 +473,7 @@ function serializeClientReference(
 }
 
 function escapeStringValue(value: string): string {
-  if (value[0] === '$' || value[0] === '@') {
+  if (value[0] === '$') {
     // We need to escape $ or @ prefixed strings since we use those to encode
     // references to IDs and as special symbol values.
     return '$' + value;

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -39,7 +39,6 @@ import {
   processModelChunk,
   processModuleChunk,
   processProviderChunk,
-  processSymbolChunk,
   processErrorChunkProd,
   processErrorChunkDev,
   processReferenceChunk,
@@ -418,6 +417,10 @@ function serializeByValueID(id: number): string {
 
 function serializeByRefID(id: number): string {
   return '$L' + id.toString(16);
+}
+
+function serializeSymbolReference(name: string): string {
+  return '$S' + name;
 }
 
 function serializeClientReference(
@@ -1109,7 +1112,8 @@ function emitModuleChunk(
 }
 
 function emitSymbolChunk(request: Request, id: number, name: string): void {
-  const processedChunk = processSymbolChunk(request, id, name);
+  const symbolReference = serializeSymbolReference(name);
+  const processedChunk = processReferenceChunk(request, id, symbolReference);
   request.completedModuleChunks.push(processedChunk);
 }
 

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -38,7 +38,6 @@ import {
   closeWithError,
   processModelChunk,
   processModuleChunk,
-  processProviderChunk,
   processErrorChunkProd,
   processErrorChunkDev,
   processReferenceChunk,
@@ -421,6 +420,10 @@ function serializeByRefID(id: number): string {
 
 function serializeSymbolReference(name: string): string {
   return '$S' + name;
+}
+
+function serializeProviderReference(name: string): string {
+  return '$P' + name;
 }
 
 function serializeClientReference(
@@ -1122,7 +1125,8 @@ function emitProviderChunk(
   id: number,
   contextName: string,
 ): void {
-  const processedChunk = processProviderChunk(request, id, contextName);
+  const contextReference = serializeProviderReference(contextName);
+  const processedChunk = processReferenceChunk(request, id, contextReference);
   request.completedJSONChunks.push(processedChunk);
 }
 

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -127,7 +127,7 @@ export function processModelChunk(
   model: ReactModel,
 ): Chunk {
   const json: string = stringify(model, request.toJSON);
-  const row = serializeRowHeader('J', id) + json + '\n';
+  const row = id.toString(16) + ':' + json + '\n';
   return stringToChunk(row);
 }
 
@@ -137,7 +137,7 @@ export function processReferenceChunk(
   reference: string,
 ): Chunk {
   const json = stringify(reference);
-  const row = serializeRowHeader('J', id) + json + '\n';
+  const row = id.toString(16) + ':' + json + '\n';
   return stringToChunk(row);
 }
 

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -80,7 +80,7 @@ export {
 const stringify = JSON.stringify;
 
 function serializeRowHeader(tag: string, id: number) {
-  return tag + id.toString(16) + ':';
+  return id.toString(16) + ':' + tag;
 }
 
 export function processErrorChunkProd(

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -151,15 +151,6 @@ export function processModuleChunk(
   return stringToChunk(row);
 }
 
-export function processProviderChunk(
-  request: Request,
-  id: number,
-  contextName: string,
-): Chunk {
-  const row = serializeRowHeader('P', id) + contextName + '\n';
-  return stringToChunk(row);
-}
-
 export {
   scheduleWork,
   flushBuffered,

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -147,7 +147,7 @@ export function processModuleChunk(
   moduleMetaData: ReactModel,
 ): Chunk {
   const json: string = stringify(moduleMetaData);
-  const row = serializeRowHeader('M', id) + json + '\n';
+  const row = serializeRowHeader('I', id) + json + '\n';
   return stringToChunk(row);
 }
 

--- a/packages/react-server/src/ReactFlightServerConfigStream.js
+++ b/packages/react-server/src/ReactFlightServerConfigStream.js
@@ -160,16 +160,6 @@ export function processProviderChunk(
   return stringToChunk(row);
 }
 
-export function processSymbolChunk(
-  request: Request,
-  id: number,
-  name: string,
-): Chunk {
-  const json = stringify(name);
-  const row = serializeRowHeader('S', id) + json + '\n';
-  return stringToChunk(row);
-}
-
 export {
   scheduleWork,
   flushBuffered,


### PR DESCRIPTION
This is just shifting around some encoding strategies for Flight in preparation for more types.

```
S1:"react.suspense"
J2:["$", "$1", {children: "@3"}]
J3:"Hello"
```

```
1:"$Sreact.suspense"
2:["$", "$1", {children: "$L3"}]
3:"Hello"
```