### PR TITLE
Revert the outer module object to an object

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -33,8 +33,6 @@ module.exports = function register() {
         // reference.
         case 'defaultProps':
           return undefined;
-        case 'getDefaultProps':
-          return undefined;
         // Avoid this attempting to be serialized.
         case 'toJSON':
           return undefined;
@@ -91,8 +89,6 @@ module.exports = function register() {
         // reference.
         case 'defaultProps':
           return undefined;
-        case 'getDefaultProps':
-          return undefined;
         // Avoid this attempting to be serialized.
         case 'toJSON':
           return undefined;
@@ -132,24 +128,13 @@ module.exports = function register() {
             // we should resolve that with a client reference that unwraps the Promise on
             // the client.
 
-            const innerModuleId = target.filepath;
-            const clientReference: Function = Object.defineProperties(
-              (function () {
-                throw new Error(
-                  `Attempted to call the module exports of ${innerModuleId} from the server` +
-                    `but it's on the client. It's not possible to invoke a client function from ` +
-                    `the server, it can only be rendered as a Component or passed to props of a` +
-                    `Client Component.`,
-                );
-              }: any),
-              {
-                // Represents the whole object instead of a particular import.
-                name: {value: '*'},
-                $$typeof: {value: CLIENT_REFERENCE},
-                filepath: {value: target.filepath},
-                async: {value: true},
-              },
-            );
+            const clientReference = Object.defineProperties(({}: any), {
+              // Represents the whole Module object instead of a particular import.
+              name: {value: '*'},
+              $$typeof: {value: CLIENT_REFERENCE},
+              filepath: {value: target.filepath},
+              async: {value: true},
+            });
             const proxy = new Proxy(clientReference, proxyHandlers);
 
             // Treat this as a resolved Promise for React's use()
@@ -221,23 +206,13 @@ module.exports = function register() {
   // $FlowFixMe[prop-missing] found when upgrading Flow
   Module._extensions['.client.js'] = function (module, path) {
     const moduleId: string = (url.pathToFileURL(path).href: any);
-    const clientReference: Function = Object.defineProperties(
-      (function () {
-        throw new Error(
-          `Attempted to call the module exports of ${moduleId} from the server` +
-            `but it's on the client. It's not possible to invoke a client function from ` +
-            `the server, it can only be rendered as a Component or passed to props of a` +
-            `Client Component.`,
-        );
-      }: any),
-      {
-        // Represents the whole object instead of a particular import.
-        name: {value: '*'},
-        $$typeof: {value: CLIENT_REFERENCE},
-        filepath: {value: moduleId},
-        async: {value: false},
-      },
-    );
+    const clientReference = Object.defineProperties(({}: any), {
+      // Represents the whole Module object instead of a particular import.
+      name: {value: '*'},
+      $$typeof: {value: CLIENT_REFERENCE},
+      filepath: {value: moduleId},
+      async: {value: false},
+    });
     // $FlowFixMe[incompatible-call] found when upgrading Flow
     module.exports = new Proxy(clientReference, proxyHandlers);
   };

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -35,7 +35,7 @@ import {setExtraStackFrame} from './ReactDebugCurrentFrame';
 import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFrame';
 import hasOwnProperty from 'shared/hasOwnProperty';
 
-const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
+const REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference');
 
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {

--- a/packages/react/src/ReactElementValidator.js
+++ b/packages/react/src/ReactElementValidator.js
@@ -35,6 +35,8 @@ import {setExtraStackFrame} from './ReactDebugCurrentFrame';
 import {describeUnknownElementTypeFrameInDEV} from 'shared/ReactComponentStackFrame';
 import hasOwnProperty from 'shared/hasOwnProperty';
 
+const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
+
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {
     if (element) {
@@ -165,10 +167,12 @@ function validateExplicitKey(element, parentType) {
  * @param {*} parentType node's parent's type.
  */
 function validateChildKeys(node, parentType) {
-  if (typeof node !== 'object') {
+  if (typeof node !== 'object' || !node) {
     return;
   }
-  if (isArray(node)) {
+  if (node.$$typeof === REACT_CLIENT_REFERENCE) {
+    // This is a reference to a client component so it's unknown.
+  } else if (isArray(node)) {
     for (let i = 0; i < node.length; i++) {
       const child = node[i];
       if (isValidElement(child)) {
@@ -180,7 +184,7 @@ function validateChildKeys(node, parentType) {
     if (node._store) {
       node._store.validated = true;
     }
-  } else if (node) {
+  } else {
     const iteratorFn = getIteratorFn(node);
     if (typeof iteratorFn === 'function') {
       // Entry iterators used to provide implicit keys,
@@ -208,6 +212,9 @@ function validatePropTypes(element) {
   if (__DEV__) {
     const type = element.type;
     if (type === null || type === undefined || typeof type === 'string') {
+      return;
+    }
+    if (type.$$typeof === REACT_CLIENT_REFERENCE) {
       return;
     }
     let propTypes;

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -32,6 +32,8 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 
+const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
+
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {
     if (element) {
@@ -179,10 +181,12 @@ function validateExplicitKey(element, parentType) {
  */
 function validateChildKeys(node, parentType) {
   if (__DEV__) {
-    if (typeof node !== 'object') {
+    if (typeof node !== 'object' || !node) {
       return;
     }
-    if (isArray(node)) {
+    if (node.$$typeof === REACT_CLIENT_REFERENCE) {
+      // This is a reference to a client component so it's unknown.
+    } else if (isArray(node)) {
       for (let i = 0; i < node.length; i++) {
         const child = node[i];
         if (isValidElement(child)) {
@@ -194,7 +198,7 @@ function validateChildKeys(node, parentType) {
       if (node._store) {
         node._store.validated = true;
       }
-    } else if (node) {
+    } else {
       const iteratorFn = getIteratorFn(node);
       if (typeof iteratorFn === 'function') {
         // Entry iterators used to provide implicit keys,
@@ -223,6 +227,9 @@ function validatePropTypes(element) {
   if (__DEV__) {
     const type = element.type;
     if (type === null || type === undefined || typeof type === 'string') {
+      return;
+    }
+    if (type.$$typeof === REACT_CLIENT_REFERENCE) {
       return;
     }
     let propTypes;

--- a/packages/react/src/jsx/ReactJSXElementValidator.js
+++ b/packages/react/src/jsx/ReactJSXElementValidator.js
@@ -32,7 +32,7 @@ import ReactSharedInternals from 'shared/ReactSharedInternals';
 const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
 const ReactDebugCurrentFrame = ReactSharedInternals.ReactDebugCurrentFrame;
 
-const REACT_CLIENT_REFERENCE: symbol = Symbol.for('react.client.reference');
+const REACT_CLIENT_REFERENCE = Symbol.for('react.client.reference');
 
 function setCurrentlyValidatingElement(element) {
   if (__DEV__) {


### PR DESCRIPTION
This is because Webpack has a `typeof ... === 'object'` before its esm compat test.

This is unfortunate because it means we can't have a nice error in CJS when someone does this:

```
const fn = require('client-fn');
fn();
```

I also fixed some checks in the validator that read off the client ref. It shouldn't do those checks against a client ref, since those now throw.
