### PR TITLE
publish-prereleases: Exit if CircleCI request fails

### DIFF
--- a/scripts/release/publish-using-ci-workflow.js
+++ b/scripts/release/publish-using-ci-workflow.js
@@ -99,6 +99,15 @@ async function main() {
     }
   );
 
+  if (!pipelineResponse.ok) {
+    console.error(
+      theme.error(
+        `Failed to access CircleCI. Responded with status: ${pipelineResponse.status}`
+      )
+    );
+    process.exit(1);
+  }
+
   const pipelineJSON = await pipelineResponse.json();
   const pipelineID = pipelineJSON.id;
 


### PR DESCRIPTION
If the publish-prereleases command fails to access CircleCI, it will now exit with a message instead of hanging indefinitely.