### PR TITLE
[Fizz] Add failing test for failed hydration when using uSES in StrictMode

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2365,7 +2365,7 @@ describe('ReactDOMFizzServer', () => {
         getClientSnapshot,
         getServerSnapshot,
       );
-      Scheduler.unstable_yieldValue(value);
+      Scheduler.log(value);
 
       return value;
     }
@@ -2380,12 +2380,16 @@ describe('ReactDOMFizzServer', () => {
       const {pipe} = renderToPipeableStream(element);
       pipe(writable);
     });
-    expect(Scheduler).toHaveYielded(['Nay!']);
 
-    ReactDOMClient.hydrateRoot(container, element);
-    expect(() => {
-      expect(Scheduler).toFlushAndYield(['Nay!', 'Yay!']);
-    }).toErrorDev([]);
+    assertLog(['Nay!']);
+    expect(getVisibleChildren(container)).toEqual('Nay!');
+
+    await clientAct(() => {
+      ReactDOMClient.hydrateRoot(container, element);
+    });
+
+    expect(getVisibleChildren(container)).toEqual('Yay!');
+    assertLog(['Nay!', 'Yay!']);
   });
 
   it(

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2384,11 +2384,7 @@ describe('ReactDOMFizzServer', () => {
 
     ReactDOMClient.hydrateRoot(container, element);
     expect(() => {
-      expect(Scheduler).toFlushAndYield([
-        'Nay!',
-        // Missing flushAndYield
-        // 'Yay!'
-      ]);
+      expect(Scheduler).toFlushAndYield(['Nay!', 'Yay!']);
     }).toErrorDev([]);
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServer-test.js
@@ -2348,6 +2348,50 @@ describe('ReactDOMFizzServer', () => {
     },
   );
 
+  it('can hydrate uSES in StrictMode with different client and server snapshot', async () => {
+    function subscribe() {
+      return () => {};
+    }
+    function getClientSnapshot() {
+      return 'Yay!';
+    }
+    function getServerSnapshot() {
+      return 'Nay!';
+    }
+
+    function App() {
+      const value = useSyncExternalStore(
+        subscribe,
+        getClientSnapshot,
+        getServerSnapshot,
+      );
+      Scheduler.unstable_yieldValue(value);
+
+      return value;
+    }
+
+    const element = (
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+
+    await act(async () => {
+      const {pipe} = renderToPipeableStream(element);
+      pipe(writable);
+    });
+    expect(Scheduler).toHaveYielded(['Nay!']);
+
+    ReactDOMClient.hydrateRoot(container, element);
+    expect(() => {
+      expect(Scheduler).toFlushAndYield([
+        'Nay!',
+        // Missing flushAndYield
+        // 'Yay!'
+      ]);
+    }).toErrorDev([]);
+  });
+
   it(
     'errors during hydration force a client render at the nearest Suspense ' +
       'boundary, and during the client render it recovers',


### PR DESCRIPTION


## Summary

Failing test for https://github.com/facebook/react/issues/26095

## How did you test this change?

- `yarn test ReactDOMFizzServer-test`