### PR TITLE
test: Don't retry flushActWork if flushUntilNextPaint threw

### DIFF
--- a/packages/jest-react/src/internalAct.js
+++ b/packages/jest-react/src/internalAct.js
@@ -128,6 +128,7 @@ function flushActWork(resolve: () => void, reject: (error: any) => void) {
       Scheduler.unstable_flushUntilNextPaint();
     } catch (error) {
       reject(error);
+      return;
     }
 
     // If Scheduler yields while there's still work, it's so that we can


### PR DESCRIPTION


## Summary

Fixes "ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down." in `ReactIncrementalErrorHandling-test.internal.js`

Alternatives:

1. Additional `await act(cb)` call where `cb` makes sure we can flush until next paint without throwing
    ```js
    // Ensure test isn't exited with pending work
    await act(async () => {
      root.render(<App shouldThrow={false} />);
    });
    ```
1. Use `toFlushAndThrow`
    ```diff
    -    let error;
    -    try {
    -      await act(async () => {
    -        root.render(<App shouldThrow={true} />);
    -      });
    -    } catch (e) {
    -      error = e;
    -    }
    +    root.render(<App shouldThrow={true} />);
     
    -    expect(error.message).toBe('Oops!');
    +    expect(Scheduler).toFlushAndThrow('Oops!');
         expect(numberOfThrows < 100).toBe(true);
    ```

But then it still wouldn't make sense to pass `resolve` and `reject` to the next `flushActWork`. Even if the next `flushActWork` would flush until next paint without throwing, we couldn't resolve or reject because we already did reject.
 

## How did you test this change?

- `yarn test --watch packages/react-reconciler/src/__tests__/ReactIncrementalErrorHandling-test.internal.js` produces no more errors after the test finishes.
