### PR TITLE
hyperlink Good First Issues like the sections above

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 Read our [contributing guide](https://reactjs.org/docs/how-to-contribute.html) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
 
-### Good First Issues
+### [Good First Issues](https://github.com/facebook/react/labels/good%20first%20issue)
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/react/labels/good%20first%20issue) that contain bugs that have a relatively limited scope. This is a great place to get started.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ Read our [contributing guide](https://reactjs.org/docs/how-to-contribute.html) t
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/react/labels/good%20first%20issue) that contain bugs that have a relatively limited scope. This is a great place to get started.
 
-### License
+### [License](./LICENSE)
 
 React is [MIT licensed](./LICENSE).


### PR DESCRIPTION
## Summary

Tiny change to hyperlink the `Good First Issues` and `License` sections in the README. The other section headers in Contributing (`Code of Conduct` and `Contributing Guide`) are hyperlinked, so `Good First Issues` and `License` should be as well for consistency.
