### PR TITLE
Only restore Yarn caches on exact key hits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,7 @@ aliases:
     restore_cache:
       name: Restore yarn cache for fixtures/dom
       keys:
-        - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
-        - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
-        - v1-yarn_cache-{{ arch }}-
-        - v1-yarn_cache-
+        - v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
 
   - &yarn_install_fixtures_dom
     run:
@@ -32,7 +29,7 @@ aliases:
   - &save_yarn_cache_fixtures_dom
     save_cache:
       name: Save yarn cache for fixtures/dom
-      key: v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
+      key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}-fixtures/dom
       paths:
         - ~/.cache/yarn
 
@@ -48,9 +45,7 @@ commands:
       - restore_cache:
           name: Restore yarn cache
           keys:
-            - v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
-            - v1-yarn_cache-{{ arch }}-
-            - v1-yarn_cache-
+            - v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: |
@@ -60,7 +55,7 @@ commands:
             fi
       - save_cache:
           name: Save yarn cache
-          key: v1-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
+          key: v2-yarn_cache-{{ arch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
 


### PR DESCRIPTION
## Summary

[Current Yarn cache size: 555MB](https://app.circleci.com/pipelines/github/facebook/react/38163/workflows/70d0149e-b0bc-44e8-b8c9-e5c744cab89b/jobs/625334?invite=true#step-102-2)
[Used Yarn cache size: 344MB](https://app.circleci.com/pipelines/github/facebook/react/38166/workflows/4825d444-1426-4321-b95b-c540e6cdc6d7/jobs/625354?invite=true#step-104-5)

When we restore a global Yarn cache that's not specific to a lockfile entry (i.e. a fallback cache), we might restore packages that are no longer used. When we then run yarn install, we potentially add new packages to the cache.
For example: 
1. we bump a package version
2. lockfile changes
3. cache restore misses for exact key
4. cache restore hits a prefix (fallback) containing the older version, 
5. yarn install adds the new version to the cache

Yarn is not clearing the unused packages from the global cache. So when we then save the cache we now retain the old and new version of a package in the global cache even though the old version is no longer used.
This means that the global cache grows indefinitely. Restoring the cache isn't free so CI install times will degrade over time.

Either we
1. periodically prune the cache
2. just not restore anything unless we have an exact hit. 


The chosen tradeoff depends on the
relation of commits changing deps to commits not changing deps. 
From my experience, we change deps rarely so I opted to only restore the cache on exact hits.

## How did you test this change?

- run on `main` has 555MB of Yarn cache: https://app.circleci.com/pipelines/github/facebook/react/38163/workflows/70d0149e-b0bc-44e8-b8c9-e5c744cab89b/jobs/625334?invite=true#step-102-2
- run on this branch only has 334MB of Yarn cache: https://app.circleci.com/pipelines/github/facebook/react/38166/workflows/4825d444-1426-4321-b95b-c540e6cdc6d7/jobs/625354?invite=true#step-104-5
