### PR TITLE
Fix hydration mismatch caused by a style of only empty values

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMServerIntegrationAttributes-test.js
@@ -416,6 +416,12 @@ describe('ReactDOMServerIntegration', () => {
         expect(e.style.width).toBe('30px');
       });
 
+      itRenders('no zero-length styles', async render => {
+        const e = await render(<div style={{color: '', width: '30px'}} />);
+        expect(e.style.color).toBe('');
+        expect(e.style.width).toBe('30px');
+      });
+
       itRenders('no empty styles', async render => {
         const e = await render(<div style={{color: null, width: null}} />);
         expect(e.style.color).toBe('');

--- a/packages/react-dom/src/__tests__/ReactServerRendering-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRendering-test.js
@@ -1153,11 +1153,5 @@ describe('ReactDOMServer', () => {
       );
       expect(output).toBe(`<my-custom-element></my-custom-element>`);
     });
-    it('Style property with empty values should be omitted.', () => {
-      const output = ReactDOMServer.renderToString(
-        <div style={{transform: ''}} />,
-      );
-      expect(output).toEqual('<div></div>');
-    });
   });
 });

--- a/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
+++ b/packages/react-dom/src/__tests__/ReactServerRenderingHydration-test.js
@@ -694,16 +694,4 @@ describe('ReactDOMServerHydration', () => {
       );
     }
   });
-  it('should not warn about style mismatch due to empty values', () => {
-    const domElement = document.createElement('div');
-    const App = () => <div style={{transform: ''}} />;
-
-    const markup = ReactDOMServer.renderToString(<App />);
-    domElement.innerHTML = markup;
-
-    expect(() => {
-      ReactDOM.hydrate(<App />, domElement);
-      expect(domElement.innerHTML).toEqual(markup);
-    }).toErrorDev([]);
-  });
 });


### PR DESCRIPTION
## Summary

Closes https://github.com/facebook/react/issues/26135

When rendering a style of only empty values, React will detect a hydration mismatch.

This is due to diverging logic in what values React throws away on the server and what the client thought it threw away.

## How did you test this change?

Test cases inside the react repository. 
