### PR TITLE
Bypass packages that are already published when confirmed by users

### DIFF
--- a/scripts/devtools/publish-release.js
+++ b/scripts/devtools/publish-release.js
@@ -91,7 +91,8 @@ async function publishToNPM() {
         )} has already been published.`
       );
 
-      await confirm('Is this expected?');
+      await confirm(`Is this expected (will skip ${npmPackage}@${version})?`);
+      continue;
     }
 
     if (DRY_RUN) {


### PR DESCRIPTION
## Summary

I ran into some two factor certification issue and had to resume the publish script. However, this time if I confirmed the published package, it will still try to publish the same version and fail. This is not expected, and it blocks me from publishing the rest of the packages.

## How did you test this change?

I re-run the publish script after the change and successfully publish the rest of the packages.

```
? Have you run the build-and-test script? Yes

✓ Checking NPM permissions for ryancat. 881 ms

? Please provide an NPM two-factor auth token: 278924


react-devtools version 4.27.2 has already been published.

? Is this expected (will skip react-devtools@4.27.2)? Yes


react-devtools-core version 4.27.2 has already been published.

? Is this expected (will skip react-devtools-core@4.27.2)? Yes

✓ Publishing package react-devtools-inline 23.1 secs

You are now ready to publish the extension to Chrome, Edge, and Firefox:
  https://fburl.com/publish-react-devtools-extensions

When publishing to Firefox, remember the following:
  Build id: 625690
  Git archive: ******
```
