### PR TITLE
Treat displayName as undefined

### DIFF
--- a/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
+++ b/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeRegister.js
@@ -48,6 +48,8 @@ module.exports = function register() {
           return target.filepath;
         case 'name':
           return target.name;
+        case 'displayName':
+          return undefined;
         case 'async':
           return target.async;
         // We need to special case this because createElement reads it if we pass this

--- a/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
+++ b/packages/react-server-dom-webpack/src/__tests__/ReactFlightDOM-test.js
@@ -466,6 +466,13 @@ describe('ReactFlightDOM', () => {
     );
   });
 
+  it('does not throw when React inspects any deep props', () => {
+    const ClientModule = clientExports({
+      Component: function () {},
+    });
+    <ClientModule.Component key="this adds instrumentation" />;
+  });
+
   it('throws when accessing a Context.Provider below the client exports', () => {
     const Context = React.createContext();
     const ClientModule = clientExports({


### PR DESCRIPTION
When we have a key we read displayName eagerly for future warnings.

In general, React should be inspecting if something is a client reference before dotting into it. However, we use displayName a lot and it kind of has defined meaning for debugging everywhere it's used so seems fine to treat this as undefined.