### PR TITLE
Fix typos in react-reconciler

### DIFF
--- a/packages/react-reconciler/README.md
+++ b/packages/react-reconciler/README.md
@@ -65,7 +65,7 @@ If these links break please file an issue and we’ll fix them. They intentional
 
 ## An (Incomplete!) Reference
 
-At the moment, we can't commit to documenting every API detail because the host config still changes very often between the releases. The documentation below is **provided in the spirit of making our best effort rather than an API guarantee**. It focuses on the parts that don't change too often. This is a compromise that strikes a balance between the need for a fast-paced development of React itself, and the usefulness of this package to the custom renderer community. If you notice parts that are out of date or don't match how the latest stable update is behaving, please file an issue or send a pull request, although a response might take time.
+At the moment, we can't commit to documenting every API detail because the host config still changes very often between releases. The documentation below is **provided in the spirit of making our best effort rather than an API guarantee**. It focuses on the parts that don't change too often. This is a compromise that strikes a balance between the need for a fast-paced development of React itself, and the usefulness of this package to the custom renderer community. If you notice parts that are out of date or don't match how the latest stable update is behaving, please file an issue or send a pull request, although a response might take time.
 
 #### Modes
 
@@ -125,7 +125,7 @@ In this method, you can perform some final mutations on the `instance`. Unlike w
 
 This method happens **in the render phase**. It can mutate `instance`, but it must not modify any other nodes. It's called while the tree is still being built up and not connected to the actual tree on the screen.
 
-There is a second purpose to this method. It lets you specify whether there is some work that needs to happen when the node is connected to the tree on the screen. If you return `true`, the instance will receive a `commitMount` call later. See its documentation below.
+There is a second purpose to this method. It lets you specify whether some work needs to happen when the node is connected to the tree on the screen. If you return `true`, the instance will receive a `commitMount` call later. See its documentation below.
 
 If you don't want to do anything here, you should return `false`.
 

--- a/packages/react-reconciler/src/ReactFiber.js
+++ b/packages/react-reconciler/src/ReactFiber.js
@@ -270,7 +270,7 @@ export function createWorkInProgress(current: Fiber, pendingProps: any): Fiber {
     // We use a double buffering pooling technique because we know that we'll
     // only ever need at most two versions of a tree. We pool the "other" unused
     // node that we're free to reuse. This is lazily created to avoid allocating
-    // extra objects for things that are never updated. It also allow us to
+    // extra objects for things that are never updated. It also allows us to
     // reclaim the extra memory if needed.
     workInProgress = createFiber(
       current.tag,

--- a/packages/react-reconciler/src/ReactFiberBeginWork.js
+++ b/packages/react-reconciler/src/ReactFiberBeginWork.js
@@ -3278,7 +3278,7 @@ function initSuspenseListRenderState(
 // We first render the head. If anything is in fallback state, we do another
 // pass through beginWork to rerender all children (including the tail) with
 // the force suspend context. If the first render didn't have anything in
-// in fallback state. Then we render each row in the tail one-by-one.
+// fallback state. Then we render each row in the tail one-by-one.
 // That happens in the completeWork phase without going back to beginWork.
 function updateSuspenseListComponent(
   current: Fiber | null,
@@ -4021,7 +4021,7 @@ function beginWork(
     didReceiveUpdate = false;
 
     if (getIsHydrating() && isForkedChild(workInProgress)) {
-      // Check if this child belongs to a list of muliple children in
+      // Check if this child belongs to a list of multiple children in
       // its parent.
       //
       // In a true multi-threaded implementation, we would render children on

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -1389,7 +1389,7 @@ function commitTransitionProgress(offscreenFiber: Fiber) {
     // the map.
 
     // We use stateNode on the Offscreen component as a stable object
-    // that doesnt change from render to render. This way we can
+    // that doesn't change from render to render. This way we can
     // distinguish between different Offscreen instances (vs. the same
     // Offscreen instance with different fibers)
     const offscreenInstance: OffscreenInstance = offscreenFiber.stateNode;
@@ -2977,7 +2977,7 @@ function commitMutationEffectsOnFiber(
           const isUpdate = current !== null;
           const wasHiddenByAncestorOffscreen =
             offscreenSubtreeIsHidden || offscreenSubtreeWasHidden;
-          // Only trigger disapper layout effects if:
+          // Only trigger disappear layout effects if:
           //   - This is an update, not first mount.
           //   - This Offscreen was not hidden before.
           //   - Ancestor Offscreen was not hidden in previous commit.
@@ -3058,7 +3058,7 @@ function commitMutationEffectsOnFiber(
 }
 function commitReconciliationEffects(finishedWork: Fiber) {
   // Placement effects (insertions, reorders) can be scheduled on any fiber
-  // type. They needs to happen after the children effects have fired, but
+  // type. They need to happen after the children effects have fired, but
   // before the effects on this fiber have fired.
   const flags = finishedWork.flags;
   if (flags & Placement) {
@@ -4235,7 +4235,7 @@ export function disconnectPassiveEffect(finishedWork: Fiber): void {
         HookPassive,
       );
       // When disconnecting passive effects, we fire the effects in the same
-      // order as during a deletiong: parent before child
+      // order as during a deletion: parent before child
       recursivelyTraverseDisconnectPassiveEffects(finishedWork);
       break;
     }

--- a/packages/react-reconciler/src/ReactFiberCompleteWork.js
+++ b/packages/react-reconciler/src/ReactFiberCompleteWork.js
@@ -1006,7 +1006,7 @@ function completeWork(
           markUpdate(workInProgress);
         } else if (workInProgress.memoizedState === null) {
           // We may have props to update on the Hoistable instance. We use the
-          // updateHostComponent path becuase it produces the update queue
+          // updateHostComponent path because it produces the update queue
           // we need for Hoistables
           updateHostComponent(
             current,

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -764,7 +764,7 @@ export function bailoutHooks(
 }
 
 export function resetHooksAfterThrow(): void {
-  // This is called immediaetly after a throw. It shouldn't reset the entire
+  // This is called immediately after a throw. It shouldn't reset the entire
   // module state, because the work loop might decide to replay the component
   // again without rewinding.
   //
@@ -1354,7 +1354,7 @@ function readFromUnsubscribedMutableSource<Source, Snapshot>(
     // but there's nothing we can do about that (short of throwing here and refusing to continue the render).
     markSourceAsDirty(source);
 
-    // Intentioally throw an error to force React to retry synchronously. During
+    // Intentionally throw an error to force React to retry synchronously. During
     // the synchronous retry, it will block interleaved mutations, so we should
     // get a consistent read. Therefore, the following error should never be
     // visible to the user.
@@ -1497,7 +1497,7 @@ function useMutableSource<Source, Snapshot>(
   // Maybe the source changed in a way that the old subscription ignored but the new one depends on.
   //
   // If the getSnapshot function changed, we also shouldn't rely on the update queue.
-  // It's possible that the underlying source was mutated between the when the last "change" event fired,
+  // It's possible that the underlying source was mutated between when the last "change" event fired,
   // and when the current render (with the new getSnapshot function) is processed.
   //
   // In both cases, we need to throw away pending updates (since they are no longer relevant)
@@ -1699,7 +1699,7 @@ function updateSyncExternalStore<T>(
   if (
     inst.getSnapshot !== getSnapshot ||
     snapshotChanged ||
-    // Check if the susbcribe function changed. We can save some memory by
+    // Check if the subscribe function changed. We can save some memory by
     // checking whether we scheduled a subscription effect above.
     (workInProgressHook !== null &&
       workInProgressHook.memoizedState.tag & HookHasEffect)
@@ -1770,7 +1770,7 @@ function updateStoreInstance<T>(
   // Something may have been mutated in between render and commit. This could
   // have been in an event that fired before the passive effects, or it could
   // have been in a layout effect. In that case, we would have used the old
-  // snapsho and getSnapshot values to bail out. We need to check one more time.
+  // snapshot and getSnapshot values to bail out. We need to check one more time.
   if (checkIfSnapshotChanged(inst)) {
     // Force a re-render.
     forceStoreRerender(fiber);

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -88,7 +88,7 @@ let hydrationParentFiber: null | Fiber = null;
 let nextHydratableInstance: null | HydratableInstance = null;
 let isHydrating: boolean = false;
 
-// This flag allows for warning supression when we expect there to be mismatches
+// This flag allows for warning suppression when we expect there to be mismatches
 // due to earlier mismatches or a suspended fiber.
 let didSuspendOrErrorDEV: boolean = false;
 

--- a/packages/react-reconciler/src/ReactFiberSuspenseContext.js
+++ b/packages/react-reconciler/src/ReactFiberSuspenseContext.js
@@ -28,8 +28,8 @@ const suspenseHandlerStackCursor: StackCursor<Fiber | null> =
 // deeper than the shell, inside a new tree that wasn't already visible.
 //
 // The main way we use this concept is to determine whether showing a fallback
-// would result in a desirable or undesirable loading state. Activing a fallback
-// in the shell is considered an undersirable loading state, because it would
+// would result in a desirable or undesirable loading state. Activating a fallback
+// in the shell is considered an undesirable loading state, because it would
 // mean hiding visible (albeit stale) content in the current tree — we prefer to
 // show the stale content, rather than switch to a fallback. But showing a
 // fallback in a new tree is fine, because there's no stale content to

--- a/packages/react-reconciler/src/ReactFiberThenable.js
+++ b/packages/react-reconciler/src/ReactFiberThenable.js
@@ -85,7 +85,7 @@ export function trackUsedThenable<T>(
     }
     default: {
       if (typeof thenable.status === 'string') {
-        // Only instrument the thenable if the status if not defined. If
+        // Only instrument the thenable if the status is not defined. If
         // it's defined, but an unknown value, assume it's been instrumented by
         // some custom userspace implementation. We treat it as "pending".
         // Attach a dummy listener, to ensure that any lazy initialization can

--- a/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.js
+++ b/packages/react-reconciler/src/ReactFiberTracingMarkerComponent.js
@@ -223,7 +223,7 @@ export function pushRootMarkerInstance(workInProgress: Fiber): void {
     }
 
     const markerInstances = [];
-    // For ever transition on the suspense boundary, we push the transition
+    // For every transition on the suspense boundary, we push the transition
     // along with its map of pending suspense boundaries onto the marker
     // instance stack.
     root.incompleteTransitions.forEach(markerInstance => {

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -1064,7 +1064,7 @@ function performConcurrentWorkOnRoot(
     if (exitStatus === RootErrored) {
       // If something threw an error, try rendering one more time. We'll
       // render synchronously to block concurrent data mutations, and we'll
-      // includes all pending updates are included. If it still fails after
+      // include all pending updates are included. If it still fails after
       // the second attempt, we'll give up and commit the resulting tree.
       const originallyAttemptedLanes = lanes;
       const errorRetryLanes = getLanesToRetrySynchronouslyOnError(
@@ -1211,7 +1211,7 @@ function recoverFromConcurrentError(
       // During the synchronous render, we attached additional ping listeners.
       // This is highly suggestive of an uncached promise (though it's not the
       // only reason this would happen). If it was an uncached promise, then
-      // it may have masked a downstream error from ocurring without actually
+      // it may have masked a downstream error from occurring without actually
       // fixing it. Example:
       //
       //    use(Promise.resolve('uncached'))
@@ -1482,7 +1482,7 @@ function performSyncWorkOnRoot(root: FiberRoot) {
   let exitStatus = renderRootSync(root, lanes);
   if (root.tag !== LegacyRoot && exitStatus === RootErrored) {
     // If something threw an error, try rendering one more time. We'll render
-    // synchronously to block concurrent data mutations, and we'll includes
+    // synchronously to block concurrent data mutations, and we'll include
     // all pending updates are included. If it still fails after the second
     // attempt, we'll give up and commit the resulting tree.
     const originallyAttemptedLanes = lanes;
@@ -2334,7 +2334,7 @@ function performUnitOfWork(unitOfWork: Fiber): void {
 }
 
 function replaySuspendedUnitOfWork(unitOfWork: Fiber): void {
-  // This is a fork of performUnitOfWork specifcally for replaying a fiber that
+  // This is a fork of performUnitOfWork specifically for replaying a fiber that
   // just suspended.
   //
   const current = unitOfWork.alternate;

--- a/packages/react-reconciler/src/__tests__/ReactActWarnings-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactActWarnings-test.js
@@ -128,7 +128,7 @@ describe('act warnings', () => {
     if (caches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `caches[index].resolve(text)`.
       caches[caches.length - 1].resolve(text);
     }

--- a/packages/react-reconciler/src/__tests__/ReactCache-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCache-test.js
@@ -176,7 +176,7 @@ describe('ReactCache', () => {
     if (textCaches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `textCaches[index].resolve(text)`.
       textCaches[textCaches.length - 1].resolve(text);
     }

--- a/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactConcurrentErrorRecovery-test.js
@@ -137,7 +137,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     if (caches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `caches[index].resolve(text)`.
       caches[caches.length - 1].resolve(text);
     }
@@ -149,7 +149,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     if (caches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `caches[index].reject(text, error)`.
       caches[caches.length - 1].reject(text, error);
     }
@@ -428,7 +428,7 @@ describe('ReactConcurrentErrorRecovery', () => {
     // This also works if the suspended component is wrapped with an error
     // boundary. (This is only interesting because when a component suspends
     // outside of a transition, we throw an error, which can be captured by
-    // an error boundary.
+    // an error boundary.)
     await act(async () => {
       startTransition(() => {
         root.render(

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -147,7 +147,7 @@ describe('ReactLazyContextPropagation', () => {
     if (caches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `caches[index].resolve(text)`.
       caches[caches.length - 1].resolve(text);
     }
@@ -159,7 +159,7 @@ describe('ReactLazyContextPropagation', () => {
   //   if (caches.length === 0) {
   //     throw Error('Cache does not exist.');
   //   } else {
-  //     // Resolve the most recently created cache. An older cache can by
+  //     // Resolve the most recently created cache. An older cache can be
   //     // resolved with `caches[index].reject(text, error)`.
   //     caches[caches.length - 1].reject(text, error);
   //   }
@@ -391,7 +391,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
-      // Intentionally not wrapping in startTransition, so that the fallback
+      // Intentionally not wrapping in startTransition, so that
       // the fallback displays despite this being a refresh.
       setContext('B');
     });
@@ -471,7 +471,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('AAA');
 
     await act(async () => {
-      // Intentionally not wrapping in startTransition, so that the fallback
+      // Intentionally not wrapping in startTransition, so that
       // the fallback displays despite this being a refresh.
       setContext('B');
     });
@@ -532,7 +532,7 @@ describe('ReactLazyContextPropagation', () => {
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
-      // Intentionally not wrapping in startTransition, so that the fallback
+      // Intentionally not wrapping in startTransition, so that
       // the fallback displays despite this being a refresh.
       setContext('B');
     });

--- a/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSchedulerIntegration-test.js
@@ -291,7 +291,7 @@ describe(
         // Expire the task
         Scheduler.unstable_advanceTime(10000);
         // Scheduling a new update is a trick to force the expiration to kick
-        // in. We don't check if a update has been starved at the beginning of
+        // in. We don't check if an update has been starved at the beginning of
         // working on it, since there's no point — we're already working on it.
         // We only check before yielding to the main thread (to avoid starvation
         // by other main thread work) or when receiving an update (to avoid

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemantics-test.js
@@ -177,7 +177,7 @@ describe('ReactSuspenseEffectsSemantics', () => {
     if (caches.length === 0) {
       throw Error('Cache does not exist.');
     } else {
-      // Resolve the most recently created cache. An older cache can by
+      // Resolve the most recently created cache. An older cache can be
       // resolved with `caches[index].resolve(text)`.
       caches[caches.length - 1].resolve(text);
     }


### PR DESCRIPTION
Minor typos


## Summary

Was reading through the reconciler source code, noticed a few typos (mostly spelling mistakes, but also a few duplicated words) on the way

## How did you test this change?

Only comment changes, no feature change. Passes linting/formatting.