### PR TITLE
[Float][Fiber] implement a faster hydration match for hoistable elements

### DIFF
--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -380,15 +380,78 @@ function updateDOMProperties(
   }
 }
 
+// creates a script element that won't execute
+export function createPotentiallyInlineScriptElement(
+  ownerDocument: Document,
+): Element {
+  // Create the script via .innerHTML so its "parser-inserted" flag is
+  // set to true and it does not execute
+  const div = ownerDocument.createElement('div');
+  if (__DEV__) {
+    if (enableTrustedTypesIntegration && !didWarnScriptTags) {
+      console.error(
+        'Encountered a script tag while rendering React component. ' +
+          'Scripts inside React components are never executed when rendering ' +
+          'on the client. Consider using template tag instead ' +
+          '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).',
+      );
+      didWarnScriptTags = true;
+    }
+  }
+  div.innerHTML = '<script><' + '/script>'; // eslint-disable-line
+  // This is guaranteed to yield a script element.
+  const firstChild = ((div.firstChild: any): HTMLScriptElement);
+  const element = div.removeChild(firstChild);
+  return element;
+}
+
+export function createSelectElement(
+  props: Object,
+  ownerDocument: Document,
+): Element {
+  let element;
+  if (typeof props.is === 'string') {
+    element = ownerDocument.createElement('select', {is: props.is});
+  } else {
+    // Separate else branch instead of using `props.is || undefined` above because of a Firefox bug.
+    // See discussion in https://github.com/facebook/react/pull/6896
+    // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
+    element = ownerDocument.createElement('select');
+  }
+  if (props.multiple) {
+    element.multiple = true;
+  } else if (props.size) {
+    // Setting a size greater than 1 causes a select to behave like `multiple=true`, where
+    // it is possible that no option is selected.
+    //
+    // This is only necessary when a select in "single selection mode".
+    element.size = props.size;
+  }
+  return element;
+}
+
 // Creates elements in the HTML namesapce
 export function createHTMLElement(
   type: string,
   props: Object,
   ownerDocument: Document,
 ): Element {
+  if (__DEV__) {
+    switch (type) {
+      case 'script':
+      case 'select':
+      case 'svg':
+      case 'math':
+        console.error(
+          'createHTMLElement was called with a "%s" type. This type has special creation logic in React and should use the create function implemented specifically for it. This is a bug in React.',
+          type,
+        );
+    }
+  }
+
   let isCustomComponentTag;
 
-  let domElement: Element;
+  let element: Element;
   if (__DEV__) {
     isCustomComponentTag = isCustomComponent(type, props);
     // Should this check be gated by parent namespace? Not sure we want to
@@ -403,59 +466,20 @@ export function createHTMLElement(
     }
   }
 
-  if (type === 'script') {
-    // Create the script via .innerHTML so its "parser-inserted" flag is
-    // set to true and it does not execute
-    const div = ownerDocument.createElement('div');
-    if (__DEV__) {
-      if (enableTrustedTypesIntegration && !didWarnScriptTags) {
-        console.error(
-          'Encountered a script tag while rendering React component. ' +
-            'Scripts inside React components are never executed when rendering ' +
-            'on the client. Consider using template tag instead ' +
-            '(https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template).',
-        );
-        didWarnScriptTags = true;
-      }
-    }
-    div.innerHTML = '<script><' + '/script>'; // eslint-disable-line
-    // This is guaranteed to yield a script element.
-    const firstChild = ((div.firstChild: any): HTMLScriptElement);
-    domElement = div.removeChild(firstChild);
-  } else if (typeof props.is === 'string') {
-    domElement = ownerDocument.createElement(type, {is: props.is});
+  if (typeof props.is === 'string') {
+    element = ownerDocument.createElement(type, {is: props.is});
   } else {
     // Separate else branch instead of using `props.is || undefined` above because of a Firefox bug.
     // See discussion in https://github.com/facebook/react/pull/6896
     // and discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1276240
-    domElement = ownerDocument.createElement(type);
-    // Normally attributes are assigned in `setInitialDOMProperties`, however the `multiple` and `size`
-    // attributes on `select`s needs to be added before `option`s are inserted.
-    // This prevents:
-    // - a bug where the `select` does not scroll to the correct option because singular
-    //  `select` elements automatically pick the first item #13222
-    // - a bug where the `select` set the first item as selected despite the `size` attribute #14239
-    // See https://github.com/facebook/react/issues/13222
-    // and https://github.com/facebook/react/issues/14239
-    if (type === 'select') {
-      const node = ((domElement: any): HTMLSelectElement);
-      if (props.multiple) {
-        node.multiple = true;
-      } else if (props.size) {
-        // Setting a size greater than 1 causes a select to behave like `multiple=true`, where
-        // it is possible that no option is selected.
-        //
-        // This is only necessary when a select in "single selection mode".
-        node.size = props.size;
-      }
-    }
+    element = ownerDocument.createElement(type);
   }
 
   if (__DEV__) {
     if (
       !isCustomComponentTag &&
       // $FlowFixMe[method-unbinding]
-      Object.prototype.toString.call(domElement) ===
+      Object.prototype.toString.call(element) ===
         '[object HTMLUnknownElement]' &&
       !hasOwnProperty.call(warnedUnknownTags, type)
     ) {
@@ -469,7 +493,7 @@ export function createHTMLElement(
     }
   }
 
-  return domElement;
+  return element;
 }
 
 export function createSVGElement(

--- a/packages/react-dom-bindings/src/client/ReactDOMComponent.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponent.js
@@ -55,12 +55,7 @@ import {
   setValueForStyles,
   validateShorthandPropertyCollisionInDev,
 } from './CSSPropertyOperations';
-import {
-  HTML_NAMESPACE,
-  MATH_NAMESPACE,
-  SVG_NAMESPACE,
-  getIntrinsicNamespace,
-} from '../shared/DOMNamespaces';
+import {HTML_NAMESPACE, getIntrinsicNamespace} from '../shared/DOMNamespaces';
 import {
   getPropertyInfo,
   shouldIgnoreAttribute,
@@ -440,10 +435,15 @@ export function createHTMLElement(
     switch (type) {
       case 'script':
       case 'select':
+        console.error(
+          'createHTMLElement was called with a "%s" type. This type has special creation logic in React and should use the create function implemented specifically for it. This is a bug in React.',
+          type,
+        );
+        break;
       case 'svg':
       case 'math':
         console.error(
-          'createHTMLElement was called with a "%s" type. This type has special creation logic in React and should use the create function implemented specifically for it. This is a bug in React.',
+          'createHTMLElement was called with a "%s" type. This type must be created with Document.createElementNS which this method does not implement. This is a bug in React.',
           type,
         );
     }
@@ -494,20 +494,6 @@ export function createHTMLElement(
   }
 
   return element;
-}
-
-export function createSVGElement(
-  type: string,
-  ownerDocument: Document,
-): Element {
-  return ownerDocument.createElementNS(SVG_NAMESPACE, type);
-}
-
-export function createMathElement(
-  type: string,
-  ownerDocument: Document,
-): Element {
-  return ownerDocument.createElementNS(MATH_NAMESPACE, type);
 }
 
 export function createTextNode(

--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -47,7 +47,7 @@ const internalEventHandlersKey = '__reactEvents$' + randomKey;
 const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
 const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
 const internalRootNodeResourcesKey = '__reactResources$' + randomKey;
-const internalResourceMarker = '__reactMarker$' + randomKey;
+const internalHoistableMarker = '__reactMarker$' + randomKey;
 
 export function detachDeletedInstance(node: Instance): void {
   // TODO: This function is only called on host components. I don't think all of
@@ -288,10 +288,16 @@ export function getResourcesFromRoot(root: HoistableRoot): RootResources {
   return resources;
 }
 
-export function isMarkedResource(node: Node): boolean {
-  return !!(node: any)[internalResourceMarker];
+export function isMarkedHoistable(node: Node): boolean {
+  return !!(node: any)[internalHoistableMarker];
 }
 
-export function markNodeAsResource(node: Node) {
-  (node: any)[internalResourceMarker] = true;
+export function markNodeAsHoistable(node: Node) {
+  (node: any)[internalHoistableMarker] = true;
+}
+
+export function isOwnedInstance(node: Node): boolean {
+  return !!(
+    (node: any)[internalHoistableMarker] || (node: any)[internalInstanceKey]
+  );
 }

--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -48,6 +48,7 @@ const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
 const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
 const internalRootNodeResourcesKey = '__reactResources$' + randomKey;
 const internalHoistableMarker = '__reactMarker$' + randomKey;
+const internalCachedMarker = '__reactCacheMarker$' + randomKey;
 
 export function detachDeletedInstance(node: Instance): void {
   // TODO: This function is only called on host components. I don't think all of
@@ -294,6 +295,14 @@ export function isMarkedHoistable(node: Node): boolean {
 
 export function markNodeAsHoistable(node: Node) {
   (node: any)[internalHoistableMarker] = true;
+}
+
+export function isMarkedCached(node: Node): boolean {
+  return !!(node: any)[internalCachedMarker];
+}
+
+export function markNodeAsCached(node: Node) {
+  (node: any)[internalCachedMarker] = true;
 }
 
 export function isOwnedInstance(node: Node): boolean {

--- a/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMComponentTree.js
@@ -48,7 +48,6 @@ const internalEventHandlerListenersKey = '__reactListeners$' + randomKey;
 const internalEventHandlesSetKey = '__reactHandles$' + randomKey;
 const internalRootNodeResourcesKey = '__reactResources$' + randomKey;
 const internalHoistableMarker = '__reactMarker$' + randomKey;
-const internalCachedMarker = '__reactCacheMarker$' + randomKey;
 
 export function detachDeletedInstance(node: Instance): void {
   // TODO: This function is only called on host components. I don't think all of
@@ -295,14 +294,6 @@ export function isMarkedHoistable(node: Node): boolean {
 
 export function markNodeAsHoistable(node: Node) {
   (node: any)[internalHoistableMarker] = true;
-}
-
-export function isMarkedCached(node: Node): boolean {
-  return !!(node: any)[internalCachedMarker];
-}
-
-export function markNodeAsCached(node: Node) {
-  (node: any)[internalCachedMarker] = true;
 }
 
 export function isOwnedInstance(node: Node): boolean {

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -25,7 +25,7 @@ import {
   getValueDescriptorExpectingEnumForWarning,
 } from '../shared/ReactDOMResourceValidation';
 
-import {createHTMLElement, setInitialProperties} from './ReactDOMComponent';
+import {setInitialProperties} from './ReactDOMComponent';
 import {
   precacheFiberNode,
   getResourcesFromRoot,
@@ -179,11 +179,7 @@ function preconnectAs(
 
       const preconnectProps = {rel, crossOrigin, href};
       if (null === ownerDocument.querySelector(key)) {
-        const preloadInstance = createHTMLElement(
-          'link',
-          preconnectProps,
-          ownerDocument,
-        );
+        const preloadInstance = ownerDocument.createElement('link');
         setInitialProperties(preloadInstance, 'link', preconnectProps);
         markNodeAsHoistable(preloadInstance);
         (ownerDocument.head: any).appendChild(preloadInstance);
@@ -293,11 +289,7 @@ function preload(href: string, options: PreloadOptions) {
       preloadPropsMap.set(key, preloadProps);
 
       if (null === ownerDocument.querySelector(preloadKey)) {
-        const preloadInstance = createHTMLElement(
-          'link',
-          preloadProps,
-          ownerDocument,
-        );
+        const preloadInstance = ownerDocument.createElement('link');
         setInitialProperties(preloadInstance, 'link', preloadProps);
         markNodeAsHoistable(preloadInstance);
         (ownerDocument.head: any).appendChild(preloadInstance);
@@ -374,11 +366,7 @@ function preinit(href: string, options: PreinitOptions) {
             preloadPropsMap.set(key, preloadProps);
 
             if (null === preloadDocument.querySelector(preloadKey)) {
-              const preloadInstance = createHTMLElement(
-                'link',
-                preloadProps,
-                preloadDocument,
-              );
+              const preloadInstance = preloadDocument.createElement('link');
               setInitialProperties(preloadInstance, 'link', preloadProps);
               markNodeAsHoistable(preloadInstance);
               (preloadDocument.head: any).appendChild(preloadInstance);
@@ -420,7 +408,7 @@ function preinit(href: string, options: PreinitOptions) {
             adoptPreloadPropsForStylesheet(stylesheetProps, preloadProps);
           }
           const ownerDocument = getDocumentFromRoot(resourceRoot);
-          instance = createHTMLElement('link', stylesheetProps, ownerDocument);
+          instance = ownerDocument.createElement('link');
           markNodeAsHoistable(instance);
           setInitialProperties(instance, 'link', stylesheetProps);
           insertStylesheet(instance, precedence, resourceRoot);
@@ -462,7 +450,7 @@ function preinit(href: string, options: PreinitOptions) {
             adoptPreloadPropsForScript(scriptProps, preloadProps);
           }
           const ownerDocument = getDocumentFromRoot(resourceRoot);
-          instance = createHTMLElement('script', scriptProps, ownerDocument);
+          instance = ownerDocument.createElement('script');
           markNodeAsHoistable(instance);
           setInitialProperties(instance, 'link', scriptProps);
           (ownerDocument.head: any).appendChild(instance);
@@ -697,11 +685,7 @@ function preloadStylesheet(
       null ===
       ownerDocument.querySelector(getPreloadStylesheetSelectorFromKey(key))
     ) {
-      const preloadInstance = createHTMLElement(
-        'link',
-        preloadProps,
-        ownerDocument,
-      );
+      const preloadInstance = ownerDocument.createElement('link');
       setInitialProperties(preloadInstance, 'link', preloadProps);
       markNodeAsHoistable(preloadInstance);
       (ownerDocument.head: any).appendChild(preloadInstance);
@@ -761,7 +745,7 @@ export function acquireResource(
 
         const styleProps = styleTagPropsFromRawProps(props);
         const ownerDocument = getDocumentFromRoot(hoistableRoot);
-        instance = createHTMLElement('style', styleProps, ownerDocument);
+        instance = ownerDocument.createElement('style');
 
         markNodeAsHoistable(instance);
         setInitialProperties(instance, 'style', styleProps);
@@ -795,7 +779,7 @@ export function acquireResource(
 
         // Construct and insert a new instance
         const ownerDocument = getDocumentFromRoot(hoistableRoot);
-        instance = createHTMLElement('link', stylesheetProps, ownerDocument);
+        instance = ownerDocument.createElement('link');
         markNodeAsHoistable(instance);
         const linkInstance: HTMLLinkElement = (instance: any);
         (linkInstance: any)._p = new Promise((resolve, reject) => {
@@ -837,7 +821,7 @@ export function acquireResource(
 
         // Construct and insert a new instance
         const ownerDocument = getDocumentFromRoot(hoistableRoot);
-        instance = createHTMLElement('script', scriptProps, ownerDocument);
+        instance = ownerDocument.createElement('script');
         markNodeAsHoistable(instance);
         setInitialProperties(instance, 'link', scriptProps);
         (ownerDocument.head: any).appendChild(instance);
@@ -945,7 +929,7 @@ export function hydrateHoistable(
         instance.namespaceURI === SVG_NAMESPACE ||
         instance.hasAttribute('itemprop')
       ) {
-        instance = createHTMLElement(type, props, ownerDocument);
+        instance = ownerDocument.createElement(type);
         (ownerDocument.head: any).insertBefore(
           instance,
           ownerDocument.querySelector('head > title'),
@@ -991,7 +975,7 @@ export function hydrateHoistable(
           break getInstance;
         }
       }
-      instance = createHTMLElement(type, props, ownerDocument);
+      instance = ownerDocument.createElement(type);
       setInitialProperties(instance, type, props);
       (ownerDocument.head: any).appendChild(instance);
       break;
@@ -1040,7 +1024,7 @@ export function hydrateHoistable(
           break getInstance;
         }
       }
-      instance = createHTMLElement(type, props, ownerDocument);
+      instance = ownerDocument.createElement(type);
       setInitialProperties(instance, type, props);
       (ownerDocument.head: any).appendChild(instance);
       break;

--- a/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMFloatClient.js
@@ -1010,6 +1010,9 @@ export function hydrateHoistable(
         for (let i = 0; i < nodes.length; i++) {
           const node = nodes[i];
 
+          // We coerce content to string because it is the most likely one to
+          // use a `toString` capable value. For the rest we just do identity match
+          // passing non-strings here is not really valid anyway.
           if (__DEV__) {
             checkAttributeStringCoercion(props.content, 'content');
           }
@@ -1020,6 +1023,8 @@ export function hydrateHoistable(
               (props.name == null ? null : props.name) ||
             node.getAttribute('property') !==
               (props.property == null ? null : props.property) ||
+            node.getAttribute('http-equiv') !==
+              (props.httpEquiv == null ? null : props.httpEquiv) ||
             node.getAttribute('charset') !==
               (props.charSet == null ? null : props.charSet)
           ) {

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -33,6 +33,8 @@ export {detachDeletedInstance};
 import {hasRole} from './DOMAccessibilityRoles';
 import {
   createHTMLElement,
+  createPotentiallyInlineScriptElement,
+  createSelectElement,
   createSVGElement,
   createMathElement,
   createTextNode,
@@ -61,7 +63,6 @@ import {
   getChildNamespace,
   SVG_NAMESPACE,
   MATH_NAMESPACE,
-  HTML_NAMESPACE,
 } from '../shared/DOMNamespaces';
 import {
   ELEMENT_NODE,
@@ -322,25 +323,30 @@ export function createInstance(
   );
 
   let domElement: Instance;
-  create: switch (namespace) {
+  switch (namespace) {
     case SVG_NAMESPACE:
       domElement = createSVGElement(type, ownerDocument);
       break;
     case MATH_NAMESPACE:
       domElement = createMathElement(type, ownerDocument);
       break;
-    case HTML_NAMESPACE:
+    default:
       switch (type) {
         case 'svg':
           domElement = createSVGElement(type, ownerDocument);
-          break create;
+          break;
         case 'math':
           domElement = createMathElement(type, ownerDocument);
-          break create;
+          break;
+        case 'script':
+          domElement = createPotentiallyInlineScriptElement(ownerDocument);
+          break;
+        case 'select':
+          domElement = createSelectElement(props, ownerDocument);
+          break;
+        default:
+          domElement = createHTMLElement(type, props, ownerDocument);
       }
-    // eslint-disable-next-line no-fallthrough
-    default:
-      domElement = createHTMLElement(type, props, ownerDocument);
   }
   precacheFiberNode(internalInstanceHandle, domElement);
   updateFiberProps(domElement, props);

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -35,8 +35,6 @@ import {
   createHTMLElement,
   createPotentiallyInlineScriptElement,
   createSelectElement,
-  createSVGElement,
-  createMathElement,
   createTextNode,
   setInitialProperties,
   diffProperties,
@@ -325,18 +323,16 @@ export function createInstance(
   let domElement: Instance;
   switch (namespace) {
     case SVG_NAMESPACE:
-      domElement = createSVGElement(type, ownerDocument);
-      break;
     case MATH_NAMESPACE:
-      domElement = createMathElement(type, ownerDocument);
+      domElement = ownerDocument.createElementNS(namespace, type);
       break;
     default:
       switch (type) {
         case 'svg':
-          domElement = createSVGElement(type, ownerDocument);
+          domElement = ownerDocument.createElementNS(SVG_NAMESPACE, type);
           break;
         case 'math':
-          domElement = createMathElement(type, ownerDocument);
+          domElement = ownerDocument.createElementNS(MATH_NAMESPACE, type);
           break;
         case 'script':
           domElement = createPotentiallyInlineScriptElement(ownerDocument);

--- a/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
+++ b/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js
@@ -26,8 +26,8 @@ import {
   getInstanceFromNode as getInstanceFromNodeDOMTree,
   isContainerMarkedAsRoot,
   detachDeletedInstance,
-  isMarkedResource,
-  markNodeAsResource,
+  isMarkedHoistable,
+  markNodeAsHoistable,
 } from './ReactDOMComponentTree';
 export {detachDeletedInstance};
 import {hasRole} from './DOMAccessibilityRoles';
@@ -284,7 +284,7 @@ export function createHoistableInstance(
   precacheFiberNode(internalInstanceHandle, domElement);
   updateFiberProps(domElement, props);
   setInitialProperties(domElement, type, props);
-  markNodeAsResource(domElement);
+  markNodeAsHoistable(domElement);
   return domElement;
 }
 
@@ -876,7 +876,7 @@ export function shouldSkipHydratableForInstance(
     return false;
   } else if (
     instance.nodeName.toLowerCase() !== type.toLowerCase() ||
-    isMarkedResource(instance)
+    isMarkedHoistable(instance)
   ) {
     // We are either about to
     return true;
@@ -1807,6 +1807,7 @@ export {
   hydrateHoistable,
   mountHoistable,
   unmountHoistable,
+  prepareToCommitHoistables,
 } from './ReactDOMFloatClient';
 
 // -------------------
@@ -1936,7 +1937,7 @@ export function clearSingleton(instance: Instance): void {
     const nextNode = node.nextSibling;
     const nodeName = node.nodeName;
     if (
-      isMarkedResource(node) ||
+      isMarkedHoistable(node) ||
       nodeName === 'HEAD' ||
       nodeName === 'BODY' ||
       nodeName === 'STYLE' ||

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -2388,7 +2388,7 @@ body {
     );
 
     ReactDOMClient.hydrateRoot(document, <App />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
@@ -2441,8 +2441,8 @@ body {
         <script itemProp="foo" />
       </html>,
     );
-    expect(() => {
-      expect(Scheduler).toFlushWithoutYielding();
+    await expect(async () => {
+      await waitForAll([]);
     }).toErrorDev([
       'Cannot render a <meta> outside the main document if it has an `itemProp` prop. `itemProp` suggests the tag belongs to an `itemScope` which can appear anywhere in the DOM. If you were intending for React to hoist this <meta> remove the `itemProp` prop. Otherwise, try moving this tag into the <head> or <body> of the Document.',
       'Cannot render a <title> outside the main document if it has an `itemProp` prop. `itemProp` suggests the tag belongs to an `itemScope` which can appear anywhere in the DOM. If you were intending for React to hoist this <title> remove the `itemProp` prop. Otherwise, try moving this tag into the <head> or <body> of the Document.',
@@ -2567,7 +2567,7 @@ body {
     // script insertion that happens because we do not SSR async scripts with load handlers.
     // All the extra inject nodes are preset
     const root = ReactDOMClient.hydrateRoot(document, <App />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html itemscope="">
         <head>

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -157,6 +157,7 @@ import {
   hydrateHoistable,
   mountHoistable,
   unmountHoistable,
+  prepareToCommitHoistables,
 } from './ReactFiberHostConfig';
 import {
   captureCommitPhaseError,
@@ -2822,6 +2823,8 @@ function commitMutationEffectsOnFiber(
     }
     case HostRoot: {
       if (enableFloat && supportsResources) {
+        prepareToCommitHoistables();
+
         const previousHoistableRoot = currentHoistableRoot;
         currentHoistableRoot = getHoistableRoot(root.containerInfo);
 

--- a/packages/react-reconciler/src/ReactFiberHostConfigWithNoResources.js
+++ b/packages/react-reconciler/src/ReactFiberHostConfigWithNoResources.js
@@ -31,3 +31,4 @@ export const hydrateHoistable = shim;
 export const mountHoistable = shim;
 export const unmountHoistable = shim;
 export const createHoistableInstance = shim;
+export const prepareToCommitHoistables = shim;

--- a/packages/react-reconciler/src/ReactFiberHydrationContext.js
+++ b/packages/react-reconciler/src/ReactFiberHydrationContext.js
@@ -436,7 +436,7 @@ function claimHydratableSingleton(fiber: Fiber): void {
   }
 }
 
-function advanceToFirstAttempableInstance(fiber: Fiber) {
+function advanceToFirstAttemptableInstance(fiber: Fiber) {
   // fiber is HostComponent Fiber
   while (
     nextHydratableInstance &&
@@ -452,7 +452,7 @@ function advanceToFirstAttempableInstance(fiber: Fiber) {
   }
 }
 
-function advanceToFirstAttempableTextInstance() {
+function advanceToFirstAttemptableTextInstance() {
   while (
     nextHydratableInstance &&
     shouldSkipHydratableForTextInstance(nextHydratableInstance)
@@ -463,7 +463,7 @@ function advanceToFirstAttempableTextInstance() {
   }
 }
 
-function advanceToFirstAttempableSuspenseInstance() {
+function advanceToFirstAttemptableSuspenseInstance() {
   while (
     nextHydratableInstance &&
     shouldSkipHydratableForSuspenseInstance(nextHydratableInstance)
@@ -490,7 +490,7 @@ function tryToClaimNextHydratableInstance(fiber: Fiber): void {
   const initialInstance = nextHydratableInstance;
   if (rootOrSingletonContext) {
     // We may need to skip past certain nodes in these contexts
-    advanceToFirstAttempableInstance(fiber);
+    advanceToFirstAttemptableInstance(fiber);
   }
   const nextInstance = nextHydratableInstance;
   if (!nextInstance) {
@@ -518,7 +518,7 @@ function tryToClaimNextHydratableInstance(fiber: Fiber): void {
     const prevHydrationParentFiber: Fiber = (hydrationParentFiber: any);
     if (rootOrSingletonContext) {
       // We may need to skip past certain nodes in these contexts
-      advanceToFirstAttempableInstance(fiber);
+      advanceToFirstAttemptableInstance(fiber);
     }
     if (
       !nextHydratableInstance ||
@@ -551,7 +551,7 @@ function tryToClaimNextHydratableTextInstance(fiber: Fiber): void {
     // We may need to skip past certain nodes in these contexts.
     // We don't skip if the text is not hydratable because we know no hydratables
     // exist which could match this Fiber
-    advanceToFirstAttempableTextInstance();
+    advanceToFirstAttemptableTextInstance();
   }
   const nextInstance = nextHydratableInstance;
   if (!nextInstance || !isHydratable) {
@@ -582,7 +582,7 @@ function tryToClaimNextHydratableTextInstance(fiber: Fiber): void {
 
     if (rootOrSingletonContext && isHydratable) {
       // We may need to skip past certain nodes in these contexts
-      advanceToFirstAttempableTextInstance();
+      advanceToFirstAttemptableTextInstance();
     }
 
     if (
@@ -611,7 +611,7 @@ function tryToClaimNextHydratableSuspenseInstance(fiber: Fiber): void {
   const initialInstance = nextHydratableInstance;
   if (rootOrSingletonContext) {
     // We may need to skip past certain nodes in these contexts
-    advanceToFirstAttempableSuspenseInstance();
+    advanceToFirstAttemptableSuspenseInstance();
   }
   const nextInstance = nextHydratableInstance;
   if (!nextInstance) {
@@ -640,7 +640,7 @@ function tryToClaimNextHydratableSuspenseInstance(fiber: Fiber): void {
 
     if (rootOrSingletonContext) {
       // We may need to skip past certain nodes in these contexts
-      advanceToFirstAttempableSuspenseInstance();
+      advanceToFirstAttemptableSuspenseInstance();
     }
 
     if (

--- a/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
+++ b/packages/react-reconciler/src/forks/ReactFiberHostConfig.custom.js
@@ -202,6 +202,7 @@ export const errorHydratingContainer = $$$hostConfig.errorHydratingContainer;
 //     Resources
 //     (optional)
 // -------------------
+export type HoistableRoot = mixed;
 export const supportsResources = $$$hostConfig.supportsResources;
 export const isHostHoistableType = $$$hostConfig.isHostHoistableType;
 export const getHoistableRoot = $$$hostConfig.getHoistableRoot;
@@ -212,7 +213,8 @@ export const hydrateHoistable = $$$hostConfig.hydrateHoistable;
 export const mountHoistable = $$$hostConfig.mountHoistable;
 export const unmountHoistable = $$$hostConfig.unmountHoistable;
 export const createHoistableInstance = $$$hostConfig.createHoistableInstance;
-export type HoistableRoot = mixed;
+export const prepareToCommitHoistables =
+  $$$hostConfig.prepareToCommitHoistables;
 
 // -------------------
 //     Singletons

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -452,5 +452,6 @@
   "464": "ReactDOMServer.renderToStaticNodeStream(): The Node Stream API is not available in Bun. Use ReactDOMServer.renderToReadableStream() instead.",
   "465": "enableFizzExternalRuntime without enableFloat is not supported. This should never appear in production, since it means you are using a misconfigured React bundle.",
   "466": "Trying to call a function from \"use server\" but the callServer option was not implemented in your router runtime.",
-  "467": "Update hook called on initial render. This is likely a bug in React. Please file an issue."
+  "467": "Update hook called on initial render. This is likely a bug in React. Please file an issue.",
+  "468": "getNodesForType encountered a type it did not expect: \"%s\". This is a bug in React."
 }


### PR DESCRIPTION
This PR is now based on #26256 

The original matching function for `hydrateHoistable` some challenging time complexity since we built up the list of matchable nodes for each link of that type and then had to check to exclusion. This new implementation aims to improve the complexity

For hoisted title tags we match the first title if it is valid (not in SVG context and does not have `itemprop`, the two ways you opt out of hoisting when rendering titles). This path is much faster than others and we use it because valid Documents only have 1 title anyway and if we did have a mismatch the rendered title still ends up as the Document.title so there is no functional degradation for misses.

For hoisted link and meta tags we track all potentially hydratable Elements of this type in a cache per Document. The cache is refreshed once each commit if and only if there is a title or meta hoistable hydrating. The caches are partitioned by a natural key for each type (href for link and content for meta). Then secondary attributes are checked to see if the potential match is matchable.

For link we check `rel`, `title`, and `crossorigin`. These should provide enough entropy that we never have collisions except is contrived cases and even then it should not affect functionality of the page. This should also be tolerant of links being injected in arbitrary places in the Document by 3rd party scripts and browser extensions

For meta we check `name`, `property`, `http-equiv`, and `charset`. These should provide enough entropy that we don't have meaningful collisions. It is concievable with og tags that there may be true duplciates `<meta property="og:image:size:height" content="100" />` but even if we did bind to the wrong instance meta tags are typically only read from SSR by bots and rarely inserted by 3rd parties so an adverse functional outcome is not expected.