### PR TITLE
Only install browsers used by Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,8 +225,8 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
-            npx playwright install
-            sudo npx playwright install-deps
+            npx playwright install chrome
+            sudo npx playwright install-deps chrome
       - run:
           environment:
             RELEASE_CHANNEL: experimental
@@ -262,8 +262,8 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
-            npx playwright install
-            sudo npx playwright install-deps
+            npx playwright install chrome
+            sudo npx playwright install-deps chrome
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >>
       - run:
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ jobs:
             # TODO: This will install the latest version of Chrome instead of the one tested against Playwright.
             # A specific Playwright version is only tested a certain version of Chrome.
             # But since we install the latest one there's no guarantee Playwright will stop working due to breaking changes in Chrome.
-            sudo npx playwright install --with-deps chrome
+            npx playwright install --with-deps chrome
             which google-chrome
       - run:
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,12 +225,11 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
-            which google-chrome
             # https://github.com/microsoft/playwright/issues/11300#issuecomment-1009322833
             # TODO: apt-get can be removed once we switch to @playwright/test@^1.18.0
             apt-get update
-            which google-chrome
             sudo npx playwright install --with-deps chrome
+            which google-chrome
       - run:
           environment:
             RELEASE_CHANNEL: experimental

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,11 +225,12 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
+            which google-chrome
             # https://github.com/microsoft/playwright/issues/11300#issuecomment-1009322833
             # TODO: apt-get can be removed once we switch to @playwright/test@^1.18.0
-            sudo apt-get update
-            npx playwright install chrome
-            sudo npx playwright install-deps chrome
+            apt-get update
+            which google-chrome
+            sudo npx playwright install --with-deps chrome
       - run:
           environment:
             RELEASE_CHANNEL: experimental

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,10 @@ jobs:
           command: |
             # https://github.com/microsoft/playwright/issues/11300#issuecomment-1009322833
             # TODO: apt-get can be removed once we switch to @playwright/test@^1.18.0
-            apt-get update
+            sudo apt-get update
+            # TODO: This will install the latest version of Chrome instead of the one tested against Playwright.
+            # A specific Playwright version is only tested a certain version of Chrome.
+            # But since we install the latest one there's no guarantee Playwright will stop working due to breaking changes in Chrome.
             sudo npx playwright install --with-deps chrome
             which google-chrome
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,9 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
+            # https://github.com/microsoft/playwright/issues/11300#issuecomment-1009322833
+            # TODO: apt-get can be removed once we switch to @playwright/test@^1.18.0
+            sudo apt-get update
             npx playwright install chrome
             sudo npx playwright install-deps chrome
       - run:
@@ -262,6 +265,9 @@ jobs:
       - run:
           name: Playwright install deps
           command: |
+            # https://github.com/microsoft/playwright/issues/11300#issuecomment-1009322833
+            # TODO: apt-get can be removed once we switch to @playwright/test@^1.18.0
+            sudo apt-get update
             npx playwright install chrome
             sudo npx playwright install-deps chrome
       - run: ./scripts/circleci/download_devtools_regression_build.js << parameters.version >>

--- a/pw-install.sh
+++ b/pw-install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eo pipefail;
+
+npx playwright install;
+sudo npx playwright install-deps;


### PR DESCRIPTION
## Summary

Currently we install Chrome, Firefox and Webkit even though we're only using Chrome. We can instruct Playwright to only install manually specified browsers.

This should reduce overall time of `build_test` since `run_devtools_e2e_tests` is usually the last job to finish

## How did you test this change?

- [ ] CI
- [x] [~60s Playwright install time on `main`](https://app.circleci.com/pipelines/github/facebook/react/38261/workflows/ee9abb3b-5ee0-4dc0-a3a6-1d4e1f387304/jobs/627104?invite=true#step-106-1)
- [ ] [?s Playwright install time on this branch]()