### PR TITLE
Remove unnecessary flowconfig ignore paths

### DIFF
--- a/scripts/flow/config/flowconfig
+++ b/scripts/flow/config/flowconfig
@@ -8,12 +8,6 @@
 .*/rollup/shims/facebook-www/.*
 .*/rollup/shims/react-native/.*
 
-.*/node_modules/@snyk/.*
-.*/node_modules/y18n/.*
-.*/node_modules/chrome-devtools-frontend/.*
-.*/node_modules/devtools-timeline-model/.*
-.*/node_modules/create-react-class/.*
-.*/node_modules/react-native-web/.*
 .*/node_modules/fbjs/lib/keyMirrorRecursive.js.flow
 .*/node_modules/resolve/test/.*
 .*/__mocks__/.*


### PR DESCRIPTION
## Summary

By removing them, the flowconfig file will be cleaner and easier to maintain.

## How did you test this change?

ci green