### PR TITLE
Fix:-Replace the render method with the new createRoot method for fixture …

### DIFF
--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -9,4 +9,4 @@
       <h1>Hello World!</h1>)
     </script>
   </body>
-</html>;
+</html>

--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,8 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.render(
-        <h1>Hello World!</h1>,
-        document.getElementById('container')
-      );
+      ReactDOM.createRoot( document.getElementById('container')).render(
+      <h1>Hello World!</h1>)
     </script>
   </body>
-</html>
+</html>;

--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,10 +5,8 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.createRoot( document.getElementById('container')).render
-      (
-       <h1>Hello World!</h1>
-      )
+      ReactDOM.createRoot( document.getElementById('container')).render (
+      <h1>Hello World!</h1>)
     </script>
   </body>
-</html>
+</html>;

--- a/fixtures/packaging/babel-standalone/dev.html
+++ b/fixtures/packaging/babel-standalone/dev.html
@@ -5,8 +5,10 @@
     <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
     <div id="container"></div>
     <script type="text/babel">
-      ReactDOM.createRoot( document.getElementById('container')).render(
-      <h1>Hello World!</h1>)
+      ReactDOM.createRoot( document.getElementById('container')).render
+      (
+       <h1>Hello World!</h1>
+      )
     </script>
   </body>
-</html>;
+</html>


### PR DESCRIPTION
Currently the Fixtures folder with the babel standalone folder which allows us to test our react changes is using the old method for the render, since react 18 is the current version, replacing it seems the way

![Mozilla Firefox 2_16_2023 12_21_08 PM](https://user-images.githubusercontent.com/72331432/219291078-21dfab5b-d8c5-4dbc-8ab3-44077a53fa40.png)
  