### PR TITLE
[difftrain] Remove dependency on node-fetch

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -8,17 +8,11 @@ jobs:
   download_artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-      - run: npm init -y
-      - run: npm install node-fetch@2
       - name: Download and unzip artifacts
         uses: actions/github-script@v6
         with:
           script: |
             const cp = require('child_process');
-            const fetch = require('node-fetch');
 
             function sleep(ms) {
               return new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
`fetch` is now provided by github-scripts implicitly in https://github.com/actions/github-script/releases/tag/v6.4.0, so this was causing a duplicate declaration error.