### PR TITLE
remove flow check in electron app.js

### DIFF
--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 const {app, BrowserWindow} = require('electron'); // Module to create native browser window.
@@ -40,17 +38,12 @@ app.on('ready', function () {
   }
 
   // https://stackoverflow.com/questions/32402327/
-  // $FlowFixMe[incompatible-use] found when upgrading Flow
-  mainWindow.webContents.on(
-    'new-window',
-    function (event: $FlowFixMe, url: $FlowFixMe) {
-      event.preventDefault();
-      require('electron').shell.openExternal(url);
-    },
-  );
+  mainWindow.webContents.on('new-window', function (event, url) {
+    event.preventDefault();
+    require('electron').shell.openExternal(url);
+  });
 
   // and load the index.html of the app.
-  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.loadURL('file://' + __dirname + '/app.html'); // eslint-disable-line no-path-concat
   // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.webContents.executeJavaScript(
@@ -61,7 +54,6 @@ app.on('ready', function () {
   );
 
   // Emitted when the window is closed.
-  // $FlowFixMe[incompatible-use] found when upgrading Flow
   mainWindow.on('closed', function () {
     mainWindow = null;
   });


### PR DESCRIPTION
When we were upgrading flow in https://github.com/facebook/react/commit/6ddcbd4f96cb103de3978617a53c200baf5b546c we added `$FlowFixMe` for some parameters in this file. However, this file is not compiled at all, and the `:` syntax breaks the code.

This PR removes the flow check in this file