### PR TITLE
Make enableCustomElementPropertySupport a dynamic flag in www build

### DIFF
--- a/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
+++ b/packages/shared/forks/ReactFeatureFlags.www-dynamic.js
@@ -26,6 +26,8 @@ export const enableUnifiedSyncLane = __VARIANT__;
 export const enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay =
   __VARIANT__;
 export const enableTransitionTracing = __VARIANT__;
+export const enableCustomElementPropertySupport = __VARIANT__;
+
 // Enable this flag to help with concurrent mode debugging.
 // It logs information to the console about React scheduling, rendering, and commit phases.
 //

--- a/packages/shared/forks/ReactFeatureFlags.www.js
+++ b/packages/shared/forks/ReactFeatureFlags.www.js
@@ -32,6 +32,7 @@ export const {
   enableUnifiedSyncLane,
   enableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay,
   enableTransitionTracing,
+  enableCustomElementPropertySupport,
 } = dynamicFeatureFlags;
 
 // On WWW, __EXPERIMENTAL__ is used for a new modern build.
@@ -99,8 +100,6 @@ export const enableServerContext = true;
 
 // Some www surfaces are still using this. Remove once they have been migrated.
 export const enableUseMutableSource = true;
-
-export const enableCustomElementPropertySupport = __EXPERIMENTAL__;
 
 export const useModernStrictMode = false;
 export const enableFizzExternalRuntime = true;


### PR DESCRIPTION
Turns enableCustomElementPropertySupport into a dynamic flag in the www build so we can turn it on behind a GK.