### PR TITLE
Fix the comment in the strip-unused-imports plugin

### DIFF
--- a/scripts/rollup/plugins/strip-unused-imports.js
+++ b/scripts/rollup/plugins/strip-unused-imports.js
@@ -14,8 +14,8 @@ module.exports = function stripUnusedImports(pureExternalModules) {
         // Ideally this would use a negative lookbehind: (?<!= *)
         // But this isn't supported by the Node <= 8.9.
         // So instead we try to handle the most common cases:
-        // 1. foo,bar=require("bar"),baz
-        // 2. foo;bar = require('bar');baz
+        // 1. foo,require("bar"),baz
+        // 2. foo;require('bar');baz
         // 3.   require('bar');
         const regExp = new RegExp(
           `([,;]| {2})require\\(["']${module}["']\\)[,;]`,


### PR DESCRIPTION
## Summary

Fix the comment in the strip-unused-imports Rollup plugin to match the actual behavior of the plugin.