### PR TITLE
Update rollup config to use moduleSideEffects

### DIFF
--- a/scripts/rollup/build.js
+++ b/scripts/rollup/build.js
@@ -564,7 +564,8 @@ async function createBundle(bundle, bundleType) {
   const rollupConfig = {
     input: resolvedEntry,
     treeshake: {
-      pureExternalModules,
+      moduleSideEffects: (id, external) =>
+        !(external && pureExternalModules.includes(id)),
     },
     external(id) {
       const containsThisModule = pkg => id === pkg || id.startsWith(pkg + '/');


### PR DESCRIPTION
## Summary

In rollup v1.19.4, The "treeshake.pureExternalModules" option is deprecated. The "treeshake.moduleSideEffects" option should be used instead, see https://github.com/rollup/rollup/blob/v1.19.4/src/Graph.ts#L130.

## How did you test this change?

ci green