### PR TITLE
Change commit message for DiffTrain commigs

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -152,8 +152,7 @@ jobs:
           commit_message: |
             ${{ github.event.head_commit.message }}
 
-            DiffTrain build for [${{ github.sha }}](https://github.com/facebook/react/commit/${{ github.sha }})
-            [View git log for this commit](https://github.com/facebook/react/commits/${{ github.sha }})
+            DiffTrain build for commit ${{ github.sha }}.
           branch: builds/facebook-www
           commit_user_name: ${{ github.actor }}
           commit_user_email: ${{ github.actor }}@users.noreply.github.com


### PR DESCRIPTION
Previously, the commit message looked something like this in Github: 
<img width="921" alt="Screenshot 2023-02-20 at 13 52 35" src="https://user-images.githubusercontent.com/1733610/220126265-d77931e0-18ac-46a0-bf23-d868f8af17a9.png">

With this change, it will look like:

DiffTrain build for commit db5e6250d4bbb70c5085c58694a2e9c78c3f6371.