### PR TITLE
Rename `yarn start` to `yarn dev` and `yarn start:prod` to `yarn start`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
             RELEASE_CHANNEL: stable
           working_directory: fixtures/dom
           command: |
-            yarn prestart
+            yarn predev
             yarn test --maxWorkers=2
 
   test_fuzz:

--- a/fixtures/attribute-behavior/README.md
+++ b/fixtures/attribute-behavior/README.md
@@ -8,7 +8,7 @@
 
 ## Instructions
 
-`yarn build --type=UMD_DEV react/index,react-dom && cd fixtures/attribute-behavior && yarn install && yarn start`
+`yarn build --type=UMD_DEV react/index,react-dom && cd fixtures/attribute-behavior && yarn install && yarn dev`
 
 ## Interpretation
 

--- a/fixtures/attribute-behavior/package.json
+++ b/fixtures/attribute-behavior/package.json
@@ -11,9 +11,9 @@
     "react-virtualized": "^9.9.0"
   },
   "scripts": {
-    "prestart":
+    "predev":
       "cp ../../build/oss-experimental/react/umd/react.development.js public/ && cp ../../build/oss-experimental/react-dom/umd/react-dom.development.js public/ && cp ../../build/oss-experimental/react-dom/umd/react-dom-server-legacy.browser.development.js public/",
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/concurrent/time-slicing/package.json
+++ b/fixtures/concurrent/time-slicing/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "copy-source": "cp -r ../../../build/oss-experimental/* ./node_modules/",
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/dom/package.json
+++ b/fixtures/dom/package.json
@@ -19,8 +19,8 @@
     "semver": "^5.5.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "prestart": "cp ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.development.js ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build/oss-stable/react/umd/react.development.js ../../build/oss-stable/react-dom/umd/react-dom.development.js ../../build/oss-stable/react/umd/react.production.min.js ../../build/oss-stable/react-dom/umd/react-dom.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.development.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.development.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.production.min.js public/ && cp -a ../../build/oss-stable/. node_modules",
+    "dev": "react-scripts start",
+    "predev": "cp ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.development.js ../../build/oss-stable/scheduler/umd/scheduler-unstable_mock.production.min.js ../../build/oss-stable/react/umd/react.development.js ../../build/oss-stable/react-dom/umd/react-dom.development.js ../../build/oss-stable/react/umd/react.production.min.js ../../build/oss-stable/react-dom/umd/react-dom.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.development.js ../../build/oss-stable/react-dom/umd/react-dom-server.browser.production.min.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.development.js ../../build/oss-stable/react-dom/umd/react-dom-test-utils.production.min.js public/ && cp -a ../../build/oss-stable/. node_modules",
     "build": "react-scripts build && cp build/index.html build/200.html",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/expiration/package.json
+++ b/fixtures/expiration/package.json
@@ -8,9 +8,9 @@
     "react-scripts": "1.0.17"
   },
   "scripts": {
-    "prestart":
+    "predev":
       "cp ../../build/oss-experimental/react/umd/react.development.js public/ && cp ../../build/oss-experimental/react-dom/umd/react-dom.development.js public/",
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/fiber-debugger/package.json
+++ b/fixtures/fiber-debugger/package.json
@@ -12,7 +12,7 @@
     "react-motion": "^0.5.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "dev": "react-scripts start",
     "build": "react-scripts build"
   }
 }

--- a/fixtures/fizz/package.json
+++ b/fixtures/fizz/package.json
@@ -28,12 +28,12 @@
     "prettier": "1.19.1"
   },
   "scripts": {
-    "start": "concurrently \"npm run server:dev\" \"npm run bundler:dev\"",
-    "start:prod": "concurrently \"npm run server:prod\" \"npm run bundler:prod\"",
-    "server:dev": "cross-env NODE_ENV=development nodemon -- --inspect server/server.js",
-    "server:prod": "cross-env NODE_ENV=production nodemon -- server/server.js",
-    "bundler:dev": "cross-env NODE_ENV=development nodemon -- scripts/build.js",
-    "bundler:prod": "cross-env NODE_ENV=production nodemon -- scripts/build.js"
+    "dev": "concurrently \"npm run dev:server\" \"npm run dev:bundler\"",
+    "start": "concurrently \"npm run start:server\" \"npm run start:bundler\"",
+    "dev:server": "cross-env NODE_ENV=development nodemon -- --inspect server/server.js",
+    "start:server": "cross-env NODE_ENV=production nodemon -- server/server.js",
+    "dev:bundler": "cross-env NODE_ENV=development nodemon -- scripts/build.js",
+    "start:bundler": "cross-env NODE_ENV=production nodemon -- scripts/build.js"
   },
   "babel": {
     "presets": [

--- a/fixtures/flight/package.json
+++ b/fixtures/flight/package.json
@@ -63,14 +63,14 @@
     "workbox-webpack-plugin": "^6.4.1"
   },
   "scripts": {
-    "prestart": "cp -r ../../build/oss-experimental/* ./node_modules/",
+    "predev": "cp -r ../../build/oss-experimental/* ./node_modules/",
     "prebuild": "cp -r ../../build/oss-experimental/* ./node_modules/",
-    "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
-    "start:client": "NODE_ENV=development BUILD_PATH=dist node scripts/start.js",
-    "start:server": "NODE_ENV=development BUILD_PATH=dist nodemon -- --experimental-loader ./loader/index.js --conditions=react-server server",
-    "start:prod": "node scripts/build.js && concurrently \"npm run start:prod-server\" \"npm run start:prod-client\"",
-    "start:prod-client": "cd ./build && python -m SimpleHTTPServer 3000",
-    "start:prod-server": "NODE_ENV=production node --experimental-loader ./loader/index.js --conditions=react-server server",
+    "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
+    "dev:client": "NODE_ENV=development BUILD_PATH=dist node scripts/start.js",
+    "dev:server": "NODE_ENV=development BUILD_PATH=dist nodemon -- --experimental-loader ./loader/index.js --conditions=react-server server",
+    "start": "node scripts/build.js && concurrently \"npm run start:server\" \"npm run start:client\"",
+    "start:client": "cd ./build && python3 -m http.server 3000",
+    "start:server": "NODE_ENV=production node --experimental-loader ./loader/index.js --conditions=react-server server",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom"
   },

--- a/fixtures/nesting/package.json
+++ b/fixtures/nesting/package.json
@@ -15,9 +15,9 @@
     "watch:legacy": "cpx 'src/shared/**' 'src/legacy/shared/' --watch --no-initial",
     "watch:modern": "cpx 'src/shared/**' 'src/modern/shared/' --watch --no-initial",
     "prebuild": "run-p copy:*",
-    "prestart": "run-p copy:*",
-    "start": "run-p start-app watch:*",
-    "start-app": "react-scripts start",
+    "predev": "run-p copy:*",
+    "dev": "run-p dev-app watch:*",
+    "dev-app": "react-scripts start",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
   },

--- a/fixtures/ssr/package.json
+++ b/fixtures/ssr/package.json
@@ -16,10 +16,10 @@
     "react-dom": "link:../../build/oss-experimental/react-dom"
   },
   "scripts": {
-    "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
-    "start:client": "PORT=3001 react-scripts start",
-    "start:server": "NODE_ENV=development node server",
-    "start:prod": "react-scripts build && NODE_ENV=production node server",
+    "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
+    "dev:client": "PORT=3001 react-scripts start",
+    "dev:server": "NODE_ENV=development node server",
+    "start": "react-scripts build && NODE_ENV=production node server",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/fixtures/ssr2/package.json
+++ b/fixtures/ssr2/package.json
@@ -28,12 +28,12 @@
     "prettier": "1.19.1"
   },
   "scripts": {
-    "start": "concurrently \"npm run server:dev\" \"npm run bundler:dev\"",
-    "start:prod": "concurrently \"npm run server:prod\" \"npm run bundler:prod\"",
-    "server:dev": "cross-env NODE_ENV=development nodemon -- server/server.js",
-    "server:prod": "cross-env NODE_ENV=production nodemon -- server/server.js",
-    "bundler:dev": "cross-env NODE_ENV=development nodemon -- scripts/build.js",
-    "bundler:prod": "cross-env NODE_ENV=production nodemon -- scripts/build.js"
+    "dev": "concurrently \"npm run dev:server\" \"npm run dev:bundler\"",
+    "start": "concurrently \"npm run start:server\" \"npm run start:bundler\"",
+    "dev:server": "cross-env NODE_ENV=development nodemon -- server/server.js",
+    "start:server": "cross-env NODE_ENV=production nodemon -- server/server.js",
+    "dev:bundler": "cross-env NODE_ENV=development nodemon -- scripts/build.js",
+    "start:bundler": "cross-env NODE_ENV=production nodemon -- scripts/build.js"
   },
   "babel": {
     "presets": [

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base    = ""
   publish = "fixtures/dom/build"
-  command = "yarn build --type=UMD_DEV && cd fixtures/dom/ && yarn && yarn prestart && yarn build"
+  command = "yarn build --type=UMD_DEV && cd fixtures/dom/ && yarn && yarn predev && yarn build"
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "test-build-prod": "yarn test --deprecated 'yarn test --build --prod'",
     "test-build-devtools": "node ./scripts/jest/jest-cli.js --build --project devtools --release-channel=experimental",
     "debug-test-build-devtools": "yarn test --deprecated 'yarn test-build-devtools --debug'",
-    "test-dom-fixture": "cd fixtures/dom && yarn && yarn prestart && yarn test",
+    "test-dom-fixture": "cd fixtures/dom && yarn && yarn predev && yarn test",
     "flow": "node ./scripts/tasks/flow.js",
     "flow-ci": "node ./scripts/tasks/flow-ci.js",
     "prettier": "node ./scripts/prettier/index.js write-changed",


### PR DESCRIPTION
The `start` convention is a CRA convention but nobody else of the modern frameworks / tools use this convention for a file watcher and dev mode. Instead the common convention is `dev`. Instead `start` is for running a production build that's already been built.