### PR TITLE
fix: sourceMaps option is invalid

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -128,6 +128,7 @@ module.exports = {
     [
       (process.env.REACT_VERSION != null).toString(),
       (process.env.NODE_ENV === 'development').toString(),
+      process.env.JEST_ENABLE_SOURCE_MAPS || '',
     ]
   ),
 };


### PR DESCRIPTION
In #24577, the `--sourceMaps` option was added, but modifying the `--sourceMaps` option has no effect.

Because `--sourceMaps` works by adding the environment variable `JEST_ENABLE_SOURCE_MAPS`, but does not add `process.env.JEST_ENABLE_SOURCE_MAPS` to the array of strings that `createCacheKeyFunction` needs to consider when generating cache keys, it caused a cache to be generated when the first test was run, and when the second test was run, modifying `process.env.JEST_ENABLE_SOURCE_MAPS` would not affect the running result, resulting in the failure of the `--sourceMaps`.