### PR TITLE
fix comment

### DIFF
--- a/packages/react-server/src/ReactServerStreamConfigBrowser.js
+++ b/packages/react-server/src/ReactServerStreamConfigBrowser.js
@@ -101,7 +101,7 @@ export function writeChunkAndReturn(
   chunk: PrecomputedChunk | Chunk,
 ): boolean {
   writeChunk(destination, chunk);
-  // in web streams there is no backpressure so we can alwas write more
+  // in web streams there is no backpressure so we can always write more
   return true;
 }
 


### PR DESCRIPTION
From alwas to always

## Summary

I was reading the source code of ReactServerStreamConfigBrowser.js and I found a little mistake. So I think we can correct it.

## How did you test this change?

There is no logic changed, so I think there is no need to add unit tests.
