### PR TITLE
Remove eventTime field from class Update type

### DIFF
--- a/packages/react-reconciler/src/ReactFiberClassComponent.js
+++ b/packages/react-reconciler/src/ReactFiberClassComponent.js
@@ -198,10 +198,9 @@ const classComponentUpdater = {
   // $FlowFixMe[missing-local-annot]
   enqueueSetState(inst: any, payload: any, callback) {
     const fiber = getInstance(inst);
-    const eventTime = requestEventTime();
     const lane = requestUpdateLane(fiber);
 
-    const update = createUpdate(eventTime, lane);
+    const update = createUpdate(lane);
     update.payload = payload;
     if (callback !== undefined && callback !== null) {
       if (__DEV__) {
@@ -212,6 +211,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      const eventTime = requestEventTime();
       scheduleUpdateOnFiber(root, fiber, lane, eventTime);
       entangleTransitions(root, fiber, lane);
     }
@@ -231,10 +231,9 @@ const classComponentUpdater = {
   },
   enqueueReplaceState(inst: any, payload: any, callback: null) {
     const fiber = getInstance(inst);
-    const eventTime = requestEventTime();
     const lane = requestUpdateLane(fiber);
 
-    const update = createUpdate(eventTime, lane);
+    const update = createUpdate(lane);
     update.tag = ReplaceState;
     update.payload = payload;
 
@@ -247,6 +246,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      const eventTime = requestEventTime();
       scheduleUpdateOnFiber(root, fiber, lane, eventTime);
       entangleTransitions(root, fiber, lane);
     }
@@ -267,10 +267,9 @@ const classComponentUpdater = {
   // $FlowFixMe[missing-local-annot]
   enqueueForceUpdate(inst: any, callback) {
     const fiber = getInstance(inst);
-    const eventTime = requestEventTime();
     const lane = requestUpdateLane(fiber);
 
-    const update = createUpdate(eventTime, lane);
+    const update = createUpdate(lane);
     update.tag = ForceUpdate;
 
     if (callback !== undefined && callback !== null) {
@@ -282,6 +281,7 @@ const classComponentUpdater = {
 
     const root = enqueueUpdate(fiber, update, lane);
     if (root !== null) {
+      const eventTime = requestEventTime();
       scheduleUpdateOnFiber(root, fiber, lane, eventTime);
       entangleTransitions(root, fiber, lane);
     }

--- a/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
+++ b/packages/react-reconciler/src/ReactFiberClassUpdateQueue.js
@@ -127,9 +127,6 @@ import {setIsStrictModeForDevtools} from './ReactFiberDevToolsHook';
 import assign from 'shared/assign';
 
 export type Update<State> = {
-  // TODO: Temporary field. Will remove this by storing a map of
-  // transition -> event time on the root.
-  eventTime: number,
   lane: Lane,
 
   tag: 0 | 1 | 2 | 3,
@@ -208,9 +205,8 @@ export function cloneUpdateQueue<State>(
   }
 }
 
-export function createUpdate(eventTime: number, lane: Lane): Update<mixed> {
+export function createUpdate(lane: Lane): Update<mixed> {
   const update: Update<mixed> = {
-    eventTime,
     lane,
 
     tag: UpdateState,
@@ -331,7 +327,6 @@ export function enqueueCapturedUpdate<State>(
         let update: Update<State> = firstBaseUpdate;
         do {
           const clone: Update<State> = {
-            eventTime: update.eventTime,
             lane: update.lane,
 
             tag: update.tag,
@@ -540,9 +535,6 @@ export function processUpdateQueue<State>(
 
     let update: Update<State> = firstBaseUpdate;
     do {
-      // TODO: Don't need this field anymore
-      const updateEventTime = update.eventTime;
-
       // An extra OffscreenLane bit is added to updates that were made to
       // a hidden tree, so that we can distinguish them from updates that were
       // already there when the tree was hidden.
@@ -561,7 +553,6 @@ export function processUpdateQueue<State>(
         // skipped update, the previous update/state is the new base
         // update/state.
         const clone: Update<State> = {
-          eventTime: updateEventTime,
           lane: updateLane,
 
           tag: update.tag,
@@ -583,7 +574,6 @@ export function processUpdateQueue<State>(
 
         if (newLastBaseUpdate !== null) {
           const clone: Update<State> = {
-            eventTime: updateEventTime,
             // This update is going to be committed so we never want uncommit
             // it. Using NoLane works because 0 is a subset of all bitmasks, so
             // this will never be skipped by the check above.

--- a/packages/react-reconciler/src/ReactFiberHooks.js
+++ b/packages/react-reconciler/src/ReactFiberHooks.js
@@ -2525,10 +2525,10 @@ function refreshCache<T>(fiber: Fiber, seedKey: ?() => T, seedValue: T): void {
       case HostRoot: {
         // Schedule an update on the cache boundary to trigger a refresh.
         const lane = requestUpdateLane(provider);
-        const eventTime = requestEventTime();
-        const refreshUpdate = createLegacyQueueUpdate(eventTime, lane);
+        const refreshUpdate = createLegacyQueueUpdate(lane);
         const root = enqueueLegacyQueueUpdate(provider, refreshUpdate, lane);
         if (root !== null) {
+          const eventTime = requestEventTime();
           scheduleUpdateOnFiber(root, provider, lane, eventTime);
           entangleLegacyQueueTransitions(root, provider, lane);
         }

--- a/packages/react-reconciler/src/ReactFiberNewContext.js
+++ b/packages/react-reconciler/src/ReactFiberNewContext.js
@@ -26,7 +26,6 @@ import {
 } from './ReactWorkTags';
 import {
   NoLanes,
-  NoTimestamp,
   isSubsetOfLanes,
   includesSomeLane,
   mergeLanes,
@@ -271,7 +270,7 @@ function propagateContextChange_eager<T>(
           if (fiber.tag === ClassComponent) {
             // Schedule a force update on the work-in-progress.
             const lane = pickArbitraryLane(renderLanes);
-            const update = createUpdate(NoTimestamp, lane);
+            const update = createUpdate(lane);
             update.tag = ForceUpdate;
             // TODO: Because we don't have a work-in-progress, this will add the
             // update to the current fiber, too, which means it will persist even if

--- a/packages/react-reconciler/src/ReactFiberReconciler.js
+++ b/packages/react-reconciler/src/ReactFiberReconciler.js
@@ -308,11 +308,11 @@ export function createHydrationContainer(
   // the update to schedule work on the root fiber (and, for legacy roots, to
   // enqueue the callback if one is provided).
   const current = root.current;
-  const eventTime = requestEventTime();
   const lane = requestUpdateLane(current);
-  const update = createUpdate(eventTime, lane);
+  const update = createUpdate(lane);
   update.callback =
     callback !== undefined && callback !== null ? callback : null;
+  const eventTime = requestEventTime();
   enqueueUpdate(current, update, lane);
   scheduleInitialHydrationOnRoot(root, lane, eventTime);
 
@@ -329,7 +329,6 @@ export function updateContainer(
     onScheduleRoot(container, element);
   }
   const current = container.current;
-  const eventTime = requestEventTime();
   const lane = requestUpdateLane(current);
 
   if (enableSchedulingProfiler) {
@@ -360,7 +359,7 @@ export function updateContainer(
     }
   }
 
-  const update = createUpdate(eventTime, lane);
+  const update = createUpdate(lane);
   // Caution: React DevTools currently depends on this property
   // being called "element".
   update.payload = {element};
@@ -381,6 +380,7 @@ export function updateContainer(
 
   const root = enqueueUpdate(current, update, lane);
   if (root !== null) {
+    const eventTime = requestEventTime();
     scheduleUpdateOnFiber(root, current, lane, eventTime);
     entangleTransitions(root, current, lane);
   }

--- a/packages/react-reconciler/src/ReactFiberThrow.js
+++ b/packages/react-reconciler/src/ReactFiberThrow.js
@@ -69,7 +69,6 @@ import {logComponentSuspended} from './DebugTracing';
 import {isDevToolsPresent} from './ReactFiberDevToolsHook';
 import {
   SyncLane,
-  NoTimestamp,
   includesSomeLane,
   mergeLanes,
   pickArbitraryLane,
@@ -86,7 +85,7 @@ function createRootErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   lane: Lane,
 ): Update<mixed> {
-  const update = createUpdate(NoTimestamp, lane);
+  const update = createUpdate(lane);
   // Unmount the root by rendering null.
   update.tag = CaptureUpdate;
   // Caution: React DevTools currently depends on this property
@@ -105,7 +104,7 @@ function createClassErrorUpdate(
   errorInfo: CapturedValue<mixed>,
   lane: Lane,
 ): Update<mixed> {
-  const update = createUpdate(NoTimestamp, lane);
+  const update = createUpdate(lane);
   update.tag = CaptureUpdate;
   const getDerivedStateFromError = fiber.type.getDerivedStateFromError;
   if (typeof getDerivedStateFromError === 'function') {
@@ -253,7 +252,7 @@ function markSuspenseBoundaryShouldCapture(
           // When we try rendering again, we should not reuse the current fiber,
           // since it's known to be in an inconsistent state. Use a force update to
           // prevent a bail out.
-          const update = createUpdate(NoTimestamp, SyncLane);
+          const update = createUpdate(SyncLane);
           update.tag = ForceUpdate;
           enqueueUpdate(sourceFiber, update, SyncLane);
         }


### PR DESCRIPTION
`eventTime` is a vestigial field that can be cleaned up. It was originally used as part of the starvation mechanism but it's since been replaced by a per-lane field on the root.

This is a part of a series of smaller refactors I'm doing to simplify/speed up the `setState` path, related to the Sync Unification project that @tyao1 has been working on.