### PR TITLE
[Fizz Node] Fix null bytes written at text chunk boundaries

### DIFF
--- a/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzServerNode-test.js
@@ -635,4 +635,17 @@ describe('ReactDOMFizzServerNode', () => {
     expect(rendered).toBe(false);
     expect(isComplete).toBe(true);
   });
+
+  it('should encode multibyte characters correctly without nulls (#24985)', () => {
+    const {writable, output} = getTestWritable();
+    const {pipe} = ReactDOMFizzServer.renderToPipeableStream(
+      <div>{Array(700).fill('ののの')}</div>,
+    );
+    pipe(writable);
+    jest.runAllTimers();
+    expect(output.result.indexOf('\u0000')).toBe(-1);
+    expect(output.result).toEqual(
+      '<div>' + Array(700).fill('ののの').join('<!-- -->') + '</div>',
+    );
+  });
 });

--- a/packages/react-server/src/ReactServerStreamConfigNode.js
+++ b/packages/react-server/src/ReactServerStreamConfigNode.js
@@ -75,12 +75,14 @@ function writeStringChunk(destination: Destination, stringChunk: string) {
   writtenBytes += written;
 
   if (read < stringChunk.length) {
-    writeToDestination(destination, (currentView: any));
+    writeToDestination(
+      destination,
+      (currentView: any).subarray(0, writtenBytes),
+    );
     currentView = new Uint8Array(VIEW_SIZE);
     writtenBytes = textEncoder.encodeInto(
       stringChunk.slice(read),
-      // $FlowFixMe[incompatible-call] found when upgrading Flow
-      currentView,
+      (currentView: any),
     ).written;
   }
 


### PR DESCRIPTION
We encode strings 2048 UTF-8 bytes at a time. If the string we are encoding crosses to the next chunk but the current chunk doesn't fit an integral number of characters, we need to make sure not to send the whole buffer, only the bytes that are actually meaningful.

Fixes #24985. I was able to verify that this fixes the repro shared in the issue (be careful when testing because the null bytes do not show when printed to my terminal, at least). However, I don't see a clear way to add a test for this that will be resilient to small changes in how we encode the markup (since it depends on where specific multibyte characters fall against the 2048-byte boundaries).