### PR TITLE
Switch to mount dispatcher after use() when needed

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactHooks-test.internal.js
@@ -1076,7 +1076,7 @@ describe('ReactHooks', () => {
       expect(() => {
         ReactTestRenderer.create(<App />);
       }).toThrow(
-        'Should have a queue. This is likely a bug in React. Please file an issue.',
+        'Update hook called on initial render. This is likely a bug in React. Please file an issue.',
       );
     }).toErrorDev([
       'Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks',

--- a/scripts/error-codes/codes.json
+++ b/scripts/error-codes/codes.json
@@ -451,5 +451,6 @@
   "463": "ReactDOMServer.renderToNodeStream(): The Node Stream API is not available in Bun. Use ReactDOMServer.renderToReadableStream() instead.",
   "464": "ReactDOMServer.renderToStaticNodeStream(): The Node Stream API is not available in Bun. Use ReactDOMServer.renderToReadableStream() instead.",
   "465": "enableFizzExternalRuntime without enableFloat is not supported. This should never appear in production, since it means you are using a misconfigured React bundle.",
-  "466": "Trying to call a function from \"use server\" but the callServer option was not implemented in your router runtime."
+  "466": "Trying to call a function from \"use server\" but the callServer option was not implemented in your router runtime.",
+  "467": "Update hook called on initial render. This is likely a bug in React. Please file an issue."
 }


### PR DESCRIPTION
When resuming a suspended render, there may be more Hooks to be called that weren't seen the previous time through. Make sure to switch to the mount dispatcher when calling use() if the next Hook call should be treated as a mount.

Fixes #25964.
