### PR TITLE
[DevTools] remove script tag immediately

### DIFF
--- a/packages/react-devtools-extensions/src/contentScripts/prepareInjection.js
+++ b/packages/react-devtools-extensions/src/contentScripts/prepareInjection.js
@@ -26,10 +26,8 @@ function injectScriptSync(src) {
 function injectScriptAsync(src) {
   const script = document.createElement('script');
   script.src = src;
-  script.onload = function () {
-    script.remove();
-  };
   nullthrows(document.documentElement).appendChild(script);
+  nullthrows(script.parentNode).removeChild(script);
 }
 
 let lastDetectionResult;


### PR DESCRIPTION
Fixes https://github.com/facebook/react/issues/25924 for React DevTools specifically.

## Summary

If we remove the script after it's loaded, it creates a race condition with other code. If some other code is searching for the first script tag or first element of the document, this might broke it.

## How did you test this change?

I've tested in my local build that even if we remove the script tag immediately, the code is still correctly executed.