### PR TITLE
Simplify nested hook warning logic in dev

### DIFF
--- a/packages/react-reconciler/src/ReactInternalTypes.js
+++ b/packages/react-reconciler/src/ReactInternalTypes.js
@@ -56,7 +56,8 @@ export type HookType =
   | 'useMutableSource'
   | 'useSyncExternalStore'
   | 'useId'
-  | 'useCacheRefresh';
+  | 'useCacheRefresh'
+  | 'useMemoCache';
 
 export type ContextDependency<T> = {
   context: ReactContext<T>,


### PR DESCRIPTION
We have so many dispatchers. And with my changes in https://github.com/facebook/react/pull/26232 it's a bit harder to see if the previous logic was correct. Here I'm moving the flag to a separate value which makes it easier to see that it will work properly with the live dispatcher switch and that the prod behavior is not affected.

I cheated and mutated ContextOnlyDispatcher in place in dev (previously ContextOnlyDispatcher.readContext would not warn when in a state update but that dispatcher wouldn't be active at the times it's relevant).

Also adds the hook ordering warnings to useMemoCache.