### PR TITLE
Fix test command --sourceMaps flag not enabling inline source maps

### DIFF
--- a/scripts/jest/preprocessor.js
+++ b/scripts/jest/preprocessor.js
@@ -128,6 +128,7 @@ module.exports = {
     [
       (process.env.REACT_VERSION != null).toString(),
       (process.env.NODE_ENV === 'development').toString(),
+      process.env.JEST_ENABLE_SOURCE_MAPS || '',
     ]
   ),
 };


### PR DESCRIPTION
## Summary

This issue was encountered when I attempted to debug React using VSCode.

I wanted to initiate debugging of React through testing, so I created the following test file:

```js
// packages/react/src/__tests__/test.js
const React = require('../React')

test('should first', () => {
  React.createElement('div')
})
```

And used the following configuration to launch VSCode debugging.

```json
// .vscode/launch.json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "test",
      "program": "${workspaceRoot}/scripts/jest/jest-cli.js",
      "args": ["${file}"],
      "env": {
        "NODE_ENV": "development"
      }
    }
  ]
}
```

When I ran it for the first time, I found that the breakpoints were not hitting the `test.js` file, but rather another file.

https://user-images.githubusercontent.com/38753204/221841953-c9e73de5-c9a0-4620-9976-22e54ceae9d2.mp4

I surmised that the issue might be due to source maps not being enabled.

I discovered that the #24577 added the `--sourceMaps` option to enable source maps when running tests.

So I added the `--sourceMaps` option in my `launch.json` file.

```json
// .vscode/launch.json
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "node",
      "request": "launch",
      "name": "test",
      "program": "${workspaceRoot}/scripts/jest/jest-cli.js",
      "args": ["--sourceMaps", "${file}"],
      "env": {
        "NODE_ENV": "development"
      }
    }
  ]
}
```

However, the result was still that the breakpoints were not hitting the `test.js` file.

https://user-images.githubusercontent.com/38753204/221842047-367e783e-e55c-404a-98a5-cb939df304e7.mp4

## How did you test this change?

Upon investigation, I found that the `--sourceMaps` option was meant to configure source maps by adding the `JEST_ENABLE_SOURCE_MAPS` flag, but since the `JEST_ENABLE_SOURCE_MAPS` was not included in the parameters of the `createCacheKeyFunction`, the generated `CacheKey` would not change when the `JEST_ENABLE_SOURCE_MAPS` changed, thus directly using the cache instead of using the `JEST_ENABLE_SOURCE_MAPS` to configure source maps.

![2023-02-28_18-51-27](https://user-images.githubusercontent.com/38753204/221842419-45c50d16-9a3a-4fee-9074-15c2e012567f.png)

To fix this issue, I added `process.env.JEST_ENABLE_SOURCE_MAPS` to the parameters of the `createCacheKeyFunction`, so that when `process.env.JEST_ENABLE_SOURCE_MAPS` changed, a different `CacheKey` would be generated, thus fixing the issue.

![2023-02-28_19-49-25](https://user-images.githubusercontent.com/38753204/221845884-777d795f-bbc6-4668-a3ac-e68150fb3d81.png)

Upon running it again, the breakpoints successfully hit the `test.js` file.

https://user-images.githubusercontent.com/38753204/221842760-85cc6285-c419-4e2e-a6ed-664fef60867f.mp4
