### PR TITLE
[eslint-plugin-react-hooks] Allow hooks inside components declared as member properties

### DIFF
--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRulesOfHooks-test.js
@@ -61,6 +61,15 @@ const tests = {
     },
     {
       code: normalizeIndent`
+        // Valid because subcomponents can use hooks
+        const Component = {};
+        Component.SubComponentWithHook = function() {
+          useHook();
+        }
+      `,
+    },
+    {
+      code: normalizeIndent`
         // Valid because hooks can use hooks.
         function useHookWithHook() {
           useHook();

--- a/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
+++ b/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js
@@ -49,7 +49,16 @@ function isHook(node) {
  */
 
 function isComponentName(node) {
-  return node.type === 'Identifier' && /^[A-Z]/.test(node.name);
+  const pattern = /^[A-Z]/;
+  if (node.type === 'Identifier') {
+    return pattern.test(node.name);
+  }
+
+  if (node.type === 'MemberExpression') {
+    return pattern.test(node.property.name);
+  }
+
+  return false;
 }
 
 function isReactFunction(node, functionName) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Hi there 👋, a common pattern that I and many other developers use is attaching dependent components to a parent component as a property. This is particularly useful in design systems and other component systems where composability is highly desirable. This look something like below:

```jsx
const Heading = ({ children }) => {
  return <div className="heading">{children}</div>
}

Heading.Title = ({ children }) => {
  useSomeHook();
  return <h1>{children}</h1>
}
```

With the current implementation, this rule is unable to detect components like `Heading.Title` above as a react component, and as such will raise an eslint error about the usage of hooks within such a component, despite this being a valid place to use a hook.

There are a few different workarounds you could use to get around this, such as declaring the subcomponent separately and then attaching it in a seperate statement, or declaring it as a named function rather than an arrow function. I can live with those workaround but thought that improving the rule would lead to code that is more expressive without a workaround needed due to the specific implementation of this rule.

You could certainly argue about the validity of this pattern in regards to module export purity, treeshaking etc however I don't believe any of that is really in the scope of what this hooks rule is looking to verify.

Hopefully this doesn't go against the intent of the existing rule 😅.

- [x] CLA Completed
- [x] Tests written

## How did you test this change?

Added a unit test to `ESLintRulesOfHooks-test.js`, verified the test fails before the change, and passes after the change.
<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->