### PR TITLE
Codemod tests to waitFor pattern (1/?)

### DIFF
--- a/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/DebugTracing-test.internal.js
@@ -12,7 +12,7 @@
 describe('DebugTracing', () => {
   let React;
   let ReactTestRenderer;
-  let Scheduler;
+  let waitForPaint;
 
   let logs;
 
@@ -27,7 +27,8 @@ describe('DebugTracing', () => {
 
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
-    Scheduler = require('scheduler');
+    const InternalTestUtils = require('internal-test-utils');
+    waitForPaint = InternalTestUtils.waitForPaint;
 
     logs = [];
 
@@ -100,7 +101,7 @@ describe('DebugTracing', () => {
   });
 
   // @gate experimental && build === 'development' && enableDebugTracing && enableCPUSuspense
-  it('should log sync render with CPU suspense', () => {
+  it('should log sync render with CPU suspense', async () => {
     function Example() {
       console.log('<Example/>');
       return null;
@@ -129,7 +130,7 @@ describe('DebugTracing', () => {
 
     logs.splice(0);
 
-    expect(Scheduler).toFlushUntilNextPaint([]);
+    await waitForPaint([]);
 
     expect(logs).toEqual([
       `group: ⚛️ render (${RETRY_LANE_STRING})`,

--- a/packages/react-reconciler/src/__tests__/ReactCache-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCache-test.js
@@ -3,6 +3,7 @@ let ReactNoop;
 let Cache;
 let getCacheSignal;
 let Scheduler;
+let assertLog;
 let act;
 let Suspense;
 let Offscreen;
@@ -31,6 +32,9 @@ describe('ReactCache', () => {
     useCacheRefresh = React.unstable_useCacheRefresh;
     startTransition = React.startTransition;
     useState = React.useState;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
 
     textCaches = [];
     seededCache = null;
@@ -203,20 +207,19 @@ describe('ReactCache', () => {
         </Cache>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A']);
+    assertLog(['A']);
     expect(root).toMatchRenderedOutput('A');
 
     await act(async () => {
       root.render('Bye');
     });
-    // no cleanup: cache is still retained at the root
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -230,20 +233,19 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A']);
+    assertLog(['A']);
     expect(root).toMatchRenderedOutput('A');
 
     await act(async () => {
       root.render('Bye');
     });
-    // no cleanup: cache is still retained at the root
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -271,26 +273,19 @@ describe('ReactCache', () => {
       root.render(<App showMore={false} />);
     });
 
-    // Even though there are two new <Cache /> trees, they should share the same
-    // data cache. So there should be only a single cache miss for A.
-    expect(Scheduler).toHaveYielded([
-      'Cache miss! [A]',
-      'Loading...',
-      'Loading...',
-    ]);
+    assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       root.render('Bye');
     });
-    // no cleanup: cache is still retained at the root
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -319,34 +314,25 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render(<App showMore={false} />);
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
     await act(async () => {
       root.render(<App showMore={true} />);
     });
-    // Even though there are two new <Cache /> trees, they should share the same
-    // data cache. So there should be only a single cache miss for A.
-    expect(Scheduler).toHaveYielded([
-      'Cache miss! [A]',
-      'Loading...',
-      'Loading...',
-    ]);
+    assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       root.render('Bye');
     });
-    // cleanup occurs for the cache shared by the inner cache boundaries (which
-    // are not shared w the root because they were added in an update)
-    // note that no cache is created for the root since the cache is never accessed
-    expect(Scheduler).toHaveYielded(['Cache cleanup: A [v1]']);
+    assertLog(['Cache cleanup: A [v1]']);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -370,22 +356,19 @@ describe('ReactCache', () => {
       await act(async () => {
         root.render(<App />);
       });
-      // Even though there is a nested <Cache /> boundary, it should share the same
-      // data cache as the root. So there should be only a single cache miss for A.
-      expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+      assertLog(['Cache miss! [A]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
       await act(async () => {
         resolveMostRecentTextCache('A');
       });
-      expect(Scheduler).toHaveYielded(['A', 'A']);
+      assertLog(['A', 'A']);
       expect(root).toMatchRenderedOutput('AA');
 
       await act(async () => {
         root.render('Bye');
       });
-      // no cleanup: cache is still retained at the root
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
       expect(root).toMatchRenderedOutput('Bye');
     },
   );
@@ -412,14 +395,14 @@ describe('ReactCache', () => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
     await act(async () => {
       root.render(<App showMore={true} />);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A [v1]',
       // New tree should use already cached data
       'A [v1]',
@@ -429,8 +412,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye');
     });
-    // no cleanup: cache is still retained at the root
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -460,14 +442,14 @@ describe('ReactCache', () => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
     await act(async () => {
       root.render(<App showMore={true} />);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A [v1]',
       // New tree should load fresh data.
       'Cache miss! [A]',
@@ -477,7 +459,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v2]']);
+    assertLog(['A [v2]']);
     expect(root).toMatchRenderedOutput('A [v1]A [v2]');
 
     // Replace all the children: this should retain the root Cache instance,
@@ -486,9 +468,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    // Cleanup occurs for the *second* cache instance: the first is still
-    // referenced by the root
-    expect(Scheduler).toHaveYielded(['Cache cleanup: A [v2]']);
+    assertLog(['Cache cleanup: A [v2]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -535,13 +515,13 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading shell...']);
+    assertLog(['Cache miss! [A]', 'Loading shell...']);
     expect(root).toMatchRenderedOutput('Loading shell...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Shell',
       // There's a cache miss for B, because it hasn't been read yet. But not
       // A, because it was cached when we rendered the shell.
@@ -558,7 +538,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('B');
     });
-    expect(Scheduler).toHaveYielded(['Content']);
+    assertLog(['Content']);
     expect(root).toMatchRenderedOutput(
       <>
         <div>Shell</div>
@@ -569,8 +549,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye');
     });
-    // no cleanup: cache is still retained at the root
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -619,19 +598,19 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render(<App showMore={false} />);
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
     await act(async () => {
       root.render(<App showMore={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading shell...']);
+    assertLog(['Cache miss! [A]', 'Loading shell...']);
     expect(root).toMatchRenderedOutput('Loading shell...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Shell',
       // There's a cache miss for B, because it hasn't been read yet. But not
       // A, because it was cached when we rendered the shell.
@@ -648,7 +627,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('B');
     });
-    expect(Scheduler).toHaveYielded(['Content']);
+    assertLog(['Content']);
     expect(root).toMatchRenderedOutput(
       <>
         <div>Shell</div>
@@ -659,10 +638,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye');
     });
-    expect(Scheduler).toHaveYielded([
-      'Cache cleanup: A [v1]',
-      'Cache cleanup: B [v1]',
-    ]);
+    assertLog(['Cache cleanup: A [v1]', 'Cache cleanup: B [v1]']);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -683,20 +659,20 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
     await act(async () => {
       startTransition(() => refresh());
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
@@ -704,9 +680,9 @@ describe('ReactCache', () => {
     });
     // Note that the version has updated
     if (getCacheSignal) {
-      expect(Scheduler).toHaveYielded(['A [v2]', 'Cache cleanup: A [v1]']);
+      assertLog(['A [v2]', 'Cache cleanup: A [v1]']);
     } else {
-      expect(Scheduler).toHaveYielded(['A [v2]']);
+      assertLog(['A [v2]']);
     }
     expect(root).toMatchRenderedOutput('A [v2]');
 
@@ -733,34 +709,32 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
     await act(async () => {
       startTransition(() => refresh());
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    // Note that the version has updated, and the previous cache is cleared
-    expect(Scheduler).toHaveYielded(['A [v2]', 'Cache cleanup: A [v1]']);
+    assertLog(['A [v2]', 'Cache cleanup: A [v1]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
     await act(async () => {
       root.render('Bye');
     });
-    // the original root cache already cleaned up when the refresh completed
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -781,20 +755,20 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
     await act(async () => {
       refresh();
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Cache miss! [A]',
       'Loading...',
       // The v1 cache can be cleaned up since everything that references it has
@@ -807,15 +781,13 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    // Note that the version has updated, and the previous cache is cleared
-    expect(Scheduler).toHaveYielded(['A [v2]']);
+    assertLog(['A [v2]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
     await act(async () => {
       root.render('Bye');
     });
-    // the original root cache already cleaned up when the refresh completed
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -847,13 +819,13 @@ describe('ReactCache', () => {
         </Cache>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Refresh for new data.
@@ -869,16 +841,13 @@ describe('ReactCache', () => {
         }),
       );
     });
-    // The root should re-render without a cache miss.
-    // The cache is not cleared up yet, since it's still reference by the root
-    expect(Scheduler).toHaveYielded(['A [v2]']);
+    assertLog(['A [v2]']);
     expect(root).toMatchRenderedOutput('A [v2]');
 
     await act(async () => {
       root.render('Bye');
     });
-    // the refreshed cache boundary is unmounted and cleans up
-    expect(Scheduler).toHaveYielded(['Cache cleanup: A [v2]']);
+    assertLog(['Cache cleanup: A [v2]']);
     expect(root).toMatchRenderedOutput('Bye');
   });
 
@@ -913,7 +882,7 @@ describe('ReactCache', () => {
       seedNextTextCache('A');
       root.render(<App showMore={false} />);
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Add a new cache boundary
@@ -921,7 +890,7 @@ describe('ReactCache', () => {
       seedNextTextCache('A');
       root.render(<App showMore={true} />);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A [v1]',
       // New tree should load fresh data.
       'A [v2]',
@@ -933,17 +902,13 @@ describe('ReactCache', () => {
     await act(async () => {
       startTransition(() => refreshShell());
     });
-    expect(Scheduler).toHaveYielded([
-      'Cache miss! [A]',
-      'Loading...',
-      'Loading...',
-    ]);
+    assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
     expect(root).toMatchRenderedOutput('A [v1]A [v2]');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A [v3]',
       'A [v3]',
       // once the refresh completes the inner showMore boundary frees its previous
@@ -955,9 +920,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    // Unmounting children releases the refreshed cache instance only; the root
-    // still retains the original cache instance used for the first render
-    expect(Scheduler).toHaveYielded(['Cache cleanup: A [v3]']);
+    assertLog(['Cache cleanup: A [v3]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1004,19 +967,13 @@ describe('ReactCache', () => {
         root.render(<App showMore={true} />);
       });
 
-      // Even though there are two new <Cache /> trees, they should share the same
-      // data cache. So there should be only a single cache miss for A.
-      expect(Scheduler).toHaveYielded([
-        'Cache miss! [A]',
-        'Loading...',
-        'Loading...',
-      ]);
+      assertLog(['Cache miss! [A]', 'Loading...', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...Loading...');
 
       await act(async () => {
         resolveMostRecentTextCache('A');
       });
-      expect(Scheduler).toHaveYielded(['A [v1]', 'A [v1]']);
+      assertLog(['A [v1]', 'A [v1]']);
       expect(root).toMatchRenderedOutput('A [v1]A [v1]');
 
       // Refresh the first boundary. It should not refresh the second boundary,
@@ -1024,12 +981,12 @@ describe('ReactCache', () => {
       await act(async () => {
         await refreshFirstBoundary();
       });
-      expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+      assertLog(['Cache miss! [A]', 'Loading...']);
 
       await act(async () => {
         resolveMostRecentTextCache('A');
       });
-      expect(Scheduler).toHaveYielded(['A [v2]']);
+      assertLog(['A [v2]']);
       expect(root).toMatchRenderedOutput('A [v2]A [v1]');
 
       // Unmount children: this should clear *both* cache instances:
@@ -1041,10 +998,7 @@ describe('ReactCache', () => {
       await act(async () => {
         root.render('Bye!');
       });
-      expect(Scheduler).toHaveYielded([
-        'Cache cleanup: A [v2]',
-        'Cache cleanup: A [v1]',
-      ]);
+      assertLog(['Cache cleanup: A [v2]', 'Cache cleanup: A [v1]']);
       expect(root).toMatchRenderedOutput('Bye!');
     },
   );
@@ -1079,11 +1033,7 @@ describe('ReactCache', () => {
       await act(async () => {
         root.render(<App showMore={false} />);
       });
-      expect(Scheduler).toHaveYielded([
-        'Cache miss! [A]',
-        'Cache miss! [B]',
-        'Loading...',
-      ]);
+      assertLog(['Cache miss! [A]', 'Cache miss! [B]', 'Loading...']);
       expect(root).toMatchRenderedOutput('Loading...');
 
       await act(async () => {
@@ -1093,7 +1043,7 @@ describe('ReactCache', () => {
         // And mount the second tree, which includes new content
         root.render(<App showMore={true} />);
       });
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         // The new tree should use a fresh cache
         'Cache miss! [A]',
         'Loading...',
@@ -1108,16 +1058,13 @@ describe('ReactCache', () => {
       await act(async () => {
         resolveMostRecentTextCache('A');
       });
-      expect(Scheduler).toHaveYielded(['A [v2]']);
+      assertLog(['A [v2]']);
       expect(root).toMatchRenderedOutput('A [v2] A [v1] B [v1]');
 
       await act(async () => {
         root.render('Bye!');
       });
-      // Unmounting children releases both cache boundaries, but the original
-      // cache instance (used by second boundary) is still referenced by the root.
-      // only the second cache instance is freed.
-      expect(Scheduler).toHaveYielded(['Cache cleanup: A [v2]']);
+      assertLog(['Cache cleanup: A [v2]']);
       expect(root).toMatchRenderedOutput('Bye!');
     },
   );
@@ -1138,7 +1085,7 @@ describe('ReactCache', () => {
         <Suspense fallback={<Text text="Loading..." />}>(empty)</Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('(empty)');
 
     await act(async () => {
@@ -1150,7 +1097,7 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('(empty)');
 
     await act(async () => {
@@ -1163,7 +1110,7 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // No cache miss, because it uses the pooled cache
       'Loading...',
     ]);
@@ -1173,7 +1120,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]', 'A [v1]']);
+    assertLog(['A [v1]', 'A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]A [v1]');
 
     // Now do another transition
@@ -1188,7 +1135,7 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // First two children use the old cache because they already finished
       'A [v1]',
       'A [v1]',
@@ -1201,7 +1148,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]', 'A [v1]', 'A [v2]']);
+    assertLog(['A [v1]', 'A [v1]', 'A [v2]']);
     expect(root).toMatchRenderedOutput('A [v1]A [v1]A [v2]');
 
     // Unmount children: the first text cache instance is created only after the root
@@ -1211,10 +1158,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([
-      'Cache cleanup: A [v1]',
-      'Cache cleanup: A [v2]',
-    ]);
+    assertLog(['Cache cleanup: A [v1]', 'Cache cleanup: A [v2]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1257,7 +1201,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['0']);
+    assertLog(['0']);
     expect(root).toMatchRenderedOutput('0');
 
     await act(async () => {
@@ -1265,13 +1209,13 @@ describe('ReactCache', () => {
         showMore();
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]', 'Loading...']);
+    assertLog(['Cache miss! [A]', 'Loading...']);
     expect(root).toMatchRenderedOutput('0');
 
     await act(async () => {
       updateUnrelated(1);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       '1',
 
       // Happens to re-render the fallback. Doesn't need to, but not relevant
@@ -1283,7 +1227,7 @@ describe('ReactCache', () => {
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]1');
 
     // Unmount children: the first text cache instance is created only after initial
@@ -1293,7 +1237,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded(['Cache cleanup: A [v1]']);
+    assertLog(['Cache cleanup: A [v1]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1310,7 +1254,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     seedNextTextCache('B');
@@ -1323,7 +1267,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['B [v2]']);
+    assertLog(['B [v2]']);
     expect(root).toMatchRenderedOutput('B [v2]');
 
     // Unmount children: the fresh cache instance for B cleans up since the cache boundary
@@ -1332,7 +1276,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded(['Cache cleanup: B [v2]']);
+    assertLog(['Cache cleanup: B [v2]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1348,13 +1292,13 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]']);
+    assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // After a mount, subsequent transitions use a fresh cache
@@ -1369,7 +1313,7 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [B]']);
+    assertLog(['Cache miss! [B]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Update to a different text and with a different key for the cache
@@ -1386,13 +1330,13 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [C]']);
+    assertLog(['Cache miss! [C]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
       resolveMostRecentTextCache('C');
     });
-    expect(Scheduler).toHaveYielded(['C [v2]']);
+    assertLog(['C [v2]']);
     expect(root).toMatchRenderedOutput('C [v2]');
 
     // Unmount children: the fresh cache used for the updates is freed, while the
@@ -1400,10 +1344,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([
-      'Cache cleanup: B [v2]',
-      'Cache cleanup: C [v2]',
-    ]);
+    assertLog(['Cache cleanup: B [v2]', 'Cache cleanup: C [v2]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1419,13 +1360,13 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]']);
+    assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('A');
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // After a mount, subsequent updates use a fresh cache
@@ -1438,7 +1379,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [B]']);
+    assertLog(['Cache miss! [B]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     // A second update uses the same fresh cache: even though this is a new
@@ -1452,13 +1393,13 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [C]']);
+    assertLog(['Cache miss! [C]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       resolveMostRecentTextCache('C');
     });
-    expect(Scheduler).toHaveYielded(['C [v2]']);
+    assertLog(['C [v2]']);
     expect(root).toMatchRenderedOutput('C [v2]');
 
     // Unmount children: the fresh cache used for the updates is freed, while the
@@ -1466,10 +1407,7 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([
-      'Cache cleanup: B [v2]',
-      'Cache cleanup: C [v2]',
-    ]);
+    assertLog(['Cache cleanup: B [v2]', 'Cache cleanup: C [v2]']);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1486,7 +1424,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Start a transition from A -> B..., which should create a fresh cache
@@ -1502,7 +1440,7 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [B]']);
+    assertLog(['Cache miss! [B]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // ...but cancel by transitioning "back" to A (which we never really left)
@@ -1517,14 +1455,14 @@ describe('ReactCache', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded(['A [v1]', 'Cache cleanup: B [v2]']);
+    assertLog(['A [v1]', 'Cache cleanup: B [v2]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Unmount children: ...
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput('Bye!');
   });
 
@@ -1544,7 +1482,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
@@ -1552,13 +1490,13 @@ describe('ReactCache', () => {
         refresh();
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]']);
+    assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // TODO: the v1 cache should *not* be cleaned up, it is still retained by the root
       // The following line is presently yielded but should not be:
       // 'Cache cleanup: A [v1]',
@@ -1588,7 +1526,7 @@ describe('ReactCache', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A [v1]']);
+    assertLog(['A [v1]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     await act(async () => {
@@ -1596,14 +1534,14 @@ describe('ReactCache', () => {
         refresh();
       });
     });
-    expect(Scheduler).toHaveYielded(['Cache miss! [A]']);
+    assertLog(['Cache miss! [A]']);
     expect(root).toMatchRenderedOutput('A [v1]');
 
     // Unmount the boundary before the refresh can complete
     await act(async () => {
       root.render('Bye!');
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // TODO: the v2 cache *should* be cleaned up, it was created for the abandoned refresh
       // The following line is presently not yielded but should be:
       'Cache cleanup: A [v2]',
@@ -1632,14 +1570,14 @@ describe('ReactCache', () => {
     await act(async () => {
       root.render(<App prerenderMore={false} />);
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput(<div hidden={true} />);
 
     seedNextTextCache('More');
     await act(async () => {
       root.render(<App prerenderMore={true} />);
     });
-    expect(Scheduler).toHaveYielded(['More']);
+    assertLog(['More']);
     expect(root).toMatchRenderedOutput(<div hidden={true}>More</div>);
   });
 

--- a/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactClassSetStateCallback-test.js
@@ -2,6 +2,7 @@ let React;
 let ReactNoop;
 let Scheduler;
 let act;
+let assertLog;
 
 describe('ReactClassSetStateCallback', () => {
   beforeEach(() => {
@@ -11,6 +12,9 @@ describe('ReactClassSetStateCallback', () => {
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
     act = require('jest-react').act;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
   });
 
   function Text({text}) {
@@ -32,7 +36,7 @@ describe('ReactClassSetStateCallback', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded([0]);
+    assertLog([0]);
 
     await act(async () => {
       if (gate(flags => flags.enableUnifiedSyncLane)) {
@@ -52,6 +56,6 @@ describe('ReactClassSetStateCallback', () => {
         );
       });
     });
-    expect(Scheduler).toHaveYielded([2, 'Callback 2', 2, 'Callback 1']);
+    assertLog([2, 'Callback 2', 2, 'Callback 1']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -9,6 +9,7 @@ let SuspenseList;
 let getCacheForType;
 let caches;
 let seededCache;
+let assertLog;
 
 describe('ReactLazyContextPropagation', () => {
   beforeEach(() => {
@@ -24,6 +25,9 @@ describe('ReactLazyContextPropagation', () => {
     if (gate(flags => flags.enableSuspenseList)) {
       SuspenseList = React.SuspenseList;
     }
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
 
     getCacheForType = React.unstable_getCacheForType;
 
@@ -202,13 +206,13 @@ describe('ReactLazyContextPropagation', () => {
       await act(async () => {
         root.render(<App />);
       });
-      expect(Scheduler).toHaveYielded([0]);
+      assertLog([0]);
       expect(root).toMatchRenderedOutput('0');
 
       await act(async () => {
         setValue(1);
       });
-      expect(Scheduler).toHaveYielded([1]);
+      assertLog([1]);
       expect(root).toMatchRenderedOutput('1');
     },
   );
@@ -244,13 +248,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded([0]);
+    assertLog([0]);
     expect(root).toMatchRenderedOutput('0');
 
     await act(async () => {
       setValue(1);
     });
-    expect(Scheduler).toHaveYielded([1]);
+    assertLog([1]);
     expect(root).toMatchRenderedOutput('1');
   });
 
@@ -287,13 +291,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded([0]);
+    assertLog([0]);
     expect(root).toMatchRenderedOutput('0');
 
     await act(async () => {
       setValue(1);
     });
-    expect(Scheduler).toHaveYielded([1]);
+    assertLog([1]);
     expect(root).toMatchRenderedOutput('1');
   });
 
@@ -325,7 +329,7 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['Consumer', 0]);
+    assertLog(['Consumer', 0]);
     expect(root).toMatchRenderedOutput('0');
 
     await act(async () => {
@@ -335,12 +339,7 @@ describe('ReactLazyContextPropagation', () => {
       setOtherValue(1);
       setOtherValue(0);
     });
-    // NOTE: If this didn't yield anything, that indicates that we never visited
-    // the consumer during the render phase, which probably means the eager
-    // bailout mechanism kicked in. Because we're testing the _lazy_ bailout
-    // mechanism, update this test to foil the _eager_ bailout, somehow. Perhaps
-    // by switching to useReducer.
-    expect(Scheduler).toHaveYielded(['Consumer']);
+    assertLog(['Consumer']);
     expect(root).toMatchRenderedOutput('0');
   });
 
@@ -387,7 +386,7 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
@@ -395,13 +394,13 @@ describe('ReactLazyContextPropagation', () => {
       // the fallback displays despite this being a refresh.
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [B]', 'Loading...', 'B']);
+    assertLog(['Suspend! [B]', 'Loading...', 'B']);
     expect(root).toMatchRenderedOutput('Loading...B');
 
     await act(async () => {
       await resolveText('B');
     });
-    expect(Scheduler).toHaveYielded(['B']);
+    assertLog(['B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -467,7 +466,7 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A', 'A']);
+    assertLog(['A', 'A', 'A']);
     expect(root).toMatchRenderedOutput('AAA');
 
     await act(async () => {
@@ -475,13 +474,13 @@ describe('ReactLazyContextPropagation', () => {
       // the fallback displays despite this being a refresh.
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [B]', 'Loading...', 'B']);
+    assertLog(['Suspend! [B]', 'Loading...', 'B']);
     expect(root).toMatchRenderedOutput('Loading...B');
 
     await act(async () => {
       await resolveText('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BBB');
   });
 
@@ -528,7 +527,7 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
@@ -536,13 +535,13 @@ describe('ReactLazyContextPropagation', () => {
       // the fallback displays despite this being a refresh.
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [B]', 'Loading...', 'B']);
+    assertLog(['Suspend! [B]', 'Loading...', 'B']);
     expect(root).toMatchRenderedOutput('Loading...B');
 
     await act(async () => {
       await resolveText('B');
     });
-    expect(Scheduler).toHaveYielded(['B']);
+    assertLog(['B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -582,13 +581,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -643,13 +642,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A', 'A']);
+    assertLog(['A', 'A', 'A']);
     expect(root).toMatchRenderedOutput('AAA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B', 'B']);
+    assertLog(['B', 'B', 'B']);
     expect(root).toMatchRenderedOutput('BBB');
   });
 
@@ -685,13 +684,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -739,13 +738,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -802,19 +801,19 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [B]', 'Loading...']);
+    assertLog(['Suspend! [B]', 'Loading...']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     await act(async () => {
       await resolveText('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -863,13 +862,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 
@@ -912,13 +911,13 @@ describe('ReactLazyContextPropagation', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A', 'A']);
+    assertLog(['A', 'A']);
     expect(root).toMatchRenderedOutput('AA');
 
     await act(async () => {
       setContext('B');
     });
-    expect(Scheduler).toHaveYielded(['B', 'B']);
+    assertLog(['B', 'B']);
     expect(root).toMatchRenderedOutput('BB');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -15,6 +15,8 @@ let startTransition;
 let useDeferredValue;
 let useMemo;
 let useState;
+let assertLog;
+let waitForPaint;
 
 describe('ReactDeferredValue', () => {
   beforeEach(() => {
@@ -28,6 +30,10 @@ describe('ReactDeferredValue', () => {
     useDeferredValue = React.useDeferredValue;
     useMemo = React.useMemo;
     useState = React.useState;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
+    waitForPaint = InternalTestUtils.waitForPaint;
   });
 
   function Text({text}) {
@@ -65,15 +71,14 @@ describe('ReactDeferredValue', () => {
     await act(async () => {
       root.render(<App value={1} />);
     });
-    expect(Scheduler).toHaveYielded(['Original: 1', 'Deferred: 1']);
+    assertLog(['Original: 1', 'Deferred: 1']);
 
     // If it's an urgent update, the value is deferred
     await act(async () => {
       root.render(<App value={2} />);
 
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 2']);
-      // The deferred value updates in a separate render
-      expect(Scheduler).toFlushUntilNextPaint(['Deferred: 2']);
+      await waitForPaint(['Original: 2']);
+      await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -87,8 +92,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
-      // The deferred value updates in the same render as the original
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 3', 'Deferred: 3']);
+      await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -126,15 +130,14 @@ describe('ReactDeferredValue', () => {
     await act(async () => {
       root.render(<App value={1} />);
     });
-    expect(Scheduler).toHaveYielded(['Original: 1', 'Deferred: 1']);
+    assertLog(['Original: 1', 'Deferred: 1']);
 
     // If it's an urgent update, the value is deferred
     await act(async () => {
       root.render(<App value={2} />);
 
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 2']);
-      // The deferred value updates in a separate render
-      expect(Scheduler).toFlushUntilNextPaint(['Deferred: 2']);
+      await waitForPaint(['Original: 2']);
+      await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -148,8 +151,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
-      // The deferred value updates in the same render as the original
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 3', 'Deferred: 3']);
+      await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -192,15 +194,14 @@ describe('ReactDeferredValue', () => {
     await act(async () => {
       root.render(<App value={1} />);
     });
-    expect(Scheduler).toHaveYielded(['Original: 1', 'Deferred: 1']);
+    assertLog(['Original: 1', 'Deferred: 1']);
 
     // If it's an urgent update, the value is deferred
     await act(async () => {
       root.render(<App value={2} />);
 
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 2']);
-      // The deferred value updates in a separate render
-      expect(Scheduler).toFlushUntilNextPaint(['Deferred: 2']);
+      await waitForPaint(['Original: 2']);
+      await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -214,8 +215,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
-      // The deferred value updates in the same render as the original
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 3', 'Deferred: 3']);
+      await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
       <div>
@@ -257,7 +257,7 @@ describe('ReactDeferredValue', () => {
     // Initial render
     await act(async () => {
       root.render(<App value={1} />);
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 1', 'Deferred: 1']);
+      await waitForPaint(['Original: 1', 'Deferred: 1']);
       expect(root).toMatchRenderedOutput(
         <div>
           <div>Original: 1</div>
@@ -270,7 +270,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={2} />);
       });
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 2', 'Deferred: 2']);
+      await waitForPaint(['Original: 2', 'Deferred: 2']);
       expect(root).toMatchRenderedOutput(
         <div>
           <div>Original: 2</div>
@@ -281,17 +281,14 @@ describe('ReactDeferredValue', () => {
 
     await act(async () => {
       root.render(<App value={3} />);
-      // In the regression, the memoized value was not updated during non-urgent
-      // updates, so this would flip the deferred value back to the initial
-      // value (1) instead of reusing the current one (2).
-      expect(Scheduler).toFlushUntilNextPaint(['Original: 3']);
+      await waitForPaint(['Original: 3']);
       expect(root).toMatchRenderedOutput(
         <div>
           <div>Original: 3</div>
           <div>Deferred: 2</div>
         </div>,
       );
-      expect(Scheduler).toFlushUntilNextPaint(['Deferred: 3']);
+      await waitForPaint(['Deferred: 3']);
       expect(root).toMatchRenderedOutput(
         <div>
           <div>Original: 3</div>

--- a/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
@@ -5,6 +5,7 @@ let Scheduler;
 let Suspense;
 let scheduleCallback;
 let NormalPriority;
+let waitForAll;
 
 describe('ReactSuspenseList', () => {
   beforeEach(() => {
@@ -20,6 +21,9 @@ describe('ReactSuspenseList', () => {
 
     scheduleCallback = Scheduler.unstable_scheduleCallback;
     NormalPriority = Scheduler.unstable_NormalPriority;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   function Text(props) {
@@ -61,16 +65,12 @@ describe('ReactSuspenseList', () => {
     const root = ReactNoop.createRoot(null);
 
     root.render(<App show={false} />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     React.startTransition(() => {
       root.render(<App show={true} />);
     });
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Suspend! [B]',
-      'Loading...',
-    ]);
+    await waitForAll(['Suspend! [A]', 'Suspend! [B]', 'Loading...']);
     expect(root).toMatchRenderedOutput(null);
 
     Scheduler.unstable_advanceTime(2000);
@@ -92,7 +92,7 @@ describe('ReactSuspenseList', () => {
     // task should not jump the queue ahead of B.
     await expect(Scheduler).toFlushAndYieldThrough(['Resolve B']);
 
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(root).toMatchRenderedOutput('AB');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactEffectOrdering-test.js
@@ -18,8 +18,9 @@ let Scheduler;
 let act;
 let useEffect;
 let useLayoutEffect;
+let assertLog;
 
-describe('ReactHooksWithNoopRenderer', () => {
+describe('ReactEffectOrdering', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.useFakeTimers();
@@ -30,6 +31,9 @@ describe('ReactHooksWithNoopRenderer', () => {
     act = require('jest-react').act;
     useEffect = React.useEffect;
     useLayoutEffect = React.useLayoutEffect;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
   });
 
   test('layout unmounts on deletion are fired in parent -> child order', async () => {
@@ -56,7 +60,7 @@ describe('ReactHooksWithNoopRenderer', () => {
     await act(async () => {
       root.render(null);
     });
-    expect(Scheduler).toHaveYielded(['Unmount parent', 'Unmount child']);
+    assertLog(['Unmount parent', 'Unmount child']);
   });
 
   test('passive unmounts on deletion are fired in parent -> child order', async () => {
@@ -83,6 +87,6 @@ describe('ReactHooksWithNoopRenderer', () => {
     await act(async () => {
       root.render(null);
     });
-    expect(Scheduler).toHaveYielded(['Unmount parent', 'Unmount child']);
+    assertLog(['Unmount parent', 'Unmount child']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactExpiration-test.js
@@ -18,6 +18,9 @@ let resolveText;
 let startTransition;
 let useState;
 let useEffect;
+let assertLog;
+let waitFor;
+let waitForAll;
 
 describe('ReactExpiration', () => {
   beforeEach(() => {
@@ -30,6 +33,11 @@ describe('ReactExpiration', () => {
     startTransition = React.startTransition;
     useState = React.useState;
     useEffect = React.useEffect;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
+    waitFor = InternalTestUtils.waitFor;
+    waitForAll = InternalTestUtils.waitForAll;
 
     const textCache = new Map();
 
@@ -136,7 +144,7 @@ describe('ReactExpiration', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span prop="done" />);
   });
 
-  it('two updates of like priority in the same event always flush within the same batch', () => {
+  it('two updates of like priority in the same event always flush within the same batch', async () => {
     class TextClass extends React.Component {
       componentDidMount() {
         Scheduler.unstable_yieldValue(`${this.props.text} [commit]`);
@@ -163,37 +171,32 @@ describe('ReactExpiration', () => {
     });
     // Advance the timer.
     Scheduler.unstable_advanceTime(2000);
-    // Partially flush the first update, then interrupt it.
-    expect(Scheduler).toFlushAndYieldThrough(['A [render]']);
+    await waitFor(['A [render]']);
     interrupt();
 
-    // Don't advance time by enough to expire the first update.
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Schedule another update.
     ReactNoop.render(<TextClass text="B" />);
-    // Both updates are batched
-    expect(Scheduler).toFlushAndYield(['B [render]', 'B [commit]']);
+    await waitForAll(['B [render]', 'B [commit]']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
     // Now do the same thing again, except this time don't flush any work in
     // between the two updates.
     ReactNoop.render(<TextClass text="A" />);
     Scheduler.unstable_advanceTime(2000);
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
     // Schedule another update.
     ReactNoop.render(<TextClass text="B" />);
-    // The updates should flush in the same batch, since as far as the scheduler
-    // knows, they may have occurred inside the same event.
-    expect(Scheduler).toFlushAndYield(['B [render]', 'B [commit]']);
+    await waitForAll(['B [render]', 'B [commit]']);
   });
 
   it(
     'two updates of like priority in the same event always flush within the ' +
       "same batch, even if there's a sync update in between",
-    () => {
+    async () => {
       class TextClass extends React.Component {
         componentDidMount() {
           Scheduler.unstable_yieldValue(`${this.props.text} [commit]`);
@@ -220,25 +223,22 @@ describe('ReactExpiration', () => {
       });
       // Advance the timer.
       Scheduler.unstable_advanceTime(2000);
-      // Partially flush the first update, then interrupt it.
-      expect(Scheduler).toFlushAndYieldThrough(['A [render]']);
+      await waitFor(['A [render]']);
       interrupt();
 
-      // Don't advance time by enough to expire the first update.
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
       expect(ReactNoop).toMatchRenderedOutput(null);
 
       // Schedule another update.
       ReactNoop.render(<TextClass text="B" />);
-      // Both updates are batched
-      expect(Scheduler).toFlushAndYield(['B [render]', 'B [commit]']);
+      await waitForAll(['B [render]', 'B [commit]']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
       // Now do the same thing again, except this time don't flush any work in
       // between the two updates.
       ReactNoop.render(<TextClass text="A" />);
       Scheduler.unstable_advanceTime(2000);
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
       // Perform some synchronous work. The scheduler must assume we're inside
@@ -247,13 +247,11 @@ describe('ReactExpiration', () => {
 
       // Schedule another update.
       ReactNoop.render(<TextClass text="B" />);
-      // The updates should flush in the same batch, since as far as the scheduler
-      // knows, they may have occurred inside the same event.
-      expect(Scheduler).toFlushAndYield(['B [render]', 'B [commit]']);
+      await waitForAll(['B [render]', 'B [commit]']);
     },
   );
 
-  it('cannot update at the same expiration time that is already rendering', () => {
+  it('cannot update at the same expiration time that is already rendering', async () => {
     const store = {text: 'initial'};
     const subscribers = [];
     class Connected extends React.Component {
@@ -292,7 +290,7 @@ describe('ReactExpiration', () => {
     React.startTransition(() => {
       ReactNoop.render(<App />);
     });
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'initial [A] [render]',
       'initial [B] [render]',
       'initial [C] [render]',
@@ -307,10 +305,7 @@ describe('ReactExpiration', () => {
     React.startTransition(() => {
       subscribers.forEach(s => s.setState({text: '1'}));
     });
-    expect(Scheduler).toFlushAndYieldThrough([
-      '1 [A] [render]',
-      '1 [B] [render]',
-    ]);
+    await waitFor(['1 [A] [render]', '1 [B] [render]']);
 
     // Before the update can finish, update again. Even though no time has
     // advanced, this update should be given a different expiration time than
@@ -318,13 +313,10 @@ describe('ReactExpiration', () => {
     React.startTransition(() => {
       subscribers.forEach(s => s.setState({text: '2'}));
     });
-    expect(Scheduler).toFlushAndYieldThrough([
-      '1 [C] [render]',
-      '1 [D] [render]',
-    ]);
+    await waitFor(['1 [C] [render]', '1 [D] [render]']);
   });
 
-  it('stops yielding if CPU-bound update takes too long to finish', () => {
+  it('stops yielding if CPU-bound update takes too long to finish', async () => {
     const root = ReactNoop.createRoot();
     function App() {
       return (
@@ -342,18 +334,18 @@ describe('ReactExpiration', () => {
       root.render(<App />);
     });
 
-    expect(Scheduler).toFlushAndYieldThrough(['A']);
-    expect(Scheduler).toFlushAndYieldThrough(['B']);
-    expect(Scheduler).toFlushAndYieldThrough(['C']);
+    await waitFor(['A']);
+    await waitFor(['B']);
+    await waitFor(['C']);
 
     Scheduler.unstable_advanceTime(10000);
 
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded(['D', 'E']);
+    assertLog(['D', 'E']);
     expect(root).toMatchRenderedOutput('ABCDE');
   });
 
-  it('root expiration is measured from the time of the first update', () => {
+  it('root expiration is measured from the time of the first update', async () => {
     Scheduler.unstable_advanceTime(10000);
 
     const root = ReactNoop.createRoot();
@@ -372,14 +364,14 @@ describe('ReactExpiration', () => {
       root.render(<App />);
     });
 
-    expect(Scheduler).toFlushAndYieldThrough(['A']);
-    expect(Scheduler).toFlushAndYieldThrough(['B']);
-    expect(Scheduler).toFlushAndYieldThrough(['C']);
+    await waitFor(['A']);
+    await waitFor(['B']);
+    await waitFor(['C']);
 
     Scheduler.unstable_advanceTime(10000);
 
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded(['D', 'E']);
+    assertLog(['D', 'E']);
     expect(root).toMatchRenderedOutput('ABCDE');
   });
 
@@ -404,14 +396,14 @@ describe('ReactExpiration', () => {
 
     // The update should not have expired yet.
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
 
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Advance the time some more to expire the update.
     Scheduler.unstable_advanceTime(10000);
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(ReactNoop).toMatchRenderedOutput('Hi');
   });
 
@@ -427,14 +419,14 @@ describe('ReactExpiration', () => {
       ReactNoop.render('Hi');
     });
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Advancing by ~5 seconds should be sufficient to expire the update. (I
     // used a slightly larger number to allow for possible rounding.)
     Scheduler.unstable_advanceTime(6000);
     flushNextRenderIfExpired();
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(ReactNoop).toMatchRenderedOutput('Hi');
   });
 
@@ -463,7 +455,7 @@ describe('ReactExpiration', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['Sync pri: 0', 'Normal pri: 0']);
+    assertLog(['Sync pri: 0', 'Normal pri: 0']);
     expect(root).toMatchRenderedOutput('Sync pri: 0, Normal pri: 0');
 
     // First demonstrate what happens when there's no starvation
@@ -471,18 +463,16 @@ describe('ReactExpiration', () => {
       React.startTransition(() => {
         updateNormalPri();
       });
-      expect(Scheduler).toFlushAndYieldThrough(['Sync pri: 0']);
+      await waitFor(['Sync pri: 0']);
       updateSyncPri();
-      expect(Scheduler).toHaveYielded(['Sync pri: 1', 'Normal pri: 0']);
+      assertLog(['Sync pri: 1', 'Normal pri: 0']);
 
       // The remaining work hasn't expired, so the render phase is time sliced.
       // In other words, we can flush just the first child without flushing
       // the rest.
       Scheduler.unstable_flushNumberOfYields(1);
-      // Yield right after first child.
-      expect(Scheduler).toHaveYielded(['Sync pri: 1']);
-      // Now do the rest.
-      expect(Scheduler).toFlushAndYield(['Normal pri: 1']);
+      assertLog(['Sync pri: 1']);
+      await waitForAll(['Normal pri: 1']);
     });
     expect(root).toMatchRenderedOutput('Sync pri: 1, Normal pri: 1');
 
@@ -491,7 +481,7 @@ describe('ReactExpiration', () => {
       React.startTransition(() => {
         updateNormalPri();
       });
-      expect(Scheduler).toFlushAndYieldThrough(['Sync pri: 1']);
+      await waitFor(['Sync pri: 1']);
 
       // This time, a lot of time has elapsed since the normal pri update
       // started rendering. (This should advance time by some number that's
@@ -500,12 +490,12 @@ describe('ReactExpiration', () => {
       Scheduler.unstable_advanceTime(10000);
 
       updateSyncPri();
-      expect(Scheduler).toHaveYielded(['Sync pri: 2', 'Normal pri: 1']);
+      assertLog(['Sync pri: 2', 'Normal pri: 1']);
 
       // The remaining work _has_ expired, so the render phase is _not_ time
       // sliced. Attempting to flush just the first child also flushes the rest.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['Sync pri: 2', 'Normal pri: 2']);
+      assertLog(['Sync pri: 2', 'Normal pri: 2']);
     });
     expect(root).toMatchRenderedOutput('Sync pri: 2, Normal pri: 2');
   });
@@ -534,16 +524,16 @@ describe('ReactExpiration', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['Sync pri: 0', 'Idle pri: 0']);
+    assertLog(['Sync pri: 0', 'Idle pri: 0']);
     expect(root).toMatchRenderedOutput('Sync pri: 0, Idle pri: 0');
 
     // First demonstrate what happens when there's no starvation
     await act(async () => {
       updateIdlePri();
-      expect(Scheduler).toFlushAndYieldThrough(['Sync pri: 0']);
+      await waitFor(['Sync pri: 0']);
       updateSyncPri();
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // Interrupt idle update to render sync update
       'Sync pri: 1',
       'Idle pri: 0',
@@ -556,7 +546,7 @@ describe('ReactExpiration', () => {
     // Do the same thing, but starve the first update
     await act(async () => {
       updateIdlePri();
-      expect(Scheduler).toFlushAndYieldThrough(['Sync pri: 1']);
+      await waitFor(['Sync pri: 1']);
 
       // Advance a ridiculously large amount of time to demonstrate that the
       // idle work never expires
@@ -564,8 +554,7 @@ describe('ReactExpiration', () => {
 
       updateSyncPri();
     });
-    // Same thing should happen as last time
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // Interrupt idle update to render sync update
       'Sync pri: 2',
       'Idle pri: 1',
@@ -597,14 +586,14 @@ describe('ReactExpiration', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A0', 'B0', 'C']);
+    assertLog(['A0', 'B0', 'C']);
     expect(root).toMatchRenderedOutput('A0B0C');
 
     await act(async () => {
       startTransition(() => {
         setA(1);
       });
-      expect(Scheduler).toFlushAndYieldThrough(['A1']);
+      await waitFor(['A1']);
       startTransition(() => {
         setB(1);
       });
@@ -614,12 +603,12 @@ describe('ReactExpiration', () => {
       // (entangled), we should be able to finish the in-progress transition
       // without also including the next one.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['B0', 'C']);
+      assertLog(['B0', 'C']);
       expect(root).toMatchRenderedOutput('A1B0C');
 
       // The next transition also finishes without yielding.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['A1', 'B1', 'C']);
+      assertLog(['A1', 'B1', 'C']);
       expect(root).toMatchRenderedOutput('A1B1C');
     });
   });
@@ -642,28 +631,21 @@ describe('ReactExpiration', () => {
       await resolveText('A0');
       root.render(<App step={0} />);
     });
-    expect(Scheduler).toHaveYielded(['A0', 'B', 'C']);
+    assertLog(['A0', 'B', 'C']);
     expect(root).toMatchRenderedOutput('A0BC');
 
     await act(async () => {
       React.startTransition(() => {
         root.render(<App step={1} />);
       });
-      expect(Scheduler).toFlushAndYield([
-        'Suspend! [A1]',
-        'B',
-        'C',
-        'Loading...',
-      ]);
+      await waitForAll(['Suspend! [A1]', 'B', 'C', 'Loading...']);
 
       // Lots of time elapses before the promise resolves
       Scheduler.unstable_advanceTime(10000);
       await resolveText('A1');
-      expect(Scheduler).toHaveYielded(['Promise resolved [A1]']);
+      assertLog(['Promise resolved [A1]']);
 
-      // But the update doesn't expire, because it was IO bound. So we can
-      // partially rendering without finishing.
-      expect(Scheduler).toFlushAndYieldThrough(['A1']);
+      await waitFor(['A1']);
       expect(root).toMatchRenderedOutput('A0BC');
 
       // Lots more time elapses. We're CPU-bound now, so we should treat this
@@ -672,7 +654,7 @@ describe('ReactExpiration', () => {
 
       // The rest of the update finishes without yielding.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['B', 'C']);
+      assertLog(['B', 'C']);
     });
   });
 
@@ -696,13 +678,13 @@ describe('ReactExpiration', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['A0', 'B0']);
+    assertLog(['A0', 'B0']);
 
     await act(async () => {
       startTransition(() => {
         setA(1);
       });
-      expect(Scheduler).toFlushAndYieldThrough(['A1']);
+      await waitFor(['A1']);
 
       // Expire the in-progress update
       Scheduler.unstable_advanceTime(10000);
@@ -710,12 +692,12 @@ describe('ReactExpiration', () => {
       ReactNoop.flushSync(() => {
         setB(1);
       });
-      expect(Scheduler).toHaveYielded(['A0', 'B1']);
+      assertLog(['A0', 'B1']);
 
       // Now flush the original update. Because it expired, it should finish
       // without yielding.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['A1', 'B1']);
+      assertLog(['A1', 'B1']);
     });
   });
 
@@ -737,7 +719,7 @@ describe('ReactExpiration', () => {
     await act(async () => {
       root.render(<App step={0} />);
     });
-    expect(Scheduler).toHaveYielded(['A0', 'B0', 'C0', 'Effect: 0']);
+    assertLog(['A0', 'B0', 'C0', 'Effect: 0']);
     expect(root).toMatchRenderedOutput('A0B0C0');
 
     await act(async () => {
@@ -749,9 +731,8 @@ describe('ReactExpiration', () => {
 
       // The update finishes without yielding. But it does not flush the effect.
       Scheduler.unstable_flushNumberOfYields(1);
-      expect(Scheduler).toHaveYielded(['A1', 'B1', 'C1']);
+      assertLog(['A1', 'B1', 'C1']);
     });
-    // The effect flushes after paint.
-    expect(Scheduler).toHaveYielded(['Effect: 1']);
+    assertLog(['Effect: 1']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -12,6 +12,7 @@
 let React;
 let ReactNoop;
 let Scheduler;
+let waitForAll;
 
 describe('ReactFragment', () => {
   beforeEach(function () {
@@ -20,9 +21,12 @@ describe('ReactFragment', () => {
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
-  it('should render a single child via noop renderer', () => {
+  it('should render a single child via noop renderer', async () => {
     const element = (
       <>
         <span>foo</span>
@@ -30,21 +34,21 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>foo</span>);
   });
 
-  it('should render zero children via noop renderer', () => {
+  it('should render zero children via noop renderer', async () => {
     const element = <React.Fragment />;
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(null);
   });
 
-  it('should render multiple children via noop renderer', () => {
+  it('should render multiple children via noop renderer', async () => {
     const element = (
       <>
         hello <span>world</span>
@@ -52,7 +56,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -61,13 +65,13 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should render an iterable via noop renderer', () => {
+  it('should render an iterable via noop renderer', async () => {
     const element = (
       <>{new Set([<span key="a">hi</span>, <span key="b">bye</span>])}</>
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -77,7 +81,7 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should preserve state of children with 1 level nesting', function () {
+  it('should preserve state of children with 1 level nesting', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -102,10 +106,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -116,13 +120,13 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state between top-level fragments', function () {
+  it('should preserve state between top-level fragments', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -148,22 +152,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state of children nested at same level', function () {
+  it('should preserve state of children nested at same level', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -198,10 +202,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -212,13 +216,13 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state in non-top-level fragment nesting', function () {
+  it('should not preserve state in non-top-level fragment nesting', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -246,22 +250,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state of children if nested 2 levels without siblings', function () {
+  it('should not preserve state of children if nested 2 levels without siblings', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -287,22 +291,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state of children if nested 2 levels with siblings', function () {
+  it('should not preserve state of children if nested 2 levels with siblings', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -329,10 +333,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -343,13 +347,13 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state between array nested in fragment and fragment', function () {
+  it('should preserve state between array nested in fragment and fragment', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -373,22 +377,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state between top level fragment and array', function () {
+  it('should preserve state between top level fragment and array', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -412,22 +416,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state between array nested in fragment and double nested fragment', function () {
+  it('should not preserve state between array nested in fragment and double nested fragment', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -453,22 +457,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state between array nested in fragment and double nested array', function () {
+  it('should not preserve state between array nested in fragment and double nested array', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -490,22 +494,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state between double nested fragment and double nested array', function () {
+  it('should preserve state between double nested fragment and double nested array', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -531,22 +535,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state of children when the keys are different', function () {
+  it('should not preserve state of children when the keys are different', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -573,10 +577,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -587,13 +591,13 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state between unkeyed and keyed fragment', function () {
+  it('should not preserve state between unkeyed and keyed fragment', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -619,22 +623,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state with reordering in multiple levels', function () {
+  it('should preserve state with reordering in multiple levels', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -672,10 +676,10 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -689,7 +693,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -703,7 +707,7 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should not preserve state when switching to a keyed fragment to an array', function () {
+  it('should not preserve state when switching to a keyed fragment to an array', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -735,7 +739,7 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
     expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
@@ -751,7 +755,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -762,7 +766,7 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should not preserve state when switching a nested unkeyed fragment to a passthrough component', function () {
+  it('should not preserve state when switching a nested unkeyed fragment to a passthrough component', async function () {
     const ops = [];
 
     function Passthrough({children}) {
@@ -796,22 +800,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state when switching a nested keyed fragment to a passthrough component', function () {
+  it('should not preserve state when switching a nested keyed fragment to a passthrough component', async function () {
     const ops = [];
 
     function Passthrough({children}) {
@@ -845,22 +849,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should not preserve state when switching a nested keyed array to a passthrough component', function () {
+  it('should not preserve state when switching a nested keyed array to a passthrough component', async function () {
     const ops = [];
 
     function Passthrough({children}) {
@@ -890,22 +894,22 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual([]);
     expect(ReactNoop).toMatchRenderedOutput(<div>Hello</div>);
   });
 
-  it('should preserve state when it does not change positions', function () {
+  it('should preserve state when it does not change positions', async function () {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -940,8 +944,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={false} />);
-    // The key warning gets deduped because it's in the same component.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(
@@ -952,8 +955,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
-    // The key warning gets deduped because it's in the same component.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);
     expect(ReactNoop).toMatchRenderedOutput(

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseWithNoopRenderer-test.js
@@ -280,13 +280,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Render empty shell.
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield(['Foo']);
+    await waitForAll(['Foo']);
 
     // The update will suspend.
     React.startTransition(() => {
       ReactNoop.render(<Foo renderBar={true} />);
     });
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       'Bar',
       // A suspends
@@ -299,8 +299,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Resolve the data
     await resolveText('A');
-    // Renders successfully
-    expect(Scheduler).toFlushAndYield(['Foo', 'Bar', 'A', 'B']);
+    await waitForAll(['Foo', 'Bar', 'A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -322,7 +321,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>
       </Fragment>,
     );
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       'Loading A...',
       'Suspend! [B]',
@@ -339,7 +338,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // normal view. The second Suspense should still show the placeholder.
     await resolveText('A');
 
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -351,7 +350,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // normal view.
     await resolveText('B');
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -364,7 +363,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   it('continues rendering siblings after suspending', async () => {
     // A shell is needed. The update cause it to suspend.
     ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     // B suspends. Continue rendering the remaining siblings.
     React.startTransition(() => {
       ReactNoop.render(
@@ -376,21 +375,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
     });
-    // B suspends. Continue rendering the remaining siblings.
-    expect(Scheduler).toFlushAndYield([
-      'A',
-      'Suspend! [B]',
-      'C',
-      'D',
-      'Loading...',
-    ]);
+    await waitForAll(['A', 'Suspend! [B]', 'C', 'D', 'Loading...']);
     // Did not commit yet.
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Wait for data to resolve
     await resolveText('B');
-    // Renders successfully
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C', 'D']);
+    await waitForAll(['A', 'B', 'C', 'D']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -436,18 +427,18 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     React.startTransition(() => {
       ReactNoop.render(<App renderContent={true} />);
     });
-    expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
+    await waitForAll(['Suspend! [Result]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     await rejectText('Result', new Error('Failed to load: Result'));
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Error! [Result]',
 
       // React retries one more time
@@ -494,12 +485,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(Scheduler).toFlushAndYield(['Suspend! [Result]', 'Loading...']);
+    await waitForAll(['Suspend! [Result]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
     await rejectText('Result', new Error('Failed to load: Result'));
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Error! [Result]',
 
       // React retries one more time
@@ -526,9 +517,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial mount
     ReactNoop.render(<App highPri="A" lowPri="1" />);
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [1]', 'Loading...']);
+    await waitForAll(['A', 'Suspend! [1]', 'Loading...']);
     await resolveText('1');
-    expect(Scheduler).toFlushAndYield(['A', '1']);
+    await waitForAll(['A', '1']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -538,7 +529,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Update the low-pri text
     ReactNoop.render(<App highPri="A" lowPri="2" />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       // Suspends
       'Suspend! [2]',
@@ -583,13 +574,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App showA={false} showB={false} />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     React.startTransition(() => {
       ReactNoop.render(<App showA={true} showB={false} />);
     });
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Advance React's virtual time by enough to fall into a new async bucket,
@@ -598,11 +589,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     React.startTransition(() => {
       ReactNoop.render(<App showA={true} showB={true} />);
     });
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'B', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'B', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     await resolveText('A');
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -632,7 +623,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<App hide={true} />);
     });
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // The first update suspends
       'Suspend! [Async]',
       // but we have another pending update that we can work on
@@ -675,7 +666,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       root.render(<App step={0} shouldSuspend={false} />);
     });
     await advanceTimers(1000);
-    expect(Scheduler).toHaveYielded(['Sibling', 'Step 0']);
+    assertLog(['Sibling', 'Step 0']);
 
     // Schedule an update at several distinct expiration times
     await act(async () => {
@@ -683,27 +674,27 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         root.render(<App step={1} shouldSuspend={true} />);
       });
       Scheduler.unstable_advanceTime(1000);
-      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      await waitFor(['Sibling']);
       interrupt();
 
       React.startTransition(() => {
         root.render(<App step={2} shouldSuspend={true} />);
       });
       Scheduler.unstable_advanceTime(1000);
-      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      await waitFor(['Sibling']);
       interrupt();
 
       React.startTransition(() => {
         root.render(<App step={3} shouldSuspend={true} />);
       });
       Scheduler.unstable_advanceTime(1000);
-      expect(Scheduler).toFlushAndYieldThrough(['Sibling']);
+      await waitFor(['Sibling']);
       interrupt();
 
       root.render(<App step={4} shouldSuspend={false} />);
     });
 
-    expect(Scheduler).toHaveYielded(['Sibling', 'Step 4']);
+    assertLog(['Sibling', 'Step 4']);
   });
 
   // @gate enableLegacyCache
@@ -713,7 +704,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <Suspense fallback={<Text text="Loading..." />} />
       </Fragment>,
     );
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     ReactNoop.render(
       <Fragment>
@@ -724,7 +715,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // The async child suspends
       'Suspend! [Async]',
       // Render the placeholder
@@ -739,9 +730,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // the update.
     ReactNoop.expire(10000);
     await advanceTimers(10000);
-    // No additional rendering work is required, since we already prepared
-    // the placeholder.
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     // Should have committed the placeholder.
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -752,7 +741,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await resolveText('Async');
-    expect(Scheduler).toFlushAndYield(['Async']);
+    await waitForAll(['Async']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Async" />
@@ -778,7 +767,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Sync',
       // The async content suspends
       'Suspend! [Outer content]',
@@ -796,7 +785,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Resolve the outer promise.
     await resolveText('Outer content');
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Outer content',
       'Suspend! [Inner content]',
       'Loading inner...',
@@ -824,7 +813,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Finally, flush the inner promise. We should see the complete screen.
     await resolveText('Inner content');
-    expect(Scheduler).toFlushAndYield(['Inner content']);
+    await waitForAll(['Inner content']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Sync" />
@@ -848,7 +837,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Fragment>,
       ),
     );
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // The async child suspends
       'Suspend! [Async]',
       // We immediately render the fallback UI
@@ -866,7 +855,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await resolveText('Async');
-    expect(Scheduler).toFlushAndYield(['Async']);
+    await waitForAll(['Async']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Async" />
@@ -889,7 +878,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Fragment>,
       ),
     );
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend! [Async]',
       'Suspend! [Loading (inner)...]',
       'Sync',
@@ -906,7 +895,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <Suspense fallback={<Text text="Loading..." />} />
       </Fragment>,
     );
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     ReactNoop.render(
       <Fragment>
@@ -917,7 +906,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </Fragment>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // The async child suspends
       'Suspend! [Async]',
       'Loading...',
@@ -932,7 +921,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // expiration time.
     ReactNoop.expire(2000);
     await advanceTimers(2000);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Loading..." />
@@ -942,7 +931,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Once the promise resolves, we render the suspended view
     await resolveText('Async');
-    expect(Scheduler).toFlushAndYield(['Async']);
+    await waitForAll(['Async']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Async" />
@@ -958,7 +947,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <Suspense fallback={<Text text="Loading..." />} />
       </Fragment>,
     );
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     React.startTransition(() => {
       ReactNoop.render(
@@ -971,7 +960,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       );
     });
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // The async child suspends
       'Suspend! [Async]',
       'Loading...',
@@ -987,13 +976,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await advanceTimers(2000);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
-    // Even flushing won't yield a fallback in a transition.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Once the promise resolves, we render the suspended view
     await resolveText('Async');
-    expect(Scheduler).toFlushAndYield(['Async', 'Sync']);
+    await waitForAll(['Async', 'Sync']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Async" />
@@ -1010,7 +998,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <Suspense fallback={<Text text="Loading..." />} />
       </>,
     );
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(root).toMatchRenderedOutput(null);
     React.startTransition(() => {
       root.render(
@@ -1022,13 +1010,11 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
     });
-    expect(Scheduler).toFlushAndYieldThrough(['Suspend! [Async]', 'Sibling']);
+    await waitFor(['Suspend! [Async]', 'Sibling']);
 
     await resolveText('Async');
 
-    // Because we're already showing a fallback, interrupt the current render
-    // and restart immediately.
-    expect(Scheduler).toFlushAndYield(['Async', 'Sibling']);
+    await waitForAll(['Async', 'Sibling']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Async" />
@@ -1063,17 +1049,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         <AsyncText text="B" />
       </Suspense>,
     );
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Suspend! [B]',
-      'Loading...',
-    ]);
+    await waitForAll(['Suspend! [A]', 'Suspend! [B]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
     await resolveText('A');
     await resolveText('B');
 
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -1085,7 +1067,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
   // @gate enableLegacyCache
   it('can resume rendering earlier than a timeout', async () => {
     ReactNoop.render(<Suspense fallback={<Text text="Loading..." />} />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     React.startTransition(() => {
       ReactNoop.render(
@@ -1094,13 +1076,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toFlushAndYield(['Suspend! [Async]', 'Loading...']);
+    await waitForAll(['Suspend! [Async]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Resolve the promise
     await resolveText('Async');
-    // We can now resume rendering
-    expect(Scheduler).toFlushAndYield(['Async']);
+    await waitForAll(['Async']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Async" />);
   });
 
@@ -1121,37 +1102,34 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // First mount without suspending. This ensures we already have content
     // showing so that subsequent updates will suspend.
     ReactNoop.render(<App text="S" />);
-    expect(Scheduler).toFlushAndYield(['S']);
+    await waitForAll(['S']);
 
     // Schedule an update, and suspend for up to 5 seconds.
     React.startTransition(() => ReactNoop.render(<App text="A" />));
-    // The update should suspend.
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="S" />);
 
     // Advance time until right before it expires.
     await advanceTimers(4999);
     ReactNoop.expire(4999);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="S" />);
 
     // Schedule another low priority update.
     React.startTransition(() => ReactNoop.render(<App text="B" />));
-    // This update should also suspend.
-    expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+    await waitForAll(['Suspend! [B]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="S" />);
 
     // Schedule a regular update. Its expiration time will fall between
     // the expiration times of the previous two updates.
     ReactNoop.render(<App text="C" />);
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="C" />);
 
     // Flush the remaining work.
     await resolveText('A');
     await resolveText('B');
-    // Nothing else to render.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="C" />);
   });
 
@@ -1188,17 +1166,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     jest.advanceTimersByTime(1000);
     ReactNoop.render(<Foo text="goodbye" />);
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [goodbye]',
-      'Loading...',
-      'Commit: goodbye',
-    ]);
+    await waitForAll(['Suspend! [goodbye]', 'Loading...', 'Commit: goodbye']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
     await resolveText('goodbye');
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
-    expect(Scheduler).toFlushAndYield(['goodbye']);
+    await waitForAll(['goodbye']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="goodbye" />);
   });
 
@@ -1223,18 +1197,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Suspend! [B]',
-      'Suspend! [C]',
-    ]);
+    await waitForAll(['Suspend! [A]', 'Suspend! [B]', 'Suspend! [C]']);
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
 
     await resolveText('A');
     await resolveText('B');
     await resolveText('C');
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -1257,14 +1227,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Times out immediately, ignoring the specified threshold.
       ReactNoop.renderLegacySyncRoot(<App />);
-      expect(Scheduler).toHaveYielded(['Suspend! [Result]', 'Loading...']);
+      assertLog(['Suspend! [Result]', 'Loading...']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
       await act(async () => {
         resolveText('Result');
       });
 
-      expect(Scheduler).toHaveYielded(['Result']);
+      assertLog(['Result']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Result" />);
     });
 
@@ -1300,7 +1270,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Initial mount.
       await seedNextTextCache('Step: 1');
       ReactNoop.renderLegacySyncRoot(<App />);
-      expect(Scheduler).toHaveYielded(['Step: 1', 'Sibling']);
+      assertLog(['Step: 1', 'Sibling']);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <span prop="Step: 1" />
@@ -1333,7 +1303,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         resolveText('Step: 2');
       });
-      expect(Scheduler).toHaveYielded(['Step: 2']);
+      assertLog(['Step: 2']);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <span prop="Step: 2" />
@@ -1381,7 +1351,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.renderLegacySyncRoot(<App />, () =>
         Scheduler.unstable_yieldValue('Commit root'),
       );
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'A',
         'Suspend! [B]',
         'C',
@@ -1407,7 +1377,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         resolveText('B');
       });
 
-      expect(Scheduler).toHaveYielded(['B']);
+      assertLog(['B']);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <span prop="A" />
@@ -1442,22 +1412,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
 
-      expect(Scheduler).toHaveYielded([
-        'constructor',
-        'Suspend! [Hi]',
-        'Loading...',
-      ]);
+      assertLog(['constructor', 'Suspend! [Hi]', 'Loading...']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
 
       await act(async () => {
         resolveText('Hi');
       });
 
-      expect(Scheduler).toHaveYielded([
-        'constructor',
-        'Hi',
-        'componentDidMount',
-      ]);
+      assertLog(['constructor', 'Hi', 'componentDidMount']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Hi" />);
     });
 
@@ -1489,7 +1451,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       ReactNoop.renderLegacySyncRoot(<Demo />);
 
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'Suspend! [Hi]',
         'Loading...',
         // Re-render due to lifecycle update
@@ -1499,7 +1461,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         resolveText('Hi');
       });
-      expect(Scheduler).toHaveYielded(['Hi']);
+      assertLog(['Hi']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="Hi" />);
     });
 
@@ -1532,7 +1494,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
 
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'Suspend! [Hi]',
           'Loading...',
           // The child should have already been hidden
@@ -1545,7 +1507,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         await act(async () => {
           resolveText('Hi');
         });
-        expect(Scheduler).toHaveYielded(['Hi']);
+        assertLog(['Hi']);
       });
     } else {
       // @gate enableLegacyCache
@@ -1578,7 +1540,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
         ReactNoop.renderLegacySyncRoot(<App middleText="B" />);
 
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'Suspend! [Hi]',
           'Loading...',
           // The child should have already been hidden
@@ -1589,7 +1551,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           resolveText('Hi');
         });
 
-        expect(Scheduler).toHaveYielded(['Hi']);
+        assertLog(['Hi']);
       });
     }
 
@@ -1622,7 +1584,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </ErrorBoundary>,
       );
 
-      expect(Scheduler).toHaveYielded(['Suspend! [Async]']);
+      assertLog(['Suspend! [Async]']);
       expect(ReactNoop).toMatchRenderedOutput(
         'Caught an error: Error in host config.',
       );
@@ -1661,7 +1623,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<App />);
       });
-      expect(Scheduler).toHaveYielded(['Mount']);
+      assertLog(['Mount']);
       expect(root).toMatchRenderedOutput('Child');
 
       // Suspend the child. This puts it into an inconsistent state.
@@ -1674,7 +1636,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(null);
       });
-      expect(Scheduler).toHaveYielded(['Unmount']);
+      assertLog(['Unmount']);
     });
   });
 
@@ -1726,7 +1688,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.renderLegacySyncRoot(<App />, () =>
       Scheduler.unstable_yieldValue('Commit root'),
     );
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A',
       'Suspend! [B]',
       'C',
@@ -1802,7 +1764,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     ReactNoop.renderLegacySyncRoot(<App text="B" />, () =>
       Scheduler.unstable_yieldValue('Commit root'),
     );
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A',
       'Suspend! [B]',
       'C',
@@ -1816,8 +1778,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Commit root',
     ]);
 
-    // Flush passive effects.
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Effect [A]',
       // B's effect should not fire because it suspended
       // 'Effect [B]',
@@ -1837,7 +1798,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       resolveText('B');
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'B',
       'Destroy Layout Effect [Loading...]',
       'Layout Effect [B]',
@@ -1850,7 +1811,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       Scheduler.unstable_yieldValue('Commit root'),
     );
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'A',
       'Suspend! [B2]',
       'C',
@@ -1862,8 +1823,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       'Commit root',
     ]);
 
-    // Flush passive effects.
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // B2's effect should not fire because it suspended
       // 'Effect [B2]',
       'Effect [Loading...]',
@@ -1873,7 +1833,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       resolveText('B2');
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'B2',
       'Destroy Layout Effect [Loading...]',
       'Destroy Layout Effect [B]',
@@ -1896,19 +1856,18 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield(['Foo']);
+    await waitForAll(['Foo']);
 
     React.startTransition(() => {
       ReactNoop.render(<Foo renderContent={true} />);
     });
     Scheduler.unstable_advanceTime(100);
     await advanceTimers(100);
-    // Start rendering
-    expect(Scheduler).toFlushAndYieldThrough(['Foo']);
+    await waitFor(['Foo']);
     // For some reason it took a long time to render Foo.
     Scheduler.unstable_advanceTime(1250);
     await advanceTimers(1250);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // A suspends
       'Suspend! [A]',
       'Loading...',
@@ -1919,24 +1878,19 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Flush some of the time
     Scheduler.unstable_advanceTime(450);
     await advanceTimers(450);
-    // Because we've already been waiting for so long we can
-    // wait a bit longer. Still nothing...
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Eventually we'll show the fallback.
     Scheduler.unstable_advanceTime(500);
     await advanceTimers(500);
-    // No need to rerender.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     // Since this is a transition, we never fallback.
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Flush the promise completely
     await resolveText('A');
-    // Renders successfully
-    // TODO: Why does this render Foo
-    expect(Scheduler).toFlushAndYield(['Foo', 'A']);
+    await waitForAll(['Foo', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
   });
 
@@ -1955,8 +1909,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    // Start rendering
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       // A suspends
       'Suspend! [A]',
@@ -1972,8 +1925,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     Scheduler.unstable_advanceTime(5000);
     await advanceTimers(5000);
 
-    // Retry with the new content.
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       // B still suspends
       'Suspend! [B]',
@@ -1991,8 +1943,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Flush the last promise completely
     await resolveText('B');
-    // Renders successfully
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2016,8 +1967,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    // Start rendering
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       // A suspends
       'Suspend! [A]',
@@ -2030,8 +1980,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     await resolveText('A');
 
-    // Retry with the new content.
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       // B still suspends
       'Suspend! [B]',
@@ -2046,8 +1995,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Before we commit another Promise resolves.
     // We're still showing the first loading state.
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
-    // Restart and render the complete content.
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2068,18 +2016,18 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield(['Foo']);
+    await waitForAll(['Foo']);
 
     React.startTransition(() => {
       ReactNoop.render(<Foo renderContent={true} />);
     });
-    expect(Scheduler).toFlushAndYieldThrough(['Foo']);
+    await waitFor(['Foo']);
 
     // Advance some time.
     Scheduler.unstable_advanceTime(100);
     await advanceTimers(100);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // A suspends
       'Suspend! [A]',
       'Loading...',
@@ -2092,11 +2040,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     Scheduler.unstable_advanceTime(500);
     jest.advanceTimersByTime(500);
 
-    // We should have already shown the fallback.
-    // When we wrote this test, we inferred the start time of high priority
-    // updates as way earlier in the past. This test ensures that we don't
-    // use this assumption to add a very long JND.
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     // Transitions never fallback.
     expect(ReactNoop).toMatchRenderedOutput(null);
   });
@@ -2173,14 +2117,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<App />);
     });
 
-    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    assertLog(['Suspend! [A]']);
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
 
     act(() => {
       ReactNoop.flushSync(() => showB());
     });
 
-    expect(Scheduler).toHaveYielded(['Suspend! [A]', 'Suspend! [B]']);
+    assertLog(['Suspend! [A]', 'Suspend! [B]']);
   });
 
   // TODO: flip to "warns" when this is implemented again.
@@ -2236,7 +2180,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // also make sure lowpriority is okay
     await act(async () => show(true));
 
-    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    assertLog(['Suspend! [A]']);
     await resolveText('A');
 
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
@@ -2262,7 +2206,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // also make sure lowpriority is okay
     await act(async () => _setShow(true));
 
-    expect(Scheduler).toHaveYielded(['Suspend! [A]']);
+    assertLog(['Suspend! [A]']);
     await resolveText('A');
 
     expect(ReactNoop).toMatchRenderedOutput('Loading...');
@@ -2286,17 +2230,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield([
-      'Foo',
-      'Suspend! [A]',
-      'B',
-      'Initial load...',
-    ]);
+    await waitForAll(['Foo', 'Suspend! [A]', 'B', 'Initial load...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Initial load..." />);
 
     // Eventually we resolve and show the data.
     await resolveText('A');
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2306,13 +2245,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Update to show C
     ReactNoop.render(<Foo showC={true} />);
-    expect(Scheduler).toFlushAndYield([
-      'Foo',
-      'A',
-      'Suspend! [C]',
-      'Updating...',
-      'B',
-    ]);
+    await waitForAll(['Foo', 'A', 'Suspend! [C]', 'Updating...', 'B']);
     // Flush to skip suspended time.
     Scheduler.unstable_advanceTime(600);
     await advanceTimers(600);
@@ -2328,7 +2261,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Later we load the data.
     await resolveText('C');
-    expect(Scheduler).toFlushAndYield(['A', 'C']);
+    await waitForAll(['A', 'C']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2354,7 +2287,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       'Suspend! [A]',
       'B',
@@ -2364,7 +2297,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Eventually we resolve and show the data.
     await resolveText('A');
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2374,7 +2307,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Update to show C
     ReactNoop.render(<Foo showC={true} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       'A',
       'Suspend! [C]',
@@ -2393,7 +2326,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Later we load the data.
     await resolveText('C');
-    expect(Scheduler).toFlushAndYield(['A', 'C']);
+    await waitForAll(['A', 'C']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -2422,12 +2355,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield([
-      'Foo',
-      'A',
-      'Suspend! [B]',
-      'Loading B...',
-    ]);
+    await waitForAll(['Foo', 'A', 'Suspend! [B]', 'Loading B...']);
     // Flush to skip suspended time.
     Scheduler.unstable_advanceTime(600);
     await advanceTimers(600);
@@ -2463,19 +2391,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield(['Foo', 'A']);
+    await waitForAll(['Foo', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
     React.startTransition(() => {
       ReactNoop.render(<Foo showB={true} />);
     });
 
-    expect(Scheduler).toFlushAndYield([
-      'Foo',
-      'A',
-      'Suspend! [B]',
-      'Loading B...',
-    ]);
+    await waitForAll(['Foo', 'A', 'Suspend! [B]', 'Loading B...']);
     // Still suspended.
     expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
@@ -2506,14 +2429,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield(['Foo', 'A']);
+    await waitForAll(['Foo', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
     React.startTransition(() => {
       ReactNoop.render(<Foo showB={true} />);
     });
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Foo',
       'A',
       'Suspend! [B]',
@@ -2543,7 +2466,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     }
 
     ReactNoop.render(<Foo />);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     ReactNoop.render(<Foo renderContent={1} />);
 
@@ -2552,14 +2475,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     Scheduler.unstable_advanceTime(1500);
     await advanceTimers(1500);
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A...']);
+    await waitForAll(['Suspend! [A]', 'Loading A...']);
     // We're still suspended.
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     // Schedule an update at idle pri.
     ReactNoop.idleUpdates(() => ReactNoop.render(<Foo renderContent={2} />));
-    // We won't even work on Idle priority.
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     // We're still suspended.
     expect(ReactNoop).toMatchRenderedOutput(null);
@@ -2592,7 +2514,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Initial render.
       React.startTransition(() => ReactNoop.render(<App page="A" />));
 
-      expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+      await waitForAll(['Suspend! [A]', 'Loading...']);
       // Only a short time is needed to unsuspend the initial loading state.
       Scheduler.unstable_advanceTime(400);
       await advanceTimers(400);
@@ -2600,13 +2522,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-      expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+      await waitForAll(['Suspend! [B]', 'Loading...']);
       Scheduler.unstable_advanceTime(100000);
       await advanceTimers(100000);
       // Even after lots of time has passed, we have still not yet flushed the
@@ -2614,7 +2536,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
     });
 
@@ -2635,13 +2557,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App />);
-      expect(Scheduler).toFlushAndYield([]);
+      await waitForAll([]);
 
       // Initial render.
       await act(async () => {
         React.startTransition(() => transitionToPage('A'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        await waitForAll(['Suspend! [A]', 'Loading...']);
         // Only a short time is needed to unsuspend the initial loading state.
         Scheduler.unstable_advanceTime(400);
         await advanceTimers(400);
@@ -2650,14 +2572,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        await waitForAll(['Suspend! [B]', 'Loading...']);
         Scheduler.unstable_advanceTime(100000);
         await advanceTimers(100000);
         // Even after lots of time has passed, we have still not yet flushed the
@@ -2666,7 +2588,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
     });
 
@@ -2690,13 +2612,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App />);
-      expect(Scheduler).toFlushAndYield([]);
+      await waitForAll([]);
 
       // Initial render.
       await act(async () => {
         React.startTransition(() => transitionToPage('A'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        await waitForAll(['Suspend! [A]', 'Loading...']);
         // Only a short time is needed to unsuspend the initial loading state.
         Scheduler.unstable_advanceTime(400);
         await advanceTimers(400);
@@ -2705,14 +2627,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        await waitForAll(['Suspend! [B]', 'Loading...']);
         Scheduler.unstable_advanceTime(100000);
         await advanceTimers(100000);
         // Even after lots of time has passed, we have still not yet flushed the
@@ -2721,7 +2643,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
     });
   });
@@ -2740,7 +2662,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Initial render.
       React.startTransition(() => ReactNoop.render(<App page="A" />));
 
-      expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+      await waitForAll(['Suspend! [A]', 'Loading...']);
       // Only a short time is needed to unsuspend the initial loading state.
       Scheduler.unstable_advanceTime(400);
       await advanceTimers(400);
@@ -2748,13 +2670,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-      expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+      await waitForAll(['Suspend! [B]', 'Loading...']);
       Scheduler.unstable_advanceTime(2999);
       await advanceTimers(2999);
       // Since the timeout is infinite (or effectively infinite),
@@ -2763,12 +2685,12 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
       // Start a long (infinite) transition.
       React.startTransition(() => ReactNoop.render(<App page="C" />));
-      expect(Scheduler).toFlushAndYield(['Suspend! [C]', 'Loading...']);
+      await waitForAll(['Suspend! [C]', 'Loading...']);
 
       // Even after lots of time has passed, we have still not yet flushed the
       // loading state.
@@ -2794,13 +2716,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App />);
-      expect(Scheduler).toFlushAndYield([]);
+      await waitForAll([]);
 
       // Initial render.
       await act(async () => {
         React.startTransition(() => transitionToPage('A'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        await waitForAll(['Suspend! [A]', 'Loading...']);
         // Only a short time is needed to unsuspend the initial loading state.
         Scheduler.unstable_advanceTime(400);
         await advanceTimers(400);
@@ -2809,14 +2731,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        await waitForAll(['Suspend! [B]', 'Loading...']);
 
         Scheduler.unstable_advanceTime(2999);
         await advanceTimers(2999);
@@ -2827,14 +2749,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
       // Start a long (infinite) transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('C'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [C]', 'Loading...']);
+        await waitForAll(['Suspend! [C]', 'Loading...']);
 
         // Even after lots of time has passed, we have still not yet flushed the
         // loading state.
@@ -2864,13 +2786,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       }
 
       ReactNoop.render(<App />);
-      expect(Scheduler).toFlushAndYield([]);
+      await waitForAll([]);
 
       // Initial render.
       await act(async () => {
         React.startTransition(() => transitionToPage('A'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+        await waitForAll(['Suspend! [A]', 'Loading...']);
         // Only a short time is needed to unsuspend the initial loading state.
         Scheduler.unstable_advanceTime(400);
         await advanceTimers(400);
@@ -2879,14 +2801,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('A');
-      expect(Scheduler).toFlushAndYield(['A']);
+      await waitForAll(['A']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="A" />);
 
       // Start transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('B'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        await waitForAll(['Suspend! [B]', 'Loading...']);
         Scheduler.unstable_advanceTime(2999);
         await advanceTimers(2999);
         // Since the timeout is infinite (or effectively infinite),
@@ -2896,14 +2818,14 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
       // Later we load the data.
       await resolveText('B');
-      expect(Scheduler).toFlushAndYield(['B']);
+      await waitForAll(['B']);
       expect(ReactNoop).toMatchRenderedOutput(<span prop="B" />);
 
       // Start a long (infinite) transition.
       await act(async () => {
         React.startTransition(() => transitionToPage('C'));
 
-        expect(Scheduler).toFlushAndYield(['Suspend! [C]', 'Loading...']);
+        await waitForAll(['Suspend! [C]', 'Loading...']);
 
         // Even after lots of time has passed, we have still not yet flushed the
         // loading state.
@@ -2931,9 +2853,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial render.
     ReactNoop.render(<App page="A" />);
-    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [A]', 'Loading...']);
+    await waitForAll(['Hi!', 'Suspend! [A]', 'Loading...']);
     await resolveText('A');
-    expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
+    await waitForAll(['Hi!', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Hi!" />
@@ -2944,7 +2866,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Start transition.
     React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [B]', 'Loading B...']);
+    await waitForAll(['Hi!', 'Suspend! [B]', 'Loading B...']);
 
     // Suspended
     expect(ReactNoop).toMatchRenderedOutput(
@@ -2955,7 +2877,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
     Scheduler.unstable_advanceTime(1800);
     await advanceTimers(1800);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     // We should still be suspended here because this loading state should be avoided.
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2964,7 +2886,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </>,
     );
     await resolveText('B');
-    expect(Scheduler).toFlushAndYield(['Hi!', 'B']);
+    await waitForAll(['Hi!', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Hi!" />
@@ -2994,7 +2916,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial render.
     ReactNoop.render(<App page="A" />);
-    expect(Scheduler).toFlushAndYield(['Hi!', 'A']);
+    await waitForAll(['Hi!', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Hi!" />
@@ -3005,7 +2927,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Start transition.
     React.startTransition(() => ReactNoop.render(<App page="B" />));
 
-    expect(Scheduler).toFlushAndYield(['Hi!', 'Suspend! [B]', 'Loading B...']);
+    await waitForAll(['Hi!', 'Suspend! [B]', 'Loading B...']);
 
     // Suspended
     expect(ReactNoop).toMatchRenderedOutput(
@@ -3016,7 +2938,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     );
     Scheduler.unstable_advanceTime(1800);
     await advanceTimers(1800);
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     // We should still be suspended here because this loading state should be avoided.
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -3025,7 +2947,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       </>,
     );
     await resolveText('B');
-    expect(Scheduler).toFlushAndYield(['Hi!', 'B']);
+    await waitForAll(['Hi!', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Hi!" />
@@ -3051,13 +2973,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App text="Initial" />);
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [Initial]']);
+    assertLog(['Suspend! [Initial]']);
 
     // Resolve initial render
     await act(async () => {
       await resolveText('Initial');
     });
-    expect(Scheduler).toHaveYielded(['Initial']);
+    assertLog(['Initial']);
     expect(root).toMatchRenderedOutput(<span prop="Initial" />);
 
     await act(async () => {
@@ -3066,7 +2988,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       React.startTransition(() => {
         root.render(<App text="First update" />);
       });
-      expect(Scheduler).toFlushAndYield(['Suspend! [First update]']);
+      await waitForAll(['Suspend! [First update]']);
 
       // Should not display a fallback
       expect(root).toMatchRenderedOutput(<span prop="Initial" />);
@@ -3075,7 +2997,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       React.startTransition(() => {
         root.render(<App text="Second update" />);
       });
-      expect(Scheduler).toFlushAndYield(['Suspend! [Second update]']);
+      await waitForAll(['Suspend! [Second update]']);
 
       // Should not display a fallback
       expect(root).toMatchRenderedOutput(<span prop="Initial" />);
@@ -3113,22 +3035,19 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       root.render(<App />);
     });
 
-    expect(Scheduler).toHaveYielded(['Foo']);
+    assertLog(['Foo']);
 
     await act(async () => {
       foo.setState({suspend: true});
 
-      // In the regression that this covers, we would neglect to reset the
-      // current debug phase after suspending (in the catch block), so React
-      // thinks we're still inside the render phase.
-      expect(Scheduler).toFlushAndYieldThrough(['Suspend!']);
+      await waitFor(['Suspend!']);
 
       // Then when this setState happens, React would incorrectly fire a warning
       // about updates that happen the render phase (only fired by classes).
       foo.setState({suspend: false});
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       // First setState
       'Foo',
     ]);
@@ -3159,7 +3078,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial render.
     ReactNoop.render(<App showContent={false} />);
-    expect(Scheduler).toFlushAndYieldThrough(['Commit']);
+    await waitFor(['Commit']);
     expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
 
     // Start transition.
@@ -3167,16 +3086,16 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.render(<App showContent={true} />);
     });
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     await resolveText('A');
-    expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
+    await waitFor(['A', 'Commit']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <div hidden={true} />
         <span prop="A" />
       </>,
     );
-    expect(Scheduler).toFlushAndYield(['Offscreen']);
+    await waitForAll(['Offscreen']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <div hidden={true}>Offscreen</div>
@@ -3208,27 +3127,26 @@ describe('ReactSuspenseWithNoopRenderer', () => {
 
     // Initial render.
     ReactNoop.render(<App showContent={false} />);
-    expect(Scheduler).toFlushAndYieldThrough(['Commit']);
+    await waitFor(['Commit']);
     expect(ReactNoop).toMatchRenderedOutput(<div hidden={true} />);
 
-    // Partially render through the hidden content.
-    expect(Scheduler).toFlushAndYieldThrough(['Suspend! [A]']);
+    await waitFor(['Suspend! [A]']);
 
     // Start transition.
     React.startTransition(() => {
       ReactNoop.render(<App showContent={true} />);
     });
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     await resolveText('A');
-    expect(Scheduler).toFlushAndYieldThrough(['A', 'Commit']);
+    await waitFor(['A', 'Commit']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <div hidden={true} />
         <span prop="A" />
       </>,
     );
-    expect(Scheduler).toFlushAndYield(['A', 'Offscreen']);
+    await waitForAll(['A', 'Offscreen']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <div hidden={true}>
@@ -3269,7 +3187,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<Parent />);
       });
-      expect(Scheduler).toHaveYielded(['A']);
+      assertLog(['A']);
       expect(root).toMatchRenderedOutput(<span prop="A" />);
 
       await act(async () => {
@@ -3283,7 +3201,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         await resolveText('C');
         setText('C');
       });
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         // First we attempt the high pri update. It suspends.
         'Suspend! [B]',
         'Loading...',
@@ -3323,7 +3241,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<Parent />);
       });
-      expect(Scheduler).toHaveYielded(['A']);
+      assertLog(['A']);
       expect(root).toMatchRenderedOutput(<span prop="A" />);
 
       await act(async () => {
@@ -3337,7 +3255,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           setText('C');
         });
 
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           // First we attempt the high pri update. It suspends.
           'Suspend! [B]',
           'Loading...',
@@ -3352,8 +3270,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           </>,
         );
 
-        // Now flush the remaining work. The Idle update successfully finishes.
-        expect(Scheduler).toFlushAndYield(['C']);
+        await waitForAll(['C']);
         expect(root).toMatchRenderedOutput(<span prop="C" />);
       });
     },
@@ -3392,13 +3309,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<App />);
       });
-      expect(Scheduler).toHaveYielded(['A']);
+      assertLog(['A']);
       expect(root).toMatchRenderedOutput(<span prop="A" />);
 
       await act(async () => {
         // Schedule an update inside the Suspense boundary that suspends.
         setAppText('B');
-        expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+        await waitForAll(['Suspend! [B]', 'Loading...']);
       });
 
       expect(root).toMatchRenderedOutput(
@@ -3418,7 +3335,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         });
       });
 
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         // First try to render the high pri update. Still suspended.
         'Suspend! [C]',
         'Loading...',
@@ -3477,7 +3394,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<Parent />);
       });
-      expect(Scheduler).toHaveYielded(['A']);
+      assertLog(['A']);
       // At this point, the setState return path follows current fiber.
       expect(root).toMatchRenderedOutput(<span prop="A" />);
 
@@ -3486,7 +3403,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('B');
       });
-      expect(Scheduler).toHaveYielded(['B']);
+      assertLog(['B']);
       // Now the setState return path follows the *alternate* fiber.
       expect(root).toMatchRenderedOutput(<span prop="B" />);
 
@@ -3494,7 +3411,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('C');
       });
-      expect(Scheduler).toHaveYielded(['Suspend! [C]', 'Loading...']);
+      assertLog(['Suspend! [C]', 'Loading...']);
 
       // Commit. This will insert a fragment fiber to wrap around the component
       // that triggered the update.
@@ -3516,9 +3433,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('D');
       });
-      // Even though the fragment fiber is not part of the return path, we should
-      // be able to finish rendering.
-      expect(Scheduler).toHaveYielded(['D']);
+      assertLog(['D']);
       expect(root).toMatchRenderedOutput(<span prop="D" />);
     },
   );
@@ -3554,7 +3469,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<Parent />);
       });
-      expect(Scheduler).toHaveYielded(['A']);
+      assertLog(['A']);
       // At this point, the setState return path follows current fiber.
       expect(root).toMatchRenderedOutput(<span prop="A" />);
 
@@ -3563,7 +3478,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('B');
       });
-      expect(Scheduler).toHaveYielded(['B']);
+      assertLog(['B']);
       // Now the setState return path follows the *alternate* fiber.
       expect(root).toMatchRenderedOutput(<span prop="B" />);
 
@@ -3571,7 +3486,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('C');
       });
-      expect(Scheduler).toHaveYielded(['Suspend! [C]', 'Loading...']);
+      assertLog(['Suspend! [C]', 'Loading...']);
 
       // Commit. This will insert a fragment fiber to wrap around the component
       // that triggered the update.
@@ -3598,9 +3513,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
           setText('E');
         });
       });
-      // Even though the fragment fiber is not part of the return path, we should
-      // be able to finish rendering.
-      expect(Scheduler).toHaveYielded(['Suspend! [D]', 'E']);
+      assertLog(['Suspend! [D]', 'E']);
       expect(root).toMatchRenderedOutput(<span prop="E" />);
     },
   );
@@ -3663,7 +3576,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<Parent step={0} />);
       });
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'Outer text: A',
         'Outer step: 0',
         'Inner text: A',
@@ -3683,7 +3596,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         setText('B');
       });
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'Outer text: B',
         'Outer step: 0',
         'Suspend! [Inner text: B]',
@@ -3709,10 +3622,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         });
       });
 
-      // Only the outer part can update. The inner part should still show a
-      // fallback because we haven't finished loading B yet. Otherwise, the
-      // inner text would be inconsistent with the outer text.
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'Outer text: B',
         'Outer step: 1',
         'Suspend! [Inner text: B]',
@@ -3733,11 +3643,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         await resolveText('Inner text: B');
       });
-      expect(Scheduler).toHaveYielded([
-        'Inner text: B',
-        'Inner step: 1',
-        'Commit Child',
-      ]);
+      assertLog(['Inner text: B', 'Inner step: 1', 'Commit Child']);
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="Outer text: B" />
@@ -3802,7 +3708,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<Parent step={0} />);
     });
-    expect(Scheduler).toHaveYielded(['Outer: A0', 'Inner: A0', 'Commit Child']);
+    assertLog(['Outer: A0', 'Inner: A0', 'Commit Child']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: A0" />
@@ -3814,11 +3720,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       setText('B');
     });
-    expect(Scheduler).toHaveYielded([
-      'Outer: B0',
-      'Suspend! [Inner: B0]',
-      'Loading...',
-    ]);
+    assertLog(['Outer: B0', 'Suspend! [Inner: B0]', 'Loading...']);
     // Commit the placeholder
     await advanceTimers(250);
     expect(root).toMatchRenderedOutput(
@@ -3837,7 +3739,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       });
     });
 
-    expect(Scheduler).toHaveYielded(['Outer: B1', 'Inner: B1', 'Commit Child']);
+    assertLog(['Outer: B1', 'Inner: B1', 'Commit Child']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Outer: B1" />
@@ -3895,20 +3797,15 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<Root />);
     });
-    expect(Scheduler).toHaveYielded(['']);
+    assertLog(['']);
     expect(root).toMatchRenderedOutput(<span prop="" />);
 
     // Update to "a". That will suspend.
     await act(async () => {
       setTextWithShortTransition('a');
-      expect(Scheduler).toFlushAndYield([
-        'Pending...',
-        '',
-        'Suspend! [a]',
-        'Loading...',
-      ]);
+      await waitForAll(['Pending...', '', 'Suspend! [a]', 'Loading...']);
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Pending..." />
@@ -3919,7 +3816,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     // Update to "b". That will suspend, too.
     await act(async () => {
       setTextWithLongTransition('b');
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         // Neither is resolved yet.
         'Pending...',
         '',
@@ -3927,7 +3824,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         'Loading...',
       ]);
     });
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="Pending..." />
@@ -3939,7 +3836,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       await resolveText('a');
 
-      expect(Scheduler).toFlushAndYield(['Suspend! [b]', 'Loading...']);
+      await waitForAll(['Suspend! [b]', 'Loading...']);
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="Pending..." />
@@ -3951,7 +3848,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         await resolveText('b');
       });
-      expect(Scheduler).toHaveYielded(['b']);
+      assertLog(['b']);
       // The bug was that the pending state got stuck forever.
       expect(root).toMatchRenderedOutput(<span prop="b" />);
     });
@@ -3977,7 +3874,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </Suspense>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A']);
+    assertLog(['A']);
     expect(root).toMatchRenderedOutput(<span prop="A" />);
 
     await act(async () => {
@@ -3985,22 +3882,19 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       ReactNoop.idleUpdates(() => {
         setText('B');
       });
-      // Suspend the first update. The second update doesn't run because it has
-      // Idle priority.
-      expect(Scheduler).toFlushAndYield(['Suspend! [B]', 'Loading...']);
+      await waitForAll(['Suspend! [B]', 'Loading...']);
 
       // Commit the fallback. Now we'll try working on Idle.
       jest.runAllTimers();
 
-      // It also suspends.
-      expect(Scheduler).toFlushAndYield(['Suspend! [B]']);
+      await waitForAll(['Suspend! [B]']);
     });
 
     await act(async () => {
       setText('B');
       await resolveText('B');
     });
-    expect(Scheduler).toHaveYielded(['B']);
+    assertLog(['B']);
     expect(root).toMatchRenderedOutput(<span prop="B" />);
   });
 
@@ -4026,7 +3920,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
     });
-    expect(Scheduler).toHaveYielded(['A', 'Suspend! [Async]', 'Loading...']);
+    assertLog(['A', 'Suspend! [Async]', 'Loading...']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="A" />
@@ -4040,8 +3934,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       // Before the retry happens, schedule a new update.
       setText('B');
 
-      // The update should be allowed to finish before the retry is attempted.
-      expect(Scheduler).toFlushUntilNextPaint(['B']);
+      await waitForPaint(['B']);
       expect(root).toMatchRenderedOutput(
         <>
           <span prop="B" />
@@ -4049,8 +3942,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
     });
-    // Then do the retry.
-    expect(Scheduler).toHaveYielded(['Async']);
+    assertLog(['Async']);
     expect(root).toMatchRenderedOutput(
       <>
         <span prop="B" />
@@ -4087,13 +3979,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App show={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Mount Child']);
+    assertLog(['Mount Child']);
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
     await act(async () => {
       root.render(<App show={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [Async]', 'Loading...']);
+    assertLog(['Suspend! [Async]', 'Loading...']);
     expect(root).toMatchRenderedOutput(
       <>
         <span hidden={true} prop="Child" />
@@ -4104,7 +3996,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(null);
     });
-    expect(Scheduler).toHaveYielded(['Unmount Child']);
+    assertLog(['Unmount Child']);
   });
 
   // @gate enableLegacyCache
@@ -4135,13 +4027,13 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App show={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Mount Child']);
+    assertLog(['Mount Child']);
     expect(root).toMatchRenderedOutput(<span prop="Child" />);
 
     await act(async () => {
       root.render(<App show={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [Async]', 'Loading...']);
+    assertLog(['Suspend! [Async]', 'Loading...']);
     expect(root).toMatchRenderedOutput(
       <>
         <span hidden={true} prop="Child" />
@@ -4152,7 +4044,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(null);
     });
-    expect(Scheduler).toHaveYielded(['Unmount Child']);
+    assertLog(['Unmount Child']);
   });
 
   // @gate enableLegacyCache
@@ -4202,7 +4094,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<App showMore={false} />);
       });
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
       expect(root).toMatchRenderedOutput(<div />);
 
       // Update. This will cause two separate trees to suspend. The first tree
@@ -4221,7 +4113,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
       await act(async () => {
         root.render(<App showMore={true} />);
       });
-      expect(Scheduler).toHaveYielded(['Suspend! [Async]', 'Loading...', 'Hi']);
+      assertLog(['Suspend! [Async]', 'Loading...', 'Hi']);
       expect(root).toMatchRenderedOutput(
         <div>
           <span prop="Loading..." />


### PR DESCRIPTION
This converts some of our test suite to use the `waitFor` test pattern, instead of the `expect(Scheduler).toFlushAndYield` pattern. Most of these changes are automated with jscodeshift, with some slight manual cleanup in certain cases.

See #26285 for full context.