### PR TITLE
Extracted definition and access to public instances to a separate module in Fabric

### DIFF
--- a/packages/react-native-renderer/src/NativeMethodsMixinUtils.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixinUtils.js
@@ -45,26 +45,6 @@ export function mountSafeCallback_NOT_REALLY_SAFE(
   };
 }
 
-export function throwOnStylesProp(component: any, props: any) {
-  if (props.styles !== undefined) {
-    const owner = component._owner || null;
-    const name = component.constructor.displayName;
-    let msg =
-      '`styles` is not a supported property of `' +
-      name +
-      '`, did ' +
-      'you mean `style` (singular)?';
-    if (owner && owner.constructor && owner.constructor.displayName) {
-      msg +=
-        '\n\nCheck the `' +
-        owner.constructor.displayName +
-        '` parent ' +
-        ' component.';
-    }
-    throw new Error(msg);
-  }
-}
-
 export function warnForStyleProps(props: any, validAttributes: any) {
   if (__DEV__) {
     for (const key in validAttributes.style) {

--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -3,28 +3,53 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
  */
 
-function getInstanceFromInstance(instanceHandle) {
-  return instanceHandle;
-}
+import type {
+  PublicInstance,
+  Instance,
+  Props,
+  TextInstance,
+} from './ReactFabricHostConfig';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import {getPublicInstance} from './ReactFabricHostConfig';
 
-function getTagFromInstance(inst) {
-  const nativeInstance = inst.stateNode.canonical;
+// `node` is typed incorrectly here. The proper type should be `PublicInstance`.
+// This is ok in DOM because they types are interchangeable, but in React Native
+// they aren't.
+function getInstanceFromNode(node: Instance | TextInstance): Fiber | null {
+  const instance: Instance = (node: $FlowFixMe); // In React Native, node is never a text instance
 
-  if (!nativeInstance._nativeTag) {
-    throw new Error('All native instances should have a tag.');
+  if (
+    instance.internals != null &&
+    instance.internals.internalInstanceHandle != null
+  ) {
+    return instance.internals.internalInstanceHandle;
   }
 
-  return nativeInstance;
+  // $FlowFixMe[incompatible-return] DevTools incorrectly passes a fiber in React Native.
+  return node;
+}
+
+function getNodeFromInstance(fiber: Fiber): PublicInstance {
+  const publicInstance = getPublicInstance(fiber.stateNode);
+
+  if (publicInstance == null) {
+    throw new Error('Could not find host instance from fiber');
+  }
+
+  return publicInstance;
+}
+
+function getFiberCurrentPropsFromNode(instance: Instance): Props {
+  return instance && instance.internals && instance.internals.currentProps;
 }
 
 export {
-  getInstanceFromInstance as getClosestInstanceFromNode,
-  getInstanceFromInstance as getInstanceFromNode,
-  getTagFromInstance as getNodeFromInstance,
+  getInstanceFromNode,
+  getInstanceFromNode as getClosestInstanceFromNode,
+  getNodeFromInstance,
+  getFiberCurrentPropsFromNode,
 };
-
-export function getFiberCurrentPropsFromNode(inst) {
-  return inst.canonical.currentProps;
-}

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -25,6 +25,7 @@ import {
 import {batchedUpdates} from './legacy-events/ReactGenericBatching';
 import accumulateInto from './legacy-events/accumulateInto';
 
+import {getPublicInstance} from './ReactFabricHostConfig';
 import getListener from './ReactNativeGetListener';
 import {runEventsInBatch} from './legacy-events/EventBatching';
 
@@ -92,7 +93,8 @@ export function dispatchEvent(
     const stateNode = targetFiber.stateNode;
     // Guard against Fiber being unmounted
     if (stateNode != null) {
-      eventTarget = stateNode.canonical;
+      // $FlowExpectedError[incompatible-cast] public instances in Fabric do not implement `EventTarget` yet.
+      eventTarget = (getPublicInstance(stateNode): EventTarget);
     }
   }
 

--- a/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
+++ b/packages/react-native-renderer/src/ReactFabricGlobalResponderHandler.js
@@ -7,42 +7,24 @@
  * @flow
  */
 
-// Module provided by RN:
-import {UIManager} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
-
 const ReactFabricGlobalResponderHandler = {
   onChange: function (from: any, to: any, blockNativeResponder: boolean) {
-    const fromOrTo = from || to;
-    const fromOrToStateNode = fromOrTo && fromOrTo.stateNode;
-    const isFabric = !!(
-      fromOrToStateNode && fromOrToStateNode.canonical._internalInstanceHandle
-    );
+    if (from) {
+      // equivalent to clearJSResponder
+      nativeFabricUIManager.setIsJSResponder(
+        from.stateNode.node,
+        false,
+        blockNativeResponder || false,
+      );
+    }
 
-    if (isFabric) {
-      if (from) {
-        // equivalent to clearJSResponder
-        nativeFabricUIManager.setIsJSResponder(
-          from.stateNode.node,
-          false,
-          blockNativeResponder || false,
-        );
-      }
-
-      if (to) {
-        // equivalent to setJSResponder
-        nativeFabricUIManager.setIsJSResponder(
-          to.stateNode.node,
-          true,
-          blockNativeResponder || false,
-        );
-      }
-    } else {
-      if (to !== null) {
-        const tag = to.stateNode.canonical._nativeTag;
-        UIManager.setJSResponder(tag, blockNativeResponder);
-      } else {
-        UIManager.clearJSResponder();
-      }
+    if (to) {
+      // equivalent to setJSResponder
+      nativeFabricUIManager.setIsJSResponder(
+        to.stateNode.node,
+        true,
+        blockNativeResponder || false,
+      );
     }
   },
 };

--- a/packages/react-native-renderer/src/ReactFabricPublicInstance.js
+++ b/packages/react-native-renderer/src/ReactFabricPublicInstance.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type {ElementRef} from 'react';
+import type {
+  ViewConfig,
+  NativeMethods,
+  HostComponent,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from './ReactNativeTypes';
+
+import {TextInputState} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
+import {create} from './ReactNativeAttributePayload';
+
+import {warnForStyleProps} from './NativeMethodsMixinUtils';
+
+const {
+  measure: fabricMeasure,
+  measureInWindow: fabricMeasureInWindow,
+  measureLayout: fabricMeasureLayout,
+  setNativeProps,
+  getBoundingClientRect: fabricGetBoundingClientRect,
+} = nativeFabricUIManager;
+
+const noop = () => {};
+
+type ParamOf<Fn> = $Call<<T>((arg: T) => mixed) => T, Fn>;
+type ShadowNode = ParamOf<typeof fabricMeasure>;
+
+/**
+ * This is used for refs on host components.
+ */
+export class ReactFabricHostComponent implements NativeMethods {
+  // The native tag has to be accessible in `ReactFabricHostComponentUtils`.
+  __nativeTag: number;
+
+  _viewConfig: ViewConfig;
+  _internalInstanceHandle: mixed;
+
+  constructor(
+    tag: number,
+    viewConfig: ViewConfig,
+    internalInstanceHandle: mixed,
+  ) {
+    this.__nativeTag = tag;
+    this._viewConfig = viewConfig;
+    this._internalInstanceHandle = internalInstanceHandle;
+  }
+
+  blur() {
+    TextInputState.blurTextInput(this);
+  }
+
+  focus() {
+    TextInputState.focusTextInput(this);
+  }
+
+  measure(callback: MeasureOnSuccessCallback) {
+    const node = getShadowNodeFromInternalInstanceHandle(
+      this._internalInstanceHandle,
+    );
+    if (node != null) {
+      fabricMeasure(node, callback);
+    }
+  }
+
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback) {
+    const node = getShadowNodeFromInternalInstanceHandle(
+      this._internalInstanceHandle,
+    );
+    if (node != null) {
+      fabricMeasureInWindow(node, callback);
+    }
+  }
+
+  measureLayout(
+    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void /* currently unused */,
+  ) {
+    if (
+      typeof relativeToNativeNode === 'number' ||
+      !(relativeToNativeNode instanceof ReactFabricHostComponent)
+    ) {
+      if (__DEV__) {
+        console.error(
+          'Warning: ref.measureLayout must be called with a ref to a native component.',
+        );
+      }
+
+      return;
+    }
+
+    const toStateNode = getShadowNodeFromInternalInstanceHandle(
+      this._internalInstanceHandle,
+    );
+    const fromStateNode = getShadowNodeFromInternalInstanceHandle(
+      relativeToNativeNode._internalInstanceHandle,
+    );
+
+    if (toStateNode != null && fromStateNode != null) {
+      fabricMeasureLayout(
+        toStateNode,
+        fromStateNode,
+        onFail != null ? onFail : noop,
+        onSuccess != null ? onSuccess : noop,
+      );
+    }
+  }
+
+  unstable_getBoundingClientRect(): DOMRect {
+    const node = getShadowNodeFromInternalInstanceHandle(
+      this._internalInstanceHandle,
+    );
+    if (node != null) {
+      const rect = fabricGetBoundingClientRect(node);
+
+      if (rect) {
+        return new DOMRect(rect[0], rect[1], rect[2], rect[3]);
+      }
+    }
+
+    // Empty rect if any of the above failed
+    return new DOMRect(0, 0, 0, 0);
+  }
+
+  setNativeProps(nativeProps: {...}): void {
+    if (__DEV__) {
+      warnForStyleProps(nativeProps, this._viewConfig.validAttributes);
+    }
+    const updatePayload = create(nativeProps, this._viewConfig.validAttributes);
+
+    const node = getShadowNodeFromInternalInstanceHandle(
+      this._internalInstanceHandle,
+    );
+    if (node != null && updatePayload != null) {
+      setNativeProps(node, updatePayload);
+    }
+  }
+}
+
+function getShadowNodeFromInternalInstanceHandle(
+  internalInstanceHandle: mixed,
+): ?ShadowNode {
+  // $FlowExpectedError[incompatible-use] internalInstanceHandle is opaque but we need to make an exception here.
+  return internalInstanceHandle?.stateNode?.node;
+}
+
+export function createPublicInstance(
+  tag: number,
+  viewConfig: ViewConfig,
+  internalInstanceHandle: mixed,
+): ReactFabricHostComponent {
+  return new ReactFabricHostComponent(tag, viewConfig, internalInstanceHandle);
+}

--- a/packages/react-native-renderer/src/ReactFabricPublicInstanceUtils.js
+++ b/packages/react-native-renderer/src/ReactFabricPublicInstanceUtils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type {ReactFabricHostComponent} from './ReactFabricPublicInstance';
+
+/**
+ * IMPORTANT: This module is used in Paper and Fabric. It needs to be defined
+ * outside of `ReactFabricPublicInstance` because that module requires
+ * `nativeFabricUIManager` to be defined in the global scope (which does not
+ * happen in Paper).
+ */
+
+export function getNativeTagFromPublicInstance(
+  publicInstance: ReactFabricHostComponent,
+): number {
+  return publicInstance.__nativeTag;
+}

--- a/packages/react-native-renderer/src/ReactNativeComponentTree.js
+++ b/packages/react-native-renderer/src/ReactNativeComponentTree.js
@@ -24,9 +24,10 @@ function getInstanceFromTag(tag) {
 function getTagFromInstance(inst) {
   let nativeInstance = inst.stateNode;
   let tag = nativeInstance._nativeTag;
-  if (tag === undefined) {
-    nativeInstance = nativeInstance.canonical;
-    tag = nativeInstance._nativeTag;
+  if (tag === undefined && nativeInstance.internals) {
+    // For compatibility with Fabric
+    tag = nativeInstance.internals.nativeTag;
+    nativeInstance = nativeInstance.publicInstance;
   }
 
   if (!tag) {

--- a/packages/react-native-renderer/src/ReactNativeFiberInspector.js
+++ b/packages/react-native-renderer/src/ReactNativeFiberInspector.js
@@ -214,11 +214,12 @@ if (__DEV__) {
           }
 
           closestInstance =
-            internalInstanceHandle.stateNode.canonical._internalInstanceHandle;
+            internalInstanceHandle.stateNode.fabricInternals
+              .internalInstanceHandle;
 
           // Note: this is deprecated and we want to remove it ASAP. Keeping it here for React DevTools compatibility for now.
           const nativeViewTag =
-            internalInstanceHandle.stateNode.canonical._nativeTag;
+            internalInstanceHandle.stateNode.fabricInternals.nativeTag;
 
           nativeFabricUIManager.measure(
             internalInstanceHandle.stateNode.node,

--- a/packages/react-native-renderer/src/ReactNativeHostConfig.js
+++ b/packages/react-native-renderer/src/ReactNativeHostConfig.js
@@ -218,8 +218,8 @@ export function getChildHostContext(
 
 export function getPublicInstance(instance: Instance): * {
   // $FlowExpectedError[prop-missing] For compatibility with Fabric
-  if (instance.canonical) {
-    return instance.canonical;
+  if (instance.publicInstance != null) {
+    return instance.publicInstance;
   }
 
   return instance;

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -218,18 +218,6 @@ export type ReactFabricType = {
   ...
 };
 
-export type ReactNativeEventTarget = {
-  node: {...},
-  canonical: {
-    _nativeTag: number,
-    viewConfig: ViewConfig,
-    currentProps: {...},
-    _internalInstanceHandle: {...},
-    ...
-  },
-  ...
-};
-
 export type ReactFabricEventTouch = {
   identifier: number,
   locationX: number,


### PR DESCRIPTION
## Summary

The current definition of `Instance` in Fabric has 2 fields:
- `node`: reference to the native node in the shadow tree.
- `canonical`: public instance provided to users via refs.

We're currently using `canonical` not only as the public instance, but also to store internal properties that Fabric needs to access in different parts of the codebase. Those properties are, in fact, available through refs as well, which breaks encapsulation.

This PR splits that into 2 separate fields, leaving the definition of instance as:
- `node`: reference to the native node in the shadow tree.
- `publicInstance`: public instance provided to users via refs.
- `internals`: collection of properties that are required by Fabric itself, given references to the instance.

This also migrates all the current usages of `canonical` to use the right property depending on the use case.

To improve encapsulation (and in preparation for the implementation of this [proposal to bring some DOM APIs to public instances in React Native](https://github.com/react-native-community/discussions-and-proposals/pull/607)), this also moves the creation of and the access to the public instance to a separate module. In a following diff, that module will be moved into the `react-native` repository and we'll access it through `ReactNativePrivateInterface`.

## How did you test this change?

Existing unit tests.

**NOTE**: This includes the changes in https://github.com/facebook/react/pull/26290. I'll rebase this onto main when that is merged.
