### PR TITLE
[Flight] Send server reference error chunks to the client

### DIFF
--- a/fixtures/flight/src/Button.js
+++ b/fixtures/flight/src/Button.js
@@ -3,11 +3,21 @@
 import * as React from 'react';
 
 export default function Button({action, children}) {
+  const [isPending, setIsPending] = React.useState(false);
+
   return (
     <button
+      disabled={isPending}
       onClick={async () => {
-        const result = await action();
-        console.log(result);
+        setIsPending(true);
+        try {
+          const result = await action();
+          console.log(result);
+        } catch (error) {
+          console.error(error);
+        } finally {
+          setIsPending(false);
+        }
       }}>
       {children}
     </button>

--- a/fixtures/flight/src/actions.js
+++ b/fixtures/flight/src/actions.js
@@ -1,6 +1,13 @@
 'use server';
 
 export async function like() {
-  console.log('Like');
-  return 'Liked';
+  return new Promise((resolve, reject) =>
+    setTimeout(
+      () =>
+        Math.random() > 0.5
+          ? resolve('Liked')
+          : reject(new Error('Failed to like')),
+      500
+    )
+  );
 }

--- a/packages/react-server/src/ReactFlightServer.js
+++ b/packages/react-server/src/ReactFlightServer.js
@@ -293,6 +293,8 @@ function serializeThenable(request: Request, thenable: Thenable<any>): number {
       } else {
         emitErrorChunkProd(request, newTask.id, digest);
       }
+      newTask.status = ERRORED;
+      pingTask(request, newTask);
     },
   );
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/facebook/react) and create your branch from `main`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Run `yarn test --prod` to test in the production environment. It supports the same options as `yarn test`.
  6. If you need a debugger, run `yarn test --debug --watch TestName`, open `chrome://inspect`, and press "Inspect".
  7. Format your code with [prettier](https://github.com/prettier/prettier) (`yarn prettier`).
  8. Make sure your code lints (`yarn lint`). Tip: `yarn linc` to only check changed files.
  9. Run the [Flow](https://flowtype.org/) type checks (`yarn flow`).
  10. If you haven't already, complete the CLA.

  Learn more about contributing: https://reactjs.org/docs/how-to-contribute.html
-->

## Summary

Previously when a called server reference function was rejected, the emitted error chunk was not flushed, and the request was not properly closed.

## How did you test this change?

I ran `yarn test`, and clicked the like button in the flight fixture.