### PR TITLE
Add back accidentally deleted test comments

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactBatching-test.internal.js
@@ -166,9 +166,11 @@ describe('ReactBlockingMode', () => {
       assertLog(['A1', 'B1']);
       expect(root).toMatchRenderedOutput('A1B1');
     } else {
+      // Only the second update should have flushed synchronously
       assertLog(['B1']);
       expect(root).toMatchRenderedOutput('A0B1');
 
+      // Now flush the first update
       await waitForAll(['A1']);
       expect(root).toMatchRenderedOutput('A1B1');
     }

--- a/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactCPUSuspense-test.js
@@ -143,6 +143,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
     });
+    // Inner contents finish in separate commit from outer
     assertLog(['Inner']);
     expect(root).toMatchRenderedOutput(
       <>
@@ -178,6 +179,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App />);
     });
+    // Inner contents finish in separate commit from outer
     assertLog(['Outer', 'Loading...', 'Inner [0]']);
     expect(root).toMatchRenderedOutput(
       <>
@@ -190,6 +192,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       setCount(1);
     });
+    // Entire update finishes in a single commit
     assertLog(['Outer', 'Inner [1]']);
     expect(root).toMatchRenderedOutput(
       <>
@@ -227,6 +230,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
         </>,
       );
     });
+    // Inner contents suspended, so we continue showing a fallback.
     assertLog(['Suspend! [Inner]']);
     expect(root).toMatchRenderedOutput(
       <>
@@ -276,6 +280,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App />);
     });
+    // Each level commits separately
     assertLog(['A', 'Loading B...', 'B', 'Loading C...', 'C']);
     expect(root).toMatchRenderedOutput(
       <>

--- a/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactContextPropagation-test.js
@@ -339,6 +339,11 @@ describe('ReactLazyContextPropagation', () => {
       setOtherValue(1);
       setOtherValue(0);
     });
+    // NOTE: If this didn't yield anything, that indicates that we never visited
+    // the consumer during the render phase, which probably means the eager
+    // bailout mechanism kicked in. Because we're testing the _lazy_ bailout
+    // mechanism, update this test to foil the _eager_ bailout, somehow. Perhaps
+    // by switching to useReducer.
     assertLog(['Consumer']);
     expect(root).toMatchRenderedOutput('0');
   });

--- a/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactDeferredValue-test.js
@@ -78,6 +78,7 @@ describe('ReactDeferredValue', () => {
       root.render(<App value={2} />);
 
       await waitForPaint(['Original: 2']);
+      // The deferred value updates in a separate render
       await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
@@ -92,6 +93,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
+      // The deferred value updates in the same render as the original
       await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
@@ -137,6 +139,7 @@ describe('ReactDeferredValue', () => {
       root.render(<App value={2} />);
 
       await waitForPaint(['Original: 2']);
+      // The deferred value updates in a separate render
       await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
@@ -151,6 +154,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
+      // The deferred value updates in the same render as the original
       await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
@@ -201,6 +205,7 @@ describe('ReactDeferredValue', () => {
       root.render(<App value={2} />);
 
       await waitForPaint(['Original: 2']);
+      // The deferred value updates in a separate render
       await waitForPaint(['Deferred: 2']);
     });
     expect(root).toMatchRenderedOutput(
@@ -215,6 +220,7 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={3} />);
       });
+      // The deferred value updates in the same render as the original
       await waitForPaint(['Original: 3', 'Deferred: 3']);
     });
     expect(root).toMatchRenderedOutput(
@@ -270,6 +276,9 @@ describe('ReactDeferredValue', () => {
       startTransition(() => {
         root.render(<App value={2} />);
       });
+      // In the regression, the memoized value was not updated during non-urgent
+      // updates, so this would flip the deferred value back to the initial
+      // value (1) instead of reusing the current one (2).
       await waitForPaint(['Original: 2', 'Deferred: 2']);
       expect(root).toMatchRenderedOutput(
         <div>

--- a/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFlushSync-test.js
@@ -52,6 +52,7 @@ describe('ReactFlushSync', () => {
       React.startTransition(() => {
         root.render(<App />);
       });
+      // This will yield right before the passive effect fires
       await waitForPaint(['0, 0']);
 
       // The passive effect will schedule a sync update and a normal update.
@@ -67,6 +68,7 @@ describe('ReactFlushSync', () => {
       if (gate(flags => flags.enableUnifiedSyncLane)) {
         await waitForPaint([]);
       } else {
+        // Now flush it.
         await waitForPaint(['1, 1']);
       }
     });
@@ -112,9 +114,11 @@ describe('ReactFlushSync', () => {
           });
         });
       });
+      // Only the sync update should have flushed
       assertLog(['1, 0']);
       expect(root).toMatchRenderedOutput('1, 0');
     });
+    // Now the async update has flushed, too.
     assertLog(['1, 1']);
     expect(root).toMatchRenderedOutput('1, 1');
   });
@@ -162,6 +166,7 @@ describe('ReactFlushSync', () => {
       ]);
       expect(root).toMatchRenderedOutput('Child');
     });
+    // Effect flushes after paint.
     assertLog(['Effect']);
   });
 
@@ -217,6 +222,7 @@ describe('ReactFlushSync', () => {
       ]);
       expect(root).toMatchRenderedOutput('Child');
     });
+    // Effect flushes after paint.
     assertLog(['Effect']);
   });
 
@@ -236,8 +242,10 @@ describe('ReactFlushSync', () => {
 
       // Passive effects are pending. Calling flushSync should not affect them.
       ReactNoop.flushSync();
+      // Effects still haven't fired.
       assertLog([]);
     });
+    // Now the effects have fired.
     assertLog(['Effect']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -944,6 +944,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={false} />);
+    // The key warning gets deduped because it's in the same component.
     await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful']);
@@ -955,6 +956,7 @@ describe('ReactFragment', () => {
     );
 
     ReactNoop.render(<Foo condition={true} />);
+    // The key warning gets deduped because it's in the same component.
     await waitForAll([]);
 
     expect(ops).toEqual(['Update Stateful', 'Update Stateful']);


### PR DESCRIPTION
The codemod I used in #26288 accidentally caused some comments to be deleted. Because not all affected lines included comments, I didn't notice until after landing.

This adds the comments back.