### PR TITLE
Codemod tests to waitFor pattern (2/?)

### DIFF
--- a/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
@@ -18,6 +18,8 @@ let Scheduler;
 let Suspense;
 let TextResource;
 let textResourceShouldFail;
+let waitForAll;
+let assertLog;
 
 describe('ReactCache', () => {
   beforeEach(() => {
@@ -32,6 +34,10 @@ describe('ReactCache', () => {
     createResource = ReactCache.unstable_createResource;
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
 
     TextResource = createResource(
       ([text, ms = 0]) => {
@@ -105,7 +111,7 @@ describe('ReactCache', () => {
     }
   }
 
-  it('throws a promise if the requested value is not in the cache', () => {
+  it('throws a promise if the requested value is not in the cache', async () => {
     function App() {
       return (
         <Suspense fallback={<Text text="Loading..." />}>
@@ -118,11 +124,11 @@ describe('ReactCache', () => {
       unstable_isConcurrent: true,
     });
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [Hi]', 'Loading...']);
+    await waitForAll(['Suspend! [Hi]', 'Loading...']);
 
     jest.advanceTimersByTime(100);
-    expect(Scheduler).toHaveYielded(['Promise resolved [Hi]']);
-    expect(Scheduler).toFlushAndYield(['Hi']);
+    assertLog(['Promise resolved [Hi]']);
+    await waitForAll(['Hi']);
   });
 
   it('throws an error on the subsequent read if the promise is rejected', async () => {
@@ -138,22 +144,22 @@ describe('ReactCache', () => {
       unstable_isConcurrent: true,
     });
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [Hi]', 'Loading...']);
+    await waitForAll(['Suspend! [Hi]', 'Loading...']);
 
     textResourceShouldFail = true;
     jest.advanceTimersByTime(100);
-    expect(Scheduler).toHaveYielded(['Promise rejected [Hi]']);
+    assertLog(['Promise rejected [Hi]']);
 
     expect(Scheduler).toFlushAndThrow('Failed to load: Hi');
-    expect(Scheduler).toHaveYielded(['Error! [Hi]', 'Error! [Hi]']);
+    assertLog(['Error! [Hi]', 'Error! [Hi]']);
 
     // Should throw again on a subsequent read
     root.update(<App />);
     expect(Scheduler).toFlushAndThrow('Failed to load: Hi');
-    expect(Scheduler).toHaveYielded(['Error! [Hi]', 'Error! [Hi]']);
+    assertLog(['Error! [Hi]', 'Error! [Hi]']);
   });
 
-  it('warns if non-primitive key is passed to a resource without a hash function', () => {
+  it('warns if non-primitive key is passed to a resource without a hash function', async () => {
     const BadTextResource = createResource(([text, ms = 0]) => {
       return new Promise((resolve, reject) =>
         setTimeout(() => {
@@ -177,8 +183,8 @@ describe('ReactCache', () => {
     );
 
     if (__DEV__) {
-      expect(() => {
-        expect(Scheduler).toFlushAndYield(['App', 'Loading...']);
+      expect(async () => {
+        await waitForAll(['App', 'Loading...']);
       }).toErrorDev([
         'Invalid key type. Expected a string, number, symbol, or ' +
           'boolean, but instead received: Hi,100\n\n' +
@@ -186,7 +192,7 @@ describe('ReactCache', () => {
           'function as the second argument to createResource().',
       ]);
     } else {
-      expect(Scheduler).toFlushAndYield(['App', 'Loading...']);
+      await waitForAll(['App', 'Loading...']);
     }
   });
 
@@ -204,19 +210,19 @@ describe('ReactCache', () => {
         unstable_isConcurrent: true,
       },
     );
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [1]',
       'Suspend! [2]',
       'Suspend! [3]',
       'Loading...',
     ]);
     jest.advanceTimersByTime(100);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Promise resolved [1]',
       'Promise resolved [2]',
       'Promise resolved [3]',
     ]);
-    expect(Scheduler).toFlushAndYield([1, 2, 3]);
+    await waitForAll([1, 2, 3]);
     expect(root).toMatchRenderedOutput('123');
 
     // Render 1, 4, 5
@@ -228,18 +234,10 @@ describe('ReactCache', () => {
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
-      1,
-      'Suspend! [4]',
-      'Suspend! [5]',
-      'Loading...',
-    ]);
+    await waitForAll([1, 'Suspend! [4]', 'Suspend! [5]', 'Loading...']);
     jest.advanceTimersByTime(100);
-    expect(Scheduler).toHaveYielded([
-      'Promise resolved [4]',
-      'Promise resolved [5]',
-    ]);
-    expect(Scheduler).toFlushAndYield([1, 4, 5]);
+    assertLog(['Promise resolved [4]', 'Promise resolved [5]']);
+    await waitForAll([1, 4, 5]);
     expect(root).toMatchRenderedOutput('145');
 
     // We've now rendered values 1, 2, 3, 4, 5, over our limit of 3. The least
@@ -253,7 +251,7 @@ describe('ReactCache', () => {
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       // 1 is still cached
       1,
       // 2 and 3 suspend because they were evicted from the cache
@@ -262,11 +260,8 @@ describe('ReactCache', () => {
       'Loading...',
     ]);
     jest.advanceTimersByTime(100);
-    expect(Scheduler).toHaveYielded([
-      'Promise resolved [2]',
-      'Promise resolved [3]',
-    ]);
-    expect(Scheduler).toFlushAndYield([1, 2, 3]);
+    assertLog(['Promise resolved [2]', 'Promise resolved [3]']);
+    await waitForAll([1, 2, 3]);
     expect(root).toMatchRenderedOutput('123');
   });
 
@@ -287,18 +282,15 @@ describe('ReactCache', () => {
       },
     );
 
-    expect(Scheduler).toFlushAndYield(['Loading...']);
+    await waitForAll(['Loading...']);
 
     jest.advanceTimersByTime(1000);
-    expect(Scheduler).toHaveYielded([
-      'Promise resolved [B]',
-      'Promise resolved [A]',
-    ]);
-    expect(Scheduler).toFlushAndYield(['Result']);
+    assertLog(['Promise resolved [B]', 'Promise resolved [A]']);
+    await waitForAll(['Result']);
     expect(root).toMatchRenderedOutput('Result');
   });
 
-  it('if a thenable resolves multiple times, does not update the first cached value', () => {
+  it('if a thenable resolves multiple times, does not update the first cached value', async () => {
     let resolveThenable;
     const BadTextResource = createResource(
       ([text, ms = 0]) => {
@@ -349,7 +341,7 @@ describe('ReactCache', () => {
       },
     );
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [Hi]', 'Loading...']);
+    await waitForAll(['Suspend! [Hi]', 'Loading...']);
 
     resolveThenable('Hi');
     // This thenable improperly resolves twice. We should not update the
@@ -365,8 +357,8 @@ describe('ReactCache', () => {
       },
     );
 
-    expect(Scheduler).toHaveYielded([]);
-    expect(Scheduler).toFlushAndYield(['Hi']);
+    assertLog([]);
+    await waitForAll(['Hi']);
     expect(root).toMatchRenderedOutput('Hi');
   });
 

--- a/packages/react-client/src/__tests__/ReactFlight-test.js
+++ b/packages/react-client/src/__tests__/ReactFlight-test.js
@@ -20,6 +20,7 @@ let ReactNoopFlightClient;
 let ErrorBoundary;
 let NoErrorExpected;
 let Scheduler;
+let assertLog;
 
 describe('ReactFlight', () => {
   beforeEach(() => {
@@ -33,6 +34,8 @@ describe('ReactFlight', () => {
     ReactNoopFlightClient = require('react-noop-renderer/flight-client');
     act = require('jest-react').act;
     Scheduler = require('scheduler');
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
 
     ErrorBoundary = class extends React.Component {
       state = {hasError: false, error: null};
@@ -808,13 +811,13 @@ describe('ReactFlight', () => {
       const ClientDoublerModuleRef = clientReference(ClientDoubler);
 
       const transport = ReactNoopFlightServer.render(<App />);
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
 
       await act(async () => {
         ReactNoop.render(await ReactNoopFlightClient.read(transport));
       });
 
-      expect(Scheduler).toHaveYielded(['ClientDoubler']);
+      assertLog(['ClientDoubler']);
       expect(ReactNoop).toMatchRenderedOutput(
         <>
           <div prop=":S1:">:S1:</div>
@@ -997,7 +1000,7 @@ describe('ReactFlight', () => {
 
       const transport = ReactNoopFlightServer.render(<Foo />);
 
-      expect(Scheduler).toHaveYielded(['suspended']);
+      assertLog(['suspended']);
 
       await act(async () => {
         resolve();
@@ -1005,7 +1008,7 @@ describe('ReactFlight', () => {
         jest.runAllImmediates();
       });
 
-      expect(Scheduler).toHaveYielded(['rendered']);
+      assertLog(['rendered']);
 
       await act(async () => {
         ServerContext._currentRenderer = null;
@@ -1045,7 +1048,7 @@ describe('ReactFlight', () => {
 
       const transport = ReactNoopFlightServer.render(model);
 
-      expect(Scheduler).toHaveYielded([]);
+      assertLog([]);
 
       await act(async () => {
         ServerContext._currentRenderer = null;
@@ -1054,7 +1057,7 @@ describe('ReactFlight', () => {
         ReactNoop.render(flightModel.foo);
       });
 
-      expect(Scheduler).toHaveYielded(['ClientBar']);
+      assertLog(['ClientBar']);
       expect(ReactNoop).toMatchRenderedOutput(<span>hi this is server</span>);
 
       expect(() => {

--- a/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
+++ b/packages/react-debug-tools/src/__tests__/ReactDevToolsHooksIntegration-test.js
@@ -19,6 +19,7 @@ describe('React hooks DevTools integration', () => {
   let overrideHookState;
   let scheduleUpdate;
   let setSuspenseHandler;
+  let waitForAll;
 
   global.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -40,6 +41,9 @@ describe('React hooks DevTools integration', () => {
     ReactDebugTools = require('react-debug-tools');
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
 
     act = ReactTestRenderer.act;
   });
@@ -256,7 +260,7 @@ describe('React hooks DevTools integration', () => {
       ),
     );
 
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     // Ensure we timeout any suspense time.
     jest.advanceTimersByTime(1000);
     const fiber = renderer.root._currentFiber().child;

--- a/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFiberAsync-test.js
@@ -15,6 +15,7 @@ let ReactDOM;
 let ReactDOMClient;
 let Scheduler;
 let act;
+let waitForAll;
 
 const setUntrackedInputValue = Object.getOwnPropertyDescriptor(
   HTMLInputElement.prototype,
@@ -32,6 +33,9 @@ describe('ReactDOMFiberAsync', () => {
     ReactDOMClient = require('react-dom/client');
     act = require('jest-react').act;
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
 
     document.body.appendChild(container);
   });
@@ -592,7 +596,7 @@ describe('ReactDOMFiberAsync', () => {
     expect(containerC.textContent).toEqual('Finished');
   });
 
-  it('updates flush without yielding in the next event', () => {
+  it('updates flush without yielding in the next event', async () => {
     const root = ReactDOMClient.createRoot(container);
 
     function Text(props) {
@@ -612,7 +616,7 @@ describe('ReactDOMFiberAsync', () => {
     expect(container.textContent).toEqual('');
 
     // Everything should render immediately in the next event
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
     expect(container.textContent).toEqual('ABC');
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFizzSuppressHydrationWarning-test.js
@@ -22,6 +22,7 @@ let container;
 let buffer = '';
 let hasErrored = false;
 let fatalError = undefined;
+let waitForAll;
 
 describe('ReactDOMFizzServerHydrationWarning', () => {
   beforeEach(() => {
@@ -32,6 +33,9 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
     ReactDOMClient = require('react-dom/client');
     ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
 
     // Test Environment
     const jsdom = new JSDOM(
@@ -155,7 +159,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     // The text mismatch should be *silently* fixed. Even in production.
     expect(getVisibleChildren(container)).toEqual(
       <div>
@@ -195,7 +199,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>
@@ -236,8 +240,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);
@@ -283,7 +287,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span>{'Client'}</span>
@@ -319,8 +323,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);
@@ -367,8 +371,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);
@@ -418,8 +422,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);
@@ -467,8 +471,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
@@ -521,7 +525,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <span class="server" style="opacity:0" data-serveronly="server-only" />
@@ -558,7 +562,7 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(getVisibleChildren(container)).toEqual(
       <div>
         <p>Server HTML</p>
@@ -591,8 +595,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);
@@ -637,8 +641,8 @@ describe('ReactDOMFizzServerHydrationWarning', () => {
         Scheduler.unstable_yieldValue(error.message);
       },
     });
-    expect(() => {
-      expect(Scheduler).toFlushAndYield([
+    await expect(async () => {
+      await waitForAll([
         'Hydration failed because the initial UI does not match what was rendered on the server.',
         'There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering.',
       ]);

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -33,6 +33,8 @@ let buffer = '';
 let hasErrored = false;
 let fatalError = undefined;
 let renderOptions;
+let waitForAll;
+let assertLog;
 
 function resetJSDOM(markup) {
   // Test Environment
@@ -62,6 +64,10 @@ describe('ReactDOMFloat', () => {
     ReactDOMFizzServer = require('react-dom/server');
     Stream = require('stream');
     Suspense = React.Suspense;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
 
     textCache = new Map();
 
@@ -259,10 +265,14 @@ describe('ReactDOMFloat', () => {
     root.render(children);
     return expect(() => {
       try {
-        expect(Scheduler).toFlushWithoutYielding();
+        // TODO: Migrate this to waitForAll()
+        Scheduler.unstable_flushAll();
+        assertLog([]);
       } catch (e) {
         try {
-          expect(Scheduler).toFlushWithoutYielding();
+          // TODO: Migrate this to waitForAll()
+          Scheduler.unstable_flushAll();
+          assertLog([]);
         } catch (f) {}
       }
     });
@@ -283,11 +293,11 @@ describe('ReactDOMFloat', () => {
       </>,
     );
     try {
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
     } catch (e) {
       // for DOMExceptions that happen when expecting this test to fail we need
       // to clear the scheduler first otherwise the expected failure will fail
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       throw e;
     }
     expect(getMeaningfulChildren(document)).toEqual(
@@ -351,7 +361,7 @@ describe('ReactDOMFloat', () => {
         <body>foo</body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -476,7 +486,7 @@ describe('ReactDOMFloat', () => {
         <script async={true} src="foo" />
       </>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -494,7 +504,7 @@ describe('ReactDOMFloat', () => {
         <script data-new="new" async={true} src="foo" />
       </>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     // we don't see the attribute because the resource is the same and was not reconstructed
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
@@ -671,7 +681,7 @@ describe('ReactDOMFloat', () => {
         </body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -968,7 +978,7 @@ body {
         </body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
@@ -1107,7 +1117,7 @@ body {
         errors.push(err.digest);
       },
     });
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -1157,7 +1167,7 @@ body {
         <body>Hello</body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -1634,7 +1644,7 @@ body {
         </body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -1656,7 +1666,7 @@ body {
         </body>
       </html>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -1701,7 +1711,7 @@ body {
         <Throw />
       </ErrorBoundary>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(getMeaningfulChildren(document)).toEqual(
       <html>
         <head>
@@ -2334,8 +2344,8 @@ body {
       );
 
       const root = ReactDOMClient.hydrateRoot(document, <App url="foo" />);
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev([
         'ReactDOM.prefetchDNS(): Expected only one argument, `href`, but encountered something with type "object" as a second argument instead. This argument is reserved for future options and is currently disallowed. Try calling ReactDOM.prefetchDNS() with just a single string argument, `href`.',
         'ReactDOM.prefetchDNS(): Expected only one argument, `href`, but encountered something with type "object" as a second argument instead. This argument is reserved for future options and is currently disallowed. It looks like the you are attempting to set a crossOrigin property for this DNS lookup hint. Browsers do not perform DNS queries using CORS and setting this attribute on the resource hint has no effect. Try calling ReactDOM.prefetchDNS() with just a single string argument, `href`.',
@@ -2350,8 +2360,8 @@ body {
       );
 
       root.render(<App url="bar" />);
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev([
         'ReactDOM.prefetchDNS(): Expected only one argument, `href`, but encountered something with type "object" as a second argument instead. This argument is reserved for future options and is currently disallowed. Try calling ReactDOM.prefetchDNS() with just a single string argument, `href`.',
         'ReactDOM.prefetchDNS(): Expected only one argument, `href`, but encountered something with type "object" as a second argument instead. This argument is reserved for future options and is currently disallowed. It looks like the you are attempting to set a crossOrigin property for this DNS lookup hint. Browsers do not perform DNS queries using CORS and setting this attribute on the resource hint has no effect. Try calling ReactDOM.prefetchDNS() with just a single string argument, `href`.',
@@ -2404,8 +2414,8 @@ body {
       );
 
       const root = ReactDOMClient.hydrateRoot(document, <App url="foo" />);
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev(
         'ReactDOM.preconnect(): Expected the `crossOrigin` option (second argument) to be a string but encountered something with type "boolean" instead. Try removing this option or passing a string value instead.',
       );
@@ -2421,8 +2431,8 @@ body {
       );
 
       root.render(<App url="bar" />);
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev(
         'ReactDOM.preconnect(): Expected the `crossOrigin` option (second argument) to be a string but encountered something with type "boolean" instead. Try removing this option or passing a string value instead.',
       );
@@ -2509,7 +2519,7 @@ body {
         );
       }
       ReactDOMClient.hydrateRoot(document, <ClientApp />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -2731,7 +2741,7 @@ body {
       }
 
       ReactDOMClient.hydrateRoot(document, <ClientApp />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -2761,7 +2771,7 @@ body {
 
       const root = ReactDOMClient.createRoot(document);
       root.render(<App />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -2836,7 +2846,7 @@ body {
       }
 
       ReactDOMClient.hydrateRoot(document, <ClientApp />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -2865,7 +2875,7 @@ body {
 
       const root = ReactDOMClient.createRoot(document);
       root.render(<App />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3057,7 +3067,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
@@ -3095,7 +3105,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
@@ -3178,7 +3188,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3213,7 +3223,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       root.render(
         <html>
@@ -3221,7 +3231,7 @@ body {
           <body>hello world</body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3263,8 +3273,8 @@ body {
           },
         },
       );
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev(
         [
           'Warning: Text content did not match. Server: "server" Client: "client"',
@@ -3315,8 +3325,8 @@ body {
           },
         },
       );
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev(
         [
           'Warning: Text content did not match. Server: "server" Client: "client"',
@@ -3349,7 +3359,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3371,7 +3381,7 @@ body {
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       // The reason we do not see preloads in the head is they are inserted synchronously
       // during render and then when the new singleton mounts it resets it's content, retaining only styles
       expect(getMeaningfulChildren(document)).toEqual(
@@ -3408,7 +3418,7 @@ body {
           container
         </>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3468,7 +3478,7 @@ body {
           container
         </>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3539,7 +3549,7 @@ body {
         );
       }
       root.render(<ClientApp />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3602,7 +3612,7 @@ body {
       container = document.getElementById('container');
       const root = ReactDOMClient.createRoot(container);
       root.render(<App />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -3678,7 +3688,7 @@ body {
           </svg>
         </div>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.body)).toEqual(
         <div>
           <svg>
@@ -3724,7 +3734,7 @@ body {
           </noscript>
         </div>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.body)).toEqual(
         <div>
           {/* On the client, <noscript> never renders children */}
@@ -3799,8 +3809,8 @@ body {
           </body>
         </html>,
       );
-      expect(() => {
-        expect(Scheduler).toFlushWithoutYielding();
+      await expect(async () => {
+        await waitForAll([]);
       }).toErrorDev([
         'React encountered a <link rel="stylesheet" href="foo" ... /> with a `precedence` prop that also included the `onLoad` and `onError` props. The presence of loading and error handlers indicates an intent to manage the stylesheet loading state from your from your Component code and React will not hoist or deduplicate this stylesheet. If your intent was to have React hoist and deduplciate this stylesheet using the `precedence` prop remove the `onLoad` and `onError` props, otherwise remove the `precedence` prop.',
       ]);
@@ -4070,7 +4080,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
@@ -4101,7 +4111,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -4244,7 +4254,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       // The async script with onLoad is inserted in the right place but does not cause the hydration
       // to fail.
       expect(getMeaningfulChildren(document)).toEqual(
@@ -4311,7 +4321,7 @@ background-color: green;
           </svg>
         </div>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.body)).toEqual(
         <div>
           <svg>
@@ -4357,7 +4367,7 @@ background-color: green;
           </noscript>
         </div>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.body)).toEqual(
         <div>
           {/* On the client, <noscript> never renders children */}
@@ -4459,7 +4469,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -4474,7 +4484,7 @@ background-color: green;
           <body />
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head />
@@ -4493,7 +4503,7 @@ background-color: green;
           </div>,
         );
       });
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document.head)).toEqual(
         <meta name="foo" data-foo="data" content="bar" />,
@@ -4501,7 +4511,7 @@ background-color: green;
       expect(getMeaningfulChildren(container)).toEqual(<div />);
 
       root.render(<div />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
@@ -4535,7 +4545,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -4550,7 +4560,7 @@ background-color: green;
           <body />
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head />
@@ -4569,7 +4579,7 @@ background-color: green;
           </div>,
         );
       });
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document.head)).toEqual(
         <link rel="foo" data-foo="data" href="foo" />,
@@ -4577,7 +4587,7 @@ background-color: green;
       expect(getMeaningfulChildren(container)).toEqual(<div />);
 
       root.render(<div />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
@@ -4611,7 +4621,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -4626,7 +4636,7 @@ background-color: green;
           <body />
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head />
@@ -4645,7 +4655,7 @@ background-color: green;
           </div>,
         );
       });
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
 
       expect(getMeaningfulChildren(document.head)).toEqual(
         <title data-foo="foo">a title</title>,
@@ -4653,7 +4663,7 @@ background-color: green;
       expect(getMeaningfulChildren(container)).toEqual(<div />);
 
       root.render(<div />);
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document.head)).toEqual(undefined);
     });
 
@@ -4782,7 +4792,7 @@ background-color: green;
           <meta name="after" />
         </>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>
@@ -4802,7 +4812,7 @@ background-color: green;
           {null}
         </>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head />
@@ -4908,8 +4918,8 @@ background-color: green;
         },
       );
       try {
-        expect(() => {
-          expect(Scheduler).toFlushWithoutYielding();
+        await expect(async () => {
+          await waitForAll([]);
         }).toErrorDev(
           [
             'Warning: Text content did not match. Server: "server" Client: "client"',
@@ -4920,7 +4930,7 @@ background-color: green;
       } catch (e) {
         // When gates are false this test fails on a DOMException if you don't clear the scheduler after catching.
         // When gates are true this branch should not be hit
-        expect(Scheduler).toFlushWithoutYielding();
+        await waitForAll([]);
         throw e;
       }
       expect(getMeaningfulChildren(document)).toEqual(

--- a/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
+++ b/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
@@ -13,6 +13,7 @@ let React;
 let ReactNoop;
 let Scheduler;
 let JSXDEVRuntime;
+let waitForAll;
 
 describe('ReactDeprecationWarnings', () => {
   beforeEach(() => {
@@ -20,6 +21,8 @@ describe('ReactDeprecationWarnings', () => {
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
     if (__DEV__) {
       JSXDEVRuntime = require('react/jsx-dev-runtime');
     }
@@ -86,7 +89,7 @@ describe('ReactDeprecationWarnings', () => {
     );
   });
 
-  it('should warn when owner and self are the same for string refs', () => {
+  it('should warn when owner and self are the same for string refs', async () => {
     class RefComponent extends React.Component {
       render() {
         return null;
@@ -102,7 +105,7 @@ describe('ReactDeprecationWarnings', () => {
     }).toErrorDev([
       'Component "Component" contains the string ref "refComponent". Support for string refs will be removed in a future major release.',
     ]);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
   });
 
   it('should warn when owner and self are different for string refs', () => {

--- a/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfilerDevToolsIntegration-test.internal.js
@@ -17,6 +17,8 @@ describe('ReactProfiler DevTools integration', () => {
   let Scheduler;
   let AdvanceTime;
   let hook;
+  let waitForAll;
+  let waitFor;
 
   beforeEach(() => {
     global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook = {
@@ -33,6 +35,10 @@ describe('ReactProfiler DevTools integration', () => {
     Scheduler = require('scheduler');
     React = require('react');
     ReactTestRenderer = require('react-test-renderer');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    waitFor = InternalTestUtils.waitFor;
 
     AdvanceTime = class extends React.Component {
       static defaultProps = {
@@ -138,7 +144,7 @@ describe('ReactProfiler DevTools integration', () => {
     ).toBe(7);
   });
 
-  it('regression test: #17159', () => {
+  it('regression test: #17159', async () => {
     function Text({text}) {
       Scheduler.unstable_yieldValue(text);
       return text;
@@ -148,7 +154,7 @@ describe('ReactProfiler DevTools integration', () => {
 
     // Commit something
     root.update(<Text text="A" />);
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
     expect(root).toMatchRenderedOutput('A');
 
     // Advance time by many seconds, larger than the default expiration time
@@ -160,9 +166,9 @@ describe('ReactProfiler DevTools integration', () => {
     });
 
     // Update B should not instantly expire.
-    expect(Scheduler).toFlushAndYieldThrough([]);
+    await waitFor([]);
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
     expect(root).toMatchRenderedOutput('B');
   });
 });

--- a/packages/react/src/__tests__/forwardRef-test.internal.js
+++ b/packages/react/src/__tests__/forwardRef-test.internal.js
@@ -14,6 +14,7 @@ describe('forwardRef', () => {
   let ReactFeatureFlags;
   let ReactNoop;
   let Scheduler;
+  let waitForAll;
 
   beforeEach(() => {
     jest.resetModules();
@@ -23,9 +24,12 @@ describe('forwardRef', () => {
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
-  it('should work without a ref to be forwarded', () => {
+  it('should work without a ref to be forwarded', async () => {
     class Child extends React.Component {
       render() {
         Scheduler.unstable_yieldValue(this.props.value);
@@ -42,10 +46,10 @@ describe('forwardRef', () => {
     ));
 
     ReactNoop.render(<RefForwardingComponent value={123} />);
-    expect(Scheduler).toFlushAndYield([123]);
+    await waitForAll([123]);
   });
 
-  it('should forward a ref for a single child', () => {
+  it('should forward a ref for a single child', async () => {
     class Child extends React.Component {
       render() {
         Scheduler.unstable_yieldValue(this.props.value);
@@ -64,11 +68,11 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} value={123} />);
-    expect(Scheduler).toFlushAndYield([123]);
+    await waitForAll([123]);
     expect(ref.current instanceof Child).toBe(true);
   });
 
-  it('should forward a ref for multiple children', () => {
+  it('should forward a ref for multiple children', async () => {
     class Child extends React.Component {
       render() {
         Scheduler.unstable_yieldValue(this.props.value);
@@ -93,11 +97,11 @@ describe('forwardRef', () => {
         <div />
       </div>,
     );
-    expect(Scheduler).toFlushAndYield([123]);
+    await waitForAll([123]);
     expect(ref.current instanceof Child).toBe(true);
   });
 
-  it('should maintain child instance and ref through updates', () => {
+  it('should maintain child instance and ref through updates', async () => {
     class Child extends React.Component {
       constructor(props) {
         super(props);
@@ -125,16 +129,16 @@ describe('forwardRef', () => {
     };
 
     ReactNoop.render(<RefForwardingComponent ref={setRef} value={123} />);
-    expect(Scheduler).toFlushAndYield([123]);
+    await waitForAll([123]);
     expect(ref instanceof Child).toBe(true);
     expect(setRefCount).toBe(1);
     ReactNoop.render(<RefForwardingComponent ref={setRef} value={456} />);
-    expect(Scheduler).toFlushAndYield([456]);
+    await waitForAll([456]);
     expect(ref instanceof Child).toBe(true);
     expect(setRefCount).toBe(1);
   });
 
-  it('should not break lifecycle error handling', () => {
+  it('should not break lifecycle error handling', async () => {
     class ErrorBoundary extends React.Component {
       state = {error: null};
       componentDidCatch(error) {
@@ -175,7 +179,7 @@ describe('forwardRef', () => {
         <RefForwardingComponent ref={ref} />
       </ErrorBoundary>,
     );
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'ErrorBoundary.render: try',
       'Wrapper',
       'BadRender throw',
@@ -192,7 +196,7 @@ describe('forwardRef', () => {
     expect(ref.current).toBe(null);
   });
 
-  it('should not re-run the render callback on a deep setState', () => {
+  it('should not re-run the render callback on a deep setState', async () => {
     let inst;
 
     class Inner extends React.Component {
@@ -219,9 +223,9 @@ describe('forwardRef', () => {
     }
 
     ReactNoop.render(<App />);
-    expect(Scheduler).toFlushAndYield(['App', 'Forward', 'Middle', 'Inner']);
+    await waitForAll(['App', 'Forward', 'Middle', 'Inner']);
 
     inst.setState({});
-    expect(Scheduler).toFlushAndYield(['Inner']);
+    await waitForAll(['Inner']);
   });
 });

--- a/packages/react/src/__tests__/forwardRef-test.js
+++ b/packages/react/src/__tests__/forwardRef-test.js
@@ -13,17 +13,19 @@ describe('forwardRef', () => {
   let PropTypes;
   let React;
   let ReactNoop;
-  let Scheduler;
+  let waitForAll;
 
   beforeEach(() => {
     jest.resetModules();
     PropTypes = require('prop-types');
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
-  it('should update refs when switching between children', () => {
+  it('should update refs when switching between children', async () => {
     function FunctionComponent({forwardedRef, setRefOnDiv}) {
       return (
         <section>
@@ -40,25 +42,25 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} setRefOnDiv={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} setRefOnDiv={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current.type).toBe('span');
   });
 
-  it('should support rendering null', () => {
+  it('should support rendering null', async () => {
     const RefForwardingComponent = React.forwardRef((props, ref) => null);
 
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current).toBe(null);
   });
 
-  it('should support rendering null for multiple children', () => {
+  it('should support rendering null for multiple children', async () => {
     const RefForwardingComponent = React.forwardRef((props, ref) => null);
 
     const ref = React.createRef();
@@ -70,11 +72,11 @@ describe('forwardRef', () => {
         <div />
       </div>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current).toBe(null);
   });
 
-  it('should support propTypes and defaultProps', () => {
+  it('should support propTypes and defaultProps', async () => {
     function FunctionComponent({forwardedRef, optional, required}) {
       return (
         <div ref={forwardedRef}>
@@ -103,14 +105,14 @@ describe('forwardRef', () => {
     ReactNoop.render(
       <RefForwardingComponent ref={ref} optional="foo" required="bar" />,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current.children).toEqual([
       {text: 'foo', hidden: false},
       {text: 'bar', hidden: false},
     ]);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} required="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ref.current.children).toEqual([
       {text: 'default', hidden: false},
       {text: 'foo', hidden: false},
@@ -344,7 +346,7 @@ describe('forwardRef', () => {
     );
   });
 
-  it('should not bailout if forwardRef is not wrapped in memo', () => {
+  it('should not bailout if forwardRef is not wrapped in memo', async () => {
     const Component = props => <div {...props} />;
 
     let renderCount = 0;
@@ -357,15 +359,15 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(1);
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(2);
   });
 
-  it('should bailout if forwardRef is wrapped in memo', () => {
+  it('should bailout if forwardRef is wrapped in memo', async () => {
     const Component = props => <div ref={props.forwardedRef} />;
 
     let renderCount = 0;
@@ -380,13 +382,13 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(1);
 
     const differentRef = React.createRef();
@@ -394,18 +396,18 @@ describe('forwardRef', () => {
     ReactNoop.render(
       <RefForwardingComponent ref={differentRef} optional="foo" />,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(2);
 
     expect(ref.current).toBe(null);
     expect(differentRef.current.type).toBe('div');
 
     ReactNoop.render(<RefForwardingComponent ref={ref} optional="bar" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(3);
   });
 
-  it('should custom memo comparisons to compose', () => {
+  it('should custom memo comparisons to compose', async () => {
     const Component = props => <div ref={props.forwardedRef} />;
 
     let renderCount = 0;
@@ -421,19 +423,19 @@ describe('forwardRef', () => {
     const ref = React.createRef();
 
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="0" c="1" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(1);
 
     expect(ref.current.type).toBe('div');
 
     // Changing either a or b rerenders
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="1" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(2);
 
     // Changing c doesn't rerender
     ReactNoop.render(<RefForwardingComponent ref={ref} a="0" b="1" c="2" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(2);
 
     const ComposedMemo = React.memo(
@@ -442,29 +444,29 @@ describe('forwardRef', () => {
     );
 
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="0" c="0" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(3);
 
     // Changing just b no longer updates
     ReactNoop.render(<ComposedMemo ref={ref} a="0" b="1" c="0" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(3);
 
     // Changing just a and c updates
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="2" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(4);
 
     // Changing just c does not update
     ReactNoop.render(<ComposedMemo ref={ref} a="2" b="2" c="3" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(4);
 
     // Changing ref still rerenders
     const differentRef = React.createRef();
 
     ReactNoop.render(<ComposedMemo ref={differentRef} a="2" b="2" c="3" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(renderCount).toBe(5);
 
     expect(ref.current).toBe(null);

--- a/scripts/jest/config.build-devtools.js
+++ b/scripts/jest/config.build-devtools.js
@@ -17,6 +17,12 @@ const packages = readdirSync(packagesRoot).filter(dir => {
   if (dir.includes('react-devtools')) {
     return false;
   }
+  if (dir === 'internal-test-utils') {
+    // This is an internal package used only for testing. It's OK to read
+    // from source.
+    // TODO: Maybe let's have some convention for this?
+    return false;
+  }
   const packagePath = join(packagesRoot, dir, 'package.json');
   let stat;
   try {


### PR DESCRIPTION
This converts some of our test suite to use the `waitFor` test pattern, instead of the `expect(Scheduler).toFlushAndYield` pattern. Most of these changes are automated with jscodeshift, with some slight manual cleanup in certain cases.

See #26285 for full context.