### PR TITLE
Convert ReactLazy-test to waitFor pattern

### DIFF
--- a/packages/internal-test-utils/enqueueTask.js
+++ b/packages/internal-test-utils/enqueueTask.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+let didWarnAboutMessageChannel = false;
+let enqueueTaskImpl = null;
+
+// Same as shared/enqeuueTask, but while that one used by the public
+// implementation of `act`, this is only used by our internal testing helpers.
+export default function enqueueTask(task: () => void): void {
+  if (enqueueTaskImpl === null) {
+    try {
+      // read require off the module object to get around the bundlers.
+      // we don't want them to detect a require and bundle a Node polyfill.
+      const requireString = ('require' + Math.random()).slice(0, 7);
+      const nodeRequire = module && module[requireString];
+      // assuming we're in node, let's try to get node's
+      // version of setImmediate, bypassing fake timers if any.
+      enqueueTaskImpl = nodeRequire.call(module, 'timers').setImmediate;
+    } catch (_err) {
+      // we're in a browser
+      // we can't use regular timers because they may still be faked
+      // so we try MessageChannel+postMessage instead
+      enqueueTaskImpl = function (callback: () => void) {
+        if (__DEV__) {
+          if (didWarnAboutMessageChannel === false) {
+            didWarnAboutMessageChannel = true;
+            if (typeof MessageChannel === 'undefined') {
+              console['error'](
+                'This browser does not have a MessageChannel implementation, ' +
+                  'so enqueuing tasks via await act(async () => ...) will fail. ' +
+                  'Please file an issue at https://github.com/facebook/react/issues ' +
+                  'if you encounter this warning.',
+              );
+            }
+          }
+        }
+        const channel = new MessageChannel();
+        channel.port1.onmessage = callback;
+        channel.port2.postMessage(undefined);
+      };
+    }
+  }
+  return enqueueTaskImpl(task);
+}

--- a/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
@@ -183,7 +183,7 @@ describe('ReactCache', () => {
     );
 
     if (__DEV__) {
-      expect(async () => {
+      await expect(async () => {
         await waitForAll(['App', 'Loading...']);
       }).toErrorDev([
         'Invalid key type. Expected a string, number, symbol, or ' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalScheduling-test.js
@@ -93,7 +93,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span prop={5} />);
   });
 
-  it('works on deferred roots in the order they were scheduled', () => {
+  it('works on deferred roots in the order they were scheduled', async () => {
     const {useEffect} = React;
     function Text({text}) {
       useEffect(() => {
@@ -114,7 +114,7 @@ describe('ReactIncrementalScheduling', () => {
     expect(ReactNoop.getChildrenAsJSX('c')).toEqual('c:1');
 
     // Schedule deferred work in the reverse order
-    act(async () => {
+    await act(async () => {
       React.startTransition(() => {
         ReactNoop.renderToRootWithID(<Text text="c:2" />, 'c');
         ReactNoop.renderToRootWithID(<Text text="b:2" />, 'b');

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -518,7 +518,7 @@ describe('ReactIncrementalUpdates', () => {
     expect(ReactNoop).toMatchRenderedOutput(<span prop="derived state" />);
   });
 
-  it('regression: does not expire soon due to layout effects in the last batch', () => {
+  it('regression: does not expire soon due to layout effects in the last batch', async () => {
     const {useState, useLayoutEffect} = React;
 
     let setCount;
@@ -533,7 +533,7 @@ describe('ReactIncrementalUpdates', () => {
       return null;
     }
 
-    act(async () => {
+    await act(async () => {
       React.startTransition(() => {
         ReactNoop.render(<App />);
       });


### PR DESCRIPTION
I'm in the process of codemodding our test suite to the waitFor pattern. See #26285 for full context.

This module required a lot of manual changes so I'm doing it as its own PR. The reason is that most of the tests involved simulating an async import by wrapping them in `Promise.resolve()`, which means they would immediately resolve the next time the microtask queue was flushed. I rewrote the tests to resolve the simulated import explicitly.

While converting these tests, I also realized that the `waitFor` helpers weren't properly waiting for the entire microtask queue to recursively finish — if a microtask schedules another microtask, the subsequent one wouldn't fire until after `waitFor` had resolved. To fix this, I used the same strategy as `act` — wait for a real task to finish before proceeding, such as a message event.