### PR TITLE
Codemod tests to waitFor pattern (6/?)

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -18,6 +18,8 @@ let ReactNoop;
 let Suspense;
 let Scheduler;
 let act;
+let waitForAll;
+let assertLog;
 
 describe('memo', () => {
   beforeEach(() => {
@@ -29,6 +31,10 @@ describe('memo', () => {
     Scheduler = require('scheduler');
     act = require('jest-react').act;
     ({Suspense} = React);
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
   });
 
   function Text(props) {
@@ -105,9 +111,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Loading...']);
-        await Promise.resolve();
-        expect(Scheduler).toFlushAndYield([0]);
+        await waitForAll(['Loading...', 0]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
         // Should bail out because props have not changed
@@ -116,7 +120,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield([]);
+        await waitForAll([]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
         // Should update because count prop changed
@@ -125,7 +129,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield([1]);
+        await waitForAll([1]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
       });
 
@@ -160,19 +164,17 @@ describe('memo', () => {
 
         const parent = React.createRef(null);
         ReactNoop.render(<Parent ref={parent} />);
-        expect(Scheduler).toFlushAndYield(['Loading...']);
-        await Promise.resolve();
-        expect(Scheduler).toFlushAndYield(['Count: 0']);
+        await waitForAll(['Loading...', 'Count: 0']);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
         // Should bail out because props have not changed
         ReactNoop.render(<Parent ref={parent} />);
-        expect(Scheduler).toFlushAndYield([]);
+        await waitForAll([]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 0" />);
 
         // Should update because there was a context change
         parent.current.setState({count: 1});
-        expect(Scheduler).toFlushAndYield(['Count: 1']);
+        await waitForAll(['Count: 1']);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="Count: 1" />);
       });
 
@@ -273,7 +275,7 @@ describe('memo', () => {
         await act(async () => {
           root.render(<App prop="A" />);
         });
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'SimpleMemo [A0]',
           'ComplexMemo [A0]',
           'MemoWithIndirection [A0]',
@@ -283,7 +285,7 @@ describe('memo', () => {
         await act(async () => {
           root.render(<App prop="B" />);
         });
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'SimpleMemo [B0]',
           'ComplexMemo [B0]',
           'MemoWithIndirection [B0]',
@@ -298,7 +300,7 @@ describe('memo', () => {
           root.render(<App prop="B" />);
         });
         // Nothing re-renders
-        expect(Scheduler).toHaveYielded([]);
+        assertLog([]);
 
         // Demonstrate what happens when the prop object changes, it bails out
         // because all the props are the same, but we still render the
@@ -309,7 +311,7 @@ describe('memo', () => {
         });
         // The components should re-render with the new local state, but none
         // of the props objects should have changed
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'SimpleMemo [B1]',
           'ComplexMemo [B1]',
           'MemoWithIndirection [B1]',
@@ -322,7 +324,7 @@ describe('memo', () => {
         });
         // The components should re-render with the new local state, but none
         // of the props objects should have changed
-        expect(Scheduler).toHaveYielded([
+        assertLog([
           'SimpleMemo [B2]',
           'ComplexMemo [B2]',
           'MemoWithIndirection [B2]',
@@ -345,9 +347,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Loading...']);
-        await Promise.resolve();
-        expect(Scheduler).toFlushAndYield([0]);
+        await waitForAll(['Loading...', 0]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
         // Should bail out because props have not changed
@@ -356,7 +356,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Old count: 0, New count: 0']);
+        await waitForAll(['Old count: 0, New count: 0']);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={0} />);
 
         // Should update because count prop changed
@@ -365,7 +365,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Old count: 0, New count: 1', 1]);
+        await waitForAll(['Old count: 0, New count: 1', 1]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={1} />);
       });
 
@@ -383,9 +383,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Loading...']);
-        await Promise.resolve();
-        expect(Scheduler).toFlushAndYield(['0!']);
+        await waitForAll(['Loading...', '0!']);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="0!" />);
 
         // Should bail out because props have not changed
@@ -394,7 +392,7 @@ describe('memo', () => {
             <Counter count={0} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield([]);
+        await waitForAll([]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="0!" />);
 
         // Should update because count prop changed
@@ -403,7 +401,7 @@ describe('memo', () => {
             <Counter count={1} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['1!']);
+        await waitForAll(['1!']);
         expect(ReactNoop).toMatchRenderedOutput(<span prop="1!" />);
       });
 
@@ -436,10 +434,8 @@ describe('memo', () => {
             <Counter e={5} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield(['Loading...']);
-        await Promise.resolve();
-        expect(() => {
-          expect(Scheduler).toFlushAndYield([15]);
+        await expect(async () => {
+          await waitForAll(['Loading...', 15]);
         }).toErrorDev([
           'Counter: Support for defaultProps will be removed from memo components in a future major release. Use JavaScript default parameters instead.',
         ]);
@@ -451,7 +447,7 @@ describe('memo', () => {
             <Counter e={5} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield([]);
+        await waitForAll([]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={15} />);
 
         // Should update because count prop changed
@@ -460,7 +456,7 @@ describe('memo', () => {
             <Counter e={10} />
           </Suspense>,
         );
-        expect(Scheduler).toFlushAndYield([20]);
+        await waitForAll([20]);
         expect(ReactNoop).toMatchRenderedOutput(<span prop={20} />);
       });
 
@@ -480,7 +476,7 @@ describe('memo', () => {
         );
       });
 
-      it('validates propTypes declared on the inner component', () => {
+      it('validates propTypes declared on the inner component', async () => {
         function FnInner(props) {
           return props.inner;
         }
@@ -488,23 +484,23 @@ describe('memo', () => {
         const Fn = React.memo(FnInner);
 
         // Mount
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(<Fn inner="2" />);
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev(
           'Invalid prop `inner` of type `string` supplied to `FnInner`, expected `number`.',
         );
 
         // Update
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(<Fn inner={false} />);
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev(
           'Invalid prop `inner` of type `boolean` supplied to `FnInner`, expected `number`.',
         );
       });
 
-      it('validates propTypes declared on the outer component', () => {
+      it('validates propTypes declared on the outer component', async () => {
         function FnInner(props) {
           return props.outer;
         }
@@ -512,25 +508,25 @@ describe('memo', () => {
         Fn.propTypes = {outer: PropTypes.number.isRequired};
 
         // Mount
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(<Fn outer="3" />);
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `string` supplied to `FnInner`, expected `number`.',
         );
 
         // Update
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(<Fn outer={false} />);
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev(
           // Outer props are checked in createElement
           'Invalid prop `outer` of type `boolean` supplied to `FnInner`, expected `number`.',
         );
       });
 
-      it('validates nested propTypes declarations', () => {
+      it('validates nested propTypes declarations', async () => {
         function Inner(props) {
           return props.inner + props.middle + props.outer;
         }
@@ -549,20 +545,20 @@ describe('memo', () => {
             <Outer />
           </div>,
         );
-        expect(() => {
-          expect(Scheduler).toFlushWithoutYielding();
+        await expect(async () => {
+          await waitForAll([]);
         }).toErrorDev([
           'Inner: Support for defaultProps will be removed from memo components in a future major release. Use JavaScript default parameters instead.',
         ]);
 
         // Mount
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(
             <div>
               <Outer inner="2" middle="3" outer="4" />
             </div>,
           );
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev([
           'Invalid prop `outer` of type `string` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `string` supplied to `Inner`, expected `number`.',
@@ -570,13 +566,13 @@ describe('memo', () => {
         ]);
 
         // Update
-        expect(() => {
+        await expect(async () => {
           ReactNoop.render(
             <div>
               <Outer inner={false} middle={false} outer={false} />
             </div>,
           );
-          expect(Scheduler).toFlushWithoutYielding();
+          await waitForAll([]);
         }).toErrorDev([
           'Invalid prop `outer` of type `boolean` supplied to `Inner`, expected `number`.',
           'Invalid prop `middle` of type `boolean` supplied to `Inner`, expected `number`.',

--- a/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactNoopRendererAct-test.js
@@ -13,6 +13,7 @@ const React = require('react');
 const ReactNoop = require('react-noop-renderer');
 const Scheduler = require('scheduler');
 const act = require('jest-react').act;
+const {assertLog, waitForAll} = require('internal-test-utils');
 
 // TODO: These tests are no longer specific to the noop renderer
 // implementation. They test the internal implementation we use in the React
@@ -34,7 +35,7 @@ describe('internal act()', () => {
         />,
       );
     });
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(calledLog).toEqual([0]);
   });
 
@@ -56,8 +57,8 @@ describe('internal act()', () => {
     await act(async () => {
       ReactNoop.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['stage 1', 'stage 2']);
-    expect(Scheduler).toFlushWithoutYielding();
+    assertLog(['stage 1', 'stage 2']);
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('1');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactPersistent-test.js
@@ -12,7 +12,7 @@
 
 let React;
 let ReactNoopPersistent;
-let Scheduler;
+let waitForAll;
 
 describe('ReactPersistent', () => {
   beforeEach(() => {
@@ -20,7 +20,8 @@ describe('ReactPersistent', () => {
 
     React = require('react');
     ReactNoopPersistent = require('react-noop-renderer/persistent');
-    Scheduler = require('scheduler');
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   // Inlined from shared folder so we can run this test on a bundle.
@@ -57,7 +58,7 @@ describe('ReactPersistent', () => {
     return ReactNoopPersistent.dangerouslyGetChildren();
   }
 
-  it('can update child nodes of a host instance', () => {
+  it('can update child nodes of a host instance', async () => {
     function Bar(props) {
       return <span>{props.text}</span>;
     }
@@ -72,19 +73,19 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const originalChildren = dangerouslyGetChildren();
     expect(originalChildren).toEqual([div(span())]);
 
     render(<Foo text="World" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const newChildren = dangerouslyGetChildren();
     expect(newChildren).toEqual([div(span(), span())]);
 
     expect(originalChildren).toEqual([div(span())]);
   });
 
-  it('can reuse child nodes between updates', () => {
+  it('can reuse child nodes between updates', async () => {
     function Baz(props) {
       return <span prop={props.text} />;
     }
@@ -106,12 +107,12 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const originalChildren = dangerouslyGetChildren();
     expect(originalChildren).toEqual([div(span('Hello'))]);
 
     render(<Foo text="World" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const newChildren = dangerouslyGetChildren();
     expect(newChildren).toEqual([div(span('Hello'), span('World'))]);
 
@@ -121,7 +122,7 @@ describe('ReactPersistent', () => {
     expect(newChildren[0].children[0]).toBe(originalChildren[0].children[0]);
   });
 
-  it('can update child text nodes', () => {
+  it('can update child text nodes', async () => {
     function Foo(props) {
       return (
         <div>
@@ -132,19 +133,19 @@ describe('ReactPersistent', () => {
     }
 
     render(<Foo text="Hello" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const originalChildren = dangerouslyGetChildren();
     expect(originalChildren).toEqual([div('Hello', span())]);
 
     render(<Foo text="World" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     const newChildren = dangerouslyGetChildren();
     expect(newChildren).toEqual([div('World', span())]);
 
     expect(originalChildren).toEqual([div('Hello', span())]);
   });
 
-  it('supports portals', () => {
+  it('supports portals', async () => {
     function Parent(props) {
       return <div>{props.children}</div>;
     }
@@ -173,7 +174,7 @@ describe('ReactPersistent', () => {
     const portalContainer = {rootID: 'persistent-portal-test', children: []};
     const emptyPortalChildSet = portalContainer.children;
     render(<Parent>{createPortal(<Child />, portalContainer, null)}</Parent>);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     expect(emptyPortalChildSet).toEqual([]);
 
@@ -187,7 +188,7 @@ describe('ReactPersistent', () => {
         {createPortal(<Child>Hello {'World'}</Child>, portalContainer, null)}
       </Parent>,
     );
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const newChildren = dangerouslyGetChildren();
     expect(newChildren).toEqual([div()]);
@@ -204,7 +205,7 @@ describe('ReactPersistent', () => {
 
     // Deleting the Portal, should clear its children
     render(<Parent />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const clearedPortalChildren = portalContainer.children;
     expect(clearedPortalChildren).toEqual([]);

--- a/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSubtreeFlagsWarning-test.js
@@ -8,6 +8,7 @@ let getCacheForType;
 
 let caches;
 let seededCache;
+let assertLog;
 
 describe('ReactSuspenseWithNoopRenderer', () => {
   beforeEach(() => {
@@ -21,6 +22,9 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     useEffect = React.useEffect;
 
     getCacheForType = React.unstable_getCacheForType;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
 
     caches = [];
     seededCache = null;
@@ -160,7 +164,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       root.render(<App />);
     });
-    expect(Scheduler).toHaveYielded(['Suspend! [Async]']);
+    assertLog(['Suspend! [Async]']);
     expect(root).toMatchRenderedOutput('Loading...');
 
     // When the promise resolves, a passive static effect flag is added. In the
@@ -169,7 +173,7 @@ describe('ReactSuspenseWithNoopRenderer', () => {
     await act(async () => {
       resolveText('Async');
     });
-    expect(Scheduler).toHaveYielded(['Async', 'Effect']);
+    assertLog(['Async', 'Effect']);
     expect(root).toMatchRenderedOutput('Async');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseCallback-test.js
@@ -12,6 +12,7 @@
 let React;
 let ReactNoop;
 let Scheduler;
+let waitForAll;
 
 describe('ReactSuspense', () => {
   beforeEach(() => {
@@ -20,6 +21,9 @@ describe('ReactSuspense', () => {
     React = require('react');
     ReactNoop = require('react-noop-renderer');
     Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   function createThenable() {
@@ -83,13 +87,13 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Waiting');
     expect(ops).toEqual([new Set([promise])]);
     ops = [];
 
     await resolve();
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Done');
     expect(ops).toEqual([]);
   });
@@ -122,27 +126,27 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Waiting Tier 1');
     expect(ops).toEqual([new Set([promise1, promise2])]);
     ops = [];
 
     await resolve1();
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Waiting Tier 1');
     expect(ops).toEqual([new Set([promise2])]);
     ops = [];
 
     await resolve2();
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('DoneDone');
     expect(ops).toEqual([]);
   });
 
   // @gate www
-  it('nested suspense promises are reported only for their tier', () => {
+  it('nested suspense promises are reported only for their tier', async () => {
     const {promise, PromiseComp} = createThenable();
 
     const ops1 = [];
@@ -167,7 +171,7 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Waiting Tier 2');
     expect(ops1).toEqual([]);
     expect(ops2).toEqual([new Set([promise])]);
@@ -209,7 +213,7 @@ describe('ReactSuspense', () => {
     );
 
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('Waiting Tier 1');
     expect(ops1).toEqual([new Set([promise1])]);
     expect(ops2).toEqual([]);
@@ -218,7 +222,7 @@ describe('ReactSuspense', () => {
 
     await resolve1();
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     // Force fallback to commit.
     // TODO: Should be able to use `act` here.
@@ -232,7 +236,7 @@ describe('ReactSuspense', () => {
 
     await resolve2();
     ReactNoop.render(element);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('DoneDone');
     expect(ops1).toEqual([]);
     expect(ops2).toEqual([]);


### PR DESCRIPTION
This converts some of our test suite to use the `waitFor` test pattern, instead of the `expect(Scheduler).toFlushAndYield` pattern. Most of these changes are automated with jscodeshift, with some slight manual cleanup in certain cases.

See #26285 for full context.