### PR TITLE
Codemod tests to waitFor pattern (7/?)

### DIFF
--- a/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseEffectsSemanticsDOM-test.js
@@ -15,6 +15,8 @@ let ReactDOMClient;
 let Scheduler;
 let act;
 let container;
+let waitForAll;
+let assertLog;
 
 describe('ReactSuspenseEffectsSemanticsDOM', () => {
   beforeEach(() => {
@@ -25,6 +27,10 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     ReactDOMClient = require('react-dom/client');
     Scheduler = require('scheduler');
     act = require('jest-react').act;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -139,23 +145,23 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     act(() => {
       root.render(<Parent swap={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...']);
+    assertLog(['Loading...']);
 
     await LazyChildA;
-    expect(Scheduler).toFlushAndYield(['A', 'Ref mount: A']);
+    await waitForAll(['A', 'Ref mount: A']);
     expect(container.innerHTML).toBe('<span>A</span>');
 
     // Swap the position of A and B
     ReactDOM.flushSync(() => {
       root.render(<Parent swap={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...', 'Ref unmount: A']);
+    assertLog(['Loading...', 'Ref unmount: A']);
     expect(container.innerHTML).toBe(
       '<span style="display: none;">A</span>Loading...',
     );
 
     await LazyChildB;
-    expect(Scheduler).toFlushAndYield(['B', 'Ref mount: B']);
+    await waitForAll(['B', 'Ref mount: B']);
     expect(container.innerHTML).toBe('<span>B</span>');
   });
 
@@ -199,21 +205,21 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     act(() => {
       root.render(<Parent swap={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...']);
+    assertLog(['Loading...']);
 
     await LazyChildA;
-    expect(Scheduler).toFlushAndYield(['A', 'Did mount: A']);
+    await waitForAll(['A', 'Did mount: A']);
     expect(container.innerHTML).toBe('A');
 
     // Swap the position of A and B
     ReactDOM.flushSync(() => {
       root.render(<Parent swap={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...', 'Will unmount: A']);
+    assertLog(['Loading...', 'Will unmount: A']);
     expect(container.innerHTML).toBe('Loading...');
 
     await LazyChildB;
-    expect(Scheduler).toFlushAndYield(['B', 'Did mount: B']);
+    await waitForAll(['B', 'Did mount: B']);
     expect(container.innerHTML).toBe('B');
   });
 
@@ -251,24 +257,24 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     act(() => {
       root.render(<Parent swap={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...']);
+    assertLog(['Loading...']);
 
     await LazyChildA;
-    expect(Scheduler).toFlushAndYield(['A', 'Did mount: A']);
+    await waitForAll(['A', 'Did mount: A']);
     expect(container.innerHTML).toBe('A');
 
     // Swap the position of A and B
     ReactDOM.flushSync(() => {
       root.render(<Parent swap={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...', 'Will unmount: A']);
+    assertLog(['Loading...', 'Will unmount: A']);
     expect(container.innerHTML).toBe('Loading...');
 
     // Destroy the whole tree, including the hidden A
     ReactDOM.flushSync(() => {
       root.render(<h1>Hello</h1>);
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(container.innerHTML).toBe('<h1>Hello</h1>');
   });
 
@@ -318,17 +324,17 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     act(() => {
       root.render(<Parent swap={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...']);
+    assertLog(['Loading...']);
 
     await LazyChildA;
-    expect(Scheduler).toFlushAndYield(['A', 'Ref mount: A']);
+    await waitForAll(['A', 'Ref mount: A']);
     expect(container.innerHTML).toBe('<span>A</span>');
 
     // Swap the position of A and B
     ReactDOM.flushSync(() => {
       root.render(<Parent swap={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...', 'Ref unmount: A']);
+    assertLog(['Loading...', 'Ref unmount: A']);
     expect(container.innerHTML).toBe(
       '<span style="display: none;">A</span>Loading...',
     );
@@ -337,7 +343,7 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     ReactDOM.flushSync(() => {
       root.render(<h1>Hello</h1>);
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(container.innerHTML).toBe('<h1>Hello</h1>');
   });
 
@@ -381,24 +387,24 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
     act(() => {
       root.render(<Parent swap={false} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...']);
+    assertLog(['Loading...']);
 
     await LazyChildA;
-    expect(Scheduler).toFlushAndYield(['A', 'Did mount: A']);
+    await waitForAll(['A', 'Did mount: A']);
     expect(container.innerHTML).toBe('A');
 
     // Swap the position of A and B
     ReactDOM.flushSync(() => {
       root.render(<Parent swap={true} />);
     });
-    expect(Scheduler).toHaveYielded(['Loading...', 'Will unmount: A']);
+    assertLog(['Loading...', 'Will unmount: A']);
     expect(container.innerHTML).toBe('Loading...');
 
     // Destroy the whole tree, including the hidden A
     ReactDOM.flushSync(() => {
       root.render(<h1>Hello</h1>);
     });
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
     expect(container.innerHTML).toBe('<h1>Hello</h1>');
   });
 
@@ -432,12 +438,12 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
 
     // Initial render
     ReactDOM.render(<App showMore={false} />, container);
-    expect(Scheduler).toHaveYielded(['Child', 'Mount']);
+    assertLog(['Child', 'Mount']);
 
     // Update that suspends, causing the existing tree to switches it to
     // a fallback.
     ReactDOM.render(<App showMore={true} />, container);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Child',
       'Loading...',
 
@@ -448,6 +454,6 @@ describe('ReactSuspenseEffectsSemanticsDOM', () => {
 
     // Delete the tree and unmount the effect
     ReactDOM.render(null, container);
-    expect(Scheduler).toHaveYielded(['Unmount']);
+    assertLog(['Unmount']);
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseFallback-test.js
@@ -13,6 +13,7 @@ let Suspense;
 let getCacheForType;
 let caches;
 let seededCache;
+let waitForAll;
 
 describe('ReactSuspenseFallback', () => {
   beforeEach(() => {
@@ -25,6 +26,9 @@ describe('ReactSuspenseFallback', () => {
     getCacheForType = React.unstable_getCacheForType;
     caches = [];
     seededCache = null;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
   function createTextCache() {
@@ -128,26 +132,26 @@ describe('ReactSuspenseFallback', () => {
   }
 
   // @gate enableLegacyCache
-  it('suspends and shows fallback', () => {
+  it('suspends and shows fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Loading..." />}>
         <AsyncText text="A" ms={100} />
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
   });
 
   // @gate enableLegacyCache
-  it('suspends and shows null fallback', () => {
+  it('suspends and shows null fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={null}>
         <AsyncText text="A" ms={100} />
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       // null
     ]);
@@ -155,14 +159,14 @@ describe('ReactSuspenseFallback', () => {
   });
 
   // @gate enableLegacyCache
-  it('suspends and shows undefined fallback', () => {
+  it('suspends and shows undefined fallback', async () => {
     ReactNoop.render(
       <Suspense>
         <AsyncText text="A" ms={100} />
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       // null
     ]);
@@ -170,7 +174,7 @@ describe('ReactSuspenseFallback', () => {
   });
 
   // @gate enableLegacyCache
-  it('suspends and shows inner fallback', () => {
+  it('suspends and shows inner fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense fallback={<Text text="Loading..." />}>
@@ -179,12 +183,12 @@ describe('ReactSuspenseFallback', () => {
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading...']);
+    await waitForAll(['Suspend! [A]', 'Loading...']);
     expect(ReactNoop).toMatchRenderedOutput(<span prop="Loading..." />);
   });
 
   // @gate enableLegacyCache
-  it('suspends and shows inner undefined fallback', () => {
+  it('suspends and shows inner undefined fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense>
@@ -193,7 +197,7 @@ describe('ReactSuspenseFallback', () => {
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       // null
     ]);
@@ -201,7 +205,7 @@ describe('ReactSuspenseFallback', () => {
   });
 
   // @gate enableLegacyCache
-  it('suspends and shows inner null fallback', () => {
+  it('suspends and shows inner null fallback', async () => {
     ReactNoop.render(
       <Suspense fallback={<Text text="Should not show..." />}>
         <Suspense fallback={null}>
@@ -210,7 +214,7 @@ describe('ReactSuspenseFallback', () => {
       </Suspense>,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       // null
     ]);

--- a/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactSuspenseList-test.js
@@ -5,6 +5,9 @@ let act;
 let Profiler;
 let Suspense;
 let SuspenseList;
+let waitForAll;
+let assertLog;
+let waitFor;
 
 describe('ReactSuspenseList', () => {
   beforeEach(() => {
@@ -19,6 +22,11 @@ describe('ReactSuspenseList', () => {
     if (gate(flags => flags.enableSuspenseList)) {
       SuspenseList = React.SuspenseList;
     }
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
+    waitFor = InternalTestUtils.waitFor;
   });
 
   function Text(props) {
@@ -106,22 +114,22 @@ describe('ReactSuspenseList', () => {
   });
 
   // @gate enableSuspenseList
-  it('warns if a single element is passed to a "forwards" list', () => {
+  it('warns if a single element is passed to a "forwards" list', async () => {
     function Foo({children}) {
       return <SuspenseList revealOrder="forwards">{children}</SuspenseList>;
     }
 
     ReactNoop.render(<Foo />);
     // No warning
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo>{null}</Foo>);
     // No warning
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
 
     ReactNoop.render(<Foo>{false}</Foo>);
     // No warning
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
 
     ReactNoop.render(
       <Foo>
@@ -213,7 +221,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -231,7 +239,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -243,7 +251,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -280,13 +288,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.renderLegacySyncRoot(<Foo />);
 
-    expect(Scheduler).toHaveYielded([
-      'A',
-      'Suspend! [B]',
-      'Loading B',
-      'Suspend! [C]',
-      'Loading C',
-    ]);
+    assertLog(['A', 'Suspend! [B]', 'Loading B', 'Suspend! [C]', 'Loading C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -300,7 +302,7 @@ describe('ReactSuspenseList', () => {
       C.resolve();
     });
 
-    expect(Scheduler).toHaveYielded(['C']);
+    assertLog(['C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -314,7 +316,7 @@ describe('ReactSuspenseList', () => {
       B.resolve();
     });
 
-    expect(Scheduler).toHaveYielded(['B']);
+    assertLog(['B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -351,7 +353,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -372,7 +374,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'Suspend! [C]']);
+    await waitForAll(['A', 'B', 'Suspend! [C]']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -384,7 +386,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -425,7 +427,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -450,7 +452,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'Suspend! [C]']);
+    await waitForAll(['A', 'B', 'Suspend! [C]']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -466,7 +468,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -510,7 +512,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'B',
       'Suspend! [C]',
@@ -532,7 +534,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -572,7 +574,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'B',
       'Suspend! [C]',
@@ -592,7 +594,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -640,7 +642,7 @@ describe('ReactSuspenseList', () => {
     // Mount
     await A.resolve();
     ReactNoop.render(<Foo step={0} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -654,7 +656,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
     await B.resolve();
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -665,7 +667,7 @@ describe('ReactSuspenseList', () => {
     // Update
     await C.resolve();
     ReactNoop.render(<Foo step={1} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'C',
       'Suspend! [D]',
       'Loading D',
@@ -679,7 +681,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
     await D.resolve();
-    expect(Scheduler).toFlushAndYield(['C', 'D']);
+    await waitForAll(['C', 'D']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>C</span>
@@ -724,20 +726,20 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading']);
+    await waitForAll(['Suspend! [A]', 'Loading']);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>Loading</span>);
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
     // Let's do an update that should consult the avoided boundaries.
     ReactNoop.render(<Foo showMore={true} />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -763,7 +765,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+    await waitForAll(['B', 'Suspend! [C]']);
 
     // Even though we could now show B, we're still waiting on C.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -776,7 +778,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'C']);
+    await waitForAll(['B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -817,7 +819,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       // null
     ]);
@@ -826,14 +828,14 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
     // Let's do an update that should consult the avoided boundaries.
     ReactNoop.render(<Foo showMore={true} />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       // null
@@ -853,14 +855,14 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+    await waitForAll(['B', 'Suspend! [C]']);
 
     // Even though we could now show B, we're still waiting on C.
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'C']);
+    await waitForAll(['B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -897,12 +899,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Loading A',
-      'Loading B',
-      'Loading C',
-    ]);
+    await waitForAll(['Suspend! [A]', 'Loading A', 'Loading B', 'Loading C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -914,7 +911,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [B]']);
+    await waitForAll(['A', 'Suspend! [B]']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -926,7 +923,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'C']);
+    await waitForAll(['B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -963,12 +960,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [C]',
-      'Loading C',
-      'Loading B',
-      'Loading A',
-    ]);
+    await waitForAll(['Suspend! [C]', 'Loading C', 'Loading B', 'Loading A']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -980,7 +972,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['C', 'Suspend! [B]']);
+    await waitForAll(['C', 'Suspend! [B]']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -992,7 +984,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'A']);
+    await waitForAll(['B', 'A']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1036,7 +1028,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield(['B', 'D']);
+    await waitForAll(['B', 'D']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1059,7 +1051,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       'Loading A',
       'B',
@@ -1087,7 +1079,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [C]']);
+    await waitForAll(['A', 'Suspend! [C]']);
 
     // Even though we could show A, it is still in a fallback state because
     // C is not yet resolved. We need to resolve everything in the head first.
@@ -1104,7 +1096,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'C', 'Suspend! [E]']);
+    await waitForAll(['A', 'C', 'Suspend! [E]']);
 
     // We can now resolve the full head.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1120,7 +1112,7 @@ describe('ReactSuspenseList', () => {
 
     await E.resolve();
 
-    expect(Scheduler).toFlushAndYield(['E', 'Suspend! [F]']);
+    await waitForAll(['E', 'Suspend! [F]']);
 
     // In the tail we can resolve one-by-one.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1147,7 +1139,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield(['D', 'E', 'F']);
+    await waitForAll(['D', 'E', 'F']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1203,7 +1195,7 @@ describe('ReactSuspenseList', () => {
         ]}
       />,
     );
-    expect(Scheduler).toFlushAndYield(['F', 'E', 'D', 'C', 'B', 'A']);
+    await waitForAll(['F', 'E', 'D', 'C', 'B', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -1229,7 +1221,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Suspend! [A]',
       'Loading A',
       'Suspend! [B]',
@@ -1273,7 +1265,7 @@ describe('ReactSuspenseList', () => {
 
     await F.resolve();
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [D]', 'F']);
+    await waitForAll(['Suspend! [D]', 'F']);
 
     // Even though we could show F, it is still in a fallback state because
     // E is not yet resolved. We need to resolve everything in the head first.
@@ -1294,7 +1286,7 @@ describe('ReactSuspenseList', () => {
 
     await D.resolve();
 
-    expect(Scheduler).toFlushAndYield(['D', 'F', 'Suspend! [B]']);
+    await waitForAll(['D', 'F', 'Suspend! [B]']);
 
     // We can now resolve the full head.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1312,7 +1304,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [A]']);
+    await waitForAll(['B', 'Suspend! [A]']);
 
     // In the tail we can resolve one-by-one.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1329,7 +1321,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1366,12 +1358,12 @@ describe('ReactSuspenseList', () => {
       ReactNoop.render(<Foo />);
     });
 
-    expect(Scheduler).toFlushAndYieldThrough(['A']);
+    await waitFor(['A']);
 
     Scheduler.unstable_advanceTime(200);
     jest.advanceTimersByTime(200);
 
-    expect(Scheduler).toFlushAndYieldThrough(['B']);
+    await waitFor(['B']);
 
     Scheduler.unstable_advanceTime(300);
     jest.advanceTimersByTime(300);
@@ -1383,7 +1375,7 @@ describe('ReactSuspenseList', () => {
     // Time has now elapsed for so long that we're just going to give up
     // rendering the rest of the content. So that we can at least show
     // something.
-    expect(Scheduler).toFlushAndYieldThrough([
+    await waitFor([
       'Loading C',
       'C', // I'll flush through into the next render so that the first commits.
     ]);
@@ -1397,7 +1389,7 @@ describe('ReactSuspenseList', () => {
     );
 
     // Then we do a second pass to commit the last item.
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1432,13 +1424,13 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A']);
+    await waitForAll(['Suspend! [A]', 'Loading A']);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>Loading A</span>);
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [B]', 'Loading B']);
+    await waitForAll(['A', 'Suspend! [B]', 'Loading B']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1452,7 +1444,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]', 'Loading C']);
+    await waitForAll(['B', 'Suspend! [C]', 'Loading C']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1467,7 +1459,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1546,12 +1538,12 @@ describe('ReactSuspenseList', () => {
       ReactNoop.render(<Foo />);
     });
 
-    expect(Scheduler).toFlushAndYieldThrough(['A']);
+    await waitFor(['A']);
 
     Scheduler.unstable_advanceTime(200);
     jest.advanceTimersByTime(200);
 
-    expect(Scheduler).toFlushAndYieldThrough(['B']);
+    await waitFor(['B']);
 
     Scheduler.unstable_advanceTime(300);
     jest.advanceTimersByTime(300);
@@ -1563,7 +1555,7 @@ describe('ReactSuspenseList', () => {
     // Time has now elapsed for so long that we're just going to give up
     // rendering the rest of the content. So that we can at least show
     // something.
-    expect(Scheduler).toFlushAndYieldThrough([
+    await waitFor([
       'Loading C',
       'C', // I'll flush through into the next render so that the first commits.
     ]);
@@ -1577,7 +1569,7 @@ describe('ReactSuspenseList', () => {
     );
 
     // Then we do a second pass to commit the last two items.
-    expect(Scheduler).toFlushAndYield(['D']);
+    await waitForAll(['D']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -1622,7 +1614,7 @@ describe('ReactSuspenseList', () => {
     await A.resolve();
     await D.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'D']);
+    await waitForAll(['A', 'D']);
 
     // First render commits A and D.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1646,7 +1638,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -1673,7 +1665,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+    await waitForAll(['B', 'Suspend! [C]']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1693,13 +1685,7 @@ describe('ReactSuspenseList', () => {
     await C.resolve();
     await E.resolve();
 
-    expect(Scheduler).toFlushAndYield([
-      'B',
-      'C',
-      'E',
-      'Suspend! [F]',
-      'Loading F',
-    ]);
+    await waitForAll(['B', 'C', 'E', 'Suspend! [F]', 'Loading F']);
 
     jest.advanceTimersByTime(500);
 
@@ -1716,7 +1702,7 @@ describe('ReactSuspenseList', () => {
 
     await F.resolve();
 
-    expect(Scheduler).toFlushAndYield(['F']);
+    await waitForAll(['F']);
 
     jest.advanceTimersByTime(500);
 
@@ -1765,7 +1751,7 @@ describe('ReactSuspenseList', () => {
     await C.resolve();
     await F.resolve();
 
-    expect(Scheduler).toFlushAndYield(['F', 'C']);
+    await waitForAll(['F', 'C']);
 
     // First render commits C and F.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1789,7 +1775,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'C',
       'Suspend! [D]',
       'Loading D',
@@ -1816,7 +1802,7 @@ describe('ReactSuspenseList', () => {
 
     await D.resolve();
 
-    expect(Scheduler).toFlushAndYield(['D', 'Suspend! [E]']);
+    await waitForAll(['D', 'Suspend! [E]']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1841,13 +1827,7 @@ describe('ReactSuspenseList', () => {
     await D.resolve();
     await E.resolve();
 
-    expect(Scheduler).toFlushAndYield([
-      'D',
-      'E',
-      'B',
-      'Suspend! [A]',
-      'Loading A',
-    ]);
+    await waitForAll(['D', 'E', 'B', 'Suspend! [A]', 'Loading A']);
 
     jest.advanceTimersByTime(500);
 
@@ -1864,7 +1844,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A']);
+    await waitForAll(['A']);
 
     jest.advanceTimersByTime(500);
 
@@ -1916,7 +1896,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'D']);
+    await waitForAll(['A', 'D']);
 
     // First render commits A and D.
     expect(ReactNoop).toMatchRenderedOutput(
@@ -1941,7 +1921,7 @@ describe('ReactSuspenseList', () => {
       />,
     );
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -1976,7 +1956,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]']);
+    await waitForAll(['B', 'Suspend! [C]']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -1999,13 +1979,7 @@ describe('ReactSuspenseList', () => {
     await D.resolve();
     await E.resolve();
 
-    expect(Scheduler).toFlushAndYield([
-      'C',
-      'D',
-      'E',
-      'Suspend! [F]',
-      'Loading F',
-    ]);
+    await waitForAll(['C', 'D', 'E', 'Suspend! [F]', 'Loading F']);
 
     jest.advanceTimersByTime(500);
 
@@ -2022,7 +1996,7 @@ describe('ReactSuspenseList', () => {
 
     await F.resolve();
 
-    expect(Scheduler).toFlushAndYield(['F']);
+    await waitForAll(['F']);
 
     jest.advanceTimersByTime(500);
 
@@ -2062,13 +2036,13 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A']);
+    await waitForAll(['Suspend! [A]', 'Loading A']);
 
     expect(ReactNoop).toMatchRenderedOutput(null);
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [B]', 'Loading B']);
+    await waitForAll(['A', 'Suspend! [B]', 'Loading B']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -2077,7 +2051,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'Suspend! [C]', 'Loading C']);
+    await waitForAll(['B', 'Suspend! [C]', 'Loading C']);
 
     // Incremental loading is suspended.
     jest.advanceTimersByTime(500);
@@ -2091,7 +2065,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2129,7 +2103,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -2153,7 +2127,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C', 'D']);
+    await waitForAll(['A', 'B', 'C', 'D']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2189,19 +2163,13 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
-      'A',
-      'Suspend! [B]',
-      'Loading B',
-      'C',
-      'Loading C',
-    ]);
+    await waitForAll(['A', 'Suspend! [B]', 'Loading B', 'C', 'Loading C']);
 
     expect(ReactNoop).toMatchRenderedOutput(<span>Loading C</span>);
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C']);
+    await waitForAll(['A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2238,7 +2206,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo showB={false} />);
 
-    expect(Scheduler).toFlushAndYield(['A', 'C']);
+    await waitForAll(['A', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2251,14 +2219,7 @@ describe('ReactSuspenseList', () => {
     // so we're now effectively in "together" mode for the head.
     ReactNoop.render(<Foo showB={true} />);
 
-    expect(Scheduler).toFlushAndYield([
-      'A',
-      'Suspend! [B]',
-      'Loading B',
-      'C',
-      'A',
-      'C',
-    ]);
+    await waitForAll(['A', 'Suspend! [B]', 'Loading B', 'C', 'A', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2269,7 +2230,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2303,7 +2264,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', '-']);
+    await waitForAll(['A', 'B', '-']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
@@ -2316,7 +2277,7 @@ describe('ReactSuspenseList', () => {
     // Update the row adjacent to the list
     act(() => updateAdjacent('C'));
 
-    expect(Scheduler).toHaveYielded(['C']);
+    assertLog(['C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <div>
@@ -2359,7 +2320,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['A', 'Sync B']);
+    await waitForAll(['A', 'Sync B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2373,7 +2334,7 @@ describe('ReactSuspenseList', () => {
     // During an update we suspend on B.
     act(() => setAsyncB(true));
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend! [B]',
       'Loading B',
       // The second pass is the "force hide" pass
@@ -2391,7 +2352,7 @@ describe('ReactSuspenseList', () => {
     // This should leave the tree intact.
     act(() => ReactNoop.render(<Foo updateList={true} />));
 
-    expect(Scheduler).toHaveYielded(['A', 'Suspend! [B]', 'Loading B']);
+    assertLog(['A', 'Suspend! [B]', 'Loading B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2402,7 +2363,7 @@ describe('ReactSuspenseList', () => {
 
     await AsyncB.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2448,7 +2409,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['A', 'Sync B']);
+    await waitForAll(['A', 'Sync B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2462,7 +2423,7 @@ describe('ReactSuspenseList', () => {
     // During an update we suspend on B.
     act(() => setAsyncB(true));
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend! [B]',
       'Loading B',
       // The second pass is the "force hide" pass
@@ -2480,7 +2441,7 @@ describe('ReactSuspenseList', () => {
     // This should leave the tree intact.
     act(() => ReactNoop.render(<Foo updateList={true} />));
 
-    expect(Scheduler).toHaveYielded(['A', 'Suspend! [B]', 'Loading B']);
+    assertLog(['A', 'Suspend! [B]', 'Loading B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2491,7 +2452,7 @@ describe('ReactSuspenseList', () => {
 
     await AsyncB.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B']);
+    await waitForAll(['B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2535,7 +2496,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([]);
+    await waitForAll([]);
 
     expect(ReactNoop).toMatchRenderedOutput(null);
 
@@ -2544,13 +2505,13 @@ describe('ReactSuspenseList', () => {
         updateLowPri(true);
       });
       // Flush partially through.
-      expect(Scheduler).toFlushAndYieldThrough(['B', 'C']);
+      await waitFor(['B', 'C']);
 
       // Schedule another update at higher priority.
       ReactNoop.flushSync(() => updateHighPri(true));
 
       // That will intercept the previous render.
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'Suspend! [A]',
         'Loading A',
         // Re-render at forced.
@@ -2560,13 +2521,13 @@ describe('ReactSuspenseList', () => {
       expect(ReactNoop).toMatchRenderedOutput(<span>Loading A</span>);
 
       // Try again on low-pri.
-      expect(Scheduler).toFlushAndYield(['Suspend! [A]', 'Loading A']);
+      await waitForAll(['Suspend! [A]', 'Loading A']);
       expect(ReactNoop).toMatchRenderedOutput(<span>Loading A</span>);
     });
 
     await AsyncA.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'B', 'C', 'D']);
+    await waitForAll(['A', 'B', 'C', 'D']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2612,7 +2573,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'A',
       'Suspend! [B]',
       'Loading B',
@@ -2631,7 +2592,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield(['A', 'B']);
+    await waitForAll(['A', 'B']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2681,15 +2642,10 @@ describe('ReactSuspenseList', () => {
     React.startTransition(() => {
       ReactNoop.render(<App />);
     });
-    expect(Scheduler).toFlushAndYieldThrough([
-      'App',
-      'First Pass A',
-      'Mount A',
-      'A',
-    ]);
+    await waitFor(['App', 'First Pass A', 'Mount A', 'A']);
     expect(ReactNoop).toMatchRenderedOutput(<span>A</span>);
 
-    expect(Scheduler).toFlushAndYieldThrough(['First Pass B', 'Mount B', 'B']);
+    await waitFor(['First Pass B', 'Mount B', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2697,7 +2653,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2749,7 +2705,7 @@ describe('ReactSuspenseList', () => {
     React.startTransition(() => {
       ReactNoop.render(<App />);
     });
-    expect(Scheduler).toFlushAndYieldThrough([
+    await waitFor([
       'App',
       'First Pass A',
       'Loading B',
@@ -2765,7 +2721,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    expect(Scheduler).toFlushAndYieldThrough(['First Pass B', 'Mount B', 'B']);
+    await waitFor(['First Pass B', 'Mount B', 'B']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2774,7 +2730,7 @@ describe('ReactSuspenseList', () => {
       </>,
     );
 
-    expect(Scheduler).toFlushAndYield(['C']);
+    await waitForAll(['C']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2840,13 +2796,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<App suspendTail={true} />);
 
-    expect(Scheduler).toFlushAndYield([
-      'App',
-      'A',
-      'B',
-      'Suspend! [C]',
-      'Fallback',
-    ]);
+    await waitForAll(['App', 'A', 'B', 'Suspend! [C]', 'Fallback']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -2868,7 +2818,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<App suspendTail={false} />);
 
-    expect(Scheduler).toFlushAndYield(['App', 'A', 'B', 'C']);
+    await waitForAll(['App', 'A', 'B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -2886,7 +2836,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<App addRow={true} suspendTail={true} />);
 
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'App',
       'A',
       'B',
@@ -2928,7 +2878,7 @@ describe('ReactSuspenseList', () => {
 
     await C.resolve();
 
-    expect(Scheduler).toFlushAndYield(['C', 'Suspend! [D]']);
+    await waitForAll(['C', 'Suspend! [D]']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span>A</span>
@@ -3003,12 +2953,7 @@ describe('ReactSuspenseList', () => {
 
     ReactNoop.render(<Foo />);
 
-    expect(Scheduler).toFlushAndYield([
-      'Suspend! [A]',
-      'Loading A',
-      'Loading B',
-      'Loading C',
-    ]);
+    await waitForAll(['Suspend! [A]', 'Loading A', 'Loading B', 'Loading C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -3020,7 +2965,7 @@ describe('ReactSuspenseList', () => {
 
     await A.resolve();
 
-    expect(Scheduler).toFlushAndYield(['A', 'Suspend! [B]']);
+    await waitForAll(['A', 'Suspend! [B]']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>
@@ -3032,7 +2977,7 @@ describe('ReactSuspenseList', () => {
 
     await B.resolve();
 
-    expect(Scheduler).toFlushAndYield(['B', 'C']);
+    await waitForAll(['B', 'C']);
 
     expect(ReactNoop).toMatchRenderedOutput(
       <>

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelFragment-test.js
@@ -12,7 +12,7 @@
 
 let React;
 let ReactNoop;
-let Scheduler;
+let waitForAll;
 
 // This is a new feature in Fiber so I put it in its own test file. It could
 // probably move to one of the other test files once it is official.
@@ -21,18 +21,20 @@ describe('ReactTopLevelFragment', function () {
     jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
-  it('should render a simple fragment at the top of a component', function () {
+  it('should render a simple fragment at the top of a component', async function () {
     function Fragment() {
       return [<div key="a">Hello</div>, <div key="b">World</div>];
     }
     ReactNoop.render(<Fragment />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
   });
 
-  it('should preserve state when switching from a single child', function () {
+  it('should preserve state when switching from a single child', async function () {
     let instance = null;
 
     class Stateful extends React.Component {
@@ -50,21 +52,21 @@ describe('ReactTopLevelFragment', function () {
       );
     }
     ReactNoop.render(<Fragment />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceB = instance;
 
     expect(instanceB).toBe(instanceA);
   });
 
-  it('should not preserve state when switching to a nested array', function () {
+  it('should not preserve state when switching to a nested array', async function () {
     let instance = null;
 
     class Stateful extends React.Component {
@@ -82,21 +84,21 @@ describe('ReactTopLevelFragment', function () {
       );
     }
     ReactNoop.render(<Fragment />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceB = instance;
 
     expect(instanceB).not.toBe(instanceA);
   });
 
-  it('preserves state if an implicit key slot switches from/to null', function () {
+  it('preserves state if an implicit key slot switches from/to null', async function () {
     let instance = null;
 
     class Stateful extends React.Component {
@@ -112,28 +114,28 @@ describe('ReactTopLevelFragment', function () {
         : [<div key="b">Hello</div>, <Stateful key="a" />];
     }
     ReactNoop.render(<Fragment />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceB = instance;
 
     expect(instanceB).toBe(instanceA);
 
     ReactNoop.render(<Fragment condition={false} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceC = instance;
 
     expect(instanceC === instanceA).toBe(true);
   });
 
-  it('should preserve state in a reorder', function () {
+  it('should preserve state in a reorder', async function () {
     let instance = null;
 
     class Stateful extends React.Component {
@@ -149,14 +151,14 @@ describe('ReactTopLevelFragment', function () {
         : [[<Stateful key="a" />, <div key="b">World</div>], <div key="c" />];
     }
     ReactNoop.render(<Fragment />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceA = instance;
 
     expect(instanceA).not.toBe(null);
 
     ReactNoop.render(<Fragment condition={true} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     const instanceB = instance;
 

--- a/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTopLevelText-test.js
@@ -12,7 +12,7 @@
 
 let React;
 let ReactNoop;
-let Scheduler;
+let waitForAll;
 
 // This is a new feature in Fiber so I put it in its own test file. It could
 // probably move to one of the other test files once it is official.
@@ -21,20 +21,22 @@ describe('ReactTopLevelText', () => {
     jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
   });
 
-  it('should render a component returning strings directly from render', () => {
+  it('should render a component returning strings directly from render', async () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value="foo" />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('foo');
   });
 
-  it('should render a component returning numbers directly from render', () => {
+  it('should render a component returning numbers directly from render', async () => {
     const Text = ({value}) => value;
     ReactNoop.render(<Text value={10} />);
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
     expect(ReactNoop).toMatchRenderedOutput('10');
   });
 });

--- a/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
@@ -12,6 +12,8 @@ let React;
 let ReactNoop;
 let Scheduler;
 let act;
+let waitForAll;
+let assertLog;
 
 let getCacheForType;
 let useState;
@@ -42,6 +44,10 @@ describe('ReactInteractionTracing', () => {
     Scheduler = require('scheduler');
 
     act = require('jest-react').act;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
 
     useState = React.useState;
     startTransition = React.startTransition;
@@ -233,7 +239,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       await act(async () => {
         startTransition(() => root.render(<App navigate={true} />));
@@ -242,12 +248,12 @@ describe('ReactInteractionTracing', () => {
         await advanceTimers(1000);
 
         // Doesn't call transition or marker code
-        expect(Scheduler).toFlushAndYield(['Page Two']);
+        await waitForAll(['Page Two']);
 
         startTransition(() => root.render(<App navigate={false} />), {
           name: 'transition',
         });
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           'Page One',
           'onTransitionStart(transition, 2000)',
           'onTransitionComplete(transition, 2000, 2000)',
@@ -299,7 +305,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       await act(async () => {
         startTransition(() => navigateToPageTwo(), {name: 'page transition'});
@@ -307,7 +313,7 @@ describe('ReactInteractionTracing', () => {
         ReactNoop.expire(1000);
         await advanceTimers(1000);
 
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           'Page Two',
           'onTransitionStart(page transition, 1000)',
           'onTransitionComplete(page transition, 1000, 2000)',
@@ -358,7 +364,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One: hide']);
+      await waitForAll(['Page One: hide']);
 
       await act(async () => {
         startTransition(
@@ -372,7 +378,7 @@ describe('ReactInteractionTracing', () => {
         ReactNoop.expire(1000);
         await advanceTimers(1000);
 
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           'Page Two: show',
           'onTransitionStart(page transition, 1000)',
           'onTransitionComplete(page transition, 1000, 2000)',
@@ -431,7 +437,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -440,7 +446,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'onTransitionStart(page transition, 1000)',
@@ -451,7 +457,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
       await resolveText('Page Two');
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'onTransitionProgress(page transition, 1000, 3000, [])',
         'onTransitionComplete(page transition, 1000, 3000)',
@@ -526,13 +532,13 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
       startTransition(() => navigateToPageTwo(), {name: 'page transition'});
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'onTransitionStart(page transition, 1000)',
@@ -542,14 +548,14 @@ describe('ReactInteractionTracing', () => {
       await resolveText('Page Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'onTransitionProgress(page transition, 1000, 2000, [])',
         'onTransitionComplete(page transition, 1000, 2000)',
       ]);
 
       startTransition(() => showTextFn(), {name: 'text transition'});
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Show Text]',
         'Show Text Loading...',
         'Page Two',
@@ -560,7 +566,7 @@ describe('ReactInteractionTracing', () => {
       await resolveText('Show Text');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text',
         'onTransitionProgress(text transition, 2000, 3000, [])',
         'onTransitionComplete(text transition, 2000, 3000)',
@@ -633,7 +639,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -641,7 +647,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'onTransitionStart(page transition, 1000)',
@@ -652,7 +658,7 @@ describe('ReactInteractionTracing', () => {
     await act(async () => {
       startTransition(() => showTextFn(), {name: 'show text'});
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Show Text]',
         'Show Text Loading...',
         'Suspend [Page Two]',
@@ -667,7 +673,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'onTransitionProgress(page transition, 1000, 3000, [])',
         'onTransitionComplete(page transition, 1000, 3000)',
@@ -677,7 +683,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text',
         'onTransitionProgress(show text, 2000, 4000, [])',
         'onTransitionComplete(show text, 2000, 4000)',
@@ -750,7 +756,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -758,7 +764,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Suspend [Show Text One]',
         'Show Text One Loading...',
@@ -773,7 +779,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'Suspend [Show Text One]',
         'Show Text One Loading...',
@@ -786,7 +792,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text One',
         'onTransitionProgress(page transition, 1000, 4000, [show text two])',
       ]);
@@ -795,7 +801,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text Two',
         'onTransitionProgress(page transition, 1000, 5000, [])',
         'onTransitionComplete(page transition, 1000, 5000)',
@@ -881,7 +887,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -890,7 +896,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Suspend [Show Text One]',
         'Show Text One Loading...',
@@ -906,7 +912,7 @@ describe('ReactInteractionTracing', () => {
       resolveText('Page Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'Suspend [Show Text One]',
         'Show Text One Loading...',
@@ -920,7 +926,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'Suspend [Show Text One]',
         'Show Text One Loading...',
@@ -938,7 +944,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text',
         'onTransitionProgress(navigate, 1000, 5000, [show text one])',
         'onTransitionProgress(show text one, 1000, 5000, [show text one])',
@@ -948,7 +954,7 @@ describe('ReactInteractionTracing', () => {
       resolveText('Show Text Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text Two',
         'onTransitionProgress(show text two, 3000, 6000, [])',
         'onTransitionComplete(show text two, 3000, 6000)',
@@ -959,7 +965,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Show Text One',
         'onTransitionProgress(navigate, 1000, 7000, [])',
         'onTransitionProgress(show text one, 1000, 7000, [])',
@@ -1037,7 +1043,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       await act(async () => {
         startTransition(() => navigateToPageTwo(), {name: 'page transition'});
@@ -1045,7 +1051,7 @@ describe('ReactInteractionTracing', () => {
         ReactNoop.expire(1000);
         await advanceTimers(1000);
 
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           'Page Two',
           'onTransitionStart(page transition, 1000)',
           'onMarkerComplete(page transition, marker two, 1000, 2000)',
@@ -1124,7 +1130,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -1133,7 +1139,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Suspend [Marker Text]',
         'Loading...',
@@ -1145,7 +1151,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
       await resolveText('Page Two');
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'Suspend [Marker Text]',
         'Loading...',
@@ -1157,7 +1163,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
       await resolveText('Marker Text');
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Marker Text',
         'onMarkerProgress(page transition, async marker, 1000, 4000, [])',
         'onMarkerComplete(page transition, async marker, 1000, 4000)',
@@ -1244,7 +1250,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
     });
 
     await act(async () => {
@@ -1253,7 +1259,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Outer Text]',
         'Suspend [Inner Text One]',
         'Inner One...',
@@ -1267,12 +1273,12 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
       await resolveText('Inner Text Two');
-      expect(Scheduler).toFlushAndYield([]);
+      await waitForAll([]);
 
       ReactNoop.expire(1000);
       await advanceTimers(1000);
       await resolveText('Outer Text');
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Outer Text',
         'Suspend [Inner Text One]',
         'Inner One...',
@@ -1284,7 +1290,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
       await resolveText('Inner Text One');
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Inner Text One',
         'onMarkerProgress(page transition, outer marker, 1000, 5000, [])',
         'onMarkerComplete(page transition, marker one, 1000, 5000)',
@@ -1367,7 +1373,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={false} markerName="marker one" />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       startTransition(
         () => root.render(<App navigate={true} markerName="marker one" />),
@@ -1378,7 +1384,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'onTransitionStart(transition one, 1000)',
@@ -1400,7 +1406,7 @@ describe('ReactInteractionTracing', () => {
       resolveText('Page Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'onMarkerProgress(transition one, marker one, 1000, 4000, [])',
         'onTransitionProgress(transition one, 1000, 4000, [])',
@@ -1501,7 +1507,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={false} showMarker={true} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       startTransition(
         () => root.render(<App navigate={true} showMarker={true} />),
@@ -1511,7 +1517,7 @@ describe('ReactInteractionTracing', () => {
       );
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'Suspend [Sibling Text]',
@@ -1526,7 +1532,7 @@ describe('ReactInteractionTracing', () => {
 
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'Suspend [Sibling Text]',
@@ -1539,7 +1545,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={true} showMarker={true} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading...',
         'Suspend [Sibling Text]',
@@ -1550,12 +1556,12 @@ describe('ReactInteractionTracing', () => {
     resolveText('Page Two');
     ReactNoop.expire(1000);
     await advanceTimers(1000);
-    expect(Scheduler).toFlushAndYield(['Page Two']);
+    await waitForAll(['Page Two']);
 
     resolveText('Sibling Text');
     ReactNoop.expire(1000);
     await advanceTimers(1000);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Sibling Text',
       'onMarkerProgress(transition one, parent, 1000, 6000, [])',
       'onMarkerProgress(transition one, sibling, 1000, 6000, [])',
@@ -1652,7 +1658,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={false} deleteOne={false} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       startTransition(
         () => root.render(<App navigate={true} deleteOne={false} />),
@@ -1662,7 +1668,7 @@ describe('ReactInteractionTracing', () => {
       );
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page One]',
         'Loading One...',
         'Suspend [Page Two]',
@@ -1677,7 +1683,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={true} deleteOne={true} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading Two...',
         'onMarkerProgress(transition, parent, 1000, 3000, [suspense two])',
@@ -1688,7 +1694,7 @@ describe('ReactInteractionTracing', () => {
       await resolveText('Page Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         // Marker progress will still get called after incomplete but not marker complete
         'onMarkerProgress(transition, parent, 1000, 4000, [])',
@@ -1793,7 +1799,7 @@ describe('ReactInteractionTracing', () => {
 
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield(['Page One']);
+      await waitForAll(['Page One']);
 
       startTransition(
         () => root.render(<App navigate={true} deleteOne={false} />),
@@ -1803,7 +1809,7 @@ describe('ReactInteractionTracing', () => {
       );
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page One]',
         'Suspend [Child]',
         'Loading Child...',
@@ -1820,7 +1826,7 @@ describe('ReactInteractionTracing', () => {
       await resolveText('Page One');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page One',
         'Suspend [Child]',
         'Loading Child...',
@@ -1833,7 +1839,7 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={true} deleteOne={true} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Page Two]',
         'Loading Two...',
         // "suspense one" has unsuspended so shouldn't be included
@@ -1848,7 +1854,7 @@ describe('ReactInteractionTracing', () => {
       await resolveText('Page Two');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Page Two',
         'onMarkerProgress(transition, parent, 1000, 5000, [])',
         'onMarkerProgress(transition, two, 1000, 5000, [])',
@@ -1933,7 +1939,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Suspend [Child]',
         'onTransitionStart(transition, 0)',
         'onMarkerProgress(transition, parent, 0, 1000, [child])',
@@ -1945,23 +1951,20 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
       // This appended child isn't part of the transition so we
       // don't call any callback
-      expect(Scheduler).toFlushAndYield([
-        'Suspend [Appended child]',
-        'Suspend [Child]',
-      ]);
+      await waitForAll(['Suspend [Appended child]', 'Suspend [Child]']);
 
       // This deleted child isn't part of the transition so we
       // don't call any callbacks
       root.render(<App show={false} />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield(['Suspend [Child]']);
+      await waitForAll(['Suspend [Child]']);
 
       await resolveText('Child');
       ReactNoop.expire(1000);
       await advanceTimers(1000);
 
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'Child',
         'onMarkerProgress(transition, parent, 0, 4000, [])',
         'onMarkerComplete(transition, parent, 0, 4000)',
@@ -2056,7 +2059,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Child]',
       'onTransitionStart(transition one, 0)',
       'onMarkerProgress(transition one, parent, 0, 1000, [child])',
@@ -2075,7 +2078,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Appended child]',
       'Suspend [Child]',
       'onTransitionStart(transition two, 1000)',
@@ -2089,7 +2092,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Child]',
       'onMarkerProgress(transition two, appended child, 1000, 3000, [])',
       'onMarkerIncomplete(transition two, appended child, 1000, [{endTime: 3000, name: appended child, type: suspense}])',
@@ -2101,7 +2104,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Child',
       'onMarkerProgress(transition one, parent, 0, 4000, [])',
       'onMarkerComplete(transition one, parent, 0, 4000)',
@@ -2161,7 +2164,7 @@ describe('ReactInteractionTracing', () => {
       );
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'one',
         'onTransitionStart(transition one, 0)',
         'onMarkerComplete(transition one, one, 0, 1000)',
@@ -2175,10 +2178,10 @@ describe('ReactInteractionTracing', () => {
       );
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(() => {
+      await expect(async () => {
         // onMarkerComplete shouldn't be called for transitions with
         // new keys
-        expect(Scheduler).toFlushAndYield([
+        await waitForAll([
           'two',
           'onTransitionStart(transition two, 1000)',
           'onTransitionComplete(transition two, 1000, 2000)',
@@ -2195,7 +2198,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       await advanceTimers(1000);
       // This should not warn and onMarkerComplete should be called
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'three',
         'onTransitionStart(transition three, 2000)',
         'onMarkerComplete(transition three, three, 2000, 3000)',
@@ -2247,7 +2250,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       advanceTimers(1000);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Text]',
       'Loading...',
       'Suspend [Hidden Text]',
@@ -2260,7 +2263,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       advanceTimers(1000);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Text',
       'onMarkerComplete(transition, marker, 0, 2000)',
       'onTransitionComplete(transition, 0, 2000)',
@@ -2271,7 +2274,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       advanceTimers(1000);
     });
-    expect(Scheduler).toHaveYielded(['Hidden Text']);
+    assertLog(['Hidden Text']);
   });
 
   // @gate enableTransitionTracing
@@ -2317,7 +2320,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Page Two]',
       'Loading...',
       'onTransitionStart(page transition, 0)',
@@ -2329,7 +2332,7 @@ describe('ReactInteractionTracing', () => {
       await advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Page Two',
       'onTransitionProgress(page transition, 0, 2000, [])',
       'onTransitionComplete(page transition, 0, 2000)',
@@ -2387,7 +2390,7 @@ describe('ReactInteractionTracing', () => {
       advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Text]',
       'Loading...',
       'Suspend [Text Two]',
@@ -2404,7 +2407,7 @@ describe('ReactInteractionTracing', () => {
       ReactNoop.expire(1000);
       advanceTimers(1000);
     });
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Text Two',
       'onTransitionProgress(transition, 0, 2000, [])',
       'onTransitionComplete(transition, 0, 2000)',
@@ -2465,7 +2468,7 @@ describe('ReactInteractionTracing', () => {
       advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Suspend [Text one]',
       'Loading one...',
       'Suspend [Text two]',
@@ -2482,7 +2485,7 @@ describe('ReactInteractionTracing', () => {
       advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Text one',
       'onTransitionProgress(transition one, 0, 2000, []) /root one/',
       'onTransitionComplete(transition one, 0, 2000) /root one/',
@@ -2494,7 +2497,7 @@ describe('ReactInteractionTracing', () => {
       advanceTimers(1000);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Text two',
       'onTransitionProgress(transition two, 0, 3000, []) /root two/',
       'onTransitionComplete(transition two, 0, 3000) /root two/',

--- a/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactUpdaters-test.internal.js
@@ -19,6 +19,9 @@ let allSchedulerTags;
 let allSchedulerTypes;
 let onCommitRootShouldYield;
 let act;
+let waitFor;
+let waitForAll;
+let assertLog;
 
 describe('updaters', () => {
   beforeEach(() => {
@@ -91,6 +94,11 @@ describe('updaters', () => {
     Scheduler = require('scheduler');
 
     act = require('jest-react').act;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitFor = InternalTestUtils.waitFor;
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
   });
 
   it('should report the (host) root as the scheduler for root-level render', async () => {
@@ -210,10 +218,7 @@ describe('updaters', () => {
     const root = ReactDOMClient.createRoot(document.createElement('div'));
     await act(async () => {
       root.render(<Parent />);
-      expect(Scheduler).toFlushAndYieldThrough([
-        'CascadingChild 0',
-        'onCommitRoot',
-      ]);
+      await waitFor(['CascadingChild 0', 'onCommitRoot']);
     });
     expect(triggerActiveCascade).not.toBeNull();
     expect(triggerPassiveCascade).not.toBeNull();
@@ -221,7 +226,7 @@ describe('updaters', () => {
 
     await act(async () => {
       triggerActiveCascade();
-      expect(Scheduler).toFlushAndYieldThrough([
+      await waitFor([
         'CascadingChild 0',
         'onCommitRoot',
         'CascadingChild 1',
@@ -236,7 +241,7 @@ describe('updaters', () => {
 
     await act(async () => {
       triggerPassiveCascade();
-      expect(Scheduler).toFlushAndYieldThrough([
+      await waitFor([
         'CascadingChild 1',
         'onCommitRoot',
         'CascadingChild 2',
@@ -252,7 +257,7 @@ describe('updaters', () => {
     ]);
 
     // Verify no outstanding flushes
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
   });
 
   it('should cover suspense pings', async () => {
@@ -291,7 +296,7 @@ describe('updaters', () => {
 
     await act(async () => {
       ReactDOM.render(<Parent />, document.createElement('div'));
-      expect(Scheduler).toHaveYielded(['onCommitRoot']);
+      assertLog(['onCommitRoot']);
     });
     expect(setShouldSuspend).not.toBeNull();
     expect(allSchedulerTypes).toEqual([[null]]);
@@ -299,7 +304,7 @@ describe('updaters', () => {
     await act(async () => {
       setShouldSuspend(true);
     });
-    expect(Scheduler).toHaveYielded(['onCommitRoot']);
+    assertLog(['onCommitRoot']);
     expect(allSchedulerTypes).toEqual([[null], [Suspender]]);
 
     expect(resolver).not.toBeNull();
@@ -307,11 +312,11 @@ describe('updaters', () => {
       resolver('abc');
       return promise;
     });
-    expect(Scheduler).toHaveYielded(['onCommitRoot']);
+    assertLog(['onCommitRoot']);
     expect(allSchedulerTypes).toEqual([[null], [Suspender], [Suspender]]);
 
     // Verify no outstanding flushes
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
   });
 
   it('should cover error handling', async () => {
@@ -354,7 +359,7 @@ describe('updaters', () => {
     await act(async () => {
       root.render(<Parent shouldError={false} />);
     });
-    expect(Scheduler).toHaveYielded(['initial', 'onCommitRoot']);
+    assertLog(['initial', 'onCommitRoot']);
     expect(triggerError).not.toBeNull();
 
     allSchedulerTypes.splice(0);
@@ -363,11 +368,11 @@ describe('updaters', () => {
     await act(async () => {
       triggerError();
     });
-    expect(Scheduler).toHaveYielded(['onCommitRoot', 'error', 'onCommitRoot']);
+    assertLog(['onCommitRoot', 'error', 'onCommitRoot']);
     expect(allSchedulerTypes).toEqual([[Parent], [ErrorBoundary]]);
 
     // Verify no outstanding flushes
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
   });
 
   it('should distinguish between updaters in the case of interleaved work', async () => {
@@ -409,7 +414,7 @@ describe('updaters', () => {
     );
 
     // Render everything initially.
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'SyncPriorityUpdater 0',
       'Yield HighPriority 0',
       'LowPriorityUpdater 0',
@@ -421,14 +426,14 @@ describe('updaters', () => {
     expect(allSchedulerTags).toEqual([[HostRoot]]);
 
     // Render a partial update, but don't finish.
-    act(() => {
+    await act(async () => {
       triggerLowPriorityUpdate();
-      expect(Scheduler).toFlushAndYieldThrough(['LowPriorityUpdater 1']);
+      await waitFor(['LowPriorityUpdater 1']);
       expect(allSchedulerTags).toEqual([[HostRoot]]);
 
       // Interrupt with higher priority work.
       ReactDOM.flushSync(triggerSyncPriorityUpdate);
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'SyncPriorityUpdater 1',
         'Yield HighPriority 1',
         'onCommitRoot',
@@ -437,7 +442,7 @@ describe('updaters', () => {
 
       // Finish the initial partial update
       triggerLowPriorityUpdate();
-      expect(Scheduler).toFlushAndYield([
+      await waitForAll([
         'LowPriorityUpdater 2',
         'Yield LowPriority 2',
         'onCommitRoot',
@@ -455,6 +460,6 @@ describe('updaters', () => {
     ]);
 
     // Verify no outstanding flushes
-    Scheduler.unstable_flushAll();
+    await waitForAll([]);
   });
 });

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -13,6 +13,7 @@ let React;
 let ReactTestRenderer;
 let Scheduler;
 let act;
+let assertLog;
 
 describe('StrictEffectsMode', () => {
   beforeEach(() => {
@@ -21,6 +22,9 @@ describe('StrictEffectsMode', () => {
     ReactTestRenderer = require('react-test-renderer');
     Scheduler = require('scheduler');
     act = require('jest-react').act;
+
+    const InternalTestUtils = require('internal-test-utils');
+    assertLog = InternalTestUtils.assertLog;
   });
 
   function supportsDoubleInvokeEffects() {
@@ -51,10 +55,7 @@ describe('StrictEffectsMode', () => {
       ReactTestRenderer.create(<App text={'mount'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
-      'useLayoutEffect mount',
-      'useEffect mount',
-    ]);
+    assertLog(['useLayoutEffect mount', 'useEffect mount']);
   });
 
   it('double invoking for effects works properly', () => {
@@ -80,7 +81,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'useLayoutEffect mount',
         'useEffect mount',
         'useLayoutEffect unmount',
@@ -89,17 +90,14 @@ describe('StrictEffectsMode', () => {
         'useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
-        'useLayoutEffect mount',
-        'useEffect mount',
-      ]);
+      assertLog(['useLayoutEffect mount', 'useEffect mount']);
     }
 
     act(() => {
       renderer.update(<App text={'update'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'useLayoutEffect unmount',
       'useLayoutEffect mount',
       'useEffect unmount',
@@ -110,10 +108,7 @@ describe('StrictEffectsMode', () => {
       renderer.unmount();
     });
 
-    expect(Scheduler).toHaveYielded([
-      'useLayoutEffect unmount',
-      'useEffect unmount',
-    ]);
+    assertLog(['useLayoutEffect unmount', 'useEffect unmount']);
   });
 
   it('multiple effects are double invoked in the right order (all mounted, all unmounted, all remounted)', () => {
@@ -139,7 +134,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'useEffect One mount',
         'useEffect Two mount',
         'useEffect One unmount',
@@ -148,17 +143,14 @@ describe('StrictEffectsMode', () => {
         'useEffect Two mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
-        'useEffect One mount',
-        'useEffect Two mount',
-      ]);
+      assertLog(['useEffect One mount', 'useEffect Two mount']);
     }
 
     act(() => {
       renderer.update(<App text={'update'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'useEffect One unmount',
       'useEffect Two unmount',
       'useEffect One mount',
@@ -169,10 +161,7 @@ describe('StrictEffectsMode', () => {
       renderer.unmount(null);
     });
 
-    expect(Scheduler).toHaveYielded([
-      'useEffect One unmount',
-      'useEffect Two unmount',
-    ]);
+    assertLog(['useEffect One unmount', 'useEffect Two unmount']);
   });
 
   it('multiple layout effects are double invoked in the right order (all mounted, all unmounted, all remounted)', () => {
@@ -200,7 +189,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'useLayoutEffect One mount',
         'useLayoutEffect Two mount',
         'useLayoutEffect One unmount',
@@ -209,17 +198,14 @@ describe('StrictEffectsMode', () => {
         'useLayoutEffect Two mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
-        'useLayoutEffect One mount',
-        'useLayoutEffect Two mount',
-      ]);
+      assertLog(['useLayoutEffect One mount', 'useLayoutEffect Two mount']);
     }
 
     act(() => {
       renderer.update(<App text={'update'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'useLayoutEffect One unmount',
       'useLayoutEffect Two unmount',
       'useLayoutEffect One mount',
@@ -230,10 +216,7 @@ describe('StrictEffectsMode', () => {
       renderer.unmount();
     });
 
-    expect(Scheduler).toHaveYielded([
-      'useLayoutEffect One unmount',
-      'useLayoutEffect Two unmount',
-    ]);
+    assertLog(['useLayoutEffect One unmount', 'useLayoutEffect Two unmount']);
   });
 
   it('useEffect and useLayoutEffect is called twice when there is no unmount', () => {
@@ -257,33 +240,27 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'useLayoutEffect mount',
         'useEffect mount',
         'useLayoutEffect mount',
         'useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
-        'useLayoutEffect mount',
-        'useEffect mount',
-      ]);
+      assertLog(['useLayoutEffect mount', 'useEffect mount']);
     }
 
     act(() => {
       renderer.update(<App text={'update'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
-      'useLayoutEffect mount',
-      'useEffect mount',
-    ]);
+    assertLog(['useLayoutEffect mount', 'useEffect mount']);
 
     act(() => {
       renderer.unmount();
     });
 
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
   });
 
   it('passes the right context to class component lifecycles', () => {
@@ -315,13 +292,13 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'componentDidMount',
         'componentWillUnmount',
         'componentDidMount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded(['componentDidMount']);
+      assertLog(['componentDidMount']);
     }
   });
 
@@ -352,26 +329,26 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'componentDidMount',
         'componentWillUnmount',
         'componentDidMount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded(['componentDidMount']);
+      assertLog(['componentDidMount']);
     }
 
     act(() => {
       renderer.update(<App text={'update'} />);
     });
 
-    expect(Scheduler).toHaveYielded(['componentDidUpdate']);
+    assertLog(['componentDidUpdate']);
 
     act(() => {
       renderer.unmount();
     });
 
-    expect(Scheduler).toHaveYielded(['componentWillUnmount']);
+    assertLog(['componentWillUnmount']);
   });
 
   it('should not double invoke class lifecycles in legacy mode', () => {
@@ -397,7 +374,7 @@ describe('StrictEffectsMode', () => {
       ReactTestRenderer.create(<App text={'mount'} />);
     });
 
-    expect(Scheduler).toHaveYielded(['componentDidMount']);
+    assertLog(['componentDidMount']);
   });
 
   it('double flushing passive effects only results in one double invoke', () => {
@@ -427,7 +404,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'mount',
         'useLayoutEffect mount',
         'useEffect mount',
@@ -442,7 +419,7 @@ describe('StrictEffectsMode', () => {
         'useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'mount',
         'useLayoutEffect mount',
         'useEffect mount',
@@ -492,7 +469,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'App useLayoutEffect mount',
         'App useEffect mount',
         'App useLayoutEffect unmount',
@@ -501,10 +478,7 @@ describe('StrictEffectsMode', () => {
         'App useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
-        'App useLayoutEffect mount',
-        'App useEffect mount',
-      ]);
+      assertLog(['App useLayoutEffect mount', 'App useEffect mount']);
     }
 
     act(() => {
@@ -512,7 +486,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'App useLayoutEffect unmount',
         'Child useLayoutEffect mount',
         'App useLayoutEffect mount',
@@ -525,7 +499,7 @@ describe('StrictEffectsMode', () => {
         'Child useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'App useLayoutEffect unmount',
         'Child useLayoutEffect mount',
         'App useLayoutEffect mount',
@@ -580,7 +554,7 @@ describe('StrictEffectsMode', () => {
     });
 
     if (supportsDoubleInvokeEffects()) {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'componentDidMount',
         'useLayoutEffect mount',
         'useEffect mount',
@@ -592,7 +566,7 @@ describe('StrictEffectsMode', () => {
         'useEffect mount',
       ]);
     } else {
-      expect(Scheduler).toHaveYielded([
+      assertLog([
         'componentDidMount',
         'useLayoutEffect mount',
         'useEffect mount',
@@ -603,7 +577,7 @@ describe('StrictEffectsMode', () => {
       renderer.update(<App text={'mount'} />);
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'useLayoutEffect unmount',
       'useLayoutEffect mount',
       'useEffect unmount',
@@ -614,7 +588,7 @@ describe('StrictEffectsMode', () => {
       renderer.unmount();
     });
 
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'componentWillUnmount',
       'useLayoutEffect unmount',
       'useEffect unmount',

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -26,6 +26,8 @@ describe('useEffectEvent', () => {
   let useEffect;
   let useLayoutEffect;
   let useMemo;
+  let waitForAll;
+  let assertLog;
 
   beforeEach(() => {
     React = require('react');
@@ -40,6 +42,10 @@ describe('useEffectEvent', () => {
     useEffect = React.useEffect;
     useLayoutEffect = React.useLayoutEffect;
     useMemo = React.useMemo;
+
+    const InternalTestUtils = require('internal-test-utils');
+    waitForAll = InternalTestUtils.waitForAll;
+    assertLog = InternalTestUtils.assertLog;
   });
 
   function Text(props) {
@@ -48,7 +54,7 @@ describe('useEffectEvent', () => {
   }
 
   // @gate enableUseEffectEventHook
-  it('memoizes basic case correctly', () => {
+  it('memoizes basic case correctly', async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -72,7 +78,7 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Counter incrementBy={1} />);
-    expect(Scheduler).toFlushAndYield(['Increment', 'Count: 0']);
+    await waitForAll(['Increment', 'Count: 0']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -81,7 +87,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 1']);
+    assertLog(['Increment', 'Count: 1']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -90,7 +96,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
       'Count: 2',
@@ -104,7 +110,7 @@ describe('useEffectEvent', () => {
 
     // Increase the increment prop amount
     ReactNoop.render(<Counter incrementBy={10} />);
-    expect(Scheduler).toFlushAndYield(['Increment', 'Count: 2']);
+    await waitForAll(['Increment', 'Count: 2']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -114,7 +120,7 @@ describe('useEffectEvent', () => {
 
     // Event uses the new prop
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 12']);
+    assertLog(['Increment', 'Count: 12']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -124,7 +130,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it('can be defined more than once', () => {
+  it('can be defined more than once', async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -158,7 +164,7 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Counter incrementBy={5} />);
-    expect(Scheduler).toFlushAndYield(['Increment', 'Count: 0']);
+    await waitForAll(['Increment', 'Count: 0']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -167,7 +173,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 5']);
+    assertLog(['Increment', 'Count: 5']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -176,7 +182,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.multiply);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 25']);
+    assertLog(['Increment', 'Count: 25']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -186,7 +192,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it('does not preserve `this` in event functions', () => {
+  it('does not preserve `this` in event functions', async () => {
     class GreetButton extends React.PureComponent {
       greet = () => {
         this.props.onClick();
@@ -217,7 +223,7 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Greeter hello={'hej'} />);
-    expect(Scheduler).toFlushAndYield(['Say hej', 'Greeting: Seb says hej']);
+    await waitForAll(['Say hej', 'Greeting: Seb says hej']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Say hej" />
@@ -226,10 +232,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.greet);
-    expect(Scheduler).toHaveYielded([
-      'Say hej',
-      'Greeting: undefined says hej',
-    ]);
+    assertLog(['Say hej', 'Greeting: undefined says hej']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Say hej" />
@@ -272,11 +275,11 @@ describe('useEffectEvent', () => {
 
     // If something throws, we try one more time synchronously in case the error was
     // caused by a data race. See recoverFromConcurrentError
-    expect(Scheduler).toHaveYielded(['Count: 0', 'Count: 0']);
+    assertLog(['Count: 0', 'Count: 0']);
   });
 
   // @gate enableUseEffectEventHook
-  it("useLayoutEffect shouldn't re-fire when event handlers change", () => {
+  it("useLayoutEffect shouldn't re-fire when event handlers change", async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -307,8 +310,8 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Counter incrementBy={1} />);
-    expect(Scheduler).toHaveYielded([]);
-    expect(Scheduler).toFlushAndYield([
+    assertLog([]);
+    await waitForAll([
       'Increment',
       'Count: 0',
       'Effect: by 2',
@@ -323,7 +326,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
       'Count: 3',
@@ -336,7 +339,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
       'Count: 4',
@@ -350,7 +353,7 @@ describe('useEffectEvent', () => {
 
     // Increase the increment prop amount
     ReactNoop.render(<Counter incrementBy={10} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Increment',
       'Count: 4',
       'Effect: by 20',
@@ -366,7 +369,7 @@ describe('useEffectEvent', () => {
 
     // Event uses the new prop
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 34']);
+    assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -376,7 +379,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it("useEffect shouldn't re-fire when event handlers change", () => {
+  it("useEffect shouldn't re-fire when event handlers change", async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -407,7 +410,7 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Counter incrementBy={1} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Increment',
       'Count: 0',
       'Effect: by 2',
@@ -422,7 +425,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
       'Count: 3',
@@ -435,7 +438,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
       'Count: 4',
@@ -449,7 +452,7 @@ describe('useEffectEvent', () => {
 
     // Increase the increment prop amount
     ReactNoop.render(<Counter incrementBy={10} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Increment',
       'Count: 4',
       'Effect: by 20',
@@ -465,7 +468,7 @@ describe('useEffectEvent', () => {
 
     // Event uses the new prop
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 34']);
+    assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -475,7 +478,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it('is stable in a custom hook', () => {
+  it('is stable in a custom hook', async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -512,7 +515,7 @@ describe('useEffectEvent', () => {
 
     const button = React.createRef(null);
     ReactNoop.render(<Counter incrementBy={1} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Increment',
       'Count: 0',
       'Effect: by 2',
@@ -527,7 +530,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Effect should not re-run because the dependency hasn't changed.
       'Count: 3',
@@ -540,7 +543,7 @@ describe('useEffectEvent', () => {
     );
 
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded([
+    assertLog([
       'Increment',
       // Event should use the updated callback function closed over the new value.
       'Count: 4',
@@ -554,7 +557,7 @@ describe('useEffectEvent', () => {
 
     // Increase the increment prop amount
     ReactNoop.render(<Counter incrementBy={10} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'Increment',
       'Count: 4',
       'Effect: by 20',
@@ -570,7 +573,7 @@ describe('useEffectEvent', () => {
 
     // Event uses the new prop
     act(button.current.increment);
-    expect(Scheduler).toHaveYielded(['Increment', 'Count: 34']);
+    assertLog(['Increment', 'Count: 34']);
     expect(ReactNoop).toMatchRenderedOutput(
       <>
         <span prop="Increment" />
@@ -580,7 +583,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it('is mutated before all other effects', () => {
+  it('is mutated before all other effects', async () => {
     function Counter({value}) {
       useInsertionEffect(() => {
         Scheduler.unstable_yieldValue('Effect value: ' + value);
@@ -597,14 +600,14 @@ describe('useEffectEvent', () => {
     }
 
     ReactNoop.render(<Counter value={1} />);
-    expect(Scheduler).toFlushAndYield(['Effect value: 1', 'Event value: 1']);
+    await waitForAll(['Effect value: 1', 'Event value: 1']);
 
     act(() => ReactNoop.render(<Counter value={2} />));
-    expect(Scheduler).toHaveYielded(['Effect value: 2', 'Event value: 2']);
+    assertLog(['Effect value: 2', 'Event value: 2']);
   });
 
   // @gate enableUseEffectEventHook
-  it("doesn't provide a stable identity", () => {
+  it("doesn't provide a stable identity", async () => {
     function Counter({shouldRender, value}) {
       const onClick = useEffectEvent(() => {
         Scheduler.unstable_yieldValue(
@@ -627,16 +630,16 @@ describe('useEffectEvent', () => {
     }
 
     ReactNoop.render(<Counter shouldRender={true} value={0} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'onClick, shouldRender=true, value=0',
       'onClick, shouldRender=true, value=0',
     ]);
 
     ReactNoop.render(<Counter shouldRender={true} value={1} />);
-    expect(Scheduler).toFlushAndYield(['onClick, shouldRender=true, value=1']);
+    await waitForAll(['onClick, shouldRender=true, value=1']);
 
     ReactNoop.render(<Counter shouldRender={false} value={2} />);
-    expect(Scheduler).toFlushAndYield([
+    await waitForAll([
       'onClick, shouldRender=false, value=2',
       'onClick, shouldRender=false, value=2',
     ]);
@@ -676,7 +679,7 @@ describe('useEffectEvent', () => {
     await act(async () => {
       root.render(<App value={1} />);
     });
-    expect(Scheduler).toHaveYielded(['Commit new event handler']);
+    assertLog(['Commit new event handler']);
     expect(root).toMatchRenderedOutput('Latest rendered value 1');
     expect(committedEventHandler()).toBe('Value seen by useEffectEvent: 1');
 
@@ -686,14 +689,14 @@ describe('useEffectEvent', () => {
     });
     // No new event handler should be committed, because it was omitted from
     // the dependency array.
-    expect(Scheduler).toHaveYielded([]);
+    assertLog([]);
     // But the event handler should still be able to see the latest value.
     expect(root).toMatchRenderedOutput('Latest rendered value 2');
     expect(committedEventHandler()).toBe('Value seen by useEffectEvent: 2');
   });
 
   // @gate enableUseEffectEventHook
-  it('integration: implements docs chat room example', () => {
+  it('integration: implements docs chat room example', async () => {
     function createConnection() {
       let connectedCallback;
       let timeout;
@@ -738,47 +741,47 @@ describe('useEffectEvent', () => {
     }
 
     act(() => ReactNoop.render(<ChatRoom roomId="general" theme="light" />));
-    expect(Scheduler).toHaveYielded(['Welcome to the general room!']);
+    assertLog(['Welcome to the general room!']);
     expect(ReactNoop).toMatchRenderedOutput(
       <span prop="Welcome to the general room!" />,
     );
 
     jest.advanceTimersByTime(100);
     Scheduler.unstable_advanceTime(100);
-    expect(Scheduler).toHaveYielded(['Connected! theme: light']);
+    assertLog(['Connected! theme: light']);
 
     // change roomId only
     act(() => ReactNoop.render(<ChatRoom roomId="music" theme="light" />));
-    expect(Scheduler).toHaveYielded(['Welcome to the music room!']);
+    assertLog(['Welcome to the music room!']);
     expect(ReactNoop).toMatchRenderedOutput(
       <span prop="Welcome to the music room!" />,
     );
     jest.advanceTimersByTime(100);
     Scheduler.unstable_advanceTime(100);
     // should trigger a reconnect
-    expect(Scheduler).toHaveYielded(['Connected! theme: light']);
+    assertLog(['Connected! theme: light']);
 
     // change theme only
     act(() => ReactNoop.render(<ChatRoom roomId="music" theme="dark" />));
-    expect(Scheduler).toHaveYielded(['Welcome to the music room!']);
+    assertLog(['Welcome to the music room!']);
     expect(ReactNoop).toMatchRenderedOutput(
       <span prop="Welcome to the music room!" />,
     );
     jest.advanceTimersByTime(100);
     Scheduler.unstable_advanceTime(100);
     // should not trigger a reconnect
-    expect(Scheduler).toFlushWithoutYielding();
+    await waitForAll([]);
 
     // change roomId only
     act(() => ReactNoop.render(<ChatRoom roomId="travel" theme="dark" />));
-    expect(Scheduler).toHaveYielded(['Welcome to the travel room!']);
+    assertLog(['Welcome to the travel room!']);
     expect(ReactNoop).toMatchRenderedOutput(
       <span prop="Welcome to the travel room!" />,
     );
     jest.advanceTimersByTime(100);
     Scheduler.unstable_advanceTime(100);
     // should trigger a reconnect
-    expect(Scheduler).toHaveYielded(['Connected! theme: dark']);
+    assertLog(['Connected! theme: dark']);
   });
 
   // @gate enableUseEffectEventHook
@@ -837,12 +840,9 @@ describe('useEffectEvent', () => {
         </AppShell>,
       ),
     );
-    expect(Scheduler).toHaveYielded([
-      'Add to cart',
-      'url: /shop/1, numberOfItems: 0',
-    ]);
+    assertLog(['Add to cart', 'url: /shop/1, numberOfItems: 0']);
     act(button.current.addToCart);
-    expect(Scheduler).toHaveYielded(['Add to cart']);
+    assertLog(['Add to cart']);
 
     act(() =>
       ReactNoop.render(
@@ -851,9 +851,6 @@ describe('useEffectEvent', () => {
         </AppShell>,
       ),
     );
-    expect(Scheduler).toHaveYielded([
-      'Add to cart',
-      'url: /shop/2, numberOfItems: 1',
-    ]);
+    assertLog(['Add to cart', 'url: /shop/2, numberOfItems: 1']);
   });
 });


### PR DESCRIPTION
This converts some of our test suite to use the `waitFor` test pattern, instead of the `expect(Scheduler).toFlushAndYield` pattern. Most of these changes are automated with jscodeshift, with some slight manual cleanup in certain cases.

See #26285 for full context.