### PR TITLE
Codemod tests to waitFor pattern (9/?)

### DIFF
--- a/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
+++ b/packages/react-cache/src/__tests__/ReactCacheOld-test.internal.js
@@ -20,6 +20,7 @@ let TextResource;
 let textResourceShouldFail;
 let waitForAll;
 let assertLog;
+let waitForThrow;
 
 describe('ReactCache', () => {
   beforeEach(() => {
@@ -38,6 +39,7 @@ describe('ReactCache', () => {
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
     assertLog = InternalTestUtils.assertLog;
+    waitForThrow = InternalTestUtils.waitForThrow;
 
     TextResource = createResource(
       ([text, ms = 0]) => {
@@ -150,12 +152,12 @@ describe('ReactCache', () => {
     jest.advanceTimersByTime(100);
     assertLog(['Promise rejected [Hi]']);
 
-    expect(Scheduler).toFlushAndThrow('Failed to load: Hi');
+    await waitForThrow('Failed to load: Hi');
     assertLog(['Error! [Hi]', 'Error! [Hi]']);
 
     // Should throw again on a subsequent read
     root.update(<App />);
-    expect(Scheduler).toFlushAndThrow('Failed to load: Hi');
+    await waitForThrow('Failed to load: Hi');
     assertLog(['Error! [Hi]', 'Error! [Hi]']);
   });
 

--- a/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
+++ b/packages/react-dom/src/__tests__/ReactDOMFloat-test.js
@@ -4398,7 +4398,7 @@ background-color: green;
           </body>
         </html>,
       );
-      expect(Scheduler).toFlushWithoutYielding();
+      await waitForAll([]);
       expect(getMeaningfulChildren(document)).toEqual(
         <html>
           <head>

--- a/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
+++ b/packages/react-dom/src/__tests__/ReactDeprecationWarnings-test.js
@@ -11,7 +11,6 @@
 
 let React;
 let ReactNoop;
-let Scheduler;
 let JSXDEVRuntime;
 let waitForAll;
 
@@ -20,7 +19,6 @@ describe('ReactDeprecationWarnings', () => {
     jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
     if (__DEV__) {
@@ -28,7 +26,7 @@ describe('ReactDeprecationWarnings', () => {
     }
   });
 
-  it('should warn when given defaultProps', () => {
+  it('should warn when given defaultProps', async () => {
     function FunctionalComponent(props) {
       return null;
     }
@@ -38,14 +36,14 @@ describe('ReactDeprecationWarnings', () => {
     };
 
     ReactNoop.render(<FunctionalComponent />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Warning: FunctionalComponent: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
     );
   });
 
-  it('should warn when given defaultProps on a memoized function', () => {
+  it('should warn when given defaultProps on a memoized function', async () => {
     const MemoComponent = React.memo(function FunctionalComponent(props) {
       return null;
     });
@@ -59,14 +57,14 @@ describe('ReactDeprecationWarnings', () => {
         <MemoComponent />
       </div>,
     );
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Warning: FunctionalComponent: Support for defaultProps ' +
         'will be removed from memo components in a future major ' +
         'release. Use JavaScript default parameters instead.',
     );
   });
 
-  it('should warn when given string refs', () => {
+  it('should warn when given string refs', async () => {
     class RefComponent extends React.Component {
       render() {
         return null;
@@ -79,7 +77,7 @@ describe('ReactDeprecationWarnings', () => {
     }
 
     ReactNoop.render(<Component />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Warning: Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'We recommend using useRef() or createRef() instead. ' +
@@ -108,7 +106,7 @@ describe('ReactDeprecationWarnings', () => {
     await waitForAll([]);
   });
 
-  it('should warn when owner and self are different for string refs', () => {
+  it('should warn when owner and self are different for string refs', async () => {
     class RefComponent extends React.Component {
       render() {
         return null;
@@ -121,7 +119,7 @@ describe('ReactDeprecationWarnings', () => {
     }
 
     ReactNoop.render(<Component />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
+    await expect(async () => await waitForAll([])).toErrorDev([
       'Warning: Component "Component" contains the string ref "refComponent". ' +
         'Support for string refs will be removed in a future major release. ' +
         'This case cannot be automatically converted to an arrow function. ' +
@@ -132,7 +130,7 @@ describe('ReactDeprecationWarnings', () => {
   });
 
   if (__DEV__) {
-    it('should warn when owner and self are different for string refs', () => {
+    it('should warn when owner and self are different for string refs', async () => {
       class RefComponent extends React.Component {
         render() {
           return null;
@@ -152,7 +150,7 @@ describe('ReactDeprecationWarnings', () => {
       }
 
       ReactNoop.render(<Component />);
-      expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+      await expect(async () => await waitForAll([])).toErrorDev(
         'Warning: Component "Component" contains the string ref "refComponent". ' +
           'Support for string refs will be removed in a future major release. ' +
           'This case cannot be automatically converted to an arrow function. ' +

--- a/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactDisableSchedulerTimeoutBasedOnReactExpirationTime-test.internal.js
@@ -6,6 +6,7 @@ let Suspense;
 let scheduleCallback;
 let NormalPriority;
 let waitForAll;
+let waitFor;
 
 describe('ReactSuspenseList', () => {
   beforeEach(() => {
@@ -24,6 +25,7 @@ describe('ReactSuspenseList', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
+    waitFor = InternalTestUtils.waitFor;
   });
 
   function Text(props) {
@@ -86,11 +88,11 @@ describe('ReactSuspenseList', () => {
     });
 
     // This resolves A and schedules a task for React to retry.
-    await expect(Scheduler).toFlushAndYieldThrough(['Resolve A']);
+    await waitFor(['Resolve A']);
 
     // The next task that flushes should be the one that resolves B. The render
     // task should not jump the queue ahead of B.
-    await expect(Scheduler).toFlushAndYieldThrough(['Resolve B']);
+    await waitFor(['Resolve B']);
 
     await waitForAll(['A', 'B']);
     expect(root).toMatchRenderedOutput('AB');

--- a/packages/react-reconciler/src/__tests__/ReactFragment-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactFragment-test.js
@@ -11,7 +11,6 @@
 
 let React;
 let ReactNoop;
-let Scheduler;
 let waitForAll;
 
 describe('ReactFragment', () => {
@@ -20,7 +19,6 @@ describe('ReactFragment', () => {
 
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
 
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
@@ -707,7 +705,7 @@ describe('ReactFragment', () => {
     );
   });
 
-  it('should not preserve state when switching to a keyed fragment to an array', async function () {
+  it('should not preserve state when switching to a keyed fragment to an array', async () => {
     const ops = [];
 
     class Stateful extends React.Component {
@@ -742,7 +740,7 @@ describe('ReactFragment', () => {
     await waitForAll([]);
 
     ReactNoop.render(<Foo condition={false} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 
@@ -939,7 +937,7 @@ describe('ReactFragment', () => {
     }
 
     ReactNoop.render(<Foo condition={true} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Each child in a list should have a unique "key" prop.',
     );
 

--- a/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncremental-test.js
@@ -1896,7 +1896,7 @@ describe('ReactIncremental', () => {
   });
 
   if (!require('shared/ReactFeatureFlags').disableModulePatternComponents) {
-    it('does not leak own context into context provider (factory components)', () => {
+    it('does not leak own context into context provider (factory components)', async () => {
       function Recurse(props, context) {
         return {
           getChildContext() {
@@ -1919,13 +1919,14 @@ describe('ReactIncremental', () => {
       };
 
       ReactNoop.render(<Recurse />);
-      expect(() =>
-        expect(Scheduler).toFlushAndYield([
-          'Recurse {}',
-          'Recurse {"n":2}',
-          'Recurse {"n":1}',
-          'Recurse {"n":0}',
-        ]),
+      await expect(
+        async () =>
+          await waitForAll([
+            'Recurse {}',
+            'Recurse {"n":2}',
+            'Recurse {"n":1}',
+            'Recurse {"n":0}',
+          ]),
       ).toErrorDev([
         'Warning: The <Recurse /> component appears to be a function component that returns a class instance. ' +
           'Change Recurse to a class that extends React.Component instead. ' +
@@ -2281,7 +2282,7 @@ describe('ReactIncremental', () => {
     instance.setState({
       throwError: true,
     });
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Error boundaries should implement getDerivedStateFromError()',
     );
   });

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorLogging-test.js
@@ -14,6 +14,7 @@ let React;
 let ReactNoop;
 let Scheduler;
 let waitForAll;
+let waitForThrow;
 
 describe('ReactIncrementalErrorLogging', () => {
   beforeEach(() => {
@@ -24,6 +25,7 @@ describe('ReactIncrementalErrorLogging', () => {
 
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
+    waitForThrow = InternalTestUtils.waitForThrow;
   });
 
   // Note: in this test file we won't be using toErrorDev() matchers
@@ -39,7 +41,7 @@ describe('ReactIncrementalErrorLogging', () => {
     oldConsoleError = null;
   });
 
-  it('should log errors that occur during the begin phase', () => {
+  it('should log errors that occur during the begin phase', async () => {
     class ErrorThrowingComponent extends React.Component {
       constructor(props) {
         super(props);
@@ -56,7 +58,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(Scheduler).toFlushAndThrow('constructor error');
+    await waitForThrow('constructor error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -76,7 +78,7 @@ describe('ReactIncrementalErrorLogging', () => {
     );
   });
 
-  it('should log errors that occur during the commit phase', () => {
+  it('should log errors that occur during the commit phase', async () => {
     class ErrorThrowingComponent extends React.Component {
       componentDidMount() {
         throw new Error('componentDidMount error');
@@ -92,7 +94,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(Scheduler).toFlushAndThrow('componentDidMount error');
+    await waitForThrow('componentDidMount error');
     expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenCalledWith(
       __DEV__
@@ -112,7 +114,7 @@ describe('ReactIncrementalErrorLogging', () => {
     );
   });
 
-  it('should ignore errors thrown in log method to prevent cycle', () => {
+  it('should ignore errors thrown in log method to prevent cycle', async () => {
     const logCapturedErrorCalls = [];
     console.error.mockImplementation(error => {
       // Test what happens when logging itself is buggy.
@@ -131,7 +133,7 @@ describe('ReactIncrementalErrorLogging', () => {
         </span>
       </div>,
     );
-    expect(Scheduler).toFlushAndThrow('render error');
+    await waitForThrow('render error');
     expect(logCapturedErrorCalls.length).toBe(1);
     expect(logCapturedErrorCalls[0]).toEqual(
       __DEV__

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalErrorReplay-test.js
@@ -12,23 +12,23 @@
 
 let React;
 let ReactNoop;
-let Scheduler;
 let waitForAll;
+let waitForThrow;
 
 describe('ReactIncrementalErrorReplay', () => {
   beforeEach(() => {
     jest.resetModules();
     React = require('react');
     ReactNoop = require('react-noop-renderer');
-    Scheduler = require('scheduler');
 
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
+    waitForThrow = InternalTestUtils.waitForThrow;
   });
 
-  it('should fail gracefully on error in the host environment', () => {
+  it('should fail gracefully on error in the host environment', async () => {
     ReactNoop.render(<errorInBeginPhase />);
-    expect(Scheduler).toFlushAndThrow('Error in host config.');
+    await waitForThrow('Error in host config.');
   });
 
   it("should ignore error if it doesn't throw on retry", async () => {

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalSideEffects-test.js
@@ -1296,7 +1296,7 @@ describe('ReactIncrementalSideEffects', () => {
     }
 
     ReactNoop.render(<Foo show={true} />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev(
+    await expect(async () => await waitForAll([])).toErrorDev(
       'Warning: Function components cannot be given refs. ' +
         'Attempts to access this ref will fail. ' +
         'Did you mean to use React.forwardRef()?\n\n' +

--- a/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactIncrementalUpdates-test.js
@@ -421,27 +421,28 @@ describe('ReactIncrementalUpdates', () => {
       return {a: 'a'};
     });
 
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(
-        gate(flags =>
-          flags.deferRenderPhaseUpdateToNextBatch
-            ? [
-                'setState updater',
-                // In the new reconciler, updates inside the render phase are
-                // treated as if they came from an event, so the update gets
-                // shifted to a subsequent render.
-                'render',
-                'render',
-              ]
-            : [
-                'setState updater',
-                // In the old reconciler, updates in the render phase receive
-                // the currently rendering expiration time, so the update
-                // flushes immediately in the same render.
-                'render',
-              ],
+    await expect(
+      async () =>
+        await waitForAll(
+          gate(flags =>
+            flags.deferRenderPhaseUpdateToNextBatch
+              ? [
+                  'setState updater',
+                  // In the new reconciler, updates inside the render phase are
+                  // treated as if they came from an event, so the update gets
+                  // shifted to a subsequent render.
+                  'render',
+                  'render',
+                ]
+              : [
+                  'setState updater',
+                  // In the old reconciler, updates in the render phase receive
+                  // the currently rendering expiration time, so the update
+                  // flushes immediately in the same render.
+                  'render',
+                ],
+          ),
         ),
-      ),
     ).toErrorDev(
       'An update (setState, replaceState, or forceUpdate) was scheduled ' +
         'from inside an update function. Update functions should be pure, ' +

--- a/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/ReactLazy-test.internal.js
@@ -314,7 +314,7 @@ describe('ReactLazy', () => {
 
     await resolveFakeImport(T);
 
-    expect(() => expect(Scheduler).toFlushAndYield(['Hi'])).toErrorDev(
+    await expect(async () => await waitForAll(['Hi'])).toErrorDev(
       'Warning: T: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
@@ -369,8 +369,8 @@ describe('ReactLazy', () => {
 
     await resolveFakeImport(LazyImpl);
 
-    expect(() =>
-      expect(Scheduler).toFlushAndYield(['Lazy', 'Sibling', 'A']),
+    await expect(
+      async () => await waitForAll(['Lazy', 'Sibling', 'A']),
     ).toErrorDev(
       'Warning: LazyImpl: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
@@ -676,7 +676,7 @@ describe('ReactLazy', () => {
     expect(root).not.toMatchRenderedOutput('Hi Bye');
 
     await resolveFakeImport(T);
-    expect(() => expect(Scheduler).toFlushAndYield(['Hi Bye'])).toErrorDev(
+    await expect(async () => await waitForAll(['Hi Bye'])).toErrorDev(
       'Warning: T: Support for defaultProps ' +
         'will be removed from function components in a future major ' +
         'release. Use JavaScript default parameters instead.',
@@ -721,7 +721,7 @@ describe('ReactLazy', () => {
         <BadLazy />
       </Suspense>,
     );
-    expect(Scheduler).toFlushAndThrow(
+    await waitForThrow(
       'Element type is invalid. Received a promise that resolves to: 42. ' +
         'Lazy element type must resolve to a class or function.',
     );
@@ -749,7 +749,7 @@ describe('ReactLazy', () => {
         <Lazy2 text="Hello" />
       </Suspense>,
     );
-    expect(Scheduler).toFlushAndThrow(
+    await waitForThrow(
       'Element type is invalid. Received a promise that resolves to: [object Object]. ' +
         'Lazy element type must resolve to a class or function.' +
         (__DEV__

--- a/packages/react-reconciler/src/__tests__/ReactMemo-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactMemo-test.js
@@ -58,7 +58,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
+    await expect(async () => await waitForAll([])).toErrorDev([
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',
     ]);
@@ -76,7 +76,7 @@ describe('memo', () => {
       return <App ref={() => {}} />;
     }
     ReactNoop.render(<Outer />);
-    expect(() => expect(Scheduler).toFlushWithoutYielding()).toErrorDev([
+    await expect(async () => await waitForAll([])).toErrorDev([
       'App: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.',
       'Warning: Function components cannot be given refs. Attempts to access ' +
         'this ref will fail.',

--- a/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
+++ b/packages/react-reconciler/src/__tests__/ReactTransitionTracing-test.js
@@ -1395,12 +1395,13 @@ describe('ReactInteractionTracing', () => {
       root.render(<App navigate={true} markerName="marker two" />);
       ReactNoop.expire(1000);
       await advanceTimers(1000);
-      expect(() =>
-        expect(Scheduler).toFlushAndYield([
-          'Suspend [Page Two]',
-          'Loading...',
-          'onMarkerIncomplete(transition one, marker one, 1000, [{endTime: 3000, name: marker one, newName: marker two, type: marker}])',
-        ]),
+      await expect(
+        async () =>
+          await waitForAll([
+            'Suspend [Page Two]',
+            'Loading...',
+            'onMarkerIncomplete(transition one, marker one, 1000, [{endTime: 3000, name: marker one, newName: marker two, type: marker}])',
+          ]),
       ).toErrorDev('');
 
       resolveText('Page Two');

--- a/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
+++ b/packages/react-reconciler/src/__tests__/useEffectEvent-test.js
@@ -28,6 +28,7 @@ describe('useEffectEvent', () => {
   let useMemo;
   let waitForAll;
   let assertLog;
+  let waitForThrow;
 
   beforeEach(() => {
     React = require('react');
@@ -46,6 +47,7 @@ describe('useEffectEvent', () => {
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
     assertLog = InternalTestUtils.assertLog;
+    waitForThrow = InternalTestUtils.waitForThrow;
   });
 
   function Text(props) {
@@ -242,7 +244,7 @@ describe('useEffectEvent', () => {
   });
 
   // @gate enableUseEffectEventHook
-  it('throws when called in render', () => {
+  it('throws when called in render', async () => {
     class IncrementButton extends React.PureComponent {
       increment = () => {
         this.props.onClick();
@@ -269,7 +271,7 @@ describe('useEffectEvent', () => {
     }
 
     ReactNoop.render(<Counter incrementBy={1} />);
-    expect(Scheduler).toFlushAndThrow(
+    await waitForThrow(
       "A function wrapped in useEffectEvent can't be called during rendering.",
     );
 

--- a/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
+++ b/packages/react-reconciler/src/__tests__/useMutableSource-test.internal.js
@@ -1518,16 +1518,14 @@ describe('useMutableSource', () => {
     }
 
     const root = ReactNoop.createRoot();
-    await act(async () => {
-      root.render(
-        <>
-          <Read />
-        </>,
-      );
-      expect(() => expect(Scheduler).toFlushAndYield(['a'])).toErrorDev(
-        'Mutable source should not return a function as the snapshot value.',
-      );
-    });
+    root.render(
+      <>
+        <Read />
+      </>,
+    );
+    await expect(async () => await waitForAll(['a'])).toErrorDev(
+      'Mutable source should not return a function as the snapshot value.',
+    );
     expect(root).toMatchRenderedOutput('a');
   });
 

--- a/packages/react/src/__tests__/ReactProfiler-test.internal.js
+++ b/packages/react/src/__tests__/ReactProfiler-test.internal.js
@@ -20,6 +20,7 @@ let AdvanceTime;
 let assertLog;
 let waitFor;
 let waitForAll;
+let waitForThrow;
 
 function loadModules({
   enableProfilerTimer = true,
@@ -56,6 +57,7 @@ function loadModules({
   assertLog = InternalTestUtils.assertLog;
   waitFor = InternalTestUtils.waitFor;
   waitForAll = InternalTestUtils.waitForAll;
+  waitForThrow = InternalTestUtils.waitForThrow;
 
   AdvanceTime = class extends React.Component {
     static defaultProps = {
@@ -1230,7 +1232,7 @@ describe(`onRender`, () => {
               <errorInCompletePhase>hi</errorInCompletePhase>
             </React.Profiler>,
           );
-          expect(Scheduler).toFlushAndThrow('Error in host config.');
+          await waitForThrow('Error in host config.');
 
           // A similar case we've seen caused by an invariant in ReactDOM.
           // It didn't reproduce without a host component inside.
@@ -1241,7 +1243,7 @@ describe(`onRender`, () => {
               </errorInCompletePhase>
             </React.Profiler>,
           );
-          expect(Scheduler).toFlushAndThrow('Error in host config.');
+          await waitForThrow('Error in host config.');
 
           // So long as the profiler timer's fiber stack is reset correctly,
           // Subsequent renders should not error.

--- a/packages/scheduler/src/__tests__/SchedulerMock-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerMock-test.js
@@ -144,7 +144,8 @@ describe('Scheduler', () => {
     assertLog([]);
 
     Scheduler.unstable_advanceTime(1);
-    expect(Scheduler).toFlushExpired(['A']);
+    Scheduler.unstable_flushExpired();
+    assertLog(['A']);
   });
 
   it('continues working on same task after yielding', async () => {
@@ -221,7 +222,8 @@ describe('Scheduler', () => {
 
     // Advance time by just a bit more. This should expire all the remaining work.
     Scheduler.unstable_advanceTime(1);
-    expect(Scheduler).toFlushExpired(['C', 'D']);
+    Scheduler.unstable_flushExpired();
+    assertLog(['C', 'D']);
   });
 
   it('continuations are interrupted by higher priority work', async () => {
@@ -326,7 +328,8 @@ describe('Scheduler', () => {
     // Immediate callback hasn't fired, yet.
     assertLog([]);
     // They all flush immediately within the subsequent task.
-    expect(Scheduler).toFlushExpired(['A', 'B', 'C', 'D']);
+    Scheduler.unstable_flushExpired();
+    assertLog(['A', 'B', 'C', 'D']);
   });
 
   it('nested immediate callbacks are added to the queue of immediate callbacks', () => {
@@ -345,7 +348,8 @@ describe('Scheduler', () => {
     );
     assertLog([]);
     // C should flush at the end
-    expect(Scheduler).toFlushExpired(['A', 'B', 'D', 'C']);
+    Scheduler.unstable_flushExpired();
+    assertLog(['A', 'B', 'D', 'C']);
   });
 
   it('wrapped callbacks have same signature as original callback', () => {
@@ -410,12 +414,12 @@ describe('Scheduler', () => {
       throw new Error('Oops C');
     });
 
-    expect(() => expect(Scheduler).toFlushExpired()).toThrow('Oops A');
+    expect(() => Scheduler.unstable_flushExpired()).toThrow('Oops A');
     assertLog(['A']);
 
     // B and C flush in a subsequent event. That way, the second error is not
     // swallowed.
-    expect(() => expect(Scheduler).toFlushExpired()).toThrow('Oops C');
+    expect(() => Scheduler.unstable_flushExpired()).toThrow('Oops C');
     assertLog(['B', 'C']);
   });
 

--- a/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
+++ b/packages/scheduler/src/__tests__/SchedulerProfiling-test.js
@@ -26,6 +26,7 @@ let cancelCallback;
 // let shouldYield;
 let waitForAll;
 let waitFor;
+let waitForThrow;
 
 function priorityLevelToString(priorityLevel) {
   switch (priorityLevel) {
@@ -75,6 +76,7 @@ describe('Scheduler', () => {
     const InternalTestUtils = require('internal-test-utils');
     waitForAll = InternalTestUtils.waitForAll;
     waitFor = InternalTestUtils.waitFor;
+    waitForThrow = InternalTestUtils.waitForThrow;
   });
 
   const TaskStartEvent = 1;
@@ -335,7 +337,7 @@ Task 1 [Normal]              │██████░░🡐 canceled
       throw Error('Oops');
     });
 
-    expect(Scheduler).toFlushAndThrow('Oops');
+    await waitForThrow('Oops');
     Scheduler.unstable_advanceTime(100);
 
     Scheduler.unstable_advanceTime(1000);


### PR DESCRIPTION
This converts some of our test suite to use the `waitFor` test pattern, instead of the `expect(Scheduler).toFlushAndYield` pattern. Most of these changes are automated with jscodeshift, with some slight manual cleanup in certain cases.

See #26285 for full context.