### PR TITLE
Refactor ReactFabricHostComponent

### DIFF
--- a/packages/react-native-renderer/src/NativeMethodsMixinUtils.js
+++ b/packages/react-native-renderer/src/NativeMethodsMixinUtils.js
@@ -45,26 +45,6 @@ export function mountSafeCallback_NOT_REALLY_SAFE(
   };
 }
 
-export function throwOnStylesProp(component: any, props: any) {
-  if (props.styles !== undefined) {
-    const owner = component._owner || null;
-    const name = component.constructor.displayName;
-    let msg =
-      '`styles` is not a supported property of `' +
-      name +
-      '`, did ' +
-      'you mean `style` (singular)?';
-    if (owner && owner.constructor && owner.constructor.displayName) {
-      msg +=
-        '\n\nCheck the `' +
-        owner.constructor.displayName +
-        '` parent ' +
-        ' component.';
-    }
-    throw new Error(msg);
-  }
-}
-
 export function warnForStyleProps(props: any, validAttributes: any) {
   if (__DEV__) {
     for (const key in validAttributes.style) {

--- a/packages/react-native-renderer/src/ReactFabric.js
+++ b/packages/react-native-renderer/src/ReactFabric.js
@@ -122,6 +122,7 @@ export {
 };
 
 injectIntoDevTools({
+  // $FlowExpectedError[incompatible-call] The type of `Instance` in `getClosestInstanceFromNode` does not match in Fabric and the legacy renderer, so it fails to typecheck here.
   findFiberByHostInstance: getClosestInstanceFromNode,
   bundleType: __DEV__ ? 1 : 0,
   version: ReactVersion,

--- a/packages/react-native-renderer/src/ReactFabricComponentTree.js
+++ b/packages/react-native-renderer/src/ReactFabricComponentTree.js
@@ -3,28 +3,44 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
  */
 
-function getInstanceFromInstance(instanceHandle) {
-  return instanceHandle;
+import type {
+  PublicInstance,
+  Instance,
+  Props,
+  TextInstance,
+} from './ReactFabricHostConfig';
+import type {Fiber} from 'react-reconciler/src/ReactInternalTypes';
+import {getPublicInstance} from './ReactFabricHostConfig';
+
+// `node` is typed incorrectly here. The proper type should be `PublicInstance`.
+// This is ok in DOM because they types are interchangeable, but in React Native
+// they aren't.
+function getInstanceFromNode(node: Instance | TextInstance): Fiber | null {
+  // $FlowFixMe[incompatible-return] DevTools incorrectly passes a fiber in React Native.
+  return node;
 }
 
-function getTagFromInstance(inst) {
-  const nativeInstance = inst.stateNode.canonical;
+function getNodeFromInstance(fiber: Fiber): PublicInstance {
+  const publicInstance = getPublicInstance(fiber.stateNode);
 
-  if (!nativeInstance._nativeTag) {
-    throw new Error('All native instances should have a tag.');
+  if (publicInstance == null) {
+    throw new Error('Could not find host instance from fiber');
   }
 
-  return nativeInstance;
+  return publicInstance;
+}
+
+function getFiberCurrentPropsFromNode(instance: Instance): Props {
+  return instance.canonical.currentProps;
 }
 
 export {
-  getInstanceFromInstance as getClosestInstanceFromNode,
-  getInstanceFromInstance as getInstanceFromNode,
-  getTagFromInstance as getNodeFromInstance,
+  getInstanceFromNode,
+  getInstanceFromNode as getClosestInstanceFromNode,
+  getNodeFromInstance,
+  getFiberCurrentPropsFromNode,
 };
-
-export function getFiberCurrentPropsFromNode(inst) {
-  return inst.canonical.currentProps;
-}

--- a/packages/react-native-renderer/src/ReactFabricEventEmitter.js
+++ b/packages/react-native-renderer/src/ReactFabricEventEmitter.js
@@ -29,6 +29,7 @@ import getListener from './ReactNativeGetListener';
 import {runEventsInBatch} from './legacy-events/EventBatching';
 
 import {RawEventEmitter} from 'react-native/Libraries/ReactPrivate/ReactNativePrivateInterface';
+import {getPublicInstance} from './ReactFabricHostConfig';
 
 export {getListener, registrationNameModules as registrationNames};
 
@@ -92,7 +93,8 @@ export function dispatchEvent(
     const stateNode = targetFiber.stateNode;
     // Guard against Fiber being unmounted
     if (stateNode != null) {
-      eventTarget = stateNode.canonical;
+      // $FlowExpectedError[incompatible-cast] public instances in Fabric do not implement `EventTarget` yet.
+      eventTarget = (getPublicInstance(stateNode): EventTarget);
     }
   }
 

--- a/packages/react-native-renderer/src/ReactNativeTypes.js
+++ b/packages/react-native-renderer/src/ReactNativeTypes.js
@@ -218,18 +218,6 @@ export type ReactFabricType = {
   ...
 };
 
-export type ReactNativeEventTarget = {
-  node: {...},
-  canonical: {
-    _nativeTag: number,
-    viewConfig: ViewConfig,
-    currentProps: {...},
-    _internalInstanceHandle: {...},
-    ...
-  },
-  ...
-};
-
 export type ReactFabricEventTouch = {
   identifier: number,
   locationX: number,


### PR DESCRIPTION
## Summary

This is a small refactor of `ReactFabricHostComponent` to remove unnecessary dependencies, unused methods and type definitions to simplify a larger refactor of the class in a following PR (https://github.com/facebook/react/pull/26321).

## How did you test this change?

Existing unit tests.