### PR TITLE
Build: make version in build artifacts match

### DIFF
--- a/scripts/rollup/build-all-release-channels.js
+++ b/scripts/rollup/build-all-release-channels.js
@@ -332,7 +332,7 @@ function updatePlaceholderReactVersionInCompiledArtifacts(
 
   for (const artifactFilename of artifactFilenames) {
     const originalText = fs.readFileSync(artifactFilename, 'utf8');
-    const replacedText = originalText.replace(
+    const replacedText = originalText.replaceAll(
       PLACEHOLDER_REACT_VERSION,
       newVersion
     );


### PR DESCRIPTION
Some build artifacts contain multiple version strings. It seems like an oversight to me that this `.replace` call just replaces the one that happens to be first.