### PR TITLE
Codesandbox: upgrade to Node.js 18

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/react", "packages/react-dom", "packages/scheduler"],
   "buildCommand": "download-build-in-codesandbox-ci",
-  "node": "14",
+  "node": "18",
   "publishDirectory": {
     "react": "build/oss-experimental/react",
     "react-dom": "build/oss-experimental/react-dom",


### PR DESCRIPTION
Turns out Codesandbox didn't support `String.prototype.replaceAll` in PR.

This updates the config to use Node.js 18 for Codesandbox builds.