### PR TITLE
Use content hash for facebook-www builds

### DIFF
--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -123,6 +123,9 @@ jobs:
             ./compiled/babel-plugin-react-refresh/index.js
 
           ls -R ./compiled
+      - name: Add REVISION file
+        run: |
+          echo ${{ github.sha }} >> ./compiled/facebook-www/REVISION
       - uses: actions/upload-artifact@v3
         with:
           name: compiled
@@ -142,6 +145,12 @@ jobs:
           name: compiled
           path: compiled/
       - run: git status -u
+      - name: Abort if only REVISION file changed
+        run: |
+          if [[ $(git status -u --porcelain | wc -l) -eq 1 && $(git status -u --porcelain | grep REVISION) ]]; then
+            echo "Only REVISION file changed. Aborting."
+            circleci-agent step halt
+          fi
       - name: Commit changes to branch
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -145,13 +145,16 @@ jobs:
           name: compiled
           path: compiled/
       - run: git status -u
-      - name: Abort if only REVISION file changed
+      - name: Check if only the REVISION file has changed
+        id: check_should_commit
         run: |
-          if [[ $(git status -u --porcelain | wc -l) -eq 1 && $(git status -u --porcelain | grep REVISION) ]]; then
-            echo "Only REVISION file changed. Aborting."
-            circleci-agent step halt
+          if git status --porcelain | grep -qv '/REVISION$'; then
+            echo "should_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_commit=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit changes to branch
+        if: steps.check_should_commit.outputs.should_commit == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: |

--- a/.github/workflows/commit_artifacts.yml
+++ b/.github/workflows/commit_artifacts.yml
@@ -123,10 +123,6 @@ jobs:
             ./compiled/babel-plugin-react-refresh/index.js
 
           ls -R ./compiled
-      - name: Add REVISION files
-        run: |
-          echo ${{ github.sha }} >> ./compiled/facebook-www/REVISION
-          cp ./compiled/facebook-www/REVISION ./compiled/facebook-www/REVISION_TRANSFORMS
       - uses: actions/upload-artifact@v3
         with:
           name: compiled


### PR DESCRIPTION
Currently, any commit to React causes an internal sync since the Git commit hash is part of the build. This creates a lot more sync commits and noise than necessary, see: https://github.com/facebook/react/commits/builds/facebook-www

This PR changes the version string to be a hash of the target build files instead. This way we get a new version with any change that actually impacts the generated files and still have a matching version across the files.

A downside is that the internal React upgrade command can no longer print a changelog, but I don't think folks have been using that since using diff train. (If this PR is approved, I'll update the internal command to no longer depend on the `REVISIONS` file).