### PR TITLE
Tests for useInsertionEffect's behavior in strict mode.

### DIFF
--- a/packages/react-reconciler/src/ReactFiberFlags.js
+++ b/packages/react-reconciler/src/ReactFiberFlags.js
@@ -11,6 +11,63 @@ import {enableCreateEventHandleAPI} from 'shared/ReactFeatureFlags';
 
 export type Flags = number;
 
+export const listFlags = (inputFlag: Flags): string[] => {
+  if (__DEV__) {
+    const list = [];
+    const flags = [
+      [NoFlags, 'NoFlags'],
+      [PerformedWork, 'PerformedWork'],
+      [Placement, 'Placement'],
+      [DidCapture, 'DidCapture'],
+      [Hydrating, 'Hydrating'],
+      [Update, 'Update'],
+      [ChildDeletion, 'ChildDeletion'],
+      [ContentReset, 'ContentReset'],
+      [Callback, 'Callback'],
+      [ForceClientRender, 'ForceClientRender'],
+      [Ref, 'Ref'],
+      [Snapshot, 'Snapshot'],
+      [Passive, 'Passive'],
+      [Visibility, 'Visibility'],
+      [StoreConsistency, 'StoreConsistency'],
+      [HostEffectMask, 'HostEffectMask'],
+      [Incomplete, 'Incomplete'],
+      [ShouldCapture, 'ShouldCapture'],
+      [ForceUpdateForLegacySuspense, 'ForceUpdateForLegacySuspense'],
+      [DidPropagateContext, 'DidPropagateContext'],
+      [NeedsPropagation, 'NeedsPropagation'],
+      [Forked, 'Forked'],
+      [RefStatic, 'RefStatic'],
+      [LayoutStatic, 'LayoutStatic'],
+      [PassiveStatic, 'PassiveStatic'],
+      [PlacementDEV, 'PlacementDEV'],
+      [MountLayoutDev, 'MountLayoutDev'],
+      [MountPassiveDev, 'MountPassiveDev'],
+      [MountInsertionDev, 'MountInsertionDev'],
+    ];
+    flags.forEach(flag => {
+      if (flag[0] & inputFlag) {
+        list.push(flag[1]);
+        inputFlag &= ~flag[0];
+      }
+    });
+    if (inputFlag !== NoFlags) {
+      list.push('Unknown flag: ' + inputFlag);
+    }
+    return list;
+  } else {
+    return [];
+  }
+};
+
+export function prettyFlags(flags: Flags): string {
+  if (__DEV__) {
+    return listFlags(flags).join('\n');
+  } else {
+    return '';
+  }
+}
+
 // Don't change these values. They're used by React Dev Tools.
 export const NoFlags = /*                      */ 0b000000000000000000000000000;
 export const PerformedWork = /*                */ 0b000000000000000000000000001;
@@ -63,6 +120,7 @@ export const PassiveStatic = /*                */ 0b000100000000000000000000000;
 export const PlacementDEV = /*                 */ 0b001000000000000000000000000;
 export const MountLayoutDev = /*               */ 0b010000000000000000000000000;
 export const MountPassiveDev = /*              */ 0b100000000000000000000000000;
+export const MountInsertionDev = /*           */ 0b1000000000000000000000000000;
 
 // Groups of flags that are used in the commit phase to skip over trees that
 // don't contain effects, by checking subtreeFlags.

--- a/packages/react-reconciler/src/ReactFiberWorkLoop.js
+++ b/packages/react-reconciler/src/ReactFiberWorkLoop.js
@@ -129,6 +129,7 @@ import {
   Visibility,
   MountPassiveDev,
   MountLayoutDev,
+  MountInsertionDev,
 } from './ReactFiberFlags';
 import {
   NoLanes,
@@ -200,6 +201,8 @@ import {
   invokeLayoutEffectMountInDEV,
   invokePassiveEffectMountInDEV,
   invokeLayoutEffectUnmountInDEV,
+  invokeInsertionEffectMountInDEV,
+  invokeInsertionEffectUnmountInDEV,
   invokePassiveEffectUnmountInDEV,
 } from './ReactFiberCommitWork';
 import {enqueueUpdate} from './ReactFiberClassUpdateQueue';
@@ -3688,11 +3691,17 @@ function legacyCommitDoubleInvokeEffectsInDEV(
   // Maybe not a big deal since this is DEV only behavior.
 
   setCurrentDebugFiberInDEV(fiber);
+  invokeEffectsInDev(
+    fiber,
+    MountInsertionDev,
+    invokeInsertionEffectUnmountInDEV,
+  );
   invokeEffectsInDev(fiber, MountLayoutDev, invokeLayoutEffectUnmountInDEV);
   if (hasPassiveEffects) {
     invokeEffectsInDev(fiber, MountPassiveDev, invokePassiveEffectUnmountInDEV);
   }
 
+  invokeEffectsInDev(fiber, MountInsertionDev, invokeInsertionEffectMountInDEV);
   invokeEffectsInDev(fiber, MountLayoutDev, invokeLayoutEffectMountInDEV);
   if (hasPassiveEffects) {
     invokeEffectsInDev(fiber, MountPassiveDev, invokePassiveEffectMountInDEV);
@@ -3707,6 +3716,7 @@ function invokeEffectsInDev(
 ) {
   let current: null | Fiber = firstChild;
   let subtreeRoot = null;
+
   while (current != null) {
     const primarySubtreeFlag = current.subtreeFlags & fiberFlags;
     if (

--- a/packages/react-reconciler/src/ReactHookEffectTags.js
+++ b/packages/react-reconciler/src/ReactHookEffectTags.js
@@ -18,3 +18,32 @@ export const HasEffect = /* */ 0b0001;
 export const Insertion = /* */ 0b0010;
 export const Layout = /*    */ 0b0100;
 export const Passive = /*   */ 0b1000;
+
+export const listFlags = (inputFlag: HookFlags): string[] => {
+  if (__DEV__) {
+    const list = [];
+    const flags = [
+      [NoFlags, 'NoFlags'],
+      [HasEffect, 'HasEffect'],
+      [Insertion, 'Insertion'],
+      [Layout, 'Layout'],
+      [Passive, 'Passive'],
+    ];
+    flags.forEach(flag => {
+      if (flag[0] & inputFlag) {
+        list.push(flag[1]);
+      }
+    });
+    return list;
+  } else {
+    return [];
+  }
+};
+
+export function prettyFlags(flags: HookFlags): string {
+  if (__DEV__) {
+    return listFlags(flags).join('\n');
+  } else {
+    return '';
+  }
+}

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -90,8 +90,10 @@ describe('StrictEffectsMode', () => {
         'useInsertionEffect mount',
         'useLayoutEffect mount',
         'useEffect mount',
+        'useInsertionEffect unmount',
         'useLayoutEffect unmount',
         'useEffect unmount',
+        'useInsertionEffect mount',
         'useLayoutEffect mount',
         'useEffect mount',
       ]);

--- a/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
+++ b/packages/react-reconciler/src/__tests__/StrictEffectsMode-test.js
@@ -70,6 +70,11 @@ describe('StrictEffectsMode', () => {
         return () => Scheduler.log('useLayoutEffect unmount');
       });
 
+      React.useInsertionEffect(() => {
+        Scheduler.log('useInsertionEffect mount');
+        return () => Scheduler.log('useInsertionEffect unmount');
+      });
+
       return text;
     }
 
@@ -82,6 +87,7 @@ describe('StrictEffectsMode', () => {
 
     if (supportsDoubleInvokeEffects()) {
       assertLog([
+        'useInsertionEffect mount',
         'useLayoutEffect mount',
         'useEffect mount',
         'useLayoutEffect unmount',
@@ -90,7 +96,11 @@ describe('StrictEffectsMode', () => {
         'useEffect mount',
       ]);
     } else {
-      assertLog(['useLayoutEffect mount', 'useEffect mount']);
+      assertLog([
+        'useInsertionEffect mount',
+        'useLayoutEffect mount',
+        'useEffect mount',
+      ]);
     }
 
     act(() => {
@@ -98,6 +108,8 @@ describe('StrictEffectsMode', () => {
     });
 
     assertLog([
+      'useInsertionEffect unmount',
+      'useInsertionEffect mount',
       'useLayoutEffect unmount',
       'useLayoutEffect mount',
       'useEffect unmount',
@@ -108,7 +120,11 @@ describe('StrictEffectsMode', () => {
       renderer.unmount();
     });
 
-    assertLog(['useLayoutEffect unmount', 'useEffect unmount']);
+    assertLog([
+      'useLayoutEffect unmount',
+      'useInsertionEffect unmount',
+      'useEffect unmount',
+    ]);
   });
 
   it('multiple effects are double invoked in the right order (all mounted, all unmounted, all remounted)', () => {


### PR DESCRIPTION
Tested/linted/prettier'd. The site gave me an error message when I tried to sign the CLA, but I may have already signed it.

## Summary

In strict mode, `useInsertionEffect` does not go through the mount-unmount-mount cycle the way `useEffect` and `useLayoutEffect` do, but I did not see any tests that cover this behavior, so this PR adds tests.

## How did you test this change?

```bash
Test Suites: 2 skipped, 292 passed, 292 of 294 total
Tests:       90 skipped, 7745 passed, 7835 total
Snapshots:   141 passed, 141 total
Time:        135.524 s
Ran all test suites.
✨  Done in 136.89s.

react (main) $ yarn prettier
yarn run v1.22.19
$ node ./scripts/prettier/index.js write-changed
> git merge-base HEAD main
> git diff --name-only --diff-filter=ACMRTUB 722f02fa6b2354349936286fc14970d1015296e4
> git ls-files --others --exclude-standard
✨  Done in 1.25s.

react (main) $ yarn lint
yarn run v1.22.19
$ node ./scripts/tasks/eslint.js
Linting all files...
Hint: run `yarn linc` to only lint changed files.

Lint passed.
✨  Done in 6.33s.

react (main) $ yarn flow-ci
yarn run v1.22.19
$ node ./scripts/tasks/flow-ci.js
Running Flow on the dom-node renderer...
Found 0 errors
Flow passed for the dom-node renderer

Running Flow on the dom-bun renderer...
...
✨  Done in 189.15s.
```